### PR TITLE
Add vector set acl category

### DIFF
--- a/modules/vector-sets/commands.json
+++ b/modules/vector-sets/commands.json
@@ -97,7 +97,7 @@
       "WRITE",
       "DENYOOM"
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": ["VECTORSET", "WRITE"]
   },
   "VREM": {
     "summary": "Remove one or more elements from a vector set",
@@ -120,7 +120,7 @@
         "multiple": true
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": ["VECTORSET", "WRITE"]
   },
   "VSIM": {
     "summary": "Return elements by vector similarity",
@@ -211,7 +211,7 @@
         "optional": true
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": ["VECTORSET", "READ"]
   },
   "VDIM": {
     "summary": "Return the dimension of vectors in the vector set",
@@ -230,7 +230,7 @@
         "type": "key"
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": ["VECTORSET", "READ", "FAST"]
   },
   "VCARD": {
     "summary": "Return the number of elements in a vector set",
@@ -249,7 +249,7 @@
         "type": "key"
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": ["VECTORSET", "READ", "FAST"]
   },
   "VEMB": {
     "summary": "Return the vector associated with an element",
@@ -277,7 +277,7 @@
         "optional": true
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": ["VECTORSET", "READ", "FAST"]
   },
   "VLINKS": {
     "summary": "Return the neighbors of an element at each layer in the HNSW graph",
@@ -305,7 +305,7 @@
         "optional": true
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": ["VECTORSET", "READ", "FAST"]
   },
   "VINFO": {
     "summary": "Return information about a vector set",
@@ -324,7 +324,7 @@
         "type": "key"
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": ["VECTORSET", "READ", "FAST"]
   },
   "VSETATTR": {
     "summary": "Associate or remove the JSON attributes of elements",
@@ -350,7 +350,7 @@
         "type": "string"
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": ["VECTORSET", "WRITE", "FAST"]
   },
   "VGETATTR": {
     "summary": "Retrieve the JSON attributes of elements",
@@ -372,7 +372,7 @@
         "type": "string"
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": ["VECTORSET", "READ", "FAST"]
   },
   "VRANDMEMBER": {
     "summary": "Return one or multiple random members from a vector set",
@@ -395,6 +395,6 @@
         "optional": true
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": ["VECTORSET", "READ"]
   }
 }

--- a/modules/vector-sets/commands.json
+++ b/modules/vector-sets/commands.json
@@ -97,7 +97,7 @@
       "WRITE",
       "DENYOOM"
     ],
-    "acl_categories": ["VECTORSET", "WRITE"]
+    "acl_categories": ["VECTORSET"]
   },
   "VREM": {
     "summary": "Remove one or more elements from a vector set",
@@ -120,7 +120,7 @@
         "multiple": true
       }
     ],
-    "acl_categories": ["VECTORSET", "WRITE"]
+    "acl_categories": ["VECTORSET"]
   },
   "VSIM": {
     "summary": "Return elements by vector similarity",
@@ -211,7 +211,7 @@
         "optional": true
       }
     ],
-    "acl_categories": ["VECTORSET", "READ"]
+    "acl_categories": ["VECTORSET"]
   },
   "VDIM": {
     "summary": "Return the dimension of vectors in the vector set",
@@ -230,7 +230,7 @@
         "type": "key"
       }
     ],
-    "acl_categories": ["VECTORSET", "READ", "FAST"]
+    "acl_categories": ["VECTORSET"]
   },
   "VCARD": {
     "summary": "Return the number of elements in a vector set",
@@ -249,7 +249,7 @@
         "type": "key"
       }
     ],
-    "acl_categories": ["VECTORSET", "READ", "FAST"]
+    "acl_categories": ["VECTORSET"]
   },
   "VEMB": {
     "summary": "Return the vector associated with an element",
@@ -277,7 +277,7 @@
         "optional": true
       }
     ],
-    "acl_categories": ["VECTORSET", "READ", "FAST"]
+    "acl_categories": ["VECTORSET"]
   },
   "VLINKS": {
     "summary": "Return the neighbors of an element at each layer in the HNSW graph",
@@ -305,7 +305,7 @@
         "optional": true
       }
     ],
-    "acl_categories": ["VECTORSET", "READ", "FAST"]
+    "acl_categories": ["VECTORSET"]
   },
   "VINFO": {
     "summary": "Return information about a vector set",
@@ -324,7 +324,7 @@
         "type": "key"
       }
     ],
-    "acl_categories": ["VECTORSET", "READ", "FAST"]
+    "acl_categories": ["VECTORSET"]
   },
   "VSETATTR": {
     "summary": "Associate or remove the JSON attributes of elements",
@@ -350,7 +350,7 @@
         "type": "string"
       }
     ],
-    "acl_categories": ["VECTORSET", "WRITE", "FAST"]
+    "acl_categories": ["VECTORSET"]
   },
   "VGETATTR": {
     "summary": "Retrieve the JSON attributes of elements",
@@ -372,7 +372,7 @@
         "type": "string"
       }
     ],
