### PR TITLE
append AOF into aof_buf directly

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1414,13 +1414,11 @@ void feedAppendOnlyFile(int dictid, robj **argv, int argc) {
     if (server.aof_state == AOF_ON ||
         (server.aof_state == AOF_WAIT_REWRITE && server.child_type == CHILD_TYPE_AOF))
     {
-        sds buf = server.aof_buf;
-
         /* Feed timestamp if needed */
         if (server.aof_timestamp_enabled) {
             sds ts = genAofTimestampAnnotationIfNeeded(0);
             if (ts != NULL) {
-                buf = sdscatsds(buf, ts);
+                server.aof_buf = sdscatsds(server.aof_buf, ts);
                 sdsfree(ts);
             }
         }
@@ -1431,16 +1429,14 @@ void feedAppendOnlyFile(int dictid, robj **argv, int argc) {
             char seldb[64];
 
             snprintf(seldb,sizeof(seldb),"%d",dictid);
-            buf = sdscatprintf(buf,"*2\r\n$6\r\nSELECT\r\n$%lu\r\n%s\r\n",
+            server.aof_buf = sdscatprintf(server.aof_buf,"*2\r\n$6\r\nSELECT\r\n$%lu\r\n%s\r\n",
                 (unsigned long)strlen(seldb),seldb);
             server.aof_selected_db = dictid;
         }
 
         /* All commands should be propagated the same way in AOF as in replication.
          * No need for AOF-specific translation. */
-        buf = catAppendOnlyGenericCommand(buf,argc,argv);
-
-        server.aof_buf = buf;
+        server.aof_buf = catAppendOnlyGenericCommand(server.aof_buf,argc,argv);
     } else {
         if (dictid != -1 && dictid != server.aof_selected_db) {
             server.aof_selected_db = dictid;

--- a/src/aof.c
+++ b/src/aof.c
@@ -1406,33 +1406,7 @@ sds genAofTimestampAnnotationIfNeeded(int force) {
  * argc   - Number of values in argv
  */
 void feedAppendOnlyFile(int dictid, robj **argv, int argc) {
-    sds buf = sdsempty();
-
     serverAssert(dictid == -1 || (dictid >= 0 && dictid < server.dbnum));
-
-    /* Feed timestamp if needed */
-    if (server.aof_timestamp_enabled) {
-        sds ts = genAofTimestampAnnotationIfNeeded(0);
-        if (ts != NULL) {
-            buf = sdscatsds(buf, ts);
-            sdsfree(ts);
-        }
-    }
-
-    /* The DB this command was targeting is not the same as the last command
-     * we appended. To issue a SELECT command is needed. */
-    if (dictid != -1 && dictid != server.aof_selected_db) {
-        char seldb[64];
-
-        snprintf(seldb,sizeof(seldb),"%d",dictid);
-        buf = sdscatprintf(buf,"*2\r\n$6\r\nSELECT\r\n$%lu\r\n%s\r\n",
-            (unsigned long)strlen(seldb),seldb);
-        server.aof_selected_db = dictid;
-    }
-
-    /* All commands should be propagated the same way in AOF as in replication.
-     * No need for AOF-specific translation. */
-    buf = catAppendOnlyGenericCommand(buf,argc,argv);
 
     /* Append to the AOF buffer. This will be flushed on disk just before
      * of re-entering the event loop, so before the client will get a
@@ -1440,10 +1414,38 @@ void feedAppendOnlyFile(int dictid, robj **argv, int argc) {
     if (server.aof_state == AOF_ON ||
         (server.aof_state == AOF_WAIT_REWRITE && server.child_type == CHILD_TYPE_AOF))
     {
-        server.aof_buf = sdscatlen(server.aof_buf, buf, sdslen(buf));
-    }
+        sds buf = server.aof_buf;
 
-    sdsfree(buf);
+        /* Feed timestamp if needed */
+        if (server.aof_timestamp_enabled) {
+            sds ts = genAofTimestampAnnotationIfNeeded(0);
+            if (ts != NULL) {
+                buf = sdscatsds(buf, ts);
+                sdsfree(ts);
+            }
+        }
+
+        /* The DB this command was targeting is not the same as the last command
+        * we appended. To issue a SELECT command is needed. */
+        if (dictid != -1 && dictid != server.aof_selected_db) {
+            char seldb[64];
+
+            snprintf(seldb,sizeof(seldb),"%d",dictid);
+            buf = sdscatprintf(buf,"*2\r\n$6\r\nSELECT\r\n$%lu\r\n%s\r\n",
+                (unsigned long)strlen(seldb),seldb);
+            server.aof_selected_db = dictid;
+        }
+
+        /* All commands should be propagated the same way in AOF as in replication.
+         * No need for AOF-specific translation. */
+        buf = catAppendOnlyGenericCommand(buf,argc,argv);
+
+        server.aof_buf = buf;
+    } else {
+        if (dictid != -1 && dictid != server.aof_selected_db) {
+            server.aof_selected_db = dictid;
+        }
+    }
 }
 
 /* ----------------------------------------------------------------------------


### PR DESCRIPTION
in `feedAppendOnlyFile` the AOF is saved in a sds buf at first, and append it into `server.aof_buf`, why don't we append the AOF into `server.aof_buf` directly?