### PR TITLE
Correctly update kvstore overhead after emptying or releasing dict

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -262,12 +262,14 @@ int _dictResize(dict *d, unsigned long size, int* malloc_failed)
     d->ht_table[1] = new_ht_table;
     d->rehashidx = 0;
     if (d->type->rehashingStarted) d->type->rehashingStarted(d);
+    if (d->type->sizeChanged) d->type->sizeChanged(d, DICTHT_SIZE(d->ht_size_exp[1]));
 
     /* Is this the first initialization or is the first hash table empty? If so
      * it's not really a rehashing, we can just set the first hash table so that
      * it can accept keys. */
     if (d->ht_table[0] == NULL || d->ht_used[0] == 0) {
         if (d->type->rehashingCompleted) d->type->rehashingCompleted(d);
+        if (d->type->sizeChanged) d->type->sizeChanged(d, -DICTHT_SIZE(d->ht_size_exp[0]));
         if (d->ht_table[0]) zfree(d->ht_table[0]);
         d->ht_size_exp[0] = new_ht_size_exp;
         d->ht_used[0] = new_ht_used;
@@ -370,6 +372,7 @@ static int dictCheckRehashingCompleted(dict *d) {
     if (d->ht_used[0] != 0) return 0;
     
     if (d->type->rehashingCompleted) d->type->rehashingCompleted(d);
+    if (d->type->sizeChanged) d->type->sizeChanged(d, -DICTHT_SIZE(d->ht_size_exp[0]));
     zfree(d->ht_table[0]);
     /* Copy the new ht onto the old one */
     d->ht_table[0] = d->ht_table[1];
@@ -755,8 +758,15 @@ void dictRelease(dict *d)
 {
     /* Someone may be monitoring a dict that started rehashing, before
      * destroying the dict fake completion. */
-    if (dictIsRehashing(d) && d->type->rehashingCompleted)
-        d->type->rehashingCompleted(d);
+    if (dictIsRehashing(d)) {
+        if (d->type->rehashingCompleted)
+            d->type->rehashingCompleted(d);
+        if (d->type->sizeChanged)
+            d->type->sizeChanged(d, -(DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1])));
+    } else {
+        if (d->type->sizeChanged)
+            d->type->sizeChanged(d, -DICTHT_SIZE(d->ht_size_exp[0]));
+    }
 
     if (d->type->onDictRelease)
         d->type->onDictRelease(d);
@@ -1673,8 +1683,15 @@ void *dictFindPositionForInsert(dict *d, const void *key, dictEntry **existing) 
 void dictEmpty(dict *d, void(callback)(dict*)) {
     /* Someone may be monitoring a dict that started rehashing, before
      * destroying the dict fake completion. */
-    if (dictIsRehashing(d) && d->type->rehashingCompleted)
-        d->type->rehashingCompleted(d);
+    if (dictIsRehashing(d)) {
+        if (d->type->rehashingCompleted)
+            d->type->rehashingCompleted(d);
+        if (d->type->sizeChanged)
+            d->type->sizeChanged(d, -(DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1])));
+    } else {
+        if (d->type->sizeChanged)
+            d->type->sizeChanged(d, -DICTHT_SIZE(d->ht_size_exp[0]));
+    }
     _dictClear(d,0,callback);
     _dictClear(d,1,callback);
     d->rehashidx = -1;