-    "acl_categories": ["VECTORSET", "READ", "FAST"]
+    "acl_categories": ["VECTORSET"]
   },
   "VRANDMEMBER": {
     "summary": "Return one or multiple random members from a vector set",
@@ -395,6 +395,6 @@
         "optional": true
       }
     ],
-    "acl_categories": ["VECTORSET", "READ"]
+    "acl_categories": ["VECTORSET"]
   }
 }

--- a/modules/vector-sets/commands.json
+++ b/modules/vector-sets/commands.json
@@ -96,7 +96,15 @@
     "command_flags": [
       "WRITE",
       "DENYOOM"
-    ]
+    ],
+    "key_specs": [
+      {
+        "flags": ["RW", "INSERT"],
+        "begin_search": { "index": { "pos": 1 } },
+        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
+      }
+    ],
+    "acl_categories": ["VECTORSET"]
   },
   "VREM": {
     "summary": "Remove one or more elements from a vector set",
@@ -118,7 +126,15 @@
         "type": "string",
         "multiple": true
       }
-    ]
+    ],
+    "key_specs": [
+      {
+        "flags": ["RW", "DELETE"],
+        "begin_search": { "index": { "pos": 1 } },
+        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
+      }
+    ],
+    "acl_categories": ["VECTORSET"]
   },
   "VSIM": {
     "summary": "Return elements by vector similarity",
@@ -208,7 +224,15 @@
         "type": "pure-token",
         "optional": true
       }
-    ]
+    ],
+    "key_specs": [
+      {
+        "flags": ["RO", "ACCESS"],
+        "begin_search": { "index": { "pos": 1 } },
+        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
+      }
+    ],
+    "acl_categories": ["VECTORSET"]
   },
   "VDIM": {
     "summary": "Return the dimension of vectors in the vector set",
@@ -226,7 +250,15 @@
         "name": "key",
         "type": "key"
       }
-    ]
+    ],
+    "key_specs": [
+      {
+        "flags": ["RO", "ACCESS"],
+        "begin_search": { "index": { "pos": 1 } },
+        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
+      }
+    ],
+    "acl_categories": ["VECTORSET"]
   },
   "VCARD": {
     "summary": "Return the number of elements in a vector set",
@@ -244,7 +276,15 @@
         "name": "key",
         "type": "key"
       }
-    ]
+    ],
+    "key_specs": [
+      {
+        "flags": ["RO", "ACCESS"],
+        "begin_search": { "index": { "pos": 1 } },
+        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
+      }
+    ],
+    "acl_categories": ["VECTORSET"]
   },
   "VEMB": {
     "summary": "Return the vector associated with an element",
@@ -271,7 +311,15 @@
         "type": "pure-token",
         "optional": true
       }
-    ]
+    ],
+    "key_specs": [
+      {
+        "flags": ["RO", "ACCESS"],
+        "begin_search": { "index": { "pos": 1 } },
+        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
+      }
+    ],
+    "acl_categories": ["VECTORSET"]
   },
   "VLINKS": {
     "summary": "Return the neighbors of an element at each layer in the HNSW graph",
@@ -298,7 +346,15 @@
         "type": "pure-token",
         "optional": true
       }
-    ]
+    ],
+    "key_specs": [
+      {
+        "flags": ["RO", "ACCESS"],
+        "begin_search": { "index": { "pos": 1 } },
+        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
+      }
+    ],
+    "acl_categories": ["VECTORSET"]
   },
   "VINFO": {
     "summary": "Return information about a vector set",
@@ -316,7 +372,15 @@
         "name": "key",
         "type": "key"
       }
-    ]
+    ],
+    "key_specs": [
+      {
+        "flags": ["RO", "ACCESS"],
+        "begin_search": { "index": { "pos": 1 } },
+        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
+      }
+    ],
+    "acl_categories": ["VECTORSET"]
   },
   "VSETATTR": {
     "summary": "Associate or remove the JSON attributes of elements",
@@ -341,7 +405,15 @@
         "name": "json",
         "type": "string"
       }
-    ]
+    ],
+    "key_specs": [
+      {
+        "flags": ["RW", "UPDATE"],
+        "begin_search": { "index": { "pos": 1 } },
+        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
+      }
+    ],
+    "acl_categories": ["VECTORSET"]
   },
   "VGETATTR": {
     "summary": "Retrieve the JSON attributes of elements",
@@ -362,7 +434,15 @@
         "name": "element",
         "type": "string"
       }
-    ]
+    ],
+    "key_specs": [
+      {
+        "flags": ["RO", "ACCESS"],
+        "begin_search": { "index": { "pos": 1 } },
+        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
+      }
+    ],
+    "acl_categories": ["VECTORSET"]
   },
   "VRANDMEMBER": {
     "summary": "Return one or multiple random members from a vector set",
@@ -384,6 +464,14 @@
         "type": "integer",
         "optional": true
       }
