### PR TITLE
Update SECURITY.md and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,7 +828,7 @@ Please consult the [TLS.md](TLS.md) file for more information on how to use Redi
 
 ## Code contributions
 
-By contributing code to the Redis project in any form, including sending a pull request via GitHub, a code fragment or patch via private email or public discussion groups, you agree to release your code under the terms of the Redis Software Grant and Contributor License Agreement. Please see the CONTRIBUTING.md file in this source distribution for more information. For security bugs and vulnerabilities, please see SECURITY.md. Open Source Redis releases are subject to the following licenses:
+By contributing code to the Redis project in any form, including sending a pull request via GitHub, a code fragment or patch via private email or public discussion groups, you agree to release your code under the terms of the Redis Software Grant and Contributor License Agreement. Please see the CONTRIBUTING.md file in this source distribution for more information. For security bugs and vulnerabilities, please see SECURITY.md and the description of the ability of users to backport security patches under Redis Open Source 7.4+ under BSDv3. Open Source Redis releases are subject to the following licenses:
 
 1. Version 7.2.x and prior releases are subject to BSDv3. These contributions to the original Redis core project are owned by their contributors and licensed under the 3BSDv3 license as referenced in the REDISCONTRIBUTIONS.txt file. Any copy of that license in this repository applies only to those contributions;
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,10 +11,10 @@ unless this is not possible or feasible with a reasonable effort.
 
 | Version | Supported                                                   |
 |---------|-------------------------------------------------------------|
+| 8.2.x   | :white_check_mark:                                          |
 | 8.0.x   | :white_check_mark:                                          |
 | 7.4.x   | :white_check_mark:                                          |
-| 7.2.x   | :white_check_mark:                                          |
-| < 7.2.x | :x:                                                         |
+| < 7.4.x | :x:                                                         |
 | 6.2.x   | :white_check_mark: Support may be removed after end of 2025 |
 | < 6.2.x | :x:                                                         |
 
@@ -38,3 +38,12 @@ embargo on public disclosure.
 
 If you believe you should be on the list, please contact us and we will
 consider your request based on the above criteria.
+
+## License Compatibility
+
+For security vulnerability patches released under Redis Open Source 7.4 and 
+thereafter, Redis permits users of earlier versions (7.2 and prior) to access 
+patches under the BSD3 license noted in REDISCONTRIBUTIONS.txt instead of the 
+full license requirements described in LICENSE.txt. Security fixes are tested 
+only against the specific versions for which they are provided. Applicability 
+or portability to other versions or forks has not been evaluated.


### PR DESCRIPTION
For security vulnerability patches released under Redis Open Source 7.4 and thereafter, Redis permits users of earlier versions (7.2 and prior) to access patches under the BSD3 license noted in REDISCONTRIBUTIONS.txt instead of the full license requirements described in LICENSE.txt.