### PR TITLE
Fix crash when freeing newly created node when nodeIp2String fail

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2891,7 +2891,7 @@ int clusterProcessPacket(clusterLink *link) {
                  * valid IP, the node becomes unusable in the cluster. This failure might be
                  * due to the connection being closed. */
                 serverLog(LL_NOTICE, "Closing link even though we received a MEET packet on it, "
-                                      "because the connection has an error");
+                                     "because the connection has an error");
                 freeClusterLink(link);
                 return 0;
             }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2885,9 +2885,19 @@ int clusterProcessPacket(clusterLink *link) {
          * resolved when we'll receive PONGs from the node. */
         if (!sender && type == CLUSTERMSG_TYPE_MEET) {
             clusterNode *node;
+            char ip[NET_IP_STR_LEN] = {0};
+            if (nodeIp2String(ip, link, hdr->myip) != C_OK) {
+                /* Unable to retrieve the node's IP address from the connection. Without a
+                 * valid IP, the node becomes unusable in the cluster. This failure might be
+                 * due to the connection being closed. */
+                serverLog(LL_NOTICE, "Closing link even though we received a MEET packet on it, "
+                                      "because the connection has an error");
+                freeClusterLink(link);
+                return 0;
+            }
 
             node = createClusterNode(NULL,CLUSTER_NODE_HANDSHAKE);
-            serverAssert(nodeIp2String(node->ip,link,hdr->myip) == C_OK);
+            memcpy(node->ip, ip, sizeof(ip));
             getClientPortFromClusterMsg(hdr, &node->tls_port, &node->tcp_port);
             node->cport = ntohs(hdr->cport);
             clusterAddNode(node);


### PR DESCRIPTION
This PR is a reference from https://github.com/valkey-io/valkey/pull/1535

In the process of handling the failure(https://github.com/redis/redis/pull/14024) of ARM64 CI with TLS, found in slow environment, the nodes might frequent disconnect and trigger this assertion.

```
Logged crash report (pid 690141):
=== REDIS BUG REPORT START: Cut & paste starting from here ===
690141:M 30 Apr 2025 02:41:12.704 # === ASSERTION FAILED ===
690141:M 30 Apr 2025 02:41:12.704 # ==> cluster_legacy.c:2889 'nodeIp2String(node->ip,link,hdr->myip) == C_OK' is not true

------ STACK TRACE ------

690201 bio_lazy_free
/lib/aarch64-linux-gnu/libc.so.6(+0x81ea0)[0xe75885781ea0]
/lib/aarch64-linux-gnu/libc.so.6(pthread_cond_wait+0x200)[0xe75885784b20]
src/redis-server 127.0.0.1:28638 [cluster](bioProcessBackgroundJobs+0x21c)[0xb14c5547c72c]
/lib/aarch64-linux-gnu/libc.so.6(+0x8595c)[0xe7588578595c]
/lib/aarch64-linux-gnu/libc.so.6(+0xeba4c)[0xe758857eba4c]

690192 bio_close_file
/lib/aarch64-linux-gnu/libc.so.6(+0x81ea0)[0xe75885781ea0]
/lib/aarch64-linux-gnu/libc.so.6(pthread_cond_wait+0x200)[0xe75885784b20]
src/redis-server 127.0.0.1:28638 [cluster](bioProcessBackgroundJobs+0x21c)[0xb14c5547c72c]
/lib/aarch64-linux-gnu/libc.so.6(+0x8595c)[0xe7588578595c]
/lib/aarch64-linux-gnu/libc.so.6(+0xeba4c)[0xe758857eba4c]

690200 bio_aof
/lib/aarch64-linux-gnu/libc.so.6(+0x81ea0)[0xe75885781ea0]
/lib/aarch64-linux-gnu/libc.so.6(pthread_cond_wait+0x200)[0xe75885784b20]
src/redis-server 127.0.0.1:28638 [cluster](bioProcessBackgroundJobs+0x21c)[0xb14c5547c72c]
/lib/aarch64-linux-gnu/libc.so.6(+0x8595c)[0xe7588578595c]
/lib/aarch64-linux-gnu/libc.so.6(+0xeba4c)[0xe758857eba4c]

690141 redis-server *
src/redis-server 127.0.0.1:28638 [cluster](clusterProcessPacket+0xdc8)[0xb14c554685c8]
src/redis-server 127.0.0.1:28638 [cluster](clusterReadHandler+0x144)[0xb14c554689c4]
src/redis-server 127.0.0.1:28638 [cluster](+0x1fa774)[0xb14c554fa774]
src/redis-server 127.0.0.1:28638 [cluster](+0x201130)[0xb14c55501130]
src/redis-server 127.0.0.1:28638 [cluster](aeMain+0x128)[0xb14c5539c02c]
src/redis-server 127.0.0.1:28638 [cluster](main+0x514)[0xb14c55390dc4]
/lib/aarch64-linux-gnu/libc.so.6(+0x284c4)[0xe758857284c4]
/lib/aarch64-linux-gnu/libc.so.6(__libc_start_main+0x98)[0xe75885728598]
src/redis-server 127.0.0.1:28638 [cluster](_start+0x30)[0xb14c55391470]
```

-------------------------------------
Co-authored-by: Binbin <binloveplay1314@qq.com>