-    ]
+    ],
+    "key_specs": [
+      {
+        "flags": ["RO", "ACCESS"],
+        "begin_search": { "index": { "pos": 1 } },
+        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
+      }
+    ],
+    "acl_categories": ["VECTORSET"]
   }
 }

--- a/modules/vector-sets/commands.json
+++ b/modules/vector-sets/commands.json
@@ -97,13 +97,6 @@
       "WRITE",
       "DENYOOM"
     ],
-    "key_specs": [
-      {
-        "flags": ["RW", "INSERT"],
-        "begin_search": { "index": { "pos": 1 } },
-        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
-      }
-    ],
     "acl_categories": ["VECTORSET"]
   },
   "VREM": {
@@ -125,13 +118,6 @@
         "name": "element",
         "type": "string",
         "multiple": true
-      }
-    ],
-    "key_specs": [
-      {
-        "flags": ["RW", "DELETE"],
-        "begin_search": { "index": { "pos": 1 } },
-        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
       }
     ],
     "acl_categories": ["VECTORSET"]
@@ -225,13 +211,6 @@
         "optional": true
       }
     ],
-    "key_specs": [
-      {
-        "flags": ["RO", "ACCESS"],
-        "begin_search": { "index": { "pos": 1 } },
-        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
-      }
-    ],
     "acl_categories": ["VECTORSET"]
   },
   "VDIM": {
@@ -251,13 +230,6 @@
         "type": "key"
       }
     ],
-    "key_specs": [
-      {
-        "flags": ["RO", "ACCESS"],
-        "begin_search": { "index": { "pos": 1 } },
-        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
-      }
-    ],
     "acl_categories": ["VECTORSET"]
   },
   "VCARD": {
@@ -275,13 +247,6 @@
       {
         "name": "key",
         "type": "key"
-      }
-    ],
-    "key_specs": [
-      {
-        "flags": ["RO", "ACCESS"],
-        "begin_search": { "index": { "pos": 1 } },
-        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
       }
     ],
     "acl_categories": ["VECTORSET"]
@@ -312,13 +277,6 @@
         "optional": true
       }
     ],
-    "key_specs": [
-      {
-        "flags": ["RO", "ACCESS"],
-        "begin_search": { "index": { "pos": 1 } },
-        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
-      }
-    ],
     "acl_categories": ["VECTORSET"]
   },
   "VLINKS": {
@@ -347,13 +305,6 @@
         "optional": true
       }
     ],
-    "key_specs": [
-      {
-        "flags": ["RO", "ACCESS"],
-        "begin_search": { "index": { "pos": 1 } },
-        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
-      }
-    ],
     "acl_categories": ["VECTORSET"]
   },
   "VINFO": {
@@ -371,13 +322,6 @@
       {
         "name": "key",
         "type": "key"
-      }
-    ],
-    "key_specs": [
-      {
-        "flags": ["RO", "ACCESS"],
-        "begin_search": { "index": { "pos": 1 } },
-        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
       }
     ],
     "acl_categories": ["VECTORSET"]
@@ -406,13 +350,6 @@
         "type": "string"
       }
     ],
-    "key_specs": [
-      {
-        "flags": ["RW", "UPDATE"],
-        "begin_search": { "index": { "pos": 1 } },
-        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
-      }
-    ],
     "acl_categories": ["VECTORSET"]
   },
   "VGETATTR": {
@@ -433,13 +370,6 @@
       {
         "name": "element",
         "type": "string"
-      }
-    ],
-    "key_specs": [
-      {
-        "flags": ["RO", "ACCESS"],
-        "begin_search": { "index": { "pos": 1 } },
-        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
       }
     ],
     "acl_categories": ["VECTORSET"]
@@ -463,13 +393,6 @@
         "name": "count",
         "type": "integer",
         "optional": true
-      }
-    ],
-    "key_specs": [
-      {
-        "flags": ["RO", "ACCESS"],
-        "begin_search": { "index": { "pos": 1 } },
-        "find_keys": { "range": { "lastkey": 0, "step": 1, "limit": 0 } }
       }
     ],
     "acl_categories": ["VECTORSET"]

--- a/modules/vector-sets/commands.json
+++ b/modules/vector-sets/commands.json
@@ -6,6 +6,13 @@
     "since": "8.0.0",
     "arity": -1,
     "function": "vaddCommand",
