### PR TITLE
Move WITHATTRIBS token from vlinks to vsim

### DIFF
--- a/modules/vector-sets/commands.json
+++ b/modules/vector-sets/commands.json
@@ -167,6 +167,12 @@
         "optional": true
       },
       {
+        "token": "WITHATTRIBS",
+        "name": "withattribs",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
         "token": "COUNT",
         "name": "count",
         "type": "integer",
@@ -289,12 +295,6 @@
       {
         "token": "WITHSCORES",
         "name": "withscores",
-        "type": "pure-token",
-        "optional": true
-      },
-      {
-        "token": "WITHATTRIBS",
-        "name": "withattribs",
         "type": "pure-token",
         "optional": true
       }


### PR DESCRIPTION
# Description
The `WITHATTRIBS` token was incorrectly documented under the `vlinks` command in #14065 