### PR TITLE
Cleanup redundant declaration of kvstoreDictFetchValue()

### DIFF
--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -106,7 +106,6 @@ void kvstoreDictSetAtLink(kvstore *kvs, int didx, void *kv, dictEntryLink *link,
 /* dict with distinct key & value (no_value=1) currently is used only by pubsub. */
 void kvstoreDictSetKey(kvstore *kvs, int didx, dictEntry* de, void *key);
 void kvstoreDictSetVal(kvstore *kvs, int didx, dictEntry *de, void *val);
-void *kvstoreDictFetchValue(kvstore *kvs, int didx, const void *key);
 
 #ifdef REDIS_TEST
 int kvstoreTest(int argc, char *argv[], int flags);

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -91,6 +91,7 @@ int kvstoreDictExpand(kvstore *kvs, int didx, unsigned long size);
 unsigned long kvstoreDictScanDefrag(kvstore *kvs, int didx, unsigned long v, dictScanFunction *fn, dictDefragFunctions *defragfns, void *privdata);
 typedef dict *(kvstoreDictLUTDefragFunction)(dict *d);
 unsigned long kvstoreDictLUTDefrag(kvstore *kvs, unsigned long cursor, kvstoreDictLUTDefragFunction *defragfn);
+void *kvstoreDictFetchValue(kvstore *kvs, int didx, const void *key);
 dictEntry *kvstoreDictFind(kvstore *kvs, int didx, void *key);
 dictEntry *kvstoreDictAddRaw(kvstore *kvs, int didx, void *key, dictEntry **existing);
 dictEntryLink kvstoreDictTwoPhaseUnlinkFind(kvstore *kvs, int didx, const void *key, int *table_index);

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -91,7 +91,6 @@ int kvstoreDictExpand(kvstore *kvs, int didx, unsigned long size);
 unsigned long kvstoreDictScanDefrag(kvstore *kvs, int didx, unsigned long v, dictScanFunction *fn, dictDefragFunctions *defragfns, void *privdata);
 typedef dict *(kvstoreDictLUTDefragFunction)(dict *d);
 unsigned long kvstoreDictLUTDefrag(kvstore *kvs, unsigned long cursor, kvstoreDictLUTDefragFunction *defragfn);
-void *kvstoreDictFetchValue(kvstore *kvs, int didx, const void *key);
 dictEntry *kvstoreDictFind(kvstore *kvs, int didx, void *key);
 dictEntry *kvstoreDictAddRaw(kvstore *kvs, int didx, void *key, dictEntry **existing);
 dictEntryLink kvstoreDictTwoPhaseUnlinkFind(kvstore *kvs, int didx, const void *key, int *table_index);


### PR DESCRIPTION
Remove redundant declaration of kvstoreDictFetchValue, declared at both lines 109 and 94:

https://github.com/redis/redis/blob/ba88a7fbb6ec7cb7aeda61e1981146e1a21dee43/src/kvstore.h#L94
https://github.com/redis/redis/blob/ba88a7fbb6ec7cb7aeda61e1981146e1a21dee43/src/kvstore.h#L109