+    "command_flags": [
+      "WRITE",
+      "DENYOOM"
+    ],
+    "acl_categories": [
+      "VECTORSET"
+    ],
     "arguments": [
       {
         "name": "key",
@@ -92,13 +99,6 @@
         "type": "integer",
         "optional": true
       }
-    ],
-    "command_flags": [
-      "WRITE",
-      "DENYOOM"
-    ],
-    "acl_categories": [
-      "VECTORSET"
     ]
   },
   "VREM": {
@@ -111,6 +111,9 @@
     "command_flags": [
       "WRITE"
     ],
+    "acl_categories": [
+      "VECTORSET"
+    ],
     "arguments": [
       {
         "name": "key",
@@ -121,9 +124,6 @@
         "type": "string",
         "multiple": true
       }
-    ],
-    "acl_categories": [
-      "VECTORSET"
     ]
   },
   "VSIM": {
@@ -135,6 +135,9 @@
     "function": "vsimCommand",
     "command_flags": [
       "READONLY"
+    ],
+    "acl_categories": [
+      "VECTORSET"
     ],
     "arguments": [
       {
@@ -214,9 +217,6 @@
         "type": "pure-token",
         "optional": true
       }
-    ],
-    "acl_categories": [
-      "VECTORSET"
     ]
   },
   "VDIM": {
@@ -230,14 +230,14 @@
       "READONLY",
       "FAST"
     ],
+    "acl_categories": [
+      "VECTORSET"
+    ],
     "arguments": [
       {
         "name": "key",
         "type": "key"
       }
-    ],
-    "acl_categories": [
-      "VECTORSET"
     ]
   },
   "VCARD": {
@@ -251,14 +251,14 @@
       "READONLY",
       "FAST"
     ],
+    "acl_categories": [
+      "VECTORSET"
+    ],
     "arguments": [
       {
         "name": "key",
         "type": "key"
       }
-    ],
-    "acl_categories": [
-      "VECTORSET"
     ]
   },
   "VEMB": {
@@ -270,6 +270,9 @@
     "function": "vembCommand",
     "command_flags": [
       "READONLY"
+    ],
+    "acl_categories": [
+      "VECTORSET"
     ],
     "arguments": [
       {
@@ -286,9 +289,6 @@
         "type": "pure-token",
         "optional": true
       }
-    ],
-    "acl_categories": [
-      "VECTORSET"
     ]
   },
   "VLINKS": {
@@ -300,6 +300,9 @@
     "function": "vlinksCommand",
     "command_flags": [
       "READONLY"
+    ],
+    "acl_categories": [
+      "VECTORSET"
     ],
     "arguments": [
       {
@@ -316,9 +319,6 @@
         "type": "pure-token",
         "optional": true
       }
-    ],
-    "acl_categories": [
-      "VECTORSET"
     ]
   },
   "VINFO": {
@@ -332,14 +332,14 @@
       "READONLY",
       "FAST"
     ],
+    "acl_categories": [
+      "VECTORSET"
+    ],
     "arguments": [
       {
         "name": "key",
         "type": "key"
       }
-    ],
-    "acl_categories": [
-      "VECTORSET"
     ]
   },
   "VSETATTR": {
@@ -351,6 +351,9 @@
     "function": "vsetattrCommand",
     "command_flags": [
       "WRITE"
+    ],
+    "acl_categories": [
+      "VECTORSET"
     ],
     "arguments": [
       {
@@ -365,9 +368,6 @@
         "name": "json",
         "type": "string"
       }
-    ],
-    "acl_categories": [
-      "VECTORSET"
     ]
   },
   "VGETATTR": {
@@ -380,6 +380,9 @@
     "command_flags": [
       "READONLY"
     ],
+    "acl_categories": [
+      "VECTORSET"
+    ],
     "arguments": [
       {
         "name": "key",
@@ -389,9 +392,6 @@
         "name": "element",
         "type": "string"
       }
-    ],
-    "acl_categories": [
-      "VECTORSET"
     ]
   },
   "VRANDMEMBER": {
@@ -404,6 +404,9 @@
     "command_flags": [
       "READONLY"
     ],
+    "acl_categories": [
+      "VECTORSET"
+    ],
     "arguments": [
       {
         "name": "key",
@@ -414,9 +417,6 @@
         "type": "integer",
         "optional": true
       }
-    ],
-    "acl_categories": [
-      "VECTORSET"
     ]
   }
 }