--- a/src/dict.c
+++ b/src/dict.c
@@ -269,7 +269,7 @@ int _dictResize(dict *d, unsigned long size, int* malloc_failed)
      * it can accept keys. */
     if (d->ht_table[0] == NULL || d->ht_used[0] == 0) {
         if (d->type->rehashingCompleted) d->type->rehashingCompleted(d);
-        if (d->type->sizeChanged) d->type->sizeChanged(d, -DICTHT_SIZE(d->ht_size_exp[0]));
+        if (d->type->sizeChanged) d->type->sizeChanged(d, -(long long)DICTHT_SIZE(d->ht_size_exp[0]));
         if (d->ht_table[0]) zfree(d->ht_table[0]);
         d->ht_size_exp[0] = new_ht_size_exp;
         d->ht_used[0] = new_ht_used;
@@ -372,7 +372,7 @@ static int dictCheckRehashingCompleted(dict *d) {
     if (d->ht_used[0] != 0) return 0;
     
     if (d->type->rehashingCompleted) d->type->rehashingCompleted(d);
-    if (d->type->sizeChanged) d->type->sizeChanged(d, -DICTHT_SIZE(d->ht_size_exp[0]));
+    if (d->type->sizeChanged) d->type->sizeChanged(d, -(long long)DICTHT_SIZE(d->ht_size_exp[0]));
     zfree(d->ht_table[0]);
     /* Copy the new ht onto the old one */
     d->ht_table[0] = d->ht_table[1];
@@ -765,9 +765,10 @@ void dictRelease(dict *d)
      *   are subtracted from the total.
      * - If rehashing is not in progress, only the size of dict[0] is subtracted. */
     if (d->type->sizeChanged) {
-        d->type->sizeChanged(d, dictIsRehashing(d) ?
-            -(DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1])) :
-            -DICTHT_SIZE(d->ht_size_exp[0]));
+        unsigned long bucket_count = dictIsRehashing(d) ?
+            DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1]) :
+            DICTHT_SIZE(d->ht_size_exp[0]);
+        d->type->sizeChanged(d, -(long long)bucket_count);
     }
 
     if (d->type->onDictRelease)
@@ -1692,9 +1693,10 @@ void dictEmpty(dict *d, void(callback)(dict*)) {
      *   are subtracted from the total.
      * - If rehashing is not in progress, only the size of dict[0] is subtracted. */
     if (d->type->sizeChanged) {
-        d->type->sizeChanged(d, dictIsRehashing(d) ?
-            -(DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1])) :
-            -DICTHT_SIZE(d->ht_size_exp[0]));
+        unsigned long bucket_count = dictIsRehashing(d) ?
+            DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1]) :
+            DICTHT_SIZE(d->ht_size_exp[0]);
+        d->type->sizeChanged(d, -(long long)bucket_count);
     }
 
     _dictClear(d,0,callback);

--- a/src/dict.c
+++ b/src/dict.c
@@ -1683,15 +1683,18 @@ void *dictFindPositionForInsert(dict *d, const void *key, dictEntry **existing) 
 void dictEmpty(dict *d, void(callback)(dict*)) {
     /* Someone may be monitoring a dict that started rehashing, before
      * destroying the dict fake completion. */
-    if (dictIsRehashing(d)) {
-        if (d->type->rehashingCompleted)
-            d->type->rehashingCompleted(d);
-        if (d->type->sizeChanged)
-            d->type->sizeChanged(d, -(DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1])));
-    } else {
-        if (d->type->sizeChanged)
-            d->type->sizeChanged(d, -DICTHT_SIZE(d->ht_size_exp[0]));
+    if (dictIsRehashing(d) && d->type->rehashingCompleted)
+        d->type->rehashingCompleted(d);
+
+    if (d->type->sizeChanged) {
+        /* - If rehashing is in progress, the sizes of both dict[0] and dict[1]
+         *   are subtracted from the total.
+         * - If rehashing is not in progress, only the size of dict[0] is subtracted. */
+        d->type->sizeChanged(d, dictIsRehashing(d) ?
+            -(DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1])) :
+            -DICTHT_SIZE(d->ht_size_exp[0]));
     }
+
     _dictClear(d,0,callback);
     _dictClear(d,1,callback);
     d->rehashidx = -1;

--- a/src/dict.c
+++ b/src/dict.c
@@ -764,10 +764,9 @@ void dictRelease(dict *d)
     if (dictIsRehashing(d) && d->type->rehashingCompleted)
         d->type->rehashingCompleted(d);
 
-    if (d->type->bucketChanged) {
-        /* Subtract the size of all buckets. */
+    /* Subtract the size of all buckets. */
+    if (d->type->bucketChanged)
         d->type->bucketChanged(d, -(long long)dictBuckets(d));
-    }
 
     if (d->type->onDictRelease)
         d->type->onDictRelease(d);
