### PR TITLE
Fix alpine missing __STRING #define

### DIFF
--- a/modules/vector-sets/vset_config.c
+++ b/modules/vector-sets/vset_config.c
@@ -10,6 +10,11 @@
 
 #include "vset_config.h"
 
+/* Define __STRING macro for portability (not available in all environments) */
+#ifndef __STRING
+#define __STRING(x) #x
+#endif
+
 #define RM_TRY(expr)                                                  \
   if (expr == REDISMODULE_ERR) {                                      \
     RedisModule_Log(ctx, "warning", "Could not run " __STRING(expr)); \


### PR DESCRIPTION
Alpine Linux doesn't provide the  __STRING macro, causing build failure:
Adding conditional define the macro if not already available.