### PR TITLE
Add boundary assert to connTypeRegister

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -47,6 +47,7 @@ int connTypeRegister(ConnectionType *ct) {
         }
     }
 
+    serverAssert(type < CONN_TYPE_MAX);
     serverLog(LL_VERBOSE, "Connection type %s registered", typename);
     connTypes[type] = ct;
 


### PR DESCRIPTION
Add boundary assertion to prevent array overflow in `connTypeRegister` when reaching **CONN_TYPE_MAX** limit.