### PR TITLE
Parsing command is truly offloaded to IO threads in pipeline mode

### DIFF
--- a/src/iothread.c
+++ b/src/iothread.c
@@ -51,17 +51,18 @@ void enqueuePendingClientsToMainThread(client *c, int unbind) {
     if (unbind) connUnbindEventLoop(c->conn);
     /* Just skip if it already is transferred. */
     if (c->io_thread_client_list_node) {
+        IOThread *t = &IOThreads[c->tid];
         /* If there are several clients to process, let the main thread handle them ASAP.
          * Since the client being added to the queue may still need to be processed by
          * the IO thread, we must call this before adding it to the queue to avoid
          * races with the main thread. */
-        sendPendingClientsToMainThreadIfNeeded(&IOThreads[c->tid], 1);
-        /* Remove the client from clients list of IO thread. */
-        listDelNode(IOThreads[c->tid].clients, c->io_thread_client_list_node);
-        c->io_thread_client_list_node = NULL;
+        sendPendingClientsToMainThreadIfNeeded(t, 1);
         /* Disable read and write to avoid race when main thread processes. */
         c->io_flags &= ~(CLIENT_IO_READ_ENABLED | CLIENT_IO_WRITE_ENABLED);
-        listAddNodeTail(IOThreads[c->tid].pending_clients_to_main_thread, c);
+        /* Remove the client from IO thread, add it to main thread's pending list. */
+        listUnlinkNode(t->clients, c->io_thread_client_list_node);
+        listLinkNodeTail(t->pending_clients_to_main_thread, c->io_thread_client_list_node);
+        c->io_thread_client_list_node = NULL;
     }
 }
 
@@ -539,7 +540,8 @@ int processClientsFromMainThread(IOThread *t) {
 
         /* Link client in IO thread clients list first. */
         serverAssert(c->io_thread_client_list_node == NULL);
-        listAddNodeTail(t->clients, c);
+        listUnlinkNode(t->processing_clients, ln);
+        listLinkNodeTail(t->clients, ln);
         c->io_thread_client_list_node = listLast(t->clients);
 
         /* The client is asked to close, we just let main thread free it. */
@@ -567,7 +569,8 @@ int processClientsFromMainThread(IOThread *t) {
             }
         }
     }
