### PR TITLE
Increase tilt message verbosity to lower the average WTFPS of a Redis Sentinel user (and save kittens)

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -5447,7 +5447,9 @@ void sentinelCheckTiltCondition(void) {
         sentinel.tilt = 1;
         sentinel.tilt_start_time = mstime();
         sentinel.total_tilt++;
-        sentinelEvent(LL_WARNING,"+tilt",NULL,"#tilt mode entered");
+        sentinelEvent(LL_WARNING,"+tilt",NULL,
+            "#tilt mode entered (now: %lld, delta: %lld, tilt_trigger: %lld)",
+            now, delta, sentinel_tilt_trigger);
     }
     sentinel.previous_time = mstime();
 }


### PR DESCRIPTION
## TL;DR

Add more info to the [tilt mode](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/#tilt-mode) enter message, for the good of humanity.


## Poetic version

For eons have tormented souls feared the wicked power of TILT.

<LOTR opening music starts>

Just like the victims of #10547, we have all spent sleepless nights wondering what dark magic commands our Sentinel instances.

And just like https://github.com/bitnami/charts/issues/9689 we kept on failing to unveil the dark secrets.

No more!

Let's repel the darkness of:

```sh
+tilt #tilt mode entered
-tilt #tilt mode exited
```

.. and print more information on the time, delta and trigger values!

Is my clock wrong? Or am I starving my beloved child unwittingly?

Let's find out!


## PS

First time contributor to redis, go easy on me!