### PR TITLE
Fix db->expires can't be defragged due to incorrect comparison in the expires stage

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1241,7 +1241,7 @@ static doneStatus defragStageDbKeys(void *ctx, monotime endtime) {
 static doneStatus defragStageExpiresKvstore(void *ctx, monotime endtime) {
     defragKeysCtx *defrag_keys_ctx = ctx;
     redisDb *db = &server.db[defrag_keys_ctx->dbid];
-    if (db->keys != defrag_keys_ctx->kvstate.kvs) {
+    if (db->expires != defrag_keys_ctx->kvstate.kvs) {
         /* There has been a change of the kvs (flushdb, swapdb, etc.). Just complete the stage. */
         return DEFRAG_DONE;
     }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1241,7 +1241,7 @@ static doneStatus defragStageDbKeys(void *ctx, monotime endtime) {
 static doneStatus defragStageExpiresKvstore(void *ctx, monotime endtime) {
     defragKeysCtx *defrag_keys_ctx = ctx;
     redisDb *db = &server.db[defrag_keys_ctx->dbid];
-    if (db->keys != defrag_keys_ctx->kvstate.kvs) {
+    if (db->expires != defrag_keys_ctx->kvstate.kvs) {
         /* There has been a change of the kvs (flushdb, swapdb, etc.). Just complete the stage. */
         return DEFRAG_DONE;
     }
@@ -1316,6 +1316,12 @@ static doneStatus defragStagePubsubKvstore(void *ctx, monotime endtime) {
         .defragKey = NULL, /* Handled by defragPubsubScanCallback */
         .defragVal = NULL, /* Not needed for expires (no value) */
     };
+
+    defragPubSubCtx *defrag_pubsub_ctx = ctx;
+    if (defrag_pubsub_ctx->kvstate.kvs != server.pubsub_channels) {
+        /* There has been a change of the kvs (flushdb, swapdb, etc.). Just complete the stage. */
+        return DEFRAG_DONE;
+    }
 
     return defragStageKvstoreHelper(endtime, ctx,
         defragPubsubScanCallback, NULL, &defragfns);
@@ -1579,7 +1585,9 @@ static int activeDefragTimeProc(struct aeEventLoop *eventLoop, long long id, voi
     latencyAddSampleIfNeeded("active-defrag-cycle", latency);
 
     if (haveMoreWork) {
-        return computeDelayMs(endtime);
+        int delay = computeDelayMs(endtime);
+        return delay;
+        // return computeDelayMs(endtime);
     } else {
         endDefragCycle(1);
         return AE_NOMORE; /* Ends the timer proc */

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1317,12 +1317,6 @@ static doneStatus defragStagePubsubKvstore(void *ctx, monotime endtime) {
         .defragVal = NULL, /* Not needed for expires (no value) */
     };
 
-    defragPubSubCtx *defrag_pubsub_ctx = ctx;
-    if (defrag_pubsub_ctx->kvstate.kvs != server.pubsub_channels) {
-        /* There has been a change of the kvs (flushdb, swapdb, etc.). Just complete the stage. */
-        return DEFRAG_DONE;
-    }
-
     return defragStageKvstoreHelper(endtime, ctx,
         defragPubsubScanCallback, NULL, &defragfns);
 }

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -526,7 +526,7 @@ run_solo {defrag} {
             r config set active-defrag-threshold-lower 5
             r config set active-defrag-cycle-min 65
             r config set active-defrag-cycle-max 75
-            r config set active-defrag-ignore-bytes 1500kb
+            r config set active-defrag-ignore-bytes 1000kb
             r config set maxmemory 0
             r config set hash-max-listpack-value 512
             r config set hash-max-listpack-entries 10

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -523,7 +523,7 @@ run_solo {defrag} {
             r config set activedefrag no
             wait_for_defrag_stop 500 100
             r config resetstat
-            r config set active-defrag-threshold-lower 7
+            r config set active-defrag-threshold-lower 5
             r config set active-defrag-cycle-min 65
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 1500kb
@@ -597,7 +597,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 500 100 1.07
+                wait_for_defrag_stop 500 100 1.05
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -56,8 +56,8 @@ run_solo {defrag} {
             [s active_defrag_running] eq 0 && ($expect_frag == 0 || [s allocator_frag_ratio] <= $expect_frag)
         } else {
             after 120 ;# serverCron only updates the info once in 100ms
-            puts [r info memory]
-            puts [r info stats]
+            puts [r info all]
+            # puts [r info stats]
             puts [r memory malloc-stats]
             if {$expect_frag != 0} {
                 fail "defrag didn't stop or failed to achieve expected frag ratio ([s allocator_frag_ratio] > $expect_frag)"
@@ -516,20 +516,20 @@ run_solo {defrag} {
             $rd_pubsub close
         }
 
-        foreach {eb_container fields n} {eblist 16 3000 ebrax 30 1600 large_ebrax 1600 30} {
+        foreach {eb_container fields n} {ebrax 20 2500} {
         test "Active Defrag HFE with $eb_container: $type" {
             r flushdb
             r config set hz 100
             r config set activedefrag no
             wait_for_defrag_stop 500 100
             r config resetstat
-            r config set active-defrag-threshold-lower 7
+            r config set active-defrag-threshold-lower 6
             r config set active-defrag-cycle-min 65
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 1500kb
             r config set maxmemory 0
             r config set hash-max-listpack-value 512
-            r config set hash-max-listpack-entries 10
+            r config set hash-max-listpack-entries 5
 
             # Populate memory with interleaving hash field of same size
             set dummy_field "[string repeat x 400]"
@@ -597,7 +597,9 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 500 100 1.07
+                wait_for_defrag_stop 500 100 1.05
+                puts [r info all]
+                puts [r memory malloc-stats]
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms
@@ -931,11 +933,11 @@ run_solo {defrag} {
     }
     }
 
-    start_cluster 1 0 {tags {"defrag external:skip cluster"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save "" loglevel notice}} {
-        test_active_defrag "cluster"
-    }
+    # start_cluster 1 0 {tags {"defrag external:skip cluster"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save "" loglevel debug}} {
+    #     test_active_defrag "cluster"
+    # }
 
-    start_server {tags {"defrag external:skip standalone"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save "" loglevel notice}} {
+    start_server {tags {"defrag external:skip standalone"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save "" loglevel debug}} {
         test_active_defrag "standalone"
     }
 } ;# run_solo


### PR DESCRIPTION
This bug was introduced by https://github.com/redis/redis/issues/13814

When defragmenting `db->expires`, if the process exits early and `db->expires` was modified in the meantime (e.g., FLUSHDB), we need to check whether the previously defragmented expires is still the same as the current one when resuming. If they differ, we should abort the current defragmentation of expires.

However, in https://github.com/redis/redis/issues/13814, I made a mistake by using `db->keys` and `db->expires`, as expires will never be defragged.