### PR TITLE
fix mem leak in cliInitHelp

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -943,7 +943,10 @@ static void cliInitHelp(void) {
         cliLegacyIntegrateHelp();
         return;
     };
-    if (commandTable->type != REDIS_REPLY_MAP && commandTable->type != REDIS_REPLY_ARRAY) return;
+    if (commandTable->type != REDIS_REPLY_MAP && commandTable->type != REDIS_REPLY_ARRAY) {
+        freeReplyObject(commandTable);
+        return;
+    }
 
     /* Scan the array reported by COMMAND DOCS and fill in the entries */
     helpEntriesLen = cliCountCommands(commandTable);


### PR DESCRIPTION
fix a memory leak in cliInitHelp @ redis-cli.c; fix #14180 