### PR TITLE
Bump RediSearch to 8.2.0

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.1.90
+MODULE_VERSION = v8.2.0
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
* Expose more compression variants for the new SVS-VAMANA vector index - https://github.com/RediSearch/RediSearch/pull/6430
*  Add the optional `SHARD_K_RATIO` parameter for KNN vector query in a cluster environment to favor network latency reduction at the expense of accuracy (under unsatble features) - https://github.com/RediSearch/RediSearch/pull/6531, https://github.com/RediSearch/RediSearch/pull/6535