### PR TITLE
Include missing getchannels.tcl in moduleapi tests and fix incorrect assertions

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -32,6 +32,7 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/auth \
 --single unit/moduleapi/keyspace_events \
 --single unit/moduleapi/blockedclient \
+--single unit/moduleapi/getchannels \
 --single unit/moduleapi/getkeys \
 --single unit/moduleapi/test_lazyfree \
 --single unit/moduleapi/defrag \

--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -14,4 +14,47 @@ then
 fi
 
 $MAKE -C tests/modules && \
-ONLY_MODULEAPI=1 $TCLSH tests/test_helper.tcl "${@}"
+$TCLSH tests/test_helper.tcl \
+--single unit/moduleapi/commandfilter \
+--single unit/moduleapi/basics \
+--single unit/moduleapi/fork \
+--single unit/moduleapi/testrdb \
+--single unit/moduleapi/infotest \
+--single unit/moduleapi/moduleconfigs \
+--single unit/moduleapi/infra \
+--single unit/moduleapi/propagate \
+--single unit/moduleapi/hooks \
+--single unit/moduleapi/misc \
+--single unit/moduleapi/blockonkeys \
+--single unit/moduleapi/blockonbackground \
+--single unit/moduleapi/scan \
+--single unit/moduleapi/datatype \
+--single unit/moduleapi/auth \
+--single unit/moduleapi/keyspace_events \
+--single unit/moduleapi/blockedclient \
+--single unit/moduleapi/getkeys \
+--single unit/moduleapi/test_lazyfree \
+--single unit/moduleapi/defrag \
+--single unit/moduleapi/keyspecs \
+--single unit/moduleapi/hash \
+--single unit/moduleapi/zset \
+--single unit/moduleapi/list \
+--single unit/moduleapi/stream \
+--single unit/moduleapi/mallocsize \
+--single unit/moduleapi/datatype2 \
+--single unit/moduleapi/cluster \
+--single unit/moduleapi/aclcheck \
+--single unit/moduleapi/subcommands \
+--single unit/moduleapi/reply \
+--single unit/moduleapi/cmdintrospection \
+--single unit/moduleapi/eventloop \
+--single unit/moduleapi/timer \
+--single unit/moduleapi/publish \
+--single unit/moduleapi/usercall \
+--single unit/moduleapi/postnotifications \
+--single unit/moduleapi/async_rm_call \
+--single unit/moduleapi/moduleauth \
+--single unit/moduleapi/rdbloadsave \
+--single unit/moduleapi/crash \
+--single unit/moduleapi/internalsecret \
+"${@}"

--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -14,47 +14,4 @@ then
 fi
 
 $MAKE -C tests/modules && \
-$TCLSH tests/test_helper.tcl \
---single unit/moduleapi/commandfilter \
---single unit/moduleapi/basics \
---single unit/moduleapi/fork \
---single unit/moduleapi/testrdb \
---single unit/moduleapi/infotest \
---single unit/moduleapi/moduleconfigs \
---single unit/moduleapi/infra \
---single unit/moduleapi/propagate \
---single unit/moduleapi/hooks \
---single unit/moduleapi/misc \
---single unit/moduleapi/blockonkeys \
---single unit/moduleapi/blockonbackground \
---single unit/moduleapi/scan \
---single unit/moduleapi/datatype \
---single unit/moduleapi/auth \
---single unit/moduleapi/keyspace_events \
---single unit/moduleapi/blockedclient \
---single unit/moduleapi/getkeys \
---single unit/moduleapi/test_lazyfree \
---single unit/moduleapi/defrag \
---single unit/moduleapi/keyspecs \
---single unit/moduleapi/hash \
---single unit/moduleapi/zset \
---single unit/moduleapi/list \
---single unit/moduleapi/stream \
---single unit/moduleapi/mallocsize \
---single unit/moduleapi/datatype2 \
---single unit/moduleapi/cluster \
---single unit/moduleapi/aclcheck \
---single unit/moduleapi/subcommands \
---single unit/moduleapi/reply \
---single unit/moduleapi/cmdintrospection \
---single unit/moduleapi/eventloop \
---single unit/moduleapi/timer \
---single unit/moduleapi/publish \
---single unit/moduleapi/usercall \
---single unit/moduleapi/postnotifications \
---single unit/moduleapi/async_rm_call \
---single unit/moduleapi/moduleauth \
---single unit/moduleapi/rdbloadsave \
---single unit/moduleapi/crash \
---single unit/moduleapi/internalsecret \
-"${@}"
+ONLY_MODULEAPI=1 $TCLSH tests/test_helper.tcl "${@}"

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -28,13 +28,6 @@ set test_dirs {
     integration
 }
 
