### PR TITLE
Improve SCAN performance by only performing expiration checks on DBs with volatile keys 

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1249,6 +1249,8 @@ typedef struct {
     int no_values; /* set to 1 means to return keys only */
     size_t (*strlen)(char *s); /* (o->type == OBJ_HASH) ? hfieldlen : sdslen */
     sds typename; /* typename string, NULL means no type filter */
+    redisDb *db;  /* database reference for expiration checks */
+    int skip_expiration_check; /* optimization: set to 1 to skip expiration checks when safe */
 } scanData;
 
 /* Helper function to compare key type in scan commands */
@@ -1284,16 +1286,24 @@ void scanCallback(void *privdata, const dictEntry *de, dictEntryLink plink) {
     if (!o) { /* If scanning keyspace */
         kvobj *kv = dictGetKV(de);
 
+        /* Expiration check first - only for database keyspace scanning */
+        if (!data->skip_expiration_check) {
+            robj kobj;
+            sds keyname = kvobjGetKey(kv);
+            initStaticStringObject(kobj, keyname);
+            if (expireIfNeeded(data->db, &kobj, kv, 0) != KEY_VALID) {
+                return;
+            }
+        }
+
         /* Type filtering - only for database keyspace scanning */
         if (data->typename) {
             /* For unknown types (LLONG_MAX), skip all keys */
-            if (data->type == LLONG_MAX) {
-                return; /* Skip all keys for unknown type */
-            }
+            if (data->type == LLONG_MAX)
+                return;
             /* For known types, skip keys that don't match */
-            if (!objectTypeCompare(kv, data->type)) {
-                return; /* Skip key that doesn't match type */
-            }
+            if (!objectTypeCompare(kv, data->type))
+                return;
         }
 
         keyStr = kvobjGetKey(kv);
@@ -1528,6 +1538,8 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
             .no_values = no_values,
             .strlen = (isKeysHfield) ? hfieldlen : sdslen,
             .typename = typename,
+            .db = c->db,
+            .skip_expiration_check = (o == NULL) ? (kvstoreSize(c->db->expires) == 0) : 0,
         };
 
         /* A pattern may restrict all matching keys to one cluster slot. */
@@ -1685,23 +1697,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         serverPanic("Not handled encoding in SCAN.");
     }
 
-    /* Step 3: Filter the expired keys.
-     * In case there are no volatile keys on the DB we can skip this step. */
-    if (o == NULL && listLength(keys) && kvstoreSize(c->db->expires) > 0) {
-        robj kobj;
-        listIter li;
-        listNode *ln;
-        listRewind(keys, &li);
-        while ((ln = listNext(&li))) {
-            sds key = listNodeValue(ln);
-            initStaticStringObject(kobj, key);
-            if (expireIfNeeded(c->db, &kobj, NULL, 0) != KEY_VALID) {
-                listDelNode(keys, ln);
-            }
-        }
-    }
-
-    /* Step 4: Reply to the client. */
+    /* Step 3: Reply to the client. */
     addReplyArrayLen(c, 2);
     addReplyBulkLongLong(c,cursor);
 

--- a/src/db.c
+++ b/src/db.c
@@ -1674,8 +1674,8 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         serverPanic("Not handled encoding in SCAN.");
     }
 