--- a/modules/vector-sets/commands.json
+++ b/modules/vector-sets/commands.json
@@ -97,7 +97,9 @@
       "WRITE",
       "DENYOOM"
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": [
+        "VECTORSET"
+    ]
   },
   "VREM": {
     "summary": "Remove one or more elements from a vector set",

--- a/modules/vector-sets/commands.json
+++ b/modules/vector-sets/commands.json
@@ -98,7 +98,7 @@
       "DENYOOM"
     ],
     "acl_categories": [
-        "VECTORSET"
+      "VECTORSET"
     ]
   },
   "VREM": {
@@ -122,7 +122,9 @@
         "multiple": true
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": [
+      "VECTORSET"
+    ]
   },
   "VSIM": {
     "summary": "Return elements by vector similarity",
@@ -213,7 +215,9 @@
         "optional": true
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": [
+      "VECTORSET"
+    ]
   },
   "VDIM": {
     "summary": "Return the dimension of vectors in the vector set",
@@ -232,7 +236,9 @@
         "type": "key"
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": [
+      "VECTORSET"
+    ]
   },
   "VCARD": {
     "summary": "Return the number of elements in a vector set",
@@ -251,7 +257,9 @@
         "type": "key"
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": [
+      "VECTORSET"
+    ]
   },
   "VEMB": {
     "summary": "Return the vector associated with an element",
@@ -279,7 +287,9 @@
         "optional": true
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": [
+      "VECTORSET"
+    ]
   },
   "VLINKS": {
     "summary": "Return the neighbors of an element at each layer in the HNSW graph",
@@ -307,7 +317,9 @@
         "optional": true
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": [
+      "VECTORSET"
+    ]
   },
   "VINFO": {
     "summary": "Return information about a vector set",
@@ -326,7 +338,9 @@
         "type": "key"
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": [
+      "VECTORSET"
+    ]
   },
   "VSETATTR": {
     "summary": "Associate or remove the JSON attributes of elements",
@@ -352,7 +366,9 @@
         "type": "string"
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": [
+      "VECTORSET"
+    ]
   },
   "VGETATTR": {
     "summary": "Retrieve the JSON attributes of elements",
@@ -374,7 +390,9 @@
         "type": "string"
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": [
+      "VECTORSET"
+    ]
   },
   "VRANDMEMBER": {
     "summary": "Return one or multiple random members from a vector set",
@@ -397,6 +415,8 @@
         "optional": true
       }
     ],
-    "acl_categories": ["VECTORSET"]
+    "acl_categories": [
+      "VECTORSET"
+    ]
   }
 }

--- a/modules/vector-sets/tests/acls.py
+++ b/modules/vector-sets/tests/acls.py
@@ -1,6 +1,4 @@
 from test import TestCase
