### PR TITLE
Fix replication lseek check

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1574,7 +1574,14 @@ void sendBulkToSlave(connection *conn) {
     }
 
     /* If the preamble was already transferred, send the RDB bulk data. */
-    lseek(slave->repldbfd,slave->repldboff,SEEK_SET);
+    if(lseek(slave->repldbfd,slave->repldboff,SEEK_SET) == -1){
+	serverLog(LL_WARNING,"Failed to lseek the RDB file to offset %lld for replica %s: %s",
+	    (long long)slave->repldboff,
+	    replicationGetSlaveName(slave),
+	    strerror(errno));
+	freeClient(slave);
+	return;
+    }
     buflen = read(slave->repldbfd,buf,PROTO_IOBUF_LEN);
     if (buflen <= 0) {
         serverLog(LL_WARNING,"Read error sending DB to replica: %s",

--- a/src/replication.c
+++ b/src/replication.c
@@ -1574,7 +1574,7 @@ void sendBulkToSlave(connection *conn) {
     }
 
     /* If the preamble was already transferred, send the RDB bulk data. */
-    if(lseek(slave->repldbfd,slave->repldboff,SEEK_SET) == -1){
+    if (lseek(slave->repldbfd,slave->repldboff,SEEK_SET) == -1) {
 	serverLog(LL_WARNING,"Failed to lseek the RDB file to offset %lld for replica %s: %s",
 	    (long long)slave->repldboff,
 	    replicationGetSlaveName(slave),

--- a/src/replication.c
+++ b/src/replication.c
@@ -1576,9 +1576,7 @@ void sendBulkToSlave(connection *conn) {
     /* If the preamble was already transferred, send the RDB bulk data. */
     if (lseek(slave->repldbfd,slave->repldboff,SEEK_SET) == -1) {
 	serverLog(LL_WARNING,"Failed to lseek the RDB file to offset %lld for replica %s: %s",
-	    (long long)slave->repldboff,
-	    replicationGetSlaveName(slave),
-	    strerror(errno));
+	    (long long)slave->repldboff, replicationGetSlaveName(slave), strerror(errno));
 	freeClient(slave);
 	return;
     }


### PR DESCRIPTION
In `sendBulkToSlave`, the `lseek()` call used to position the RDB file descriptor before reading the next data chunk was not checked for errors.
If the `lseek()` system call were to fail, the file descriptor would remain at an incorrect position. The subsequent `read()` would then fetch the wrong data, leading to a corrupted RDB stream being sent to the replica. This could cause the replication to fail or result in data inconsistency.
This patch introduces a check for the `lseek()` return value. On failure, it logs a detailed warning and aborts the replication by freeing the client, mirroring the existing error handling for `read()` and `write()` calls within the same function. This improves the robustness of the RDB transfer process.