@@ -1687,10 +1686,9 @@ void dictEmpty(dict *d, void(callback)(dict*)) {
     if (dictIsRehashing(d) && d->type->rehashingCompleted)
         d->type->rehashingCompleted(d);
 
-    if (d->type->bucketChanged) {
-        /* Subtract the size of all buckets. */
+    /* Subtract the size of all buckets. */
+    if (d->type->bucketChanged)
         d->type->bucketChanged(d, -(long long)dictBuckets(d));
-    }
 
     _dictClear(d,0,callback);
     _dictClear(d,1,callback);

--- a/src/dict.c
+++ b/src/dict.c
@@ -262,14 +262,16 @@ int _dictResize(dict *d, unsigned long size, int* malloc_failed)
     d->ht_table[1] = new_ht_table;
     d->rehashidx = 0;
     if (d->type->rehashingStarted) d->type->rehashingStarted(d);
-    if (d->type->sizeChanged) d->type->sizeChanged(d, DICTHT_SIZE(d->ht_size_exp[1]));
+    if (d->type->bucketChanged)
+        d->type->bucketChanged(d, DICTHT_SIZE(d->ht_size_exp[1]));
 
     /* Is this the first initialization or is the first hash table empty? If so
      * it's not really a rehashing, we can just set the first hash table so that
      * it can accept keys. */
     if (d->ht_table[0] == NULL || d->ht_used[0] == 0) {
         if (d->type->rehashingCompleted) d->type->rehashingCompleted(d);
-        if (d->type->sizeChanged) d->type->sizeChanged(d, -(long long)DICTHT_SIZE(d->ht_size_exp[0]));
+        if (d->type->bucketChanged)
+            d->type->bucketChanged(d, -(long long)DICTHT_SIZE(d->ht_size_exp[0]));
         if (d->ht_table[0]) zfree(d->ht_table[0]);
         d->ht_size_exp[0] = new_ht_size_exp;
         d->ht_used[0] = new_ht_used;
@@ -372,7 +374,8 @@ static int dictCheckRehashingCompleted(dict *d) {
     if (d->ht_used[0] != 0) return 0;
     
     if (d->type->rehashingCompleted) d->type->rehashingCompleted(d);
-    if (d->type->sizeChanged) d->type->sizeChanged(d, -(long long)DICTHT_SIZE(d->ht_size_exp[0]));
+    if (d->type->bucketChanged)
+        d->type->bucketChanged(d, -(long long)DICTHT_SIZE(d->ht_size_exp[0]));
     zfree(d->ht_table[0]);
     /* Copy the new ht onto the old one */
     d->ht_table[0] = d->ht_table[1];
@@ -761,10 +764,9 @@ void dictRelease(dict *d)
     if (dictIsRehashing(d) && d->type->rehashingCompleted)
         d->type->rehashingCompleted(d);
 
-    if (d->type->sizeChanged) {
+    if (d->type->bucketChanged) {
         /* Subtract the size of all buckets. */
-        unsigned long bucket_count = DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1]);
-        d->type->sizeChanged(d, -(long long)bucket_count);
+        d->type->bucketChanged(d, -(long long)dictBuckets(d));
     }
 
     if (d->type->onDictRelease)
@@ -1685,10 +1687,9 @@ void dictEmpty(dict *d, void(callback)(dict*)) {
     if (dictIsRehashing(d) && d->type->rehashingCompleted)
         d->type->rehashingCompleted(d);
 
-    if (d->type->sizeChanged) {
+    if (d->type->bucketChanged) {
         /* Subtract the size of all buckets. */
-        unsigned long bucket_count = DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1]);
-        d->type->sizeChanged(d, -(long long)bucket_count);
+        d->type->bucketChanged(d, -(long long)dictBuckets(d));
     }
 
     _dictClear(d,0,callback);

--- a/src/dict.c
+++ b/src/dict.c
@@ -758,14 +758,16 @@ void dictRelease(dict *d)
 {
     /* Someone may be monitoring a dict that started rehashing, before
      * destroying the dict fake completion. */
-    if (dictIsRehashing(d)) {
-        if (d->type->rehashingCompleted)
-            d->type->rehashingCompleted(d);
-        if (d->type->sizeChanged)
-            d->type->sizeChanged(d, -(DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1])));
-    } else {
-        if (d->type->sizeChanged)
-            d->type->sizeChanged(d, -DICTHT_SIZE(d->ht_size_exp[0]));
+    if (dictIsRehashing(d) && d->type->rehashingCompleted)
+        d->type->rehashingCompleted(d);
+
+    /* - If rehashing is in progress, the sizes of both dict[0] and dict[1]
+     *   are subtracted from the total.
+     * - If rehashing is not in progress, only the size of dict[0] is subtracted. */
+    if (d->type->sizeChanged) {
+        d->type->sizeChanged(d, dictIsRehashing(d) ?
+            -(DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1])) :
+            -DICTHT_SIZE(d->ht_size_exp[0]));
     }
 
     if (d->type->onDictRelease)