-    listEmpty(t->processing_clients);
+    /* All clients must are processed. */
+    serverAssert(listLength(t->processing_clients) == 0);
     return processed;
 }
 

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -418,7 +418,7 @@ int processClientsFromIOThread(IOThread *t) {
         /* Update the client in the mem usage */
         updateClientMemUsageAndBucket(c);
 
-        /* Process the pending command and input buffer. */
+        /* Only process the pending command. */
         if (!c->read_error && c->io_flags & CLIENT_IO_PENDING_COMMAND) {
             if (processCommandAndResetClient(c) == C_ERR) {
                 /* If the client is no longer valid, it must be freed safely. */

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -96,6 +96,7 @@ void keepClientInMainThread(client *c) {
     c->tid = IOTHREAD_MAIN_THREAD_ID;
     /* Main thread starts to manage it. */
     server.io_threads_clients_num[c->tid]++;
+    trimClientQueryBuffer(c); /* Avoid missing trim in IO threads. */
 }
 
 /* If the client is managed by IO thread, we should fetch it from IO thread
@@ -131,6 +132,7 @@ void fetchClientFromIOThread(client *c) {
     /* Now main thread can process it. */
     c->running_tid = IOTHREAD_MAIN_THREAD_ID;
     resumeIOThread(c->tid);
+    trimClientQueryBuffer(c); /* Avoid missing trim in IO threads. */
 }
 
 /* For some clients, we must handle them in the main thread, since there is
@@ -418,8 +420,7 @@ int processClientsFromIOThread(IOThread *t) {
 
         /* Process the pending command and input buffer. */
         if (!c->read_error && c->io_flags & CLIENT_IO_PENDING_COMMAND) {
-            c->flags |= CLIENT_PENDING_COMMAND;
-            if (processPendingCommandAndInputBuffer(c) == C_ERR) {
+            if (processCommandAndResetClient(c) == C_ERR) {
                 /* If the client is no longer valid, it must be freed safely. */
                 continue;
             }
@@ -559,6 +560,19 @@ int processClientsFromMainThread(IOThread *t) {
             connRebindEventLoop(c->conn, t->el);
             serverAssert(!connHasReadHandler(c->conn));
             connSetReadHandler(c->conn, readQueryFromClient);
+        }
+
+        /* The main thread only handles the first parsed command, so IO threads
+         * need to process the remaining queries if needed. */
+        if (c->querybuf && sdslen(c->querybuf) > 0) {
+            if (processInputBuffer(c) == C_ERR) continue;
+            /* If a command is parsed, we transfer the client to the main thread to
+             * process, don't write pending replies to avoid many short write(2). */
+            if (c->io_flags & CLIENT_IO_PENDING_COMMAND)
+                continue;
+
+            /* Trim the query buffer ASAP when all commands in it have been processed. */
+            trimClientQueryBuffer(c);
         }
 
         /* If the client has pending replies, write replies to client. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -2870,8 +2870,12 @@ int processInputBuffer(client *c) {
             c->qb_pos -= c->repl_applied;
             c->repl_applied = 0;
         }
-    } else if (c->qb_pos) {
-        /* Trim to pos */
+    } else if (c->qb_pos && (c->qb_pos == sdslen(c->querybuf) ||
+                             !(c->io_flags & CLIENT_IO_PENDING_COMMAND)))
+    {
+        /* For io threads, we don't trim the query buffer if there still is remaining data
+         * in the buffer, since we just parse the first command, to avoid many sdsrange
+         * (memmove), we trim it when we fully parse the command. */
         sdsrange(c->querybuf,c->qb_pos,-1);
         c->qb_pos = 0;
     }
@@ -3016,10 +3020,16 @@ done:
     }
 
     if (c && (c->io_flags & CLIENT_IO_REUSABLE_QUERYBUFFER)) {
-        serverAssert(c->qb_pos == 0); /* Ensure the client's query buffer is trimmed in processInputBuffer */
         resetReusableQueryBuf(c);
     }
     beforeNextClient(c);
+}
+
+void trimClientQueryBuffer(client *c) {
+    if (c->querybuf && c->qb_pos) {
+        sdsrange(c->querybuf,c->qb_pos,-1);
+        c->qb_pos = 0;
+    }
 }
 
 /* A Redis "Address String" is a colon separated ip:port pair.

--- a/src/server.h
+++ b/src/server.h
@@ -2895,6 +2895,7 @@ void unprotectClient(client *c);
 client *lookupClientByID(uint64_t id);
 int authRequired(client *c);
 void putClientInPendingWriteQueue(client *c);
+void trimClientQueryBuffer(client *c);
 /* reply macros */
 #define ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c, str) addReplyBulkCBuffer(c, str, strlen(str))
 


### PR DESCRIPTION
For pipeline mode, the IO thread only parses the first command in query buffer, and the main thread parses the remaining commands. Now in this commit, the IO thread parses the first command in the query buffer, the main thread handles just that first one, but then passes control of client back to the IO thread for the rest, repeat the above process until all commands are processed, so all the commands in pipeline are truly parsed by IO threads instead of only the first one. That is, we truly offload command parsing job to IO threads, even in pipeline mode, this can reduce the workload of the main thread.

This also means the `argv` of clients are completely allocated by  IO thread, plus https://github.com/redis/redis/pull/13968, the `argv` will be deallocated by IO thread, so for pipeline, we also can avoid memory arena contention issue.

And this also makes memory prefetching work well, since if we only prefetch the first command in query buffer, but the main thread handles all commands in the query buffer, when parsing and executing the remaining command, this may make prefetched data in cache invalid, causing cache miss. But this commit can avoid this happen.

This commit causes clients to be passed between the IO thread and the main thread more frequently, maybe brings performance regression, but https://github.com/redis/redis/pull/13969 can reduce the impact, it supports to deliver clients between the main thread and IO threads without notifications.

For single thread, in `processInputBuffer`, we try to parse alls command in query buffer, and trim the buffer after executing all command. But for multithreading, we only parse the first command, and them trim the buffer, so this approach leads unnecessary `trim` (memmove) operations. And this commit even makes it worse, since we will trim multiple times if there are many commands in the buffer. So in this commit, we defer the `trim` operation after all commands in the buffer are processed.

Due to more frequent client transfers, and dynamic allocation when building the linked list, the creation and destruction of list nodes also consume some CPU. In this commit, we reuse list nodes to avoid this issue.

**Alternative solution:**
Let IO threads batch parse all commands in query buffer, and then pass them to the main thread for processing, this way can avoid frequent client transfers. But it is much complex, we need to record several states for each command(such as argc, argv, offset, read_error), maybe we can try in the future. cc @oranagra 