### PR TITLE
[DRAFT] EXPIRE Implementation Redesign

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -527,7 +527,7 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
 
     if (o == NULL) {
         o = createObject(OBJ_STRING,sdsnewlen(NULL, byte+1));
-        dbAddByLink(c->db,c->argv[1],&o,&link);
+        dbAddByLink(c->db,c->argv[1],&o,&link, 0);
         *strGrowSize = byte + 1;
         *strOldSize = 0;
     } else {

--- a/src/db.c
+++ b/src/db.c
@@ -415,9 +415,15 @@ kvobj *dbAddRDBLoad(redisDb *db, sds key, robj **valref, long long expire) {
  *   replacement (in which case we need to emit deletion signals), or just an
  *   update of a value of an existing key (when false).
  * - The `link` is optional, can save lookup, if provided.
+ * 
+ * Arguments:
+ * 
+ * flags - Either SETKEY_KEEPTTL, SETKEY_HAS_EXPIRE or NONE. 
  */
 static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link, 
-                       int overwrite, int updateKeySizes, int keepTTL) {
+                       int overwrite, int updateKeySizes, int flags)
+{
+    debugServerAssert(flags == (flags & (SETKEY_KEEPTTL|SETKEY_HAS_EXPIRE)));
     robj *val = *valref;
     int slot = getKeySlot(key->ptr);
     if (!link) {
@@ -468,15 +474,17 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
         /* Replace the old value at its location in the key space. */
         val->lru = old->lru;
         /* Update expire reference if needed */
-        long long expire = getExpire(db, key->ptr, old);
-        kvNew = kvobjSet(key->ptr, val, keepTTL ? expire : -1);
+        long long oldExpiry = getExpire(db, key->ptr, old);
+        int keepTTL = (oldExpiry >= 0) && (flags & SETKEY_KEEPTTL);
+        int hasExpire = flags & SETKEY_HAS_EXPIRE;
+        kvNew = kvobjSet(key->ptr, val, hasExpire || keepTTL);
         kvstoreDictSetAtLink(db->keys, slot, kvNew, &link, 0);
 
         /* Replace the old value at its location in the expire space. */
-        if (expire >= 0) {
+        if (oldExpiry >= 0) {
             estoreRemove(db->expiresNew, slot, old);
             if (keepTTL)
-                estoreAdd(db->expiresNew, kvNew, slot, expire);
+                estoreAdd(db->expiresNew, kvNew, slot, oldExpiry);
         }
     }
 
@@ -510,7 +518,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
 /* Replace an existing key with a new value, we just replace value and don't
  * emit any events */
 void dbReplaceValue(redisDb *db, robj *key, robj **valref, int updateKeySizes) {
-    dbSetValue(db, key, valref, NULL, 0, updateKeySizes, 1);
+    dbSetValue(db, key, valref, NULL, 0, updateKeySizes, SETKEY_KEEPTTL);
 }
 
 /* Replace an existing key with a new value (don't emit any events)
@@ -518,7 +526,7 @@ void dbReplaceValue(redisDb *db, robj *key, robj **valref, int updateKeySizes) {
  * parameter 'link' is optional. If provided, saves lookup.
  */
 void dbReplaceValueWithLink(redisDb *db, robj *key, robj **val, dictEntryLink link) {
-    dbSetValue(db, key, val, link, 0, 1, 1);
+    dbSetValue(db, key, val, link, 0, 1, SETKEY_KEEPTTL);
 }
 
 /* High level Set operation. This function can be used in order to set
@@ -565,7 +573,7 @@ void setKeyByLink(client *c, redisDb *db, robj *key, robj **valref, int flags, d
 
     if (exists) {
         /* Update the value of an existing key */
-        dbSetValue(db, key, valref, *link, 1, 1, flags & SETKEY_KEEPTTL);
+        dbSetValue(db, key, valref, *link, 1, 1, flags);
     } else {
         /* Add the new key to the database */
         dbAddByLink(db, key, valref, link,  (flags & SETKEY_HAS_EXPIRE) ? 1 : 0);
@@ -859,6 +867,7 @@ void discardTempDb(redisDb *tempDb) {
         /* Destroy global HFE DS before deleting the hashes since ebuckets DS is
          * embedded in the stored objects. */
         ebDestroy(&tempDb[i].hexpires, &hashExpireBucketsType, NULL);
+        /* Must release expiration store before releasing kvstore */
         estoreRelease(tempDb[i].expiresNew);
         kvstoreRelease(tempDb[i].keys);
     }
@@ -2242,6 +2251,7 @@ kvobj *setExpire(client *c, redisDb *db, robj *key, long long when) {
 
 /* Like setExpire(), but accepts an optional `keyLink` to save lookup */
 kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntryLink keyLink) {
+    debugServerAssert(when >= 0);
     /* Reuse the sds from the main dict in the expire dict */
     int slot = getKeySlot(key);
     if (!keyLink) {
@@ -2253,10 +2263,8 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
 
     if (old_when != -1) { /* old expire */
         estoreRemove(db->expiresNew, slot, kv);
-        estoreAdd(db->expiresNew, kv, slot, when);
+
     } else { /* No old expire */
-        /* No expire was set and still isn't */
-        if (when == -1) return kv;
 
         /* If not reserved space in kvobj for expiry */
         if  (!kv->expirable) {
@@ -2273,9 +2281,10 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
 
             if (hexpire != EB_EXPIRE_TIME_INVALID)
                 hashTypeAddToExpires(db, kv, hexpire);
-        }        
-        estoreAdd(db->expiresNew, kv, slot, when);
+        }
     }
+
+    estoreAdd(db->expiresNew, kv, slot, when);
 
     int writable_slave = server.masterhost && server.repl_slave_ro == 0;
     if (c && writable_slave && !(c->flags & CLIENT_MASTER))

--- a/src/db.c
+++ b/src/db.c
@@ -768,11 +768,11 @@ long long emptyDbStructure(redisDb *dbarray, int dbnum, int async,
         if (async) {
             emptyDbAsync(&dbarray[j]);
         } else {
-            /* Destroy global HFE DS before deleting the hashes since ebuckets
-             * DS is embedded in the stored objects. */
+            /* Destroy global HFE DS & ESTORE before deleting keyspace, since 
+             * those DS is embedded in the keyspace. */
             ebDestroy(&dbarray[j].hexpires, &hashExpireBucketsType, NULL);
-            kvstoreEmpty(dbarray[j].keys, callback);
             estoreEmpty(dbarray[j].expiresNew);
+            kvstoreEmpty(dbarray[j].keys, callback);
         }
         /* Because all keys of database are removed, reset average ttl. */
         dbarray[j].avg_ttl = 0;

--- a/src/db.c
+++ b/src/db.c
@@ -2263,11 +2263,6 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
          * to manipulate and maybe free kv object */
         if (kv->type == OBJ_HASH)
             hexpire = hashTypeRemoveFromExpires(&db->hexpires, kv);
-        
-        /* If hash with HFEs, take care to remove from global HFE DS before attempting
-         * to manipulate and maybe free kv object */
-        if (kv->type == OBJ_HASH)
-            hexpire = hashTypeRemoveFromExpires(&db->hexpires, kv);
 
         kvobj *kvnew;
         if (!kv->expirable) {

--- a/src/db.c
+++ b/src/db.c
@@ -322,10 +322,10 @@ kvobj *lookupKeyWriteOrReply(client *c, robj *key, robj *reply) {
  * link - Optional link to bucket where the key should be added.
  *          On return, get updated, by need, to the inserted key.
  */
-kvobj *dbAddByLink(redisDb *db, robj *key, robj **valref, dictEntryLink *link) {
+kvobj *dbAddByLink(redisDb *db, robj *key, robj **valref, dictEntryLink *link, int hasExpire) {
     int slot = getKeySlot(key->ptr);
     robj *val = *valref;
-    kvobj *kv = kvobjSet(key->ptr, val, -1);
+    kvobj *kv = kvobjSet(key->ptr, val, hasExpire);
     initObjectLRUOrLFU(kv);
     kvstoreDictSetAtLink(db->keys, slot, kv, link, 1);
     signalKeyAsReady(db, key, kv->type);
@@ -337,7 +337,7 @@ kvobj *dbAddByLink(redisDb *db, robj *key, robj **valref, dictEntryLink *link) {
 
 /* Read dbAddByLink() comment */
 kvobj *dbAdd(redisDb *db, robj *key, robj **valref) {
-    return dbAddByLink(db, key, valref, NULL);
+    return dbAddByLink(db, key, valref, NULL, 0);
 }
 
 /* Returns key's hash slot when cluster mode is enabled, or 0 when disabled.
@@ -385,13 +385,14 @@ kvobj *dbAddRDBLoad(redisDb *db, sds key, robj **valref, long long expire) {
         return NULL;
 
     /* prepare kvobj for insertion. Pass expire to reserve space for it */
-    kvobj *kv = kvobjSet(key, *valref, -1);
+    int hasExpire = expire != -1;
+    kvobj *kv = kvobjSet(key, *valref, hasExpire);
     initObjectLRUOrLFU(kv);
     kvstoreDictSetAtLink(db->keys, slot, kv, &bucket, 1);
 
     /* Set the expire time if needed */
-    if (expire != -1)
-        kv = setExpireByLink(NULL, db, key, expire, bucket);
+    if (hasExpire)
+        estoreAdd(db->expiresNew, kv, slot, expire);
 
     updateKeysizesHist(db, slot, kv->type, -1, (int64_t) getObjectLength(kv));
     return *valref = kv;
@@ -473,14 +474,9 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
 
         /* Replace the old value at its location in the expire space. */
         if (expire >= 0) {
-            if (keepTTL) {
-                dictEntryLink exLink = kvstoreDictFindLink(db->expires, slot,
-                                                           key->ptr, NULL);
-                serverAssertWithInfo(NULL, key, exLink != NULL);
-                kvstoreDictSetAtLink(db->expires, slot, kvNew, &exLink, 0);
-            } else {
-                kvstoreDictDelete(db->expires, slot, key->ptr);
-            }
+            estoreRemove(db->expiresNew, slot, old);
+            if (keepTTL)
+                estoreAdd(db->expiresNew, kvNew, slot, expire);
         }
     }
 
@@ -572,7 +568,7 @@ void setKeyByLink(client *c, redisDb *db, robj *key, robj **valref, int flags, d
         dbSetValue(db, key, valref, *link, 1, 1, flags & SETKEY_KEEPTTL);
     } else {
         /* Add the new key to the database */
-        dbAddByLink(db, key, valref, link);
+        dbAddByLink(db, key, valref, link,  (flags & SETKEY_HAS_EXPIRE) ? 1 : 0);
     }
 
     if (!(flags & SETKEY_NO_SIGNAL))
@@ -586,7 +582,7 @@ void setKeyByLink(client *c, redisDb *db, robj *key, robj **valref, int flags, d
 robj *dbRandomKey(redisDb *db) {
     dictEntry *de;
     int maxtries = 100;
-    int allvolatile = kvstoreSize(db->keys) == kvstoreSize(db->expires);
+    int allvolatile = kvstoreSize(db->keys) == estoreSize(db->expiresNew);
 
     while(1) {
         robj *keyobj;
@@ -625,32 +621,35 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
     link = kvstoreDictTwoPhaseUnlinkFind(db->keys, slot, key->ptr, &table);
 
     if (link) {
-        kvobj *val = dictGetKV(*link);
+        kvobj *kv = dictGetKV(*link);
 
-        int64_t oldlen = (int64_t) getObjectLength(val);
-        int type = val->type;
+        int64_t oldlen = (int64_t) getObjectLength(kv);
+        int type = kv->type;
 
         /* If hash object with expiry on fields, remove it from HFE DS of DB */
         if (type == OBJ_HASH)
-            hashTypeRemoveFromExpires(&db->hexpires, val);
+            hashTypeRemoveFromExpires(&db->hexpires, kv);
 
         /* RM_StringDMA may call dbUnshareStringValue which may free val, so we
          * need to incr to retain val */
-        incrRefCount(val); /* refcnt=1->2 */
+        incrRefCount(kv); /* refcnt=1->2 */
         /* Tells the module that the key has been unlinked from the database. */
-        moduleNotifyKeyUnlink(key,val,db->id,flags);
+        moduleNotifyKeyUnlink(key, kv, db->id, flags);
         /* We want to try to unblock any module clients or clients using a blocking XREADGROUP */
         signalDeletedKeyAsReady(db,key,type);
         /* We should call decr before freeObjAsync. If not, the refcount may be
          * greater than 1, so freeObjAsync doesn't work */
-        decrRefCount(val);
+        decrRefCount(kv);
 
-        /* Delete an entry from the expires dict is not decrRefCount of kvobj */
-        kvstoreDictDelete(db->expires, slot, key->ptr);
+        /* Because of dbUnshareStringValue, the val in db may change. */
+        kv = dictGetKV(*link);
+        
+        /* Delete an entry from the estore. No need to decrRefCount */
+        if (kvobjGetExpire(kv) != -1)
+            estoreRemove(db->expiresNew, slot, kv);
 
         if (async) {
-            /* Because of dbUnshareStringValue, the val in db may change. */
-            freeObjAsync(key, dictGetKV(*link), db->id);
+            freeObjAsync(key, kv, db->id);
             /* Set the key to NULL in the main dictionary. */
             kvstoreDictSetAtLink(db->keys, slot, NULL, &link, 0);
         }
@@ -765,7 +764,7 @@ long long emptyDbStructure(redisDb *dbarray, int dbnum, int async,
              * DS is embedded in the stored objects. */
             ebDestroy(&dbarray[j].hexpires, &hashExpireBucketsType, NULL);
             kvstoreEmpty(dbarray[j].keys, callback);
-            kvstoreEmpty(dbarray[j].expires, callback);
+            estoreEmpty(dbarray[j].expiresNew);
         }
         /* Because all keys of database are removed, reset average ttl. */
         dbarray[j].avg_ttl = 0;
@@ -843,8 +842,8 @@ redisDb *initTempDb(void) {
         tempDb[i].id = i;
         tempDb[i].keys = kvstoreCreate(&dbDictType, slot_count_bits,
                                        flags | KVSTORE_ALLOC_META_KEYS_HIST);
-        tempDb[i].expires = kvstoreCreate(&dbExpiresDictType, slot_count_bits, flags);
         tempDb[i].hexpires = ebCreate();
+        tempDb[i].expiresNew = estoreCreate(&estoreBucketsType, slot_count_bits);
     }
 
     return tempDb;
@@ -860,8 +859,8 @@ void discardTempDb(redisDb *tempDb) {
         /* Destroy global HFE DS before deleting the hashes since ebuckets DS is
          * embedded in the stored objects. */
         ebDestroy(&tempDb[i].hexpires, &hashExpireBucketsType, NULL);
+        estoreRelease(tempDb[i].expiresNew);
         kvstoreRelease(tempDb[i].keys);
-        kvstoreRelease(tempDb[i].expires);
     }
 
     zfree(tempDb);
@@ -1901,9 +1900,10 @@ void moveCommand(client *c) {
     incrRefCount(kv);            /* ref counter = 1->2 */
     dbDelete(src,c->argv[1]);    /* ref counter = 2->1 */
 
-    dbAddByLink(dst, c->argv[1], &kv, &dstBucket);
-    if (expire != -1)
-        setExpireByLink(c, dst, c->argv[1]->ptr, expire, dstBucket);
+    int hasExpire = expire != -1;
+    dbAddByLink(dst, c->argv[1], &kv, &dstBucket, hasExpire);
+    if (hasExpire)
+        estoreAdd(dst->expiresNew, kv, getKeySlot(c->argv[1]->ptr), expire);
 
     /* If object of type hash with expiration on fields. Taken care to add the
      * hash to hexpires of `dst` only after dbDelete(). */
@@ -1928,8 +1928,8 @@ void copyCommand(client *c) {
     long long expire;
     int j, replace = 0, delete = 0;
 
-    /* Obtain source and target DB pointers 
-     * Default target DB is the same as the source DB 
+    /* Obtain source and target DB pointers
+     * Default target DB is the same as the source DB
      * Parse the REPLACE option and targetDB option. */
     src = c->db;
     dst = c->db;
@@ -2111,13 +2111,13 @@ int dbSwapDatabases(int id1, int id2) {
      * ready_keys and watched_keys, since we want clients to
      * remain in the same DB they were. */
     db1->keys = db2->keys;
-    db1->expires = db2->expires;
+    db1->expiresNew = db2->expiresNew;
     db1->hexpires = db2->hexpires;
     db1->avg_ttl = db2->avg_ttl;
     db1->expires_cursor = db2->expires_cursor;
 
     db2->keys = aux.keys;
-    db2->expires = aux.expires;
+    db2->expiresNew = aux.expiresNew;
     db2->hexpires = aux.hexpires;
     db2->avg_ttl = aux.avg_ttl;
     db2->expires_cursor = aux.expires_cursor;
@@ -2155,13 +2155,13 @@ void swapMainDbWithTempDb(redisDb *tempDb) {
          * ready_keys and watched_keys, since clients 
          * remain in the same DB they were. */
         activedb->keys = newdb->keys;
-        activedb->expires = newdb->expires;
+        activedb->expiresNew = newdb->expiresNew;
         activedb->hexpires = newdb->hexpires;
         activedb->avg_ttl = newdb->avg_ttl;
         activedb->expires_cursor = newdb->expires_cursor;
 
         newdb->keys = aux.keys;
-        newdb->expires = aux.expires;
+        newdb->expiresNew = aux.expiresNew;
         newdb->hexpires = aux.hexpires;
         newdb->avg_ttl = aux.avg_ttl;
         newdb->expires_cursor = aux.expires_cursor;
@@ -2218,21 +2218,14 @@ void swapdbCommand(client *c) {
  * Expires API
  *----------------------------------------------------------------------------*/
 
-/* Remove expiry from key
- *
- *  Remove the object from db->expires and set to -1 attached TTL to KV
- */
-int removeExpire(redisDb *db, robj *key) {
-    int table;
+/* Remove expiry from kv */
+int removeExpire(redisDb *db, robj *key, kvobj *kv) {
     int slot = getKeySlot(key->ptr);
-    dictEntryLink link = kvstoreDictTwoPhaseUnlinkFind(db->expires, slot, key->ptr, &table);
 
-    if (link == NULL) return 0;
-    dictEntry *de = *link;
-    kvobj *kv = dictGetKV(de);
-    kvobj *newkv = kvobjSetExpire(kv, -1);
-    serverAssert(newkv == kv);
-    kvstoreDictTwoPhaseUnlinkFree(db->expires, slot, link, table);
+    if (kvobjGetExpire(kv) == -1) return 0;
+    
+    /* Remove from estore */
+    estoreRemove(db->expiresNew, slot, kv);
     return 1;
 }
 
@@ -2259,26 +2252,31 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
     long long old_when = kvobjGetExpire(kv);
 
     if (old_when != -1) { /* old expire */
-        kvobj *kvnew = kvobjSetExpire(kv, when); /* release kv if reallocated */
-        /* Val already had an expire field, so it was not reallocated. */
-        serverAssert(kv == kvnew);
+        estoreRemove(db->expiresNew, slot, kv);
+        estoreAdd(db->expiresNew, kv, slot, when);
     } else { /* No old expire */
+        /* No expire was set and still isn't */
+        if (when == -1) return kv;
+
         uint64_t hexpire = EB_EXPIRE_TIME_INVALID;
         /* If hash with HFEs, take care to remove from global HFE DS before attempting
          * to manipulate and maybe free kv object */
         if (kv->type == OBJ_HASH)
             hexpire = hashTypeRemoveFromExpires(&db->hexpires, kv);
+        
+        /* If hash with HFEs, take care to remove from global HFE DS before attempting
+         * to manipulate and maybe free kv object */
+        if (kv->type == OBJ_HASH)
+            hexpire = hashTypeRemoveFromExpires(&db->hexpires, kv);
 
-        kvobj *kvnew = kvobjSetExpire(kv, when); /* release kv if reallocated */
-        /* if kvobj was reallocated, update dict */
-        if (kv != kvnew) {
+        kvobj *kvnew;
+        if (!kv->expirable) {
+            kvnew = kvobjSet(kvobjGetKey(kv), kv, 1);
             kvstoreDictSetAtLink(db->keys, slot, kvnew, &keyLink, 0);
             kv = kvnew;
         }
-        /* Now add to expires */
-        dictEntry *de = kvstoreDictAddRaw(db->expires, slot, kv, NULL);
-        serverAssert(de != NULL);
-
+        estoreAdd(db->expiresNew, kv, slot, when);
+        
         if (hexpire != EB_EXPIRE_TIME_INVALID)
             hashTypeAddToExpires(db, kv, hexpire);
     }
@@ -2295,7 +2293,7 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
  * To avoid lookup, pass key-value object (`kv`) instead of `key`.
  */
 long long getExpire(redisDb *db, sds key, kvobj *kv) {
-    if (kv == NULL) kv = dbFindExpires(db, key);
+    if (kv == NULL) kv = dbFind(db, key);
     if (kv == NULL) return -1;
     return kvobjGetExpire(kv);
 }
@@ -2533,10 +2531,6 @@ int dbExpand(redisDb *db, uint64_t db_size, int try_expand) {
     return dbExpandGeneric(db->keys, db_size, try_expand);
 }
 
-int dbExpandExpires(redisDb *db, uint64_t db_size, int try_expand) {
-    return dbExpandGeneric(db->expires, db_size, try_expand);
-}
-
 static kvobj *dbFindGeneric(kvstore *kvs, sds key) {
     dictEntry *res = kvstoreDictFind(kvs, getKeySlot(key), key);
     return (res) ? dictGetKey(res) : NULL;
@@ -2564,10 +2558,6 @@ kvobj *dbFindByLink(redisDb *db, sds key, dictEntryLink *plink) {
         if (plink) *plink = link;
         return dictGetKV(*link);
     }
-}
-
-kvobj *dbFindExpires(redisDb *db, sds key) {
-    return dbFindGeneric(db->expires, key);
 }
 
 unsigned long long dbSize(redisDb *db) {
@@ -2626,10 +2616,10 @@ int64_t getAllKeySpecsFlags(struct redisCommand *cmd, int inv) {
 
 /* Fetch the keys based of the provided key specs. Returns the number of keys found, or -1 on error.
  * There are several flags that can be used to modify how this function finds keys in a command.
- * 
+ *
  * GET_KEYSPEC_INCLUDE_NOT_KEYS: Return 'fake' keys as if they were keys.
  * GET_KEYSPEC_RETURN_PARTIAL:   Skips invalid and incomplete keyspecs but returns the keys
- *                               found in other valid keyspecs. 
+ *                               found in other valid keyspecs.
  */
 int getKeysUsingKeySpecs(struct redisCommand *cmd, robj **argv, int argc, int search_flags, getKeysResult *result) {
     long j, i, last, first, step;
@@ -2746,13 +2736,13 @@ invalid_spec:
     return result->numkeys;
 }
 
-/* Return all the arguments that are keys in the command passed via argc / argv. 
+/* Return all the arguments that are keys in the command passed via argc / argv.
  * This function will eventually replace getKeysFromCommand.
  *
  * The command returns the positions of all the key arguments inside the array,
  * so the actual return value is a heap allocated array of integers. The
  * length of the array is returned by reference into *numkeys.
- * 
+ *
  * Along with the position, this command also returns the flags that are
  * associated with how Redis will access the key.
  *
@@ -2829,14 +2819,14 @@ int doesCommandHaveChannelsWithFlags(struct redisCommand *cmd, int flags) {
     return 0;
 }
 
-/* Return all the arguments that are channels in the command passed via argc / argv. 
- * This function behaves similar to getKeysFromCommandWithSpecs, but with channels 
+/* Return all the arguments that are channels in the command passed via argc / argv.
+ * This function behaves similar to getKeysFromCommandWithSpecs, but with channels
  * instead of keys.
- * 
+ *
  * The command returns the positions of all the channel arguments inside the array,
  * so the actual return value is a heap allocated array of integers. The
  * length of the array is returned by reference into *numkeys.
- * 
+ *
  * Along with the position, this command also returns the flags that are
  * associated with how Redis will access the channel.
  *
@@ -2870,12 +2860,12 @@ int getChannelsFromCommand(struct redisCommand *cmd, robj **argv, int argc, getK
 /* The base case is to use the keys position as given in the command table
  * (firstkey, lastkey, step).
  * This function works only on command with the legacy_range_key_spec,
- * all other commands should be handled by getkeys_proc. 
- * 
+ * all other commands should be handled by getkeys_proc.
+ *
  * If the commands keyspec is incomplete, no keys will be returned, and the provided
  * keys function should be called instead.
- * 
- * NOTE: This function does not guarantee populating the flags for 
+ *
+ * NOTE: This function does not guarantee populating the flags for
  * the keys, in order to get flags you should use getKeysUsingKeySpecs. */
 int getKeysUsingLegacyRangeSpec(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
     int j, i = 0, last, first, step;
@@ -2959,7 +2949,7 @@ void getKeysFreeResult(getKeysResult *result) {
  * 'keyCountOfs': num-keys index.
  * 'firstKeyOfs': firstkey index.
  * 'keyStep': the interval of each key, usually this value is 1.
- * 
+ *
  * The commands using this function have a fully defined keyspec, so returning flags isn't needed. */
 int genericGetKeys(int storeKeyOfs, int keyCountOfs, int firstKeyOfs, int keyStep,
                     robj **argv, int argc, getKeysResult *result) {
@@ -2982,12 +2972,12 @@ int genericGetKeys(int storeKeyOfs, int keyCountOfs, int firstKeyOfs, int keySte
     for (i = 0; i < num; i++) {
         keys[i].pos = firstKeyOfs+(i*keyStep);
         keys[i].flags = 0;
-    } 
+    }
 
     if (storeKeyOfs) {
         keys[num].pos = storeKeyOfs;
         keys[num].flags = 0;
-    } 
+    }
     return result->numkeys;
 }
 
@@ -3065,8 +3055,8 @@ int sortROGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult
  *
  * The first argument of SORT is always a key, however a list of options
  * follow in SQL-alike style. Here we parse just the minimum in order to
- * correctly identify keys in the "STORE" option. 
- * 
+ * correctly identify keys in the "STORE" option.
+ *
  * This command declares incomplete keys, so the flags are correctly set for this function */
 int sortGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
     int i, j, num, found_store = 0;
@@ -3126,7 +3116,7 @@ int migrateGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResul
     struct {
         char* name;
         int skip;
-    } skip_keywords[] = {       
+    } skip_keywords[] = {
         {"copy", 0},
         {"replace", 0},
         {"auth", 1},
@@ -3139,7 +3129,7 @@ int migrateGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResul
                 if (sdslen(argv[3]->ptr) > 0) {
                     /* This is a syntax error. So ignore the keys and leave
                      * the syntax error to be handled by migrateCommand. */
-                    num = 0; 
+                    num = 0;
                 } else {
                     first = i + 1;
                     num = argc - first;
@@ -3159,7 +3149,7 @@ int migrateGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResul
     for (i = 0; i < num; i++) {
         keys[i].pos = first+i;
         keys[i].flags = CMD_KEY_RW | CMD_KEY_ACCESS | CMD_KEY_DELETE;
-    } 
+    }
     result->numkeys = num;
     return num;
 }
@@ -3168,7 +3158,7 @@ int migrateGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResul
  * GEORADIUS key x y radius unit [WITHDIST] [WITHHASH] [WITHCOORD] [ASC|DESC]
  *                             [COUNT count] [STORE key|STOREDIST key]
  * GEORADIUSBYMEMBER key member radius unit ... options ...
- * 
+ *
  * This command has a fully defined keyspec, so returning flags isn't needed. */
 int georadiusGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
     int i, num;
@@ -3251,8 +3241,8 @@ int xreadGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult 
     keys = getKeysPrepareResult(result, num);
     for (i = streams_pos+1; i < argc-num; i++) {
         keys[i-streams_pos-1].pos = i;
-        keys[i-streams_pos-1].flags = 0; 
-    } 
+        keys[i-streams_pos-1].flags = 0;
+    }
     result->numkeys = num;
     return num;
 }

--- a/src/db.c
+++ b/src/db.c
@@ -2258,22 +2258,23 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
         /* No expire was set and still isn't */
         if (when == -1) return kv;
 
-        uint64_t hexpire = EB_EXPIRE_TIME_INVALID;
-        /* If hash with HFEs, take care to remove from global HFE DS before attempting
-         * to manipulate and maybe free kv object */
-        if (kv->type == OBJ_HASH)
-            hexpire = hashTypeRemoveFromExpires(&db->hexpires, kv);
+        /* If not reserved space in kvobj for expiry */
+        if  (!kv->expirable) {
+            uint64_t hexpire = EB_EXPIRE_TIME_INVALID;
 
-        kvobj *kvnew;
-        if (!kv->expirable) {
-            kvnew = kvobjSet(kvobjGetKey(kv), kv, 1);
-            kvstoreDictSetAtLink(db->keys, slot, kvnew, &keyLink, 0);
-            kv = kvnew;
-        }
+            /* If hash with HFEs, take care to remove from global HFE DS before 
+             * attempting realloc kv object */
+            if (kv->type == OBJ_HASH)
+                hexpire = hashTypeRemoveFromExpires(&db->hexpires, kv);
+
+            /* reallocate kvobj to make it expirable and store it in keyspace */
+            kv = kvobjSet(kvobjGetKey(kv), kv, 1);
+            kvstoreDictSetAtLink(db->keys, slot, kv, &keyLink, 0);
+
+            if (hexpire != EB_EXPIRE_TIME_INVALID)
+                hashTypeAddToExpires(db, kv, hexpire);
+        }        
         estoreAdd(db->expiresNew, kv, slot, when);
-        
-        if (hexpire != EB_EXPIRE_TIME_INVALID)
-            hashTypeAddToExpires(db, kv, hexpire);
     }
 
     int writable_slave = server.masterhost && server.repl_slave_ro == 0;

--- a/src/debug.c
+++ b/src/debug.c
@@ -939,8 +939,8 @@ NULL
         kvstoreGetStats(server.db[dbid].keys, buf, sizeof(buf), full);
         stats = sdscat(stats,buf);
 
-        stats = sdscatprintf(stats,"[Expires HT]\n");
-        kvstoreGetStats(server.db[dbid].expires, buf, sizeof(buf), full);
+        stats = sdscatprintf(stats,"[EBUCKETS]\n");
+        estoreGetStats(server.db[dbid].expiresNew, buf, sizeof(buf), full);
         stats = sdscat(stats,buf);
 
         addReplyVerbatim(c,stats,sdslen(stats),"txt");

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -894,6 +894,8 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
      * the pointer it holds, since it won't be able to do the string
      * compare. Search it before, if needed. */ 
      if (expire != -1) {
+         serverAssert(0); // TODO_MOTI: Implement estore defrag
+         
          exlink = kvstoreDictFindLink(db->expires, slot, kvobjGetKey(ob), NULL);
          serverAssert(exlink != NULL);
      }
@@ -906,8 +908,10 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
     }
     if (kvnew) {
         kvstoreDictSetAtLink(db->keys, slot, kvnew, &link, 0);
-        if (expire != -1)
+        if (expire != -1) {
+            serverAssert(0); // TODO_MOTI: Implement estore defrag
             kvstoreDictSetAtLink(db->expires, slot, kvnew, &exlink, 0);
+        }
         ob = kvnew;
     }
 

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -18,7 +18,6 @@
 
 #define UNUSED(x) (void)(x)
 
-
 /*** DEBUGGING & VALIDATION
  *
  * To validate DS on add(), remove() and ebExpire()
@@ -42,33 +41,36 @@
  */
 
 /*
- *  Keep just enough bytes of bucket-key, taking into consideration configured
- *  EB_BUCKET_KEY_PRECISION, and ignoring LSB bits that has no impact.
- *
- * The main motivation is that since the bucket-key size determines the maximum
- * depth of the rax tree, then we can prune the tree to be more shallow and thus
- * reduce the maintenance and traversal of each node in the B-tree.
- */
-#if EB_BUCKET_KEY_PRECISION < 8
-#define EB_KEY_SIZE 6
-#elif EB_BUCKET_KEY_PRECISION >= 8 && EB_BUCKET_KEY_PRECISION < 16
-#define EB_KEY_SIZE 5
-#else
-#define EB_KEY_SIZE 4
-#endif
-
-/*
  * EB_SEG_MAX_ITEMS - Maximum number of items in rax-segment before trying to
  * split. To simplify, it has the same value as EB_LIST_MAX_ITEMS.
  */
 #define EB_SEG_MAX_ITEMS 16
 #define EB_LIST_MAX_ITEMS EB_SEG_MAX_ITEMS
 
-/* From expiration time to bucket-key */
-#define EB_BUCKET_KEY(exptime) ((exptime) >> EB_BUCKET_KEY_PRECISION)
+/* From expiration time in msec to bucket-key - using the type's bucketPrecision */
+#define EB_BUCKET_KEY(exptime, type) ((exptime) >> (type)->ebp.precision)
 
- /* From bucket-key to expiration time */
-#define EB_BUCKET_EXP_TIME(bucketKey) ((uint64_t)(bucketKey) << EB_BUCKET_KEY_PRECISION)
+/* From bucket-key to expiration time in msec */
+#define EB_BUCKET_EXP_TIME(bucketKey, type) ((uint64_t)(bucketKey) << (type)->ebp.precision)
+
+/* ebstack macro helper to adjust type before run command on ebuckets L1/2 */
+#define EB_STACK_EXEC_L1(type, ebCommand)            \
+    do {                                             \
+        (type)->isEbStack = 0;                       \
+        ebCommand;                                   \
+        (type)->isEbStack = 1;                       \
+    } while (0)
+#define EB_STACK_EXEC_L2(type, ebCommand)            \
+    do {                                             \
+        (type)->isEbStack = 0;                       \
+        EBucketPrecision __ebp_tmp = (type)->ebp;    \
+        (type)->ebp = ebpStackL2;                    \
+        ebCommand;                                   \
+        (type)->ebp = __ebp_tmp;                     \
+        (type)->isEbStack = 1;                       \
+    } while (0)
+
+#define EB_STACK_L3_SIZEOF(n) (sizeof(ebVector) + sizeof(eItem) * (n))
 
 /*** structs ***/
 
@@ -117,16 +119,72 @@ typedef struct NextSegHdr {
     FirstSegHdr *firstSeg; /* pointer to first segment of the bucket */
 } NextSegHdr;
 
-/* Selective copy of ifndef from server.h instead of including it */
+typedef struct ebVector {
+    uint64_t items;
+    uint64_t vecSize; /* Power of 2 */
+    eItem vec[];
+} ebVector;
+
+typedef struct ebStack {
+    uint64_t items;
+    ebuckets l1;
+    ebuckets l2;
+    ebVector *l3; /*infinity*/
+} ebStack;
+
+/* Unlike ebuckets level 1 in ebStack, the level 2 precision is not configurable
+ * and is fixed to 21 bits (~34.9 minutes). This is because active expiration
+ * cycle is fine-tuned based on it. For up to 30 days of expiration values, it
+ * will be limited by no more than 1235 buckets and in the common case, it will be
+ * considerably less. */
+const EBucketPrecision ebpStackL2 = {
+    .precision = 21, /* L2 Bucket bits precision */
+    .keySize = EB_PRECISION2KEYSIZE(21),
+};
+
+/* ExpireMetaL3 is used for items stored in ebStack Level 3 (the "infinity" vector)
+ * which holds very long expiration times (> EB_EXPIRE_TIME_MAX = 48 bits). Regular 
+ * ExpireMeta can only store 48-bit timestamps (sufficient until year 10889), but 
+ * L3 items need full 64-bit timestamps for practically infinite expiration times.
+ *
+ * Key differences from ExpireMeta:
+ * - expireIndexLo/Hi: 6-byte index into the infinity vector (replaces expireTimeLo/Hi)
+ * - expireTime: Full 8-byte timestamp (replaces the `next` pointer)
+ * - Same size and alignment as ExpireMeta for memory compatibility
+ */
+typedef struct ExpireMetaL3 {
+    uint32_t expireIndexLo;     /* Lo Index in infinity vector */
+    uint16_t expireIndexHi;     /* Hi Index in infinity vector */
+    EXPIRE_META_FLAGS
+    uint64_t expireTime;        /* replaces `next` with actual 8 bytes timestamp */
+} ExpireMetaL3;
+
+/* Selective declarations from server.h instead of including it */
 #ifndef static_assert
 #define static_assert(expr, lit) extern char __static_assert_failure[(expr) ? 1:-1]
 #endif
+
+#ifndef REDIS_TEST
+typedef long long mstime_t; /* millisecond time type. */
+mstime_t commandTimeSnapshot(void);
+#else /* Let tests control time */
+uint64_t __now__ = 0;
+#define commandTimeSnapshot() __now__
+#endif
+
 /* Verify that "head" field is aligned in FirstSegHdr, NextSegHdr and CommonSegHdr */
 static_assert(offsetof(FirstSegHdr, head) == 0, "FirstSegHdr head is not aligned");
 static_assert(offsetof(NextSegHdr, head) == 0, "FirstSegHdr head is not aligned");
 static_assert(offsetof(CommonSegHdr, head) == 0, "FirstSegHdr head is not aligned");
 /* Verify attached metadata to rax is aligned */
 static_assert(offsetof(rax, metadata) % sizeof(void*) == 0, "metadata field is not aligned in rax");
+/* Verify that EBucketPrecision is sizeof uint64_t */
+static_assert(sizeof(EBucketPrecision) == sizeof(uint64_t), "EBucketPrecision is not 64bit");
+/* Verify that ExpireMetaL3 aligned with ExpireMeta */
+static_assert(sizeof(ExpireMetaL3) == sizeof(ExpireMeta), "ExpireMetaL3 not aligned");
+static_assert(offsetof(ExpireMetaL3, expireIndexLo) == offsetof(ExpireMeta, expireTimeLo), "ExpireMetaL3 not aligned");
+static_assert(offsetof(ExpireMetaL3, expireIndexHi) == offsetof(ExpireMeta, expireTimeHi), "ExpireMetaL3 not aligned");
+static_assert(offsetof(ExpireMetaL3, expireTime) == offsetof(ExpireMeta, next), "ExpireMetaL3 not aligned");
 
 /* EBucketNew - Indicates the caller to create a new bucket following the addition
  * of another item to a bucket (either single-segment or extended-segment). */
@@ -166,12 +224,16 @@ static inline eItem ebGetListPtr(EbucketsType *type, ebuckets eb) {
         return (void*)((uintptr_t)(eb) & ~1);
 }
 
+static inline void ebSetMetaL3Index(ExpireMetaL3 *em3, uint64_t idx) { 
+    ebSetMetaExpTime( (ExpireMeta *)em3, idx); 
+}
+
 /* Converts the logical starting time value of a given bucket-key to its equivalent
  * "physical" value in the context of an rax tree (rax-key). Although their values
  * are the same, their memory layouts differ. The raxKey layout orders bytes in
- * memory is from the MSB to the LSB, and the length of the key is EB_KEY_SIZE. */
-static inline void bucketKey2RaxKey(uint64_t bucketKey, unsigned char *raxKey) {
-    for (int i = EB_KEY_SIZE-1; i >= 0; --i) {
+ * memory is from the MSB to the LSB, and the length of the key is "t->keySize" */
+static inline void bucketKey2RaxKey(uint64_t bucketKey, unsigned char *raxKey, const EbucketsType *t) {
+    for (int i = t->ebp.keySize-1; i >= 0; --i) {
         raxKey[i] = (unsigned char) (bucketKey & 0xFF);
         bucketKey >>= 8;
     }
@@ -180,11 +242,11 @@ static inline void bucketKey2RaxKey(uint64_t bucketKey, unsigned char *raxKey) {
 /* Converts the "physical" value of rax-key to its logical counterpart, representing
  * the starting time value of a bucket. The values are equivalent, but their memory
  * layouts differ. The raxKey is assumed to be ordered from the MSB to the LSB with
- * a length of EB_KEY_SIZE. The resulting bucket-key is the logical representation
+ * a length of "t->keySize". The resulting bucket-key is the logical representation
  * with respect to ebuckets. */
-static inline uint64_t raxKey2BucketKey(unsigned char *raxKey) {
+static inline uint64_t raxKey2BucketKey(unsigned char *raxKey, const EbucketsType *t) {
     uint64_t bucketKey = 0;
-    for (int i = 0; i < EB_KEY_SIZE ; ++i)
+    for (unsigned int i = 0; i < t->ebp.keySize ; ++i)
         bucketKey = (bucketKey<<8) + raxKey[i];
     return bucketKey;
 }
@@ -303,11 +365,11 @@ static int ebTrySegSplit(EbucketsType *type, FirstSegHdr *seg, EBucketNew *newBu
     for (int i = 0 ; i < EB_SEG_MAX_ITEMS-1 ; i++) {
         //printf ("i=%d\n", i);
         mNext = type->getExpireMeta(mIter->next);
-        if (EB_BUCKET_KEY(ebGetMetaExpTime(mNext)) > EB_BUCKET_KEY(
-                                                         ebGetMetaExpTime(mIter))) {
+        if (EB_BUCKET_KEY(ebGetMetaExpTime(mNext), type) >
+            EB_BUCKET_KEY(ebGetMetaExpTime(mIter), type)) {
             /* If found better middle index before reaching halfway, save it */
             if (i < (EB_SEG_MAX_ITEMS/2)) {
-                splitKey = EB_BUCKET_KEY(ebGetMetaExpTime(mNext));
+                splitKey = EB_BUCKET_KEY(ebGetMetaExpTime(mNext), type);
                 bestMiddleIndex = i;
                 mLastItemFirstPart = mIter;
                 mFirstItemSecondPart = mNext;
@@ -316,7 +378,7 @@ static int ebTrySegSplit(EbucketsType *type, FirstSegHdr *seg, EBucketNew *newBu
             } else {
                 /* after crossing the middle need only to look for the first diff */
                 if (minMidDist > (i + 1 - EB_SEG_MAX_ITEMS / 2)) {
-                    splitKey = EB_BUCKET_KEY(ebGetMetaExpTime(mNext));
+                    splitKey = EB_BUCKET_KEY(ebGetMetaExpTime(mNext), type);
                     bestMiddleIndex = i;
                     mLastItemFirstPart = mIter;
                     mFirstItemSecondPart = mNext;
@@ -356,9 +418,9 @@ static int ebTrySegSplit(EbucketsType *type, FirstSegHdr *seg, EBucketNew *newBu
 
 /* Return 1 if managed to expire the entire segment. Returns 0 otherwise. */
 int ebSingleSegExpire(FirstSegHdr *firstSegHdr,
-                             EbucketsType *type,
-                             ExpireInfo *info,
-                             eItem *updateList)
+                      EbucketsType *type,
+                      ExpireInfo *info,
+                      eItem *updateList)
 {
     uint64_t itemExpTime;
     eItem iter = firstSegHdr->head;
@@ -375,7 +437,8 @@ int ebSingleSegExpire(FirstSegHdr *firstSegHdr,
 
         /* keep aside next before deletion of iter */
         eItem next = mIter->next;
-        mIter->trash = 1;
+        int storedInTmp = mIter->storedIn;
+        mIter->storedIn = EB_STORED_IN_TRASH;
         ExpireAction act = info->onExpireItem(iter, info->ctx);
 
         /* if (act == ACT_REMOVE_EXP_ITEM)
@@ -383,7 +446,7 @@ int ebSingleSegExpire(FirstSegHdr *firstSegHdr,
 
         /* If indicated to stop then break (cb didn't delete the item) */
         if (act == ACT_STOP_ACTIVE_EXP) {
-            mIter->trash = 0;
+            mIter->storedIn = storedInTmp;
             break;
         }
 
@@ -449,7 +512,8 @@ static int ebSegExpire(FirstSegHdr *firstSegHdr,
 
             /* keep aside `next` before removing `iter` by onExpireItem */
             eItem next = mIter->next;
-            mIter->trash = 1;
+            int storedInTmp = mIter->storedIn;
+            mIter->storedIn = EB_STORED_IN_TRASH;
             ExpireAction act = info->onExpireItem(iter, info->ctx);
 
             /* if (act == ACT_REMOVE_EXP_ITEM)
@@ -457,7 +521,7 @@ static int ebSegExpire(FirstSegHdr *firstSegHdr,
 
             /* If indicated to stop then break (callback didn't delete the item) */
             if (act == ACT_STOP_ACTIVE_EXP) {
-                mIter->trash = 0;
+                mIter->storedIn = storedInTmp;
                 break;
             }
 
@@ -535,17 +599,17 @@ static rax *ebConvertListToRax(eItem listHead, EbucketsType *type) {
 
     /* update last item to point on the segment header */
     ExpireMeta *metaItem = type->getExpireMeta(listHead);
-    uint64_t bucketKey = EB_BUCKET_KEY(ebGetMetaExpTime(metaItem));
+    uint64_t bucketKey = EB_BUCKET_KEY(ebGetMetaExpTime(metaItem), type);
     while (metaItem->lastItemBucket == 0)
         metaItem = type->getExpireMeta(metaItem->next);
     metaItem->next = firstSegHdr;
 
     /* Use min expire-time for the first segment in rax */
-    unsigned char raxKey[EB_KEY_SIZE];
-    bucketKey2RaxKey(bucketKey, raxKey);
+    unsigned char raxKey[6 /* max keySize */];
+    bucketKey2RaxKey(bucketKey, raxKey, type);
     rax *rax = raxNewWithMetadata(sizeof(uint64_t));
     *ebRaxNumItems(rax) = EB_LIST_MAX_ITEMS;
-    raxInsert(rax, raxKey, EB_KEY_SIZE, firstSegHdr, NULL);
+    raxInsert(rax, raxKey, type->ebp.keySize, firstSegHdr, NULL);
     return rax;
 }
 
@@ -664,11 +728,55 @@ static int ebRemoveFromList(ebuckets *eb, EbucketsType *type, eItem item) {
     return 0; /* not removed */
 }
 
-/* return 1 if none left. Otherwise return 0 */
-static int ebListExpire(ebuckets *eb,
-                        EbucketsType *type,
-                        ExpireInfo *info,
-                        eItem *updateList)
+static void ebRaxExpire(ebuckets *eb, EbucketsType *type, ExpireInfo *info, eItem *updateList) {
+    rax *rax = ebGetRaxPtr(*eb);
+    raxIterator iter;
+
+    raxStart(&iter, rax);
+
+    uint64_t nowKey = EB_BUCKET_KEY(info->now, type);
+    uint64_t itemsExpiredBefore = info->itemsExpired;
+
+    while (1) {
+        raxSeek(&iter,"^",NULL,0);
+        if (!raxNext(&iter)) break;
+
+        uint64_t bucketKey = raxKey2BucketKey(iter.key, type);
+
+        FirstSegHdr *firstSegHdr = iter.data;
+
+        /* We need to take into consideration bucketPrecision. The value of
+         * "info->now" will be adjusted to lookup only for all buckets with assigned
+         * keys that are older than 1<<bucketPrecision msec ago. That is, it
+         * is needed to visit only the buckets with keys that are "<" than:
+         * EB_BUCKET_KEY(info->now, type). */
+        if (bucketKey >= nowKey) {
+            /* Take care to update next expire time based on next segment to expire */
+            info->nextExpireTime = ebGetMetaExpTime(
+                    type->getExpireMeta(firstSegHdr->head));
+            break;
+        }
+
+        /* If not managed to remove entire bucket then return */
+        if (ebSegExpire(firstSegHdr, type, info, updateList) == 0)
+            break;
+
+        raxRemove(iter.rt, iter.key, type->ebp.keySize, NULL);
+    }
+
+    raxStop(&iter);
+    *ebRaxNumItems(rax) -= info->itemsExpired - itemsExpiredBefore;
+
+    if(raxEOF(&iter) && (*updateList == 0)) {
+        raxFree(rax);
+        *eb = NULL;
+    }
+}
+
+static void ebListExpire(ebuckets *eb,
+                         EbucketsType *type,
+                         ExpireInfo *info,
+                         eItem *updateList)
 {
     uint32_t expired = 0;
     eItem item = ebGetListPtr(type, *eb);
@@ -681,7 +789,8 @@ static int ebListExpire(ebuckets *eb,
 
         /* Items are arranged in ascending expire-time order in a list. Stops list
          * active expiration when an item's expiration time is greater than `now`. */
-        if (itemExpTime > info->now)
+////////        if (itemExpTime > info->now)
+        if (itemExpTime >= info->now)
             break;
 
         if (info->itemsExpired == info->maxToExpire)
@@ -689,7 +798,8 @@ static int ebListExpire(ebuckets *eb,
 
         /* keep aside `next` before removing `iter` by onExpireItem */
         eItem *next = metaItem->next;
-        metaItem->trash = 1;
+        int storedInTmp = metaItem->storedIn;
+        metaItem->storedIn = EB_STORED_IN_TRASH;
         ExpireAction act = info->onExpireItem(item, info->ctx);
 
         /* if (act == ACT_REMOVE_EXP_ITEM)
@@ -697,7 +807,7 @@ static int ebListExpire(ebuckets *eb,
 
         /* If indicated to stop then break (cb didn't delete the item) */
         if (act == ACT_STOP_ACTIVE_EXP) {
-            metaItem->trash = 0;
+            metaItem->storedIn = storedInTmp;
             break;
         }
 
@@ -716,14 +826,13 @@ static int ebListExpire(ebuckets *eb,
     if (expired == numItems) {
         *eb = NULL;
         info->nextExpireTime = EB_EXPIRE_TIME_INVALID;
-        return 1;
+        return;
     }
 
     metaItem->numItems = numItems - expired;
     metaItem->firstItemBucket = 1;
     info->nextExpireTime = ebGetMetaExpTime(metaItem);
     *eb = ebMarkAsList(item);
-    return 0;
 }
 
 /* Validate the general structure of the list */
@@ -804,7 +913,7 @@ static int ebBucketPrint(uint64_t bucketKey, EbucketsType *type, FirstSegHdr *fi
     iter = firstSeg->head;
     mHead = type->getExpireMeta(iter);
 
-    printf("Bucket(key=%06" PRIu64 ",tot=%04d,sgs=%04d) :", bucketKey, firstSeg->totalItems, firstSeg->numSegs);
+    printf("Bucket(key=0x%06" PRIx64 ",tot=%04d,sgs=%04d) :", bucketKey, firstSeg->totalItems, firstSeg->numSegs);
     while (1) {
         mIter = type->getExpireMeta(iter);  /* not really needed. Just to hash the compiler */
         printf("    [");
@@ -813,15 +922,15 @@ static int ebBucketPrint(uint64_t bucketKey, EbucketsType *type, FirstSegHdr *fi
             uint64_t expireTime = ebGetMetaExpTime(mIter);
 
             if (i == 0 && PRINT_EXPIRE_META_FLAGS)
-                printf("%" PRIu64 "<n=%d,f=%d,ls=%d,lb=%d>, ",
+                printf("0x%" PRIx64 "<n=%d,f=%d,ls=%d,lb=%d>, ",
                        expireTime, mIter->numItems, mIter->firstItemBucket,
                        mIter->lastInSegment, mIter->lastItemBucket);
             else if (i == (mHead->numItems - 1) && PRINT_EXPIRE_META_FLAGS) {
-                printf("%" PRIu64 "<n=%d,f=%d,ls=%d,lb=%d>",
+                printf("0x%" PRIx64 "<n=%d,f=%d,ls=%d,lb=%d>",
                        expireTime, mIter->numItems, mIter->firstItemBucket,
                        mIter->lastInSegment, mIter->lastItemBucket);
             } else
-                printf("%" PRIu64 "%s", expireTime, (i == mHead->numItems - 1) ? "" : ", ");
+                printf("0x%" PRIx64 "%s", expireTime, (i == mHead->numItems - 1) ? "" : ", ");
 
             iter = mIter->next;
         }
@@ -871,7 +980,7 @@ static int ebAddToBucket(EbucketsType *type,
              * after the split, bucket-key of `newBucket` is bigger than bucket-key of
              * `firstSegBkt`. That is `firstSegBkt` preserves its bucket-key value
              * (and its location in rax tree) before the split */
-            if (EB_BUCKET_KEY(ebGetMetaExpTime(type->getExpireMeta(item))) < newBucket->ebKey) {
+            if (EB_BUCKET_KEY(ebGetMetaExpTime(type->getExpireMeta(item)), type) < newBucket->ebKey) {
                 return ebSegAddAvail(type, firstSegBkt, item);
             } else {
                 /* Add the `item` to the new bucket */
@@ -897,8 +1006,8 @@ static int ebAddToBucket(EbucketsType *type,
     ExpireMeta *mHead = type->getExpireMeta(firstSegBkt->head);
     ExpireMeta *mItem = type->getExpireMeta(item);
 
-    uint64_t bucketKey = EB_BUCKET_KEY(ebGetMetaExpTime(mHead)); /* same for all items in the segment */
-    uint64_t itemKey = EB_BUCKET_KEY(ebGetMetaExpTime(mItem));
+    uint64_t bucketKey = EB_BUCKET_KEY(ebGetMetaExpTime(mHead), type); /* same for all items in the segment */
+    uint64_t itemKey = EB_BUCKET_KEY(ebGetMetaExpTime(mItem), type);
 
     if (bucketKey == itemKey) {
         /* New item has the same bucket-key as the ones in this bucket, Add it as well */
@@ -923,7 +1032,7 @@ static int ebAddToBucket(EbucketsType *type,
         if (bucketKey > itemKey)
             *updateBucketKey = bucketKey;
 
-        ebNewBucket(type, newBucket, item, EB_BUCKET_KEY(ebGetMetaExpTime(mItem)));
+        ebNewBucket(type, newBucket, item, EB_BUCKET_KEY(ebGetMetaExpTime(mItem), type));
         return 0;
     }
 }
@@ -947,9 +1056,9 @@ static int ebRemoveFromRax(ebuckets *eb, EbucketsType *type, eItem item) {
     if (unlikely(mItem->firstItemBucket && mItem->lastItemBucket)) {
         raxIterator ri;
         raxStart(&ri, rax);
-        unsigned char raxKey[EB_KEY_SIZE];
-        bucketKey2RaxKey(EB_BUCKET_KEY(ebGetMetaExpTime(mItem)), raxKey);
-        raxSeek(&ri, "<=", raxKey, EB_KEY_SIZE);
+        unsigned char raxKey[6 /* max keySize */];
+        bucketKey2RaxKey(EB_BUCKET_KEY(ebGetMetaExpTime(mItem), type), raxKey, type);
+        raxSeek(&ri, "<=", raxKey, type->ebp.keySize);
 
         if (raxNext(&ri) == 0)
             return 0; /* not removed */
@@ -960,7 +1069,7 @@ static int ebRemoveFromRax(ebuckets *eb, EbucketsType *type, eItem item) {
             return 0; /* not removed */
 
         zfree(segHdr);
-        raxRemove(ri.rt, ri.key, EB_KEY_SIZE, NULL);
+        raxRemove(ri.rt, ri.key, type->ebp.keySize, NULL);
         raxStop(&ri);
 
         /* If last bucket in rax, then delete the rax */
@@ -1122,14 +1231,205 @@ static int ebRemoveFromRax(ebuckets *eb, EbucketsType *type, eItem item) {
     return 1; /* removed */
 }
 
+static int ebRemoveFromStack(ebuckets *eb, EbucketsType *type, eItem item) {
+    int res;
+    ebStack *stack = (ebStack *)*eb;
+    ExpireMeta *metaItem = type->getExpireMeta(item);
+    if (metaItem->storedIn == EB_STORED_IN_EB) {
+        EB_STACK_EXEC_L1(type, res = ebRemove(&stack->l1, type, item));
+    } if (metaItem->storedIn == EB_STORED_IN_EB_L2) {
+        EB_STACK_EXEC_L2(type, res = ebRemove(&stack->l2, type, item));
+    } else if (metaItem->storedIn == EB_STORED_IN_EB_L3) {
+        ExpireMetaL3 *m = (ExpireMetaL3 *) metaItem;
+        uint64_t idx = m->expireIndexLo | ((uint64_t) m->expireIndexHi << 32);
+        debugAssert(stack->l3 && idx < stack->l3->items && stack->l3->vec[idx] == item);
+        if (idx < stack->l3->items - 1) {
+            /* Move last item in the vector to the place of the removed item */
+            eItem another = stack->l3->vec[stack->l3->items - 1];
+            stack->l3->vec[idx] = another;
+            /* Update expireMeta of the moved item */
+            ebSetMetaL3Index((ExpireMetaL3 *) type->getExpireMeta(another), idx);
+        }
+
+        /* Free or shrink L3 vector if needed */
+        if (--stack->l3->items == 0) {
+            zfree(stack->l3);
+            stack->l3 = NULL;
+        } else if (stack->l3->items < stack->l3->vecSize / 4) {
+            uint64_t newSize = stack->l3->vecSize / 2;
+            stack->l3 = zrealloc(stack->l3, EB_STACK_L3_SIZEOF(newSize));
+            stack->l3->vecSize = newSize;
+        }
+        res = 1;
+    }
+    
+    /* Free stack if L1, L2 and L3 are empty (then ebuckets must be NULL) */
+    if (--stack->items == 0) {
+        zfree(stack);
+        *eb = NULL;
+    }
+
+    return res;
+}
+
+
+
+
+/* Add another eItem to ebStack and based on commandTimeSnapshot() determines
+ * if it should be added to L1, L2. */
+int ebAddToStack(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTime) {
+    ebStack *stack;
+    int result = 0;
+    /* Initialize ebStack if it doesn't exist */
+    if (unlikely(ebIsEmpty(*eb))) {
+        stack = zmalloc(sizeof(ebStack));
+        stack->items = 0;
+        stack->l1 = ebCreate();
+        stack->l2 = ebCreate();
+        stack->l3 = NULL;
+        *eb = stack;
+    }
+    stack = (ebStack *)*eb;
+
+    ExpireMeta *itemMeta = type->getExpireMeta(item);
+    
+    debugAssert(itemMeta->storedIn == EB_STORED_IN_TRASH);
+
+    /* If ebStack level 3 (infinity) */
+    if (unlikely(expireTime > EB_EXPIRE_TIME_MAX)) {
+        // TODO_MOTI: Need to change EB_EXPIRE_TIME_INVALID to be 0 and MAX to be 2^64-1
+        //assert(expireTime <= EB_EXPIRE_TIME_MAX);
+      
+        /* init or expand the l3 if needed */
+        if (stack->l3 == NULL) {
+            stack->l3 = zmalloc(EB_STACK_L3_SIZEOF(2));
+            stack->l3->items = 0;
+            stack->l3->vecSize = 2;
+        } else if (stack->l3->items == stack->l3->vecSize) {
+            /* Expand vector (power of 2) */
+            uint64_t newSize = stack->l3->vecSize * 2;
+            stack->l3 = zrealloc(stack->l3, EB_STACK_L3_SIZEOF(newSize));
+            stack->l3->vecSize = newSize;
+        }
+
+        /* Store index of new item in its expireMeta */
+        ebSetMetaL3Index(((ExpireMetaL3 *) itemMeta) , stack->l3->items);
+        itemMeta->storedIn = EB_STORED_IN_EB_L3;
+
+        /* Add item to infinity vector */
+        stack->l3->vec[stack->l3->items++] = item;
+        stack->items++;
+        return 0;
+    }
+
+    /* Determine which level to add the item to based on bucket key precision */
+    uint64_t now = commandTimeSnapshot();
+    uint64_t nowL2BucketKey = now >> ebpStackL2.precision;
+    uint64_t itemL2BucketKey = expireTime >> ebpStackL2.precision;
+
+    /* If ebStack level 1 */
+    if (itemL2BucketKey <= (nowL2BucketKey + 1)) {
+        EB_STACK_EXEC_L1(type, result = ebAdd(&stack->l1, type, item, expireTime));
+        if (result == 0)
+            stack->items++;
+        return result;
+    } else {
+        /* If ebStack level 2 */
+        EB_STACK_EXEC_L2(type, result = ebAdd(&stack->l2, type, item, expireTime));
+        if (result == 0) {
+            itemMeta->storedIn = EB_STORED_IN_EB_L2; /* override */
+            stack->items++;
+        }
+        return result;
+    }
+}
+
+typedef struct ebCascadeCtx {
+    ebuckets *l1;
+    EbucketsType l1Type;
+} ebCascadeCtx;
+
+/* Callback for ebExpire() to cascade items from L2 to L1 */
+static ExpireAction onCascadeItem(eItem item, void *ctx) {
+    ebCascadeCtx *cc = (ebCascadeCtx *) ctx;
+
+    ExpireMeta *itemMeta = cc->l1Type.getExpireMeta(item);
+    uint64_t expireTime = ebGetMetaExpTime(itemMeta);
+
+    /* If adding to L1 failed, then stop */
+    if (ebAdd(cc->l1, &cc->l1Type, item, expireTime) != 0)
+        return ACT_STOP_ACTIVE_EXP;
+
+    /* Update storage location from L2 to L1 */
+    itemMeta->storedIn = EB_STORED_IN_EB;
+
+    return ACT_REMOVE_EXP_ITEM;
+}
+
+/**
+ * Cascades items from Level 2 (L2) to Level 1 (L1)
+ *
+ * This function should be called periodically to promote items that are approaching
+ * expiration in L2 and require higher precision tracking in L1.
+ *
+ * The cascade threshold is calculated as:
+ *     now + (2 << ebStackL2Precision)
+ *
+ * This defines a time boundary starting from the current time (`now`), extended by
+ * the duration of two L2 buckets. Any items in L2 with expiration times less than or
+ * equal to this threshold are considered eligible for cascading into L1.
+ *
+ * With hardcoded ebStackL2Precision = 21 (i.e., 2^21 ms = ~34.9 minutes):
+ * - L2 buckets that are less or equal to `now + (1 << ebStackL2Precision)`(=~34.9min) 
+ *   will be cascaded to L1 with corresponding TTLs ranges ~35min-70min
+ *
+ * This staging provides ample time to cascade all items in such segments before expiration.
+ *
+ * @param eb - Pointer to the ebuckets handler (must be an ebStack)
+ * @param type - Pointer to the EbucketsType structure (must describe an ebStack)
+ * @param now - Current logical time
+ * @param maxCascade - Maximum number of items to cascade in this invocation
+ *
+ * @return Number of items cascaded from L2 to L1
+ */
+uint64_t ebCascade(ebuckets *eb, EbucketsType *type, uint64_t now, uint64_t maxCascade)
+{
+    /* If empty, not ebStack, or L2 is empty, then nothing to cascade */
+    if (ebIsEmpty(*eb) || !type->isEbStack || ebIsEmpty(((ebStack *)*eb)->l2))
+        return 0;
+
+    ebStack *stack = (ebStack *)*eb;
+
+    /* Use iterator to traverse L2 and find items to cascade */
+    ebCascadeCtx ctx;
+    ctx.l1 = &stack->l1;
+    ctx.l1Type = *type;
+    ctx.l1Type.isEbStack = 0; /* L1 is not hierarchical */
+
+    /* Calculate cascade threshold */
+    uint64_t cascadeThreshold = now + (2 << ebpStackL2.precision);
+
+    /* Reuse ebExpire() to cascade items from L2 to L1 */
+    ExpireInfo info = {
+        .maxToExpire = maxCascade,
+        .onExpireItem = onCascadeItem,
+        .ctx = &ctx,
+        .now = cascadeThreshold,
+        .itemsExpired = 0
+    };
+
+    EB_STACK_EXEC_L2(type, ebExpire(&stack->l2, type, &info));
+    return info.itemsExpired; /* Number of items cascaded */
+}
+
 int ebAddToRax(ebuckets *eb, EbucketsType *type, eItem item, uint64_t bucketKeyItem) {
     EBucketNew newBucket; /* ebAddToBucket takes care to update newBucket.segment.head */
     raxIterator iter;
-    unsigned char raxKey[EB_KEY_SIZE];
-    bucketKey2RaxKey(bucketKeyItem, raxKey);
+    unsigned char raxKey[6 /* max keySize */];
+    bucketKey2RaxKey(bucketKeyItem, raxKey, type);
     rax *rax = ebGetRaxPtr(*eb);
     raxStart(&iter,rax);
-    raxSeek(&iter, "<=", raxKey, EB_KEY_SIZE);
+    raxSeek(&iter, "<=", raxKey, type->ebp.keySize);
     *ebRaxNumItems(rax) += 1;
     /* If expireTime of the item is below the bucket-key of first bucket in rax,
      * then need to add it as a new bucket at the beginning of the rax. */
@@ -1146,8 +1446,8 @@ int ebAddToRax(ebuckets *eb, EbucketsType *type, eItem item, uint64_t bucketKeyI
         metaItem->firstItemBucket = 1;
         metaItem->numItems = 1;
         metaItem->next = firstSegHdr;
-        bucketKey2RaxKey(bucketKeyItem, raxKey);
-        raxInsert(rax, raxKey, EB_KEY_SIZE, firstSegHdr, NULL);
+        bucketKey2RaxKey(bucketKeyItem, raxKey, type);
+        raxInsert(rax, raxKey, type->ebp.keySize, firstSegHdr, NULL);
         raxStop(&iter);
         return 0;
     }
@@ -1157,10 +1457,10 @@ int ebAddToRax(ebuckets *eb, EbucketsType *type, eItem item, uint64_t bucketKeyI
     ebAddToBucket(type, iter.data, item, &newBucket, &updateBucketKey);
 
     /* If following the addition need to `updateBucketKey` of `foundBucket` in rax */
-    if(unlikely(updateBucketKey && updateBucketKey != raxKey2BucketKey(iter.key))) {
-        raxRemove(iter.rt, iter.key, EB_KEY_SIZE, NULL);
-        bucketKey2RaxKey(updateBucketKey, raxKey);
-        raxInsert(iter.rt, raxKey, EB_KEY_SIZE, iter.data, NULL);
+    if(unlikely(updateBucketKey && updateBucketKey != raxKey2BucketKey(iter.key, type))) {
+        raxRemove(iter.rt, iter.key, type->ebp.keySize, NULL);
+        bucketKey2RaxKey(updateBucketKey, raxKey, type);
+        raxInsert(iter.rt, raxKey, type->ebp.keySize, iter.data, NULL);
     }
 
     /* If ebAddToBucket() returned a new bucket, then add the bucket to rax.
@@ -1178,8 +1478,8 @@ int ebAddToRax(ebuckets *eb, EbucketsType *type, eItem item, uint64_t bucketKeyI
         /* Update 'next' of last item in segment to point to 'FirstSegHdr` */
         newBucket.mLast->next = newSeg;
         /* Insert the new bucket to rax */
-        bucketKey2RaxKey(newBucket.ebKey, raxKey);
-        raxInsert(iter.rt, raxKey, EB_KEY_SIZE, newSeg, NULL);
+        bucketKey2RaxKey(newBucket.ebKey, raxKey, type);
+        raxInsert(iter.rt, raxKey, type->ebp.keySize, newSeg, NULL);
     }
 
     raxStop(&iter);
@@ -1210,7 +1510,7 @@ static void ebValidateRax(rax *rax, EbucketsType *type) {
             for (int i = 0; i < mHead->numItems ; ++i) {
                 assert(iter != NULL);
                 mIter = type->getExpireMeta(iter);
-                curBktKey = EB_BUCKET_KEY(ebGetMetaExpTime(mIter));
+                curBktKey = EB_BUCKET_KEY(ebGetMetaExpTime(mIter), type);
 
                 if (i == 0) {
                     assert(mIter->numItems > 0 && mIter->numItems <= EB_SEG_MAX_ITEMS);
@@ -1273,7 +1573,7 @@ void ebRaxDeleteCb(void *item, void *context) {
         for (uint32_t i = 0; i < numItemsInSeg ; ++i) {
             mIter = ctx->type->getExpireMeta(itemIter);
             eItem toDelete = itemIter;
-            mIter->trash = 1;
+            mIter->storedIn = EB_STORED_IN_TRASH;
             itemIter = mIter->next;
             if (ctx->type->onDeleteItem) ctx->type->onDeleteItem(toDelete, &ctx->userCtx);
         }
@@ -1283,66 +1583,6 @@ void ebRaxDeleteCb(void *item, void *context) {
             itemIter = ((NextSegHdr *) nextSegHdr)->head;
     }
 
-}
-
-static void _ebPrint(ebuckets eb, EbucketsType *type, int64_t usedMem, int printItems) {
-    if (ebIsEmpty(eb)) {
-        printf("Empty ebuckets\n");
-        return;
-    }
-
-    if (ebIsList(eb)) {
-        /* mock rax segment */
-        eItem head = ebGetListPtr(type, eb);
-        ExpireMeta *metaHead = type->getExpireMeta(head);
-        FirstSegHdr mockSeg = { head, metaHead->numItems, 1};
-        if (printItems)
-            ebBucketPrint(0, type, &mockSeg);
-        return;
-    }
-
-    uint64_t totalItems = 0;
-    uint64_t numBuckets = 0;
-    uint64_t numSegments = 0;
-
-    rax *rax = ebGetRaxPtr(eb);
-    raxIterator iter;
-    raxStart(&iter, rax);
-    raxSeek(&iter, "^", NULL, 0);
-    while (raxNext(&iter)) {
-        FirstSegHdr *seg = iter.data;
-        if (printItems)
-            ebBucketPrint(raxKey2BucketKey(iter.key), type, seg);
-        totalItems += seg->totalItems;
-        numBuckets++;
-        numSegments += seg->numSegs;
-    }
-
-    printf("Total number of items              : %" PRIu64 "\n", totalItems);
-    printf("Total number of buckets            : %" PRIu64 "\n", numBuckets);
-    printf("Total number of segments           : %" PRIu64 "\n", numSegments);
-    printf("Average items per bucket           : %.2f\n",
-           (double) totalItems / numBuckets);
-    printf("Average items per segment          : %.2f\n",
-           (double) totalItems / numSegments);
-    printf("Average segments per bucket        : %.2f\n",
-           (double) numSegments / numBuckets);
-
-    if (usedMem != -1)
-    {
-        printf("\nEbuckets memory usage (including FirstSegHdr/NexSegHdr):\n");
-        printf("Total                              : %.2f KBytes\n",
-               (double) usedMem / 1024);
-        printf("Average per bucket                 : %" PRIu64 " Bytes\n",
-               usedMem / numBuckets);
-        printf("Average per item                   : %" PRIu64 " Bytes\n",
-               usedMem / totalItems);
-        printf("EB_BUCKET_KEY_PRECISION            : %d\n",
-               EB_BUCKET_KEY_PRECISION);
-        printf("EB_SEG_MAX_ITEMS                   : %d\n",
-               EB_SEG_MAX_ITEMS);
-    }
-    raxStop(&iter);
 }
 
 /*** API functions ***/
@@ -1358,14 +1598,28 @@ void ebDestroy(ebuckets *eb, EbucketsType *type, void *ctx) {
     if (ebIsEmpty(*eb))
         return;
 
-    if (ebIsList(*eb)) {
+    if (type->isEbStack) {
+        ebStack *stack = (ebStack *) *eb;
+        EB_STACK_EXEC_L1(type, ebDestroy(&stack->l1, type, ctx));
+        EB_STACK_EXEC_L2(type, ebDestroy(&stack->l2, type, ctx));
+        if (stack->l3) {
+            for (uint64_t i = 0; i < stack->l3->items; i++) {
+                eItem toDelete = stack->l3->vec[i];
+                ExpireMeta *metaToDelete = type->getExpireMeta(toDelete);
+                metaToDelete->storedIn = EB_STORED_IN_TRASH;
+                if (type->onDeleteItem) type->onDeleteItem(toDelete, ctx);
+            }
+            zfree(stack->l3);
+        }
+        zfree(stack);
+    } else if (ebIsList(*eb)) {
         eItem head = ebGetListPtr(type, *eb);
         eItem *pItemNext = &head;
         while ( (*pItemNext) != NULL) {
             eItem toDelete = *pItemNext;
             ExpireMeta *metaToDelete = type->getExpireMeta(toDelete);
             *pItemNext = metaToDelete->next;
-            metaToDelete->trash = 1;
+            metaToDelete->storedIn = EB_STORED_IN_TRASH;
             if (type->onDeleteItem) type->onDeleteItem(toDelete, ctx);
         }
     } else {
@@ -1390,19 +1644,20 @@ void ebDestroy(ebuckets *eb, EbucketsType *type, void *ctx) {
  * @return 1 if the item was successfully removed; otherwise, return 0.
  */
 int ebRemove(ebuckets *eb, EbucketsType *type, eItem item) {
-
+    int res;
     if (ebIsEmpty(*eb))
         return 0; /* not removed */
-
-    int res;
-    if (ebIsList(*eb))
+        
+    if (type->isEbStack)
+        res = ebRemoveFromStack(eb, type, item);
+    else if (ebIsList(*eb))
         res = ebRemoveFromList(eb, type, item);
     else  /* rax */
         res = ebRemoveFromRax(eb, type, item);
 
     /* if removed then mark as trash */
     if (res)
-        type->getExpireMeta(item)->trash = 1;
+        type->getExpireMeta(item)->storedIn = EB_STORED_IN_TRASH;
 
     EB_VALIDATE_STRUCTURE(*eb, type);
 
@@ -1425,6 +1680,8 @@ int ebRemove(ebuckets *eb, EbucketsType *type, eItem item) {
  */
 int ebAdd(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTime) {
     int res;
+    if (type->isEbStack)
+        return ebAddToStack(eb, type, item, expireTime);
 
     assert(expireTime <= EB_EXPIRE_TIME_MAX);
 
@@ -1435,18 +1692,18 @@ int ebAdd(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTime) {
     itemMeta->firstItemBucket = 0;
     itemMeta->lastItemBucket = 0;
     itemMeta->numItems = 0;
-    itemMeta->trash = 0;
+    itemMeta->storedIn = EB_STORED_IN_EB;
 
     if (ebIsList(*eb) || (ebIsEmpty(*eb))) {
         /* Try add item to list */
         if ( (res = ebAddToList(eb, type, item)) == 1) {
             /* Failed to add since list reached maximum size. Convert to rax */
             *eb = ebConvertListToRax(ebGetListPtr(type, *eb), type);
-            res = ebAddToRax(eb, type, item, EB_BUCKET_KEY(expireTime));
+            res = ebAddToRax(eb, type, item, EB_BUCKET_KEY(expireTime, type));
         }
     } else {
         /* Add item to rax */
-        res = ebAddToRax(eb, type, item, EB_BUCKET_KEY(expireTime));
+        res = ebAddToRax(eb, type, item, EB_BUCKET_KEY(expireTime, type));
     }
 
     EB_VALIDATE_STRUCTURE(*eb, type);
@@ -1456,7 +1713,7 @@ int ebAdd(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTime) {
 
 /**
  * Performs expiration on the given ebucket, removing items that have expired.
- *
+ * Only buckets with keys < EB_BUCKET_KEY(info->now, type) are considered expired.
  * If all items in the data structure are expired, 'eb' will be set to NULL.
  *
  * @param eb - Pointer to the ebuckets handler, which may get updated
@@ -1464,6 +1721,13 @@ int ebAdd(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTime) {
  * @param info - Providing information about the expiration action.
  */
 void ebExpire(ebuckets *eb, EbucketsType *type, ExpireInfo *info) {
+
+    if (type->isEbStack) {
+        /* Only items from L1 get expired */
+        EB_STACK_EXEC_L1(type, ebExpire(&((ebStack *)*eb)->l1, type, info));
+        return;
+    }
+
     /* updateList - maintain a list of expired items that the callback `onExpireItem`
      * indicated to update their expiration time rather than removing them.
      * At the end of this function, the items will be `ebAdd()` back.
@@ -1481,55 +1745,10 @@ void ebExpire(ebuckets *eb, EbucketsType *type, ExpireInfo *info) {
 
     if (ebIsList(*eb)) {
         ebListExpire(eb, type, info, &updateList);
-        goto END_ACTEXP;
+    } else {
+        ebRaxExpire(eb, type, info, &updateList);
     }
 
-    /* handle rax expiry */
-
-    rax *rax = ebGetRaxPtr(*eb);
-    raxIterator iter;
-
-    raxStart(&iter, rax);
-
-    uint64_t nowKey = EB_BUCKET_KEY(info->now);
-    uint64_t itemsExpiredBefore = info->itemsExpired;
-
-    while (1) {
-        raxSeek(&iter,"^",NULL,0);
-        if (!raxNext(&iter)) break;
-
-        uint64_t bucketKey = raxKey2BucketKey(iter.key);
-
-        FirstSegHdr *firstSegHdr = iter.data;
-
-        /* We need to take into consideration EB_BUCKET_KEY_PRECISION. The value of
-         * "info->now" will be adjusted to lookup only for all buckets with assigned
-         * keys that are older than 1<<EB_BUCKET_KEY_PRECISION msec ago. That is, it
-         * is needed to visit only the buckets with keys that are "<" than:
-         * EB_BUCKET_KEY(info->now). */
-        if (bucketKey >= nowKey) {
-            /* Take care to update next expire time based on next segment to expire */
-            info->nextExpireTime = ebGetMetaExpTime(
-                    type->getExpireMeta(firstSegHdr->head));
-            break;
-        }
-
-        /* If not managed to remove entire bucket then return */
-        if (ebSegExpire(firstSegHdr, type, info, &updateList) == 0)
-            break;
-
-        raxRemove(iter.rt, iter.key, EB_KEY_SIZE, NULL);
-    }
-
-    raxStop(&iter);
-    *ebRaxNumItems(rax) -= info->itemsExpired - itemsExpiredBefore;
-
-    if(raxEOF(&iter) && (updateList == 0)) {
-        raxFree(rax);
-        *eb = NULL;
-    }
-
-END_ACTEXP:
     /* Add back items with updated expiration time */
     while (updateList) {
         ExpireMeta *mItem = type->getExpireMeta(updateList);
@@ -1546,8 +1765,6 @@ END_ACTEXP:
     }
 
     EB_VALIDATE_STRUCTURE(*eb, type);
-
-    return;
 }
 
 /* Performs active expiration dry-run to evaluate number of expired items
@@ -1585,7 +1802,7 @@ uint64_t ebExpireDryRun(ebuckets eb, EbucketsType *type, uint64_t now) {
     rax *rax = ebGetRaxPtr(eb);
     raxIterator iter;
     raxStart(&iter, rax);
-    uint64_t nowKey = EB_BUCKET_KEY(now);
+    uint64_t nowKey = EB_BUCKET_KEY(now, type);
     raxSeek(&iter,"^",NULL,0);
     assert(raxNext(&iter)); /* must be at least one bucket */
     FirstSegHdr *currBucket = iter.data;
@@ -1596,7 +1813,7 @@ uint64_t ebExpireDryRun(ebuckets eb, EbucketsType *type, uint64_t now) {
         FirstSegHdr *nextBucket = iter.data;
 
         /* if 'nextBucket' is not less than now then break */
-        if (raxKey2BucketKey(iter.key) >= nowKey) break;
+        if (raxKey2BucketKey(iter.key, type) >= nowKey) break;
 
         /* nextBucket less than now. For sure all items in currBucket are expired */
         numExpired += currBucket->totalItems;
@@ -1621,7 +1838,7 @@ uint64_t ebExpireDryRun(ebuckets eb, EbucketsType *type, uint64_t now) {
     }
 
     /* Bucket key exactly reflect expiration time of all items (currBucket->numSegs > 1) */
-    if (EB_BUCKET_KEY_PRECISION == 0) {
+    if (type->ebp.precision == 0) {
         if (ebGetMetaExpTime(type->getExpireMeta(currBucket->head)) >= now)
             return numExpired;
         else
@@ -1632,7 +1849,7 @@ uint64_t ebExpireDryRun(ebuckets eb, EbucketsType *type, uint64_t now) {
 
     /* Unreachable code, provided for completeness. Following operation is not
      * bound in time and this is the main reason why we set above
-     * EB_BUCKET_KEY_PRECISION to 0 and have early return on previous condition */
+     * bucketPrecision to 0 and have early return on previous condition */
 
     ExpireMeta *mIter = type->getExpireMeta(currBucket->head);
     while(1) {
@@ -1652,19 +1869,21 @@ uint64_t ebExpireDryRun(ebuckets eb, EbucketsType *type, uint64_t now) {
 /**
  * Retrieves the expiration time of the item with the nearest expiration
  *
- * @param eb - The ebucket to be checked.
+ * @param eb - The ebucket to be checked (not ebStack)
  * @param type - Pointer to the EbucketsType structure defining the type of ebucket.
  *
  * @return The expiration time of the item with the nearest expiration time in
  *         the ebucket. If empty, return EB_EXPIRE_TIME_INVALID. If ebuckets is
  *         of type rax and minimal bucket is extended-segment, then it might not
- *         return accurate result up-to 1<<EB_BUCKET_KEY_PRECISION-1 msec (we
+ *         return accurate result up-to 1<<bucketPrecision-1 msec (we
  *         don't want to traverse the entire extended-segment since it might not
  *         bounded).
  */
 uint64_t ebGetNextTimeToExpire(ebuckets eb, EbucketsType *type) {
     if (ebIsEmpty(eb))
         return EB_EXPIRE_TIME_INVALID;
+
+    debugAssert(type->isEbStack == 0); /* Not required for now */
 
     if (ebIsList(eb))
         return ebGetMetaExpTime(type->getExpireMeta(ebGetListPtr(type, eb)));
@@ -1677,7 +1896,7 @@ uint64_t ebGetNextTimeToExpire(ebuckets eb, EbucketsType *type) {
     raxSeek(&iter, "^", NULL, 0);
     raxNext(&iter); /* seek to the last bucket */
     FirstSegHdr *firstSegHdr = iter.data;
-    if ((firstSegHdr->numSegs == 1) || (EB_BUCKET_KEY_PRECISION == 0)) {
+    if ((firstSegHdr->numSegs == 1) || (type->ebp.precision == 0)) {
         /* Single segment, or extended-segments that all have same expiration time.
          * return the first item with the nearest expiration time */
         minExpire = ebGetMetaExpTime(type->getExpireMeta(firstSegHdr->head));
@@ -1695,88 +1914,29 @@ uint64_t ebGetNextTimeToExpire(ebuckets eb, EbucketsType *type) {
          * other way around.
          */
         uint64_t expTime = ebGetMetaExpTime(type->getExpireMeta(firstSegHdr->head));
-        minExpire = expTime | ( (1<<EB_BUCKET_KEY_PRECISION)-1) ;
+        unsigned int mask = (1<<type->ebp.precision) - 1;
+        minExpire = (expTime+mask) & (~mask);
     }
     raxStop(&iter);
     return minExpire;
 }
 
-/**
- * Retrieves the expiration time of the item with the latest expiration
- *
- * However, precision loss (EB_BUCKET_KEY_PRECISION) in rax tree buckets
- * may result in slight inaccuracies, up to a variation of
- * 1<<EB_BUCKET_KEY_PRECISION msec.
- *
- * @param eb - The ebucket to be checked.
- * @param type - Pointer to the EbucketsType structure defining the type of ebucket.
- * @param accurate - If 1, then the function will return accurate result. Otherwise,
- *                   it might return the upper limit with slight inaccuracy of
- *                   1<<EB_BUCKET_KEY_PRECISION msec.
- *
- *                   This special case is relevant only when the last bucket
- *                   is of type extended-segment. In this case, we might don't
- *                   want to traverse the entire bucket to find the accurate
- *                   expiration time  since there might be unbounded number of
- *                   items in the extended-segment. If EB_BUCKET_KEY_PRECISION
- *                   is 0, then the function will return accurate result anyway.
- *
- * @return The expiration time of the item with the latest expiration time in
- *         the ebucket. If empty, return EB_EXPIRE_TIME_INVALID.
- */
-uint64_t ebGetMaxExpireTime(ebuckets eb, EbucketsType *type, int accurate) {
+/* Returns number of items in ebStack level (Level can be either 1, 2 or 3) */
+uint64_t ebStackItems(ebuckets eb, EbucketsType *type, int level) {
+    debugAssert(type->isEbStack);
+    uint64_t res = 0;
     if (ebIsEmpty(eb))
-        return EB_EXPIRE_TIME_INVALID;
-
-    if (ebIsList(eb)) {
-        eItem item = ebGetListPtr(type, eb);
-        ExpireMeta *em = type->getExpireMeta(item);
-        while (em->lastInSegment == 0)
-            em = type->getExpireMeta(em->next);
-        return ebGetMetaExpTime(em);
-    }
-
-    /* rax */
-    uint64_t maxExpire;
-    rax *rax = ebGetRaxPtr(eb);
-    raxIterator iter;
-    raxStart(&iter, rax);
-    raxSeek(&iter, "$", NULL, 0);
-    raxNext(&iter); /* seek to the last bucket */
-    FirstSegHdr *firstSegHdr = iter.data;
-    if (firstSegHdr->numSegs == 1) {
-        /* Single segment. return the last item with the highest expiration time */
-        ExpireMeta *em = type->getExpireMeta(firstSegHdr->head);
-        while (em->lastInSegment == 0)
-            em = type->getExpireMeta(em->next);
-        maxExpire = ebGetMetaExpTime(em);
-    } else if (EB_BUCKET_KEY_PRECISION == 0) {
-        /* Extended-segments that all have same expiration time */
-        maxExpire = ebGetMetaExpTime(type->getExpireMeta(firstSegHdr->head));
-    } else {
-        if (accurate == 0) {
-            /* return upper limit of the last bucket */
-            int mask = (1<<EB_BUCKET_KEY_PRECISION)-1;
-            uint64_t expTime = ebGetMetaExpTime(type->getExpireMeta(firstSegHdr->head));
-            maxExpire = (expTime + (mask+1)) & (~mask);
-        } else {
-            maxExpire = 0;
-            ExpireMeta *mIter = type->getExpireMeta(firstSegHdr->head);
-            while(1) {
-                while(1) {
-                    if (maxExpire < ebGetMetaExpTime(mIter))
-                        maxExpire = ebGetMetaExpTime(mIter);
-                    if (mIter->lastInSegment == 1) break;
-                    mIter = type->getExpireMeta(mIter->next);
-                }
-
-                if (mIter->lastItemBucket) break;
-                mIter = type->getExpireMeta(((NextSegHdr *) mIter->next)->head);
-            }
-        }
-    }
-    raxStop(&iter);
-    return maxExpire;
+        return 0;
+    ebStack *stack = (ebStack *) eb;
+    if (level == 1)
+        EB_STACK_EXEC_L1(type, res = ebGetTotalItems(stack->l1, type));
+    else if (level == 2)
+        EB_STACK_EXEC_L2(type, res = ebGetTotalItems(stack->l2, type));
+    else if (level == 3)
+        res = stack->l3 ? stack->l3->items : 0;
+    else
+        debugAssert(0);
+    return res;
 }
 
 /**
@@ -1785,16 +1945,46 @@ uint64_t ebGetMaxExpireTime(ebuckets eb, EbucketsType *type, int accurate) {
 uint64_t ebGetTotalItems(ebuckets eb, EbucketsType *type) {
     if (ebIsEmpty(eb))
         return 0;
+    if (type->isEbStack)
+        return ((ebStack *) eb)->items;
 
     if (ebIsList(eb))
         return type->getExpireMeta(ebGetListPtr(type, eb))->numItems;
-    else
-        return *ebRaxNumItems(ebGetRaxPtr(eb));
+
+    /* else rax */ 
+    return *ebRaxNumItems(ebGetRaxPtr(eb));
 }
 
 /* print expiration-time of items, ebuckets layout and some statistics */
-void ebPrint(ebuckets eb, EbucketsType *type) {
-    _ebPrint(eb, type, -1, 1);
+void ebPrintItems(ebuckets eb, EbucketsType *type) {
+    if (type->isEbStack) {
+        ebStack *stack = (ebStack *) eb;
+        printf("[EBSTACK-LEVEL1]:\n");
+        EB_STACK_EXEC_L1(type, ebPrintItems(stack->l1, type));
+        printf("[EBSTACK-LEVEL2]:\n");
+        EB_STACK_EXEC_L2(type, ebPrintItems(stack->l2, type));
+        printf("[EBSTACK-LEVEL3]:\n");
+        if (stack->l3)
+            printf("Infinity bucket: %" PRIu64 " items\n", stack->l3->items);
+        return;
+    }
+
+    if (ebIsList(eb)) {
+        /* mock rax segment */
+        eItem head = ebGetListPtr(type, eb);
+        ExpireMeta *metaHead = type->getExpireMeta(head);
+        FirstSegHdr mockSeg = { head, metaHead->numItems, 1};
+        ebBucketPrint(0, type, &mockSeg);
+        return;
+    }
+    rax *rax = ebGetRaxPtr(eb);
+    raxIterator iter;
+    raxStart(&iter, rax);
+    raxSeek(&iter, "^", NULL, 0);
+    while (raxNext(&iter)) {
+        FirstSegHdr *seg = iter.data;
+        ebBucketPrint(raxKey2BucketKey(iter.key, type), type, seg);
+    }
 }
 
 /* Validate the general structure of ebuckets. Calls assert(0) on error. */
@@ -1802,10 +1992,15 @@ void ebValidate(ebuckets eb, EbucketsType *type) {
     if (ebIsEmpty(eb))
         return;
 
-    if (ebIsList(eb))
+    if (type->isEbStack) {
+        ebStack *stack = (ebStack *) eb;
+        EB_STACK_EXEC_L1(type, ebValidate(stack->l1, type));
+        EB_STACK_EXEC_L2(type, ebValidate(stack->l2, type));
+    } else if (ebIsList(eb)) {
         ebValidateList(ebGetListPtr(type, eb), type);
-    else
+    } else {
         ebValidateRax(ebGetRaxPtr(eb), type);
+    }
 }
 
 /* Defrag callback for radix tree iterator, called for each node,
@@ -1916,7 +2111,7 @@ int ebDefragRax(ebuckets *eb, EbucketsType *type, unsigned long *cursor,
 {
     rax *newrax, *rax = ebGetRaxPtr(*eb);
     raxIterator ri;
-    static unsigned char next[EB_KEY_SIZE];
+    static unsigned char next[6];
 
     /* defrag the rax struct */
     if (!*cursor) {
@@ -1939,7 +2134,7 @@ int ebDefragRax(ebuckets *eb, EbucketsType *type, unsigned long *cursor,
          * Since node_cb is set after seek operation, any node traversed during seek wouldn't
          * be defragmented. To prevent this, we advance to next node before exiting previous
          * run, ensuring it gets defragmented instead of being skipped during current seek. */
-        if (!raxSeek(&ri, ">=", next, EB_KEY_SIZE)) {
+        if (!raxSeek(&ri, ">=", next, type->ebp.keySize)) {
             *cursor = 0;
             raxStop(&ri);
             return 0;
@@ -1984,6 +2179,10 @@ int ebScanDefrag(ebuckets *eb, EbucketsType *type, unsigned long *cursor,
         *cursor = 0;
         return 0;
     }
+    
+    if (type->isEbStack) {
+        assert(0); // TODO_MOTI: Implement ebScanDefragStack() for ebStack
+    }
 
     if (ebIsList(*eb)) {
         ebDefragList(eb, type, defragfns, privdata);
@@ -1998,7 +2197,14 @@ int ebScanDefrag(ebuckets *eb, EbucketsType *type, unsigned long *cursor,
  * ExpireMeta is marked as trash, then return EB_EXPIRE_TIME_INVALID */
 uint64_t ebGetExpireTime(EbucketsType *type, eItem item) {
     ExpireMeta *meta = type->getExpireMeta(item);
-    if (unlikely(meta->trash)) return EB_EXPIRE_TIME_INVALID;
+    
+    if (unlikely(meta->storedIn == EB_STORED_IN_TRASH))
+        return EB_EXPIRE_TIME_INVALID;
+
+    // TODO_MOTI: Modify EB_EXPIRE_TIME_INVALID from 0x0000FFFFFFFFFFFF to 0x0
+    if (unlikely(meta->storedIn == EB_STORED_IN_EB_L3))
+        return ((uint64_t) ((ExpireMetaL3 *) meta)->expireTime);
+    
     return ebGetMetaExpTime(meta);
 }
 
@@ -2017,6 +2223,8 @@ void ebStart(EbucketsIterator *iter, ebuckets eb, EbucketsType *type) {
     if (ebIsEmpty(eb)) {
         iter->currItem = NULL;
         iter->itemsCurrBucket = 0;
+    } else if (type->isEbStack) {
+        assert(0); /* Not implemented (Not needed) */
     } else if (ebIsList(eb)) {
         iter->currItem = ebGetListPtr(type, eb);
         iter->itemsCurrBucket = type->getExpireMeta(iter->currItem)->numItems;
@@ -2101,6 +2309,71 @@ void ebStop(EbucketsIterator *iter) {
         raxStop(&iter->raxIter);
 }
 
+/* Collect ebuckets statistics.
+   Caller needs to provide a pre-allocated, empty ebucketsStats structure. */ 
+void ebGetStats(ebuckets eb, EbucketsType *type, ebucketsStats *stats) {
+    if (ebIsEmpty(eb)) {
+        return;
+    }
+    if (type->isEbStack) {
+        ebStack *stack = (ebStack *) eb;
+        EB_STACK_EXEC_L1(type, ebGetStats(stack->l1, type, stats));        
+        EB_STACK_EXEC_L1(type, ebGetStats(stack->l2, type, stats));
+    } else if (ebIsList(eb)) {
+        eItem head = ebGetListPtr(type, eb);
+        ExpireMeta *meta = type->getExpireMeta(head);
+        uint64_t numItems = meta->numItems;
+        stats->totalItems += numItems;
+        stats->totalBuckets += 1;  /* List is treated as single bucket */
+        stats->totalSegments += 1; /* List is treated as single segment */
+    } else {
+        rax *rax = ebGetRaxPtr(eb);
+        raxIterator iter;
+        raxStart(&iter, rax);
+        raxSeek(&iter, "^", NULL, 0);
+        while (raxNext(&iter)) {
+            FirstSegHdr *seg = iter.data;
+            stats->totalItems += seg->totalItems;
+            stats->totalSegments += seg->numSegs;
+            stats->totalBuckets++;
+        }
+        raxStop(&iter);
+    }
+    if (stats->totalBuckets == 0) return;
+    
+    stats->avgItemsPerBucket = stats->totalItems / stats->totalBuckets;
+    stats->avgItemsPerSegment = stats->totalItems / stats->totalSegments;
+    stats->avgSegPerBucket = stats->totalSegments / stats->totalBuckets;
+}
+
+size_t ebGetStatsMsg(char *buf, size_t bufsize, ebucketsStats *stats, int full) {
+    if (stats->totalItems == 0) {
+        return snprintf(buf, bufsize,"Ebuckets stats:\nNo stats available for empty ebuckets\n");
+    }
+
+    size_t l = 0;
+
+    l += snprintf(buf + l, bufsize - l,
+                  "Ebuckets stats:\n"
+                  " total items: %lu\n"
+                  " total buckets: %lu\n"
+                  " total segments: %lu\n",
+                  stats->totalItems, stats->totalBuckets, stats->totalSegments);
+
+    if (full && stats->totalBuckets > 0 && stats->totalSegments > 0) {
+        l += snprintf(buf + l, bufsize - l,
+                      " avg items per bucket: %lu\n"
+                      " avg items per segment: %lu\n"
+                      " avg segments per bucket: %lu\n",
+                      stats->avgItemsPerBucket, stats->avgItemsPerSegment, stats->avgSegPerBucket);
+    }
+
+    /* Make sure there is a NULL term at the end. */
+    buf[bufsize-1] = '\0';
+    /* Unlike snprintf(), return the number of characters actually written. */
+    return strlen(buf);
+}
+
 /*** Unit tests ***/
 
 #ifdef REDIS_TEST
@@ -2123,29 +2396,33 @@ typedef struct TimeRange {
     uint64_t end;
 } TimeRange;
 
-ExpireMeta *getMyItemExpireMeta(const eItem item) {
+ExpireMeta *getMyItemExpireMeta(const void *item) {
     return &((MyItem *)item)->mexpire;
 }
 
 ExpireAction expireItemCb(void *item, eItem ctx);
 void deleteItemCb(eItem item, void *ctx);
-EbucketsType myEbucketsType = {
+EbucketsType myEbType = {
     .getExpireMeta = getMyItemExpireMeta,
     .onDeleteItem = deleteItemCb,
     .itemsAddrAreOdd = 0,
+    .ebp.precision = 0,
+    .ebp.keySize = EB_PRECISION2KEYSIZE(0 /*.precision*/),
 };
 
-EbucketsType myEbucketsType2 = {
+EbucketsType myEbType2 = {
     .getExpireMeta = getMyItemExpireMeta,
     .onDeleteItem = NULL,
     .itemsAddrAreOdd = 0,
+    .ebp.precision = 0,
+    .ebp.keySize = EB_PRECISION2KEYSIZE(0 /*.precision*/),
 };
 
 /* XOR over all items time-expiration. Must be 0 after all addition/removal */
 uint64_t expItemsHashValue = 0;
 
 ExpireAction expireItemCb(eItem item, void *ctx) {
-    ExpireMeta *meta = myEbucketsType.getExpireMeta(item);
+    ExpireMeta *meta = myEbType.getExpireMeta(item);
     uint64_t expTime = ebGetMetaExpTime(meta);
     expItemsHashValue = expItemsHashValue ^ expTime;
 
@@ -2182,7 +2459,7 @@ void addItems(ebuckets *eb, uint64_t startExpire, int step, uint64_t numItems, M
         expItemsHashValue = expItemsHashValue ^ expireTime;
         MyItem *item = zmalloc(sizeof(MyItem));
         if (ar) ar[i] = item;
-        ebAdd(eb, &myEbucketsType, item, expireTime);
+        ebAdd(eb, &myEbType, item, expireTime);
     }
 }
 
@@ -2203,7 +2480,7 @@ void distributeTest(int lowestTime,
     expItemsHashValue = 0;
     void *listOfItems = NULL;
     for (int i = 0; i < numRanges; i++) {
-        uint64_t endRange = EB_BUCKET_EXP_TIME(expireRanges[i]);
+        uint64_t endRange = EB_BUCKET_EXP_TIME(expireRanges[i], &myEbType);
         for (int j = 0; j < ItemsPerRange[i]; j++) {
             uint64_t randomExpirey = (rand() % (endRange - startRange)) + startRange;
             expItemsHashValue = expItemsHashValue ^ (uint32_t) randomExpirey;
@@ -2212,7 +2489,7 @@ void distributeTest(int lowestTime,
             listOfItems = item;
             ebSetMetaExpTime(getMyItemExpireMeta(item), randomExpirey);
         }
-        startRange = EB_BUCKET_EXP_TIME(expireRanges[i]); /* next start range */
+        startRange = EB_BUCKET_EXP_TIME(expireRanges[i], &myEbType); /* next start range */
     }
 
     /* Take to sample memory after all items allocated and before insertion to ebuckets */
@@ -2223,18 +2500,26 @@ void distributeTest(int lowestTime,
         MyItem *item = (MyItem *)listOfItems;
         listOfItems = getMyItemExpireMeta(item)->next;
         uint64_t expireTime = ebGetMetaExpTime(&item->mexpire);
-        ebAdd(&eb, &myEbucketsType, item, expireTime);
+        ebAdd(&eb, &myEbType, item, expireTime);
     }
     gettimeofday(&timeAfter, NULL);
     timersub(&timeAfter, &timeBefore, &timeCreation);
 
     gettimeofday(&timeBefore, NULL);
-    ebExpireDryRun(eb, &myEbucketsType, 0xFFFFFFFFFFFF);  /* expire dry-run all */
+    ebExpireDryRun(eb, &myEbType, 0xFFFFFFFFFFFF);  /* expire dry-run all */
     gettimeofday(&timeAfter, NULL);
     timersub(&timeAfter, &timeBefore, &timeDryRun);
 
     if (printStat) {
-        _ebPrint(eb, &myEbucketsType, zmalloc_used_memory() - usedMemBefore, 0);
+        char buf[4096];
+        ebucketsStats stats = {0}; /* must be zeroed */
+        ebGetStats(eb, &myEbType, &stats);
+        ebGetStatsMsg(buf, sizeof(buf), &stats, 1);
+        printf("%s", buf);
+        
+        /* print used memory */
+        printf("Total Ebuckets memory usage (including FirstSegHdr/NexSegHdr): %.2f KBytes\n",
+               (double) (zmalloc_used_memory() - usedMemBefore) / 1024);
     }
 
     gettimeofday(&timeBefore, NULL);
@@ -2254,17 +2539,17 @@ void distributeTest(int lowestTime,
              *
              * The '-1' in case of list brings makes both cases aligned to have
              * same result */
-            uint64_t now = EB_BUCKET_EXP_TIME(expireRanges[i]) + (ebIsList(eb) ? -1 : 0);
+            uint64_t now = EB_BUCKET_EXP_TIME(expireRanges[i], &myEbType) + (ebIsList(eb) ? -1 : 0);
 
-            TimeRange range = {EB_BUCKET_EXP_TIME(startRange), EB_BUCKET_EXP_TIME(expireRanges[i]) };
+            TimeRange range = {EB_BUCKET_EXP_TIME(startRange, &myEbType), EB_BUCKET_EXP_TIME(expireRanges[i], &myEbType) };
             ExpireInfo info = {
                     .maxToExpire = 0xFFFFFFFF,
                     .onExpireItem = expireItemCb,
                     .ctx = &range,
-                    .now = now,
+                    .now = now+1,
                     .itemsExpired = 0};
 
-            ebExpire(&eb, &myEbucketsType, &info);
+            ebExpire(&eb, &myEbType, &info);
 
             assert( (eb==NULL && (i + 1 == numRanges)) || (eb!=NULL && (i + 1 < numRanges)) );
             assert( info.itemsExpired == (uint64_t) ItemsPerRange[i]);
@@ -2273,7 +2558,7 @@ void distributeTest(int lowestTime,
         assert(eb == NULL);
         assert( (expItemsHashValue & 0xFFFFFFFF) == 0);
     }
-    ebDestroy(&eb, &myEbucketsType, NULL);
+    ebDestroy(&eb, &myEbType, NULL);
     gettimeofday(&timeAfter, NULL);
     timersub(&timeAfter, &timeBefore, &timeDestroy);
 
@@ -2344,7 +2629,7 @@ int ebucketsTest(int argc, char **argv, int flags) {
 
         /* expireRanges[] is provided to distributeTest() as bucket-key values */
         for (uint32_t j = 0; j < ARRAY_SIZE(expireRanges); ++j) {
-            expireRanges[j] = expireRanges[j] >> EB_BUCKET_KEY_PRECISION;
+            expireRanges[j] = expireRanges[j] >> myEbType.precision;
         }
 
         distributeTest(0, expireRanges, itemsPerRange, ARRAY_SIZE(expireRanges), 1, 1);
@@ -2361,11 +2646,11 @@ int ebucketsTest(int argc, char **argv, int flags) {
             /* Create and add items to ebuckets */
             for (uint32_t i = 0; i < numItems; i++) {
                 items[i] = zmalloc(sizeof(MyItem));
-                ebAdd(&eb, &myEbucketsType, items[i], i);
+                ebAdd(&eb, &myEbType, items[i], i);
             }
 
             /* iterate items */
-            ebStart(&iter, eb, &myEbucketsType);
+            ebStart(&iter, eb, &myEbType);
             for (uint32_t i = 0; i < numItems; i++) {
                 assert(iter.currItem == items[i]);
                 int res = ebNext(&iter);
@@ -2380,7 +2665,7 @@ int ebucketsTest(int argc, char **argv, int flags) {
             ebStop(&iter);
 
             /* iterate buckets */
-            ebStart(&iter, eb, &myEbucketsType);
+            ebStart(&iter, eb, &myEbType);
             uint32_t countItems = 0;
 
             uint32_t countBuckets = 0;
@@ -2392,24 +2677,24 @@ int ebucketsTest(int argc, char **argv, int flags) {
             ebStop(&iter);
             assert(countItems == numItems);
             if (numItems>=8) assert(numItems/8 >= countBuckets);
-            ebDestroy(&eb, &myEbucketsType, NULL);
+            ebDestroy(&eb, &myEbType, NULL);
         }
     }
 
     TEST("list - Create a single item, get TTL, and remove") {
         MyItem *singleItem = zmalloc(sizeof(MyItem));
         ebuckets eb = NULL;
-        ebAdd(&eb, &myEbucketsType, singleItem, 1000);
-        assert(ebGetExpireTime(&myEbucketsType, singleItem) == 1000 );
+        ebAdd(&eb, &myEbType, singleItem, 1000);
+        assert(ebGetExpireTime(&myEbType, singleItem) == 1000 );
 
         /* remove the item */
-        assert(ebRemove(&eb, &myEbucketsType, singleItem));
+        assert(ebRemove(&eb, &myEbType, singleItem));
         /* now the ebuckets is empty */
-        assert(ebRemove(&eb, &myEbucketsType, singleItem) == 0);
+        assert(ebRemove(&eb, &myEbType, singleItem) == 0);
 
         zfree(singleItem);
 
-        ebDestroy(&eb, &myEbucketsType, NULL);
+        ebDestroy(&eb, &myEbType, NULL);
     }
 
     TEST("list - Create few items on different times, get TTL, and then remove") {
@@ -2417,18 +2702,18 @@ int ebucketsTest(int argc, char **argv, int flags) {
         ebuckets eb = NULL;
         for (int i = 0 ; i < EB_LIST_MAX_ITEMS  ; i++) {
             items[i] = zmalloc(sizeof(MyItem));
-            ebAdd(&eb, &myEbucketsType, items[i], i);
+            ebAdd(&eb, &myEbType, items[i], i);
         }
 
         for (uint64_t i = 0 ; i < EB_LIST_MAX_ITEMS ; i++) {
-            assert(ebGetExpireTime(&myEbucketsType, items[i]) == i );
-            assert(ebRemove(&eb, &myEbucketsType, items[i]));
+            assert(ebGetExpireTime(&myEbType, items[i]) == i );
+            assert(ebRemove(&eb, &myEbType, items[i]));
         }
 
         for (int i = 0 ; i < EB_LIST_MAX_ITEMS  ; i++)
             zfree(items[i]);
 
-        ebDestroy(&eb, &myEbucketsType, NULL);
+        ebDestroy(&eb, &myEbType, NULL);
     }
 
     TEST("list - Create few items on different times, get TTL, and then delete") {
@@ -2436,24 +2721,24 @@ int ebucketsTest(int argc, char **argv, int flags) {
         ebuckets eb = NULL;
         for (int i = 0 ; i < EB_LIST_MAX_ITEMS  ; i++) {
             items[i] = zmalloc(sizeof(MyItem));
-            ebAdd(&eb, &myEbucketsType, items[i], i);
+            ebAdd(&eb, &myEbType, items[i], i);
         }
 
         for (uint64_t i = 0 ; i < EB_LIST_MAX_ITEMS ; i++) {
-            assert(ebGetExpireTime(&myEbucketsType, items[i]) == i );
+            assert(ebGetExpireTime(&myEbType, items[i]) == i );
         }
 
-        ebDestroy(&eb, &myEbucketsType, NULL);
+        ebDestroy(&eb, &myEbType, NULL);
     }
 
     TEST_COND("ebuckets - Add items with increased/decreased expiration time and then expire",
-              EB_BUCKET_KEY_PRECISION > 0)
+              myEbType.ebp.precision > 0)
     {
         ebuckets eb = NULL;
 
         for (int isDecr = 0; isDecr < 2; ++isDecr) {
             for (uint32_t numItems = 1; numItems < 64; ++numItems) {
-                uint64_t step = 1 << EB_BUCKET_KEY_PRECISION;
+                uint64_t step = 1 << myEbType.ebp.precision;
 
                 if (isDecr == 0)
                     addItems(&eb, 0, step, numItems, NULL);
@@ -2461,35 +2746,39 @@ int ebucketsTest(int argc, char **argv, int flags) {
                     addItems(&eb, (numItems - 1) * step, -step, numItems, NULL);
 
                 for (uint32_t i = 1; i <= numItems; i++) {
-                    TimeRange range = {EB_BUCKET_EXP_TIME(i - 1), EB_BUCKET_EXP_TIME(i)};
+                    TimeRange range = {EB_BUCKET_EXP_TIME(i - 1, &myEbType), EB_BUCKET_EXP_TIME(i, &myEbType)};
                     ExpireInfo info = {
                             .maxToExpire = 1,
                             .onExpireItem = expireItemCb,
                             .ctx = &range,
-                            .now = EB_BUCKET_EXP_TIME(i),
+                            .now = EB_BUCKET_EXP_TIME(i, &myEbType),
                             .itemsExpired = 0};
 
-                    ebExpire(&eb, &myEbucketsType, &info);
+                    ebExpire(&eb, &myEbType, &info);
                     assert(info.itemsExpired == 1);
                     if (i == numItems) { /* if last item */
                         assert(eb == NULL);
                         assert(info.nextExpireTime == EB_EXPIRE_TIME_INVALID);
                     } else {
-                        assert(info.nextExpireTime == EB_BUCKET_EXP_TIME(i));
+                        assert(info.nextExpireTime == EB_BUCKET_EXP_TIME(i, &myEbType));
                     }
                 }
             }
         }
     }
 
-    TEST_COND("ebuckets - Create items with same expiration time and then expire",
-              EB_BUCKET_KEY_PRECISION > 0)
+    TEST("ebuckets - Create items with same expiration time and then expire")
     {
+        /*temporary modify myEbType precision for the test*/
+        EBucketPrecision tmp = myEbType.ebp;
+        myEbType.ebp.precision = 8;
+        myEbType.ebp.keySize = EB_PRECISION2KEYSIZE(myEbType.ebp.precision);
+
         ebuckets eb = NULL;
         uint64_t expirePerIter = 2;
         for (uint32_t numIterations = 1; numIterations < 100; ++numIterations) {
             uint32_t numItems = numIterations * expirePerIter;
-            uint64_t expireTime = (1 << EB_BUCKET_KEY_PRECISION) + 1;
+            uint64_t expireTime = (1 << myEbType.ebp.precision) + 1;
             addItems(&eb, expireTime, 0, numItems, NULL);
 
             for (uint32_t i = 1; i <= numIterations; i++) {
@@ -2497,9 +2786,9 @@ int ebucketsTest(int argc, char **argv, int flags) {
                         .maxToExpire = expirePerIter,
                         .onExpireItem = expireItemCb,
                         .ctx = NULL,
-                        .now = (2 << EB_BUCKET_KEY_PRECISION),
+                        .now = (2 << myEbType.ebp.precision),
                         .itemsExpired = 0};
-                ebExpire(&eb, &myEbucketsType, &info);
+                ebExpire(&eb, &myEbType, &info);
                 assert(info.itemsExpired == expirePerIter);
                 if (i == numIterations) { /* if last item */
                     assert(eb == NULL);
@@ -2509,7 +2798,244 @@ int ebucketsTest(int argc, char **argv, int flags) {
                 }
             }
         }
+
+        /*restore*/
+        myEbType.ebp = tmp;
     }
+
+    TEST("ebStack - L1 & L2 basic functionality") {
+        uint64_t expireAt;
+        const int L2_BUCKET_INTERVAL = 1 << ebpStackL2.precision;
+        __now__ = L2_BUCKET_INTERVAL + 1;
+        EbucketsType type = myEbType2;
+        type.isEbStack = 1; /* Set to hierarchical ebuckets stack for the test */
+
+        /* Test basic ebStack functionality */
+        ebuckets eb = ebCreate();
+        uint64_t at = 0;
+        MyItem items[10];
+
+        /* Test Level 1: Short-term expiration (high precision) */
+        expireAt = __now__ + 1000;
+        ebAdd(&eb, &type, items + at, expireAt);
+        assert(!ebIsEmpty(eb));
+
+        /* Verify 1 item was stored in L1 */
+        ebStack *stack = (ebStack *)eb;
+        assert(ebGetTotalItems(eb, &type) == at+1);
+        assert(stack->items == at+1);
+        assert(ebStackItems(eb, &type, 1) == 1);
+        assert(ebStackItems(eb, &type, 2) == 0);
+        assert(ebStackItems(eb, &type, 3) == 0);
+        assert(type.getExpireMeta(&items[at])->storedIn == EB_STORED_IN_EB);
+        
+        at++;
+        
+        /* Test Level 1: Short-term expiration (high precision) */
+        expireAt = __now__ + L2_BUCKET_INTERVAL;
+        ebAdd(&eb, &type, items + at, expireAt);
+        assert(!ebIsEmpty(eb));
+        /* Verify 2 item are stored in L1 */        
+        assert(ebGetTotalItems(eb, &type) == at+1);
+        assert(stack->items == at+1);
+        assert(ebStackItems(eb, &type, 1) == 2);
+        assert(ebStackItems(eb, &type, 2) == 0);
+        assert(ebStackItems(eb, &type, 3) == 0);
+        assert(type.getExpireMeta(&items[at])->storedIn == EB_STORED_IN_EB);
+        
+        at++;
+
+        /* Verify level 2: Add item that should be added to L2 */
+        expireAt = __now__ + (2 << ebpStackL2.precision);
+        ebAdd(&eb, &type, &items[at], expireAt);
+        assert(ebGetTotalItems(eb, &type) == at+1);
+        assert(stack->items == at+1);
+        assert(ebStackItems(eb, &type, 1) == 2);
+        assert(ebStackItems(eb, &type, 2) == 1);
+        assert(ebStackItems(eb, &type, 3) == 0);
+        assert(type.getExpireMeta(&items[at])->storedIn == EB_STORED_IN_EB_L2);
+        
+        at++;
+        
+        /* Verify level 2: Add another item that should be added to L2 */
+        expireAt = __now__ + (3 << ebpStackL2.precision);
+        ebAdd(&eb, &type, &items[at], expireAt);
+        assert(ebGetTotalItems(eb, &type) == at+1);
+        assert(stack->items == at+1);
+        assert(ebStackItems(eb, &type, 1) == 2);
+        assert(ebStackItems(eb, &type, 2) == 2);
+        assert(ebStackItems(eb, &type, 3) == 0);
+        assert(type.getExpireMeta(&items[at])->storedIn == EB_STORED_IN_EB_L2);
+
+        ebPrintItems(eb, &type);
+        /* Now cascade such that the 1st item in L2 should be cascaded to L1 */
+        __now__ += L2_BUCKET_INTERVAL;
+        uint64_t cascaded = ebCascade(&eb, &type, __now__, 10);
+        ebPrintItems(eb, &type);
+        assert(cascaded == 1);
+        assert(ebGetTotalItems(eb, &type) == at+1);
+        assert(stack->items == at+1);
+        assert(ebStackItems(eb, &type, 1) == 3);
+        assert(ebStackItems(eb, &type, 2) == 1);
+        assert(ebStackItems(eb, &type, 3) == 0);
+        assert(type.getExpireMeta(&items[at-1])->storedIn == EB_STORED_IN_EB);
+
+//        /* Test Level 3: TBD */
+//
+//        /* Test ebCascade functionality */
+//        /* Add some items to L2 that should be cascaded to L1 */
+//        /* Use a large value that will definitely go to L2 due to precision difference */
+//        uint64_t l2Expire = (1ULL << 30); /* Should go to L2 due to precision difference */
+//
+//        /* Add item that will be eligible for cascade */
+//        ebAdd(&eb, &type, &items[2], l2Expire);
+//        assert(ebGetTotalItems(eb, &type) == 3);
+//        assert(stack->items == 3);
+//        assert(type.getExpireMeta(&items[2])->storedIn == EB_STORED_IN_EB_L2);
+
+        ebDestroy(&eb, &type, NULL);
+    }
+//
+//    TEST("ebStack - Cascading") {
+//        EbucketsType type = myEbType2;
+//        type.isEbStack = 1; /* Set to hierarchical ebuckets stack for the test */
+//
+//        /* Test 1: Basic cascading functionality */
+//        {
+//            ebuckets eb = ebCreate();
+//            MyItem items[5];
+//
+//            /* Current time for testing - use a base time */
+//            uint64_t baseTime = 1000000; /* Base time in milliseconds */
+//
+//            /* Add items to L2 that should be eligible for cascading */
+//            /* Items with expiration times that fall within cascade threshold should move to L1 */
+//
+//            /* Calculate L2 bucket precision threshold */
+//            uint64_t l2BucketDuration = (1ULL << ebpStackL2.precision); /* ~34.9 minutes */
+//            //uint64_t cascadeThreshold = baseTime + (2 * l2BucketDuration); /* Cascade threshold */
+//
+//            /* Add item to L2 that should be cascaded (expires before threshold) */
+//            uint64_t l2ExpireEarly = baseTime + l2BucketDuration; /* Within cascade window */
+//            ebAdd(&eb, &type, &items[0], l2ExpireEarly);
+//
+//            /* Add item to L2 that should NOT be cascaded (expires after threshold) */
+//            uint64_t l2ExpireLate = baseTime + (3 * l2BucketDuration); /* Beyond cascade window */
+//            ebAdd(&eb, &type, &items[1], l2ExpireLate);
+//
+//            /* Verify initial state - both items should be in L2 */
+//            ebStack *stack = (ebStack *)eb;
+//            assert(ebGetTotalItems(eb, &type) == 2);
+//            assert(stack->items == 2);
+//            assert(ebIsEmpty(stack->l1)); /* L1 should be empty initially */
+//            assert(!ebIsEmpty(stack->l2)); /* L2 should have items */
+//            assert(type.getExpireMeta(&items[0])->storedIn == EB_STORED_IN_EB_L2);
+//            assert(type.getExpireMeta(&items[1])->storedIn == EB_STORED_IN_EB_L2);
+//
+//            /* Perform cascade operation */
+//            uint64_t cascaded = ebCascade(&eb, &type, baseTime, 10); /* Allow up to 10 cascades */
+//
+//            /* Verify cascade results */
+//            assert(cascaded == 1); /* Only one item should be cascaded */
+//            assert(ebGetTotalItems(eb, &type) == 2); /* Total items unchanged */
+//            assert(stack->items == 2);
+//            assert(!ebIsEmpty(stack->l1)); /* L1 should now have the cascaded item */
+//            assert(!ebIsEmpty(stack->l2)); /* L2 should still have the late item */
+//
+//            /* Verify storage locations after cascade */
+//            assert(type.getExpireMeta(&items[0])->storedIn == EB_STORED_IN_EB); /* Moved to L1 */
+//            assert(type.getExpireMeta(&items[1])->storedIn == EB_STORED_IN_EB_L2); /* Stayed in L2 */
+//
+//            ebDestroy(&eb, &type, NULL);
+//        }
+//
+//        /* Test 2: Edge cases */
+//        {
+//            /* Test empty ebStack */
+//            ebuckets emptyEb = ebCreate();
+//            uint64_t cascaded = ebCascade(&emptyEb, &type, 1000, 10);
+//            assert(cascaded == 0); /* No items to cascade */
+//            ebDestroy(&emptyEb, &type, NULL);
+//
+//            /* Test non-ebStack */
+//            EbucketsType nonStackType = myEbType2;
+//            nonStackType.isEbStack = 0; /* Not an ebStack */
+//            ebuckets nonStackEb = ebCreate();
+//            MyItem item;
+//            ebAdd(&nonStackEb, &nonStackType, &item, 1000);
+//            cascaded = ebCascade(&nonStackEb, &nonStackType, 1000, 10);
+//            assert(cascaded == 0); /* Should not cascade non-ebStack */
+//            ebDestroy(&nonStackEb, &nonStackType, NULL);
+//        }
+//
+//        /* Test 3: MaxCascade limit */
+//        {
+//            ebuckets eb = ebCreate();
+//            MyItem items[5];
+//            uint64_t baseTime = 2000000;
+//            uint64_t l2BucketDuration = (1ULL << ebpStackL2.precision);
+//
+//            /* Add multiple items to L2 that should all be cascaded */
+//            for (int i = 0; i < 3; i++) {
+//                uint64_t expireTime = baseTime + (l2BucketDuration / 2); /* All within cascade window */
+//                ebAdd(&eb, &type, &items[i], expireTime);
+//            }
+//
+//            /* Verify all items are in L2 */
+//            ebStack *stack = (ebStack *)eb;
+//            assert(ebGetTotalItems(eb, &type) == 3);
+//            assert(ebIsEmpty(stack->l1));
+//            assert(!ebIsEmpty(stack->l2));
+//
+//            /* Cascade with limit of 2 items */
+//            uint64_t cascaded = ebCascade(&eb, &type, baseTime, 2);
+//
+//            /* Should cascade exactly 2 items due to limit */
+//            assert(cascaded == 2);
+//            assert(ebGetTotalItems(eb, &type) == 3); /* Total unchanged */
+//            assert(!ebIsEmpty(stack->l1)); /* L1 should have cascaded items */
+//            assert(!ebIsEmpty(stack->l2)); /* L2 should still have remaining item */
+//
+//            ebDestroy(&eb, &type, NULL);
+//        }
+//
+//        /* Test 4: Cascade with L1 already having items */
+//        {
+//            ebuckets eb = ebCreate();
+//            MyItem items[3];
+//            uint64_t baseTime = 3000000;
+//            uint64_t l2BucketDuration = (1ULL << ebpStackL2.precision);
+//
+//            /* Add item directly to L1 (short expiration) */
+//            uint64_t l1ExpireTime = baseTime + 1000; /* Should go to L1 */
+//            ebAdd(&eb, &type, &items[0], l1ExpireTime);
+//
+//            /* Add item to L2 that should be cascaded */
+//            uint64_t l2ExpireTime = baseTime + l2BucketDuration; /* Should cascade to L1 */
+//            ebAdd(&eb, &type, &items[1], l2ExpireTime);
+//
+//            /* Verify initial state */
+//            ebStack *stack = (ebStack *)eb;
+//            assert(ebGetTotalItems(eb, &type) == 2);
+//            assert(!ebIsEmpty(stack->l1)); /* L1 has one item */
+//            assert(!ebIsEmpty(stack->l2)); /* L2 has one item */
+//            assert(type.getExpireMeta(&items[0])->storedIn == EB_STORED_IN_EB); /* In L1 */
+//            assert(type.getExpireMeta(&items[1])->storedIn == EB_STORED_IN_EB_L2); /* In L2 */
+//
+//            /* Perform cascade */
+//            uint64_t cascaded = ebCascade(&eb, &type, baseTime, 10);
+//
+//            /* Verify results */
+//            assert(cascaded == 1); /* One item cascaded */
+//            assert(ebGetTotalItems(eb, &type) == 2); /* Total unchanged */
+//            assert(!ebIsEmpty(stack->l1)); /* L1 now has both items */
+//            assert(ebIsEmpty(stack->l2)); /* L2 should be empty */
+//            assert(type.getExpireMeta(&items[0])->storedIn == EB_STORED_IN_EB); /* Still in L1 */
+//            assert(type.getExpireMeta(&items[1])->storedIn == EB_STORED_IN_EB); /* Moved to L1 */
+//
+//            ebDestroy(&eb, &type, NULL);
+//        }
+//    }
 
     TEST("list - Create few items on random times and then expire/delete ") {
         for (int isExpire = 0 ; isExpire <= 1 ; ++isExpire ) {
@@ -2558,12 +3084,12 @@ int ebucketsTest(int argc, char **argv, int flags) {
             for (int numItems = 1; numItems <= EB_SEG_MAX_ITEMS*3; ++numItems) {
                 for (int offset = 0; offset < numItems; offset++) {
                     MyItem *items[numItems];
-                    uint64_t startValue = 1000 << EB_BUCKET_KEY_PRECISION;
-                    int stepValue = step * (1 << EB_BUCKET_KEY_PRECISION);
+                    uint64_t startValue = 1000 << myEbType.ebp.precision;
+                    int stepValue = step * (1 << myEbType.ebp.precision);
                     addItems(&eb, startValue, stepValue, numItems, items);
                     for (int i = 0; i < numItems; i++) {
                         int at = (i + offset) % numItems;
-                        assert(ebRemove(&eb, &myEbucketsType, items[at]));
+                        assert(ebRemove(&eb, &myEbType, items[at]));
                         zfree(items[at]);
                     }
                     assert(eb == NULL);
@@ -2582,35 +3108,39 @@ int ebucketsTest(int argc, char **argv, int flags) {
                 uint64_t expireTime = rand();
                 if (expireTime < minExpTime) minExpTime = expireTime;
                 if (expireTime > maxExpTime) maxExpTime = expireTime;
-                ebAdd(&eb, &myEbucketsType2, items + i, expireTime);
-                assert(ebGetNextTimeToExpire(eb, &myEbucketsType2) == minExpTime);
-                assert(ebGetMaxExpireTime(eb, &myEbucketsType2, 0) == maxExpTime);
+                ebAdd(&eb, &myEbType2, items + i, expireTime);
+                assert(ebGetNextTimeToExpire(eb, &myEbType2) == minExpTime);
             }
-            ebDestroy(&eb, &myEbucketsType2, NULL);
+            ebDestroy(&eb, &myEbType2, NULL);
         }
     }
 
-    TEST_COND("ebuckets - test min/max expire time, with extended-segment",
-              (1<<EB_BUCKET_KEY_PRECISION) > 2*EB_SEG_MAX_ITEMS) {
+    TEST("ebuckets - test min/max expire time, with extended-segment") {
+        /*temporary modify myEbType2 precision for the test*/
+        EBucketPrecision tmp = myEbType2.ebp;
+        myEbType2.ebp.precision = 10;  // Take care: (1<<precision) > 2*EB_SEG_MAX_ITEMS
+        myEbType2.ebp.keySize = EB_PRECISION2KEYSIZE(myEbType2.ebp.precision);
+
         ebuckets eb = NULL;
         MyItem items[(2*EB_SEG_MAX_ITEMS)-1];
         for (int numItems = EB_SEG_MAX_ITEMS+1 ; numItems < (int)ARRAY_SIZE(items) ; numItems++) {
             /* First reach extended-segment (two chained segments in a bucket) */
             for (int i = 0; i <= EB_SEG_MAX_ITEMS; i++) {
-                uint64_t itemExpireTime = (1<<EB_BUCKET_KEY_PRECISION) + i;
-                ebAdd(&eb, &myEbucketsType2, items + i, itemExpireTime);
+                uint64_t itemExpireTime = (1<<myEbType2.ebp.precision) + i;
+                ebAdd(&eb, &myEbType2, items + i, itemExpireTime);
             }
 
             /* Now start adding more items to extended-segment and verify min/max */
             for (int i = EB_SEG_MAX_ITEMS+1; i < numItems; i++) {
-                uint64_t itemExpireTime = (1<<EB_BUCKET_KEY_PRECISION) + i;
-                ebAdd(&eb, &myEbucketsType2, items + i, itemExpireTime);
-                assert(ebGetNextTimeToExpire(eb, &myEbucketsType2) == (uint64_t)(2<<EB_BUCKET_KEY_PRECISION));
-                assert(ebGetMaxExpireTime(eb, &myEbucketsType2, 0) == (uint64_t)(2<<EB_BUCKET_KEY_PRECISION));
-                assert(ebGetMaxExpireTime(eb, &myEbucketsType2, 1) == (uint64_t)((1<<EB_BUCKET_KEY_PRECISION) + i));
+                uint64_t itemExpireTime = (1<<myEbType2.ebp.precision) + i;
+                ebAdd(&eb, &myEbType2, items + i, itemExpireTime);
+                uint64_t nextTimeToExp = ebGetNextTimeToExpire(eb, &myEbType2);
+                assert(nextTimeToExp == (uint64_t)(2<<myEbType2.ebp.precision));
             }
-            ebDestroy(&eb, &myEbucketsType2, NULL);
+            ebDestroy(&eb, &myEbType2, NULL);
         }
+
+        myEbType2.ebp.v = tmp.v; /*restore*/
     }
 
     TEST("ebuckets - active-expire dry-run") {
@@ -2622,23 +3152,23 @@ int ebucketsTest(int argc, char **argv, int flags) {
             /* Allocate numItems and add to ebuckets */
             for (int i = 0; i < numItems; i++) {
                 /* generate random expiration time */
-                uint64_t expireTime = (rand() % maxExpireKey) << EB_BUCKET_KEY_PRECISION;
-                ebAdd(&eb, &myEbucketsType2, items + i, expireTime);
+                uint64_t expireTime = (rand() % maxExpireKey) << myEbType2.ebp.precision;
+                ebAdd(&eb, &myEbType2, items + i, expireTime);
             }
 
             for (int i = 0 ; i <= maxExpireKey ; ++i) {
-                uint64_t now = i << EB_BUCKET_KEY_PRECISION;
+                uint64_t now = i << myEbType2.ebp.precision;
 
                 /* Count how much items are expired */
                 uint64_t expectedNumExpired = 0;
                 for (int j = 0; j < numItems; j++) {
-                    if (ebGetExpireTime(&myEbucketsType2, items + j) < now)
+                    if (ebGetExpireTime(&myEbType2, items + j) < now)
                         expectedNumExpired++;
                 }
                 /* Perform dry-run and verify number of expired items */
-                assert(ebExpireDryRun(eb, &myEbucketsType2, now) == expectedNumExpired);
+                assert(ebExpireDryRun(eb, &myEbType2, now) == expectedNumExpired);
             }
-            ebDestroy(&eb, &myEbucketsType2, NULL);
+            ebDestroy(&eb, &myEbType2, NULL);
         }
     }
 
@@ -2655,33 +3185,33 @@ int ebucketsTest(int argc, char **argv, int flags) {
 
         /* Allocate numItems and add to ebuckets */
         for (int i = 0; i < numItems; i++)
-            ebAdd(&eb, &myEbucketsType2, items + i, expiredAt << EB_BUCKET_KEY_PRECISION);
+            ebAdd(&eb, &myEbType2, items + i, expiredAt << myEbType2.ebp.precision);
 
         /* active-expire. Expected that all but one will be expired */
         ExpireInfo info = {
                 .maxToExpire = 0xFFFFFFFF,
                 .onExpireItem = expireUpdateThirdItemCb,
-                .ctx = (void *) (uintptr_t) (updateItemTo << EB_BUCKET_KEY_PRECISION),
-                .now = applyActiveExpireAt << EB_BUCKET_KEY_PRECISION,
+                .ctx = (void *) (uintptr_t) (updateItemTo << myEbType2.ebp.precision),
+                .now = applyActiveExpireAt << myEbType2.ebp.precision,
                 .itemsExpired = 0};
-        ebExpire(&eb, &myEbucketsType2, &info);
+        ebExpire(&eb, &myEbType2, &info);
         assert(info.itemsExpired == (uint64_t) numItems);
-        assert(info.nextExpireTime == (uint64_t)updateItemTo << EB_BUCKET_KEY_PRECISION);
-        assert(ebGetTotalItems(eb, &myEbucketsType2) == 1);
+        assert(info.nextExpireTime == (uint64_t)updateItemTo << myEbType2.ebp.precision);
+        assert(ebGetTotalItems(eb, &myEbType2) == 1);
 
         /* active-expire. Expected that all will be expired */
         ExpireInfo info2 = {
                 .maxToExpire = 0xFFFFFFFF,
                 .onExpireItem = expireUpdateThirdItemCb,
-                .ctx = (void *) (uintptr_t) (updateItemTo << EB_BUCKET_KEY_PRECISION),
-                .now = expectedExpiredAt << EB_BUCKET_KEY_PRECISION,
+                .ctx = (void *) (uintptr_t) (updateItemTo << myEbType2.ebp.precision),
+                .now = expectedExpiredAt << myEbType2.ebp.precision,
                 .itemsExpired = 0};
-        ebExpire(&eb, &myEbucketsType2, &info2);
+        ebExpire(&eb, &myEbType2, &info2);
         assert(info2.itemsExpired == (uint64_t) 1);
         assert(info2.nextExpireTime == EB_EXPIRE_TIME_INVALID);
-        assert(ebGetTotalItems(eb, &myEbucketsType2) == 0);
+        assert(ebGetTotalItems(eb, &myEbType2) == 0);
 
-        ebDestroy(&eb, &myEbucketsType2, NULL);
+        ebDestroy(&eb, &myEbType2, NULL);
 
     }
 
@@ -2692,7 +3222,7 @@ int ebucketsTest(int argc, char **argv, int flags) {
             for (int i = 0; i < s; i++) {
                 items[i] = zmalloc(sizeof(MyItem));
                 items[i]->index = i;
-                ebAdd(&eb, &myEbucketsType, items[i], i);
+                ebAdd(&eb, &myEbType, items[i], i);
             }
             assert((s <= EB_LIST_MAX_ITEMS) ? ebIsList(eb) : !ebIsList(eb));
             /* Defrag all the items. */
@@ -2701,12 +3231,12 @@ int ebucketsTest(int argc, char **argv, int flags) {
                 .defragAlloc = defragCallback,
                 .defragItem = defragItemCallback,
             };
-            while (ebScanDefrag(&eb, &myEbucketsType, &cursor, &defragfns, items)) {}
+            while (ebScanDefrag(&eb, &myEbType, &cursor, &defragfns, items)) {}
             /* Verify that the data is not corrupted. */
-            ebValidate(eb, &myEbucketsType);
+            ebValidate(eb, &myEbType);
             for (int i = 0; i < s; i++)
                 assert(items[i]->index == i);
-            ebDestroy(&eb, &myEbucketsType, NULL);
+            ebDestroy(&eb, &myEbType, NULL);
         }
     }
 

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -72,6 +72,9 @@
 
 #define EB_STACK_L3_SIZEOF(n) (sizeof(ebVector) + sizeof(eItem) * (n))
 
+/* Minimum expiration time for L3 (infinity) */
+#define EB_STACK_L3_MIN (EB_EXPIRE_TIME_INVALID)
+
 /*** structs ***/
 
 typedef struct CommonSegHdr {
@@ -156,7 +159,7 @@ typedef struct ExpireMetaL3 {
     uint32_t expireIndexLo;
     uint16_t expireIndexHi;
     
-    /* Same flags like ExpireMeta (but only `storedIn` is being used) */
+    /* Flags are aligned with ExpireMeta (but here only `storedIn` is being used) */
     EXPIRE_META_FLAGS
     
     /* 8-byte of expiration time (Overlays the `ExpireMeta.next` pointer) */
@@ -371,14 +374,15 @@ static int ebTrySegSplit(EbucketsType *type, FirstSegHdr *seg, EBucketNew *newBu
      * have the same expiration time and therefore the split won't necessarily be
      * balanced (Or won't be possible to split at all if all have the same exp-time!)
      */
+    uint64_t iterKey = EB_BUCKET_KEY(ebGetMetaExpTime(mIter), type);
     for (int i = 0 ; i < EB_SEG_MAX_ITEMS-1 ; i++) {
-        //printf ("i=%d\n", i);
         mNext = type->getExpireMeta(mIter->next);
-        if (EB_BUCKET_KEY(ebGetMetaExpTime(mNext), type) >
-            EB_BUCKET_KEY(ebGetMetaExpTime(mIter), type)) {
+        uint64_t nextKey = EB_BUCKET_KEY(ebGetMetaExpTime(mNext), type);
+
+        if (nextKey > iterKey) {
             /* If found better middle index before reaching halfway, save it */
             if (i < (EB_SEG_MAX_ITEMS/2)) {
-                splitKey = EB_BUCKET_KEY(ebGetMetaExpTime(mNext), type);
+                splitKey = nextKey;
                 bestMiddleIndex = i;
                 mLastItemFirstPart = mIter;
                 mFirstItemSecondPart = mNext;
@@ -387,7 +391,7 @@ static int ebTrySegSplit(EbucketsType *type, FirstSegHdr *seg, EBucketNew *newBu
             } else {
                 /* after crossing the middle need only to look for the first diff */
                 if (minMidDist > (i + 1 - EB_SEG_MAX_ITEMS / 2)) {
-                    splitKey = EB_BUCKET_KEY(ebGetMetaExpTime(mNext), type);
+                    splitKey = nextKey;
                     bestMiddleIndex = i;
                     mLastItemFirstPart = mIter;
                     mFirstItemSecondPart = mNext;
@@ -397,6 +401,7 @@ static int ebTrySegSplit(EbucketsType *type, FirstSegHdr *seg, EBucketNew *newBu
             }
         }
         mIter = mNext;
+        iterKey = EB_BUCKET_KEY(ebGetMetaExpTime(mIter), type);
     }
 
     /* If cannot find index to split because all with same EB_BUCKET_KEY(), then
@@ -441,7 +446,7 @@ int ebSingleSegExpire(FirstSegHdr *firstSegHdr,
 
         /* Items are arranged in ascending expire-time order in a segment. Stops
          * active expiration when an item's expire time is greater than `now`. */
-        if (itemExpTime > info->now)
+        if (itemExpTime >= info->now)
             break;
 
         /* keep aside next before deletion of iter */
@@ -647,7 +652,7 @@ static int ebAddToList(ebuckets *eb, EbucketsType *type, eItem item) {
         *eb = ebMarkAsList(item);
         return 0;
     }
-
+    uint64_t itemExpireTime = ebGetMetaExpTime(metaItem);
     eItem head = ebGetListPtr(type, *eb);
     ExpireMeta *metaHead = type->getExpireMeta(head);
 
@@ -656,7 +661,7 @@ static int ebAddToList(ebuckets *eb, EbucketsType *type, eItem item) {
         return 1;
 
     /* if expiry time of 'item' is smaller than the head then add it as the new head */
-    if (ebGetMetaExpTime(metaHead) > ebGetMetaExpTime(metaItem)) {
+    if (ebGetMetaExpTime(metaHead) > itemExpireTime) {
         /* Insert item as the new head */
         metaItem->next = head;
         metaItem->firstItemBucket = 1;
@@ -673,7 +678,7 @@ static int ebAddToList(ebuckets *eb, EbucketsType *type, eItem item) {
     for (int i = 1 ; i < metaHead->numItems ; i++) {
         ExpireMeta *nextMeta = type->getExpireMeta(mIter->next);
         /* Insert item in the middle */
-        if (ebGetMetaExpTime(nextMeta) > ebGetMetaExpTime(metaItem)) {
+        if (ebGetMetaExpTime(nextMeta) > itemExpireTime) {
             metaHead->numItems += 1;
             metaItem->next = mIter->next;
             mIter->next = item;
@@ -852,9 +857,12 @@ static void ebValidateList(eItem head, EbucketsType *type) {
     ExpireMeta *mHead = type->getExpireMeta(head);
     eItem iter = head;
     ExpireMeta *mIter = type->getExpireMeta(iter), *mIterPrev = NULL;
+    
+    int storedIn = mIter->storedIn; /* Verify all items are in the same level */
 
     for (int i = 0; i < mHead->numItems ; ++i) {
         mIter = type->getExpireMeta(iter);
+        assert(mIter->storedIn == storedIn);
         if (i == 0) {
             /* first item */
             assert(mIter->numItems > 0 && mIter->numItems <= EB_LIST_MAX_ITEMS);
@@ -1257,9 +1265,10 @@ static int ebRemoveFromStack(ebuckets *eb, EbucketsType *type, eItem item) {
     ExpireMeta *metaItem = type->getExpireMeta(item);
     if (metaItem->storedIn == EB_STORED_IN_EB) {
         EB_STACK_EXEC_L1(type, res = ebRemove(&stack->l1, type, item));
-    } if (metaItem->storedIn == EB_STORED_IN_EB_L2) {
+    } else if (metaItem->storedIn == EB_STORED_IN_EB_L2) {
         EB_STACK_EXEC_L2(type, res = ebRemove(&stack->l2, type, item));
-    } else if (metaItem->storedIn == EB_STORED_IN_EB_L3) {
+    } else {
+        debugAssert(metaItem->storedIn == EB_STORED_IN_EB_L3);
         ExpireMetaL3 *m = (ExpireMetaL3 *) metaItem;
         uint64_t idx = m->expireIndexLo | ((uint64_t) m->expireIndexHi << 32);
         debugAssert(stack->l3 && idx < stack->l3->items && stack->l3->vec[idx] == item);
@@ -1292,11 +1301,19 @@ static int ebRemoveFromStack(ebuckets *eb, EbucketsType *type, eItem item) {
     return res;
 }
 
+static uint64_t ebStackCascadeThreshold(uint64_t now) {
+    return ((now + (2 << ebpStackL2.precision)) & (~((1<< ebpStackL2.precision) - 1)));
+}
 
-
+static int ebStackIsL1(uint64_t expireTime) {
+    return expireTime <= ebStackCascadeThreshold(commandTimeSnapshot());
+}
 
 /* Add another eItem to ebStack and based on commandTimeSnapshot() determines
- * if it should be added to L1, L2. */
+ * if it should be added to L1, L2.
+ * 
+ * @return 0 if the item was successfully added. Otherwise, return -1.
+ */
 int ebAddToStack(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTime) {
     ebStack *stack;
     int result = 0;
@@ -1312,11 +1329,9 @@ int ebAddToStack(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTi
     stack = (ebStack *)*eb;
 
     ExpireMeta *itemMeta = type->getExpireMeta(item);
-    
-    debugAssert(itemMeta->storedIn == EB_STORED_IN_TRASH);
 
     /* If ebStack level 3 (infinity) */
-    if (unlikely(expireTime > EB_EXPIRE_TIME_MAX)) {
+    if (unlikely(expireTime >= EB_STACK_L3_MIN)) {
         /* init or expand the l3 if needed */
         if (stack->l3 == NULL) {
             stack->l3 = zmalloc(EB_STACK_L3_SIZEOF(2));
@@ -1333,34 +1348,29 @@ int ebAddToStack(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTi
         ebSetMetaL3Index(((ExpireMetaL3 *) itemMeta) , stack->l3->items);
         ebSetMetaL3ExpireTime(((ExpireMetaL3 *) itemMeta), expireTime);
 
-        itemMeta->storedIn = EB_STORED_IN_EB_L3;
-
         /* Add item to infinity vector */
+        itemMeta->storedIn = EB_STORED_IN_EB_L3;
         stack->l3->vec[stack->l3->items++] = item;
         stack->items++;
         return 0;
     }
-
-    /* Determine which level to add the item to based on bucket key precision */
-    uint64_t now = commandTimeSnapshot();
-    uint64_t nowL2BucketKey = now >> ebpStackL2.precision;
-    uint64_t itemL2BucketKey = expireTime >> ebpStackL2.precision;
-
-    /* If ebStack level 1 */
-    if (itemL2BucketKey <= (nowL2BucketKey + 1)) {
+    
+    if (ebStackIsL1(expireTime)) {
+        itemMeta->storedIn = EB_STORED_IN_EB;
         EB_STACK_EXEC_L1(type, result = ebAdd(&stack->l1, type, item, expireTime));
-        if (result == 0)
-            stack->items++;
-        return result;
     } else {
         /* If ebStack level 2 */
+        itemMeta->storedIn = EB_STORED_IN_EB_L2;
         EB_STACK_EXEC_L2(type, result = ebAdd(&stack->l2, type, item, expireTime));
-        if (result == 0) {
-            itemMeta->storedIn = EB_STORED_IN_EB_L2; /* override */
-            stack->items++;
-        }
-        return result;
     }
+    if (likely(result == 0)) {
+        stack->items++;
+        return 0;
+    }
+    
+    /* Got failed. Mark as trash */
+    itemMeta->storedIn = EB_STORED_IN_TRASH;
+    return 1;
 }
 
 typedef struct ebCascadeCtx {
@@ -1375,12 +1385,12 @@ static ExpireAction onCascadeItem(eItem item, void *ctx) {
     ExpireMeta *itemMeta = cc->l1Type.getExpireMeta(item);
     uint64_t expireTime = ebGetMetaExpTime(itemMeta);
 
+    /* Update storage location from L2 to L1 */
+    itemMeta->storedIn = EB_STORED_IN_EB;
+
     /* If adding to L1 failed, then stop */
     if (ebAdd(cc->l1, &cc->l1Type, item, expireTime) != 0)
         return ACT_STOP_ACTIVE_EXP;
-
-    /* Update storage location from L2 to L1 */
-    itemMeta->storedIn = EB_STORED_IN_EB;
 
     return ACT_REMOVE_EXP_ITEM;
 }
@@ -1425,15 +1435,12 @@ uint64_t ebStackCascade(ebuckets *eb, EbucketsType *type, uint64_t now, uint64_t
     ctx.l1Type = *type;
     ctx.l1Type.isEbStack = 0; /* L1 is not hierarchical */
 
-    /* Calculate cascade threshold */
-    uint64_t cascadeThreshold = now + (2 << ebpStackL2.precision);
-
     /* Reuse ebExpire() to cascade items from L2 to L1 */
     ExpireInfo info = {
         .maxToExpire = maxCascade,
         .onExpireItem = onCascadeItem,
         .ctx = &ctx,
-        .now = cascadeThreshold,
+        .now = ebStackCascadeThreshold(now),
         .itemsExpired = 0
     };
 
@@ -1506,6 +1513,7 @@ int ebAddToRax(ebuckets *eb, EbucketsType *type, eItem item, uint64_t bucketKeyI
 
 /* Validate the general structure of the buckets in rax */
 static void ebValidateRax(rax *rax, EbucketsType *type) {
+    int storedIn = -1; /*uninit*/
     uint64_t numItemsTotal = 0;
     raxIterator raxIter;
     raxStart(&raxIter, rax);
@@ -1523,13 +1531,14 @@ static void ebValidateRax(rax *rax, EbucketsType *type) {
         void *segHdr = firstSegHdr;
 
         mIter = type->getExpireMeta(iter);
+        if (storedIn == -1) storedIn = mIter->storedIn;
         while (1) {
             uint64_t curBktKey, prevBktKey;
             for (int i = 0; i < mHead->numItems ; ++i) {
                 assert(iter != NULL);
                 mIter = type->getExpireMeta(iter);
-                curBktKey = EB_BUCKET_KEY(ebGetMetaExpTime(mIter), type);
-
+                assert(mIter->storedIn == storedIn);
+                curBktKey = EB_BUCKET_KEY(ebGetMetaExpTime(mIter), type);                
                 if (i == 0) {
                     assert(mIter->numItems > 0 && mIter->numItems <= EB_SEG_MAX_ITEMS);
                     assert(mIter->firstItemBucket == expectFirstItemBucket);
@@ -1705,12 +1714,12 @@ int ebAdd(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTime) {
 
     /* Set expire-time and reset segment flags */
     ExpireMeta *itemMeta = type->getExpireMeta(item);
-    ebSetMetaExpTime(itemMeta, expireTime);
     itemMeta->lastInSegment = 0;
     itemMeta->firstItemBucket = 0;
     itemMeta->lastItemBucket = 0;
     itemMeta->numItems = 0;
     itemMeta->storedIn = EB_STORED_IN_EB;
+    ebSetMetaExpTime(itemMeta, expireTime);
 
     if (ebIsList(*eb) || (ebIsEmpty(*eb))) {
         /* Try add item to list */
@@ -1739,6 +1748,8 @@ int ebAdd(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTime) {
  * @param info - Providing information about the expiration action.
  */
 void ebExpire(ebuckets *eb, EbucketsType *type, ExpireInfo *info) {
+    /* if empty ebuckets */
+    if (ebIsEmpty(*eb)) return;
 
     if (type->isEbStack) {
         /* Only items from L1 get expired */
@@ -1757,9 +1768,6 @@ void ebExpire(ebuckets *eb, EbucketsType *type, ExpireInfo *info) {
     /* reset info outputs */
     info->nextExpireTime = EB_EXPIRE_TIME_INVALID;
     info->itemsExpired = 0;
-
-    /* if empty ebuckets */
-    if (ebIsEmpty(*eb)) return;
 
     if (ebIsList(*eb)) {
         ebListExpire(eb, type, info, &updateList);
@@ -1906,7 +1914,7 @@ uint64_t ebExpireDryRun(ebuckets eb, EbucketsType *type, uint64_t now) {
  *         bounded).
  */
 uint64_t ebGetNextTimeToExpire(ebuckets eb, EbucketsType *type) {
-    debugAssert(eb.isEbStack == 0); /* Not required for now */
+    debugAssert(type->isEbStack == 0); /* Not required for now */
     if (ebIsEmpty(eb))
         return EB_EXPIRE_TIME_INVALID;
 
@@ -2017,20 +2025,48 @@ void ebPrintItems(ebuckets eb, EbucketsType *type) {
     }
 }
 
+/* Validate the general structure of L3 vector */
+static void ebStackValidate(ebuckets eb, EbucketsType *type) {
+    ebStack *stack = (ebStack *) eb;
+    EB_STACK_EXEC_L1(type, ebValidate(stack->l1, type));
+    EB_STACK_EXEC_L2(type, ebValidate(stack->l2, type));
+    if (stack->l3 == NULL) return;
+
+    /* Validate vector structure */
+    assert(stack->l3->items <= stack->l3->vecSize);
+    assert(stack->l3->vecSize > 0);
+    /* Verify vecSize is power of 2 */
+    assert((stack->l3->vecSize & (stack->l3->vecSize - 1)) == 0);
+
+    /* Validate each item in the vector */
+    for (uint64_t i = 0; i < stack->l3->items; i++) {
+        eItem item = stack->l3->vec[i];
+        assert(item != NULL);
+
+        ExpireMetaL3 *meta = (ExpireMetaL3 *) type->getExpireMeta(item);
+
+        /* Verify item is marked as stored in L3 */
+        assert(meta->storedIn == EB_STORED_IN_EB_L3);
+
+        /* Verify the index stored in ExpireMetaL3 matches vector position */
+        uint64_t storedIdx = meta->expireIndexLo | ((uint64_t) meta->expireIndexHi << 32);
+        assert(storedIdx == i);
+
+        /* Verify expiration time is >= L3 minimum (infinity) */
+        assert(meta->expireTime >= EB_STACK_L3_MIN);
+    }
+}
+
 /* Validate the general structure of ebuckets. Calls assert(0) on error. */
 void ebValidate(ebuckets eb, EbucketsType *type) {
     if (ebIsEmpty(eb))
         return;
-
-    if (type->isEbStack) {
-        ebStack *stack = (ebStack *) eb;
-        EB_STACK_EXEC_L1(type, ebValidate(stack->l1, type));
-        EB_STACK_EXEC_L2(type, ebValidate(stack->l2, type));
-    } else if (ebIsList(eb)) {
+    if (type->isEbStack)
+        ebStackValidate(eb, type);
+    else if (ebIsList(eb))
         ebValidateList(ebGetListPtr(type, eb), type);
-    } else {
+    else
         ebValidateRax(ebGetRaxPtr(eb), type);
-    }
 }
 
 /* Defrag callback for radix tree iterator, called for each node,
@@ -2857,82 +2893,119 @@ int ebucketsTest(int argc, char **argv, int flags) {
         myEbType.ebp = tmp;
     }
 
+    TEST("ebStack - simple add/remove") {
+        EbucketsType type = myEbType2;
+        type.isEbStack = 1; /* Enable hierarchical ebuckets stack mode for the test */
+
+        ebuckets eb = ebCreate();
+        MyItem items[100];
+        for (uint64_t j = 1; j < ARRAY_SIZE(items) ; j++) {
+            for (uint64_t i = 0; i < j ; i++) {
+                ebAdd(&eb, &type, items + i, i);
+            } 
+            for (uint64_t i = 0; i < j ; i++) {
+                assert(ebRemove(&eb, &type, items + i));
+            }
+            assert(eb == NULL);
+        }
+    }
+
     TEST("ebStack - L1 & L2 basic functionality") {
         EbucketsType type = myEbType2;
-        type.isEbStack = 1; /* Set to hierarchical ebuckets stack for the test */
+        type.isEbStack = 1; /* Enable hierarchical ebuckets stack mode for the test */
 
-        for (int nowAlignment = 0; nowAlignment < 2; nowAlignment++) {
-            const int L2_BUCKET_INTERVAL = 1 << ebpStackL2.precision;
-            __NOW__ = L2_BUCKET_INTERVAL + nowAlignment;
-            uint64_t l1MaxExpireTime = (__NOW__ + (1 << ebpStackL2.precision)) | ((1 << ebpStackL2.precision) - 1);
+        /* Test with different time alignments to ensure robustness across bucket boundaries */
+        for (int nowAlignment = -1; nowAlignment < 2; nowAlignment++) {
+            const int L2_BUCKET_INTERVAL = 1 << ebpStackL2.precision;  /* basic L2 bucket size */
+            __NOW__ = L2_BUCKET_INTERVAL + nowAlignment;  /* Set current time */
+
+            /* Define time ranges for each level */
+            uint64_t l1MaxExpireTime = ebStackCascadeThreshold(__NOW__);
             uint64_t l2MinExpireTime = l1MaxExpireTime + 1;
-            uint64_t l2MaxDeltaExpireTime = (5 * L2_BUCKET_INTERVAL);        
-            MyItem items[80];        
-            uint64_t l1, l2, l3;
-            //srand(0);
-    
+            uint64_t l2MaxDeltaExpireTime = (5 * L2_BUCKET_INTERVAL);  /* limit for the test */
+            MyItem items[80];  /* Test items array */
+            uint64_t l1, l2, l3;  /* Item counts for each level */
+
+            /* Test cascade behavior at different future times */
             for (int cascadeIter = 1; cascadeIter <= 2; cascadeIter++) {
-                uint64_t cascadeTime = __NOW__ + (cascadeIter << ebpStackL2.precision);            
-                for (uint64_t totalItems = 0 ; totalItems < 80; totalItems++) {
+                uint64_t newTime = __NOW__ + (cascadeIter << ebpStackL2.precision);
+
+                /* Test with varying total item counts and distributions across levels */
+                for (uint64_t totalItems = 0 ; totalItems < ARRAY_SIZE(items) ; totalItems++) {
                     for (l1 = 0; l1 <= totalItems; l1++) {
                         for (l2 = 0; l2 <= totalItems - l1; l2++) {
-                            l3 = totalItems - l1 - l2;                            
-                            uint64_t cascadedItemsLo = 0, cascadedItemsHi = 0;    
-                            /* 1. Create ebStack */
+                            l3 = totalItems - l1 - l2;  /* Remaining items go to L3 */
+
+                            /* Track expected cascade counts for validation */
+                            uint64_t cascadedItems = 0;
+
                             ebuckets eb = ebCreate();
-                            
-                            /* 2. Randomize l1/l2/l3 items */
+
+                            /* Populate L1 with items having short-term expiration times */
                             int counter = 0;
                             for (uint64_t i = 0; i < l1; i++) {
-                                uint64_t expireTime = __NOW__ + (rand() % (l1MaxExpireTime - __NOW__));
+                                uint64_t expireTime = rand() % (l1MaxExpireTime + 1);
                                 ebAdd(&eb, &type, items + counter, expireTime);
                                 counter++;
-                            }                       
-                            
+                            }
+
+                            /* Populate L2 with items having medium-term expiration times */
                             for (uint64_t i = 0; i < l2; i++) {
+                                /* Generate random expiration time within L2 range */
                                 uint64_t expireTime = l2MinExpireTime + (rand() % l2MaxDeltaExpireTime);
                                 ebAdd(&eb, &type, items + counter, expireTime);
                                 counter++;
-                                
-                                /* Can expired either based on accurate comparison of the item
-                                 * expire time, or based on bucket key. */
-                                if (expireTime < cascadeTime + (2 << ebpStackL2.precision))
-                                    cascadedItemsLo++;
-                                if ( (expireTime >> ebpStackL2.precision) < (2 + (cascadeTime >> ebpStackL2.precision)))
-                                    cascadedItemsHi++;
+
+                                /* Calculate expected cascade behavior for this item:
+                                 * Items can be cascaded based on either accurate expiration time
+                                 * comparison or bucket key comparison (with precision loss) */
+
+                                if  (expireTime < ebStackCascadeThreshold(newTime))
+                                    cascadedItems++;
                             }
+
+                            /* Populate L3 with items having very long expiration times */
                             for (uint64_t i = 0; i < l3; i++) {
                                 uint64_t expireTime = ((uint64_t)rand() << 32) | (uint64_t)rand();
-                                if (expireTime < (1ULL << 48)) 
-                                    expireTime += (1ULL << 48); 
-        
+                                if (expireTime < (1ULL << 48))
+                                    expireTime += (1ULL << 48);
+
                                 ebAdd(&eb, &type, items + counter, expireTime);
                                 counter++;
                             }
-                            assert(ebGetTotalItems(eb, &type) == totalItems);
-                            assert(ebStackItems(eb, &type, 1) == l1);
-                            assert(ebStackItems(eb, &type, 2) == l2);
-                            assert(ebStackItems(eb, &type, 3) == l3);
-                            
-                            /* Now let's cascade */
-                            ebStack *stack = (ebStack *)eb;
-                            
-                            if (ebIsEmpty(eb) || ebIsEmpty(stack->l2))
-                                continue;
 
-                            /* Verify no cascade before cascadeTime */
-                            assert(0 == ebCascade(&eb, &type, __NOW__, 1000000 /*no limit*/ ));
-                            /* Verify cascade on cascadeTime */
-                            uint64_t cascaded = ebCascade(&eb, &type, cascadeTime, 1000000 /*no limit*/ );
-                            assert( (cascadedItemsHi <= cascaded) && (cascaded <= cascadedItemsLo));
-            
+                            /* Verify correct item distribution across levels */
+                            assert(ebGetTotalItems(eb, &type) == totalItems);  /* Total count matches */
+                            volatile uint64_t l1items = ebStackItems(eb, &type, 1); 
+                            assert(l1items == l1);         /* L1 count matches */
+                            assert(ebStackItems(eb, &type, 2) == l2);         /* L2 count matches */
+                            assert(ebStackItems(eb, &type, 3) == l3);         /* L3 count matches */
+
+                            /* Verify no premature cascade occurs before the designated time */
+                            assert(0 == ebStackCascade(&eb, &type, __NOW__, 1000000 /*no limit*/ ));
+
+                            /* Verify cascade behavior at the designated cascade time */
+                            uint64_t cascaded = ebStackCascade(&eb, &type, newTime, 1000000 /*no limit*/ );
+                            if (cascadedItems != cascaded) {
+                                printf("ERROR: Cascade count mismatch! Details:\n");
+                                printf("  Time config: nowAlignment=%d, cascadeIter=%d" PRIx64 "\n", nowAlignment, cascadeIter);
+                                printf("  Item distribution before cascade: totalItems=%ld (L1=%ld, L2=%ld L3=%ld)\n", totalItems, l1, l2, l3);
+                                printf("  Time: Time=0x%lx, cascadeThreshold(now)=0x%" PRIx64 ", l1MaxExpireTime=0x%" PRIx64 "\n", __NOW__, ebStackCascadeThreshold(__NOW__), l1MaxExpireTime);
+                                printf("  New time: newTime=0x%lx, cascadeThreshold(newTime)=0x%lx\n", newTime, ebStackCascadeThreshold(newTime));
+                                printf("  Cascade counts: expected=%ld, actual=%ld\n", cascadedItems, cascaded);
+                                printf("  ebuckets structure after cascade:\n----------------START----------------\n");
+                                ebPrintItems(eb, &type);
+                                printf("----------------END----------------\n");
+                                assert(0);
+                            }
+
                             ebDestroy(&eb, &type, NULL);
                         }
                     }
                 }
             }
         }
-    }    
+    }
 
     TEST("list - Create few items on random times and then expire/delete ") {
         for (int isExpire = 0 ; isExpire <= 1 ; ++isExpire ) {

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -2372,7 +2372,7 @@ void ebGetStats(ebuckets eb, EbucketsType *type, ebucketsStats *stats) {
     if (type->isEbStack) {
         ebStack *stack = (ebStack *) eb;
         EB_STACK_EXEC_L1(type, ebGetStats(stack->l1, type, stats));        
-        EB_STACK_EXEC_L1(type, ebGetStats(stack->l2, type, stats));
+        EB_STACK_EXEC_L2(type, ebGetStats(stack->l2, type, stats));
     } else if (ebIsList(eb)) {
         eItem head = ebGetListPtr(type, eb);
         ExpireMeta *meta = type->getExpireMeta(head);

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -1447,7 +1447,6 @@ int ebAddToRax(ebuckets *eb, EbucketsType *type, eItem item, uint64_t bucketKeyI
         metaItem->firstItemBucket = 1;
         metaItem->numItems = 1;
         metaItem->next = firstSegHdr;
-        bucketKey2RaxKey(bucketKeyItem, raxKey, type);
         raxInsert(rax, raxKey, type->ebp.keySize, firstSegHdr, NULL);
         raxStop(&iter);
         return 0;

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -168,8 +168,8 @@ typedef struct ExpireMetaL3 {
 typedef long long mstime_t; /* millisecond time type. */
 mstime_t commandTimeSnapshot(void);
 #else /* Let tests control time */
-uint64_t __now__ = 0;
-#define commandTimeSnapshot() __now__
+uint64_t __NOW__ = 0;
+#define commandTimeSnapshot() __NOW__
 #endif
 
 /* Verify that "head" field is aligned in FirstSegHdr, NextSegHdr and CommonSegHdr */
@@ -224,6 +224,7 @@ static inline eItem ebGetListPtr(EbucketsType *type, ebuckets eb) {
         return (void*)((uintptr_t)(eb) & ~1);
 }
 
+/* Set the index of the item in the infinity vector (L3) */
 static inline void ebSetMetaL3Index(ExpireMetaL3 *em3, uint64_t idx) { 
     ebSetMetaExpTime( (ExpireMeta *)em3, idx); 
 }
@@ -1957,6 +1958,9 @@ uint64_t ebGetTotalItems(ebuckets eb, EbucketsType *type) {
 
 /* print expiration-time of items, ebuckets layout and some statistics */
 void ebPrintItems(ebuckets eb, EbucketsType *type) {
+    if (ebIsEmpty(eb))
+        return;
+
     if (type->isEbStack) {
         ebStack *stack = (ebStack *) eb;
         printf("[EBSTACK-LEVEL1]:\n");
@@ -2529,9 +2533,9 @@ void distributeTest(int lowestTime,
         for (int i = 0 ; i < numRanges ; i++) {
 
             /* When checking how many items are expired, we need to take into
-             * consideration EB_BUCKET_KEY_PRECISION. The value of "info->now"
+             * consideration EbucketsType.ebp.precision. The value of "info->now"
              * will be adjusted by ebActiveExpire() to lookup only for all buckets
-             * with assigned keys that are older than 1<<EB_BUCKET_KEY_PRECISION
+             * with assigned keys that are older than 1<<EbucketsType.ebp.precision
              * msec ago. That is, it is needed to visit only the buckets with keys
              * that are "<" EB_BUCKET_KEY(info->now) and not "<=".
              * But if there is a list behind ebuckets, then this limitation is not
@@ -2539,14 +2543,14 @@ void distributeTest(int lowestTime,
              *
              * The '-1' in case of list brings makes both cases aligned to have
              * same result */
-            uint64_t now = EB_BUCKET_EXP_TIME(expireRanges[i], &myEbType) + (ebIsList(eb) ? -1 : 0);
+            uint64_t now = EB_BUCKET_EXP_TIME(expireRanges[i], &myEbType);
 
             TimeRange range = {EB_BUCKET_EXP_TIME(startRange, &myEbType), EB_BUCKET_EXP_TIME(expireRanges[i], &myEbType) };
             ExpireInfo info = {
                     .maxToExpire = 0xFFFFFFFF,
                     .onExpireItem = expireItemCb,
                     .ctx = &range,
-                    .now = now+1,
+                    .now = now,
                     .itemsExpired = 0};
 
             ebExpire(&eb, &myEbType, &info);
@@ -2804,238 +2808,81 @@ int ebucketsTest(int argc, char **argv, int flags) {
     }
 
     TEST("ebStack - L1 & L2 basic functionality") {
-        uint64_t expireAt;
-        const int L2_BUCKET_INTERVAL = 1 << ebpStackL2.precision;
-        __now__ = L2_BUCKET_INTERVAL + 1;
         EbucketsType type = myEbType2;
         type.isEbStack = 1; /* Set to hierarchical ebuckets stack for the test */
 
-        /* Test basic ebStack functionality */
-        ebuckets eb = ebCreate();
-        uint64_t at = 0;
-        MyItem items[10];
-
-        /* Test Level 1: Short-term expiration (high precision) */
-        expireAt = __now__ + 1000;
-        ebAdd(&eb, &type, items + at, expireAt);
-        assert(!ebIsEmpty(eb));
-
-        /* Verify 1 item was stored in L1 */
-        ebStack *stack = (ebStack *)eb;
-        assert(ebGetTotalItems(eb, &type) == at+1);
-        assert(stack->items == at+1);
-        assert(ebStackItems(eb, &type, 1) == 1);
-        assert(ebStackItems(eb, &type, 2) == 0);
-        assert(ebStackItems(eb, &type, 3) == 0);
-        assert(type.getExpireMeta(&items[at])->storedIn == EB_STORED_IN_EB);
+        for (int nowAlignment = 0; nowAlignment < 2; nowAlignment++) {
+            const int L2_BUCKET_INTERVAL = 1 << ebpStackL2.precision;
+            __NOW__ = L2_BUCKET_INTERVAL + nowAlignment;
+            uint64_t l1MaxExpireTime = (__NOW__ + (1 << ebpStackL2.precision)) | ((1 << ebpStackL2.precision) - 1);
+            uint64_t l2MinExpireTime = l1MaxExpireTime + 1;
+            uint64_t l2MaxDeltaExpireTime = (5 * L2_BUCKET_INTERVAL);        
+            MyItem items[80];        
+            uint64_t l1, l2, l3;
+            //srand(0);
+    
+            for (int cascadeIter = 1; cascadeIter <= 2; cascadeIter++) {
+                uint64_t cascadeTime = __NOW__ + (cascadeIter << ebpStackL2.precision);            
+                for (uint64_t totalItems = 0 ; totalItems < 80; totalItems++) {
+                    for (l1 = 0; l1 <= totalItems; l1++) {
+                        for (l2 = 0; l2 <= totalItems - l1; l2++) {
+                            l3 = totalItems - l1 - l2;                            
+                            uint64_t cascadedItemsLo = 0, cascadedItemsHi = 0;    
+                            /* 1. Create ebStack */
+                            ebuckets eb = ebCreate();
+                            
+                            /* 2. Randomize l1/l2/l3 items */
+                            int counter = 0;
+                            for (uint64_t i = 0; i < l1; i++) {
+                                uint64_t expireTime = __NOW__ + (rand() % (l1MaxExpireTime - __NOW__));
+                                ebAdd(&eb, &type, items + counter, expireTime);
+                                counter++;
+                            }                       
+                            
+                            for (uint64_t i = 0; i < l2; i++) {
+                                uint64_t expireTime = l2MinExpireTime + (rand() % l2MaxDeltaExpireTime);
+                                ebAdd(&eb, &type, items + counter, expireTime);
+                                counter++;
+                                
+                                /* Can expired either based on accurate comparison of the item
+                                 * expire time, or based on bucket key. */
+                                if (expireTime < cascadeTime + (2 << ebpStackL2.precision))
+                                    cascadedItemsLo++;
+                                if ( (expireTime >> ebpStackL2.precision) < (2 + (cascadeTime >> ebpStackL2.precision)))
+                                    cascadedItemsHi++;
+                            }
+                            for (uint64_t i = 0; i < l3; i++) {
+                                uint64_t expireTime = ((uint64_t)rand() << 32) | (uint64_t)rand();
+                                if (expireTime < (1ULL << 48)) 
+                                    expireTime += (1ULL << 48); 
         
-        at++;
-        
-        /* Test Level 1: Short-term expiration (high precision) */
-        expireAt = __now__ + L2_BUCKET_INTERVAL;
-        ebAdd(&eb, &type, items + at, expireAt);
-        assert(!ebIsEmpty(eb));
-        /* Verify 2 item are stored in L1 */        
-        assert(ebGetTotalItems(eb, &type) == at+1);
-        assert(stack->items == at+1);
-        assert(ebStackItems(eb, &type, 1) == 2);
-        assert(ebStackItems(eb, &type, 2) == 0);
-        assert(ebStackItems(eb, &type, 3) == 0);
-        assert(type.getExpireMeta(&items[at])->storedIn == EB_STORED_IN_EB);
-        
-        at++;
+                                ebAdd(&eb, &type, items + counter, expireTime);
+                                counter++;
+                            }
+                            assert(ebGetTotalItems(eb, &type) == totalItems);
+                            assert(ebStackItems(eb, &type, 1) == l1);
+                            assert(ebStackItems(eb, &type, 2) == l2);
+                            assert(ebStackItems(eb, &type, 3) == l3);
+                            
+                            /* Now let's cascade */
+                            ebStack *stack = (ebStack *)eb;
+                            
+                            if (ebIsEmpty(eb) || ebIsEmpty(stack->l2))
+                                continue;
 
-        /* Verify level 2: Add item that should be added to L2 */
-        expireAt = __now__ + (2 << ebpStackL2.precision);
-        ebAdd(&eb, &type, &items[at], expireAt);
-        assert(ebGetTotalItems(eb, &type) == at+1);
-        assert(stack->items == at+1);
-        assert(ebStackItems(eb, &type, 1) == 2);
-        assert(ebStackItems(eb, &type, 2) == 1);
-        assert(ebStackItems(eb, &type, 3) == 0);
-        assert(type.getExpireMeta(&items[at])->storedIn == EB_STORED_IN_EB_L2);
-        
-        at++;
-        
-        /* Verify level 2: Add another item that should be added to L2 */
-        expireAt = __now__ + (3 << ebpStackL2.precision);
-        ebAdd(&eb, &type, &items[at], expireAt);
-        assert(ebGetTotalItems(eb, &type) == at+1);
-        assert(stack->items == at+1);
-        assert(ebStackItems(eb, &type, 1) == 2);
-        assert(ebStackItems(eb, &type, 2) == 2);
-        assert(ebStackItems(eb, &type, 3) == 0);
-        assert(type.getExpireMeta(&items[at])->storedIn == EB_STORED_IN_EB_L2);
-
-        ebPrintItems(eb, &type);
-        /* Now cascade such that the 1st item in L2 should be cascaded to L1 */
-        __now__ += L2_BUCKET_INTERVAL;
-        uint64_t cascaded = ebCascade(&eb, &type, __now__, 10);
-        ebPrintItems(eb, &type);
-        assert(cascaded == 1);
-        assert(ebGetTotalItems(eb, &type) == at+1);
-        assert(stack->items == at+1);
-        assert(ebStackItems(eb, &type, 1) == 3);
-        assert(ebStackItems(eb, &type, 2) == 1);
-        assert(ebStackItems(eb, &type, 3) == 0);
-        assert(type.getExpireMeta(&items[at-1])->storedIn == EB_STORED_IN_EB);
-
-//        /* Test Level 3: TBD */
-//
-//        /* Test ebCascade functionality */
-//        /* Add some items to L2 that should be cascaded to L1 */
-//        /* Use a large value that will definitely go to L2 due to precision difference */
-//        uint64_t l2Expire = (1ULL << 30); /* Should go to L2 due to precision difference */
-//
-//        /* Add item that will be eligible for cascade */
-//        ebAdd(&eb, &type, &items[2], l2Expire);
-//        assert(ebGetTotalItems(eb, &type) == 3);
-//        assert(stack->items == 3);
-//        assert(type.getExpireMeta(&items[2])->storedIn == EB_STORED_IN_EB_L2);
-
-        ebDestroy(&eb, &type, NULL);
-    }
-//
-//    TEST("ebStack - Cascading") {
-//        EbucketsType type = myEbType2;
-//        type.isEbStack = 1; /* Set to hierarchical ebuckets stack for the test */
-//
-//        /* Test 1: Basic cascading functionality */
-//        {
-//            ebuckets eb = ebCreate();
-//            MyItem items[5];
-//
-//            /* Current time for testing - use a base time */
-//            uint64_t baseTime = 1000000; /* Base time in milliseconds */
-//
-//            /* Add items to L2 that should be eligible for cascading */
-//            /* Items with expiration times that fall within cascade threshold should move to L1 */
-//
-//            /* Calculate L2 bucket precision threshold */
-//            uint64_t l2BucketDuration = (1ULL << ebpStackL2.precision); /* ~34.9 minutes */
-//            //uint64_t cascadeThreshold = baseTime + (2 * l2BucketDuration); /* Cascade threshold */
-//
-//            /* Add item to L2 that should be cascaded (expires before threshold) */
-//            uint64_t l2ExpireEarly = baseTime + l2BucketDuration; /* Within cascade window */
-//            ebAdd(&eb, &type, &items[0], l2ExpireEarly);
-//
-//            /* Add item to L2 that should NOT be cascaded (expires after threshold) */
-//            uint64_t l2ExpireLate = baseTime + (3 * l2BucketDuration); /* Beyond cascade window */
-//            ebAdd(&eb, &type, &items[1], l2ExpireLate);
-//
-//            /* Verify initial state - both items should be in L2 */
-//            ebStack *stack = (ebStack *)eb;
-//            assert(ebGetTotalItems(eb, &type) == 2);
-//            assert(stack->items == 2);
-//            assert(ebIsEmpty(stack->l1)); /* L1 should be empty initially */
-//            assert(!ebIsEmpty(stack->l2)); /* L2 should have items */
-//            assert(type.getExpireMeta(&items[0])->storedIn == EB_STORED_IN_EB_L2);
-//            assert(type.getExpireMeta(&items[1])->storedIn == EB_STORED_IN_EB_L2);
-//
-//            /* Perform cascade operation */
-//            uint64_t cascaded = ebCascade(&eb, &type, baseTime, 10); /* Allow up to 10 cascades */
-//
-//            /* Verify cascade results */
-//            assert(cascaded == 1); /* Only one item should be cascaded */
-//            assert(ebGetTotalItems(eb, &type) == 2); /* Total items unchanged */
-//            assert(stack->items == 2);
-//            assert(!ebIsEmpty(stack->l1)); /* L1 should now have the cascaded item */
-//            assert(!ebIsEmpty(stack->l2)); /* L2 should still have the late item */
-//
-//            /* Verify storage locations after cascade */
-//            assert(type.getExpireMeta(&items[0])->storedIn == EB_STORED_IN_EB); /* Moved to L1 */
-//            assert(type.getExpireMeta(&items[1])->storedIn == EB_STORED_IN_EB_L2); /* Stayed in L2 */
-//
-//            ebDestroy(&eb, &type, NULL);
-//        }
-//
-//        /* Test 2: Edge cases */
-//        {
-//            /* Test empty ebStack */
-//            ebuckets emptyEb = ebCreate();
-//            uint64_t cascaded = ebCascade(&emptyEb, &type, 1000, 10);
-//            assert(cascaded == 0); /* No items to cascade */
-//            ebDestroy(&emptyEb, &type, NULL);
-//
-//            /* Test non-ebStack */
-//            EbucketsType nonStackType = myEbType2;
-//            nonStackType.isEbStack = 0; /* Not an ebStack */
-//            ebuckets nonStackEb = ebCreate();
-//            MyItem item;
-//            ebAdd(&nonStackEb, &nonStackType, &item, 1000);
-//            cascaded = ebCascade(&nonStackEb, &nonStackType, 1000, 10);
-//            assert(cascaded == 0); /* Should not cascade non-ebStack */
-//            ebDestroy(&nonStackEb, &nonStackType, NULL);
-//        }
-//
-//        /* Test 3: MaxCascade limit */
-//        {
-//            ebuckets eb = ebCreate();
-//            MyItem items[5];
-//            uint64_t baseTime = 2000000;
-//            uint64_t l2BucketDuration = (1ULL << ebpStackL2.precision);
-//
-//            /* Add multiple items to L2 that should all be cascaded */
-//            for (int i = 0; i < 3; i++) {
-//                uint64_t expireTime = baseTime + (l2BucketDuration / 2); /* All within cascade window */
-//                ebAdd(&eb, &type, &items[i], expireTime);
-//            }
-//
-//            /* Verify all items are in L2 */
-//            ebStack *stack = (ebStack *)eb;
-//            assert(ebGetTotalItems(eb, &type) == 3);
-//            assert(ebIsEmpty(stack->l1));
-//            assert(!ebIsEmpty(stack->l2));
-//
-//            /* Cascade with limit of 2 items */
-//            uint64_t cascaded = ebCascade(&eb, &type, baseTime, 2);
-//
-//            /* Should cascade exactly 2 items due to limit */
-//            assert(cascaded == 2);
-//            assert(ebGetTotalItems(eb, &type) == 3); /* Total unchanged */
-//            assert(!ebIsEmpty(stack->l1)); /* L1 should have cascaded items */
-//            assert(!ebIsEmpty(stack->l2)); /* L2 should still have remaining item */
-//
-//            ebDestroy(&eb, &type, NULL);
-//        }
-//
-//        /* Test 4: Cascade with L1 already having items */
-//        {
-//            ebuckets eb = ebCreate();
-//            MyItem items[3];
-//            uint64_t baseTime = 3000000;
-//            uint64_t l2BucketDuration = (1ULL << ebpStackL2.precision);
-//
-//            /* Add item directly to L1 (short expiration) */
-//            uint64_t l1ExpireTime = baseTime + 1000; /* Should go to L1 */
-//            ebAdd(&eb, &type, &items[0], l1ExpireTime);
-//
-//            /* Add item to L2 that should be cascaded */
-//            uint64_t l2ExpireTime = baseTime + l2BucketDuration; /* Should cascade to L1 */
-//            ebAdd(&eb, &type, &items[1], l2ExpireTime);
-//
-//            /* Verify initial state */
-//            ebStack *stack = (ebStack *)eb;
-//            assert(ebGetTotalItems(eb, &type) == 2);
-//            assert(!ebIsEmpty(stack->l1)); /* L1 has one item */
-//            assert(!ebIsEmpty(stack->l2)); /* L2 has one item */
-//            assert(type.getExpireMeta(&items[0])->storedIn == EB_STORED_IN_EB); /* In L1 */
-//            assert(type.getExpireMeta(&items[1])->storedIn == EB_STORED_IN_EB_L2); /* In L2 */
-//
-//            /* Perform cascade */
-//            uint64_t cascaded = ebCascade(&eb, &type, baseTime, 10);
-//
-//            /* Verify results */
-//            assert(cascaded == 1); /* One item cascaded */
-//            assert(ebGetTotalItems(eb, &type) == 2); /* Total unchanged */
-//            assert(!ebIsEmpty(stack->l1)); /* L1 now has both items */
-//            assert(ebIsEmpty(stack->l2)); /* L2 should be empty */
-//            assert(type.getExpireMeta(&items[0])->storedIn == EB_STORED_IN_EB); /* Still in L1 */
-//            assert(type.getExpireMeta(&items[1])->storedIn == EB_STORED_IN_EB); /* Moved to L1 */
-//
-//            ebDestroy(&eb, &type, NULL);
-//        }
-//    }
+                            /* Verify no cascade before cascadeTime */
+                            assert(0 == ebCascade(&eb, &type, __NOW__, 1000000 /*no limit*/ ));
+                            /* Verify cascade on cascadeTime */
+                            uint64_t cascaded = ebCascade(&eb, &type, cascadeTime, 1000000 /*no limit*/ );
+                            assert( (cascadedItemsHi <= cascaded) && (cascaded <= cascadedItemsLo));
+            
+                            ebDestroy(&eb, &type, NULL);
+                        }
+                    }
+                }
+            }
+        }
+    }    
 
     TEST("list - Create few items on random times and then expire/delete ") {
         for (int isExpire = 0 ; isExpire <= 1 ; ++isExpire ) {

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -1012,8 +1012,19 @@ static int ebAddToBucket(EbucketsType *type,
 
     if (bucketKey == itemKey) {
         /* New item has the same bucket-key as the ones in this bucket, Add it as well */
-        if (mHead->numItems < EB_SEG_MAX_ITEMS)
-            return ebSegAddAvail(type, firstSegBkt, item); /* Add item to first segment */
+        if (mHead->numItems < EB_SEG_MAX_ITEMS) {
+            /* Add item to the head of the segment (Don't sort. All with same expiry) */
+            mItem->next = firstSegBkt->head;
+            mItem->firstItemBucket = 1;
+            mItem->numItems = mHead->numItems + 1;
+            /* Modify previous head to be the second item */
+            mHead->firstItemBucket = 0;
+            mHead->numItems = 0;
+            /* Update firstSegHdr */
+            firstSegBkt->totalItems++;
+            firstSegBkt->head = item;
+            return 0;
+        }
         else  {
             /* If a regular segment becomes extended-segment, then update the
              * bucket-key to be aligned with the expiration-time of the items
@@ -1434,7 +1445,7 @@ int ebAddToRax(ebuckets *eb, EbucketsType *type, eItem item, uint64_t bucketKeyI
     *ebRaxNumItems(rax) += 1;
     /* If expireTime of the item is below the bucket-key of first bucket in rax,
      * then need to add it as a new bucket at the beginning of the rax. */
-    if(raxNext(&iter) == 0) {
+    if(unlikely(raxNext(&iter) == 0)) {
         FirstSegHdr *firstSegHdr = zmalloc(sizeof(FirstSegHdr));
         firstSegHdr->head = item;
         firstSegHdr->totalItems = 1;

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -126,10 +126,12 @@ typedef struct ebVector {
 } ebVector;
 
 typedef struct ebStack {
-    uint64_t items;
-    ebuckets l1;
-    ebuckets l2;
-    ebVector *l3; /*infinity*/
+    /* Hierarchical ebuckets stack */
+    ebuckets l1;          /* LEVEL1: TTL < 2^(ebpStackL2.precision+1) msec */
+    ebuckets l2;          /* LEVEL2: expiration-time < 2^48 msec */
+    ebVector *l3;         /* LEVEL3: expiration-time >= 2^48 msec (infinity) */
+    
+    uint64_t items;       /* Total number of items in the stack */
 } ebStack;
 
 /* Unlike ebuckets level 1 in ebStack, the level 2 precision is not configurable
@@ -147,16 +149,18 @@ const EBucketPrecision ebpStackL2 = {
  * ExpireMeta can only store 48-bit timestamps (sufficient until year 10889), but 
  * L3 items need full 64-bit timestamps for practically infinite expiration times.
  *
- * Key differences from ExpireMeta:
- * - expireIndexLo/Hi: 6-byte index into the infinity vector (replaces expireTimeLo/Hi)
- * - expireTime: Full 8-byte timestamp (replaces the `next` pointer)
- * - Same size and alignment as ExpireMeta for memory compatibility
+ * The struct is aligned with ExpireMeta to allow in-place conversion.
  */
 typedef struct ExpireMetaL3 {
-    uint32_t expireIndexLo;     /* Lo Index in infinity vector */
-    uint16_t expireIndexHi;     /* Hi Index in infinity vector */
+    /* 48 bits of Index into infinity vector (Overlays ExpireMeta.expireTimeLo/Hi) */
+    uint32_t expireIndexLo;
+    uint16_t expireIndexHi;
+    
+    /* Same flags like ExpireMeta (but only `storedIn` is being used) */
     EXPIRE_META_FLAGS
-    uint64_t expireTime;        /* replaces `next` with actual 8 bytes timestamp */
+    
+    /* 8-byte of expiration time (Overlays the `ExpireMeta.next` pointer) */
+    uint64_t expireTime;
 } ExpireMetaL3;
 
 /* Selective declarations from server.h instead of including it */
@@ -227,6 +231,10 @@ static inline eItem ebGetListPtr(EbucketsType *type, ebuckets eb) {
 /* Set the index of the item in the infinity vector (L3) */
 static inline void ebSetMetaL3Index(ExpireMetaL3 *em3, uint64_t idx) { 
     ebSetMetaExpTime( (ExpireMeta *)em3, idx); 
+}
+
+static inline void ebSetMetaL3ExpireTime(ExpireMetaL3 *em3, uint64_t t) { 
+    em3->expireTime = t; 
 }
 
 /* Converts the logical starting time value of a given bucket-key to its equivalent
@@ -1309,9 +1317,6 @@ int ebAddToStack(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTi
 
     /* If ebStack level 3 (infinity) */
     if (unlikely(expireTime > EB_EXPIRE_TIME_MAX)) {
-        // TODO_MOTI: Need to change EB_EXPIRE_TIME_INVALID to be 0 and MAX to be 2^64-1
-        //assert(expireTime <= EB_EXPIRE_TIME_MAX);
-      
         /* init or expand the l3 if needed */
         if (stack->l3 == NULL) {
             stack->l3 = zmalloc(EB_STACK_L3_SIZEOF(2));
@@ -1324,8 +1329,10 @@ int ebAddToStack(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTi
             stack->l3->vecSize = newSize;
         }
 
-        /* Store index of new item in its expireMeta */
+        /* Store expireTime & L3 index of new item in its expireMeta */
         ebSetMetaL3Index(((ExpireMetaL3 *) itemMeta) , stack->l3->items);
+        ebSetMetaL3ExpireTime(((ExpireMetaL3 *) itemMeta), expireTime);
+
         itemMeta->storedIn = EB_STORED_IN_EB_L3;
 
         /* Add item to infinity vector */
@@ -1404,7 +1411,7 @@ static ExpireAction onCascadeItem(eItem item, void *ctx) {
  *
  * @return Number of items cascaded from L2 to L1
  */
-uint64_t ebCascade(ebuckets *eb, EbucketsType *type, uint64_t now, uint64_t maxCascade)
+uint64_t ebStackCascade(ebuckets *eb, EbucketsType *type, uint64_t now, uint64_t maxCascade)
 {
     /* If empty, not ebStack, or L2 is empty, then nothing to cascade */
     if (ebIsEmpty(*eb) || !type->isEbStack || ebIsEmpty(((ebStack *)*eb)->l2))
@@ -1790,6 +1797,14 @@ void ebExpire(ebuckets *eb, EbucketsType *type, ExpireInfo *info) {
  */
 uint64_t ebExpireDryRun(ebuckets eb, EbucketsType *type, uint64_t now) {
     if (ebIsEmpty(eb)) return 0;
+    
+    if (unlikely(type->isEbStack)) {
+        /* Only items from L1 get expired */
+        ebStack *stack = (ebStack *) eb;
+        uint64_t res = 0;
+        EB_STACK_EXEC_L1(type, res = ebExpireDryRun(stack->l1, type, now));
+        return res;
+    }
 
     uint64_t numExpired = 0;
 
@@ -1891,6 +1906,7 @@ uint64_t ebExpireDryRun(ebuckets eb, EbucketsType *type, uint64_t now) {
  *         bounded).
  */
 uint64_t ebGetNextTimeToExpire(ebuckets eb, EbucketsType *type) {
+    debugAssert(eb.isEbStack == 0); /* Not required for now */
     if (ebIsEmpty(eb))
         return EB_EXPIRE_TIME_INVALID;
 
@@ -1932,7 +1948,7 @@ uint64_t ebGetNextTimeToExpire(ebuckets eb, EbucketsType *type) {
     return minExpire;
 }
 
-/* Returns number of items in ebStack level (Level can be either 1, 2 or 3) */
+/* Returns number of items in ebStack level (Used only for testing) */
 uint64_t ebStackItems(ebuckets eb, EbucketsType *type, int level) {
     debugAssert(type->isEbStack);
     uint64_t res = 0;
@@ -2206,19 +2222,41 @@ int ebScanDefrag(ebuckets *eb, EbucketsType *type, unsigned long *cursor,
         return ebDefragRax(eb, type, cursor, defragfns, privdata);
     }
 }
-
-/* Retrieves the expiration time associated with the given item. If associated
- * ExpireMeta is marked as trash, then return EB_EXPIRE_TIME_INVALID */
+/* Gets the item's expiration timestamp. Returns EB_EXPIRE_TIME_INVALID 
+ * if the item's ExpireMeta is marked as trash  */
 uint64_t ebGetExpireTime(EbucketsType *type, eItem item) {
+    debugAssert(type->isEbStack == 0); /* See ebStackGetExpireTime() */
     ExpireMeta *meta = type->getExpireMeta(item);
     
     if (unlikely(meta->storedIn == EB_STORED_IN_TRASH))
         return EB_EXPIRE_TIME_INVALID;
-
-    // TODO_MOTI: Modify EB_EXPIRE_TIME_INVALID from 0x0000FFFFFFFFFFFF to 0x0
-    if (unlikely(meta->storedIn == EB_STORED_IN_EB_L3))
-        return ((uint64_t) ((ExpireMetaL3 *) meta)->expireTime);
     
+    if (unlikely(meta->storedIn == EB_STORED_IN_EB_L3))
+        return ((ExpireMetaL3 *) meta)->expireTime;
+    
+    return ebGetMetaExpTime(meta);
+}
+
+/* Gets the expiration timestamp for an item stored in ebStack.
+ * 
+ * ebStack also extends ebuckets to handle timestamps beyond the standard limit
+ * (timestamps ≥ 2^48 msec are considered "infinite") with L3 vector. 
+ * 
+ * Returns -1 if the item is marked as trash, otherwise returns the actual
+ * expiration time. (can't use here the value EB_EXPIRE_TIME_INVALID!) */
+long long ebStackGetExpireTime(EbucketsType *type, eItem item) {
+    debugAssert(type->isEbStack);
+    
+    ExpireMeta *meta = type->getExpireMeta(item);
+
+    if (unlikely(meta->storedIn == EB_STORED_IN_TRASH))
+        return -1;
+
+    /* L3 */
+    if (unlikely(meta->storedIn == EB_STORED_IN_EB_L3))
+        return ((ExpireMetaL3 *) meta)->expireTime;
+
+    /* L1 or L2 */
     return ebGetMetaExpTime(meta);
 }
 
@@ -2230,6 +2268,7 @@ uint64_t ebGetExpireTime(EbucketsType *type, eItem item) {
  * iter->currItem will be NULL and iter->itemsCurrBucket will be set to 0.
  */
 void ebStart(EbucketsIterator *iter, ebuckets eb, EbucketsType *type) {
+    debugAssert(type->isEbStack == 0); /* Not required for now */
     iter->eb = eb;
     iter->type = type;
     iter->isRax = 0;
@@ -2237,8 +2276,6 @@ void ebStart(EbucketsIterator *iter, ebuckets eb, EbucketsType *type) {
     if (ebIsEmpty(eb)) {
         iter->currItem = NULL;
         iter->itemsCurrBucket = 0;
-    } else if (type->isEbStack) {
-        assert(0); /* Not implemented (Not needed) */
     } else if (ebIsList(eb)) {
         iter->currItem = ebGetListPtr(type, eb);
         iter->itemsCurrBucket = type->getExpireMeta(iter->currItem)->numItems;
@@ -2262,6 +2299,7 @@ void ebStart(EbucketsIterator *iter, ebuckets eb, EbucketsType *type) {
  *   - 1 otherwise, updating `iter->currItem` to the next item.
  */
 int ebNext(EbucketsIterator *iter) {
+    debugAssert(iter->type->isEbStack == 0); /* Not required for now */
     if (iter->currItem == NULL)
         return 0;
 
@@ -2303,6 +2341,7 @@ int ebNext(EbucketsIterator *iter) {
  *       next ebucket.
  */
 int ebNextBucket(EbucketsIterator *iter) {
+    debugAssert(iter->type->isEbStack == 0); /* Not required for now */
     if (iter->currItem == NULL)
         return 0;
 
@@ -2319,6 +2358,7 @@ int ebNextBucket(EbucketsIterator *iter) {
 
 /* Stop and cleanup the ebuckets iterator */
 void ebStop(EbucketsIterator *iter) {
+    debugAssert(iter->type->isEbStack == 0); /* Not required for now */
     if (iter->isRax)
         raxStop(&iter->raxIter);
 }

--- a/src/ebuckets.h
+++ b/src/ebuckets.h
@@ -92,11 +92,11 @@
  * without compromise on accuracy because the exact expiration-time is kept
  * attached as well to each item, in `ExpireMeta`, and each traversal of item with
  * expiration will behave as expected down to the msec. Take care to configure
- * `EB_BUCKET_KEY_PRECISION` according to your needs.
+ * `EbucketsType.ebp.precision` according to your needs.
  *
  * EBUCKET KEY
  * -----------
- * Taking into account configured value of `EB_BUCKET_KEY_PRECISION`, two items
+ * Taking into account configured value of `EbucketsType.ebp.precision`, two items
  * with expiration-time t1 and t2 will be considered to have the same key in the
  * rax-tree/buckets if and only if:
  *

--- a/src/ebuckets.h
+++ b/src/ebuckets.h
@@ -126,17 +126,16 @@
  *
  * level #3 - A plain vector of items with very long expiration times, treated
  *            as practically infinite. This level avoids the overhead of
- *            bucket or rax structures entirely. Since regular ExpireMeta can 
- *            only store 48-bit timestamps (sufficient until year 10889), L3 items
+ *            bucket or rax structures entirely. Since regular ExpireMeta is optimized 
+ *            to store 48-bit timestamps (sufficient until year 10889), L3 items
  *            use `ExpireMetaL3` which replaces the `next` pointer with a full
  *            64-bit timestamp and stores the index (expireIndexLo/Hi) into the 
  *            infinity vector instead of the expiration time in the expireTimeLo/Hi 
- *            fields.            
+ *            fields. See struct ExpireMetaL3 for more details.           
  *
  * It is specifically designed for Redis’s EXPIRE use case, but can be adapted
- * to other use cases. Internally, this multi-level logic is abstracted away from 
- * the ebuckets API. From the user's perspective, ebuckets appear as a single 
- * expiration structure. This hierarchical mode is enabled by setting `isEbStack` 
+ * to other use cases. Internally, this multi-level logic is mostly abstracted away 
+ * from the ebuckets API. This hierarchical mode is enabled by setting `isEbStack` 
  * in the `EbucketsType` structure. Yet, the caller must periodically call 
  * `ebCascade()` to promote items from level 2 to level 1 as their TTL shortens. 
  *
@@ -155,6 +154,7 @@
 #include <sys/types.h>
 #include <stdarg.h>
 #include <stdint.h>
+#include "redisassert.h"
 #include "rax.h"
 
 
@@ -338,7 +338,16 @@ typedef struct {
     ebDefragAllocItemFunction *defragItem;  /* Defrag-realloc eitem */
 } ebDefragFunctions;
 
-/* ebuckets API */
+typedef struct ebucketsStats {
+    uint64_t totalItems;           /* Total number of items */
+    uint64_t totalBuckets;         /* Total number of buckets */
+    uint64_t totalSegments;        /* Total number of segments */
+    uint64_t avgItemsPerBucket;    /* Average number of items per bucket */
+    uint64_t avgItemsPerSegment;   /* Average number of items per segment */
+    uint64_t avgSegPerBucket;      /* Average number of segments per bucket */
+} ebucketsStats;
+
+/* Common API (ebuckets and ebStack) */
 
 static inline ebuckets ebCreate(void) { return NULL; } /* Empty ebuckets */
 
@@ -354,13 +363,19 @@ uint64_t ebGetNextTimeToExpire(ebuckets eb, EbucketsType *type);
 
 uint64_t ebGetTotalItems(ebuckets eb, EbucketsType *type);
 
-/* Item related API */
-
 int ebRemove(ebuckets *eb, EbucketsType *type, eItem item);
 
 int ebAdd(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTime);
 
-uint64_t ebCascade(ebuckets *eb, EbucketsType *type, uint64_t now, uint64_t maxCascade);
+
+/* Common statistics API */
+
+void ebGetStats(ebuckets eb, EbucketsType *type, ebucketsStats *stats);
+
+size_t ebGetStatsMsg(char *buf, size_t bufsize, ebucketsStats *stats, int full);
+
+
+/* ebuckets API (cannot be used with ebStack) */
 
 uint64_t ebGetExpireTime(EbucketsType *type, eItem item);
 
@@ -372,34 +387,31 @@ int ebNext(EbucketsIterator *iter);
 
 int ebNextBucket(EbucketsIterator *iter);
 
-int ebScanDefrag(ebuckets *eb, EbucketsType *type, unsigned long *cursor,
-                 ebDefragFunctions *defragfns, void *privdata);
+int ebScanDefrag(ebuckets *eb, EbucketsType *type, unsigned long *cursor, // TODO_MOTI: Support ebStack
+                 ebDefragFunctions *defragfns, void *privdata); 
 
-/* Cannot be used with ebStack L3 */
+static inline uint64_t ebGetMetaExpTime(ExpireMeta *expMeta);
+
+static inline void ebSetMetaExpTime(ExpireMeta *expMeta, uint64_t t);
+
+/* ebStack only API */
+
+long long ebStackGetExpireTime(EbucketsType *type, eItem item);
+
+uint64_t ebStackCascade(ebuckets *eb, EbucketsType *type, uint64_t now, uint64_t maxCascade);
+
+/* inline functions */
+
 static inline uint64_t ebGetMetaExpTime(ExpireMeta *expMeta) {
+    debugAssert(expMeta->storedIn != EB_STORED_IN_EB_L3);
     return (((uint64_t)(expMeta)->expireTimeHi << 32) | (expMeta)->expireTimeLo);
 }
 
-/* Cannot be used with ebStack L3 */
 static inline void ebSetMetaExpTime(ExpireMeta *expMeta, uint64_t t) {
+    debugAssert(expMeta->storedIn != EB_STORED_IN_EB_L3);
     expMeta->expireTimeLo = (uint32_t)(t&0xFFFFFFFF);
     expMeta->expireTimeHi = (uint16_t)((t) >> 32);
 }
-
-/* Statistics API */
-
-#define EBUCKETS_STATS_VECTLEN 50
-
-typedef struct ebucketsStats {
-    uint64_t totalItems;           /* Total number of items */
-    uint64_t totalBuckets;         /* Total number of buckets */
-    uint64_t totalSegments;        /* Total number of segments */
-    uint64_t avgItemsPerBucket;    /* Average number of items per bucket */
-    uint64_t avgItemsPerSegment;   /* Average number of items per segment */
-    uint64_t avgSegPerBucket;      /* Average number of segments per bucket */
-} ebucketsStats;
-void ebGetStats(ebuckets eb, EbucketsType *type, ebucketsStats *stats);
-size_t ebGetStatsMsg(char *buf, size_t bufsize, ebucketsStats *stats, int full);
 
 /* Debug API */
 

--- a/src/ebuckets.h
+++ b/src/ebuckets.h
@@ -108,6 +108,38 @@
  * ebuckets will start as a simple linked-list and only when it reaches some
  * threshold, it will be converted to rax.
  *
+ * HIERARCHICAL EBUCKETS STACK (ebStack)
+ * -------------------------------------
+ * The hierarchical ebuckets stack, or `ebStack`, is a multi-tiered structure
+ * designed to manage items across varying expiration time ranges efficiently.
+ * Inspired by hierarchical timing wheels algorithm (https://dl.acm.org/doi/10.1145/41457.37504),
+ * it is organized into three levels, each reflecting a different time range and
+ * precision, forming a coherent expiration system:
+ *
+ * level #1 - High-precision ebuckets, optimized for items expected to expire
+ *            in the short term. This level uses fine time granularity to
+ *            support accurate expiration and precise eviction.
+ *
+ * level #2 - Low-precision ebuckets, suitable for items with longer-term
+ *            expiration. Precision is reduced to lower memory usage, fewer
+ *            buckets and limit modifications to the rax tree.
+ *
+ * level #3 - A plain vector of items with very long expiration times, treated
+ *            as practically infinite. This level avoids the overhead of
+ *            bucket or rax structures entirely. Since regular ExpireMeta can 
+ *            only store 48-bit timestamps (sufficient until year 10889), L3 items
+ *            use `ExpireMetaL3` which replaces the `next` pointer with a full
+ *            64-bit timestamp and stores the index (expireIndexLo/Hi) into the 
+ *            infinity vector instead of the expiration time in the expireTimeLo/Hi 
+ *            fields.            
+ *
+ * It is specifically designed for Redis’s EXPIRE use case, but can be adapted
+ * to other use cases. Internally, this multi-level logic is abstracted away from 
+ * the ebuckets API. From the user's perspective, ebuckets appear as a single 
+ * expiration structure. This hierarchical mode is enabled by setting `isEbStack` 
+ * in the `EbucketsType` structure. Yet, the caller must periodically call 
+ * `ebCascade()` to promote items from level 2 to level 1 as their TTL shortens. 
+ *
  * TODO
  * ----
  * - ebRemove() optimize to merge small segments into one segment.
@@ -125,29 +157,15 @@
 #include <stdint.h>
 #include "rax.h"
 
-/*
- * EB_BUCKET_KEY_PRECISION - Defines the number of bits to ignore from the
- * expiration-time when mapping to buckets. The higher the value, the more items
- * with similar expiration-time will be aggregated into the same bucket. The lower
- * the value, the more "accurate" the active expiration of buckets will be.
- *
- * Note that the accurate time expiration of each item is preserved anyway and
- * enforced by lazy expiration. It only impacts the active expiration that will
- * be able to work on buckets older than (1<<EB_BUCKET_KEY_PRECISION) msec ago.
- * For example if EB_BUCKET_KEY_PRECISION is 10, then active expiration
- * will work only on buckets that already got expired at least 1sec ago.
- *
- * The idea of it is to trim the rax tree depth, avoid having too many branches,
- * and reduce frequent modifications of the tree to the minimum.
- */
-#define EB_BUCKET_KEY_PRECISION 0   /* TBD: modify to 10 */
-
-/* From expiration time to bucket-key */
-#define EB_BUCKET_KEY(exptime) ((exptime) >> EB_BUCKET_KEY_PRECISION)
-
 
 #define EB_EXPIRE_TIME_MAX     ((uint64_t)0x0000FFFFFFFFFFFF) /* Maximum expire-time. */
 #define EB_EXPIRE_TIME_INVALID (EB_EXPIRE_TIME_MAX+1) /* assumed bigger than max */
+
+/* ExpireMeta.storedIn values */
+#define EB_STORED_IN_TRASH 0
+#define EB_STORED_IN_EB    1
+#define EB_STORED_IN_EB_L2 2
+#define EB_STORED_IN_EB_L3 3
 
 /* Handler to ebuckets DS. Pointer to a list, rax or NULL (empty DS). See also ebIsList(). */
 typedef void *ebuckets;
@@ -158,49 +176,50 @@ typedef void *ebuckets;
  */
 typedef void *eItem;
 
+/* Flags in ExpireMeta & ExpireMetaL3 */
+#define EXPIRE_META_FLAGS \
+    unsigned int lastInSegment    : 1;  /* Last item in segment. If set, then 'next' will   \
+                                           point to the NextSegHdr, unless lastItemBucket=1 \
+                                           then it will point to segment header of the      \
+                                           current segment. */                              \
+    unsigned int firstItemBucket  : 1;  /* First item in bucket. This flag assist           \
+                                           to manipulate segments directly without          \
+                                           the need to traverse from start the              \
+                                           rax tree  */                                     \
+    unsigned int lastItemBucket   : 1;  /* Last item in bucket. This flag assist            \
+                                           to manipulate segments directly without          \
+                                           the need to traverse from start the              \
+                                           rax tree  */                                     \
+    unsigned int numItems         : 5;  /* Only first item in segment will maintain         \
+                                           this value. */                                   \
+                                                                                            \
+    unsigned int storedIn         : 2;  /* This flag indicates whether the item             \
+                                           is stored in ebuckets or trash. If               \
+                                           ebuckets is actually hierarchical ebuckets       \
+                                           stack (ebStack) then it will distinct            \
+                                           between the storage in level 1, 2 or 3. */       \
+                                                                                            \
+    unsigned int userData         : 3;  /* ebuckets can be used to store in same            \
+                                           instance few different types of items,           \
+                                           such as, listpack and hash. This field           \
+                                           is reserved to store such identification         \
+                                           associated with the item and can help            \
+                                           to distinct on delete or expire callback.        \
+                                           It is not used by ebuckets internally and        \
+                                           should be maintained by the user */              \
+                                                                                            \
+    unsigned int reserved         : 3;
+
 /* This struct Should be embedded inside `eItem` and must be aligned in memory. */
 typedef struct ExpireMeta {
     /* 48bits of unix-time in msec.  This value is sufficient to represent, in
      * unix-time, until the date of 02 August, 10889
      */
-    uint32_t expireTimeLo;              /* Low bits of expireTime. */
-    uint16_t expireTimeHi;              /* High bits of expireTime. */
-
-    unsigned int lastInSegment    : 1;  /* Last item in segment. If set, then 'next' will
-                                           point to the NextSegHdr, unless lastItemBucket=1
-                                           then it will point to segment header of the
-                                           current segment. */
-    unsigned int firstItemBucket  : 1;  /* First item in bucket. This flag assist
-                                           to manipulate segments directly without
-                                           the need to traverse from start the
-                                           rax tree  */
-    unsigned int lastItemBucket   : 1;  /* Last item in bucket. This flag assist
-                                           to manipulate segments directly without
-                                           the need to traverse from start the
-                                           rax tree  */
-    unsigned int numItems         : 5;  /* Only first item in segment will maintain
-                                           this value. */
-
-    unsigned int trash            : 1;  /* This flag indicates whether the ExpireMeta
-                                           associated with the item is leftover.
-                                           There is always a potential to reuse the
-                                           item after removal/deletion. Note that,
-                                           the user can still safely O(1) TTL lookup
-                                           a given item and verify whether attached
-                                           TTL is valid or leftover. See function
-                                           ebGetExpireTime(). */
-
-    unsigned int userData         : 3;  /* ebuckets can be used to store in same
-                                           instance few different types of items,
-                                           such as, listpack and hash. This field
-                                           is reserved to store such identification
-                                           associated with the item and can help
-                                           to distinct on delete or expire callback.
-                                           It is not used by ebuckets internally and
-                                           should be maintained by the user */
-
-    unsigned int reserved         : 4;
-
+    uint32_t expireTimeLo;            /* Low bits of expireTime. */
+    uint16_t expireTimeHi;            /* High bits of expireTime. */
+    
+    EXPIRE_META_FLAGS
+    
     void *next;                       /* - If not last item in segment then next
                                            points to next eItem (lastInSegment=0).
                                          - If last in segment but not last in
@@ -211,22 +230,64 @@ typedef struct ExpireMeta {
                                            of type FirstSegHdr or NextSegHdr). */
 } ExpireMeta;
 
-/* Each instance of ebuckets need to have corresponding EbucketsType that holds
+/* Defines the number of bits to ignore from the expiration-time when mapping
+ * to buckets. The higher the value, the more items with similar expiration-time
+ * will be aggregated into the same bucket. The lower the value, the more
+ * "accurate" the active expiration of buckets will be. */
+typedef union EBucketPrecision {
+    struct {
+        /* Number of bits to ignore from the expiration-time when mapping to buckets. */
+        uint32_t precision;
+
+        /* The size of the key in bytes used for rax operations. This value is derived
+         * from bucketPrecision and must be aligned with it. That is, for rax key size
+         * of 6 bytes, we can keep just enough bytes of bucket-key, taking into
+         * consideration configured `bucketPrecision`, and ignore LSB bits that has
+         * no impact. The main motivation is that since the bucket-key size determines
+         * the maximum depth of the rax tree, then we can prune the tree to be more
+         * shallow and thus reduce the maintenance and traversal of each node in the
+         * * B-tree. The following mapping should always hold true:
+         *    0  <= bucketPrecision < 8     -->    keySize = 6
+         *    8  <= bucketPrecision < 16    -->    keySize = 5
+         *    16 <= bucketPrecision < 32    -->    keySize = 4
+         *    32 <= bucketPrecision         -->    keySize = 3
+         */
+#define EB_PRECISION2KEYSIZE(bp) ((bp)<8 ? 6 : ((bp)<16 ? 5 : ((bp)<32 ? 4 : 3)))
+        uint32_t keySize; /* Use EB_PRECISION2KEYSIZE() to set it. */
+    };
+
+    uint64_t v;
+
+} EBucketPrecision;
+
+extern const EBucketPrecision ebpStackL2;
+
+/* Each instance of ebuckets needs to have corresponding EbucketsType that holds
  * the necessary callbacks and configuration to operate correctly on the type
- * of items that are stored in it. Conceptually it should have hold reference
- * from ebuckets instance to this type, but to save memory we will pass it as
- * an argument to each API call. */
+ * of items that are stored in it. Conceptually an instance should have hold
+ * reference from ebuckets instance to this type, but to save memory we will pass
+ * it as an argument to each API call. This approach also makes it easier to 
+ * manipulate the type when needed. */
 typedef struct EbucketsType {
     /* getter to extract the ExpireMeta from the item */
-    ExpireMeta* (*getExpireMeta)(const eItem item);
+    ExpireMeta* (*getExpireMeta)(const void *item);
 
     /* Called during ebDestroy(). Set to NULL if not needed. */
     void (*onDeleteItem)(eItem item, void *ctx);
 
+    /* Number of bits to ignore from the expiration-time when mapping to buckets.
+     * If `isEbStack` is set, then this value is relevant only for level 1. 
+     * Level 2 has fixed precision of 21 bits. See EBucketPrecision for more details. */
+    EBucketPrecision ebp;
+
+    /* For hierarchical ebuckets stack (ebStack), Set to 1. */
+    int isEbStack;
+
     /* Is addresses of items are odd in memory. It is taken into consideration
      * and used by ebuckets to know how to distinct between ebuckets pointer to
      * rax versus a pointer to item which is head of list. */
-    unsigned int itemsAddrAreOdd;
+    int itemsAddrAreOdd;
+
 } EbucketsType;
 
 /* Returned value by `onExpireItem` callback to indicate the action to be taken by
@@ -291,8 +352,6 @@ static inline int ebIsEmpty(ebuckets eb) { return eb == NULL; }
 
 uint64_t ebGetNextTimeToExpire(ebuckets eb, EbucketsType *type);
 
-uint64_t ebGetMaxExpireTime(ebuckets eb, EbucketsType *type, int accurate);
-
 uint64_t ebGetTotalItems(ebuckets eb, EbucketsType *type);
 
 /* Item related API */
@@ -300,6 +359,8 @@ uint64_t ebGetTotalItems(ebuckets eb, EbucketsType *type);
 int ebRemove(ebuckets *eb, EbucketsType *type, eItem item);
 
 int ebAdd(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTime);
+
+uint64_t ebCascade(ebuckets *eb, EbucketsType *type, uint64_t now, uint64_t maxCascade);
 
 uint64_t ebGetExpireTime(EbucketsType *type, eItem item);
 
@@ -314,20 +375,37 @@ int ebNextBucket(EbucketsIterator *iter);
 int ebScanDefrag(ebuckets *eb, EbucketsType *type, unsigned long *cursor,
                  ebDefragFunctions *defragfns, void *privdata);
 
+/* Cannot be used with ebStack L3 */
 static inline uint64_t ebGetMetaExpTime(ExpireMeta *expMeta) {
     return (((uint64_t)(expMeta)->expireTimeHi << 32) | (expMeta)->expireTimeLo);
 }
 
+/* Cannot be used with ebStack L3 */
 static inline void ebSetMetaExpTime(ExpireMeta *expMeta, uint64_t t) {
     expMeta->expireTimeLo = (uint32_t)(t&0xFFFFFFFF);
     expMeta->expireTimeHi = (uint16_t)((t) >> 32);
 }
 
+/* Statistics API */
+
+#define EBUCKETS_STATS_VECTLEN 50
+
+typedef struct ebucketsStats {
+    uint64_t totalItems;           /* Total number of items */
+    uint64_t totalBuckets;         /* Total number of buckets */
+    uint64_t totalSegments;        /* Total number of segments */
+    uint64_t avgItemsPerBucket;    /* Average number of items per bucket */
+    uint64_t avgItemsPerSegment;   /* Average number of items per segment */
+    uint64_t avgSegPerBucket;      /* Average number of segments per bucket */
+} ebucketsStats;
+void ebGetStats(ebuckets eb, EbucketsType *type, ebucketsStats *stats);
+size_t ebGetStatsMsg(char *buf, size_t bufsize, ebucketsStats *stats, int full);
+
 /* Debug API */
 
 void ebValidate(ebuckets eb, EbucketsType *type);
 
-void ebPrint(ebuckets eb, EbucketsType *type);
+void ebPrintItems(ebuckets eb, EbucketsType *type);
 
 #ifdef REDIS_TEST
 int ebucketsTest(int argc, char *argv[], int flags);

--- a/src/ebuckets.h
+++ b/src/ebuckets.h
@@ -408,7 +408,6 @@ static inline uint64_t ebGetMetaExpTime(ExpireMeta *expMeta) {
 }
 
 static inline void ebSetMetaExpTime(ExpireMeta *expMeta, uint64_t t) {
-    debugAssert(expMeta->storedIn != EB_STORED_IN_EB_L3);
     expMeta->expireTimeLo = (uint32_t)(t&0xFFFFFFFF);
     expMeta->expireTimeHi = (uint16_t)((t) >> 32);
 }

--- a/src/evict.c
+++ b/src/evict.c
@@ -567,6 +567,8 @@ int performEvictions(void) {
                         kvs = db->keys;
                     } else {
                         kvs = db->expires;
+                        
+                        serverAssert(0); // TODO_MOTI: Implement estore eviction
                     }
                     unsigned long sampled_keys = 0;
                     unsigned long current_db_keys = kvstoreSize(kvs);
@@ -599,6 +601,8 @@ int performEvictions(void) {
                         kvs = server.db[bestdbid].keys;
                     } else {
                         kvs = server.db[bestdbid].expires;
+                        
+                        serverAssert(0); // TODO_MOTI: Implement estore eviction                        
                     }
                     de = kvstoreDictFind(kvs, pool[k].slot, pool[k].key);
 
@@ -633,17 +637,35 @@ int performEvictions(void) {
                 kvstore *kvs;
                 if (server.maxmemory_policy == MAXMEMORY_ALLKEYS_RANDOM) {
                     kvs = db->keys;
+                    int slot = kvstoreGetFairRandomDictIndex(kvs);
+                    de = kvstoreDictGetRandomKey(kvs, slot);
+                    if (de) {
+                        kvobj *kv = dictGetKV(de);
+                        bestkey = kvobjGetKey(kv);
+                        bestdbid = j;
+                        break;
+                    }
                 } else {
-                    kvs = db->expires;
+                    /* Evict next minimum TTL from db->expiresNew */
+                    if (db->expiresNew != NULL && !estoreSlotIsEmpty(db->expiresNew, 0)) {
+                        ebuckets *bucket = estoreGetBucket(db->expiresNew, 0);
+
+                        /* Get the item with the minimum TTL */
+                        EbucketsIterator iter;
+                        ebStart(&iter, *bucket, db->expiresNew->bucket_type);
+
+                        /* If we can get the first item, it's the one with minimum TTL */
+                        if (ebNext(&iter)) {
+                            kvobj *kv = (kvobj *)iter.currItem;
+                            bestkey = kvobjGetKey(kv);
+                            bestdbid = j;
+                            ebStop(&iter);
+                            break;
+                        }
+                        ebStop(&iter);
+                    }
                 }
-                int slot = kvstoreGetFairRandomDictIndex(kvs);
-                de = kvstoreDictGetRandomKey(kvs, slot);
-                if (de) {
-                    kvobj *kv = dictGetKV(de);
-                    bestkey = kvobjGetKey(kv);
-                    bestdbid = j;
-                    break;
-                }
+
             }
         }
 

--- a/src/expire.c
+++ b/src/expire.c
@@ -108,7 +108,7 @@ void estoreAdd(estore *es, kvobj *kv, int slot, long long when) {
 
 void estoreIncrementalCascade(estore *es, uint64_t now, uint64_t maxCascade) {
     if (!server.cluster_enabled) {
-        ebCascade(es->buckets + 0, es->bucket_type, now, maxCascade);
+        ebStackCascade(es->buckets + 0, es->bucket_type, now, maxCascade);
         return;
     } else {
         assert(0); // TODO_MOTI: Support cluster mode (See:kvstoreIncrementalCascade())

--- a/src/expire.c
+++ b/src/expire.c
@@ -11,6 +11,141 @@
  */
 
 #include "server.h"
+#include "expire.h"
+#include "redisassert.h"
+
+/* Define the EbucketsType for keys */
+EbucketsType estoreBucketsType = {
+    .onDeleteItem = NULL,
+    .getExpireMeta = kvobjGetExpireMeta,   /* get ExpireMeta attached to each hash */
+    .itemsAddrAreOdd = 0,                 /* Addresses of kvobj are even */
+    .ebp.precision = 10,
+    .ebp.keySize = EB_PRECISION2KEYSIZE(10 /*.precision*/),
+    .isEbStack = 1,
+};
+
+/* Expiration store - wrapper around ebuckets for key expiration
+ * Similar to kvstore, but using ebuckets instead of dict
+ * In cluster mode, we have one ebuckets per slot
+ * In non-cluster mode, we have a single ebuckets for the entire db
+ *
+ * The structure is defined in expire.h
+ */
+
+/* Create a new expiration store
+ * type - The EbucketsType to use for the buckets
+ * num_buckets_bits - The log2 of the number of buckets (0 for 1 bucket,
+ *                    CLUSTER_SLOT_MASK_BITS for CLUSTER_SLOTS buckets)
+ * flags - Configuration flags
+ */
+estore *estoreCreate(EbucketsType *type, int num_buckets_bits) {
+    /* We can't support more than 2^16 buckets to be consistent with kvstore */
+    assert(num_buckets_bits <= 16);
+
+    estore *es = zmalloc(sizeof(estore));
+
+    /* Store the bucket type */
+    es->bucket_type = type;
+
+    /* Calculate number of buckets based on num_buckets_bits */
+    es->num_buckets_bits = num_buckets_bits;
+    es->num_buckets = 1 << num_buckets_bits;
+
+    /* Allocate the buckets array */
+    es->buckets = zmalloc(sizeof(ebuckets) * es->num_buckets);
+
+    /* Initialize all buckets */
+    for (int i = 0; i < es->num_buckets; i++) {
+        es->buckets[i] = ebCreate();
+    }
+
+    es->count = 0;
+    return es;
+}
+
+/* Empty an expiration store (clear all entries but keep the structure) */
+void estoreEmpty(estore *es) {
+    if (es == NULL) return;
+
+    for (int i = 0; i < es->num_buckets; i++) {
+        ebDestroy(&es->buckets[i], es->bucket_type, NULL);
+        es->buckets[i] = ebCreate();
+    }
+
+    es->count = 0;
+}
+
+/* Release an expiration store (free all memory) */
+void estoreRelease(estore *es) {
+    if (es == NULL) return;
+
+    for (int i = 0; i < es->num_buckets; i++) {
+        ebDestroy(&es->buckets[i], es->bucket_type, NULL);
+    }
+
+    zfree(es->buckets);
+    zfree(es);
+}
+
+/* Remove kv from estore. Assumed kv is not null and exists in 'es'. */
+void estoreRemove(estore *es, int slot, kvobj *kv) {
+    if (es == NULL) return;
+
+    ebuckets *bucket = estoreGetBucket(es, slot);
+    if (ebRemove(bucket, es->bucket_type, kv)) {
+        es->count--;
+    }
+}
+
+/* Add kv to estore with the given expiration time */
+void estoreAdd(estore *es, kvobj *kv, int slot, long long when) {
+    if (es == NULL || kv == NULL) return;
+
+    ebuckets *bucket = estoreGetBucket(es, slot);
+    if (ebAdd(bucket, es->bucket_type, kv, when) == 0)
+        es->count++;
+}
+
+void estoreIncrementalCascade(estore *es, uint64_t now, uint64_t maxCascade) {
+    if (!server.cluster_enabled) {
+        ebCascade(es->buckets + 0, es->bucket_type, now, maxCascade);
+        return;
+    } else {
+        assert(0); // TODO_MOTI: Support cluster mode (See:kvstoreIncrementalCascade())
+    }
+}
+
+void estoreGetStats(estore *es, char *buf, size_t bufsize, int full) {
+    if (!server.cluster_enabled) {
+        ebucketsStats stats = {0}; /* must be zeroed */
+        ebGetStats(es->buckets[0], es->bucket_type, &stats);
+        ebGetStatsMsg(buf, bufsize, &stats, full);
+    } else {
+        assert(0); // TODO_MOTI: Support cluster mode (See:kvstoreGetStats())
+    }        
+}
+
+/* Get the total number of items in the expiration store */
+unsigned long long estoreSize(estore *es) {
+    if (es == NULL) return 0;
+    return es->count;
+}
+
+/* Get the number of items in a specific slot */
+unsigned long long estoreSlotSize(estore *es, int slot) {
+    if (es == NULL) return 0;
+
+    ebuckets *bucket = estoreGetBucket(es, slot);
+    return ebGetTotalItems(*bucket, es->bucket_type);
+}
+
+/* Check if a specific slot is empty */
+int estoreSlotIsEmpty(estore *es, int slot) {
+    if (es == NULL) return 1;
+
+    ebuckets *bucket = estoreGetBucket(es, slot);
+    return ebIsEmpty(*bucket);
+}
 
 /*-----------------------------------------------------------------------------
  * Incremental collection of expired keys.
@@ -20,9 +155,10 @@
  * if no access is performed on them.
  *----------------------------------------------------------------------------*/
 
-/* Constants table from pow(0.98, 1) to pow(0.98, 16). 
+/* Constants table from pow(0.98, 1) to pow(0.98, 16).
  * Help calculating the db->avg_ttl. */
-static double avg_ttl_factor[16] = {0.98, 0.9604, 0.941192, 0.922368, 0.903921, 0.885842, 0.868126, 0.850763, 0.833748, 0.817073, 0.800731, 0.784717, 0.769022, 0.753642, 0.738569, 0.723798};
+//static double avg_ttl_factor[16] = {0.98, 0.9604, 0.941192, 0.922368, 0.903921, 0.885842, 0.868126, 0.850763, 0.833748, 0.817073, 0.800731, 0.784717, 0.769022, 0.753642, 0.738569, 0.723798};
+// TODO_MOTI: Support avg_ttl calculation
 
 /* Helper function for the activeExpireCycle() function.
  * This function will try to expire the key-value entry that is stored in the 
@@ -184,6 +320,108 @@ static inline void activeExpireHashFieldCycle(int type) {
     }
 }
 
+/* Callback for active expiration of keys */
+static ExpireAction keyExpireCallback(eItem item, void *ctx) {
+    redisDb *db = (redisDb *)ctx;
+    kvobj *kv = (kvobj *)item;
+
+    /* Get key name */
+    sds keyname = kvobjGetKey(kv);
+    robj *key = createStringObject(keyname, sdslen(keyname));
+
+    /* Delete the key from the database */
+    enterExecutionUnit(1, 0);
+    deleteExpiredKeyAndPropagate(db, key);
+    decrRefCount(key);
+    exitExecutionUnit();
+    postExecutionUnitOperations();
+
+    server.stat_expiredkeys++;
+
+    return ACT_REMOVE_EXP_ITEM;
+}
+
+/* Perform active expiration on keys using ebuckets */
+unsigned int estoreActiveExpire(redisDb *db, unsigned int max_keys) {
+    if (db == NULL || db->expiresNew == NULL) return 0;
+    if (estoreSize(db->expiresNew) == 0) return 0;
+
+    unsigned int keys_expired = 0;
+    mstime_t now = mstime();
+
+    /* In cluster mode, we need to process only slots that belong to this node */
+    int start_slot = 0;
+    int end_slot = db->expiresNew->num_buckets;
+
+    UNUSED(start_slot);
+    UNUSED(end_slot);
+
+    if (server.cluster_enabled) {
+//        /* Process only slots that belong to this node */
+//        for (int i = start_slot; i < end_slot && keys_expired < max_keys; i++) {
+//            /* Skip slots that don't belong to this node */
+//            if (server.cluster && !clusterNodeCoversSlot(getMyClusterNode(), i)) {
+//                continue;
+//            }
+//
+//            /* Skip empty slots */
+//            if (estoreSlotIsEmpty(db->expiresNew, i)) continue;
+//
+//            ebuckets *bucket = estoreGetBucket(db->expiresNew, i);
+//
+//            ExpireInfo info = {
+//                .maxToExpire = max_keys - keys_expired,
+//                .onExpireItem = keyExpireCallback,
+//                .ctx = db,
+//                .now = now,
+//                .itemsExpired = 0
+//            };
+//
+//            ebExpire(bucket, db->expiresNew->bucket_type, &info);
+//            keys_expired += info.itemsExpired;
+//        }
+    } else {
+        /* In non-cluster mode, we just have a single bucket */
+        ebuckets *bucket = estoreGetBucket(db->expiresNew, 0);
+
+        ExpireInfo info = {
+            .maxToExpire = max_keys,
+            .onExpireItem = keyExpireCallback,
+            .ctx = db,
+            .now = now,
+            .itemsExpired = 0
+        };
+
+        ebExpire(bucket, db->expiresNew->bucket_type, &info);
+        
+        /* Move expired keys from secondary ebuckets */
+        
+        keys_expired = info.itemsExpired;
+    }
+
+    return keys_expired;
+}
+
+/* Get the appropriate bucket for a given slot */
+ebuckets *estoreGetBucket(estore *es, int slot) {
+    if (server.cluster_enabled)
+        return &es->buckets[slot];
+    else
+        return &es->buckets[0];
+}
+
+size_t estoreMemUsage(estore *es) {
+    if (es == NULL) return 0;
+
+    // TODO_MOTI: Follow kvstoreMemUsage() to imp for estoreMemUsage()
+//    size_t mem = sizeof(*es);
+//    for (int i = 0; i < es->num_buckets; i++) {
+//        mem += ebMemUsage(es->buckets[i], es->bucket_type);
+//    }
+    return 0;
+}
+
+
 void activeExpireCycle(int type) {
     /* Adjust the running parameters according to the configured expire
      * effort. The default effort is 1, and the maximum configurable effort
@@ -270,12 +508,13 @@ void activeExpireCycle(int type) {
         expireScanData data;
         data.ttl_sum = 0;
         data.ttl_samples = 0;
+        UNUSED(data);
 
         redisDb *db = server.db+(current_db % server.dbnum);
         data.db = db;
 
-        int db_done = 0; /* The scan of the current DB is done? */
-        int update_avg_ttl_times = 0, repeat = 0;
+        //int db_done = 0; /* The scan of the current DB is done? */
+        //int update_avg_ttl_times = 0, repeat = 0;
 
         /* Increment the DB now so we are sure if we run out of time
          * in the current DB we'll restart from the next. This allows to
@@ -287,99 +526,126 @@ void activeExpireCycle(int type) {
          * active expiration */
         activeExpireHashFieldCycle(type);
 
-        if (kvstoreSize(db->expires))
+//        /* Check if we have keys to expire in the old dict-based structure */
+//        if (kvstoreSize(db->expires)) {
+//            dbs_performed++;
+//
+//            /* Continue to expire if at the end of the cycle there are still
+//             * a big percentage of keys to expire, compared to the number of keys
+//             * we scanned. The percentage, stored in config_cycle_acceptable_stale
+//             * is not fixed, but depends on the Redis configured "expire effort". */
+//            do {
+//                unsigned long num;
+//                iteration++;
+//
+//                /* If there is nothing to expire try next DB ASAP. */
+//                if ((num = kvstoreSize(db->expires)) == 0) {
+//                    db->avg_ttl = 0;
+//                    break;
+//                }
+//                data.now = mstime();
+//
+//                /* The main collection cycle. Scan through keys among keys
+//                 * with an expire set, checking for expired ones. */
+//                data.sampled = 0;
+//                data.expired = 0;
+//
+//                if (num > config_keys_per_loop)
+//                    num = config_keys_per_loop;
+//
+//                /* Here we access the low level representation of the hash table
+//                 * for speed concerns: this makes this code coupled with dict.c,
+//                 * but it hardly changed in ten years.
+//                 *
+//                 * Note that certain places of the hash table may be empty,
+//                 * so we want also a stop condition about the number of
+//                 * buckets that we scanned. However scanning for free buckets
+//                 * is very fast: we are in the cache line scanning a sequential
+//                 * array of NULL pointers, so we can scan a lot more buckets
+//                 * than keys in the same time. */
+//                long max_buckets = num*20;
+//                long checked_buckets = 0;
+//
+//                int origin_ttl_samples = data.ttl_samples;
+//
+//                while (data.sampled < num && checked_buckets < max_buckets) {
+//                    db->expires_cursor = kvstoreScan(db->expires, db->expires_cursor, -1, expireScanCallback, isExpiryDictValidForSamplingCb, &data);
+//                    if (db->expires_cursor == 0) {
+//                        db_done = 1;
+//                        break;
+//                    }
+//                    checked_buckets++;
+//                }
+//                total_expired += data.expired;
+//                total_sampled += data.sampled;
+//
+//                /* If find keys with ttl not yet expired, we need to update the average TTL stats once. */
+//                if (data.ttl_samples - origin_ttl_samples > 0) update_avg_ttl_times++;
+//
+//                /* We don't repeat the cycle for the current database if the db is done
+//                 * for scanning or an acceptable number of stale keys (logically expired
+//                 * but yet not reclaimed). */
+//                repeat = db_done ? 0 : (data.sampled == 0 || (data.expired * 100 / data.sampled) > config_cycle_acceptable_stale);
+//
+//                /* We can't block forever here even if there are many keys to
+//                 * expire. So after a given amount of microseconds return to the
+//                 * caller waiting for the other active expire cycle. */
+//                if ((iteration & 0xf) == 0 || !repeat) { /* Update the average TTL stats every 16 iterations or about to exit. */
+//                    /* Update the average TTL stats for this database,
+//                     * because this may reach the time limit. */
+//                    if (data.ttl_samples) {
+//                        long long avg_ttl = data.ttl_sum / data.ttl_samples;
+//
+//                        /* Do a simple running average with a few samples.
+//                         * We just use the current estimate with a weight of 2%
+//                         * and the previous estimate with a weight of 98%. */
+//                        if (db->avg_ttl == 0) {
+//                            db->avg_ttl = avg_ttl;
+//                        } else {
+//                            /* The origin code is as follow.
+//                             * for (int i = 0; i < update_avg_ttl_times; i++) {
+//                             *   db->avg_ttl = (db->avg_ttl/50)*49 + (avg_ttl/50);
+//                             * }
+//                             * We can convert the loop into a sum of a geometric progression.
+//                             * db->avg_ttl = db->avg_ttl * pow(0.98, update_avg_ttl_times) +
+//                             *                  avg_ttl / 50 * (pow(0.98, update_avg_ttl_times - 1) + ... + 1)
+//                             *             = db->avg_ttl * pow(0.98, update_avg_ttl_times) +
+//                             *                  avg_ttl * (1 - pow(0.98, update_avg_ttl_times))
+//                             *             = avg_ttl +  (db->avg_ttl - avg_ttl) * pow(0.98, update_avg_ttl_times)
+//                             * Notice that update_avg_ttl_times is between 1 and 16, we use a constant table
+//                             * to accelerate the calculation of pow(0.98, update_avg_ttl_times).*/
+//                            db->avg_ttl = avg_ttl + (db->avg_ttl - avg_ttl) * avg_ttl_factor[update_avg_ttl_times - 1] ;
+//                        }
+//                        update_avg_ttl_times = 0;
+//                        data.ttl_sum = 0;
+//                        data.ttl_samples = 0;
+//                    }
+//                    if ((iteration & 0xf) == 0) { /* check time limit every 16 iterations. */
+//                        elapsed = ustime()-start;
+//                        if (elapsed > timelimit) {
+//                            timelimit_exit = 1;
+//                            server.stat_expired_time_cap_reached_count++;
+//                            break;
+//                        }
+//                    }
+//                }
+//            } while (repeat);
+//        }
+
+        /* Cascade items from L2 to L1 if needed */
+        // TODO_MOTI: Fine tune estoreIncrementalCascade()
+        uint64_t maxCascade = 20000 / server.hz; 
+        estoreIncrementalCascade(db->expiresNew, commandTimeSnapshot(), maxCascade);
+
+        /* Now check if we have keys to expire in the new ebuckets-based structure */
+        if (estoreSize(db->expiresNew)) {
             dbs_performed++;
-
-        /* Continue to expire if at the end of the cycle there are still
-         * a big percentage of keys to expire, compared to the number of keys
-         * we scanned. The percentage, stored in config_cycle_acceptable_stale
-         * is not fixed, but depends on the Redis configured "expire effort". */
-        do {
-            unsigned long num;
-            iteration++;
-
-            /* If there is nothing to expire try next DB ASAP. */
-            if ((num = kvstoreSize(db->expires)) == 0) {
-                db->avg_ttl = 0;
-                break;
-            }
-            data.now = mstime();
-
-            /* The main collection cycle. Scan through keys among keys
-             * with an expire set, checking for expired ones. */
-            data.sampled = 0;
-            data.expired = 0;
-
-            if (num > config_keys_per_loop)
-                num = config_keys_per_loop;
-
-            /* Here we access the low level representation of the hash table
-             * for speed concerns: this makes this code coupled with dict.c,
-             * but it hardly changed in ten years.
-             *
-             * Note that certain places of the hash table may be empty,
-             * so we want also a stop condition about the number of
-             * buckets that we scanned. However scanning for free buckets
-             * is very fast: we are in the cache line scanning a sequential
-             * array of NULL pointers, so we can scan a lot more buckets
-             * than keys in the same time. */
-            long max_buckets = num*20;
-            long checked_buckets = 0;
-
-            int origin_ttl_samples = data.ttl_samples;
-
-            while (data.sampled < num && checked_buckets < max_buckets) {
-                db->expires_cursor = kvstoreScan(db->expires, db->expires_cursor, -1, expireScanCallback, isExpiryDictValidForSamplingCb, &data);
-                if (db->expires_cursor == 0) {
-                    db_done = 1;
-                    break;
-                }
-                checked_buckets++;
-            }
-            total_expired += data.expired;
-            total_sampled += data.sampled;
-
-            /* If find keys with ttl not yet expired, we need to update the average TTL stats once. */
-            if (data.ttl_samples - origin_ttl_samples > 0) update_avg_ttl_times++;
-
-            /* We don't repeat the cycle for the current database if the db is done
-             * for scanning or an acceptable number of stale keys (logically expired
-             * but yet not reclaimed). */
-            repeat = db_done ? 0 : (data.sampled == 0 || (data.expired * 100 / data.sampled) > config_cycle_acceptable_stale);
-
-            /* We can't block forever here even if there are many keys to
-             * expire. So after a given amount of microseconds return to the
-             * caller waiting for the other active expire cycle. */
-            if ((iteration & 0xf) == 0 || !repeat) { /* Update the average TTL stats every 16 iterations or about to exit. */
-                /* Update the average TTL stats for this database, 
-                 * because this may reach the time limit. */
-                if (data.ttl_samples) {
-                    long long avg_ttl = data.ttl_sum / data.ttl_samples;
-
-                    /* Do a simple running average with a few samples.
-                     * We just use the current estimate with a weight of 2%
-                     * and the previous estimate with a weight of 98%. */
-                    if (db->avg_ttl == 0) {
-                        db->avg_ttl = avg_ttl;
-                    } else {
-                        /* The origin code is as follow.
-                         * for (int i = 0; i < update_avg_ttl_times; i++) {
-                         *   db->avg_ttl = (db->avg_ttl/50)*49 + (avg_ttl/50);
-                         * } 
-                         * We can convert the loop into a sum of a geometric progression.
-                         * db->avg_ttl = db->avg_ttl * pow(0.98, update_avg_ttl_times) + 
-                         *                  avg_ttl / 50 * (pow(0.98, update_avg_ttl_times - 1) + ... + 1) 
-                         *             = db->avg_ttl * pow(0.98, update_avg_ttl_times) + 
-                         *                  avg_ttl * (1 - pow(0.98, update_avg_ttl_times))
-                         *             = avg_ttl +  (db->avg_ttl - avg_ttl) * pow(0.98, update_avg_ttl_times) 
-                         * Notice that update_avg_ttl_times is between 1 and 16, we use a constant table 
-                         * to accelerate the calculation of pow(0.98, update_avg_ttl_times).*/
-                        db->avg_ttl = avg_ttl + (db->avg_ttl - avg_ttl) * avg_ttl_factor[update_avg_ttl_times - 1] ;
-                    }
-                    update_avg_ttl_times = 0;
-                    data.ttl_sum = 0;
-                    data.ttl_samples = 0;
-                }
+            unsigned int expired;
+            /* Perform active expiration using ebuckets */
+            do {
+                iteration++;
+                expired = estoreActiveExpire(db, config_keys_per_loop);
+                total_expired += expired;
                 if ((iteration & 0xf) == 0) { /* check time limit every 16 iterations. */
                     elapsed = ustime()-start;
                     if (elapsed > timelimit) {
@@ -387,9 +653,20 @@ void activeExpireCycle(int type) {
                         server.stat_expired_time_cap_reached_count++;
                         break;
                     }
-                }
+                }            
+            } while (expired == config_keys_per_loop);
+            
+            
+
+            /* We can't block forever here even if there are many keys to
+             * expire. So after a given amount of milliseconds return to the
+             * caller waiting for the other active expire cycle. */
+            elapsed = ustime()-start;
+            if (elapsed > timelimit) {
+                timelimit_exit = 1;
+                server.stat_expired_time_cap_reached_count++;
             }
-        } while (repeat);
+        }
     }
 
     elapsed = ustime()-start;
@@ -464,7 +741,7 @@ void expireSlaveKeys(void) {
         while(dbids && dbid < server.dbnum) {
             if ((dbids & 1) != 0) {
                 redisDb *db = server.db+dbid;
-                kvobj *kv = dbFindExpires(db, keyname);
+                kvobj *kv = dbFind(db, keyname);
                 int expired = kv && activeExpireCycleTryExpire(server.db+dbid, kv, start);
 
                 /* If the key was not expired in this DB, we need to set the
@@ -808,8 +1085,9 @@ void pexpiretimeCommand(client *c) {
 
 /* PERSIST key */
 void persistCommand(client *c) {
-    if (lookupKeyWrite(c->db,c->argv[1])) {
-        if (removeExpire(c->db,c->argv[1])) {
+    kvobj *kv;
+    if ((kv = lookupKeyWrite(c->db,c->argv[1])) != NULL) {
+        if (removeExpire(c->db,c->argv[1], kv)) {
             signalModifiedKey(c,c->db,c->argv[1]);
             notifyKeyspaceEvent(NOTIFY_GENERIC,"persist",c->argv[1],c->db->id);
             addReply(c,shared.cone);

--- a/src/expire.c
+++ b/src/expire.c
@@ -931,7 +931,8 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
     when += basetime;
 
     /* No key, return zero. */
-    kvobj *kv = lookupKeyWrite(c->db,key); 
+    dictEntryLink link;
+    kvobj *kv = lookupKeyWriteWithLink(c->db, key, &link);
     if (kv == NULL) {
         addReply(c,shared.czero);
         return;
@@ -996,7 +997,7 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         addReply(c, shared.cone);
         return;
     } else {
-        kv = setExpire(c,c->db,key,when); /* might realloc kv */
+        kv = setExpireByLink(c,c->db,key->ptr,when, link); /* might realloc kv */
         addReply(c,shared.cone);
         /* Propagate as PEXPIREAT millisecond-timestamp
          * Only rewrite the command arg if not already PEXPIREAT */

--- a/src/expire.c
+++ b/src/expire.c
@@ -19,8 +19,8 @@ EbucketsType estoreBucketsType = {
     .onDeleteItem = NULL,
     .getExpireMeta = kvobjGetExpireMeta,   /* get ExpireMeta attached to each hash */
     .itemsAddrAreOdd = 0,                 /* Addresses of kvobj are even */
-    .ebp.precision = 10,
-    .ebp.keySize = EB_PRECISION2KEYSIZE(10 /*.precision*/),
+    .ebp.precision = 11,
+    .ebp.keySize = EB_PRECISION2KEYSIZE(11 /*.precision*/),
     .isEbStack = 1,
 };
 

--- a/src/expire.h
+++ b/src/expire.h
@@ -1,7 +1,6 @@
 #ifndef __EXPIRE_H__
 #define __EXPIRE_H__
 
-#include "server.h"
 #include "ebuckets.h"
 
 /* resolve circular dependency */

--- a/src/expire.h
+++ b/src/expire.h
@@ -1,0 +1,63 @@
+#ifndef __EXPIRE_H__
+#define __EXPIRE_H__
+
+#include "server.h"
+#include "ebuckets.h"
+
+/* resolve circular dependency */
+typedef struct redisDb redisDb;
+typedef struct redisObject kvobj;
+
+
+/* Forward declaration of the estore structure */
+typedef struct _estore {
+    int flags;                            /* Flags for configuration options */
+    EbucketsType *bucket_type;            /* Type of buckets used in this store */
+    ebuckets *buckets;                    /* Array of ebuckets (one per slot in cluster mode, or just one) */
+    int num_buckets_bits;                 /* Log2 of the number of buckets */
+    int num_buckets;                      /* Number of buckets (1 << num_buckets_bits) */
+    unsigned long long count;             /* Total number of kv's in this estore */
+} estore;
+
+extern EbucketsType estoreBucketsType;
+
+/* Active expiration cycle for keys */
+void activeExpireKeyCycle(int type);
+
+/* Create a new expiration store */
+estore *estoreCreate(EbucketsType *type, int num_buckets_bits);
+
+/* Empty an expiration store (clear all entries but keep the structure) */
+void estoreEmpty(estore *es);
+
+/* Release an expiration store (free all memory) */
+void estoreRelease(estore *es);
+
+/* Remove kv from estore */
+void estoreRemove(estore *es, int slot, kvobj *kv);
+
+/* Add kv to estore with the given expiration time */
+void estoreAdd(estore *es, kvobj *kv, int slot, long long when);
+
+void estoreIncrementalCascade(estore *es, uint64_t now, uint64_t maxCascade);
+
+void estoreGetStats(estore *es, char *buf, size_t bufsize, int full);
+
+/* Get the total number of kv's in estore */
+unsigned long long estoreSize(estore *es);
+
+/* Get the number of kv's in a specific slot of estore */
+unsigned long long estoreSlotSize(estore *es, int slot);
+
+/* Check if a specific slot is empty */
+int estoreSlotIsEmpty(estore *es, int slot);
+
+/* Perform active expiration on keys using ebuckets */
+unsigned int estoreActiveExpire(redisDb *db, unsigned int max_keys);
+
+/* Get the appropriate bucket for a given slot */
+ebuckets *estoreGetBucket(estore *es, int slot);
+
+size_t estoreMemUsage(estore *es);
+
+#endif

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1426,7 +1426,7 @@ void pfaddCommand(client *c) {
          * hold our HLL data structure. sdsnewlen() when NULL is passed
          * is guaranteed to return bytes initialized to zero. */
         robj *o = createHLLObject();
-        kv = dbAddByLink(c->db, c->argv[1], &o, &link);
+        kv = dbAddByLink(c->db, c->argv[1], &o, &link, 0);
         updated++;
     } else {
         if (isHLLObjectOrReply(c,kv) != C_OK) return;
@@ -1592,7 +1592,7 @@ void pfmergeCommand(client *c) {
          * hold our HLL data structure. sdsnewlen() when NULL is passed
          * is guaranteed to return bytes initialized to zero. */
         robj *o = createHLLObject();
-        kv = dbAddByLink(c->db, c->argv[1], &o, &link);
+        kv = dbAddByLink(c->db, c->argv[1], &o, &link, 0);
     } else {
         /* If key exists we are sure it's of the right type/size
          * since we checked when merging the different HLLs, so we

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -22,12 +22,17 @@ void lazyfreeFreeObject(void *args[]) {
  * when the database was logically deleted. */
 void lazyfreeFreeDatabase(void *args[]) {
     kvstore *da1 = args[0];
-    kvstore *da2 = args[1];
+    //kvstore *da2 = args[1];
+    estore *oldExpiresNew = args[1];
     ebuckets oldHfe = args[2];
+    
+
+    /* Destroy the hash field expiration store */
     ebDestroy(&oldHfe, &hashExpireBucketsType, NULL);
+
     size_t numkeys = kvstoreSize(da1);
     kvstoreRelease(da1);
-    kvstoreRelease(da2);
+    estoreRelease(oldExpiresNew);
     atomicDecr(lazyfree_objects,numkeys);
     atomicIncr(lazyfreed_objects,numkeys);
 
@@ -205,13 +210,17 @@ void emptyDbAsync(redisDb *db) {
         slot_count_bits = CLUSTER_SLOT_MASK_BITS;
         flags |= KVSTORE_FREE_EMPTY_DICTS;
     }
-    kvstore *oldkeys = db->keys, *oldexpires = db->expires;
+    kvstore *oldkeys = db->keys;
     ebuckets oldHfe = db->hexpires;
+    estore *oldExpiresNew = db->expiresNew;
+
     db->keys = kvstoreCreate(&dbDictType, slot_count_bits, flags | KVSTORE_ALLOC_META_KEYS_HIST);
-    db->expires = kvstoreCreate(&dbExpiresDictType, slot_count_bits, flags);
+    //db->expires = kvstoreCreate(&dbExpiresDictType, slot_count_bits, flags);
     db->hexpires = ebCreate();
+    db->expiresNew = estoreCreate(&estoreBucketsType, slot_count_bits);
+
     atomicIncr(lazyfree_objects, kvstoreSize(oldkeys));
-    bioCreateLazyFreeJob(lazyfreeFreeDatabase, 3, oldkeys, oldexpires, oldHfe);
+    bioCreateLazyFreeJob(lazyfreeFreeDatabase, 4, oldkeys, /*oldexpires*/ oldExpiresNew, oldHfe);
 }
 
 /* Free the key tracking table.

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -26,13 +26,14 @@ void lazyfreeFreeDatabase(void *args[]) {
     estore *oldExpiresNew = args[1];
     ebuckets oldHfe = args[2];
     
-
     /* Destroy the hash field expiration store */
     ebDestroy(&oldHfe, &hashExpireBucketsType, NULL);
 
+    /* Must release expiration store before releasing kvstore */ 
+    estoreRelease(oldExpiresNew);
+    
     size_t numkeys = kvstoreSize(da1);
     kvstoreRelease(da1);
-    estoreRelease(oldExpiresNew);
     atomicDecr(lazyfree_objects,numkeys);
     atomicIncr(lazyfreed_objects,numkeys);
 

--- a/src/module.c
+++ b/src/module.c
@@ -4272,7 +4272,7 @@ int RM_SetExpire(RedisModuleKey *key, mstime_t expire) {
         /* setExpire() might realloc kvobj */ 
         key->kv = setExpire(key->ctx->client,key->db,key->key,expire);
     } else {
-        removeExpire(key->db,key->key);
+        removeExpire(key->db,key->key, key->kv);
     }
     return REDISMODULE_OK;
 }
@@ -4302,7 +4302,7 @@ int RM_SetAbsExpire(RedisModuleKey *key, mstime_t expire) {
     if (expire != REDISMODULE_NO_EXPIRE) {
         key->kv = setExpire(key->ctx->client,key->db,key->key,expire);
     } else {
-        removeExpire(key->db,key->key);
+        removeExpire(key->db,key->key, key->kv);
     }
     return REDISMODULE_OK;
 }

--- a/src/mstr.c
+++ b/src/mstr.c
@@ -199,7 +199,7 @@ mstrFlags *mstrFlagsRef(mstr s) {
  * to the starting location where it would have been written among other metadatas.
  * To verify if `flagIdx` of some metadata is attached, use `mstrGetFlag(s, flagIdx)`.
  */
-void *mstrMetaRef(mstr s, struct mstrKind *kind, int flagIdx) {
+void *mstrMetaRef(const mstr s, struct mstrKind *kind, int flagIdx) {
     int metaOffset = 0;
     /* start iterating from flags backward */
     mstrFlags *pFlags = mstrFlagsRef(s);

--- a/src/mstr.h
+++ b/src/mstr.h
@@ -200,7 +200,7 @@ void mstrFree(struct mstrKind *kind, mstr s);
 
 mstrFlags *mstrFlagsRef(mstr s);
 
-void *mstrMetaRef(mstr s, struct mstrKind *kind, int flagIdx);
+void *mstrMetaRef(const mstr s, struct mstrKind *kind, int flagIdx);
 
 size_t mstrlen(const mstr s);
 

--- a/src/object.c
+++ b/src/object.c
@@ -2,7 +2,7 @@
  *
  * Copyright (c) 2009-Present, Redis Ltd.
  * All rights reserved.
- * 
+ *
  * Copyright (c) 2024-present, Valkey contributors.
  * All rights reserved.
  *
@@ -14,6 +14,7 @@
 #include "server.h"
 #include "functions.h"
 #include "intset.h"  /* Compact integer set structure */
+#include "expire.h"
 #include <math.h>
 #include <ctype.h>
 
@@ -27,20 +28,20 @@
 
 /* ===================== Creation and parsing of objects ==================== */
 
-/* Creates an object, with embedded key and expire fields. The key and expire 
+/* Creates an object, with embedded key and expire fields. The key and expire
  * fields can be omitted by passing NULL and -1, respectively.
- * 
+ *
  * Example of kvobj "mykey" WITH expiry (16+8+1+7=32bytes):
- * 
+ *
  *    +-----------+------------+------------------+------------------------+
- *    | robj (16) | expiry (8) | key-hdr-size (1) | sdshdr5 "mykey" \0 (7) | 
+ *    | robj (16) | expiry (8) | key-hdr-size (1) | sdshdr5 "mykey" \0 (7) |
  *    +-----------+------------+------------------+------------------------+
  */
-kvobj *kvobjCreate(int type, const sds key, void *ptr, long long expire) {
+kvobj *kvobjCreate(int type, const sds key, void *ptr, int hasExpire) {
     /* Determine embedded key and expiration flags */
     serverAssert(key != NULL);
-    int has_expire = ((expire != -1) || (sdslen(key) >= KEY_SIZE_TO_INCLUDE_EXPIRE_THRESHOLD));
-    
+    int has_expire = (hasExpire || (sdslen(key) >= KEY_SIZE_TO_INCLUDE_EXPIRE_THRESHOLD));
+
     /* Calculate embedded key size */
     size_t key_sds_len = sdslen(key);
     char key_sds_type = sdsReqType(key_sds_len);
@@ -48,7 +49,9 @@ kvobj *kvobjCreate(int type, const sds key, void *ptr, long long expire) {
 
     /* Compute the base object size */
     size_t min_size = sizeof(robj);
-    if (has_expire) min_size += sizeof(long long);
+    if (has_expire) {
+        min_size += sizeof(ExpireMeta);        
+    }
     min_size += 1 + key_sds_size; /* 1 byte for SDS header size */
 
     /* Allocate object memory */
@@ -62,9 +65,9 @@ kvobj *kvobjCreate(int type, const sds key, void *ptr, long long expire) {
     o->iskvobj = 1;
 
     /* If extra space allows, pre-allocate anyway expiration */
-    if ((!has_expire) && (bufsize >= min_size + sizeof(long long))) {
+    if ((!has_expire) && (bufsize >= min_size + sizeof(ExpireMeta))) {
         has_expire = 1;
-        min_size += sizeof(long long);
+        min_size += sizeof(ExpireMeta);
     }
     o->expirable = has_expire;
 
@@ -73,8 +76,9 @@ kvobj *kvobjCreate(int type, const sds key, void *ptr, long long expire) {
 
     /* Set the expire field. */
     if (o->expirable) {
-        *(long long *)data = expire;
-        data += sizeof(long long);
+        ExpireMeta *meta = (ExpireMeta *)data;
+        meta->storedIn = EB_STORED_IN_TRASH;
+        data += sizeof(ExpireMeta);
     }
 
     /* Store embedded key. */
@@ -133,16 +137,15 @@ robj *createRawStringObject(const char *ptr, size_t len) {
 }
 
 /* Creates a new embedded string object and copies the content of key, val and
- * expire to the new object. LRU is set to 0. 
- * 
+ * expire to the new object. LRU is set to 0.
+ *
  * Example of kvobj "mykey" with embedded "myvalue" (16+1+7+11 = 35bytes):
  *    +-----------+------------------+------------------------+----------------------------+
- *    | robj (16) | key-hdr-size (1) | sdshdr5 "mykey" \0 (7) | sdshdr8 "myvalue" \0  (11) | 
+ *    | robj (16) | key-hdr-size (1) | sdshdr5 "mykey" \0 (7) | sdshdr8 "myvalue" \0  (11) |
  *    +-----------+------------------+------------------------+----------------------------+
  */
 static kvobj *kvobjCreateEmbedString(const char *val_ptr, size_t val_len,
-                                     const sds key, long long expire)
-                                               
+                                     const sds key, int hasExpire) 
 {
     serverAssert(key != NULL);
 
@@ -156,7 +159,7 @@ static kvobj *kvobjCreateEmbedString(const char *val_ptr, size_t val_len,
 
     /* Compute base object size */
     size_t min_size = sizeof(robj) + val_sds_size;
-    if (expire != -1) min_size += sizeof(long long);
+    if (hasExpire) min_size += sizeof(ExpireMeta);
     min_size += 1 + key_sds_size; /* 1 byte for SDS header size */
 
     /* Allocate object memory */
@@ -166,14 +169,14 @@ static kvobj *kvobjCreateEmbedString(const char *val_ptr, size_t val_len,
     o->encoding = OBJ_ENCODING_EMBSTR;
     o->refcount = 1;
     o->lru = 0;
-    o->expirable = (expire != -1);
+    o->expirable = hasExpire;
     o->iskvobj = 1;
 
     /* If the allocation has enough space for an expire field, add it even if we
      * don't need it now. Then we don't need to realloc if it's needed later. */
-    if (!o->expirable && bufsize >= min_size + sizeof(long long)) {
+    if (!o->expirable && bufsize >= min_size + sizeof(ExpireMeta)) {
         o->expirable = 1;
-        min_size += sizeof(long long);
+        min_size += sizeof(ExpireMeta);
     }
 
     /* The memory after the struct where we embedded data. */
@@ -181,8 +184,8 @@ static kvobj *kvobjCreateEmbedString(const char *val_ptr, size_t val_len,
 
     /* Set the expire field. */
     if (o->expirable) {
-        *(long long *)data = expire;
-        data += sizeof(long long);
+        ((ExpireMeta *)data)->storedIn = EB_STORED_IN_TRASH; /* let's mark for now as not thrash */
+        data += sizeof(ExpireMeta);
     }
 
     /* Store embedded key */
@@ -200,16 +203,16 @@ static kvobj *kvobjCreateEmbedString(const char *val_ptr, size_t val_len,
 /* Create a string object with encoding OBJ_ENCODING_EMBSTR, that is
  * an object where the sds string is actually an unmodifiable string
  * allocated in the same chunk as the object itself.
- * 
+ *
  * Example of robj with embedded "myvalue" (16+1+11 = 28 bytes):
  *    +-----------+------------------+----------------------------+
- *    | robj (16) | key-hdr-size (1) | sdshdr8 "myvalue" \0  (11) | 
+ *    | robj (16) | key-hdr-size (1) | sdshdr8 "myvalue" \0  (11) |
  *    +-----------+------------------+----------------------------+
  */
 robj *createEmbeddedStringObject(const char *val_ptr, size_t val_len) {
     /* Calculate size for embedded value (always SDS_TYPE_8) */
     size_t val_sds_size = sdsReqSize(val_len, SDS_TYPE_8);
-    
+
     /* Allocate object memory */
     size_t bufsize = 0;
     robj *o = zmalloc_usable(sizeof(robj) + val_sds_size, &bufsize);
@@ -222,7 +225,7 @@ robj *createEmbeddedStringObject(const char *val_ptr, size_t val_len) {
 
     /* The memory after the struct where we embedded data. */
     char *data = (char *)(o + 1);
-    
+
     /* Copy embedded value (EMBSTR) always as SDS TYPE 8. Account for unused
      * memory in the SDS alloc field. */
     size_t remaining_size = bufsize - (data - (char *)(void *)o);
@@ -234,7 +237,7 @@ sds kvobjGetKey(const kvobj *kv) {
     unsigned char *data = (void *)(kv + 1);
     if (kv->expirable) {
         /* Skip expire field */
-        data += sizeof(long long);
+        data += sizeof(ExpireMeta);
     }
     if (kv->iskvobj) {
         uint8_t hdr_size = *(uint8_t *)data;
@@ -244,10 +247,22 @@ sds kvobjGetKey(const kvobj *kv) {
     return NULL;
 }
 
-long long kvobjGetExpire(const kvobj *kv) {
+ExpireMeta *kvobjGetExpireMeta(const void *kvptr) {
+    kvobj *kv = (kvobj *)kvptr;
     unsigned char *data = (void *)(kv + 1);
     if (kv->expirable) {
-        return *(long long *)data;
+        return (ExpireMeta *)data;
+    } else {
+        return NULL;
+    }
+}
+
+long long kvobjGetExpire(const kvobj *kv) {
+    if (kv->expirable) {
+        uint64_t expireTime = ebGetExpireTime(&estoreBucketsType, (eItem) kv);
+        if (expireTime == EB_EXPIRE_TIME_INVALID)
+            return -1;
+        return (long long) expireTime;
     } else {
         return -1;
     }
@@ -256,23 +271,7 @@ long long kvobjGetExpire(const kvobj *kv) {
 /* This functions may reallocate the value. The new allocation is returned and
  * the old object's reference counter is decremented and possibly freed. Use the
  * returned object instead of 'val' after calling this function. */
-kvobj *kvobjSetExpire(kvobj *kv, long long expire) {
-    if (kv->expirable) {
-        /* Update existing expire field. */
-        unsigned char *data = (void *)(kv + 1);
-        *(long long *)data = expire;
-        return kv;
-    } else if (expire == -1) {
-        return kv;
-    } else {
-        return kvobjSet(kvobjGetKey(kv), kv, expire);
-    }
-}
-
-/* This functions may reallocate the value. The new allocation is returned and
- * the old object's reference counter is decremented and possibly freed. Use the
- * returned object instead of 'val' after calling this function. */
-kvobj *kvobjSet(sds key, robj *val, long long expire) {
+kvobj *kvobjSet(sds key, robj *val, int hasExpire) {
     if (val->type == OBJ_STRING && val->encoding == OBJ_ENCODING_EMBSTR) {
         kvobj *kv;
         size_t len = sdslen(val->ptr);
@@ -280,12 +279,12 @@ kvobj *kvobjSet(sds key, robj *val, long long expire) {
         /* Embed when the sum is up to 64 bytes. */
         size_t size = sizeof(kvobj);
         size += (key != NULL) * (sdslen(key) + 3); /* hdr size (1) + hdr (1) + nullterm (1) */
-        size += (expire != -1) * sizeof(long long);
+        size += hasExpire * sizeof(ExpireMeta);
         size += 4 + len; /* embstr header (3) + nullterm (1) */
         if (size <= CACHE_LINE_SIZE) {
-            kv = kvobjCreateEmbedString(val->ptr, len, key, expire);
+            kv = kvobjCreateEmbedString(val->ptr, len, key, hasExpire);
         } else {
-            kv = kvobjCreate(OBJ_STRING, key, sdsnewlen(val->ptr, len), expire);
+            kv = kvobjCreate(OBJ_STRING, key, sdsnewlen(val->ptr, len), hasExpire);
         }
 
         kv->lru = val->lru;
@@ -310,7 +309,7 @@ kvobj *kvobjSet(sds key, robj *val, long long expire) {
          * can be duplicated, but for a module type is not always possible. */
         serverPanic("Not implemented");
     }
-    robj *new = kvobjCreate(val->type, key, valptr, expire);
+    robj *new = kvobjCreate(val->type, key, valptr, hasExpire);
     new->encoding = val->encoding;
     new->lru = val->lru;
     decrRefCount(val);
@@ -816,7 +815,7 @@ void trimStringObjectIfNeeded(robj *o, int trim_small_values) {
     if (o->encoding != OBJ_ENCODING_RAW) return;
     /* A string may have free space in the following cases:
      * 1. When an arg len is greater than PROTO_MBULK_BIG_ARG the query buffer may be used directly as the SDS string.
-     * 2. When utilizing the argument caching mechanism in Lua. 
+     * 2. When utilizing the argument caching mechanism in Lua.
      * 3. When calling from RM_TrimStringAllocation (trim_small_values is true). */
     size_t len = sdslen(o->ptr);
     if (len >= PROTO_MBULK_BIG_ARG ||
@@ -1477,18 +1476,18 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
         mh->db[mh->num_dbs].overhead_ht_main = mem;
         mem_total+=mem;
 
-        mem = kvstoreMemUsage(db->expires);
+        mem = estoreMemUsage(db->expiresNew);
         mh->db[mh->num_dbs].overhead_ht_expires = mem;
         mem_total+=mem;
 
         mh->num_dbs++;
 
         mh->overhead_db_hashtable_lut += kvstoreOverheadHashtableLut(db->keys);
-        mh->overhead_db_hashtable_lut += kvstoreOverheadHashtableLut(db->expires);
+        //mh->overhead_db_hashtable_lut += kvstoreOverheadHashtableLut(db->expires);   need to do something in here with ebuckets
         mh->overhead_db_hashtable_rehashing += kvstoreOverheadHashtableRehashing(db->keys);
-        mh->overhead_db_hashtable_rehashing += kvstoreOverheadHashtableRehashing(db->expires);
+        //mh->overhead_db_hashtable_rehashing += kvstoreOverheadHashtableRehashing(db->expires);
         mh->db_dict_rehashing_count += kvstoreDictRehashingCount(db->keys);
-        mh->db_dict_rehashing_count += kvstoreDictRehashingCount(db->expires);
+        //mh->db_dict_rehashing_count += kvstoreDictRehashingCount(db->expires);
     }
 
     mh->overhead_total = mem_total;

--- a/src/object.c
+++ b/src/object.c
@@ -258,14 +258,10 @@ ExpireMeta *kvobjGetExpireMeta(const void *kvptr) {
 }
 
 long long kvobjGetExpire(const kvobj *kv) {
-    if (kv->expirable) {
-        uint64_t expireTime = ebGetExpireTime(&estoreBucketsType, (eItem) kv);
-        if (expireTime == EB_EXPIRE_TIME_INVALID)
-            return -1;
-        return (long long) expireTime;
-    } else {
+    if (!kv->expirable)
         return -1;
-    }
+    
+    return ebStackGetExpireTime(&estoreBucketsType, (eItem) kv);
 }
 
 /* This functions may reallocate the value. The new allocation is returned and

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1387,7 +1387,8 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter) {
     written += res;
 
     /* Write the RESIZE DB opcode. */
-    unsigned long long expires_size = kvstoreSize(db->expires);
+    //unsigned long long expires_size = kvstoreSize(db->expires);
+    unsigned long long expires_size = estoreSize(db->expiresNew);
     if ((res = rdbSaveType(rdb,RDB_OPCODE_RESIZEDB)) < 0) goto werr;
     written += res;
     if ((res = rdbSaveLen(rdb,db_size)) < 0) goto werr;
@@ -1408,7 +1409,8 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter) {
             written += res;
             if ((res = rdbSaveLen(rdb, kvstoreDictSize(db->keys, curr_slot))) < 0) goto werr;
             written += res;
-            if ((res = rdbSaveLen(rdb, kvstoreDictSize(db->expires, curr_slot))) < 0) goto werr;
+            //if ((res = rdbSaveLen(rdb, kvstoreDictSize(db->expires, curr_slot))) < 0) goto werr;
+            if ((res = rdbSaveLen(rdb, estoreSlotSize(db->expiresNew, curr_slot))) < 0) goto werr;
             written += res;
             last_slot = curr_slot;
         }
@@ -3437,7 +3439,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             }
             /* In cluster mode we resize individual slot specific dictionaries based on the number of keys that slot holds. */
             kvstoreDictExpand(db->keys, slot_id, slot_size);
-            kvstoreDictExpand(db->expires, slot_id, expires_slot_size);
+            //kvstoreDictExpand(db->expires, slot_id, expires_slot_size);
             should_expand_db = 0;
             continue; /* Read next opcode. */
         } else if (type == RDB_OPCODE_AUX) {
@@ -3572,7 +3574,6 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
          * In this case we want to estimate number of keys per slot and resize accordingly. */
         if (should_expand_db) {
             dbExpand(db, db_size, 0);
-            dbExpandExpires(db, expires_size, 0);
             should_expand_db = 0;
         }
 

--- a/src/server.c
+++ b/src/server.c
@@ -1232,7 +1232,7 @@ void databasesCron(void) {
         for (j = 0; j < dbs_per_call; j++) {
             redisDb *db = &server.db[resize_db % server.dbnum];
             kvstoreTryResizeDicts(db->keys, CRON_DICTS_PER_DB);
-            kvstoreTryResizeDicts(db->expires, CRON_DICTS_PER_DB);
+            //kvstoreTryResizeDicts(db->expires, CRON_DICTS_PER_DB);
             resize_db++;
         }
 
@@ -1244,9 +1244,9 @@ void databasesCron(void) {
                 elapsed_us += kvstoreIncrementallyRehash(db->keys, INCREMENTAL_REHASHING_THRESHOLD_US - elapsed_us);
                 if (elapsed_us >= INCREMENTAL_REHASHING_THRESHOLD_US)
                     break;
-                elapsed_us += kvstoreIncrementallyRehash(db->expires, INCREMENTAL_REHASHING_THRESHOLD_US - elapsed_us);
-                if (elapsed_us >= INCREMENTAL_REHASHING_THRESHOLD_US)
-                    break;
+//                elapsed_us += kvstoreIncrementallyRehash(db->expires, INCREMENTAL_REHASHING_THRESHOLD_US - elapsed_us);
+//                if (elapsed_us >= INCREMENTAL_REHASHING_THRESHOLD_US)
+//                    break;
                 rehash_db++;
             }
         }
@@ -1515,7 +1515,9 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
 
                 size = kvstoreBuckets(server.db[j].keys);
                 used = kvstoreSize(server.db[j].keys);
-                vkeys = kvstoreSize(server.db[j].expires);
+                //vkeys = kvstoreSize(server.db[j].expires);
+                vkeys = estoreSize(server.db[j].expiresNew);
+                
                 if (used || vkeys) {
                     serverLog(LL_VERBOSE,"DB %d: %lld keys (%lld volatile) in %lld slots HT.",j,used,vkeys,size);
                 }
@@ -2844,7 +2846,7 @@ void initServer(void) {
     }
     for (j = 0; j < server.dbnum; j++) {
         server.db[j].keys = kvstoreCreate(&dbDictType, slot_count_bits, flags | KVSTORE_ALLOC_META_KEYS_HIST);
-        server.db[j].expires = kvstoreCreate(&dbExpiresDictType, slot_count_bits, flags);
+        server.db[j].expiresNew = estoreCreate(&estoreBucketsType, slot_count_bits);
         server.db[j].hexpires = ebCreate();
         server.db[j].expires_cursor = 0;
         server.db[j].blocking_keys = dictCreate(&keylistDictType);
@@ -6443,7 +6445,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             long long keys, vkeys, hexpires;
 
             keys = kvstoreSize(server.db[j].keys);
-            vkeys = kvstoreSize(server.db[j].expires);
+            //vkeys = kvstoreSize(server.db[j].expires);
+            vkeys = estoreSize(server.db[j].expiresNew);
             hexpires = ebGetTotalItems(server.db[j].hexpires, &hashExpireBucketsType);
 
             if (keys || vkeys) {

--- a/src/server.h
+++ b/src/server.h
@@ -3636,11 +3636,11 @@ kvobj *dbAddRDBLoad(redisDb *db, sds key, robj **valref, long long expire);
 void dbReplaceValue(redisDb *db, robj *key, kvobj **ioKeyVal, int updateKeySizes);
 void dbReplaceValueWithLink(redisDb *db, robj *key, robj **val, dictEntryLink link);
 
-#define SETKEY_KEEPTTL 1
+#define SETKEY_KEEPTTL 1        /* Keep the TTL associated with the key */
 #define SETKEY_NO_SIGNAL 2
 #define SETKEY_ALREADY_EXIST 4
 #define SETKEY_DOESNT_EXIST 8
-#define SETKEY_HAS_EXPIRE 16
+#define SETKEY_HAS_EXPIRE 16    /* Reserve space in new kvobj for later expiry */
 
 void setKey(client *c, redisDb *db, robj *key, robj **ioval, int flags);
 void setKeyByLink(client *c, redisDb *db, robj *key, robj **valref, int flags, dictEntryLink *link);

--- a/src/server.h
+++ b/src/server.h
@@ -21,6 +21,7 @@
 #include "rio.h"
 #include "atomicvar.h"
 #include "commands.h"
+#include "expire.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -1105,7 +1106,8 @@ typedef struct replBufBlock {
  * database. The database number is the 'id' field in the structure. */
 typedef struct redisDb {
     kvstore *keys;              /* The keyspace for this DB. As metadata, holds keysizes histogram */
-    kvstore *expires;           /* Timeout of keys with a timeout set */
+    kvstore *expires;           /* Timeout of keys with a timeout set */  // TODO_MOTI: To be removed
+    estore  *expiresNew;
     ebuckets hexpires;          /* Hash expiration DS. Single TTL per hash (of next min field to expire) */
     dict *blocking_keys;        /* Keys with clients waiting for data (BLPOP)*/
     dict *blocking_keys_unblock_on_nokey;   /* Keys with clients waiting for
@@ -3061,11 +3063,11 @@ unsigned long long estimateObjectIdleTime(robj *o);
 void trimStringObjectIfNeeded(robj *o, int trim_small_values);
 #define sdsEncodedObject(objptr) (objptr->encoding == OBJ_ENCODING_RAW || objptr->encoding == OBJ_ENCODING_EMBSTR)
 
-kvobj *kvobjCreate(int type, const sds key, void *ptr, long long expire);
-kvobj *kvobjSet(sds key, robj *val, long long expire);
-kvobj *kvobjSetExpire(kvobj *kv, long long expire);
+kvobj *kvobjCreate(int type, const sds key, void *ptr, int hasExpire);
+kvobj *kvobjSet(sds key, robj *val, int hasExpire);
 sds kvobjGetKey(const kvobj *kv);
 long long kvobjGetExpire(const kvobj *val);
+ExpireMeta *kvobjGetExpireMeta(const void *kvptr);
 
 /* Synchronous I/O with timeout */
 ssize_t syncWrite(int fd, char *ptr, ssize_t size, long long timeout);
@@ -3393,10 +3395,8 @@ int calculateKeySlot(sds key);
 
 /* kvstore wrappers */
 int dbExpand(redisDb *db, uint64_t db_size, int try_expand);
-int dbExpandExpires(redisDb *db, uint64_t db_size, int try_expand);
 kvobj *dbFind(redisDb *db, sds key);
 kvobj *dbFindByLink(redisDb *db, sds key, dictEntryLink *link);
-kvobj *dbFindExpires(redisDb *db, sds key);
 unsigned long long dbSize(redisDb *db);
 unsigned long long dbScan(redisDb *db, unsigned long long cursor, dictScanFunction *scan_cb, void *privdata);
 
@@ -3599,7 +3599,7 @@ int setModuleNumericConfig(ModuleConfig *config, long long val, const char **err
 /* db.c -- Keyspace access API */
 void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, int64_t newLen);
 void dbgAssertKeysizesHist(redisDb *db);
-int removeExpire(redisDb *db, robj *key);
+int removeExpire(redisDb *db, robj *key, kvobj *kv);
 void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj);
 void deleteEvictedKeyAndPropagate(redisDb *db, robj *keyobj, long long *key_mem_freed);
 void propagateDeletion(redisDb *db, robj *key, int lazy);
@@ -3631,7 +3631,7 @@ int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle,
 
 static inline kvobj *dictGetKV(const dictEntry *de) {return (kvobj *) dictGetKey(de);}
 kvobj *dbAdd(redisDb *db, robj *key, robj **valref);
-kvobj *dbAddByLink(redisDb *db, robj *key, robj **valref, dictEntryLink *link);
+kvobj *dbAddByLink(redisDb *db, robj *key, robj **valref, dictEntryLink *link, int hasExpire);
 kvobj *dbAddRDBLoad(redisDb *db, sds key, robj **valref, long long expire);
 void dbReplaceValue(redisDb *db, robj *key, kvobj **ioKeyVal, int updateKeySizes);
 void dbReplaceValueWithLink(redisDb *db, robj *key, robj **val, dictEntryLink link);
@@ -3640,6 +3640,7 @@ void dbReplaceValueWithLink(redisDb *db, robj *key, robj **val, dictEntryLink li
 #define SETKEY_NO_SIGNAL 2
 #define SETKEY_ALREADY_EXIST 4
 #define SETKEY_DOESNT_EXIST 8
+#define SETKEY_HAS_EXPIRE 16
 
 void setKey(client *c, redisDb *db, robj *key, robj **ioval, int flags);
 void setKeyByLink(client *c, redisDb *db, robj *key, robj **valref, int flags, dictEntryLink *link);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -13,7 +13,7 @@
 
 /* Threshold for HEXPIRE and HPERSIST to be considered whether it is worth to
  * update the expiration time of the hash object in global HFE DS. */
-#define HASH_NEW_EXPIRE_DIFF_THRESHOLD max(4000, 1<<EB_BUCKET_KEY_PRECISION)
+#define HASH_NEW_EXPIRE_DIFF_THRESHOLD 4000
 
 /* Reserve 2 bits out of hash-field expiration time for possible future lightweight
  * indexing/categorizing of fields. It can be achieved by hacking HFE as follows:
@@ -47,8 +47,8 @@ typedef listpackEntry CommonEntry; /* extend usage beyond lp */
 
 /* hash field expiration (HFE) funcs */
 static ExpireAction onFieldExpire(eItem item, void *ctx);
-static ExpireMeta* hfieldGetExpireMeta(const eItem field);
-static ExpireMeta *hashGetExpireMeta(const eItem hash);
+static ExpireMeta* hfieldGetExpireMeta(const void *field);
+static ExpireMeta *hashGetExpireMeta(const void *hash);
 static void hexpireGenericCommand(client *c, long long basetime, int unit);
 static ExpireAction hashTypeActiveExpire(eItem hashObj, void *ctx);
 static uint64_t hashTypeExpire(kvobj *kv, ExpireCtx *expireCtx, int updateGlobalHFE);
@@ -117,6 +117,8 @@ EbucketsType hashExpireBucketsType = {
     .onDeleteItem = NULL,
     .getExpireMeta = hashGetExpireMeta,   /* get ExpireMeta attached to each hash */
     .itemsAddrAreOdd = 0,                 /* Addresses of dict are even */
+    .ebp.precision = 0,
+    .ebp.keySize = EB_PRECISION2KEYSIZE(0 /*.ebp.precision*/),
 };
 
 /* dictExpireMetadata - ebuckets-type for hash fields with time-Expiration. ebuckets
@@ -126,6 +128,8 @@ EbucketsType hashFieldExpireBucketsType = {
     .onDeleteItem = NULL,
     .getExpireMeta = hfieldGetExpireMeta, /* get ExpireMeta attached to each field */
     .itemsAddrAreOdd = 1,                 /* Addresses of hfield (mstr) are odd!! */
+    .ebp.precision = 0,
+    .ebp.keySize = EB_PRECISION2KEYSIZE(0 /*.ebp.precision*/),
 };
 
 /* OnFieldExpireCtx passed to OnFieldExpire() */
@@ -298,7 +302,7 @@ static void hashDictWithExpireOnRelease(dict *d) {
 
 struct listpackEx *listpackExCreate(void) {
     listpackEx *lpt = zcalloc(sizeof(*lpt));
-    lpt->meta.trash = 1;
+    lpt->meta.storedIn = EB_STORED_IN_TRASH;
     lpt->lp = NULL;
     return lpt;
 }
@@ -1138,7 +1142,7 @@ void initDictExpireMetadata(robj *o) {
 
     dictExpireMetadata *m = (dictExpireMetadata *) dictMetadata(ht);
     m->hfe = ebCreate();     /* Allocate HFE DS */
-    m->expireMeta.trash = 1; /* mark as trash (as long it wasn't ebAdd()) */
+    m->expireMeta.storedIn = EB_STORED_IN_TRASH; /* trash as long it wasn't ebAdd() */
 }
 
 /* Init HashTypeSetEx struct before calling hashTypeSetEx() */
@@ -1170,7 +1174,7 @@ int hashTypeSetExInit(robj *key, kvobj *o, client *c, redisDb *db,
 
             /* Fillup dict HFE metadata */
             m->hfe = ebCreate();     /* Allocate HFE DS */
-            m->expireMeta.trash = 1; /* mark as trash (as long it wasn't ebAdd()) */
+            m->expireMeta.storedIn = EB_STORED_IN_TRASH; /* trash as long it wasn't ebAdd() */
         }
     }
 
@@ -1277,7 +1281,7 @@ unsigned long hashTypeLength(const robj *o, int subtractExpiredFields) {
         listpackEx *lpt = o->ptr;
         length = lpLength(lpt->lp) / 3;
 
-        if (subtractExpiredFields && lpt->meta.trash == 0)
+        if (subtractExpiredFields && lpt->meta.storedIn != EB_STORED_IN_TRASH)
             length -= listpackExExpireDryRun(o);
     } else if (o->encoding == OBJ_ENCODING_HT) {
         uint64_t expiredItems = 0;
@@ -1285,7 +1289,7 @@ unsigned long hashTypeLength(const robj *o, int subtractExpiredFields) {
         if (subtractExpiredFields && isDictWithMetaHFE(d)) {
             dictExpireMetadata *meta = (dictExpireMetadata *) dictMetadata(d);
             /* If dict registered in global HFE DS */
-            if (meta->expireMeta.trash == 0)
+            if (meta->expireMeta.storedIn != EB_STORED_IN_TRASH)
                 expiredItems = ebExpireDryRun(meta->hfe,
                                               &hashFieldExpireBucketsType,
                                               commandTimeSnapshot());
@@ -1527,7 +1531,7 @@ static kvobj *hashTypeLookupWriteOrCreate(client *c, robj *key) {
 
     if (kv == NULL) {
         robj *o = createHashObject();
-        kv = dbAddByLink(c->db, key, &o, &link);
+        kv = dbAddByLink(c->db, key, &o, &link, 0);
     }
     return kv;
 }
@@ -1604,7 +1608,7 @@ void hashTypeConvertListpackEx(robj *o, int enc, ebuckets *hexpires) {
         listpackEx *lpt = o->ptr;
         uint64_t minExpire = hashTypeGetMinExpire(o, 0);
 
-        if (hexpires && lpt->meta.trash != 1)
+        if (hexpires && lpt->meta.storedIn != EB_STORED_IN_TRASH)
             ebRemove(hexpires, &hashExpireBucketsType, o);
 
         dict = dictCreate(&mstrHashDictTypeWithHFE);
@@ -1613,7 +1617,7 @@ void hashTypeConvertListpackEx(robj *o, int enc, ebuckets *hexpires) {
 
         /* Fillup dict HFE metadata */
         dictExpireMeta->hfe = ebCreate();     /* Allocate HFE DS */
-        dictExpireMeta->expireMeta.trash = 1; /* mark as trash (as long it wasn't ebAdd()) */
+        dictExpireMeta->expireMeta.storedIn = EB_STORED_IN_TRASH; /* mark as trash */
 
         hi = hashTypeInitIterator(o);
 
@@ -1681,7 +1685,7 @@ robj *hashTypeDup(kvobj *o, uint64_t *minHashExpire) {
     } else if(o->encoding == OBJ_ENCODING_LISTPACK_EX) {
         listpackEx *lpt = o->ptr;
 
-        if (lpt->meta.trash == 0)
+        if (lpt->meta.storedIn != EB_STORED_IN_TRASH)
             *minHashExpire = ebGetMetaExpTime(&lpt->meta);
 
         listpackEx *dup = listpackExCreate();
@@ -1705,11 +1709,11 @@ robj *hashTypeDup(kvobj *o, uint64_t *minHashExpire) {
             dictExpireMetaSrc = (dictExpireMetadata *) dictMetadata((dict *) o->ptr);
             dictExpireMetaDst = (dictExpireMetadata *) dictMetadata(d);
             dictExpireMetaDst->hfe = ebCreate();     /* Allocate HFE DS */
-            dictExpireMetaDst->expireMeta.trash = 1; /* mark as trash (as long it wasn't ebAdd()) */
+            dictExpireMetaDst->expireMeta.storedIn = EB_STORED_IN_TRASH; /* mark as trash (as long it wasn't ebAdd()) */
 
             /* Extract the minimum expire time of the source hash (Will be used by caller
              * to register the new hash in the global ebuckets, i.e db->hexpires) */
-            if (dictExpireMetaSrc->expireMeta.trash == 0)
+            if (dictExpireMetaSrc->expireMeta.storedIn != EB_STORED_IN_TRASH)
                 *minHashExpire = ebGetMetaExpTime(&dictExpireMetaSrc->expireMeta);
         }
         dictExpand(d, dictSize((const dict*)o->ptr));
@@ -1947,7 +1951,7 @@ uint64_t hashTypeGetMinExpire(robj *o, int accurate) {
         }
 
         /* Keep aside next hash-field expiry before updating HFE DS. Verify it is not trash */
-        if (expireMeta->trash == 1)
+        if (expireMeta->storedIn == EB_STORED_IN_TRASH)
             return EB_EXPIRE_TIME_INVALID;
 
         return ebGetMetaExpTime(expireMeta);
@@ -2066,7 +2070,7 @@ void hashTypeFree(robj *o) {
             /* Verify hash is not registered in global HFE ds */
             if (isDictWithMetaHFE((dict*)o->ptr)) {
                 dictExpireMetadata *m = (dictExpireMetadata *)dictMetadata((dict*)o->ptr);
-                serverAssert(m->expireMeta.trash == 1);
+                serverAssert(m->expireMeta.storedIn == EB_STORED_IN_TRASH);
             }
             dictRelease((dict*) o->ptr);
             break;
@@ -2075,7 +2079,7 @@ void hashTypeFree(robj *o) {
             break;
         case OBJ_ENCODING_LISTPACK_EX:
             /* Verify hash is not registered in global HFE ds */
-            serverAssert(((listpackEx *) o->ptr)->meta.trash == 1);
+            serverAssert(((listpackEx *) o->ptr)->meta.storedIn == EB_STORED_IN_TRASH);
             listpackExFree(o->ptr);
             break;
         default:
@@ -2350,7 +2354,7 @@ void hsetexCommand(client *c) {
             return;
         }
         o = createHashObject();
-        dbAddByLink(c->db, c->argv[1], &o, &link);
+        dbAddByLink(c->db, c->argv[1], &o, &link, 0);
     }
     oldlen = (int64_t) hashTypeLength(o, 0);
 
@@ -3374,7 +3378,7 @@ static hfield _hfieldNew(const void *field, size_t fieldlen, int withExpireMeta,
     ExpireMeta *expireMeta = mstrMetaRef(hf, &mstrFieldKind, HFIELD_META_EXPIRE);
 
     /* as long as it is not inside ebuckets, it is considered trash */
-    expireMeta->trash = 1;
+    expireMeta->storedIn = EB_STORED_IN_TRASH;
     return hf;
 }
 
@@ -3391,9 +3395,9 @@ int hfieldIsExpireAttached(hfield field) {
     return mstrIsMetaAttached(field) && mstrGetFlag(field, (int) HFIELD_META_EXPIRE);
 }
 
-static ExpireMeta* hfieldGetExpireMeta(const eItem field) {
+static ExpireMeta* hfieldGetExpireMeta(const void *field) {
     /* extract the expireMeta from the field of type mstr */
-    return mstrMetaRef(field, &mstrFieldKind, (int) HFIELD_META_EXPIRE);
+    return mstrMetaRef((mstr)field, &mstrFieldKind, (int) HFIELD_META_EXPIRE);
 }
 
 /* returned value is unix time in milliseconds */
@@ -3402,7 +3406,7 @@ uint64_t hfieldGetExpireTime(hfield field) {
         return EB_EXPIRE_TIME_INVALID;
 
     ExpireMeta *expireMeta = mstrMetaRef(field, &mstrFieldKind, (int) HFIELD_META_EXPIRE);
-    if (expireMeta->trash)
+    if (expireMeta->storedIn == EB_STORED_IN_TRASH)
         return EB_EXPIRE_TIME_INVALID;
 
     return ebGetMetaExpTime(expireMeta);
@@ -3419,7 +3423,7 @@ static void hfieldPersist(robj *hashObj, hfield field) {
     dictExpireMetadata *dictExpireMeta = (dictExpireMetadata *)dictMetadata(d);
 
     /* If field has valid expiry then dict must have valid metadata as well */
-    serverAssert(dictExpireMeta->expireMeta.trash == 0);
+    serverAssert(dictExpireMeta->expireMeta.storedIn != EB_STORED_IN_TRASH);
 
     /* Remove field from private HFE DS */
     ebRemove(&dictExpireMeta->hfe, &hashFieldExpireBucketsType, field);
@@ -3481,7 +3485,7 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
 
 /* Retrieve the ExpireMeta associated with the hash.
  * The caller is responsible for ensuring that it is indeed attached. */
-static ExpireMeta *hashGetExpireMeta(const eItem hash) {
+static ExpireMeta *hashGetExpireMeta(const void *hash) {
     robj *hashObj = (robj *)hash;
     if (hashObj->encoding == OBJ_ENCODING_LISTPACK_EX) {
         listpackEx *lpt = hashObj->ptr;

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -477,7 +477,7 @@ void pushGenericCommand(client *c, int where, int xx) {
         }
 
         lobj = createListListpackObject();
-        dbAddByLink(c->db, c->argv[1], &lobj, &link);
+        dbAddByLink(c->db, c->argv[1], &lobj, &link, 0);
     }
 
     listTypeTryConversionAppend(lobj,c->argv,2,c->argc-1,NULL,NULL);

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -597,7 +597,7 @@ void saddCommand(client *c) {
     
     if (set == NULL) {
         robj *o = setTypeCreate(c->argv[2]->ptr, c->argc - 2);
-        set = dbAddByLink(c->db, c->argv[1], &o, &link);
+        set = dbAddByLink(c->db, c->argv[1], &o, &link, 0);
     } else {
         setTypeMaybeConvert(set, c->argc - 2);
     }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1866,7 +1866,7 @@ kvobj *streamTypeLookupWriteOrCreate(client *c, robj *key, int no_create) {
         return NULL;
     }
     robj *o = createStreamObject();
-    dbAddByLink(c->db, key, &o, &link);
+    dbAddByLink(c->db, key, &o, &link, 0);
     return o;
 }
 

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -100,6 +100,7 @@ void setGenericCommand(client *c, int flags, robj *key, robj **valref, robj *exp
     /* When expire is not NULL, we avoid deleting the TTL so it can be updated later instead of being deleted and then created again. */
     setkey_flags |= ((flags & OBJ_KEEPTTL) || expire) ? SETKEY_KEEPTTL : 0;
     setkey_flags |= found ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST;
+    setkey_flags |= expire ? SETKEY_HAS_EXPIRE : 0;
 
     setKeyByLink(c, c->db, key, valref, setkey_flags, &link);
     /* If there's an expiration, setExpireByLink may reallocate the object.
@@ -366,12 +367,12 @@ void getexCommand(client *c) {
         return;
     }
 
-    kvobj *o;
+    kvobj *kv;
 
-    if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp])) == NULL)
+    if ((kv = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp])) == NULL)
         return;
 
-    if (checkType(c,o,OBJ_STRING)) {
+    if (checkType(c,kv,OBJ_STRING)) {
         return;
     }
 
@@ -382,7 +383,7 @@ void getexCommand(client *c) {
     }
 
     /* We need to do this before we expire the key or delete it */
-    addReplyBulk(c,o);
+    addReplyBulk(c,kv);
 
     /* This command is never propagated as is. It is either propagated as PEXPIRE[AT],DEL,UNLINK or PERSIST.
      * This why it doesn't need special handling in feedAppendOnlyFile to convert relative expire time to absolute one. */
@@ -397,7 +398,7 @@ void getexCommand(client *c) {
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
         server.dirty++;
     } else if (expire) {
-        o = setExpire(c,c->db,c->argv[1],milliseconds);
+        setExpire(c,c->db,c->argv[1],milliseconds);
         /* Propagate as PXEXPIREAT millisecond-timestamp if there is
          * EX/PX/EXAT/PXAT flag and the key has not expired. */
         robj *milliseconds_obj = createStringObjectFromLongLong(milliseconds);
@@ -407,7 +408,7 @@ void getexCommand(client *c) {
         notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",c->argv[1],c->db->id);
         server.dirty++;
     } else if (flags & OBJ_PERSIST) {
-        if (removeExpire(c->db, c->argv[1])) {
+        if (removeExpire(c->db, c->argv[1], kv)) {
             signalModifiedKey(c, c->db, c->argv[1]);
             rewriteClientCommandVector(c, 2, shared.persist, c->argv[1]);
             notifyKeyspaceEvent(NOTIFY_GENERIC,"persist",c->argv[1],c->db->id);
@@ -468,7 +469,7 @@ void setrangeCommand(client *c) {
 
         newLen = offset+value_len;
         robj *o = createObject(OBJ_STRING,sdsnewlen(NULL, newLen));
-        kv = dbAddByLink(c->db, c->argv[1], &o, &link);
+        kv = dbAddByLink(c->db, c->argv[1], &o, &link, 0);
     } else {
         /* Key exists, check type */
         if (checkType(c,kv,OBJ_STRING))
@@ -633,7 +634,7 @@ void incrDecrCommand(client *c, long long incr) {
             dbReplaceValueWithLink(c->db, c->argv[1], &new, link);
         } else {
             /* Add new key to db and also update keysizes hist */
-            dbAddByLink(c->db, c->argv[1], &new, &link);
+            dbAddByLink(c->db, c->argv[1], &new, &link, 0);
         }
     }
     addReplyLongLongFromStr(c,new);
@@ -688,7 +689,7 @@ void incrbyfloatCommand(client *c) {
     if (o)
         dbReplaceValueWithLink(c->db, c->argv[1], &new, link);
     else
-        dbAddByLink(c->db, c->argv[1], &new, &link);
+        dbAddByLink(c->db, c->argv[1], &new, &link, 0);
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_STRING,"incrbyfloat",c->argv[1],c->db->id);
     server.dirty++;
@@ -712,7 +713,7 @@ void appendCommand(client *c) {
     if (o == NULL) {
         /* Create the key */
         c->argv[2] = tryObjectEncoding(c->argv[2]);
-        dbAddByLink(c->db, c->argv[1], &c->argv[2], &link);
+        dbAddByLink(c->db, c->argv[1], &c->argv[2], &link, 0);
         incrRefCount(c->argv[2]);
         totlen = stringObjectLen(c->argv[2]);
     } else {

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -96,11 +96,19 @@ void setGenericCommand(client *c, int flags, robj *key, robj **valref, robj *exp
         }
         return;
     }
+    
+    if (found) {
+        /* mark key already exists and provide its `link` (to save lookup) */ 
+        setkey_flags |= SETKEY_ALREADY_EXIST;
+        /* if flagged to keep expiration time */
+        setkey_flags |= (flags & OBJ_KEEPTTL) ? SETKEY_KEEPTTL : 0;
 
-    /* When expire is not NULL, we avoid deleting the TTL so it can be updated later instead of being deleted and then created again. */
-    setkey_flags |= ((flags & OBJ_KEEPTTL) || expire) ? SETKEY_KEEPTTL : 0;
-    setkey_flags |= found ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST;
-    setkey_flags |= expire ? SETKEY_HAS_EXPIRE : 0;
+    } else {
+        /* mark key doesn't exists and provide `link` to insert (to save lookup) */
+        setkey_flags |= SETKEY_DOESNT_EXIST;
+        /* Indicates whether to reserve space in new kvobj */
+        setkey_flags |= (expire) ? SETKEY_HAS_EXPIRE : 0;
+    }
 
     setKeyByLink(c, c->db, key, valref, setkey_flags, &link);
     /* If there's an expiration, setExpireByLink may reallocate the object.

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -833,69 +833,69 @@ start_server {tags {"expire"}} {
         assert_equal [r debug set-active-expire 1] {OK}
     } {} {needs:debug}
 }
-
-start_cluster 1 0 {tags {"expire external:skip cluster"}} {
-    test "expire scan should skip dictionaries with lot's of empty buckets" {
-        r debug set-active-expire 0
-
-        # Collect two slots to help determine the expiry scan logic is able
-        # to go past certain slots which aren't valid for scanning at the given point of time.
-        # And the next non empty slot after that still gets scanned and expiration happens.
-
-        # hashslot(alice) is 749
-        r psetex alice 500 val
-
-        # hashslot(foo) is 12182
-        # fill data across different slots with expiration
-        for {set j 1} {$j <= 100} {incr j} {
-            r psetex "{foo}$j" 500 a
-        }
-        # hashslot(key) is 12539
-        r psetex key 500 val
-
-        # disable resizing, the reason for not using slow bgsave is because
-        # it will hit the dict_force_resize_ratio.
-        r debug dict-resizing 0
-
-        # delete data to have lot's (99%) of empty buckets (slot 12182 should be skipped)
-        for {set j 1} {$j <= 99} {incr j} {
-            r del "{foo}$j"
-        }
-
-        # Trigger a full traversal of all dictionaries.
-        r keys *
-
-        r debug set-active-expire 1
-
-        # Verify {foo}100 still exists and remaining got cleaned up
-        wait_for_condition 20 100 {
-            [r dbsize] eq 1
-        } else {
-            if {[r dbsize] eq 0} {
-                puts [r debug htstats 0]
-                fail "scan didn't handle slot skipping logic."
-            } else {
-                puts [r debug htstats 0]
-                fail "scan didn't process all valid slots."
-            }
-        }
-
-        # Enable resizing
-        r debug dict-resizing 1
-
-        # put some data into slot 12182 and trigger the resize
-        r psetex "{foo}0" 500 a
-
-        # Verify all keys have expired
-        wait_for_condition 400 100 {
-            [r dbsize] eq 0
-        } else {
-            puts [r dbsize]
-            flush stdout
-            fail "Keys did not actively expire."
-        }
-
-        # Make sure we don't have any timeouts.
-        assert_equal 0 [s 0 expired_time_cap_reached_count]
-    } {} {needs:debug}
-}
+#
+#start_cluster 1 0 {tags {"expire external:skip cluster"}} {
+#    test "expire scan should skip dictionaries with lot's of empty buckets" {
+#        r debug set-active-expire 0
+#
+#        # Collect two slots to help determine the expiry scan logic is able
+#        # to go past certain slots which aren't valid for scanning at the given point of time.
+#        # And the next non empty slot after that still gets scanned and expiration happens.
+#
+#        # hashslot(alice) is 749
+#        r psetex alice 500 val
+#
+#        # hashslot(foo) is 12182
+#        # fill data across different slots with expiration
+#        for {set j 1} {$j <= 100} {incr j} {
+#            r psetex "{foo}$j" 500 a
+#        }
+#        # hashslot(key) is 12539
+#        r psetex key 500 val
+#
+#        # disable resizing, the reason for not using slow bgsave is because
+#        # it will hit the dict_force_resize_ratio.
+#        r debug dict-resizing 0
+#
+#        # delete data to have lot's (99%) of empty buckets (slot 12182 should be skipped)
+#        for {set j 1} {$j <= 99} {incr j} {
+#            r del "{foo}$j"
+#        }
+#
+#        # Trigger a full traversal of all dictionaries.
+#        r keys *
+#
+#        r debug set-active-expire 1
+#
+#        # Verify {foo}100 still exists and remaining got cleaned up
+#        wait_for_condition 20 100 {
+#            [r dbsize] eq 1
+#        } else {
+#            if {[r dbsize] eq 0} {
+#                puts [r debug htstats 0]
+#                fail "scan didn't handle slot skipping logic."
+#            } else {
+#                puts [r debug htstats 0]
+#                fail "scan didn't process all valid slots."
+#            }
+#        }
+#
+#        # Enable resizing
+#        r debug dict-resizing 1
+#
+#        # put some data into slot 12182 and trigger the resize
+#        r psetex "{foo}0" 500 a
+#
+#        # Verify all keys have expired
+#        wait_for_condition 400 100 {
+#            [r dbsize] eq 0
+#        } else {
+#            puts [r dbsize]
+#            flush stdout
+#            fail "Keys did not actively expire."
+#        }
+#
+#        # Make sure we don't have any timeouts.
+#        assert_equal 0 [s 0 expired_time_cap_reached_count]
+#    } {} {needs:debug}
+#}

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -34,6 +34,21 @@ start_server {tags {"expire"}} {
         r expireat x [expr [clock seconds]+15]
         r ttl x
     } {1[345]}
+    
+    test {EXPIREAT - Should store timestamps up to 2^63-1} {
+        # This test also verifies also no issues with the internal 48-bit expiry
+        # time optimization storage of ebuckets
+        for {set i 46} {$i < 62} {incr i} {
+            r pexpireat x [expr (1<<$i)-1]
+            assert_equal [r pexpiretime x] [expr (1<<$i)-1]
+            r pexpireat x [expr (1<<$i)]
+            assert_equal [r pexpiretime x] [expr (1<<$i)]
+            r pexpireat x [expr (1<<$i)+1]
+            assert_equal [r pexpiretime x] [expr (1<<$i)+1]                        
+        }
+        r pexpireat x [expr (1<<63)-1]
+        assert_equal [r pexpiretime x] [expr (1<<63)-1]                               
+    }    
 
     test {SETEX - Set + Expire combo operation. Check for TTL} {
         r setex x 12 test

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -317,7 +317,7 @@ start_server {tags {"info" "external:skip"}} {
             assert_morethan $cycle1 0
             assert_morethan $el_sum1 0
             assert_morethan $cmd_sum1 0
-            after 110 ;# default hz is 10, wait for a cron tick. 
+            after 110 ;# default hz is 10, wait for a cron tick.
             set info2 [r info stats]
             set cycle2 [getInfoProperty $info2 eventloop_cycles]
             set el_sum2 [getInfoProperty $info2 eventloop_duration_sum]
@@ -531,7 +531,7 @@ start_server {tags {"info" "external:skip"}} {
 
         # Set 2 more keys to trigger rehashing
         # get the info within a transaction to make sure the rehashing is not completed
-        r multi 
+        r multi
         r set this_will_reach_max_load_factor 1
         r set this_must_be_rehashed 1
         r info memory
@@ -559,7 +559,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
 
         # In cluster mode, we use KVSTORE_FREE_EMPTY_DICTS to ensure that dicts
         # are freed when they are emptied. This test verifies that after a dict
-        # is cleared, the lut overhead is properly updated, preventing it from 
+        # is cleared, the lut overhead is properly updated, preventing it from
         # growing indefinitely.
         for {set j 1} {$j <= 500} {incr j} {
             R 0 set k v


### PR DESCRIPTION
# TL;DR
Today's expiration implementation relies on hash tables and inefficient scans for active-expiration, which don’t scale well, and impose memory pressure [[1](https://github.com/redis/redis/issues/11494), [2](https://github.com/redis/redis/issues/12602), [3](https://github.com/redis/redis/pull/12616)]. This proposal redesigns Redis’s EXPIRE mechanism around compact ebuckets data structure, introduced with [Hash Field Expiration](https://redis.io/blog/hash-field-expiration-architecture-and-benchmarks/). As part of its integration, this proposal also improves it to become a hierarchical ebucket stack, inspired by [Timing Wheel algorithm](https://dl.acm.org/doi/pdf/10.1145/37499.37504). Benchmarks show that ebuckets offers superior active expiration, better scalability, faster insertion and removal, significantly lower memory usage, and more stable and predictable performance - which contribute to the overall stability and efficiency of the system.

# Motivation
Redis currently stores keys with expiration using hash table (dict). While functional, this approach might become inefficient at scale. In such implementation the main trouble is active expiration operation, which repeatedly scans the entire dict to find expired keys, adding significant overhead as the number of entries grows into the millions. Scanning-based expiration might be effective when a high percentage of keys are expired at any given time. However, as that percentage drops, the cost of scanning increases disproportionately. Online benchmarks tends to overlook this dynamic by assigning similar TTLs to all tested keys, creating artificially ideal conditions that don't reflect real-world workloads  (Consider Test number 3 below).

Another crucial issue with hash-table is the high cost of managing it. As the expiration hash table grows or shrinks, it must also be rehashed gradually. Under memory pressure, this rehashing can occur, ironically, during most critical moments. While hash tables might be essential for constant-time keyspace lookups, they are clearly suboptimal for the EXPIRE use case.

# Suggested solution 
Two important preceding milestones makes it possible to propose this redesign: 
1. [Hash Field Expiration (HFE)](https://github.com/redis/redis/pull/13172) -  As part of this feature, introduced ebuckets data structure. From the outset, it was designed with the possibility in mind that it could later be extended to support the EXPIRE mechanism as well. It demonstrated strong qualities in terms of memory efficiency, scalability, and operational performance particularly related to active expiration. 
2. [Unification of Key, value & TTL](https://github.com/redis/redis/pull/13806) - A recent commit introduced a unified in-memory representation that combines the key, value, and optionally TTL into a single object, referred to as the kv-object, or simply kvobj. This consolidation improves memory layout, simplifies object lifecycle management, and enables true O(1) TTL lookups. It also lays the foundation for embedding expiration metadata structure (ExpireMeta struct) directly within the kvobj, making it compatible with ebuckets and enabling seamless integration.

In this pull request, ebuckets is further improved and extended to support global key expiration by introducing a hierarchical stack design that maintains efficiency even under less-than-ideal TTL distributions.

## Hierarchical ebuckets stack (ebStack)
ebuckets can efficiently group items with similar TTL into a single bucket, from 16 items per bucket to millions of items with similar TTLs. Having said that, ebuckets performance can degrades when expiration times are spread across big timelines which might lead to many buckets. Although this may not be a dominant use case, it could be well mitigated with a hierarchical approach inspired by the [Timing Wheel algorithm](https://dl.acm.org/doi/pdf/10.1145/37499.37504). Specifically, this proposal suggests addressing it by using (at least) two-level data structure of ebuckets:
* **Level 1:** Covers expirations within 1 hour, with ~1-second precision. ebuckets will have at most ~3600  buckets and in the average case considerably less.
* **Level 2:** Covers longer-term expirations, with ~0.5-hour precision. ebuckets will have at most ~1440  buckets to cover 1 month and in the average case considerably less. 

On insertion, if the key's expiration is beyond 1 hour, it would be placed using a lower-precision bucket. Otherwise, it will be added to a high precision bucket. Then, later on, the data structure would gradually cascade keys from L2 with less than 1 hour, into L1 higher-precision ebuckets for more accurate, on time, expiration handling. Note, this cascading step is trivial and affordable because it only involves iterating over the smallest linked-list bucket in Level 2 and blindly inserting its entries into high-precision buckets in Level 1, with enough time to do so ahead. 

**ebuckets 6 bytes TTL limitation**
Ebuckets implementation is very memory efficient and as such, one of its limitations is that it can store items with no more than 6 bytes of expiration time. In case of Hash Field Expiration it wasn’t an issue because it was a new feature and the limitation was clearly documented and exposed upfront. However, the legacy EXPIRE command expects to save up 8-byte timestamps (Sometimes users rely on this for storing long-lived metadata attached to keys, not just for actual expiration). To mitigate this we can store those special keys into a special “infinite” vector. This vector is intentionally simple, supporting only add and removal operations without active expiration. 


**Bringing It All Together**
Building on the previous two sections, the expiration-time space is partitioned into three tiers by hierarchical ebuckets stack (ebStack). Upon insertion into ebuckets instance, the item is added to one of the levels based on its TTL:

| Level      | Range                   | Buckets Precision   |
|------------|-------------------------|----------------------|
| L1 ebuckets | TTL < 1 hour            | ~1 second            |
| L2 ebuckets | (1 hour ≤ TTL) && (expiry-time < 2^48)     | ~0.5 hours              |
| L3 Vector   | 2^48 ≤ expiry-time              | N/A (Single bucket)  |

In cluster mode, each slot will have its own ebStack instance. Otherwise, a single instance is created per db.

## New estore API (instead of kvstore API)
Today the expiration mechanism reuses kvstore [API](https://github.com/redis/redis/pull/12822) of the keyspace. However, this approach becomes irrelevant following the redesign. Many functions of the existing API relies on hash tables or dict-like semantics—making an API modeled after dict both redundant and misleading. 

Instead, a distinct API is proposed to manage ebuckets across slots, handle the expiration data lifecycle, and offer a clean, modular interface for integration with the rest of the system. This API could also be utilized for the Hash Field Expiration (HFE)  feature, which currently maintains a single ebucket instance per db (to trace hashes with HFEs) but should be refactored to support per-slot granularity.


As part of active expiration, the function `estoreCascadeCycle()` will also be called. It will propagate effortlessly items gradually from ebuckets level2 to level1, by looking up minimal cascade bucket, with expiration of less than ~1 hour. The return value will reflect the effort left to be called next time. 

TBD.

## Volatile based eviction (Change in Behavior)
Supporting eviction policy of volatile-random, volatile-lru and volatile-lfu are fundamentally incompatible with any expiration algorithm designed for efficiency. Most such algorithms—ebuckets included—optimize by grouping items with similar expiration times into shared "buckets", typically implemented as chains or lists. In cases where, for example, a million keys fall into a single bucket, there's no practical way to select a truly random item from that group without incurring significant overhead.

As a result, when using ebuckets, eviction for `volatile-*` policies will primarily favor items with the soonest expiration times. This isn't strictly "random" or "LRU", but aligns with the natural structure of the expiration mechanism. While this may diverge slightly from legacy behavior, it ensures that eviction remains performant and predictable at scale.

TBD.

# Benchmarking

## Test1: SET EX 3
This test highlights that ebuckets not only outperforms and adds items quicker for short TTLs, but also it releases them faster. It is done entirely while the unstable still inserting items!
```
memtier_benchmark --command "SET __key__ BBB EX 3" -c 1 -t 1 --command-key-pattern=P -c 1 -t 1 --pipeline 1000 --hide-histogram --key-maximum 50000000 -n allkeys --key-prefix=1

### EBUCKETS
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Sets       923891.64         1.04379         0.85500         2.04700        28.15900     51227.06
Totals     923891.64         1.04379         0.85500         2.04700        28.15900    102454.13

### UNSTABLE
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Sets       675600.62         1.43698         0.97500         4.35100        28.67100     37460.06
Totals     675600.62         1.43698         0.97500   
```


![image](https://github.com/user-attachments/assets/0f4d75f5-1409-4d2b-b143-3bfe431c41d4)

## Test2: SET EX 20
```
memtier_benchmark --command "SET __key__ BBB EX 20" -c 1 -t 1 --command-key-pattern=P -c 1 -t 1 --pipeline 1000 --hide-histogram     --key-maximum 150000000 -n allkeys

### EBUCKETS
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Sets       855589.33         1.13678         0.79900         2.15900        28.15900     55362.03
Totals     855589.33         1.13678         0.79900         2.15900        28.15900    110724.05

### UNSTABLE
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Sets       591384.42         1.65620         1.10300         7.23100        29.82300     38266.30
Totals     591384.42         1.65620         1.10300         7.23100        29.82300     76532.60
```
![image](https://github.com/user-attachments/assets/6d59cddd-6a91-4a92-bac5-9dc50fe05650)

## Test3: (Precond: SET EX 10000 →) SET EX 10
As a precondition for this test, 50 million keys were set with a TTL of 10000 seconds, followed by another 50 million keys with a TTL of 20 seconds. Ebuckets completes the task faster, with a more aggressive expiration strategy that keeps memory usage and database size near their optimal levels. In contrast, the unstable branch achieves lower throughput, and its active expiration takes significantly longer to locate and remove expired keys—remaining high even 100 seconds after the test ends. As a result, memory remains heavily consumed.
```
### Precondition: memtier_benchmark --command "SET __key__ BBB EX 10000" -c 1 -t 1 --command-key-pattern=P -c 1 -t 1 --pipeline 1000 --hide-histogram     --key-maximum 50000000 -n allkeys --key-prefix=1

memtier_benchmark --command "SET __key__ BBB EX 10" -c 1 -t 1 --command-key-pattern=P -c 1 -t 1 --pipeline 1000 --hide-histogram     --key-maximum 50000000 -n allkeys --key-prefix=2

### EBUCKETS
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Sets       872340.41         1.10897         0.97500         2.20700        28.15900     49220.60
Totals     872340.41         1.10897         0.97500         2.20700        28.15900     98441.19

### UNSTABLE
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Sets       713215.68         1.36044         1.19900         3.00700         8.70300     40242.20
Totals     713215.68         1.36044         1.19900         3.00700         8.70300     80484.41
```
![image](https://github.com/user-attachments/assets/2589afcb-886f-49f1-ba6f-4ec56077c952)

## Test4: SET EX 120 → SET EX 120 → DEL
While previous tests demonstrated ebuckets' strengths involved with active expiration scenarios, this test isolates command throughput in the absence of actual active expiration operation. It evaluates whether the ebuckets mechanism introduces overhead for typical operations of set, update and delete, when TTLs are long enough to prevent any actual active expirations during the test window. The steps executed are:

1. SET - Insert 50M keys with a TTL of 120 seconds (ensuring they won't expire during the test).
2. SET - Update the same keys with a new TTL of 120 seconds
3. DEL - Remove the keys from the dataset.

This setup avoids triggering active expiration, focusing instead on potential performance impact from `estore` API insertions/removals themselves. 
```
                     |                          Ops/sec                    |                          used_mem
---------------------+-----------------------------------------------------+-----------------------------------------------------
numitems  Step Cmd   |        ebuckets          unstable          diff_%   |        ebuckets           unstable           diff_%
---------------------+-----------------------------------------------------+-----------------------------------------------------
5000000   1    Sets  |      1048456.51         848876.26          -19.04   |       415774432          495864288            19.26
          2    Sets  |       930310.44         967362.35            3.98   |       414366168          414530000             0.04
          3    Dels  |      1892635.34        2025357.48            7.01   |          811336             814864             0.43
10000000  1    Sets  |      1004907.47         826430.16          -17.76   |       830682160          990891872            19.29
          2    Sets  |       901985.15         986310.80            9.35   |       828684128          828213200            -0.06
          3    Dels  |      1906743.47        1872716.34           -1.78   |          811944             815472             0.43
100000000 1    Sets  |       910738.64         708861.03          -22.17   |      7865417224         9033916464            14.86
          2    Sets  |       917715.99         797980.31          -13.05   |      8095756456         8629055296             6.59
          3    Dels  |      1628581.34        1472842.70           -9.56   |          811320             816960             0.70

```

## Test5: SET EX 36000 → SET EX 36000 → DEL
```
                     |                          Ops/sec                   |                          used_mem
---------------------+----------------------------------------------------+-----------------------------------------------------
numitems  Step Cmd   |        ebuckets          unstable          diff_%  |         ebuckets           unstable           diff_%
---------------------+-----------------------------------------------------+-----------------------------------------------------
10000000  1    Sets  |      1005893.63         771828.69          -23.27  |        830675624          990967104            19.30
          2    Sets  |       936590.83         975936.81            4.20  |        828684064          828213504            -0.06
          3    Dels  |      1828827.59        1875862.19            2.57  |           812248             815776             0.43
```

## Test6: SET EX randrange(20sec -  30 days)
This scenario serves as a worst-case test for ebuckets, forcing the creation of many buckets due to keys being spread evenly across a wide time range, with minimal active expiration for ebuckets to benefit from. Even so, the hierarchical structure of the ebuckets stack helps contain the impact of this less favorable pattern — the number of buckets remains below ~4600.
```
memtier_benchmark --command "SET __key__ BBB EX __data__" -c 1 -t 1 --data-size-range=20-2592000 --command-key-pattern=P -c 1 -t 1 --pipeline 1000 --hide-histogram     --key-maximum 50000000 -n allkeys --key-prefix=1

### EBUCKETS
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Sets       835689.69         1.16080         1.20700         2.36700         3.15100     50883.36
Totals     835689.69         1.16080         1.20700         2.36700         3.15100    101766.72

### UNSTABLE
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Sets       825935.76         1.17200         1.23100         2.49500         4.79900     50289.46
Totals     825935.76         1.17200         1.23100         2.49500         4.79900    100578.93
```
(Note: I needed to modify memtier_benchmark to support placeholder __data__ as random range value for expiration “EX __data__”)

![image](https://github.com/user-attachments/assets/09cb291a-2148-4a63-89fc-50b654fe108d)

## Test7: SET EX 10 years
```
memtier_benchmark --command "SET __key__ BBB EX 311040000" -c 1 -t 1 --command-key-pattern=P -c 1 -t 1 --pipeline 1000 --hide-histogram     --key-maximum 50000000 -n allkeys

### EBUCKETS
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Sets       948760.30         1.02625         0.99100         2.11100         2.94300     67430.34
Totals     948760.30         1.02625         0.99100         2.11100         2.94300    134860.68

### UNSTABLE
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Sets       761548.50         1.27847         1.25500         2.55900         4.79900     54124.81
Totals     761548.50         1.27847         1.25500         2.55900         4.79900    108249.62
```
At first glance, on the diagram below, it might look like memory consumption is similar, but ebuckets inserts more items at the same time, indicating lower memory usage per item overall.
![image](https://github.com/user-attachments/assets/c8502bf3-6360-4afd-89a1-7bdc90e211f6)

## Test8: (Precond: SET EX 10000 →) SET EX 20 on AWS
* So far all tests were made on my priavte laptop (ubuntu 22.04.5 LTS, 6.8.0-52-generic, i7-1260P, vCPUs: 16, 32 GB). This one was benchmarked on AWS, `c6i.2xlarge` instance. 
* As a precondition for this test, 20 million keys were set with a TTL of 10000 seconds, followed by another 80 million keys with a TTL of 20 seconds. 
* Unlike previous test, this one is running memtier-benchmark with 4 clients and 2 threads. 

```
### Precondition: memtier_benchmark --command="SET __key__ XXX EX 10000" --command-key-pattern=P  -c 1 -t 1 --pipeline 1000 --hide-histogram --key-maximum $LONG_EXP_KEYS -n allkeys  --key-prefix=1

memtier_benchmark --command="SET __key__ XXX EX 20" --command-key-pattern=P  -c 4 -t 2 --pipeline 1000 --hide-histogram --key-maximum $SHORT_EXP_KEYS -n allkeys  --key-prefix=2

### EBUCKETS
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Sets       504928.08        15.70466        14.65500        41.72700        42.49500     28530.96 
Totals     504928.08        15.70466        14.65500        41.72700        42.49500     57061.91

### UNSTABLE
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Sets       270399.80        29.47288        26.75100        54.27100        55.55100     15278.94 
Totals     270399.80        29.47288        26.75100        54.27100        55.55100     30557.88
```
![image](https://github.com/user-attachments/assets/e08e170c-7c71-43eb-bf62-fea2fd0b1e0a)

## Test9:  RPS of Related Commands on AWS
We measured the RPS of related commands on a c6i.2xlarge instance. The results show moderate degradation in the SET (or UPDATE) command and significant degradation in the EXPIRE command.

```
                                      Ops/sec_ebuckets  Ops/sec_unstable  Ops/sec_diff_%  used_memory_ebuckets  used_memory_unstable  used_memory_diff_%  rss_ebuckets  rss_unstable  rss_diff_%
numitems Test           Step Cmd                                                                                                                                                                
1000000  STRING_EX_1000 1    SET            757614.84         815484.82            7.64              72314440              76898872                6.34      82333696      87461888        6.23
                        2    SET(update)    722941.60         847487.58           17.23              72339344              76923560                6.34      82333696      87461888        6.23
                        3    EXPIRE         965130.60        1220679.58           26.48              72364544              76948248                6.33      82333696      87461888        6.23
                        4    GET           1665462.26        1800261.69            8.09              72389232              76972936                6.33      82464768      87592960        6.22
                        5    TTL           1657546.57        1760220.32            6.19              72413920              76997624                6.33      82284544      87592960        6.45
                        6    DEL           3166164.09        2710700.74          -14.39                860176                864408                0.49      60788736      62636032        3.04
5000000  STRING_EX_1000 1    SET            716223.15         741784.11            3.57             375247864             414590520               10.48     394637312     442904576       12.23
                        2    SET(update)    739365.36         768521.66            3.94             375247816             414590520               10.48     394637312     442904576       12.23
                        3    EXPIRE         956981.19        1194336.20           24.80             375264616             414590520               10.48     394637312     442904576       12.23
                        4    GET           1690330.68        1708923.04            1.10             375264616             414590520               10.48     394637312     442904576       12.23
                        5    TTL           1651389.33        1661637.33            0.62             375264616             414590520               10.48     394465280     442748928       12.24
                        6    DEL           2987314.49        3022224.17            1.17                884864                889096                0.48      13303808      15183872       14.13
1000000  STRING_EX_20   1    SET            759228.52         801454.99            5.56              72462624              77047000                6.33      84869120      91127808        7.37
                        2    SET(update)    770419.88         831134.08            7.88              72462888              77047000                6.33      84869120      91127808        7.37
                        3    EXPIRE        1000450.80        1221534.28           22.10              72465904              77047000                6.32      85000192      91258880        7.36
5000000  STRING_EX_20   1    SET            724700.13         729983.86            0.73             375247128             414590672               10.48     394108928     442646528       12.32
                        2    SET(update)    736894.99         779144.01            5.73             375247968             414590672               10.48     394240000     442777600       12.31
                        3    EXPIRE         947494.50        1174384.00           23.95             375269192             414590672               10.48     394371072     442908672       12.31

```
Much of the degradation — even at the initial SET step — comes from multiple clients and threads applying the exact same command, turning this flow into a dominant case of updating key expiration. This brings me to the next section.

# Update: 29.6.25 - Status
Some tradeoffs are inevitable. Unlike the legacy implementation which kept all keys with expirations in an unordered hash table, ebuckets enforces a certain ordering over the items. It remains competitive with the legacy approach on insertion and removal of items—and offers superior performance for active expiration. However, ebucket cannot just update the expiration time of an item as the legacy approach does, because it must also maintain the correct ordering. Or can it?

In practice, the common case is updating the expiration time to a later point. I am experimenting right now how this distinction allows ebuckets to remain competitive even for updates. Typically, removing an item from ebuckets requires iterating through an entire singly linked list segment in the ebuckets to find the previous item and unlink it. We can improve this removal-and-insertion by marking the item with flag “to-update” and deferring its re-insertion to the active expiration process, which is already optimized to scan and remove items sequentially (Goanna be on vacation until mid July).

# TODO
- [ ] Implement eStore API. (Verify it also satisfies HFE use case)
- [ ] Fine tune Active Expiration
- [ ] Eviction Policy adaptation
- [ ] More benchmarking
- [ ] Support defrag
- [ ] Stabilize tests
- [ ] Fix EB_EXPIRE_TIME_INVALID 
- [ ] Review and adapt exposed metadata info related EXPIRE (adapt avg_ttl, etc)
- [ ] Migrate Global HFE ebuckets to eStore (distinct effort)