-# If the environment variable 'only_module' is set to "1" run only module-related tests.
-# This is typically used when running ./runtest-moduleapi to focus on module API behavior
-# and avoid running unrelated general tests.
-if {[info exists env(ONLY_MODULEAPI)] && $env(ONLY_MODULEAPI) eq "1"} {
-    set test_dirs {unit/moduleapi}
-}
-
 foreach test_dir $test_dirs {
     set files [glob -nocomplain $dir/tests/$test_dir/*.tcl]
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -28,6 +28,13 @@ set test_dirs {
     integration
 }
 
+# If the environment variable 'only_module' is set to "1" run only module-related tests.
+# This is typically used when running ./runtest-moduleapi to focus on module API behavior
+# and avoid running unrelated general tests.
+if {[info exists env(ONLY_MODULEAPI)] && $env(ONLY_MODULEAPI) eq "1"} {
+    set test_dirs {unit/moduleapi}
+}
+
 foreach test_dir $test_dirs {
     set files [glob -nocomplain $dir/tests/$test_dir/*.tcl]
 

--- a/tests/unit/moduleapi/getchannels.tcl
+++ b/tests/unit/moduleapi/getchannels.tcl
@@ -11,12 +11,12 @@ start_server {tags {"modules"}} {
         assert_equal "OK" [r ACL DRYRUN testuser getchannels.command publish literal channel publish literal pattern1]
         assert_equal "OK" [r ACL DRYRUN testuser getchannels.command unsubscribe literal channel unsubscribe literal pattern1]
 
-        assert_equal "This user has no permissions to access the 'nopattern1' channel" [r ACL DRYRUN testuser getchannels.command subscribe literal channel subscribe literal nopattern1]
-        assert_equal "This user has no permissions to access the 'nopattern1' channel" [r ACL DRYRUN testuser getchannels.command publish literal channel subscribe literal nopattern1]
+        assert_equal "User testuser has no permissions to access the 'nopattern1' channel" [r ACL DRYRUN testuser getchannels.command subscribe literal channel subscribe literal nopattern1]
+        assert_equal "User testuser has no permissions to access the 'nopattern1' channel" [r ACL DRYRUN testuser getchannels.command publish literal channel subscribe literal nopattern1]
         assert_equal "OK" [r ACL DRYRUN testuser getchannels.command unsubscribe literal channel unsubscribe literal nopattern1]
 
-        assert_equal "This user has no permissions to access the 'otherchannel' channel" [r ACL DRYRUN testuser getchannels.command subscribe literal otherchannel subscribe literal pattern1]
-        assert_equal "This user has no permissions to access the 'otherchannel' channel" [r ACL DRYRUN testuser getchannels.command publish literal otherchannel subscribe literal pattern1]
+        assert_equal "User testuser has no permissions to access the 'otherchannel' channel" [r ACL DRYRUN testuser getchannels.command subscribe literal otherchannel subscribe literal pattern1]
+        assert_equal "User testuser has no permissions to access the 'otherchannel' channel" [r ACL DRYRUN testuser getchannels.command publish literal otherchannel subscribe literal pattern1]
         assert_equal "OK" [r ACL DRYRUN testuser getchannels.command unsubscribe literal otherchannel unsubscribe literal pattern1]
     }
 
@@ -25,12 +25,12 @@ start_server {tags {"modules"}} {
         assert_equal "OK" [r ACL DRYRUN testuser getchannels.command publish pattern pattern*]
         assert_equal "OK" [r ACL DRYRUN testuser getchannels.command unsubscribe pattern pattern*]
 
-        assert_equal "This user has no permissions to access the 'pattern1' channel" [r ACL DRYRUN testuser getchannels.command subscribe pattern pattern1 subscribe pattern pattern*]
-        assert_equal "This user has no permissions to access the 'pattern1' channel" [r ACL DRYRUN testuser getchannels.command publish pattern pattern1 subscribe pattern pattern*]
+        assert_equal "User testuser has no permissions to access the 'pattern1' channel" [r ACL DRYRUN testuser getchannels.command subscribe pattern pattern1 subscribe pattern pattern*]
+        assert_equal "User testuser has no permissions to access the 'pattern1' channel" [r ACL DRYRUN testuser getchannels.command publish pattern pattern1 subscribe pattern pattern*]
         assert_equal "OK" [r ACL DRYRUN testuser getchannels.command unsubscribe pattern pattern1 unsubscribe pattern pattern*]
 
-        assert_equal "This user has no permissions to access the 'otherpattern*' channel" [r ACL DRYRUN testuser getchannels.command subscribe pattern otherpattern* subscribe pattern pattern*]
-        assert_equal "This user has no permissions to access the 'otherpattern*' channel" [r ACL DRYRUN testuser getchannels.command publish pattern otherpattern* subscribe pattern pattern*]
+        assert_equal "User testuser has no permissions to access the 'otherpattern*' channel" [r ACL DRYRUN testuser getchannels.command subscribe pattern otherpattern* subscribe pattern pattern*]
+        assert_equal "User testuser has no permissions to access the 'otherpattern*' channel" [r ACL DRYRUN testuser getchannels.command publish pattern otherpattern* subscribe pattern pattern*]
         assert_equal "OK" [r ACL DRYRUN testuser getchannels.command unsubscribe pattern otherpattern* unsubscribe pattern pattern*]
     }
 


### PR DESCRIPTION
## Problems 

When I try to running the moduleapi tests, I noticed that the `runtest-moduleapi` shell misses the execution of the `getchannels.tcl` test file.


## Fixed

This commit includes the missing getchannels.tcl test in the runtest-moduleapi suite.
Additionally, it fixes an incorrect assert_equal in the test to match the actual expected output, allowing the test to pass successfully.