### PR TITLE
Limiting output buffer for unauthenticated client (CVE-2025-21605)

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -4217,6 +4217,11 @@ int checkClientOutputBufferLimits(client *c) {
     int soft = 0, hard = 0, class;
     unsigned long used_mem = getClientOutputBufferMemoryUsage(c);
 
+    /* For unauthenticated clients the output buffer is limited to prevent
+     * them from abusing it by not reading the replies */
+    if (used_mem > 1024 && authRequired(c))
+        return 1;
+
     class = getClientType(c);
     /* For the purpose of output buffer limiting, masters are handled
      * like normal clients. */


### PR DESCRIPTION
For unauthenticated clients the output buffer is limited to prevent them from abusing it by not reading the replies