### PR TITLE
fix: handle missing metadata origining from COMMAND DOCS in v8.0

### DIFF
--- a/utils/generate-commands-json.py
+++ b/utils/generate-commands-json.py
@@ -69,9 +69,9 @@ def convert_entry_to_objects_array(cmd, docs):
     # The command's value is ordered so the interesting stuff that we care about
     # is at the start. Optional `None` and empty list values are filtered out.
     value = OrderedDict()
-    value['summary'] = docs.pop('summary')
-    value['since'] = docs.pop('since')
-    value['group'] = docs.pop('group')
+    set_if_not_none_or_empty(value, 'summary', docs.pop('summary', None))
+    set_if_not_none_or_empty(value, 'since', docs.pop('since', None))
+    set_if_not_none_or_empty(value, 'group', docs.pop('group', None))
     set_if_not_none_or_empty(value, 'complexity', docs.pop('complexity', None))
     set_if_not_none_or_empty(value, 'deprecated_since', docs.pop('deprecated_since', None))
     set_if_not_none_or_empty(value, 'replaced_by', docs.pop('replaced_by', None))


### PR DESCRIPTION
Fixes: #14098 

Some Redis commands, such as "VADD", lack metadata fields like "summary" or "since" in their documentation, especially for versions from v8.0 onward.
The script utils/generate-commands-json.py previously assumed that these fields would always be present, which led to a KeyError when they were missing.

This issue has been resolved by utilizing the set_if_not_none_or_empty function from the same script, which safely handles the absence of these optional fields.