-    /* Step 3: Filter the expired keys */
-    if (o == NULL && listLength(keys)) {
+    /* Step 3: Filter the expired keys in case there is something to expire. */
+    if (o == NULL && listLength(keys) && kvstoreSize(c->db->expires)) {
         robj kobj;
         listIter li;
         listNode *ln;

--- a/src/db.c
+++ b/src/db.c
@@ -1268,7 +1268,6 @@ typedef struct {
     size_t (*strlen)(char *s); /* (o->type == OBJ_HASH) ? hfieldlen : sdslen */
     sds typename; /* typename string, NULL means no type filter */
     redisDb *db;  /* database reference for expiration checks */
-    int skip_expiration_check; /* optimization: set to 1 to skip expiration checks when safe */
 } scanData;
 
 /* Helper function to compare key type in scan commands */
@@ -1305,14 +1304,11 @@ void scanCallback(void *privdata, const dictEntry *de, dictEntryLink plink) {
         kvobj *kv = dictGetKV(de);
 
         /* Expiration check first - only for database keyspace scanning */
-        if (!data->skip_expiration_check) {
-            robj kobj;
-            sds keyname = kvobjGetKey(kv);
-            initStaticStringObject(kobj, keyname);
-            if (expireIfNeeded(data->db, &kobj, kv, 0) != KEY_VALID) {
-                return;
-            }
-        }
+        robj kobj;
+        sds keyname = kvobjGetKey(kv);
+        initStaticStringObject(kobj, keyname);
+        if (expireIfNeeded(data->db, &kobj, kv, 0) != KEY_VALID)
+            return;
 
         /* Type filtering - only for database keyspace scanning */
         if (data->typename) {
@@ -1557,7 +1553,6 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
             .strlen = (isKeysHfield) ? hfieldlen : sdslen,
             .typename = typename,
             .db = c->db,
-            .skip_expiration_check = (o == NULL) ? (kvstoreSize(c->db->expires) == 0) : 0,
         };
 
         /* A pattern may restrict all matching keys to one cluster slot. */

--- a/src/db.c
+++ b/src/db.c
@@ -1248,6 +1248,7 @@ typedef struct {
     long sampled; /* cumulative number of keys sampled */
     int no_values; /* set to 1 means to return keys only */
     size_t (*strlen)(char *s); /* (o->type == OBJ_HASH) ? hfieldlen : sdslen */
+    sds typename; /* typename string, NULL means no type filter */
 } scanData;
 
 /* Helper function to compare key type in scan commands */
@@ -1282,10 +1283,19 @@ void scanCallback(void *privdata, const dictEntry *de, dictEntryLink plink) {
 
     if (!o) { /* If scanning keyspace */
         kvobj *kv = dictGetKV(de);
-        /* scan filter an element if it isn't the type we want. */
-        /* TODO: uncomment in redis 8.0
-        if (data->type != LLONG_MAX)
-            if (!objectTypeCompare(kv, data->type)) return;*/
+
+        /* Type filtering - only for database keyspace scanning */
+        if (data->typename) {
+            /* For unknown types (LLONG_MAX), skip all keys */
+            if (data->type == LLONG_MAX) {
+                return; /* Skip all keys for unknown type */
+            }
+            /* For known types, skip keys that don't match */
+            if (!objectTypeCompare(kv, data->type)) {
+                return; /* Skip key that doesn't match type */
+            }
+        }
+
         keyStr = kvobjGetKey(kv);
     } else {
         keyStr = dictGetKey(de);
@@ -1517,6 +1527,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
             .sampled = 0,
             .no_values = no_values,
             .strlen = (isKeysHfield) ? hfieldlen : sdslen,
+            .typename = typename,
         };
 
         /* A pattern may restrict all matching keys to one cluster slot. */
@@ -1674,27 +1685,17 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         serverPanic("Not handled encoding in SCAN.");
     }
 
-    /* Step 3: Filter the expired keys */
-    if (o == NULL && listLength(keys)) {
+    /* Step 3: Filter the expired keys.
+     * In case there are no volatile keys on the DB we can skip this step. */
+    if (o == NULL && listLength(keys) && kvstoreSize(c->db->expires) > 0) {
         robj kobj;
         listIter li;
         listNode *ln;
         listRewind(keys, &li);
-        /* Only check expiration when there are volatile keys on the DB. */
-        const int contains_volatile = kvstoreSize(c->db->expires) > 0;
         while ((ln = listNext(&li))) {
             sds key = listNodeValue(ln);
             initStaticStringObject(kobj, key);
-            /* Filter an element if it isn't the type we want. */
-            /* TODO: remove this in redis 8.0 */
-            if (typename) {
-                kvobj* kv = lookupKeyReadWithFlags(c->db, &kobj, LOOKUP_NOTOUCH|LOOKUP_NONOTIFY);
-                if (!kv || !objectTypeCompare(kv, type)) {
-                    listDelNode(keys, ln);
-                }
-                continue;
-            }
-            if (contains_volatile && expireIfNeeded(c->db, &kobj, NULL, 0) != KEY_VALID) {
+            if (expireIfNeeded(c->db, &kobj, NULL, 0) != KEY_VALID) {
                 listDelNode(keys, ln);
             }
         }

--- a/src/db.c
+++ b/src/db.c
@@ -1674,12 +1674,14 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         serverPanic("Not handled encoding in SCAN.");
     }
 
-    /* Step 3: Filter the expired keys in case there is something to expire. */
-    if (o == NULL && listLength(keys) && kvstoreSize(c->db->expires)) {
+    /* Step 3: Filter the expired keys */
+    if (o == NULL && listLength(keys)) {
         robj kobj;
         listIter li;
         listNode *ln;
         listRewind(keys, &li);
+        /* Only check expiration when there are volatile keys on the DB. */
+        const int contains_volatile = kvstoreSize(c->db->expires) > 0;
         while ((ln = listNext(&li))) {
             sds key = listNodeValue(ln);
             initStaticStringObject(kobj, key);
@@ -1692,7 +1694,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
                 }
                 continue;
             }
-            if (expireIfNeeded(c->db, &kobj, NULL, 0) != KEY_VALID) {
+            if (contains_volatile && expireIfNeeded(c->db, &kobj, NULL, 0) != KEY_VALID) {
                 listDelNode(keys, ln);
             }
         }


### PR DESCRIPTION
This PR optimizes scanGenericCommand by moving type filtering and expiration checks from post-processing (Step 3) to the scan callback, eliminating expensive `lookupKeyReadWithFlags()` calls and adding an optimization to skip expiration checks via dict lookup given we can now check the expiration with expiry flag in the kvobj (due to the move to the scanCallback).

Profiling data (https://pprof.me/1ac456b6d1a46b2184a5e2ef314aa0a2) showed that scanGenericCommand accounted for 2.8% of total CPU time and was a notable hotspot during SCAN-heavy workloads.

## Key optimizations:
1. **Type filtering moved to scanCallback**: Uses existing `kvobj *kv` instead of expensive lookups
2. **Expiration check optimization**: Skips `expireIfNeeded()` calls when database has no volatile keys
3. **Better cache locality**: Processes filtering during iteration rather than post-processing

Benchmarking with memtier_benchmark (1M keys, pipeline=10) showed significant performance improvements, with type-filtered scans seeing the largest gains due to eliminated lookup overhead:

| Test                  | Metric           | Baseline | Optimized (aeb229edc3f148f449077e8f7587c1e8c78b5c1d) | Δ (Improvement) |
| --------------------- | ---------------- | -------- | --------- | --------------- |
| **generic-scan**      | Ops/sec          | 800,970  | 857,274   | **+7.03%**      |
|                       | p50 Latency (ms) | 1.239    | 1.151     | **-7.11%**      |
|                       | p99 Latency (ms) | 1.695    | 1.615     | **-4.72%**      |
| **generic-scan-type** | Ops/sec          | 611,104  | 793,533   | **+29.9%**      |
|                       | p50 Latency (ms) | 1.623    | 1.247     | **-23.2%**      |
|                       | p99 Latency (ms) | 2.175    | 1.727     | **-20.6%**      |


The dramatic improvement in type-filtered scans (+30% ops/sec) demonstrates the effectiveness of eliminating expensive type lookups during scanning.

## To reproduce with benchmark suite

```bash
pip3 install redis-benchmarks-specification==0.1.267
redis-benchmarks-spec-client-runner --tests-regexp ".*-scan-" --flushall_on_every_test_start --flushall_on_every_test_end --cpuset_start_pos 2 --override-memtier-test-time 30 --benchmark_local_install --override-test-runs 3 --db_server_port <...port...> --db_server_password <...password...> --db_server_host <...host...>
```
