### PR TITLE
Fix case sensitivity of escapes in `stringmatch`

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -119,8 +119,6 @@ static int stringmatchlen_impl(const char *pattern, int patternLen,
                 if (patternLen >= 2 && pattern[0] == '\\') {
                     pattern++;
                     patternLen--;
-                    if (pattern[0] == string[0])
-                        match = 1;
                 } else if (patternLen == 0) {
                     pattern--;
                     patternLen++;
@@ -141,18 +139,18 @@ static int stringmatchlen_impl(const char *pattern, int patternLen,
                         end = tolower(end);
                         c = tolower(c);
                     }
-                    pattern += 2;
-                    patternLen -= 2;
+                    pattern += 3;
+                    patternLen -= 3;
                     if (c >= start && c <= end)
                         match = 1;
+                    continue;
+                }
+                if (!nocase) {
+                    if (pattern[0] == string[0])
+                        match = 1;
                 } else {
-                    if (!nocase) {
-                        if (pattern[0] == string[0])
-                            match = 1;
-                    } else {
-                        if (tolower((int)pattern[0]) == tolower((int)string[0]))
-                            match = 1;
-                    }
+                    if (tolower((int)pattern[0]) == tolower((int)string[0]))
+                        match = 1;
                 }
                 pattern++;
                 patternLen--;


### PR DESCRIPTION
When matching with case-insensitive patterns, escaped characters are case-insensitive when outside a character class, but not when inside. This is undocumented and appears to be unintentional. Since case-insensitive patterns are only used for matching command and function names with `COMMAND LIST FILTERBY PATTERN <pattern>` and `FUNCTION LIST LIBRARYNAME <pattern>`, this behavior is not useful and is only confusing.