### PR TITLE
ADD new api for modules equalstring

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -2953,6 +2953,14 @@ int RM_StringCompare(const RedisModuleString *a, const RedisModuleString *b) {
     return compareStringObjects(a,b);
 }
 
+/* Equal two string objects, return 1 if a and b are the same from the
+ * point of view of a string comparison, otherwise 0 is returned. Note that 
+ * this function is faster than checking for (RM_StringCompare(a,b) == 0) 
+ * because it can perform some more optimization. */
+int RM_EqualString(const RedisModuleString *a, const RedisModuleString *b) {
+    return equalStringObjects(a,b);
+}
+
 /* Return the (possibly modified in encoding) input 'str' object if
  * the string is unshared, otherwise NULL is returned. */
 RedisModuleString *moduleAssertUnsharedString(RedisModuleString *str) {
@@ -14360,6 +14368,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(RetainString);
     REGISTER_API(HoldString);
     REGISTER_API(StringCompare);
+    REGISTER_API(EqualString);
     REGISTER_API(GetContextFromIO);
     REGISTER_API(GetKeyNameFromIO);
     REGISTER_API(GetKeyNameFromModuleKey);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1148,6 +1148,7 @@ REDISMODULE_API void (*RedisModule_TrimStringAllocation)(RedisModuleString *str)
 REDISMODULE_API void (*RedisModule_RetainString)(RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_HoldString)(RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StringCompare)(const RedisModuleString *a, const RedisModuleString *b) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_EqualString)(const RedisModuleString *a, const RedisModuleString *b) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleCtx * (*RedisModule_GetContextFromIO)(RedisModuleIO *io) REDISMODULE_ATTR;
 REDISMODULE_API const RedisModuleString * (*RedisModule_GetKeyNameFromIO)(RedisModuleIO *io) REDISMODULE_ATTR;
 REDISMODULE_API const RedisModuleString * (*RedisModule_GetKeyNameFromModuleKey)(RedisModuleKey *key) REDISMODULE_ATTR;
@@ -1518,6 +1519,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(RetainString);
     REDISMODULE_GET_API(HoldString);
     REDISMODULE_GET_API(StringCompare);
+    REDISMODULE_GET_API(EqualString);
     REDISMODULE_GET_API(GetContextFromIO);
     REDISMODULE_GET_API(GetKeyNameFromIO);
     REDISMODULE_GET_API(GetKeyNameFromModuleKey);


### PR DESCRIPTION
This API complements the ability to determine whether two strings are equal, this helps reduce performance overhead.

Returns 1 if the two strings are equal, otherwise 0.