### PR TITLE
Add API to allow Redis modules to unsubscribe from keyspace notifications

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -8856,9 +8856,36 @@ int RM_SubscribeToKeyspaceEvents(RedisModuleCtx *ctx, int types, RedisModuleNoti
     sub->event_mask = types;
     sub->notify_callback = callback;
     sub->active = 0;
-
+    serverLog(LL_WARNING,"STAV - RM_SubscribeToKeyspaceEvents. event is: %d",types );
     listAddNodeTail(moduleKeyspaceSubscribers, sub);
     return REDISMODULE_OK;
+}
+// int RM_RemoveSubscribeFromKeyspaceEvents(RedisModuleCtx *ctx, RedisModuleKeyspaceSubscriber cb) {
+
+// int RM_RemoveSubscribeFromKeyspaceEvents(RedisModuleCtx *ctx, RedisModuleNotificationFunc callback) {
+int RM_RemoveSubscribeFromKeyspaceEvents(RedisModuleCtx *ctx, int types) {
+    serverLog(LL_WARNING,"STAV - RM_RemoveSubscribeFromKeyspaceEvents. START. event is: %d",types);
+    if (!ctx ) return REDISMODULE_ERR;
+    // if (!ctx || !callback) return REDISMODULE_ERR;
+
+    listIter li;
+    listNode *ln;
+    listRewind(moduleKeyspaceSubscribers,&li);
+    // listRewind(server.keyspace_events_subscribers, &li);
+    while ((ln = listNext(&li))) {
+        RedisModuleKeyspaceSubscriber* sub = ln->value;
+        serverLog(LL_WARNING,"STAV - RM_RemoveSubscribeFromKeyspaceEvents. iter. sub event : %d", sub->event_mask );
+        if (sub->event_mask == types)
+        {
+            // if (sub->notify_callback == callback) {
+            serverLog(LL_WARNING,"STAV - RM_RemoveSubscribeFromKeyspaceEvents. found event");
+            listDelNode(moduleKeyspaceSubscribers, ln);
+            // listDelNode(server.keyspace_events_subscribers, ln);
+        }
+    }
+    serverLog(LL_WARNING,"STAV - RM_RemoveSubscribeFromKeyspaceEvents. did not find");
+    return REDISMODULE_OK;
+    // return REDISMODULE_ERR;
 }
 
 void firePostExecutionUnitJobs(void) {
@@ -8938,7 +8965,7 @@ int RM_NotifyKeyspaceEvent(RedisModuleCtx *ctx, int type, const char *event, Red
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid) {
     /* Don't do anything if there aren't any subscribers */
     if (listLength(moduleKeyspaceSubscribers) == 0) return;
-
+    serverLog(LL_WARNING,"STAV - moduleNotifyKeyspaceEvent. start. list len: %lu", listLength(moduleKeyspaceSubscribers) );
     /* Ugly hack to handle modules which use write commands from within
      * notify_callback, which they should NOT do!
      * Modules should use RedisModules_AddPostNotificationJob instead.
@@ -8967,10 +8994,12 @@ void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid)
 
     while((ln = listNext(&li))) {
         RedisModuleKeyspaceSubscriber *sub = ln->value;
+        serverLog(LL_WARNING,"STAV - moduleNotifyKeyspaceEvent. in while. event is: %d event to find %d", sub->event_mask, type);
         /* Only notify subscribers on events matching the registration,
          * and avoid subscribers triggering themselves */
         if ((sub->event_mask & type) &&
             (sub->active == 0 || (sub->module->options & REDISMODULE_OPTIONS_ALLOW_NESTED_KEYSPACE_NOTIFICATIONS))) {
+            serverLog(LL_WARNING,"STAV - moduleNotifyKeyspaceEvent. in if. event is: %d ", type);
             RedisModuleCtx ctx;
             moduleCreateContext(&ctx, sub->module, REDISMODULE_CTX_TEMP_CLIENT);
             selectDb(ctx.client, dbid);
@@ -14717,6 +14746,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(NotifyKeyspaceEvent);
     REGISTER_API(GetNotifyKeyspaceEvents);
     REGISTER_API(SubscribeToKeyspaceEvents);
+    REGISTER_API(RemoveSubscribeFromKeyspaceEvents);
     REGISTER_API(AddPostNotificationJob);
     REGISTER_API(RegisterClusterMessageReceiver);
     REGISTER_API(SendClusterMessage);

--- a/src/module.c
+++ b/src/module.c
@@ -8856,36 +8856,43 @@ int RM_SubscribeToKeyspaceEvents(RedisModuleCtx *ctx, int types, RedisModuleNoti
     sub->event_mask = types;
     sub->notify_callback = callback;
     sub->active = 0;
-    serverLog(LL_WARNING,"STAV - RM_SubscribeToKeyspaceEvents. event is: %d",types );
+
     listAddNodeTail(moduleKeyspaceSubscribers, sub);
     return REDISMODULE_OK;
 }
-// int RM_RemoveSubscribeFromKeyspaceEvents(RedisModuleCtx *ctx, RedisModuleKeyspaceSubscriber cb) {
 
-// int RM_RemoveSubscribeFromKeyspaceEvents(RedisModuleCtx *ctx, RedisModuleNotificationFunc callback) {
-int RM_RemoveSubscribeFromKeyspaceEvents(RedisModuleCtx *ctx, int types) {
-    serverLog(LL_WARNING,"STAV - RM_RemoveSubscribeFromKeyspaceEvents. START. event is: %d",types);
-    if (!ctx ) return REDISMODULE_ERR;
-    // if (!ctx || !callback) return REDISMODULE_ERR;
-
+/*
+ * RM_RemoveSubscribeFromKeyspaceEvents - Unregister a module's callback from keyspace notifications for specific event types.
+ *
+ * This function removes a previously registered subscription identified by both the event mask and the callback function.
+ * It is useful to reduce performance overhead when the module no longer requires notifications for certain events.
+ *
+ * Parameters:
+ *  - ctx: The RedisModuleCtx associated with the calling module.
+ *  - types: The event mask representing the keyspace notification types to unsubscribe from.
+ *  - callback: The callback function pointer that was originally registered for these events.
+ *
+ * Returns:
+ *  - REDISMODULE_OK on successful removal of the subscription.
+ *  - REDISMODULE_ERR if no matching subscription was found or if invalid parameters were provided.
+ */
+int RM_RemoveSubscribeFromKeyspaceEvents(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc callback) {
+    if (!ctx || !callback) return REDISMODULE_ERR;
+    int removed = 0;
     listIter li;
     listNode *ln;
     listRewind(moduleKeyspaceSubscribers,&li);
-    // listRewind(server.keyspace_events_subscribers, &li);
+
     while ((ln = listNext(&li))) {
         RedisModuleKeyspaceSubscriber* sub = ln->value;
-        serverLog(LL_WARNING,"STAV - RM_RemoveSubscribeFromKeyspaceEvents. iter. sub event : %d", sub->event_mask );
-        if (sub->event_mask == types)
+        if (sub->event_mask == types && sub->notify_callback == callback && sub->module == ctx->module)
         {
-            // if (sub->notify_callback == callback) {
-            serverLog(LL_WARNING,"STAV - RM_RemoveSubscribeFromKeyspaceEvents. found event");
+            zfree(sub);
             listDelNode(moduleKeyspaceSubscribers, ln);
-            // listDelNode(server.keyspace_events_subscribers, ln);
+            removed++;
         }
     }
-    serverLog(LL_WARNING,"STAV - RM_RemoveSubscribeFromKeyspaceEvents. did not find");
-    return REDISMODULE_OK;
-    // return REDISMODULE_ERR;
+    return removed > 0 ? REDISMODULE_OK : REDISMODULE_ERR;
 }
 
 void firePostExecutionUnitJobs(void) {
@@ -8965,7 +8972,7 @@ int RM_NotifyKeyspaceEvent(RedisModuleCtx *ctx, int type, const char *event, Red
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid) {
     /* Don't do anything if there aren't any subscribers */
     if (listLength(moduleKeyspaceSubscribers) == 0) return;
-    serverLog(LL_WARNING,"STAV - moduleNotifyKeyspaceEvent. start. list len: %lu", listLength(moduleKeyspaceSubscribers) );
+
     /* Ugly hack to handle modules which use write commands from within
      * notify_callback, which they should NOT do!
      * Modules should use RedisModules_AddPostNotificationJob instead.
@@ -8994,12 +9001,10 @@ void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid)
 
     while((ln = listNext(&li))) {
         RedisModuleKeyspaceSubscriber *sub = ln->value;
-        serverLog(LL_WARNING,"STAV - moduleNotifyKeyspaceEvent. in while. event is: %d event to find %d", sub->event_mask, type);
         /* Only notify subscribers on events matching the registration,
          * and avoid subscribers triggering themselves */
         if ((sub->event_mask & type) &&
             (sub->active == 0 || (sub->module->options & REDISMODULE_OPTIONS_ALLOW_NESTED_KEYSPACE_NOTIFICATIONS))) {
-            serverLog(LL_WARNING,"STAV - moduleNotifyKeyspaceEvent. in if. event is: %d ", type);
             RedisModuleCtx ctx;
             moduleCreateContext(&ctx, sub->module, REDISMODULE_CTX_TEMP_CLIENT);
             selectDb(ctx.client, dbid);

--- a/src/module.c
+++ b/src/module.c
@@ -8883,7 +8883,7 @@ int RM_UnsubscribeFromKeyspaceEvents(RedisModuleCtx *ctx, int types, RedisModule
     listNode *ln;
     listRewind(moduleKeyspaceSubscribers,&li);
     while ((ln = listNext(&li))) {
-        RedisModuleKeyspaceSubscriber* sub = ln->value;
+        RedisModuleKeyspaceSubscriber *sub = ln->value;
         if (sub->event_mask == types && sub->notify_callback == callback && sub->module == ctx->module) {
             zfree(sub);
             listDelNode(moduleKeyspaceSubscribers, ln);

--- a/src/module.c
+++ b/src/module.c
@@ -8862,7 +8862,7 @@ int RM_SubscribeToKeyspaceEvents(RedisModuleCtx *ctx, int types, RedisModuleNoti
 }
 
 /*
- * RM_RemoveSubscribeFromKeyspaceEvents - Unregister a module's callback from keyspace notifications for specific event types.
+ * RM_UnsubscribeFromKeyspaceEvents - Unregister a module's callback from keyspace notifications for specific event types.
  *
  * This function removes a previously registered subscription identified by both the event mask and the callback function.
  * It is useful to reduce performance overhead when the module no longer requires notifications for certain events.
@@ -8876,17 +8876,15 @@ int RM_SubscribeToKeyspaceEvents(RedisModuleCtx *ctx, int types, RedisModuleNoti
  *  - REDISMODULE_OK on successful removal of the subscription.
  *  - REDISMODULE_ERR if no matching subscription was found or if invalid parameters were provided.
  */
-int RM_RemoveSubscribeFromKeyspaceEvents(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc callback) {
+int RM_UnsubscribeFromKeyspaceEvents(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc callback) {
     if (!ctx || !callback) return REDISMODULE_ERR;
     int removed = 0;
     listIter li;
     listNode *ln;
     listRewind(moduleKeyspaceSubscribers,&li);
-
     while ((ln = listNext(&li))) {
         RedisModuleKeyspaceSubscriber* sub = ln->value;
-        if (sub->event_mask == types && sub->notify_callback == callback && sub->module == ctx->module)
-        {
+        if (sub->event_mask == types && sub->notify_callback == callback && sub->module == ctx->module) {
             zfree(sub);
             listDelNode(moduleKeyspaceSubscribers, ln);
             removed++;
@@ -14751,7 +14749,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(NotifyKeyspaceEvent);
     REGISTER_API(GetNotifyKeyspaceEvents);
     REGISTER_API(SubscribeToKeyspaceEvents);
-    REGISTER_API(RemoveSubscribeFromKeyspaceEvents);
+    REGISTER_API(UnsubscribeFromKeyspaceEvents);
     REGISTER_API(AddPostNotificationJob);
     REGISTER_API(RegisterClusterMessageReceiver);
     REGISTER_API(SendClusterMessage);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1255,6 +1255,8 @@ REDISMODULE_API void (*RedisModule_ThreadSafeContextLock)(RedisModuleCtx *ctx) R
 REDISMODULE_API int (*RedisModule_ThreadSafeContextTryLock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ThreadSafeContextUnlock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SubscribeToKeyspaceEvents)(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_RemoveSubscribeFromKeyspaceEvents)(RedisModuleCtx *ctx, int types) REDISMODULE_ATTR;
+// REDISMODULE_API int (*RedisModule_RemoveSubscribeFromKeyspaceEvents(RedisModuleCtx *ctx, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_AddPostNotificationJob)(RedisModuleCtx *ctx, RedisModulePostNotificationJobFunc callback, void *pd, void (*free_pd)(void*)) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_NotifyKeyspaceEvent)(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetNotifyKeyspaceEvents)(void) REDISMODULE_ATTR;
@@ -1643,6 +1645,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(BlockedClientMeasureTimeEnd);
     REDISMODULE_GET_API(SetDisconnectCallback);
     REDISMODULE_GET_API(SubscribeToKeyspaceEvents);
+    REDISMODULE_GET_API(RemoveSubscribeFromKeyspaceEvents);
     REDISMODULE_GET_API(AddPostNotificationJob);
     REDISMODULE_GET_API(NotifyKeyspaceEvent);
     REDISMODULE_GET_API(GetNotifyKeyspaceEvents);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1255,7 +1255,7 @@ REDISMODULE_API void (*RedisModule_ThreadSafeContextLock)(RedisModuleCtx *ctx) R
 REDISMODULE_API int (*RedisModule_ThreadSafeContextTryLock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ThreadSafeContextUnlock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SubscribeToKeyspaceEvents)(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RemoveSubscribeFromKeyspaceEvents)(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_UnsubscribeFromKeyspaceEvents)(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_AddPostNotificationJob)(RedisModuleCtx *ctx, RedisModulePostNotificationJobFunc callback, void *pd, void (*free_pd)(void*)) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_NotifyKeyspaceEvent)(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetNotifyKeyspaceEvents)(void) REDISMODULE_ATTR;
@@ -1644,7 +1644,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(BlockedClientMeasureTimeEnd);
     REDISMODULE_GET_API(SetDisconnectCallback);
     REDISMODULE_GET_API(SubscribeToKeyspaceEvents);
-    REDISMODULE_GET_API(RemoveSubscribeFromKeyspaceEvents);
+    REDISMODULE_GET_API(UnsubscribeFromKeyspaceEvents);
     REDISMODULE_GET_API(AddPostNotificationJob);
     REDISMODULE_GET_API(NotifyKeyspaceEvent);
     REDISMODULE_GET_API(GetNotifyKeyspaceEvents);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1255,8 +1255,7 @@ REDISMODULE_API void (*RedisModule_ThreadSafeContextLock)(RedisModuleCtx *ctx) R
 REDISMODULE_API int (*RedisModule_ThreadSafeContextTryLock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ThreadSafeContextUnlock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SubscribeToKeyspaceEvents)(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RemoveSubscribeFromKeyspaceEvents)(RedisModuleCtx *ctx, int types) REDISMODULE_ATTR;
-// REDISMODULE_API int (*RedisModule_RemoveSubscribeFromKeyspaceEvents(RedisModuleCtx *ctx, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_RemoveSubscribeFromKeyspaceEvents)(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_AddPostNotificationJob)(RedisModuleCtx *ctx, RedisModulePostNotificationJobFunc callback, void *pd, void (*free_pd)(void*)) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_NotifyKeyspaceEvent)(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetNotifyKeyspaceEvents)(void) REDISMODULE_ATTR;

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -46,6 +46,7 @@ static int KeySpace_NotificationLoaded(RedisModuleCtx *ctx, int type, const char
 }
 
 static int KeySpace_NotificationGeneric(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
+    RedisModule_ReplyWithSimpleString(ctx, "STAV - KeySpace_NotificationGeneric event");
     REDISMODULE_NOT_USED(type);
     const char *key_str = RedisModule_StringPtrLen(key, NULL);
     if (strncmp(key_str, "count_dels_", 11) == 0 && strcmp(event, "del") == 0) {
@@ -85,7 +86,7 @@ static int KeySpace_NotificationExpired(RedisModuleCtx *ctx, int type, const cha
     REDISMODULE_NOT_USED(type);
     REDISMODULE_NOT_USED(event);
     REDISMODULE_NOT_USED(key);
-
+    RedisModule_ReplyWithSimpleString(ctx, "STAV - Received EXPIRED event");
     RedisModuleCallReply* rep = RedisModule_Call(ctx, "INCR", "c!", "testkeyspace:expired");
     RedisModule_FreeCallReply(rep);
 
@@ -116,7 +117,7 @@ static int KeySpace_NotificationModuleString(RedisModuleCtx *ctx, int type, cons
     REDISMODULE_NOT_USED(type);
     REDISMODULE_NOT_USED(event);
     RedisModuleKey *redis_key = RedisModule_OpenKey(ctx, key, REDISMODULE_READ);
-
+    RedisModule_ReplyWithSimpleString(ctx, "STAV - Received STRING event");
     size_t len = 0;
     /* RedisModule_StringDMA could change the data format and cause the old robj to be freed.
      * This code verifies that such format change will not cause any crashes.*/
@@ -296,9 +297,42 @@ static int cmdGetDels(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithLongLong(ctx, dels);
 }
 
+// extern int KeySpace_NotificationModuleString(RedisModuleCtx *, int, const char *, RedisModuleString *);
+// extern int KeySpace_NotificationModuleStringPostNotificationJob(RedisModuleCtx *, int, const char *, RedisModuleString *);
+
+static int CmdUnsub(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+{
+    if (argc != 2) {
+        return RedisModule_WrongArity(ctx);
+    }
+
+    long long event_mask;
+    if (RedisModule_StringToLongLong(argv[1], &event_mask) != REDISMODULE_OK) {
+        return RedisModule_ReplyWithError(ctx, "ERR invalid event mask");
+    }
+
+    // Your unsubscribe logic here - e.g. call your unsubscribe helper:
+    if (RedisModule_RemoveSubscribeFromKeyspaceEvents(ctx, (int)event_mask) != REDISMODULE_OK) {
+        return RedisModule_ReplyWithError(ctx, "ERR unsubscribe failed");
+    }
+
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+
+    // int count = 0;
+    //
+    // if (RedisModule_RemoveSubscribeFromKeyspaceEvents(ctx, KeySpace_NotificationModuleString) == REDISMODULE_OK)
+    //     count++;
+    //
+    // if (RedisModule_RemoveSubscribeFromKeyspaceEvents(ctx, KeySpace_NotificationModuleStringPostNotificationJob) == REDISMODULE_OK)
+    //     count++;
+    //
+    // return RedisModule_ReplyWithSimpleString(ctx,
+    //     count > 0 ? "Unsubscribed" : "No subscriptions were active");
+}
 /* This function must be present on each Redis module. It is used in order to
  * register the commands into the Redis server. */
-int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+{
     if (RedisModule_Init(ctx,"testkeyspace",1,REDISMODULE_APIVER_1) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
     }
@@ -356,33 +390,37 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_CreateCommand(ctx, "keyspace.del_key_copy", cmdDelKeyCopy,
                                   "write", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
-    }
-    
+                                  }
+
     if (RedisModule_CreateCommand(ctx, "keyspace.incr_case1", cmdIncrCase1,
                                   "write", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
-    }
-    
+                                  }
+
     if (RedisModule_CreateCommand(ctx, "keyspace.incr_case2", cmdIncrCase2,
                                   "write", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
-    }
-    
+                                  }
+
     if (RedisModule_CreateCommand(ctx, "keyspace.incr_case3", cmdIncrCase3,
                                   "write", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
-    }
+                                  }
 
     if (RedisModule_CreateCommand(ctx, "keyspace.incr_dels", cmdIncrDels,
                                   "write", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
-    }
+                                  }
 
     if (RedisModule_CreateCommand(ctx, "keyspace.get_dels", cmdGetDels,
                                   "readonly", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
-    }
+                                  }
 
+    if (RedisModule_CreateCommand(ctx, "keyspace.unsubscribe", CmdUnsub, "write", 0, 0, 0) == REDISMODULE_ERR){
+
+    return REDISMODULE_ERR;
+                                    }
     if (argc == 1) {
         const char *ptr = RedisModule_StringPtrLen(argv[0], NULL);
         if (!strcasecmp(ptr, "noload")) {

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -45,8 +45,10 @@ static int KeySpace_NotificationLoaded(RedisModuleCtx *ctx, int type, const char
     return REDISMODULE_OK;
 }
 
+static long long callback_call_count = 0;
 static int KeySpace_NotificationGeneric(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
     REDISMODULE_NOT_USED(type);
+    callback_call_count++;
     const char *key_str = RedisModule_StringPtrLen(key, NULL);
     if (strncmp(key_str, "count_dels_", 11) == 0 && strcmp(event, "del") == 0) {
         if (RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_MASTER) {
@@ -317,6 +319,13 @@ static RedisModuleNotificationFunc get_callback_for_event(int event_mask) {
     }
 }
 
+int GetCallbackCountCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    RedisModule_ReplyWithLongLong(ctx, callback_call_count);
+    return REDISMODULE_OK;
+}
+
 static int CmdUnsub(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 2) {
         return RedisModule_WrongArity(ctx);
@@ -428,6 +437,11 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_CreateCommand(ctx, "keyspace.unsubscribe", CmdUnsub, "write", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
     }
+
+    if (RedisModule_CreateCommand(ctx, "keyspace.callback_count", GetCallbackCountCommand, "", 0, 0, 0)== REDISMODULE_ERR){
+        return REDISMODULE_ERR;
+    }
+
     if (argc == 1) {
         const char *ptr = RedisModule_StringPtrLen(argv[0], NULL);
         if (!strcasecmp(ptr, "noload")) {

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -332,7 +332,7 @@ static int CmdUnsub(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return RedisModule_ReplyWithError(ctx, "ERR unknown event mask");
     }
 
-    if (RedisModule_RemoveSubscribeFromKeyspaceEvents(ctx, (int)event_mask, cb) != REDISMODULE_OK) {
+    if (RedisModule_UnsubscribeFromKeyspaceEvents(ctx, (int)event_mask, cb) != REDISMODULE_OK) {
         return RedisModule_ReplyWithError(ctx, "ERR unsubscribe failed");
     }
 
@@ -426,7 +426,6 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     }
 
     if (RedisModule_CreateCommand(ctx, "keyspace.unsubscribe", CmdUnsub, "write", 0, 0, 0) == REDISMODULE_ERR){
-
     return REDISMODULE_ERR;
    }
     if (argc == 1) {

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -46,7 +46,6 @@ static int KeySpace_NotificationLoaded(RedisModuleCtx *ctx, int type, const char
 }
 
 static int KeySpace_NotificationGeneric(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
-    RedisModule_ReplyWithSimpleString(ctx, "STAV - KeySpace_NotificationGeneric event");
     REDISMODULE_NOT_USED(type);
     const char *key_str = RedisModule_StringPtrLen(key, NULL);
     if (strncmp(key_str, "count_dels_", 11) == 0 && strcmp(event, "del") == 0) {
@@ -86,7 +85,7 @@ static int KeySpace_NotificationExpired(RedisModuleCtx *ctx, int type, const cha
     REDISMODULE_NOT_USED(type);
     REDISMODULE_NOT_USED(event);
     REDISMODULE_NOT_USED(key);
-    RedisModule_ReplyWithSimpleString(ctx, "STAV - Received EXPIRED event");
+
     RedisModuleCallReply* rep = RedisModule_Call(ctx, "INCR", "c!", "testkeyspace:expired");
     RedisModule_FreeCallReply(rep);
 
@@ -117,7 +116,7 @@ static int KeySpace_NotificationModuleString(RedisModuleCtx *ctx, int type, cons
     REDISMODULE_NOT_USED(type);
     REDISMODULE_NOT_USED(event);
     RedisModuleKey *redis_key = RedisModule_OpenKey(ctx, key, REDISMODULE_READ);
-    RedisModule_ReplyWithSimpleString(ctx, "STAV - Received STRING event");
+
     size_t len = 0;
     /* RedisModule_StringDMA could change the data format and cause the old robj to be freed.
      * This code verifies that such format change will not cause any crashes.*/
@@ -297,11 +296,28 @@ static int cmdGetDels(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithLongLong(ctx, dels);
 }
 
-// extern int KeySpace_NotificationModuleString(RedisModuleCtx *, int, const char *, RedisModuleString *);
-// extern int KeySpace_NotificationModuleStringPostNotificationJob(RedisModuleCtx *, int, const char *, RedisModuleString *);
+static RedisModuleNotificationFunc get_callback_for_event(int event_mask) {
+    switch(event_mask) {
+    case REDISMODULE_NOTIFY_LOADED:
+        return KeySpace_NotificationLoaded;
+    case REDISMODULE_NOTIFY_GENERIC:
+        return KeySpace_NotificationGeneric;
+    case REDISMODULE_NOTIFY_EXPIRED:
+        return KeySpace_NotificationExpired;
+    case REDISMODULE_NOTIFY_MODULE:
+        return KeySpace_NotificationModule;
+    case REDISMODULE_NOTIFY_KEY_MISS:
+        return KeySpace_NotificationModuleKeyMiss;
+    case REDISMODULE_NOTIFY_STRING:
+        // We have two callbacks for STRING events in your OnLoad,
+        // For simplicity, pick the first:
+        return KeySpace_NotificationModuleString;
+    default:
+        return NULL;
+    }
+}
 
-static int CmdUnsub(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
-{
+static int CmdUnsub(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 2) {
         return RedisModule_WrongArity(ctx);
     }
@@ -311,28 +327,20 @@ static int CmdUnsub(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         return RedisModule_ReplyWithError(ctx, "ERR invalid event mask");
     }
 
-    // Your unsubscribe logic here - e.g. call your unsubscribe helper:
-    if (RedisModule_RemoveSubscribeFromKeyspaceEvents(ctx, (int)event_mask) != REDISMODULE_OK) {
+    RedisModuleNotificationFunc cb = get_callback_for_event((int)event_mask);
+    if (cb == NULL) {
+        return RedisModule_ReplyWithError(ctx, "ERR unknown event mask");
+    }
+
+    if (RedisModule_RemoveSubscribeFromKeyspaceEvents(ctx, (int)event_mask, cb) != REDISMODULE_OK) {
         return RedisModule_ReplyWithError(ctx, "ERR unsubscribe failed");
     }
 
     return RedisModule_ReplyWithSimpleString(ctx, "OK");
-
-    // int count = 0;
-    //
-    // if (RedisModule_RemoveSubscribeFromKeyspaceEvents(ctx, KeySpace_NotificationModuleString) == REDISMODULE_OK)
-    //     count++;
-    //
-    // if (RedisModule_RemoveSubscribeFromKeyspaceEvents(ctx, KeySpace_NotificationModuleStringPostNotificationJob) == REDISMODULE_OK)
-    //     count++;
-    //
-    // return RedisModule_ReplyWithSimpleString(ctx,
-    //     count > 0 ? "Unsubscribed" : "No subscriptions were active");
 }
 /* This function must be present on each Redis module. It is used in order to
  * register the commands into the Redis server. */
-int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
-{
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (RedisModule_Init(ctx,"testkeyspace",1,REDISMODULE_APIVER_1) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
     }
@@ -390,37 +398,37 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     if (RedisModule_CreateCommand(ctx, "keyspace.del_key_copy", cmdDelKeyCopy,
                                   "write", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
-                                  }
+    }
 
     if (RedisModule_CreateCommand(ctx, "keyspace.incr_case1", cmdIncrCase1,
                                   "write", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
-                                  }
+    }
 
     if (RedisModule_CreateCommand(ctx, "keyspace.incr_case2", cmdIncrCase2,
                                   "write", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
-                                  }
+    }
 
     if (RedisModule_CreateCommand(ctx, "keyspace.incr_case3", cmdIncrCase3,
                                   "write", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
-                                  }
+    }
 
     if (RedisModule_CreateCommand(ctx, "keyspace.incr_dels", cmdIncrDels,
                                   "write", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
-                                  }
+    }
 
     if (RedisModule_CreateCommand(ctx, "keyspace.get_dels", cmdGetDels,
                                   "readonly", 0, 0, 0) == REDISMODULE_ERR){
         return REDISMODULE_ERR;
-                                  }
+    }
 
     if (RedisModule_CreateCommand(ctx, "keyspace.unsubscribe", CmdUnsub, "write", 0, 0, 0) == REDISMODULE_ERR){
 
     return REDISMODULE_ERR;
-                                    }
+   }
     if (argc == 1) {
         const char *ptr = RedisModule_StringPtrLen(argv[0], NULL);
         if (!strcasecmp(ptr, "noload")) {

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -426,8 +426,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     }
 
     if (RedisModule_CreateCommand(ctx, "keyspace.unsubscribe", CmdUnsub, "write", 0, 0, 0) == REDISMODULE_ERR){
-    return REDISMODULE_ERR;
-   }
+        return REDISMODULE_ERR;
+    }
     if (argc == 1) {
         const char *ptr = RedisModule_StringPtrLen(argv[0], NULL);
         if (!strcasecmp(ptr, "noload")) {

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -105,6 +105,46 @@ tags "modules" {
         test "Verify RM_StringDMA with expiration are not causing invalid memory access" {
             assert_equal {OK} [r set x 1 EX 1]
         }
+        test "Keyspace notifications: unsubscribe removes handler" {
+            # puts "Setting config to emit generic keyspace events..."
+            # # Enable keyspace notifications for generic operations (g = set/del, K = Keyspace events)
+            # r config set notify-keyspace-events Kg
+            # # Ensure we start clean
+            # r del x
+
+            # # Subscribe a client to pubsub keyspace events
+            # set client [redis_deferring_client]
+            # assert_equal {1} [psubscribe $client *]
+            # puts "1"
+            # # Trigger a set event — we expect the module to notify
+            # # r set x 123
+            # r keyspace.notify x
+            # puts "2"
+            # # assert_equal {pmessage * __keyspace@9__:x notify} [$rd1 read]
+            # assert_equal {pmessage * __keyspace@9__:x set} [$client read]
+            # puts "3"
+
+
+
+            r config set notify-keyspace-events Kd
+            r del x
+            set rd1 [redis_deferring_client]
+            assert_equal {1} [psubscribe $rd1 *]
+            r keyspace.notify x
+            assert_equal {pmessage * __keyspace@9__:x notify} [$rd1 read]
+            
+            # Now unsubscribe via your module command
+            r keyspace.unsubscribe 4 ;# 4 = REDISMODULE_NOTIFY_GENERIC
+
+            # # Trigger the same event again
+            # r set x 456
+            r keyspace.notify y
+            # # Try to read again, should timeout or return nothing
+            after 100
+            set res [$rd1 read_nonblock]
+            assert_equal {} $res
+            $rd1 close
+        }
     }
 
     start_server {} {

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -88,7 +88,7 @@ tags "modules" {
         }
 
         test "Keyspace notifications: unsubscribe removes handler" {
-            r config set notify-keyspace-events Kd
+            r config set notify-keyspace-events Kgd
             r del x
             set rd1 [redis_deferring_client]
             assert_equal {1} [psubscribe $rd1 *]

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -97,13 +97,12 @@ tags "modules" {
             } else {
                 fail "callback did not trigger"
             }
-            r keyspace.unsubscribe 4
             set before_unsub [r keyspace.callback_count]
+            r keyspace.unsubscribe 4  ;# REDISMODULE_NOTIFY_GENERIC
             r set a 1
             r del a
-            after 50
             set after_unsub [r keyspace.callback_count]
-            assert_equal $before_unsub $after_unsub ;# כלומר לא נוספה קריאה נוספת
+            assert_equal $before_unsub $after_unsub ;
 
         }
 

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -87,6 +87,25 @@ tags "modules" {
             $rd1 close
         }
 
+        test "Keyspace notifications: unsubscribe removes handler" {
+            r config set notify-keyspace-events Kd
+            r del x
+            set rd1 [redis_deferring_client]
+            assert_equal {1} [psubscribe $rd1 *]
+            r keyspace.notify x
+            assert_equal {pmessage * __keyspace@9__:x notify} [$rd1 read]
+
+            r keyspace.unsubscribe 4 ;# 4 = REDISMODULE_NOTIFY_GENERIC
+            r keyspace.notify y
+
+            # Try to read again, should timeout or return nothing
+            after 100
+            set res [$rd1 read_nonblock]
+            assert_equal {} $res
+
+            $rd1 close
+        }
+
         test {Test expired key space event} {
             set prev_expired [s expired_keys]
             r set exp 1 PX 10
@@ -104,46 +123,6 @@ tags "modules" {
 
         test "Verify RM_StringDMA with expiration are not causing invalid memory access" {
             assert_equal {OK} [r set x 1 EX 1]
-        }
-        test "Keyspace notifications: unsubscribe removes handler" {
-            # puts "Setting config to emit generic keyspace events..."
-            # # Enable keyspace notifications for generic operations (g = set/del, K = Keyspace events)
-            # r config set notify-keyspace-events Kg
-            # # Ensure we start clean
-            # r del x
-
-            # # Subscribe a client to pubsub keyspace events
-            # set client [redis_deferring_client]
-            # assert_equal {1} [psubscribe $client *]
-            # puts "1"
-            # # Trigger a set event — we expect the module to notify
-            # # r set x 123
-            # r keyspace.notify x
-            # puts "2"
-            # # assert_equal {pmessage * __keyspace@9__:x notify} [$rd1 read]
-            # assert_equal {pmessage * __keyspace@9__:x set} [$client read]
-            # puts "3"
-
-
-
-            r config set notify-keyspace-events Kd
-            r del x
-            set rd1 [redis_deferring_client]
-            assert_equal {1} [psubscribe $rd1 *]
-            r keyspace.notify x
-            assert_equal {pmessage * __keyspace@9__:x notify} [$rd1 read]
-            
-            # Now unsubscribe via your module command
-            r keyspace.unsubscribe 4 ;# 4 = REDISMODULE_NOTIFY_GENERIC
-
-            # # Trigger the same event again
-            # r set x 456
-            r keyspace.notify y
-            # # Try to read again, should timeout or return nothing
-            after 100
-            set res [$rd1 read_nonblock]
-            assert_equal {} $res
-            $rd1 close
         }
     }
 

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -88,22 +88,23 @@ tags "modules" {
         }
 
         test "Keyspace notifications: unsubscribe removes handler" {
-            r config set notify-keyspace-events Kgd
-            r del x
-            set rd1 [redis_deferring_client]
-            assert_equal {1} [psubscribe $rd1 *]
-            r keyspace.notify x
-            assert_equal {pmessage * __keyspace@9__:x notify} [$rd1 read]
+            r config set notify-keyspace-events KEA
+            set before [r keyspace.callback_count]
+            r set a 1
+            r del a
+            wait_for_condition 100 10 {
+                [r keyspace.callback_count] > $before
+            } else {
+                fail "callback did not trigger"
+            }
+            r keyspace.unsubscribe 4
+            set before_unsub [r keyspace.callback_count]
+            r set a 1
+            r del a
+            after 50
+            set after_unsub [r keyspace.callback_count]
+            assert_equal $before_unsub $after_unsub ;# כלומר לא נוספה קריאה נוספת
 
-            r keyspace.unsubscribe 4 ;# 4 = REDISMODULE_NOTIFY_GENERIC
-            r keyspace.notify y
-
-            # Try to read again, should timeout or return nothing
-            after 100
-            set res [$rd1 read_nonblock]
-            assert_equal {} $res
-
-            $rd1 close
         }
 
         test {Test expired key space event} {

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -102,8 +102,7 @@ tags "modules" {
             r set a 1
             r del a
             set after_unsub [r keyspace.callback_count]
-            assert_equal $before_unsub $after_unsub ;
-
+            assert_equal $before_unsub $after_unsub
         }
 
         test {Test expired key space event} {


### PR DESCRIPTION
This API complements module subscribe by enabling modules to unsubscribe from specific keyspace event notifications when they are no longer needed. 
This helps reduce performance overhead and unnecessary callback invocations.

The function matches subscriptions based on event mask, callback pointer,
and module identity. If a matching subscription is found, it is removed.

Returns REDISMODULE_OK if a subscription was successfully removed, otherwise REDISMODULE_ERR.