### PR TITLE
Remove redundant HASH_SET_COPY macro and hfieldGetExpireTime declaration

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -3454,7 +3454,6 @@ uint64_t hfieldGetExpireTime(hfield field);
 static inline void hfieldFree(hfield field) { mstrFree(&mstrFieldKind, field); }
 static inline void *hfieldGetAllocPtr(hfield field) { return mstrGetAllocPtr(&mstrFieldKind, field); }
 static inline size_t hfieldlen(hfield field) { return mstrlen(field);}
-uint64_t hfieldGetExpireTime(hfield field);
 
 /* Pub / Sub */
 int pubsubUnsubscribeAllChannels(client *c, int notify);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -890,7 +890,6 @@ int hashTypeExists(redisDb *db, robj *o, sds field, int hfeFlags, int *isHashDel
 #define HASH_SET_TAKE_FIELD  (1<<0)
 #define HASH_SET_TAKE_VALUE  (1<<1)
 #define HASH_SET_KEEP_TTL (1<<2)
-#define HASH_SET_COPY 0
 int hashTypeSet(redisDb *db, robj *o, sds field, sds value, int flags) {
     int update = 0;
 


### PR DESCRIPTION

This PR removes duplicate definitions and redundant code in the Redis codebase.


1. The function `uint64_t hfieldGetExpireTime(hfield field)` is already defined in:
https://github.com/redis/redis/blob/14dd59ab12836f71e7543cc82503db7d151572fe/src/server.h#L3453
This PR removes the duplicate definition.


2. The macro `#define HASH_SET_COPY 0` is currently defined in 
https://github.com/redis/redis/blob/14dd59ab12836f71e7543cc82503db7d151572fe/src/server.h#L3399
https://github.com/redis/redis/blob/14dd59ab12836f71e7543cc82503db7d151572fe/src/t_hash.c#L893

This PR removes the duplicate in `t_hash.c` to ensure consistency and avoid confusion.