### PR TITLE
Test: check always for memory leaks on MacOS.

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -730,11 +730,6 @@ proc start_server {options {code undefined}} {
         # fetch srv back from the server list, in case it was restarted by restart_server (new PID)
         set srv [lindex $::servers end]
 
-        # Don't do the leak check when no tests were run
-        if {$num_tests == $::num_tests} {
-            dict set srv "skipleaks" 1
-        }
-
         # pop the server object
         set ::servers [lrange $::servers 0 end-1]
 


### PR DESCRIPTION
When running the Redis test on MacOS, the test detects that the operating system is able to use "leaks" to test for memory leaks and executes this check after every server spinned is terminated.

While we have the ability to run the test in environments able to detect memory issues, the fact it is possible to check for leaks at every run baasically for free is very valuable, and allows to fix leaks immediately in your laptop before submitting a PR.

However, the feature avoided to run leaks when no test was run: this check was added in the early stage of Redis, when all the tests were like:

server {
   test { ... }
}

So the check counts for the number of tests ran, and if no test is executed, no leaks detection is performed. However now we have certain tests that are in the form:

test {
    server { ... }
}

For instance just loading a corrupted RDB or alike. In this case, the leaks test is not executed. This commit removes the check so that the leaks test is always executed.