### PR TITLE
Enable UNALIGNED_LE_CPU for RISC-V to optimize unaligned memory access

### DIFF
--- a/src/siphash.c
+++ b/src/siphash.c
@@ -68,7 +68,7 @@ int siptlw(int c) {
  * Two interesting conditions to speedup the function that happen to be
  * in most of x86 servers. */
 #if defined(__X86_64__) || defined(__x86_64__) || defined (__i386__) \
-	|| defined (__aarch64__) || defined (__arm64__)
+	|| defined (__aarch64__) || defined (__arm64__) || defined (__riscv)
 #define UNALIGNED_LE_CPU
 #endif
 


### PR DESCRIPTION
### Description

This PR enables the `UNALIGNED_LE_CPU` macro for RISC-V in `src/siphash.c`, allowing optimized unaligned memory access on RISC-V platforms. This change improves the performance of SipHash when running on RISC-V CPUs that support efficient unaligned access, similar to x86_64 and aarch64.

### Motivation

- Many modern RISC-V cores (especially those conforming to the Zicclsm extension) support efficient unaligned memory access.
- This optimization brings RISC-V performance closer to x86_64 and ARM64 for hash table operations.

### Changes

- Added `__riscv` to the architecture check for `UNALIGNED_LE_CPU` in `src/siphash.c`.
- The change is guarded by the existing macro logic and does not affect other architectures.

### Testing

- Build  success, redis-server and redis-benchmark run all well on Spacemit(R) X60 RISC-V CPU. 
- It is not easy to test the performance improvement brought by UNALIGNED_LE_CPU using redis-benchmark, so we wrote a micro-benchmark `siphash_bench.c` test on RISC-V.

<details>
  <summary> siphash_bench.c </summary>
  
```python
#include <stdio.h>
#include <stdint.h>
#include <stdlib.h>
#include <string.h>
#include <time.h>

uint64_t siphash(const uint8_t *in, size_t inlen, const uint8_t *k);

double now_sec() {
    struct timespec ts;
    clock_gettime(CLOCK_MONOTONIC, &ts);
    return ts.tv_sec + ts.tv_nsec / 1e9;
}

#define TEST_ROUNDS 10000000
#define BUF_SIZE 64

int main() {
    uint8_t *buffer = (uint8_t*)malloc(BUF_SIZE + 8);
    uint8_t key[16] = {0};
    memset(buffer, 0xAB, BUF_SIZE + 8);
    memset(key, 0xCD, 16);

    uint8_t *aligned_ptr = buffer + (8 - ((uintptr_t)buffer % 8)) % 8;
    uint8_t *unaligned_ptr = aligned_ptr + 1;

    // warmup
    for (int i = 0; i < 1000; ++i) {
        siphash(aligned_ptr, 8, key);
        siphash(unaligned_ptr, 8, key);
    }

    printf("Testing siphash with %d rounds, input length 8 bytes\n", TEST_ROUNDS);

    // unaligned test
    double t1 = now_sec();
    uint64_t sum = 0;
    for (int i = 0; i < TEST_ROUNDS; ++i) {
        sum += siphash(unaligned_ptr, 8, key);
    }
    double t2 = now_sec();

    printf("Unaligned: %.3f ms, sum=%llu\n", (t2-t1)*1000, (unsigned long long)sum);

    free(buffer);
    return 0;
}
```

</details>

</details>

``` bash
[root@openeuler-riscv64 src]# grep -nr "riscv" siphash_riscv.c
71:     || defined (__aarch64__) || defined (__arm64__) || defined (__riscv)
[root@openeuler-riscv64 src]# gcc siphash_bench.c siphash.c -o siphash_bench -O2
[root@openeuler-riscv64 src]# gcc siphash_bench.c siphash_riscv.c -o siphash_bench_riscv -O2
[root@openeuler-riscv64 src]# ./siphash_bench
Testing siphash with 10000000 rounds, input length 8 bytes
Unaligned: 865.980 ms, sum=16031980000301072896
[root@openeuler-riscv64 src]# ./siphash_bench_riscv
Testing siphash with 10000000 rounds, input length 8 bytes
Unaligned: 480.968 ms, sum=16031980000301072896
```
Through `siphash_bench.c` we can see the performance improvement brought by UNALIGNED_LE_CPU.