@@ -1686,10 +1688,10 @@ void dictEmpty(dict *d, void(callback)(dict*)) {
     if (dictIsRehashing(d) && d->type->rehashingCompleted)
         d->type->rehashingCompleted(d);
 
+    /* - If rehashing is in progress, the sizes of both dict[0] and dict[1]
+     *   are subtracted from the total.
+     * - If rehashing is not in progress, only the size of dict[0] is subtracted. */
     if (d->type->sizeChanged) {
-        /* - If rehashing is in progress, the sizes of both dict[0] and dict[1]
-         *   are subtracted from the total.
-         * - If rehashing is not in progress, only the size of dict[0] is subtracted. */
         d->type->sizeChanged(d, dictIsRehashing(d) ?
             -(DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1])) :
             -DICTHT_SIZE(d->ht_size_exp[0]));

--- a/src/dict.c
+++ b/src/dict.c
@@ -761,13 +761,9 @@ void dictRelease(dict *d)
     if (dictIsRehashing(d) && d->type->rehashingCompleted)
         d->type->rehashingCompleted(d);
 
-    /* - If rehashing is in progress, the sizes of both dict[0] and dict[1]
-     *   are subtracted from the total.
-     * - If rehashing is not in progress, only the size of dict[0] is subtracted. */
     if (d->type->sizeChanged) {
-        unsigned long bucket_count = dictIsRehashing(d) ?
-            DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1]) :
-            DICTHT_SIZE(d->ht_size_exp[0]);
+        /* Subtract the size of all buckets. */
+        unsigned long bucket_count = DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1]);
         d->type->sizeChanged(d, -(long long)bucket_count);
     }
 
@@ -1689,13 +1685,9 @@ void dictEmpty(dict *d, void(callback)(dict*)) {
     if (dictIsRehashing(d) && d->type->rehashingCompleted)
         d->type->rehashingCompleted(d);
 
-    /* - If rehashing is in progress, the sizes of both dict[0] and dict[1]
-     *   are subtracted from the total.
-     * - If rehashing is not in progress, only the size of dict[0] is subtracted. */
     if (d->type->sizeChanged) {
-        unsigned long bucket_count = dictIsRehashing(d) ?
-            DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1]) :
-            DICTHT_SIZE(d->ht_size_exp[0]);
+        /* Subtract the size of all buckets. */
+        unsigned long bucket_count = DICTHT_SIZE(d->ht_size_exp[0]) + DICTHT_SIZE(d->ht_size_exp[1]);
         d->type->sizeChanged(d, -(long long)bucket_count);
     }
 