-
-
 class AclCategories(TestCase):
     VECTOR_SET_COMMANDS = {
         b"VADD",

--- a/modules/vector-sets/tests/acls.py
+++ b/modules/vector-sets/tests/acls.py
@@ -22,12 +22,12 @@ class AclCategories(TestCase):
 
     def test(self):
         vector_set_commands = set(self.redis.execute_command("ACL CAT VECTORSET"))
-        assert AclCategories.VECTOR_SET_COMMANDS == vector_set_commands, (
+        assert self.VECTOR_SET_COMMANDS == vector_set_commands, (
             f"Expected {AclCategories.VECTOR_SET_COMMANDS}, got {vector_set_commands}"
         )
 
         readonly_commands = set(self.redis.execute_command("ACL CAT READ"))
-        assert AclCategories.VECTOR_SET_COMMANDS & readonly_commands == {
+        assert self.VECTOR_SET_COMMANDS & readonly_commands == {
             b"VGETATTR",
             b"VSIM",
             b"VCARD",
@@ -40,8 +40,19 @@ class AclCategories(TestCase):
         }
 
         write_commands = set(self.redis.execute_command("ACL CAT WRITE"))
-        assert AclCategories.VECTOR_SET_COMMANDS & write_commands == {
+        assert self.VECTOR_SET_COMMANDS & write_commands == {
             b"VADD",
             b"VREM",
+            b"VSETATTR",
+        }
+
+        fast_commands = set(self.redis.execute_command("ACL CAT FAST"))
+        assert self.VECTOR_SET_COMMANDS & fast_commands == {
+            b"VCARD",
+            b"VDIM",
+            b"VEMB",
+            b"VGETATTR",
+            b"VINFO",
+            b"VLINKS",
             b"VSETATTR",
         }

--- a/modules/vector-sets/tests/acls.py
+++ b/modules/vector-sets/tests/acls.py
@@ -1,0 +1,47 @@
+from test import TestCase
+
+
+class AclCategories(TestCase):
+    VECTOR_SET_COMMANDS = {
+        b"VADD",
+        b"VCARD",
+        b"VDIM",
+        b"VEMB",
+        b"VGETATTR",
+        b"VINFO",
+        b"VISMEMBER",
+        b"VLINKS",
+        b"VRANDMEMBER",
+        b"VREM",
+        b"VSETATTR",
+        b"VSIM",
+    }
+
+    def getname(self):
+        return "Vector set command ACL categories"
+
+    def test(self):
+        vector_set_commands = set(self.redis.execute_command("ACL CAT VECTORSET"))
+        assert AclCategories.VECTOR_SET_COMMANDS == vector_set_commands, (
+            f"Expected {AclCategories.VECTOR_SET_COMMANDS}, got {vector_set_commands}"
+        )
+
+        readonly_commands = set(self.redis.execute_command("ACL CAT READ"))
+        assert AclCategories.VECTOR_SET_COMMANDS & readonly_commands == {
+            b"VGETATTR",
+            b"VSIM",
+            b"VCARD",
+            b"VISMEMBER",
+            b"VDIM",
+            b"VRANDMEMBER",
+            b"VINFO",
+            b"VLINKS",
+            b"VEMB",
+        }
+
+        write_commands = set(self.redis.execute_command("ACL CAT WRITE"))
+        assert AclCategories.VECTOR_SET_COMMANDS & write_commands == {
+            b"VADD",
+            b"VREM",
+            b"VSETATTR",
+        }

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -106,7 +106,6 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include "../../src/redismodule.h"
-#include "../../src/sds.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -2042,19 +2041,20 @@ int VectorSets_InitModuleConfig(RedisModuleCtx *ctx) {
 
 /* Create the command and set its acl categories  */
 int VectorSets_CreateCommandWithAcls(RedisModuleCtx *ctx, char *name, RedisModuleCmdFunc func, const char *strflags, int firstkey, int lastkey, int keystep, const char *acls) {
+    RedisModule_AutoMemory(ctx);
+
     if (RedisModule_CreateCommand(ctx, name, func, strflags, firstkey, lastkey, keystep) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
     RedisModuleCommand *cmd = RedisModule_GetCommand(ctx, name);
     if (cmd == NULL)
         return REDISMODULE_ERR;
-    sds acl_categories = sdsnew("vectorset");
-    if (acls && strlen(acls) > 0)
-       acl_categories = sdscatfmt(acl_categories, " %s", acls);
-    if (RedisModule_SetCommandACLCategories(cmd, acl_categories) == REDISMODULE_ERR) {
-        sdsfree(acl_categories);
+    RedisModuleString *acl_categories =
+        acls && strlen(acls) > 0
+        ? RedisModule_CreateStringPrintf(ctx, "vectorset %s", acls)
+        : RedisModule_CreateString(ctx, "vectorset", 9);
+    if (RedisModule_SetCommandACLCategories(cmd, RedisModule_StringPtrLen(acl_categories, NULL)) == REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }
-    sdsfree(acl_categories);
     return REDISMODULE_OK;
 }
 

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -2040,7 +2040,7 @@ int VectorSets_InitModuleConfig(RedisModuleCtx *ctx) {
     return REDISMODULE_OK;
 }
 
-/* Create the command and set it's acl categories  */
+/* Create the command and set its acl categories  */
 int VectorSets_CreateCommandWithAcls(RedisModuleCtx *ctx, char *name, RedisModuleCmdFunc func, const char *strflags, int firstkey, int lastkey, int keystep, const char *acls) {
     if (RedisModule_CreateCommand(ctx, name, func, strflags, firstkey, lastkey, keystep) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
@@ -2048,7 +2048,7 @@ int VectorSets_CreateCommandWithAcls(RedisModuleCtx *ctx, char *name, RedisModul
     if (cmd == NULL)
         return REDISMODULE_ERR;
     sds acl_categories = sdsnew("vectorset");
-    if(acls && strlen(acls) > 0)
+    if (acls && strlen(acls) > 0)
        acl_categories = sdscatfmt(acl_categories, " %s", acls);
     if (RedisModule_SetCommandACLCategories(cmd, acl_categories) == REDISMODULE_ERR) {
         sdsfree(acl_categories);

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -106,6 +106,7 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include "../../src/redismodule.h"
+#include "../../src/sds.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -2039,14 +2040,21 @@ int VectorSets_InitModuleConfig(RedisModuleCtx *ctx) {
     return REDISMODULE_OK;
 }
 
-/* Create the command and associate it with the 'vectorset' acl category  */
-int VectorSets_CreateCommandWithAcls(RedisModuleCtx * ctx, char * name, RedisModuleCmdFunc func, const char * strflags, int firstkey, int lastkey, int keystep) {
-    if (RedisModule_CreateCommand(ctx, name, func, strflags, firstkey, lastkey, keystep) == REDISMODULE_ERR) 
-        return REDISMODULE_ERR; 
-    RedisModuleCommand *cmd = RedisModule_GetCommand(ctx, name); 
-    if (cmd) {
-        RedisModule_SetCommandACLCategories(cmd, "vectorset"); 
+/* Create the command and set it's acl categories  */
+int VectorSets_CreateCommandWithAcls(RedisModuleCtx *ctx, char *name, RedisModuleCmdFunc func, const char *strflags, int firstkey, int lastkey, int keystep, const char *acls) {
+    if (RedisModule_CreateCommand(ctx, name, func, strflags, firstkey, lastkey, keystep) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    RedisModuleCommand *cmd = RedisModule_GetCommand(ctx, name);
+    if (cmd == NULL)
+        return REDISMODULE_ERR;
+    sds acl_categories = sdsnew("vectorset");
+    if(acls && strlen(acls) > 0)
+       acl_categories = sdscatfmt(sdsnew("vectorset"), " %s", acls);
+    if (RedisModule_SetCommandACLCategories(cmd, acl_categories) == REDISMODULE_ERR) {
+        sdsfree(acl_categories);
+        return REDISMODULE_ERR;
     }
+    sdsfree(acl_categories);
     return REDISMODULE_OK;
 }
 
@@ -2083,41 +2091,41 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     VectorSetType = RedisModule_CreateDataType(ctx,"vectorset",0,&tm);
     if (VectorSetType == NULL) return REDISMODULE_ERR;
 
-    if (VectorSets_CreateCommandWithAcls(ctx, "VADD", 
-        VADD_RedisCommand, "write deny-oom", 1, 1, 1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VADD",
+        VADD_RedisCommand, "write deny-oom", 1, 1, 1, "write") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-    if (VectorSets_CreateCommandWithAcls(ctx, "VREM", 
-        VREM_RedisCommand, "write", 1, 1, 1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VREM",
+        VREM_RedisCommand, "write", 1, 1, 1, "write") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-    if (VectorSets_CreateCommandWithAcls(ctx, "VSIM", 
-        VSIM_RedisCommand, "readonly", 1, 1, 1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VSIM",
+        VSIM_RedisCommand, "readonly", 1, 1, 1, "read") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-    if (VectorSets_CreateCommandWithAcls(ctx, "VDIM", 
-        VDIM_RedisCommand, "readonly fast", 1, 1, 1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VDIM",
+        VDIM_RedisCommand, "readonly fast", 1, 1, 1, "read fast") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-    if (VectorSets_CreateCommandWithAcls(ctx, "VCARD", 
-        VCARD_RedisCommand, "readonly fast", 1, 1, 1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VCARD",
+        VCARD_RedisCommand, "readonly fast", 1, 1, 1, "read fast") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-    if (VectorSets_CreateCommandWithAcls(ctx, "VEMB", 
-        VEMB_RedisCommand, "readonly fast", 1, 1, 1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VEMB",
+        VEMB_RedisCommand, "readonly fast", 1, 1, 1, "read fast") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-    if (VectorSets_CreateCommandWithAcls(ctx, "VLINKS", 
-        VLINKS_RedisCommand, "readonly fast", 1, 1, 1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VLINKS",
+        VLINKS_RedisCommand, "readonly fast", 1, 1, 1, "read fast") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-    if (VectorSets_CreateCommandWithAcls(ctx, "VINFO", 
-        VINFO_RedisCommand, "readonly fast", 1, 1, 1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VINFO",
+        VINFO_RedisCommand, "readonly fast", 1, 1, 1, "read fast") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-    if (VectorSets_CreateCommandWithAcls(ctx, "VSETATTR", 
-        VSETATTR_RedisCommand, "write fast", 1, 1, 1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VSETATTR",
+        VSETATTR_RedisCommand, "write fast", 1, 1, 1, "write fast") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-    if (VectorSets_CreateCommandWithAcls(ctx, "VGETATTR", 
-        VGETATTR_RedisCommand, "readonly fast", 1, 1, 1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VGETATTR",
+        VGETATTR_RedisCommand, "readonly fast", 1, 1, 1, "read fast") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-    if (VectorSets_CreateCommandWithAcls(ctx, "VRANDMEMBER", 
-        VRANDMEMBER_RedisCommand, "readonly", 1, 1, 1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VRANDMEMBER",
+        VRANDMEMBER_RedisCommand, "readonly", 1, 1, 1, "read") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-    if (VectorSets_CreateCommandWithAcls(ctx, "VISMEMBER", 
-        VISMEMBER_RedisCommand, "readonly", 1, 1, 1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VISMEMBER",
+        VISMEMBER_RedisCommand, "readonly", 1, 1, 1, "read") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     hnsw_set_allocator(RedisModule_Free, RedisModule_Alloc,

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -2049,7 +2049,7 @@ int VectorSets_CreateCommandWithAcls(RedisModuleCtx *ctx, char *name, RedisModul
         return REDISMODULE_ERR;
     sds acl_categories = sdsnew("vectorset");
     if(acls && strlen(acls) > 0)
-       acl_categories = sdscatfmt(sdsnew("vectorset"), " %s", acls);
+       acl_categories = sdscatfmt(acl_categories, " %s", acls);
     if (RedisModule_SetCommandACLCategories(cmd, acl_categories) == REDISMODULE_ERR) {
         sdsfree(acl_categories);
         return REDISMODULE_ERR;

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -2039,6 +2039,17 @@ int VectorSets_InitModuleConfig(RedisModuleCtx *ctx) {
     return REDISMODULE_OK;
 }
 
+/* Create the command and associate it with the 'vectorset' acl category  */
+int VectorSets_CreateCommandWithAcls(RedisModuleCtx * ctx, char * name, RedisModuleCmdFunc func, const char * strflags, int firstkey, int lastkey, int keystep) {
+    if (RedisModule_CreateCommand(ctx, name, func, strflags, firstkey, lastkey, keystep) == REDISMODULE_ERR) 
+        return REDISMODULE_ERR; 
+    RedisModuleCommand *cmd = RedisModule_GetCommand(ctx, name); 
+    if (cmd) {
+        RedisModule_SetCommandACLCategories(cmd, "vectorset"); 
+    }
+    return REDISMODULE_OK;
+}
+
 /* This function must be present on each Redis module. It is used in order to
  * register the commands into the Redis server. */
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -2047,6 +2058,11 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     if (RedisModule_Init(ctx,"vectorset",1,REDISMODULE_APIVER_1)
         == REDISMODULE_ERR) return REDISMODULE_ERR;
+
+    if (RedisModule_AddACLCategory(ctx, "vectorset") == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Could not create ACL category 'vectorset'");
+        return REDISMODULE_ERR;
+    }
 
     if (VectorSets_InitModuleConfig(ctx) == REDISMODULE_ERR) {
         return REDISMODULE_ERR;
@@ -2067,51 +2083,40 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     VectorSetType = RedisModule_CreateDataType(ctx,"vectorset",0,&tm);
     if (VectorSetType == NULL) return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"VADD",
-        VADD_RedisCommand,"write deny-oom",1,1,1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VADD", 
+        VADD_RedisCommand, "write deny-oom", 1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-
-    if (RedisModule_CreateCommand(ctx,"VREM",
-        VREM_RedisCommand,"write",1,1,1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VREM", 
+        VREM_RedisCommand, "write", 1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-
-    if (RedisModule_CreateCommand(ctx,"VSIM",
-        VSIM_RedisCommand,"readonly",1,1,1) == REDISMODULE_ERR)
+    if (VectorSets_CreateCommandWithAcls(ctx, "VSIM", 
+        VSIM_RedisCommand, "readonly", 1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-
-    if (RedisModule_CreateCommand(ctx, "VDIM",
+    if (VectorSets_CreateCommandWithAcls(ctx, "VDIM", 
         VDIM_RedisCommand, "readonly fast", 1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-
-    if (RedisModule_CreateCommand(ctx, "VCARD",
+    if (VectorSets_CreateCommandWithAcls(ctx, "VCARD", 
         VCARD_RedisCommand, "readonly fast", 1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-
-    if (RedisModule_CreateCommand(ctx, "VEMB",
+    if (VectorSets_CreateCommandWithAcls(ctx, "VEMB", 
         VEMB_RedisCommand, "readonly fast", 1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-
-    if (RedisModule_CreateCommand(ctx, "VLINKS",
+    if (VectorSets_CreateCommandWithAcls(ctx, "VLINKS", 
         VLINKS_RedisCommand, "readonly fast", 1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-
-    if (RedisModule_CreateCommand(ctx, "VINFO",
+    if (VectorSets_CreateCommandWithAcls(ctx, "VINFO", 
         VINFO_RedisCommand, "readonly fast", 1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-
-    if (RedisModule_CreateCommand(ctx, "VSETATTR",
+    if (VectorSets_CreateCommandWithAcls(ctx, "VSETATTR", 
         VSETATTR_RedisCommand, "write fast", 1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-
-    if (RedisModule_CreateCommand(ctx, "VGETATTR",
+    if (VectorSets_CreateCommandWithAcls(ctx, "VGETATTR", 
         VGETATTR_RedisCommand, "readonly fast", 1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-
-    if (RedisModule_CreateCommand(ctx, "VRANDMEMBER",
+    if (VectorSets_CreateCommandWithAcls(ctx, "VRANDMEMBER", 
         VRANDMEMBER_RedisCommand, "readonly", 1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-
-    if (RedisModule_CreateCommand(ctx, "VISMEMBER",
+    if (VectorSets_CreateCommandWithAcls(ctx, "VISMEMBER", 
         VISMEMBER_RedisCommand, "readonly", 1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -2048,10 +2048,9 @@ int VectorSets_CreateCommandWithAcls(RedisModuleCtx *ctx, char *name, RedisModul
     RedisModuleCommand *cmd = RedisModule_GetCommand(ctx, name);
     if (cmd == NULL)
         return REDISMODULE_ERR;
-    RedisModuleString *acl_categories =
-        acls && strlen(acls) > 0
-        ? RedisModule_CreateStringPrintf(ctx, "vectorset %s", acls)
-        : RedisModule_CreateString(ctx, "vectorset", 9);
+    RedisModuleString *acl_categories = (acls && strlen(acls) > 0) ?
+        RedisModule_CreateStringPrintf(ctx, "vectorset %s", acls) :
+        RedisModule_CreateString(ctx, "vectorset", 9);
     if (RedisModule_SetCommandACLCategories(cmd, RedisModule_StringPtrLen(acl_categories, NULL)) == REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }


### PR DESCRIPTION
# Description

Adds the `VECTORSET` ACL category and associates all vector set commands to the category.
Additionally, synchronize `commands.json` to include the relevant `acl_categories`.