### PR TITLE
fix processMultiBulkBuffer to processMultibulkBuffer

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2900,7 +2900,7 @@ void readQueryFromClient(connection *conn) {
      * that is large enough, try to maximize the probability that the query
      * buffer contains exactly the SDS string representing the object, even
      * at the risk of requiring more read(2) calls. This way the function
-     * processMultiBulkBuffer() can avoid copying buffers to create the
+     * processMultibulkBuffer() can avoid copying buffers to create the
      * Redis Object representing the argument. */
     if (c->reqtype == PROTO_REQ_MULTIBULK && c->multibulklen && c->bulklen != -1
         && c->bulklen >= PROTO_MBULK_BIG_ARG)


### PR DESCRIPTION
I found there is invalid function name "processMultiBulkBuffer" in comments in networking.c
Actually it is processMultibulkBuffer, Bulk shoud be lowercase.

It can cause not to find valid function for reader.

Thanks.