### PR TITLE
Reduce the blocking of the main thread by iothread.

### DIFF
--- a/src/iothread.c
+++ b/src/iothread.c
@@ -392,6 +392,8 @@ int processClientsFromIOThread(IOThread *t) {
     if (processed == 0) return 0;
 
     listNode *node = NULL;
+    mstime_t now = server.mstime;
+    int curr_peak_mem_usage_slot = (now / 1000) % CLIENTS_PEAK_MEM_USAGE_SLOTS;
     while (listLength(mainThreadProcessingClients[t->id])) {
         /* Each time we pop up only the first client to process to guarantee
          * reentrancy safety. */
@@ -418,8 +420,15 @@ int processClientsFromIOThread(IOThread *t) {
             continue;
         }
 
-        /* Update the client in the mem usage */
-        updateClientMemUsageAndBucket(c);
+        if (c->last_cron_check_time + IO_THREAD_CLIENTS_MAX_CHECK_TIME < now) {
+            c->last_cron_check_time = now;
+            if (cronCheckAndFreeClient(c, curr_peak_mem_usage_slot)) {
+                continue;
+            }
+        } else {
+            /* Update the client in the mem usage */
+            updateClientMemUsageAndBucket(c);
+        }
 
         /* Process the pending command and input buffer. */
         if (!c->read_error && c->io_flags & CLIENT_IO_PENDING_COMMAND) {
@@ -502,6 +511,33 @@ int processClientsOfAllIOThreads(void) {
         processed += processClientsFromIOThread(&IOThreads[i]);
     }
     return processed;
+}
+
+/* Check whether threads in the iothread need to be checked by the main thread. */
+void IOThreadClientsCron(IOThread *t) {
+    mstime_t now = mstime();
+    int numclients = listLength(t->clients);
+    static int CHECK_FREQUENCY_PER_SECOND = 1000/IO_THREAD_CRON_TIME;
+    int iterations = numclients/CHECK_FREQUENCY_PER_SECOND;
+    /* Process at least a few clients while we are at it, even if we need
+     * to process less than CLIENTS_CRON_MIN_ITERATIONS to meet our contract
+     * of processing each client once per second. */
+    if (iterations < CLIENTS_CRON_MIN_ITERATIONS) {
+        iterations = CLIENTS_CRON_MIN_ITERATIONS;
+    }
+    listIter li;
+    listNode *ln;
+    listRewind(t->clients, &li);
+    while((ln = listNext(&li)) && iterations--) {
+        client *c = listNodeValue(ln);
+        /* Check for idle timeout first */
+        if (c->last_cron_check_time + IO_THREAD_CLIENTS_MAX_CHECK_TIME < now) {
+            enqueuePendingClientsToMainThread(c, 0);
+        } else {
+            /* If the first client doesn't meet the condition the next client will not meet either. */
+            break;
+        }
+    }
 }
 
 /* After the main thread processes the clients, it will send the clients back to
@@ -624,6 +660,22 @@ void IOThreadAfterSleep(struct aeEventLoop *el) {
     atomicSetWithSync(t->running, 1);
 }
 
+/* This is our io thread timer interrupt, called (1000/IO_THREAD_CRON_TIME) times per second.
+ * The current responsibility is to detect clients that have been stuck in the
+ * iothread for too long and hand them over to the main thread for handling. */
+
+ int ioThreadCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
+    UNUSED(eventLoop);
+    UNUSED(id);
+    IOThread *t = clientData;
+
+    if (listLength(t->clients) != 0) {
+        IOThreadClientsCron(t);
+    }
+    /* it checks every fixed 100ms. */
+    return IO_THREAD_CRON_TIME;
+ }
+
 /* The main function of IO thread, it will run an event loop. The mian thread
  * and IO thread will communicate through event notifier. */
 void *IOThreadMain(void *ptr) {
@@ -677,6 +729,13 @@ void initThreadedIO(void) {
                               AE_READABLE, handleClientsFromMainThread, t) != AE_OK)
         {
             serverLog(LL_WARNING, "Fatal: Can't register file event for IO thread notifications.");
+            exit(1);
+        }
+
+        /* This is the timer callback of the iothread, used to gradually handle 
+         * some background operations, such as client timeouts. */
+        if (aeCreateTimeEvent(t->el, 1, ioThreadCron, t, NULL) == AE_ERR) {
+            serverLog(LL_WARNING, "Fatal: Can't create event loop timers in IO thread.");
             exit(1);
         }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -212,6 +212,7 @@ client *createClient(connection *conn) {
     c->postponed_list_node = NULL;
     c->client_tracking_redirection = 0;
     c->client_tracking_prefixes = NULL;
+    c->last_cron_check_time = 0;
     c->last_memory_usage = 0;
     c->last_memory_type = CLIENT_TYPE_NORMAL;
     c->module_blocked_client = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -935,7 +935,6 @@ int clientsCronResizeOutputBuffer(client *c, mstime_t now_ms) {
  *
  * When we want to know what was recently the peak memory usage, we just scan
  * such few slots searching for the maximum value. */
-#define CLIENTS_PEAK_MEM_USAGE_SLOTS 8
 size_t ClientsPeakMemInput[CLIENTS_PEAK_MEM_USAGE_SLOTS] = {0};
 size_t ClientsPeakMemOutput[CLIENTS_PEAK_MEM_USAGE_SLOTS] = {0};
 
@@ -1074,6 +1073,33 @@ void getExpansiveClientsInfo(size_t *in_usage, size_t *out_usage) {
     *out_usage = o;
 }
 
+/* Perform client timeout and memory checks. If the client times out and is freed,
+ * return non-zero value.  */
+int cronCheckAndFreeClient(client *c, int curr_peak_mem_usage_slot) {
+    mstime_t now = server.mstime;
+    /* The following functions do different service checks on the client.
+     * The protocol is that they return non-zero if the client was
+     * terminated. */
+    if (clientsCronHandleTimeout(c,now)) return 1;
+    if (clientsCronResizeQueryBuffer(c)) return 0;
+    if (clientsCronFreeArgvIfIdle(c)) return 0;
+    if (clientsCronResizeOutputBuffer(c,now)) return 0;
+
+    if (clientsCronTrackExpansiveClients(c, curr_peak_mem_usage_slot)) return 0;
+
+    /* Iterating all the clients in getMemoryOverheadData() is too slow and
+     * in turn would make the INFO command too slow. So we perform this
+     * computation incrementally and track the (not instantaneous but updated
+     * to the second) total memory used by clients using clientsCron() in
+     * a more incremental way (depending on server.hz).
+     * If client eviction is enabled, update the bucket as well. */
+    if (!updateClientMemUsageAndBucket(c))
+        updateClientMemoryUsage(c);
+
+    if (closeClientOnOutputBufferLimitReached(c, 0)) return 1;
+    return 0;
+}
+
 /* This function is called by serverCron() and is used in order to perform
  * operations on clients that are important to perform constantly. For instance
  * we use this function in order to disconnect clients after a timeout, including
@@ -1090,7 +1116,6 @@ void getExpansiveClientsInfo(size_t *in_usage, size_t *out_usage) {
  * of clients per second, turning this function into a source of latency.
  */
 #define CLIENTS_CRON_PAUSE_IOTHREAD 8
-#define CLIENTS_CRON_MIN_ITERATIONS 5
 void clientsCron(void) {
     /* Try to process at least numclients/server.hz of clients
      * per call. Since normally (if there are no big latency events) this
@@ -1098,7 +1123,6 @@ void clientsCron(void) {
      * process all the clients in 1 second. */
     int numclients = listLength(server.clients);
     int iterations = numclients/server.hz;
-    mstime_t now = mstime();
 
     /* Process at least a few clients while we are at it, even if we need
      * to process less than CLIENTS_CRON_MIN_ITERATIONS to meet our contract
@@ -1124,16 +1148,6 @@ void clientsCron(void) {
     ClientsPeakMemInput[zeroidx] = 0;
     ClientsPeakMemOutput[zeroidx] = 0;
 
-    /* Pause the IO threads that are processing clients, to let us access clients
-     * safely. In order to avoid increasing CPU usage by pausing all threads when
-     * there are too many io threads, we pause io threads in multiple batches. */
-    static int start = 1, end = 0;
-    if (server.io_threads_num >= 1 && listLength(server.clients) > 0) {
-        end = start + CLIENTS_CRON_PAUSE_IOTHREAD - 1;
-        if (end >= server.io_threads_num) end = server.io_threads_num - 1;
-        pauseIOThreadsRange(start, end);
-    }
-
     while(listLength(server.clients) && iterations--) {
         client *c;
         listNode *head;
@@ -1144,42 +1158,18 @@ void clientsCron(void) {
         c = listNodeValue(head);
         listRotateHeadToTail(server.clients);
 
-        if (c->running_tid != IOTHREAD_MAIN_THREAD_ID &&
-            !(c->running_tid >= start && c->running_tid <= end))
-        {
-            /* Skip clients that are being processed by the IO threads that
-             * are not paused. */
+        /*
+         * Only handle scenarios without iothread or isClientMustHandledByMainThread.
+         * When iothread is enabled, this proc does not operate. Instead, the 
+         * iothread first checks its own clients, followed by the main thread performing 
+         * subsequent processing. This workflow is primarily implemented 
+         * in processClientsFromIOThread and processClientsFromMainThread.
+         */
+        if (server.io_threads_num > 1 && !isClientMustHandledByMainThread(c)) {
             continue;
         }
 
-        /* The following functions do different service checks on the client.
-         * The protocol is that they return non-zero if the client was
-         * terminated. */
-        if (clientsCronHandleTimeout(c,now)) continue;
-        if (clientsCronResizeQueryBuffer(c)) continue;
-        if (clientsCronFreeArgvIfIdle(c)) continue;
-        if (clientsCronResizeOutputBuffer(c,now)) continue;
-
-        if (clientsCronTrackExpansiveClients(c, curr_peak_mem_usage_slot)) continue;
-
-        /* Iterating all the clients in getMemoryOverheadData() is too slow and
-         * in turn would make the INFO command too slow. So we perform this
-         * computation incrementally and track the (not instantaneous but updated
-         * to the second) total memory used by clients using clientsCron() in
-         * a more incremental way (depending on server.hz).
-         * If client eviction is enabled, update the bucket as well. */
-        if (!updateClientMemUsageAndBucket(c))
-            updateClientMemoryUsage(c);
-
-        if (closeClientOnOutputBufferLimitReached(c, 0)) continue;
-    }
-
-    /* Resume the IO threads that were paused */
-    if (end) {
-        resumeIOThreadsRange(start, end);
-        start = end + 1;
-        if (start >= server.io_threads_num) start = 1;
-        end = 0;
+        cronCheckAndFreeClient(c, curr_peak_mem_usage_slot);
     }
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -1367,6 +1367,7 @@ typedef struct client {
     dictEntry *cur_script;  /* Cached pointer to the dictEntry of the script being executed. */
     time_t lastinteraction; /* Time of the last interaction, used for timeout */
     time_t obuf_soft_limit_reached_time;
+    mstime_t last_cron_check_time;    /* the last client check time in cron */
     int authenticated;      /* Needed when the default user requires auth. */
     int replstate;          /* Replication state if this is a slave. */
     int repl_start_cmd_stream_on_ack; /* Install slave write handler on first ACK. */
@@ -3576,6 +3577,12 @@ sds getConfigDebugInfo(void);
 int allowProtectedAction(int config, client *c);
 void initServerClientMemUsageBuckets(void);
 void freeServerClientMemUsageBuckets(void);
+
+#define CLIENTS_PEAK_MEM_USAGE_SLOTS 8
+#define CLIENTS_CRON_MIN_ITERATIONS 5
+#define IO_THREAD_CLIENTS_MAX_CHECK_TIME 200
+#define IO_THREAD_CRON_TIME 100
+int cronCheckAndFreeClient(client *c, int curr_peak_mem_usage_slot);
 
 /* Module Configuration */
 typedef struct ModuleConfig ModuleConfig;


### PR DESCRIPTION
In a multi-IO-thread scenario, some client checks were moved to IO threads to avoid the main thread pausing every time during clientsCron.

When the number of clients is set to 10000, there is about 20% change.

https://github.com/redis/redis/issues/13885

Here are the test results:

memtier_benchmark --data-size 521 --ratio 1:1 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 60 -c 500 -t 20 --hide-histogram -x 3

**After the modification.**

```
BEST RUN RESULTS
============================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets       228872.62          ---          ---        21.84701        18.43100        94.20700       178.17500    127095.62 
Gets       228789.87       166.42    228623.45        21.83361        18.43100        94.20700       180.22300      8944.73 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals     457662.49       166.42    228623.45        21.84031        18.43100        94.20700       179.19900    136040.34 


WORST RUN RESULTS
============================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets       223669.53          ---          ---        22.34478        18.68700       105.47100       178.17500    124206.42 
Gets       223587.09       166.52    223420.57        22.35959        18.68700       105.47100       179.19900      8743.96 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals     447256.62       166.52    223420.57        22.35219        18.68700       105.47100       178.17500    132950.38 


AGGREGATED AVERAGE RESULTS (3 runs)
============================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets       226230.28          ---          ---        22.10704        18.43100       103.93500       195.58300    125628.37 
Gets       226147.48       166.44    225981.04        22.08480        18.43100       103.93500       196.60700      8842.73 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals     452377.76       166.44    225981.04        22.09592        18.43100       103.93500       196.60700    134471.10
```

**Before the modification.**

```
BEST RUN RESULTS
============================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets       176179.35          ---          ---        28.43698        24.44700       120.31900       201.72700     97831.41 
Gets       176096.14      1011.36    175084.77        28.31696        24.19100       119.80700       204.79900      7336.40 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals     352275.48      1011.36    175084.77        28.37698        24.31900       119.80700       202.75100    105167.80 


WORST RUN RESULTS
============================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets       167608.62          ---          ---        30.26107        23.42300       199.67900       354.30300     93071.39 
Gets       167523.58       902.81    166620.77        30.13004        23.29500       199.67900       354.30300      6948.66 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals     335132.20       902.81    166620.77        30.19558        23.42300       199.67900       354.30300    100020.06 


AGGREGATED AVERAGE RESULTS (3 runs)
============================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets       172947.05          ---          ---        29.05879        24.19100       141.31100       296.95900     96036.28 
Gets       172863.63       973.35    171890.28        28.97310        24.06300       141.31100       299.00700      7191.68 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals     345810.68       973.35    171890.28        29.01596        24.19100       141.31100       299.00700    103227.96
```