### PR TITLE
Fix short read issue that causes exit() on replica

### DIFF
--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -116,6 +116,11 @@ tags "modules" {
                     $master config set dynamic-hz no
                     $replica config set dynamic-hz no
                     set start [clock clicks -milliseconds]
+                    # Generate small keys
+                    for {set k 0} {$k < 20000} {incr k} {
+                        r testrdb.set.key keysmall$k [string repeat A [expr {int(rand()*100)}]]
+                    }
+                    # Generate larger keys
                     for {set k 0} {$k < 30} {incr k} {
                         r testrdb.set.key key$k [string repeat A [expr {int(rand()*1000000)}]]
                     }


### PR DESCRIPTION
When `repl-diskless-load` is enabled on a replica, and it is in the process of loading an RDB file, a broken connection detected by the main channel may trigger a call to rioAbort(). This sets a flag to cause the rdb channel to fail on the next rioRead() call, allowing it to perform necessary cleanup.

However, there are specific scenarios where the error is checked using rioGetReadError(), which does not account for the RIO_ABORT flag (see [source](https://github.com/redis/redis/blob/79b37ff53548ee4d0fca287cb37a2eaf84c519a7/src/rdb.c#L3098)). As a result, the error goes undetected. The code then proceeds to validate a module type, fails to find a match, and calls rdbReportCorruptRDB() which logs the following error and exits the process:

```
The RDB file contains module data I can't load: no matching module type '_________'
```

To fix this issue, the RIO_ABORT flag has been removed. Now, rioAbort() sets both read and write error flags, so that subsequent operations and error checks properly detect the failure.

Additional keys were added to the short read test. It reproduces the issue with this change. We hit that problematic line once per key. My guess is that with many smaller keys, the likelihood of the connection being killed at just the right moment increases. 