### PR TITLE
Update redisearch to 8.2 RC1

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.1.00
+MODULE_VERSION = v8.1.90
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
[#Q6329](https://github.com/RediSearch/RediSearch/pull/6329), [#Q6329](https://github.com/RediSearch/RediSearch/pull/6394) - Introducing the new SVS-VAMANA vector index type which supports vector compression (optimized on Intel machines)