--- a/src/dict.h
+++ b/src/dict.h
@@ -47,7 +47,7 @@ typedef struct dictType {
     void (*rehashingCompleted)(dict *d);
     /* Invoked when the size of the dictionary changes.
      * The `delta` parameter can be positive (size increase) or negative (size decrease). */
-    void (*sizeChanged)(dict *d, long long delta);
+    void (*bucketChanged)(dict *d, long long delta);
     /* Allow a dict to carry extra caller-defined metadata. The
      * extra memory is initialized to 0 when a dict is allocated. */
     size_t (*dictMetadataBytes)(dict *d);

--- a/src/dict.h
+++ b/src/dict.h
@@ -45,6 +45,12 @@ typedef struct dictType {
     /* Invoked at the end of dict initialization/rehashing of all the entries from old to new ht. Both ht still exists
      * and are cleaned up after this callback.  */
     void (*rehashingCompleted)(dict *d);
+    /* Invoked when the size of the dictionary changes.
+     * - Adds dict[1]'s size at the start of rehashing.
+     * - Subtracts dict[0]'s size at the end of rehashing.
+     * - Subtracts both dict[0] and dict[1] sizes when the dictionary is emptied or released.
+     * The `delta` parameter can be positive (size increase) or negative (size decrease). */
+    void (*sizeChanged)(dict *d, long long delta);
     /* Allow a dict to carry extra caller-defined metadata. The
      * extra memory is initialized to 0 when a dict is allocated. */
     size_t (*dictMetadataBytes)(dict *d);

--- a/src/dict.h
+++ b/src/dict.h
@@ -46,9 +46,6 @@ typedef struct dictType {
      * and are cleaned up after this callback.  */
     void (*rehashingCompleted)(dict *d);
     /* Invoked when the size of the dictionary changes.
-     * - Adds dict[1]'s size at the start of rehashing.
-     * - Subtracts dict[0]'s size at the end of rehashing.
-     * - Subtracts both dict[0] and dict[1] sizes when the dictionary is emptied or released.
      * The `delta` parameter can be positive (size increase) or negative (size decrease). */
     void (*sizeChanged)(dict *d, long long delta);
     /* Allow a dict to carry extra caller-defined metadata. The

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -232,7 +232,6 @@ static void kvstoreDictSizeChanged(dict *d, long long delta) {
     kvs->bucket_count += delta;
 }
 
-
 /* Returns the size of the DB dict base metadata in bytes. */
 static size_t kvstoreDictMetaBaseSize(dict *d) {
     UNUSED(d);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -382,7 +382,7 @@ size_t kvstoreMemUsage(kvstore *kvs) {
     mem += listLength(kvs->rehashing) * sizeof(listNode);
 
     if (kvs->dict_size_index)
-        mem += sizeof(unsigned long long) * (kvs->allocated_dicts + 1);
+        mem += sizeof(unsigned long long) * (kvs->num_dicts + 1);
 
     return mem;
 }

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -228,7 +228,6 @@ static void kvstoreDictRehashingCompleted(dict *d) {
  * sum of buckets for a DB. */
 static void kvstoreDictBucketChanged(dict *d, long long delta) {
     kvstore *kvs = d->type->userdata;
-    assert(delta > 0 || kvs->bucket_count >= (unsigned long long)(-delta));
     kvs->bucket_count += delta;
 }
 

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -205,7 +205,6 @@ static void kvstoreDictRehashingStarted(dict *d) {
     unsigned long long from, to;
     dictRehashingInfo(d, &from, &to);
     kvs->bucket_count += to; /* Started rehashing (Add the new ht size) */
-    kvs->overhead_hashtable_lut += to;
     kvs->overhead_hashtable_rehashing += from;
 }
 
@@ -224,9 +223,18 @@ static void kvstoreDictRehashingCompleted(dict *d) {
     unsigned long long from, to;
     dictRehashingInfo(d, &from, &to);
     kvs->bucket_count -= from; /* Finished rehashing (Remove the old ht size) */
-    kvs->overhead_hashtable_lut -= from;
     kvs->overhead_hashtable_rehashing -= from;
 }
+
+/* Updates the lut count for the given dictionary in a DB. It adds the new ht size
+ * of the dictionary or removes the old ht size of the dictionary from the total
+ * sum of buckets for a DB. */
+static void kvstoreDictSizeChanged(dict *d, long long delta) {
+    kvstore *kvs = d->type->userdata;
+    assert(delta > 0 || kvs->overhead_hashtable_lut >= (size_t)(-delta));
+    kvs->overhead_hashtable_lut += delta;
+}
+
 
 /* Returns the size of the DB dict base metadata in bytes. */
 static size_t kvstoreDictMetaBaseSize(dict *d) {
@@ -274,6 +282,7 @@ kvstore *kvstoreCreate(dictType *type, int num_dicts_bits, int flags) {
         kvs->dtype.dictMetadataBytes = kvstoreDictMetaBaseSize;
     kvs->dtype.rehashingStarted = kvstoreDictRehashingStarted;
     kvs->dtype.rehashingCompleted = kvstoreDictRehashingCompleted;
+    kvs->dtype.sizeChanged = kvstoreDictSizeChanged;
 
     kvs->num_dicts_bits = num_dicts_bits;
     kvs->num_dicts = 1 << kvs->num_dicts_bits;
@@ -335,6 +344,7 @@ void kvstoreRelease(kvstore *kvs) {
             metadata->rehashing_node = NULL;
         dictRelease(d);
     }
+    assert(kvs->overhead_hashtable_lut == 0);
     zfree(kvs->dicts);
 
     listRelease(kvs->rehashing);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -46,7 +46,6 @@ struct _kvstore {
     unsigned long long key_count;          /* Total number of keys in this kvstore. */
     unsigned long long bucket_count;       /* Total number of buckets in this kvstore across dictionaries. */
     unsigned long long *dict_size_index;   /* Binary indexed tree (BIT) that describes cumulative key frequencies up until given dict-index. */
-    size_t overhead_hashtable_lut;         /* The overhead of all dictionaries. */
     size_t overhead_hashtable_rehashing;   /* The overhead of dictionaries rehashing. */
     void *metadata[];                      /* conditionally allocated based on "flags" */
 };
@@ -229,8 +228,7 @@ static void kvstoreDictRehashingCompleted(dict *d) {
  * sum of buckets for a DB. */
 static void kvstoreDictSizeChanged(dict *d, long long delta) {
     kvstore *kvs = d->type->userdata;
-    assert(delta > 0 || kvs->overhead_hashtable_lut >= (size_t)(-delta));
-    kvs->overhead_hashtable_lut += delta;
+    assert(delta > 0 || kvs->bucket_count >= (size_t)(-delta));
     kvs->bucket_count += delta;
 }
 
@@ -297,7 +295,6 @@ kvstore *kvstoreCreate(dictType *type, int num_dicts_bits, int flags) {
     kvs->resize_cursor = 0;
     kvs->dict_size_index = kvs->num_dicts > 1? zcalloc(sizeof(unsigned long long) * (kvs->num_dicts + 1)) : NULL;
     kvs->bucket_count = 0;
-    kvs->overhead_hashtable_lut = 0;
     kvs->overhead_hashtable_rehashing = 0;
     return kvs;
 }
@@ -329,7 +326,6 @@ void kvstoreEmpty(kvstore *kvs, void(callback)(dict*)) {
     kvs->bucket_count = 0;
     if (kvs->dict_size_index)
         memset(kvs->dict_size_index, 0, sizeof(unsigned long long) * (kvs->num_dicts + 1));
-    kvs->overhead_hashtable_lut = 0;
     kvs->overhead_hashtable_rehashing = 0;
 }
 
@@ -343,7 +339,7 @@ void kvstoreRelease(kvstore *kvs) {
             metadata->rehashing_node = NULL;
         dictRelease(d);
     }
-    assert(kvs->overhead_hashtable_lut == 0);
+    assert(kvs->bucket_count == 0);
     zfree(kvs->dicts);
 
     listRelease(kvs->rehashing);
@@ -708,7 +704,7 @@ uint64_t kvstoreIncrementallyRehash(kvstore *kvs, uint64_t threshold_us) {
 }
 
 size_t kvstoreOverheadHashtableLut(kvstore *kvs) {
-    return kvs->overhead_hashtable_lut * sizeof(dictEntry *);
+    return kvs->bucket_count * sizeof(dictEntry *);
 }
 
 size_t kvstoreOverheadHashtableRehashing(kvstore *kvs) {

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -223,7 +223,7 @@ static void kvstoreDictRehashingCompleted(dict *d) {
     kvs->overhead_hashtable_rehashing -= from;
 }
 
-/* Updates the lut count for the given dictionary in a DB. It adds the new ht size
+/* Updates the bucket count for the given dictionary in a DB. It adds the new ht size
  * of the dictionary or removes the old ht size of the dictionary from the total
  * sum of buckets for a DB. */
 static void kvstoreDictSizeChanged(dict *d, long long delta) {

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -226,7 +226,7 @@ static void kvstoreDictRehashingCompleted(dict *d) {
 /* Updates the bucket count for the given dictionary in a DB. It adds the new ht size
  * of the dictionary or removes the old ht size of the dictionary from the total
  * sum of buckets for a DB. */
-static void kvstoreDictSizeChanged(dict *d, long long delta) {
+static void kvstoreDictBucketChanged(dict *d, long long delta) {
     kvstore *kvs = d->type->userdata;
     assert(delta > 0 || kvs->bucket_count >= (unsigned long long)(-delta));
     kvs->bucket_count += delta;
@@ -278,7 +278,7 @@ kvstore *kvstoreCreate(dictType *type, int num_dicts_bits, int flags) {
         kvs->dtype.dictMetadataBytes = kvstoreDictMetaBaseSize;
     kvs->dtype.rehashingStarted = kvstoreDictRehashingStarted;
     kvs->dtype.rehashingCompleted = kvstoreDictRehashingCompleted;
-    kvs->dtype.sizeChanged = kvstoreDictSizeChanged;
+    kvs->dtype.bucketChanged = kvstoreDictBucketChanged;
 
     kvs->num_dicts_bits = num_dicts_bits;
     kvs->num_dicts = 1 << kvs->num_dicts_bits;

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -228,7 +228,7 @@ static void kvstoreDictRehashingCompleted(dict *d) {
  * sum of buckets for a DB. */
 static void kvstoreDictSizeChanged(dict *d, long long delta) {
     kvstore *kvs = d->type->userdata;
-    assert(delta > 0 || kvs->bucket_count >= (size_t)(-delta));
+    assert(delta > 0 || kvs->bucket_count >= (unsigned long long)(-delta));
     kvs->bucket_count += delta;
 }
 

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -204,7 +204,6 @@ static void kvstoreDictRehashingStarted(dict *d) {
 
     unsigned long long from, to;
     dictRehashingInfo(d, &from, &to);
-    kvs->bucket_count += to; /* Started rehashing (Add the new ht size) */
     kvs->overhead_hashtable_rehashing += from;
 }
 
@@ -222,7 +221,6 @@ static void kvstoreDictRehashingCompleted(dict *d) {
 
     unsigned long long from, to;
     dictRehashingInfo(d, &from, &to);
-    kvs->bucket_count -= from; /* Finished rehashing (Remove the old ht size) */
     kvs->overhead_hashtable_rehashing -= from;
 }
 
@@ -233,6 +231,7 @@ static void kvstoreDictSizeChanged(dict *d, long long delta) {
     kvstore *kvs = d->type->userdata;
     assert(delta > 0 || kvs->overhead_hashtable_lut >= (size_t)(-delta));
     kvs->overhead_hashtable_lut += delta;
+    kvs->bucket_count += delta;
 }
 
 
@@ -388,7 +387,7 @@ size_t kvstoreMemUsage(kvstore *kvs) {
     mem += listLength(kvs->rehashing) * sizeof(listNode);
 
     if (kvs->dict_size_index)
-        mem += sizeof(unsigned long long) * (kvs->num_dicts + 1);
+        mem += sizeof(unsigned long long) * (kvs->allocated_dicts + 1);
 
     return mem;
 }

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -337,7 +337,6 @@ void kvstoreRelease(kvstore *kvs) {
             metadata->rehashing_node = NULL;
         dictRelease(d);
     }
-    assert(kvs->bucket_count == 0);
     zfree(kvs->dicts);
 
     listRelease(kvs->rehashing);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -381,9 +381,6 @@ size_t kvstoreMemUsage(kvstore *kvs) {
     /* Values are dict* shared with kvs->dicts */
     mem += listLength(kvs->rehashing) * sizeof(listNode);
 
-    if (kvs->dict_size_index)
-        mem += sizeof(unsigned long long) * (kvs->num_dicts + 1);
-
     return mem;
 }
 

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -535,3 +535,27 @@ start_server {tags {"info" "external:skip"}} {
         assert_equal [dict get $mem_stats db.dict.rehashing.count] {1}
     }
 }
+
+start_cluster 1 0 {tags {external:skip cluster}} {
+    test "Verify that multiple primaries mark replica as failed" {
+        R 0 set k v ;# Make dbs overhead displayed
+        set info_mem [r memory stats]
+        set overhead_main [dict get $info_mem db.0 overhead.hashtable.main]
+        set overhead_expires [dict get $info_mem db.0 overhead.hashtable.expires]
+        assert_range $overhead_main 1 5000
+        assert_range $overhead_expires 1 1000
+
+        # In cluster mode, we use KVSTORE_FREE_EMPTY_DICTS to ensure that dicts
+        # are freed when they are emptied. This test verifies that after a dict
+        # is cleared, the lut overhead is properly updated, preventing it from 
+        # growing indefinitely.
+        for {set j 1} {$j <= 500} {incr j} {
+            R 0 set k v
+            R 0 del k
+        }
+        R 0 set k v ;# Make dbs overhead displayed
+        set info_mem [r memory stats]
+        assert_equal [dict get $info_mem db.0 overhead.hashtable.main] $overhead_main
+        assert_equal [dict get $info_mem db.0 overhead.hashtable.expires] $overhead_expires
+    }
+}

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -537,7 +537,7 @@ start_server {tags {"info" "external:skip"}} {
 }
 
 start_cluster 1 0 {tags {external:skip cluster}} {
-    test "Verify that multiple primaries mark replica as failed" {
+    test "Verify that LUT overhead is properly updated when dicts are emptied or reused (issue #13973)" {
         R 0 set k v ;# Make dbs overhead displayed
         set info_mem [r memory stats]
         set overhead_main [dict get $info_mem db.0 overhead.hashtable.main]


### PR DESCRIPTION
Close #13973

This PR fixed two bugs.
1)  `overhead_hashtable_lut` isn't updated correctly
    This bug was introduced by https://github.com/redis/redis/pull/12913
    We only update `overhead_hashtable_lut` at the beginning and end of rehashing, but we forgot to update it when a dict is emptied or released.

    This PR introduces a new `bucketChanged` callback to track the change changes in the bucket size.
    Now, `rehashingStarted` and `rehashingCompleted` callbacks are no longer responsible for bucket changes, but are entirely handled by `bucketChanged`,  this can also avoid that we need to register three callbacks to track the change of  bucket size, now only one is needed.

    In most cases, it will be triggered together with `rehashingStarted` or `rehashingCompleted`,
except when a dict is being emptied or released, in these cases, even if the dict is not rehashing, we still need to subtract its current size.

    On the other hand, `overhead_hashtable_lut` was duplicated with `bucket_count`, so we remove `overhead_hashtable_lut` and use `bucket_count` instead.

    Note that this bug only happens with cluster mode, because we don't use KVSTORE_FREE_EMPTY_DICTS without cluster.

2) The size of `dict_size_index` repeatedly counted in terms of memory usage.
    `dict_size_index` is created at startup, so its memory usage has been counted into `used_memory_startup`.
	However, when we want to count the overhead, we repeat the calculation, which may cause the overhead to exceed the total memory usage.