### PR TITLE
Fix uninitializeed RMConfigIterator::is_glob causing MSan warnings

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -13607,9 +13607,11 @@ RedisModuleConfigIterator *RM_ConfigIteratorCreate(RedisModuleCtx *ctx, const ch
     if (pattern != NULL) {
         iter->pattern = sdsnew(pattern);
         iter->is_glob = (strpbrk(pattern, "*?[") != NULL);
-    } else
+    } else {
         iter->pattern = NULL;
- 
+        iter->is_glob = false;
+    }
+
     if (ctx != NULL) autoMemoryAdd(ctx,REDISMODULE_AM_CONFIG, iter);
     return iter;
 }


### PR DESCRIPTION
Recent [PR](https://github.com/redis/redis/pull/14051) causes MSan to fail during daily CI with uninitialized value warning.
It is not a bug per se as the uninitialized member is dependent on another member not being NULL. 
With this PR now MSan does not complain.