### PR TITLE
Use pread instead of lseek + read in sendBulkToSlave to reduce system…

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1582,13 +1582,7 @@ void sendBulkToSlave(connection *conn) {
     }
 
     /* If the preamble was already transferred, send the RDB bulk data. */
-    if (lseek(slave->repldbfd,slave->repldboff,SEEK_SET) == -1) {
-	serverLog(LL_WARNING,"Failed to lseek the RDB file to offset %lld for replica %s: %s",
-	    (long long)slave->repldboff, replicationGetSlaveName(slave), strerror(errno));
-	freeClient(slave);
-	return;
-    }
-    buflen = read(slave->repldbfd,buf,PROTO_IOBUF_LEN);
+    buflen = pread(slave->repldbfd,buf,PROTO_IOBUF_LEN,slave->repldboff);
     if (buflen <= 0) {
         serverLog(LL_WARNING,"Read error sending DB to replica: %s",
             (buflen == 0) ? "premature EOF" : strerror(errno));


### PR DESCRIPTION

This PR replaces the combination of `lseek` and `read` with a single `pread` call in `sendBulkToSlave` to reduce system calls and potentially improve performance.


