### PR TITLE
 Link HdrHistogram upstream commit hash to GitHub in deps README

### DIFF
--- a/deps/README.md
+++ b/deps/README.md
@@ -100,7 +100,7 @@ Hdr_Histogram
 
 Updated source can be found here: https://github.com/HdrHistogram/HdrHistogram_c
 We use a customized version based on master branch commit e4448cf6d1cd08fff519812d3b1e58bd5a94ac42.
-1. Compare all changes under /hdr_histogram directory to upstream master commit e4448cf6d1cd08fff519812d3b1e58bd5a94ac42
+1. Compare all changes under /hdr_histogram directory to upstream master commit [e4448cf6d1cd08fff519812d3b1e58bd5a94ac42](https://github.com/HdrHistogram/HdrHistogram_c/commit/e4448cf6d1cd08fff519812d3b1e58bd5a94ac42)
 2. Copy updated files from newer version onto files in /hdr_histogram.
 3. Apply the changes from 1 above to the updated files.
 


### PR DESCRIPTION
```md
Updated source can be found here: https://github.com/HdrHistogram/HdrHistogram_c  
We use a customized version based on master branch commit e4448cf6d1cd08fff519812d3b1e58bd5a94ac42.  
1. Compare all changes under /hdr_histogram directory to upstream master commit e4448cf6d1cd08fff519812d3b1e58bd5a94ac42  
2. Copy updated files from newer version onto files in /hdr_histogram.  
3. Apply the changes from 1 above to the updated files.  
```

I looked up the referenced commit on GitHub to understand what changes were made and why we need to follow these instructions. Since the commit wasn’t linked, it was a bit inconvenient to find manually. Adding a clickable link makes it much easier to review the changes and understand the reason behind the steps.