### PR TITLE
Add size_t cast for RM_call() in module tests

### DIFF
--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -38,7 +38,7 @@ int set_aclcheck_key(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_OK;
     }
 
-    RedisModuleCallReply *rep = RedisModule_Call(ctx, "SET", "v", argv + 2, argc - 2);
+    RedisModuleCallReply *rep = RedisModule_Call(ctx, "SET", "v", argv + 2, (size_t)argc - 2);
     if (!rep) {
         RedisModule_ReplyWithError(ctx, "NULL reply returned");
     } else {
@@ -84,7 +84,7 @@ int set_aclcheck_prefixkey(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
         return REDISMODULE_OK;
     }
 
-    RedisModuleCallReply *rep = RedisModule_Call(ctx, "SET", "v", argv + 3, argc - 3);
+    RedisModuleCallReply *rep = RedisModule_Call(ctx, "SET", "v", argv + 3, (size_t)argc - 3);
     if (!rep) {
         RedisModule_ReplyWithError(ctx, "NULL reply returned");
     } else {
@@ -114,7 +114,7 @@ int publish_aclcheck_channel(RedisModuleCtx *ctx, RedisModuleString **argv, int 
         return REDISMODULE_OK;
     }
 
-    RedisModuleCallReply *rep = RedisModule_Call(ctx, "PUBLISH", "v", argv + 1, argc - 1);
+    RedisModuleCallReply *rep = RedisModule_Call(ctx, "PUBLISH", "v", argv + 1, (size_t)argc - 1);
     if (!rep) {
         RedisModule_ReplyWithError(ctx, "NULL reply returned");
     } else {
@@ -144,7 +144,7 @@ int rm_call_aclcheck_cmd(RedisModuleCtx *ctx, RedisModuleUser *user, RedisModule
 
     const char* cmd = RedisModule_StringPtrLen(argv[1], NULL);
 
-    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "v", argv + 2, argc - 2);
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "v", argv + 2, (size_t)argc - 2);
     if(!rep){
         RedisModule_ReplyWithError(ctx, "NULL reply returned");
     }else{
@@ -192,7 +192,7 @@ int rm_call_aclcheck_with_errors(RedisModuleCtx *ctx, RedisModuleString **argv, 
 
     const char* cmd = RedisModule_StringPtrLen(argv[1], NULL);
 
-    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "vEC", argv + 2, argc - 2);
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "vEC", argv + 2, (size_t)argc - 2);
     RedisModule_ReplyWithCallReply(ctx, rep);
     RedisModule_FreeCallReply(rep);
     return REDISMODULE_OK;
@@ -209,7 +209,7 @@ int rm_call_aclcheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
 
     const char* cmd = RedisModule_StringPtrLen(argv[1], NULL);
 
-    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "vC", argv + 2, argc - 2);
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "vC", argv + 2, (size_t)argc - 2);
     if(!rep) {
         char err[100];
         switch (errno) {

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -134,7 +134,7 @@ void *bg_call_worker(void *arg) {
     }
     const char *format = RedisModule_StringPtrLen(format_redis_str, NULL);
     const char *cmd = RedisModule_StringPtrLen(bg->argv[cmd_pos], NULL);
-    RedisModuleCallReply *rep = RedisModule_Call(ctx, cmd, format, bg->argv + cmd_pos + 1, bg->argc - cmd_pos - 1);
+    RedisModuleCallReply *rep = RedisModule_Call(ctx, cmd, format, bg->argv + cmd_pos + 1, (size_t)bg->argc - cmd_pos - 1);
     RedisModule_FreeString(NULL, format_redis_str);
 
     /* Free the arguments within GIL to prevent simultaneous freeing in main thread. */
@@ -211,7 +211,7 @@ int do_rm_call(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
 
     const char* cmd = RedisModule_StringPtrLen(argv[1], NULL);
 
-    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "Ev", argv + 2, argc - 2);
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "Ev", argv + 2, (size_t)argc - 2);
     if(!rep){
         RedisModule_ReplyWithError(ctx, "NULL reply returned");
     }else{
@@ -247,7 +247,7 @@ int do_rm_call_async_fire_and_forget(RedisModuleCtx *ctx, RedisModuleString **ar
     }
     const char* cmd = RedisModule_StringPtrLen(argv[1], NULL);
 
-    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "!KEv", argv + 2, argc - 2);
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "!KEv", argv + 2, (size_t)argc - 2);
 
     if(RedisModule_CallReplyType(rep) != REDISMODULE_REPLY_PROMISE) {
         RedisModule_ReplyWithCallReply(ctx, rep);
@@ -310,7 +310,7 @@ int do_rm_call_async(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
 
     const char* cmd = RedisModule_StringPtrLen(argv[1], NULL);
 
-    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, format, argv + 2, argc - 2);
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, format, argv + 2, (size_t)argc - 2);
 
     if(RedisModule_CallReplyType(rep) != REDISMODULE_REPLY_PROMISE) {
         rm_call_async_send_reply(ctx, rep);
@@ -368,7 +368,7 @@ int do_rm_call_async_on_thread(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
     const char* cmd = RedisModule_StringPtrLen(argv[1], NULL);
 
-    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "KEv", argv + 2, argc - 2);
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "KEv", argv + 2, (size_t)argc - 2);
 
     if(RedisModule_CallReplyType(rep) != REDISMODULE_REPLY_PROMISE) {
         rm_call_async_send_reply(ctx, rep);
@@ -408,7 +408,7 @@ static void wait_and_do_rm_call_async_on_unblocked(RedisModuleCtx *ctx, RedisMod
     reply = NULL;
 
     const char* cmd = RedisModule_StringPtrLen(wctx->argv[0], NULL);
-    reply = RedisModule_Call(ctx, cmd, "!EKv", wctx->argv + 1, wctx->argc - 1);
+    reply = RedisModule_Call(ctx, cmd, "!EKv", wctx->argv + 1, (size_t)wctx->argc - 1);
 
 done:
     if(RedisModule_CallReplyType(reply) != REDISMODULE_REPLY_PROMISE) {

--- a/tests/modules/commandfilter.c
+++ b/tests/modules/commandfilter.c
@@ -80,7 +80,7 @@ int CommandFilter_LogCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 
     size_t cmdlen;
     const char *cmdname = RedisModule_StringPtrLen(argv[1], &cmdlen);
-    RedisModuleCallReply *reply = RedisModule_Call(ctx, cmdname, "v", &argv[2], argc - 2);
+    RedisModuleCallReply *reply = RedisModule_Call(ctx, cmdname, "v", &argv[2], (size_t)argc - 2);
     if (reply) {
         RedisModule_ReplyWithCallReply(ctx, reply);
         RedisModule_FreeCallReply(reply);

--- a/tests/modules/internalsecret.c
+++ b/tests/modules/internalsecret.c
@@ -43,11 +43,11 @@ int call_rm_call(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RMCall
     switch (mode) {
         case RM_CALL_REGULAR:
             // Regular call, with the unrestricted user.
-            rep = RedisModule_Call(ctx, cmd, "vE", argv + 2, argc - 2);
+            rep = RedisModule_Call(ctx, cmd, "vE", argv + 2, (size_t)argc - 2);
             break;
         case RM_CALL_WITHUSER:
             // Simply call the command with the current client.
-            rep = RedisModule_Call(ctx, cmd, "vCE", argv + 2, argc - 2);
+            rep = RedisModule_Call(ctx, cmd, "vCE", argv + 2, (size_t)argc - 2);
             break;
         case RM_CALL_WITHDETACHEDCLIENT:
             // Use a context created with the thread-safe-context API
@@ -57,10 +57,10 @@ int call_rm_call(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RMCall
                 return REDISMODULE_ERR;
             }
             // Dispatch the command with the detached context
-            rep = RedisModule_Call(detached_ctx, cmd, "vCE", argv + 2, argc - 2);
+            rep = RedisModule_Call(detached_ctx, cmd, "vCE", argv + 2, (size_t)argc - 2);
             break;
         case RM_CALL_REPLICATED:
-            rep = RedisModule_Call(ctx, cmd, "vE", argv + 2, argc - 2);
+            rep = RedisModule_Call(ctx, cmd, "vE", argv + 2, (size_t)argc - 2);
     }
 
     if(!rep) {

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -65,7 +65,7 @@ int test_call_generic(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     }
 
     const char* cmdname = RedisModule_StringPtrLen(argv[1], NULL);
-    RedisModuleCallReply *reply = RedisModule_Call(ctx, cmdname, "v", argv+2, argc-2);
+    RedisModuleCallReply *reply = RedisModule_Call(ctx, cmdname, "v", argv+2, (size_t)argc-2);
     if (reply) {
         RedisModule_ReplyWithCallReply(ctx, reply);
         RedisModule_FreeCallReply(reply);
@@ -397,7 +397,7 @@ int test_rm_call(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
 
     const char* cmd = RedisModule_StringPtrLen(argv[1], NULL);
 
-    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "Ev", argv + 2, argc - 2);
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "Ev", argv + 2, (size_t)argc - 2);
     if(!rep){
         RedisModule_ReplyWithError(ctx, "NULL reply returned");
     }else{
@@ -429,7 +429,7 @@ int test_rm_call_flags(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
     const char* flg = RedisModule_StringPtrLen(flags, NULL);
     const char* cmd = RedisModule_StringPtrLen(argv[2], NULL);
 
-    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, flg, argv + 3, argc - 3);
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, flg, argv + 3, (size_t)argc - 3);
     if(!rep){
         RedisModule_ReplyWithError(ctx, "NULL reply returned");
     }else{

--- a/tests/modules/usercall.c
+++ b/tests/modules/usercall.c
@@ -13,7 +13,7 @@ int call_without_user(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     const char *cmd = RedisModule_StringPtrLen(argv[1], NULL);
 
-    RedisModuleCallReply *rep = RedisModule_Call(ctx, cmd, "Ev", argv + 2, argc - 2);
+    RedisModuleCallReply *rep = RedisModule_Call(ctx, cmd, "Ev", argv + 2, (size_t)argc - 2);
     if (!rep) {
         RedisModule_ReplyWithError(ctx, "NULL reply returned");
     } else {
@@ -37,7 +37,7 @@ int call_with_user_flag(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     const char* flg = RedisModule_StringPtrLen(flags, NULL);
     const char* cmd = RedisModule_StringPtrLen(argv[2], NULL);
 
-    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, flg, argv + 3, argc - 3);
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, flg, argv + 3, (size_t)argc - 3);
     if (!rep) {
         RedisModule_ReplyWithError(ctx, "NULL reply returned");
     } else {
@@ -134,7 +134,7 @@ void *bg_call_worker(void *arg) {
     RedisModule_StringAppendBuffer(NULL, format_redis_str, "E", 1);
     format = RedisModule_StringPtrLen(format_redis_str, NULL);
     const char *cmd = RedisModule_StringPtrLen(bg->argv[2], NULL);
-    RedisModuleCallReply *rep = RedisModule_Call(ctx, cmd, format, bg->argv + 3, bg->argc - 3);
+    RedisModuleCallReply *rep = RedisModule_Call(ctx, cmd, format, bg->argv + 3, (size_t)bg->argc - 3);
     RedisModule_FreeString(NULL, format_redis_str);
 
     /* Free the arguments within GIL to prevent simultaneous freeing in main thread. */


### PR DESCRIPTION
This PR addresses a potential misalignment issue when using `va_args`. Without this fix, [argument](https://github.com/redis/redis/blob/9a9aa921bcd2e65e5619600961b0447c864833b3/src/module.c#L6249-L6264) values may occasionally become incorrect due to stack alignment inconsistencies.