### PR TITLE
Fix missing prev update in hnsw_cursor_free causing unlink failure

### DIFF
--- a/modules/vector-sets/hnsw.c
+++ b/modules/vector-sets/hnsw.c
@@ -2324,6 +2324,7 @@ void hnsw_cursor_free(hnswCursor *cursor) {
             hfree(cursor);
             break;
         }
+        prev = x;
         x = x->next;
     }
     pthread_rwlock_unlock(&cursor->index->global_lock);


### PR DESCRIPTION
This PR fixes a bug in the `hnsw_cursor_free` function where the prev pointer was never updated during cursor list traversal. As a result, if the cursor being freed was not the head of the list, it would not be correctly unlinked, potentially causing memory leaks or corruption of the cursor list.

Note that since `hnsw_cursor_free()` is never used for now, this PR does not actually fix any bug.