### PR TITLE
New config: lazyexpire-nested-arbitrary-keys

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3114,7 +3114,7 @@ standardConfig static_configs[] = {
     createBoolConfig("aof-disable-auto-gc", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.aof_disable_auto_gc, 0, NULL, updateAofAutoGCEnabled),
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 0, NULL, NULL),
-    createBoolConfig("lazyexpire-nested-arbitrary-keys", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.avoid_arbitrary_lazyexpires, 0, NULL, NULL),
+    createBoolConfig("lazyexpire-nested-arbitrary-keys", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.lazyexpire_nested_arbitrary_keys, 1, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3114,7 +3114,7 @@ standardConfig static_configs[] = {
     createBoolConfig("aof-disable-auto-gc", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.aof_disable_auto_gc, 0, NULL, updateAofAutoGCEnabled),
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 0, NULL, NULL),
-    createBoolConfig("avoid-arbitrary-lazyexpires", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.avoid_arbitrary_lazyexpires, 0, NULL, NULL),
+    createBoolConfig("lazyexpire-nested-arbitrary-keys", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.avoid_arbitrary_lazyexpires, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3114,7 +3114,7 @@ standardConfig static_configs[] = {
     createBoolConfig("aof-disable-auto-gc", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.aof_disable_auto_gc, 0, NULL, updateAofAutoGCEnabled),
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 0, NULL, NULL),
-    createBoolConfig("allow-arbitrary-lazyexpires", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.allow_arbitrary_lazyexpires, 1, NULL, NULL),
+    createBoolConfig("avoid-arbitrary-lazyexpires", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.avoid_arbitrary_lazyexpires, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3114,6 +3114,7 @@ standardConfig static_configs[] = {
     createBoolConfig("aof-disable-auto-gc", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.aof_disable_auto_gc, 0, NULL, updateAofAutoGCEnabled),
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 0, NULL, NULL),
+    createBoolConfig("allow-arbitrary-lazyexpires", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.allow_arbitrary_lazyexpires, 1, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/db.c
+++ b/src/db.c
@@ -2515,7 +2515,7 @@ keyStatus expireIfNeeded(redisDb *db, robj *key, kvobj *kv, int flags) {
     }
 
     /* Check if user configuration disables lazy-expire deletions in current state.
-       This will only apply if the server doesn't mandate key deletion to operate correctly (write commands). */
+     * This will only apply if the server doesn't mandate key deletion to operate correctly (write commands). */
     if (!(flags & EXPIRE_FORCE_DELETE_EXPIRED) && !confAllowsExpireDel())
         return KEY_EXPIRED;
 

--- a/src/db.c
+++ b/src/db.c
@@ -2444,7 +2444,7 @@ int keyIsExpired(redisDb *db, sds key, kvobj *kv) {
     return now > when;
 }
 
-/* Check if user configuration allows key to be expired */
+/* Check if user configuration allows key to be deleted due to expiary */
 int confAllowsExpireDel() {
     if (server.allow_arbitrary_lazyexpires)
         return 1;

--- a/src/db.c
+++ b/src/db.c
@@ -2444,6 +2444,14 @@ int keyIsExpired(redisDb *db, sds key, kvobj *kv) {
     return now > when;
 }
 
+/* Check if user configuration allows key to be expired */
+int confAllowsExpireDel() {
+    if (server.allow_arbitrary_lazyexpires)
+        return 1;
+
+    return !(server.current_client->cmd->flags & CMD_TOUCHES_ARBITRARY_KEYS);
+}
+
 /* This function is called when we are going to perform some operation
  * in a given key, but such key may be already logically expired even if
  * it still exists in the database. The main way this function is called
@@ -2502,6 +2510,9 @@ keyStatus expireIfNeeded(redisDb *db, robj *key, kvobj *kv, int flags) {
         if (server.current_client && (server.current_client->flags & CLIENT_MASTER)) return KEY_VALID;
         if (!(flags & EXPIRE_FORCE_DELETE_EXPIRED)) return KEY_EXPIRED;
     }
+
+    if (!(flags & EXPIRE_FORCE_DELETE_EXPIRED) && !confAllowsExpireDel())
+        return KEY_EXPIRED;
 
     /* In some cases we're explicitly instructed to return an indication of a
      * missing key without actually deleting it, even on masters. */

--- a/src/db.c
+++ b/src/db.c
@@ -2449,7 +2449,7 @@ int confAllowsExpireDel() {
     if (server.allow_arbitrary_lazyexpires)
         return 1;
 
-    return !(server.execution_nesting > 1 && server.current_client->cmd->flags & CMD_TOUCHES_ARBITRARY_KEYS);
+    return !(server.execution_nesting > 1 && server.executing_client->cmd->flags & CMD_TOUCHES_ARBITRARY_KEYS);
 }
 
 /* This function is called when we are going to perform some operation

--- a/src/db.c
+++ b/src/db.c
@@ -2449,8 +2449,8 @@ int confAllowsExpireDel(void) {
     if (!server.avoid_arbitrary_lazyexpires)
         return 1;
 
-    /* This configuration specifically targets nested commands, to align with RE limitation -
-       transactions containing arbitrerally chosen commands will execute locally, but their
+    /* This configuration specifically targets nested commands, to align with RE's feature of replication between dbs.
+       transactions (from scripts or multi-exec) containing commands like SCAN and RANDOMKEY will execute locally, but their
        lazy-expiration DELs may induce CROSS-SLOT on remote proxy in mode replica-of (RED-161574) */
     return !(server.execution_nesting > 1 && server.executing_client->cmd->flags & CMD_TOUCHES_ARBITRARY_KEYS);
 }

--- a/src/db.c
+++ b/src/db.c
@@ -2445,10 +2445,13 @@ int keyIsExpired(redisDb *db, sds key, kvobj *kv) {
 }
 
 /* Check if user configuration allows key to be deleted due to expiary */
-int confAllowsExpireDel() {
-    if (server.allow_arbitrary_lazyexpires)
+int confAllowsExpireDel(void) {
+    if (!server.avoid_arbitrary_lazyexpires)
         return 1;
 
+    /* This configuration specifically targets nested commands, to align with RE limitation -
+       transactions containing arbitrerally chosen commands will execute locally, but their
+       lazy-expiration DELs may induce CROSS-SLOT on remote proxy in mode replica-of (RED-161574) */
     return !(server.execution_nesting > 1 && server.executing_client->cmd->flags & CMD_TOUCHES_ARBITRARY_KEYS);
 }
 
@@ -2511,6 +2514,8 @@ keyStatus expireIfNeeded(redisDb *db, robj *key, kvobj *kv, int flags) {
         if (!(flags & EXPIRE_FORCE_DELETE_EXPIRED)) return KEY_EXPIRED;
     }
 
+    /* Check if user configuration disables lazy-expire deletions in current state.
+       This will only apply if the server doesn't mandate key deletion to operate correctly (write commands). */
     if (!(flags & EXPIRE_FORCE_DELETE_EXPIRED) && !confAllowsExpireDel())
         return KEY_EXPIRED;
 

--- a/src/db.c
+++ b/src/db.c
@@ -2449,7 +2449,7 @@ int confAllowsExpireDel() {
     if (server.allow_arbitrary_lazyexpires)
         return 1;
 
-    return !(server.current_client->cmd->flags & CMD_TOUCHES_ARBITRARY_KEYS);
+    return !(server.execution_nesting > 1 && server.current_client->cmd->flags & CMD_TOUCHES_ARBITRARY_KEYS);
 }
 
 /* This function is called when we are going to perform some operation

--- a/src/db.c
+++ b/src/db.c
@@ -2450,8 +2450,8 @@ int confAllowsExpireDel(void) {
         return 1;
 
     /* This configuration specifically targets nested commands, to align with RE's feature of replication between dbs.
-       transactions (from scripts or multi-exec) containing commands like SCAN and RANDOMKEY will execute locally, but their
-       lazy-expiration DELs may induce CROSS-SLOT on remote proxy in mode replica-of (RED-161574) */
+     * transactions (from scripts or multi-exec) containing commands like SCAN and RANDOMKEY will execute locally, but their
+     * lazy-expiration DELs may induce CROSS-SLOT on remote proxy in mode replica-of (RED-161574) */
     return !(server.execution_nesting > 1 && server.executing_client->cmd->flags & CMD_TOUCHES_ARBITRARY_KEYS);
 }
 

--- a/src/db.c
+++ b/src/db.c
@@ -2446,7 +2446,7 @@ int keyIsExpired(redisDb *db, sds key, kvobj *kv) {
 
 /* Check if user configuration allows key to be deleted due to expiary */
 int confAllowsExpireDel(void) {
-    if (!server.avoid_arbitrary_lazyexpires)
+    if (server.lazyexpire_nested_arbitrary_keys)
         return 1;
 
     /* This configuration specifically targets nested commands, to align with RE's feature of replication between dbs.

--- a/src/server.h
+++ b/src/server.h
@@ -1974,6 +1974,7 @@ struct redisServer {
     unsigned int max_new_tls_conns_per_cycle; /* The maximum number of tls connections that will be accepted during each invocation of the event loop. */
     unsigned int max_new_conns_per_cycle; /* The maximum number of tcp connections that will be accepted during each invocation of the event loop. */
     int cluster_compatibility_sample_ratio; /* Sampling ratio for cluster mode incompatible commands. */
+    int allow_arbitrary_lazyexpires; /* If disabled, avoid lazy-expire from commands that touch arbitrary keys (SCAN/RANDOMKEY) within transactions */
 
     /* AOF persistence */
     int aof_enabled;                /* AOF configuration */
@@ -3616,6 +3617,7 @@ void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj);
 void deleteEvictedKeyAndPropagate(redisDb *db, robj *keyobj, long long *key_mem_freed);
 void propagateDeletion(redisDb *db, robj *key, int lazy);
 int keyIsExpired(redisDb *db, sds key, kvobj *kv);
+int confAllowsExpireDel();
 long long getExpire(redisDb *db, sds key, kvobj *kv);
 kvobj *setExpire(client *c, redisDb *db, robj *key, long long when);
 kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntryLink link);

--- a/src/server.h
+++ b/src/server.h
@@ -1974,7 +1974,7 @@ struct redisServer {
     unsigned int max_new_tls_conns_per_cycle; /* The maximum number of tls connections that will be accepted during each invocation of the event loop. */
     unsigned int max_new_conns_per_cycle; /* The maximum number of tcp connections that will be accepted during each invocation of the event loop. */
     int cluster_compatibility_sample_ratio; /* Sampling ratio for cluster mode incompatible commands. */
-    int avoid_arbitrary_lazyexpires; /* If disabled, avoid lazy-expire from commands that touch arbitrary keys (SCAN/RANDOMKEY) within transactions */
+    int lazyexpire_nested_arbitrary_keys; /* If disabled, avoid lazy-expire from commands that touch arbitrary keys (SCAN/RANDOMKEY) within transactions */
 
     /* AOF persistence */
     int aof_enabled;                /* AOF configuration */

--- a/src/server.h
+++ b/src/server.h
@@ -1974,7 +1974,7 @@ struct redisServer {
     unsigned int max_new_tls_conns_per_cycle; /* The maximum number of tls connections that will be accepted during each invocation of the event loop. */
     unsigned int max_new_conns_per_cycle; /* The maximum number of tcp connections that will be accepted during each invocation of the event loop. */
     int cluster_compatibility_sample_ratio; /* Sampling ratio for cluster mode incompatible commands. */
-    int allow_arbitrary_lazyexpires; /* If disabled, avoid lazy-expire from commands that touch arbitrary keys (SCAN/RANDOMKEY) within transactions */
+    int avoid_arbitrary_lazyexpires; /* If disabled, avoid lazy-expire from commands that touch arbitrary keys (SCAN/RANDOMKEY) within transactions */
 
     /* AOF persistence */
     int aof_enabled;                /* AOF configuration */
@@ -3617,7 +3617,7 @@ void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj);
 void deleteEvictedKeyAndPropagate(redisDb *db, robj *keyobj, long long *key_mem_freed);
 void propagateDeletion(redisDb *db, robj *key, int lazy);
 int keyIsExpired(redisDb *db, sds key, kvobj *kv);
-int confAllowsExpireDel();
+int confAllowsExpireDel(void);
 long long getExpire(redisDb *db, sds key, kvobj *kv);
 kvobj *setExpire(client *c, redisDb *db, robj *key, long long when);
 kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntryLink link);

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -1,64 +1,3 @@
-# Config lazyexpire test body
-proc conf_le_test {le_option mode use_module} {
-    r config set allow-arbitrary-lazyexpires $le_option
-    r debug set-active-expire 0
-    r flushall
-    r script LOAD {return redis.call('SCAN', 0)}
-
-    if {$use_module == "yes"} {
-        r datatype.set foo 100 bar
-    } else {
-        r set foo bar
-    }
-    r pexpire foo 1
-    after 2
-
-    set repl [attach_to_replication_stream]
-
-    # First two conditions hit lazy expire within a 'transaction', meaning
-    # DEL propagation should be blocked if 'allow-arbitrary-lazyexpires' is set.
-    if {$mode == "lua"} {
-        r eval "return redis.call('SCAN', 0)" 0
-    } elseif {$mode == "multi"} {
-        r multi
-        r scan 0
-        r exec
-    } else {
-        r scan 0
-    }
-
-    # dummy command to verify nothing else gets into the replication stream.
-    r set x 1
-
-    if {$le_option == "no" && $mode != "direct"} {
-        assert_replication_stream $repl {
-            {select *}
-            {set x 1}
-        }
-    } else {
-        assert_replication_stream $repl {
-            {select *}
-            {del foo}
-            {set x 1}
-        }
-    }
-
-    close_replication_stream $repl
-    r script flush
-    assert_equal [r config set allow-arbitrary-lazyexpires yes] {OK}
-    assert_equal [r debug set-active-expire 1] {OK}
-}
-
-foreach le_option {yes no} {
-foreach mode {direct multi lua} {
-    set use_module "no"
-    start_server {tags {"expire"}} {
-        test "allow-arbitrary-lazyexpires" {
-            conf_le_test $le_option $mode $use_module
-        } {} {needs:debug repl}
-    }
-}}
-
 start_server {tags {"expire"}} {
     test {EXPIRE - set timeouts multiple times} {
         r set x foobar
@@ -960,3 +899,59 @@ start_cluster 1 0 {tags {"expire external:skip cluster"}} {
         assert_equal 0 [s 0 expired_time_cap_reached_count]
     } {} {needs:debug}
 }
+
+# Config allow-arbitrary-lazyexpires test body
+proc conf_le_test {option mode} {
+    r config set allow-arbitrary-lazyexpires $option
+    r debug set-active-expire 0
+    r flushall
+    r script LOAD {return redis.call('SCAN', 0)}
+
+    r set foo bar
+    r pexpire foo 1
+    after 2
+
+    set repl [attach_to_replication_stream]
+
+    # First two conditions hit lazy expire within a 'transaction', meaning
+    # DEL propagation should be blocked if 'allow-arbitrary-lazyexpires' is set.
+    if {$mode == "lua"} {
+        r eval "return redis.call('SCAN', 0)" 0
+    } elseif {$mode == "multi"} {
+        r multi
+        r scan 0
+        r exec
+    } else {
+        r scan 0
+    }
+
+    # dummy command to verify nothing else gets into the replication stream.
+    r set x 1
+
+    if {$option == "no" && $mode != "direct"} {
+        assert_replication_stream $repl {
+            {select *}
+            {set x 1}
+        }
+    } else {
+        assert_replication_stream $repl {
+            {select *}
+            {del foo}
+            {set x 1}
+        }
+    }
+
+    close_replication_stream $repl
+    r script flush
+    assert_equal [r config set allow-arbitrary-lazyexpires yes] {OK}
+    assert_equal [r debug set-active-expire 1] {OK}
+}
+
+foreach option {yes no} {
+foreach mode {direct multi lua} {
+    start_server {tags {"expire"}} {
+        test "Config allow-arbitrary-lazyexpires ($option, $mode)" {
+            conf_le_test $option $mode
+        } {} {needs:debug repl}
+    }
+}}

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -900,9 +900,9 @@ start_cluster 1 0 {tags {"expire external:skip cluster"}} {
     } {} {needs:debug}
 }
 
-# Config allow-arbitrary-lazyexpires test body
+# Config avoid-arbitrary-lazyexpires test body
 proc conf_le_test {option mode} {
-    r config set allow-arbitrary-lazyexpires $option
+    r config set avoid-arbitrary-lazyexpires $option
     r debug set-active-expire 0
     r flushall
     r script LOAD {return redis.call('SCAN', 0)}
@@ -914,7 +914,7 @@ proc conf_le_test {option mode} {
     set repl [attach_to_replication_stream]
 
     # First two conditions hit lazy expire within a 'transaction', meaning
-    # DEL propagation should be blocked if 'allow-arbitrary-lazyexpires' is set.
+    # DEL propagation should be blocked if 'avoid-arbitrary-lazyexpires' is set.
     if {$mode == "lua"} {
         r eval "return redis.call('SCAN', 0)" 0
     } elseif {$mode == "multi"} {
@@ -928,7 +928,7 @@ proc conf_le_test {option mode} {
     # dummy command to verify nothing else gets into the replication stream.
     r set x 1
 
-    if {$option == "no" && $mode != "direct"} {
+    if {$option == "yes" && $mode != "direct"} {
         assert_replication_stream $repl {
             {select *}
             {set x 1}
@@ -943,14 +943,14 @@ proc conf_le_test {option mode} {
 
     close_replication_stream $repl
     r script flush
-    assert_equal [r config set allow-arbitrary-lazyexpires yes] {OK}
+    assert_equal [r config set avoid-arbitrary-lazyexpires yes] {OK}
     assert_equal [r debug set-active-expire 1] {OK}
 }
 
-foreach option {yes no} {
+foreach option {no yes} {
 foreach mode {direct multi lua} {
     start_server {tags {"expire"}} {
-        test "Config allow-arbitrary-lazyexpires ($option, $mode)" {
+        test "Config avoid-arbitrary-lazyexpires ($option, $mode)" {
             conf_le_test $option $mode
         } {} {needs:debug repl}
     }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -1,3 +1,64 @@
+# Config lazyexpire test body
+proc conf_le_test {le_option mode use_module} {
+    r config set allow-arbitrary-lazyexpires $le_option
+    r debug set-active-expire 0
+    r flushall
+    r script LOAD {return redis.call('SCAN', 0)}
+
+    if {$use_module == "yes"} {
+        r datatype.set foo 100 bar
+    } else {
+        r set foo bar
+    }
+    r pexpire foo 1
+    after 2
+
+    set repl [attach_to_replication_stream]
+
+    # First two conditions hit lazy expire within a 'transaction', meaning
+    # DEL propagation should be blocked if 'allow-arbitrary-lazyexpires' is set.
+    if {$mode == "lua"} {
+        r eval "return redis.call('SCAN', 0)" 0
+    } elseif {$mode == "multi"} {
+        r multi
+        r scan 0
+        r exec
+    } else {
+        r scan 0
+    }
+
+    # dummy command to verify nothing else gets into the replication stream.
+    r set x 1
+
+    if {$le_option == "no" && $mode != "direct"} {
+        assert_replication_stream $repl {
+            {select *}
+            {set x 1}
+        }
+    } else {
+        assert_replication_stream $repl {
+            {select *}
+            {del foo}
+            {set x 1}
+        }
+    }
+
+    close_replication_stream $repl
+    r script flush
+    assert_equal [r config set allow-arbitrary-lazyexpires yes] {OK}
+    assert_equal [r debug set-active-expire 1] {OK}
+}
+
+foreach le_option {yes no} {
+foreach mode {direct multi lua} {
+    set use_module "no"
+    start_server {tags {"expire"}} {
+        test "allow-arbitrary-lazyexpires" {
+            conf_le_test $le_option $mode $use_module
+        } {} {needs:debug repl}
+    }
+}}
+
 start_server {tags {"expire"}} {
     test {EXPIRE - set timeouts multiple times} {
         r set x foobar

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -900,9 +900,9 @@ start_cluster 1 0 {tags {"expire external:skip cluster"}} {
     } {} {needs:debug}
 }
 
-# Config avoid-arbitrary-lazyexpires test body
+# Config lazyexpire-nested-arbitrary-keys test body
 proc conf_le_test {option mode} {
-    r config set avoid-arbitrary-lazyexpires $option
+    r config set lazyexpire-nested-arbitrary-keys $option
     r debug set-active-expire 0
     r flushall
     r script LOAD {return redis.call('SCAN', 0)}
@@ -914,7 +914,7 @@ proc conf_le_test {option mode} {
     set repl [attach_to_replication_stream]
 
     # First two conditions hit lazy expire within a 'transaction', meaning
-    # DEL propagation should be blocked if 'avoid-arbitrary-lazyexpires' is set.
+    # DEL propagation should be blocked if 'lazyexpire-nested-arbitrary-keys' is set.
     if {$mode == "lua"} {
         r eval "return redis.call('SCAN', 0)" 0
     } elseif {$mode == "multi"} {
@@ -943,14 +943,14 @@ proc conf_le_test {option mode} {
 
     close_replication_stream $repl
     r script flush
-    assert_equal [r config set avoid-arbitrary-lazyexpires yes] {OK}
+    assert_equal [r config set lazyexpire-nested-arbitrary-keys yes] {OK}
     assert_equal [r debug set-active-expire 1] {OK}
 }
 
 foreach option {no yes} {
 foreach mode {direct multi lua} {
     start_server {tags {"expire"}} {
-        test "Config avoid-arbitrary-lazyexpires ($option, $mode)" {
+        test "Config lazyexpire-nested-arbitrary-keys ($option, $mode)" {
             conf_le_test $option $mode
         } {} {needs:debug repl}
     }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -928,7 +928,7 @@ proc conf_le_test {option mode} {
     # dummy command to verify nothing else gets into the replication stream.
     r set x 1
 
-    if {$option == "yes" && $mode != "direct"} {
+    if {$option == "no" && $mode != "direct"} {
         assert_replication_stream $repl {
             {select *}
             {set x 1}
@@ -947,7 +947,7 @@ proc conf_le_test {option mode} {
     assert_equal [r debug set-active-expire 1] {OK}
 }
 
-foreach option {no yes} {
+foreach option {yes no} {
 foreach mode {direct multi lua} {
     start_server {tags {"expire"}} {
         test "Config lazyexpire-nested-arbitrary-keys ($option, $mode)" {


### PR DESCRIPTION
In this PR we added hidden config - `lazyexpire-nested-arbitrary-keys`, which can take:
* yes - the default. produce and propagate lazy-expire DELs as usual.
* no - avoid lazy-expire from commands that touch arbitrary keys (such as SCAN, RANDOMKEY), if generated within a transactions (MULTI/EXEC, LUA). This ensures such commands won't induce CROSSSLOT on remote proxy, as happened in when replicating one db into another (possibly sharded differently).
Since the issue is relevant only in replicated servers (RE's replica-of mode or CRDT) - it was added to the core as a hidden config.

Please note that this config will always apply to read-only commands (see EXPIRE_FORCE_DELETE_EXPIRED flag).
Since write commands may require key expiration to operate correctly.