### PR TITLE
Fix incorrect server.cronloops update in defragWhileBlocked() causing timer to run twice as fast

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1554,12 +1554,6 @@ static int activeDefragTimeProc(struct aeEventLoop *eventLoop, long long id, voi
     monotime endtime = starttime + dutyCycleUs;
     int haveMoreWork = 1;
 
-    /* Increment server.cronloops so that run_with_period works. */
-    long hz_ms = 1000 / server.hz;
-    int cronloops = (server.mstime - server.blocked_last_cron + (hz_ms - 1)) / hz_ms; /* rounding up */
-    server.blocked_last_cron += cronloops * hz_ms;
-    server.cronloops += cronloops;
-
     mstime_t latency;
     latencyStartMonitor(latency);
 

--- a/src/server.c
+++ b/src/server.c
@@ -1703,6 +1703,12 @@ void whileBlockedCron(void) {
     if (server.blocked_last_cron >= server.mstime)
         return;
 
+    /* Increment server.cronloops so that run_with_period works. */
+    long hz_ms = 1000 / server.hz;
+    int cronloops = (server.mstime - server.blocked_last_cron + (hz_ms - 1)) / hz_ms; /* rounding up */
+    server.blocked_last_cron += cronloops * hz_ms;
+    server.cronloops += cronloops;
+
     mstime_t latency;
     latencyStartMonitor(latency);
 


### PR DESCRIPTION
This bug was introduced in [#13814](https://github.com/redis/redis/issues/13814), and was found by @guybe7.
It incorrectly moved the update of `server.cronloops` from `whileBlockedCron()` to `activeDefragTimeProc()`,
causing the cron-based timers to effectively run twice as fast when active defrag is enabled.
As a result, memory statistics are not updated during blocked operations.
The repair parts from https://github.com/redis/redis/pull/13995, because it needs to be backport, so use a separate pr repair it.

## Reproduce steps
https://github.com/redis/redis/blob/6349a7c4f9213b20f6d312b357445e7c8a6fed44/src/server.c#L1496-L1507
The above log should be printed every five seconds.

config
```
activedefrag yes
loglevel debug
```

before this PR:
```
164249:M 27 May 2025 15:09:55.522 - DB 0: 100000 keys (0 volatile) in 196608 slots HT.
# internal of 2.5 secs
164249:M 27 May 2025 15:10:00.543 - DB 0: 100000 keys (0 volatile) in 131072 slots HT.
```

after this PR:
```
162945:M 27 May 2025 15:08:38.847 - DB 0: 100000 keys (0 volatile) in 131072 slots HT.
# interval of 5 secs
162945:M 27 May 2025 15:08:43.867 - DB 0: 100000 keys (0 volatile) in 131072 slots HT.
```
