### PR TITLE
Fix short read of hfe key that causes exit() on replica

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2283,7 +2283,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
         if (rdbtype == RDB_TYPE_HASH_METADATA) {
             minExpire = rdbLoadMillisecondTime(rdb, RDB_VERSION);
             if (rioGetReadError(rdb)) {
-                rdbReportCorruptRDB("Hash failed loading minExpire");
+                rdbReportReadError("Hash failed loading minExpire");
                 return NULL;
             }
             if (minExpire > EB_EXPIRE_TIME_INVALID) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2529,7 +2529,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
              * directly to FLASH (while keeping in mem its next expiration time) */
             UNUSED(minExpire);
             if (rioGetReadError(rdb)) {
-                rdbReportCorruptRDB( "Hash listpackex integrity check failed.");
+                rdbReportReadError( "Short read of listpackex min expiration time.");
                 return NULL;
             }
         }

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -765,6 +765,8 @@ test {diskless loading short read} {
                     r set "$k string_$i" [string repeat A [expr {int(rand()*1000000)}]]
                     r hset "$k hash_small" [string repeat A [expr {int(rand()*10)}]]  0[string repeat A [expr {int(rand()*10)}]]
                     r hset "$k hash_large" [string repeat A [expr {int(rand()*10000)}]] [string repeat A [expr {int(rand()*1000000)}]]
+                    r hsetex "$k hfe_small" EX [expr {int(rand()*100)}] FIELDS 1 [string repeat A [expr {int(rand()*10)}]] 0[string repeat A [expr {int(rand()*10)}]]
+                    r hsetex "$k hfe_large" EX [expr {int(rand()*100)}] FIELDS 1 [string repeat A [expr {int(rand()*10000)}]] [string repeat A [expr {int(rand()*1000000)}]]
                     r sadd "$k set_small" [string repeat A [expr {int(rand()*10)}]]
                     r sadd "$k set_large" [string repeat A [expr {int(rand()*1000000)}]]
                     r zadd "$k zset_small" [expr {rand()}] [string repeat A [expr {int(rand()*10)}]]


### PR DESCRIPTION
During fullsync, if replica detects broken connection while reading min expiration time of hfe key, it calls exit(). 
Fixed it to handle the error gracefully without calling exit. 

To reproduce the issue, the short-read test was modified to generate many small hfe keys, increasing the likelihood of a connection drop while reading min expiration time:

```tcl
for {set k 0} {$k < 50000} {incr k} {
  for {set i 0} {$i < 1} {incr i} {
    r hsetex "$k hfe_small" EX [expr {int(rand()*10)}] FIELDS 1 [string repeat A [expr {int(rand()*10)}]] 0[string repeat A [expr {int(rand()*10)}]]
  }
}
```

We can't have the test use only hfe keys, so a few were added alongside other data. I couldn't reproduce the issue this way but with the test's randomization, it should hit this scenario in one of the runs.
