### PR TITLE
Update debian buster sources to archive.debian.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: make
       run: |
+        sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
+        sed -i 's|http://security.debian.org|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
         apt-get update && apt-get install -y build-essential
         make REDIS_CFLAGS='-Werror'
 


### PR DESCRIPTION
http://deb.debian.org/debian no longer serves Debian 10 (buster); it has been moved to http://archive.debian.org/debian.