### PR TITLE
fix memory leak with slot_nodes_str

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6085,6 +6085,7 @@ static int clusterManagerFixSlotsCoverage(char *all_slots) {
                     fixed = -1;
                     if (reply) freeReplyObject(reply);
                     if (slot_nodes) listRelease(slot_nodes);
+                    sdsfree(slot_nodes_str);
                     goto cleanup;
                 }
                 assert(reply->type == REDIS_REPLY_ARRAY);


### PR DESCRIPTION
fix simple memory leak not to free slot_nodes_str before goto cleanup