### PR TITLE
Adds DEBUG FORCE-FULL-SYNC

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -496,6 +496,8 @@ void debugCommand(client *c) {
 "    Output SHA and content of all scripts or of a specific script with its SHA.",
 "MARK-INTERNAL-CLIENT [UNMARK]",
 "    Promote the current connection to an internal connection.",
+"REPL-FORCE-FULLSYNC",
+"    Force a full-sync between this server and its master or replica.",
 NULL
         };
         addExtendedReplyHelp(c, help, clusterDebugCommandExtendedHelp());
@@ -1087,6 +1089,18 @@ NULL
             addReplySubcommandSyntaxError(c);
             return;
         }
+    } else if (!strcasecmp(c->argv[1]->ptr,"force-full-sync") && c->argc == 2) {
+        int ret = 0;
+        if (server.masterhost) {
+            ret = replicationForceFullSyncReplica();
+        } else {
+            ret = replicationForceFullSyncMaster();
+        }
+        if (!ret) {
+            addReplyError(c, "Failed to force full sync (either master without replicas or replica without a connected master)");
+            return;
+        }
+        addReply(c, shared.ok);
     } else if(!handleDebugClusterCommand(c)) {
         addReplySubcommandSyntaxError(c);
         return;

--- a/src/networking.c
+++ b/src/networking.c
@@ -1728,7 +1728,7 @@ void freeClient(client *c) {
      * some unexpected state, by checking its flags. */
     if (server.master && c->flags & CLIENT_MASTER) {
         serverLog(LL_NOTICE,"Connection with master lost.");
-        if (!(c->flags & (CLIENT_PROTOCOL_ERROR|CLIENT_BLOCKED))) {
+        if (!(c->flags & (CLIENT_PROTOCOL_ERROR|CLIENT_BLOCKED|CLIENT_NO_CACHE_MASTER))) {
             c->flags &= ~(CLIENT_CLOSE_ASAP|CLIENT_CLOSE_AFTER_REPLY);
             replicationCacheMaster(c);
             return;

--- a/src/replication.c
+++ b/src/replication.c
@@ -5083,3 +5083,24 @@ void updateFailoverStatus(void) {
             server.target_replica_port);
     }
 }
+
+int replicationForceFullSyncMaster(void) {
+    if (server.masterhost || !listLength(server.slaves))
+        return 0; /* Not a master or master without slaves. */
+
+    disconnectSlaves();
+    freeReplicationBacklog();
+    return 1;
+}
+
+int replicationForceFullSyncReplica(void) {
+    if (!server.masterhost || !server.master)
+        return 0; /* Not a replica or master is not connected. */
+
+    /* We use freeClientAsync in case this function is called from
+     * within a command received from master (we don't want to free the
+     * master client mid-command since it frees argv) */
+    server.master->flags |= CLIENT_NO_CACHE_MASTER;
+    freeClientAsync(server.master);
+    return 1;
+}

--- a/src/server.h
+++ b/src/server.h
@@ -398,6 +398,8 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_REPROCESSING_COMMAND (1ULL<<50) /* The client is re-processing the command. */
 #define CLIENT_REPL_RDB_CHANNEL (1ULL<<51)      /* Client which is used for rdb delivery as part of rdb channel replication */
 #define CLIENT_INTERNAL (1ULL<<52) /* Internal client connection */
+#define CLIENT_NO_CACHE_MASTER (1ULL<<53) /* Flag meant for master client only. Do not cache the master in case of disconnection */
+
 
 /* Any flag that does not let optimize FLUSH SYNC to run it in bg as blocking client ASYNC */
 #define CLIENT_AVOID_BLOCKING_ASYNC_FLUSH (CLIENT_DENY_BLOCKING|CLIENT_MULTI|CLIENT_LUA_DEBUG|CLIENT_LUA_DEBUG_SYNC|CLIENT_MODULE)
@@ -3060,6 +3062,8 @@ void abortFailover(const char *err);
 const char *getFailoverStateString(void);
 int replicationCheckHasMainChannel(client *slave);
 unsigned long replicationLogicalReplicaCount(void);
+int replicationForceFullSyncMaster(void);
+int replicationForceFullSyncReplica(void);
 
 /* Generic persistence functions */
 void startLoadingFile(size_t size, char* filename, int rdbflags);

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -809,15 +809,8 @@ test {diskless loading short read} {
                 set loglines [lindex $res 1]
                 if {![string match "*Internal error in RDB*" $log_text]} {
                     # force the replica to try another full sync
-                    $master multi
-                    $master client kill type replica
-                    $master set asdf asdf
-                    # fill replication backlog with new content
-                    $master config set repl-backlog-size 16384
-                    for {set keyid 0} {$keyid < 10} {incr keyid} {
-                        $master set "$keyid string_$keyid" [string repeat A 16384]
-                    }
-                    $master exec
+                    wait_for_sync $replica
+                    $master debug force-full-sync
                 }
 
                 # wait for loading to stop (fail)
@@ -1649,5 +1642,39 @@ start_server {tags {"repl external:skip"}} {
             assert_morethan [$replica dbsize] 0
             assert_equal [$master debug digest] [$replica debug digest]
         }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    # Replica
+    set replica [srv 0 client]
+    
+    start_server {} {
+        # Master
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+        
+        test "Test force full-sync" {
+            assert_equal 0 [s 0 sync_full]
+
+            # Expect error when master has no slaves
+            catch {$master debug force full-sync}
+
+            $replica replicaof $master_host $master_port
+            wait_for_sync $replica
+
+            # Test master
+            set prev [s 0 sync_full]
+            $master debug force-full-sync
+            wait_for_sync $replica
+            assert_equal [s 0 sync_full] [expr $prev+1]
+
+            # Test replica
+            set prev [s 0 sync_full]
+            $replica debug force-full-sync
+            wait_for_sync $replica
+            assert_equal [s 0 sync_full] [expr $prev+1]
+        } {} {needs:debug}
     }
 }

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -153,15 +153,8 @@ tags "modules" {
                         set loglines [lindex $res 1]
                         if {![string match "*Internal error in RDB*" $log_text]} {
                             # force the replica to try another full sync
-                            $master multi
-                            $master client kill type replica
-                            $master set asdf asdf
-                            # fill replication backlog with new content
-                            $master config set repl-backlog-size 16384
-                            for {set keyid 0} {$keyid < 10} {incr keyid} {
-                                $master set "$keyid string_$keyid" [string repeat A 16384]
-                            }
-                            $master exec
+                            wait_for_sync $replica
+                            $master debug force-full-sync
                         }
 
                         # wait for loading to stop (fail)


### PR DESCRIPTION
Mostly for tests but may also be used in production events

Replaced hacky full-sync forcing in native/module "RDB short-read" tests