### PR TITLE
Fix: build flags for dependencies 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: make
-      run: make REDIS_CFLAGS='-Werror'
+      # Fail build if there are warnings
+      # build with TLS just for compilation coverage
+      run: make REDIS_CFLAGS='-Werror' BUILD_TLS=yes
 
   build-32bit:
     runs-on: ubuntu-latest

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -64,16 +64,15 @@ distclean:
 
 .PHONY: distclean
 
-# Special care is needed to pass additional CFLAGS/LDFLAGS to hiredis as it
-# modifies these variables in its Makefile.
-HIREDIS_MAKE_FLAGS=MYCFLAGS=$(DEPS_CFLAGS) MYLDFLAGS=$(DEPS_LDFLAGS)
 ifneq (,$(filter $(BUILD_TLS),yes module))
-    HIREDIS_MAKE_FLAGS += USE_SSL=1
+    HIREDIS_MAKE_FLAGS = USE_SSL=1
 endif
 
+# Special care is needed to pass additional CFLAGS/LDFLAGS to hiredis as it
+# modifies these variables in its Makefile.
 hiredis: .make-prerequisites
 	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)
-	cd hiredis && $(MAKE) static $(HIREDIS_MAKE_FLAGS)
+	cd hiredis && $(MAKE) static $(HIREDIS_MAKE_FLAGS) HIREDIS_CFLAGS="$(DEPS_CFLAGS)" HIREDIS_LDFLAGS="$(DEPS_LDFLAGS)"
 
 .PHONY: hiredis
 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -64,13 +64,16 @@ distclean:
 
 .PHONY: distclean
 
+# Special care is needed to pass additional CFLAGS/LDFLAGS to hiredis as it
+# modifies these variables in its Makefile.
+HIREDIS_MAKE_FLAGS=MYCFLAGS=$(DEPS_CFLAGS) MYLDFLAGS=$(DEPS_LDFLAGS)
 ifneq (,$(filter $(BUILD_TLS),yes module))
-    HIREDIS_MAKE_FLAGS = USE_SSL=1
+    HIREDIS_MAKE_FLAGS += USE_SSL=1
 endif
 
 hiredis: .make-prerequisites
 	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)
-	cd hiredis && $(MAKE) static $(HIREDIS_MAKE_FLAGS) CFLAGS="$(DEPS_CFLAGS)" LDFLAGS="$(DEPS_LDFLAGS)"
+	cd hiredis && $(MAKE) static $(HIREDIS_MAKE_FLAGS)
 
 .PHONY: hiredis
 

--- a/deps/fast_float/Makefile
+++ b/deps/fast_float/Makefile
@@ -2,20 +2,23 @@
 CC ?= gcc
 CXX ?= g++
 
-CFLAGS=-Wall -O3
-# This avoids loosing the fastfloat specific compile flags when we override the CFLAGS via the main project
-FASTFLOAT_CFLAGS=-std=c++11 -DFASTFLOAT_ALLOWS_LEADING_PLUS
-LDFLAGS=
+WARN=-Wall
+OPT=-O3
+STD=-std=c++11
+DEFS=-DFASTFLOAT_ALLOWS_LEADING_PLUS
+
+FASTFLOAT_CFLAGS=$(WARN) $(OPT) $(STD) $(DEFS) $(CFLAGS)
+FASTFLOAT_LDFLAGS=$(LDFLAGS)
 
 libfast_float: fast_float_strtod.o
 	$(AR) -r libfast_float.a fast_float_strtod.o
 
-32bit: CFLAGS += -m32
-32bit: LDFLAGS += -m32
+32bit: FASTFLOAT_CFLAGS += -m32
+32bit: FASTFLOAT_LDFLAGS += -m32
 32bit: libfast_float
 
 fast_float_strtod.o: fast_float_strtod.cpp
-	$(CXX) $(CFLAGS) $(FASTFLOAT_CFLAGS) -c fast_float_strtod.cpp $(LDFLAGS)
+	$(CXX) $(FASTFLOAT_CFLAGS) -c fast_float_strtod.cpp $(FASTFLOAT_LDFLAGS)
 
 clean:
 	rm -f *.o

--- a/deps/hiredis/Makefile
+++ b/deps/hiredis/Makefile
@@ -35,14 +35,19 @@ define REDIS_TEST_CONFIG
 endef
 export REDIS_TEST_CONFIG
 
+# Flags passed from outside so as not to override CFLAGS or LDFLAGS as they may
+# be changed inside this Makefile
+MYCFLAGS=
+MYLDFLAGS=
+
 # Fallback to gcc when $CC is not in $PATH.
 CC:=$(shell sh -c 'type $${CC%% *} >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
 CXX:=$(shell sh -c 'type $${CXX%% *} >/dev/null 2>/dev/null && echo $(CXX) || echo g++')
 OPTIMIZATION?=-O3
 WARNINGS=-Wall -Wextra -Werror -Wstrict-prototypes -Wwrite-strings -Wno-missing-field-initializers
 DEBUG_FLAGS?= -g -ggdb
-REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CPPFLAGS) $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS) $(PLATFORM_FLAGS)
-REAL_LDFLAGS=$(LDFLAGS)
+REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CPPFLAGS) $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS) $(PLATFORM_FLAGS) $(MYCFLAGS)
+REAL_LDFLAGS=$(LDFLAGS) $(MYLDFLAGS)
 
 DYLIBSUFFIX=so
 STLIBSUFFIX=a

--- a/deps/hiredis/Makefile
+++ b/deps/hiredis/Makefile
@@ -37,8 +37,8 @@ export REDIS_TEST_CONFIG
 
 # Flags passed from outside so as not to override CFLAGS or LDFLAGS as they may
 # be changed inside this Makefile
-MYCFLAGS=
-MYLDFLAGS=
+HIREDIS_CFLAGS=
+HIREDIS_LDFLAGS=
 
 # Fallback to gcc when $CC is not in $PATH.
 CC:=$(shell sh -c 'type $${CC%% *} >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
@@ -46,8 +46,8 @@ CXX:=$(shell sh -c 'type $${CXX%% *} >/dev/null 2>/dev/null && echo $(CXX) || ec
 OPTIMIZATION?=-O3
 WARNINGS=-Wall -Wextra -Werror -Wstrict-prototypes -Wwrite-strings -Wno-missing-field-initializers
 DEBUG_FLAGS?= -g -ggdb
-REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CPPFLAGS) $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS) $(PLATFORM_FLAGS) $(MYCFLAGS)
-REAL_LDFLAGS=$(LDFLAGS) $(MYLDFLAGS)
+REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CPPFLAGS) $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS) $(PLATFORM_FLAGS) $(HIREDIS_CFLAGS)
+REAL_LDFLAGS=$(LDFLAGS) $(HIREDIS_LDFLAGS)
 
 DYLIBSUFFIX=so
 STLIBSUFFIX=a


### PR DESCRIPTION
PR https://github.com/redis/redis/pull/13916 introduced a regression - by overriding the `CFLAGS` and `LDFLAGS` variables for all of the dependencies hiredis and fast_float lost some of their compiler/linker flags.

This PR makes it so we can pass additional CFLAGS/LDFLAGS to hiredis, without overriding them as it contains a bit more complex Makefile. As for fast_float - passing CFLAGS/LDFLAGS from outside now doesn't break the expected behavior.

The build step in the CI was changed so that the MacOS is now build with TLS to catch such errors in the future.