### PR TITLE
Ensure empty error tables in scripts don't crash

### DIFF
--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -1585,6 +1585,9 @@ void luaExtractErrorInformation(lua_State *lua, errorInfo *err_info) {
     lua_getfield(lua, -1, "err");
     if (lua_isstring(lua, -1)) {
         err_info->msg = sdsnew(lua_tostring(lua, -1));
+    } else {
+        /* Ensure we never return a NULL msg. */
+        err_info->msg = sdsnew("ERR unknown error");
     }
     lua_pop(lua, 1);
 
@@ -1605,11 +1608,6 @@ void luaExtractErrorInformation(lua_State *lua, errorInfo *err_info) {
         err_info->ignore_err_stats_update = lua_toboolean(lua, -1);
     }
     lua_pop(lua, 1);
-
-    if (err_info->msg == NULL) {
-        /* Ensure we never return a NULL msg. */
-        err_info->msg = sdsnew("ERR unknown error");
-    }
 }
 
 void luaCallFunction(scriptRunCtx* run_ctx, lua_State *lua, robj** keys, size_t nkeys, robj** args, size_t nargs, int debug_enabled) {

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -2,9 +2,14 @@
  * Copyright (c) 2009-Present, Redis Ltd.
  * All rights reserved.
  *
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
+ *
  * Licensed under your choice of (a) the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).
+ *
+ * Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
  */
 
 #include "script_lua.h"
@@ -1600,6 +1605,11 @@ void luaExtractErrorInformation(lua_State *lua, errorInfo *err_info) {
         err_info->ignore_err_stats_update = lua_toboolean(lua, -1);
     }
     lua_pop(lua, 1);
+
+    if (err_info->msg == NULL) {
+        /* Ensure we never return a NULL msg. */
+        err_info->msg = sdsnew("ERR unknown error");
+    }
 }
 
 void luaCallFunction(scriptRunCtx* run_ctx, lua_State *lua, robj** keys, size_t nkeys, robj** args, size_t nargs, int debug_enabled) {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -2462,12 +2462,6 @@ start_server {tags {"scripting"}} {
         }
     }
 
-    test {EVAL - Scripts support NULL byte} {
-        assert_equal [r eval "return \"\x00\";" 0] "\x00"
-        # Using a null byte never seemed to work with functions, so
-        # we don't have a test for that case.
-    }
-
     test {EVAL - explicit error() call handling} {
         # error("simple string error")
         assert_error {ERR user_script:1: simple string error script: *} {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1,3 +1,17 @@
+#
+# Copyright (c) 2009-Present, Redis Ltd.
+# All rights reserved.
+#
+# Copyright (c) 2024-present, Valkey contributors.
+# All rights reserved.
+#
+# Licensed under your choice of (a) the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+#
+# Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
+#
+
 foreach is_eval {0 1} {
 
 if {$is_eval == 1} {
@@ -2445,6 +2459,29 @@ start_server {tags {"scripting"}} {
 
             # Assert the string has been trimmed and the 80 bytes from the previous alloc were not kept.
             assert { [r memory usage foo] <= $expected_memory};
+        }
+    }
+
+    test {EVAL - Scripts support NULL byte} {
+        assert_equal [r eval "return \"\x00\";" 0] "\x00"
+        # Using a null byte never seemed to work with functions, so
+        # we don't have a test for that case.
+    }
+
+    test {EVAL - explicit error() call handling} {
+        # error("simple string error")
+        assert_error {ERR user_script:1: simple string error script: *} {
+            r eval "error('simple string error')" 0
+        }
+
+        # error({"err": "ERR table error"})
+        assert_error {ERR table error script: *} {
+            r eval "error({err='ERR table error'})" 0
+        }
+
+        # error({})
+        assert_error {ERR unknown error script: *} {
+            r eval "error({})" 0
         }
     }
 }


### PR DESCRIPTION
This PR is based on: https://github.com/valkey-io/valkey/pull/2229

When calling the command `EVAL error{} 0`, Redis crashes with the following stack trace. This patch ensures we never leave the `err_info.msg` field null when we fail to extract a proper error message.

---------

Signed-off-by: Fusl <fusl@meo.ws>
Signed-off-by: Binbin <binloveplay1314@qq.com>
Co-authored-by: Fusl <fusl@meo.ws>
Co-authored-by: Binbin <binloveplay1314@qq.com>