### PR TITLE
handle SET KEEPTTL in the optimization path

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -512,6 +512,15 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
         /* Set new to old to keep the old object. Set old to val to be freed below. */
         kvNew = old;
         old = val;
+
+        /* Handle TTL in the optimization path */
+        if (!keepTTL) {
+            long long expire = getExpire(db, key->ptr, kvNew);
+            if (expire >= 0) {
+                kvobjSetExpire(kvNew, -1);
+                kvstoreDictDelete(db->expires, slot, key->ptr);
+            }
+        }
     } else {
         /* Replace the old value at its location in the key space. */
         val->lru = old->lru;

--- a/src/db.c
+++ b/src/db.c
@@ -513,7 +513,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
         kvNew = old;
         old = val;
 
-        /* Handle TTL in the optimization path */
+    /* Handle TTL in the optimization path */
     if ((!keepTTL) && (getExpire(db, key->ptr, kvNew) >= 0))
         removeExpire(db, key);
     } else {

--- a/src/db.c
+++ b/src/db.c
@@ -514,13 +514,8 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
         old = val;
 
         /* Handle TTL in the optimization path */
-        if (!keepTTL) {
-            long long expire = getExpire(db, key->ptr, kvNew);
-            if (expire >= 0) {
-                kvobjSetExpire(kvNew, -1);
-                kvstoreDictDelete(db->expires, slot, key->ptr);
-            }
-        }
+    if ((!keepTTL) && (getExpire(db, key->ptr, kvNew) >= 0))
+        removeExpire(db, key);
     } else {
         /* Replace the old value at its location in the key space. */
         val->lru = old->lru;


### PR DESCRIPTION
Fixed bug where SET key value after SET key value EX seconds would not remove the TTL as expected. The issue was in dbSetValue()'s optimization path which was missing TTL handling logic.
