### PR TITLE
Fix missing kvobj reassignment after reallocation in MOVE command

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1975,7 +1975,7 @@ void moveCommand(client *c) {
 
     dbAddByLink(dst, c->argv[1], &kv, &dstBucket);
     if (expire != -1)
-        setExpireByLink(c, dst, c->argv[1]->ptr, expire, dstBucket);
+        kv = setExpireByLink(c, dst, c->argv[1]->ptr, expire, dstBucket);
 
     /* If object of type hash with expiration on fields. Taken care to add the
      * hash to hexpires of `dst` only after dbDelete(). */

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -616,6 +616,7 @@ start_server {tags {"external:skip needs:debug"}} {
             r select 9
             r flushall
             r hset myhash field1 value1
+            r expireat myhash 2000000000000 ;# Force kvobj reallocation during move command
             r hpexpire myhash 100 NX FIELDS 1 field1
             r move myhash 10
             assert_equal [r exists myhash] 0


### PR DESCRIPTION
Introduced by https://github.com/redis/redis/issues/13806

Fixed a crash in the MOVE command when moving hash objects that have both key expiration and field expiration.

The issue occurred in the following scenario:
1. A hash has both key expiration and field expiration.
2. During MOVE command, `setExpireByLink()` is called to set the expiration time for the target hash, which may reallocate the kvobj of hash.
3. Since the hash has field expiration, `hashTypeAddToExpires()` is called to update the minimum field expiration time

Issue:
However, the kvobj pointer wasn't updated with the return value from `setExpireByLink()`, causing `hashTypeAddToExpires()` to use freed memory.

report from the test (build with SANITIZER address):
```
[err]: Sanitizer error: =================================================================
==133231==ERROR: AddressSanitizer: heap-use-after-free on address 0x50300000f760 at pc 0x55f045aa1565 bp 0x7ffd72709e30 sp 0x7ffd72709e20
READ of size 1 at 0x50300000f760 thread T0
    #0 0x55f045aa1564 in hashTypeAddToExpires /home/sundb/data/rf_1/src/t_hash.c:2021
    #1 0x55f0459ce3b1 in moveCommand /home/sundb/data/rf_1/src/db.c:1983
    #2 0x55f0459109dd in call /home/sundb/data/rf_1/src/server.c:3754
    #3 0x55f04591aa0b in processCommand /home/sundb/data/rf_1/src/server.c:4419
    #4 0x55f04597eb74 in processCommandAndResetClient /home/sundb/data/rf_1/src/networking.c:2766
    #5 0x55f04597eb74 in processInputBuffer /home/sundb/data/rf_1/src/networking.c:2960
    #6 0x55f04598ca77 in readQueryFromClient /home/sundb/data/rf_1/src/networking.c:3122
    #7 0x55f045d1461c in callHandler /home/sundb/data/rf_1/src/connhelpers.h:59
    #8 0x55f045d1461c in connSocketEventHandler /home/sundb/data/rf_1/src/socket.c:288
    #9 0x55f0458b70ec in aeProcessEvents /home/sundb/data/rf_1/src/ae.c:435
    #10 0x55f0458b70ec in aeProcessEvents /home/sundb/data/rf_1/src/ae.c:360
    #11 0x55f0458b70ec in aeMain /home/sundb/data/rf_1/src/ae.c:495
    #12 0x55f0458a8a53 in main /home/sundb/data/rf_1/src/server.c:7660
    #13 0x7ff14be2a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #14 0x7ff14be2a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #15 0x55f0458ab224 in _start (/home/sundb/data/rf_1/src/redis-server+0x150224) (BuildId: 35c15804eed53bbfa49d7f59f3b33ee7a0409286)

0x50300000f760 is located 0 bytes inside of 25-byte region [0x50300000f760,0x50300000f779)
freed by thread T0 here:
    #0 0x7ff14c6fc4d8 in free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x55f0459ac00e in kvobjSet /home/sundb/data/rf_1/src/object.c:319
    #2 0x55f0459cb4df in kvobjSetExpire /home/sundb/data/rf_1/src/object.c:266
    #3 0x55f0459cb4df in setExpireByLink /home/sundb/data/rf_1/src/db.c:2353
    #4 0x55f0459ce36f in moveCommand /home/sundb/data/rf_1/src/db.c:1978
    #5 0x55f0459109dd in call /home/sundb/data/rf_1/src/server.c:3754
    #6 0x55f04591aa0b in processCommand /home/sundb/data/rf_1/src/server.c:4419
    #7 0x55f04597eb74 in processCommandAndResetClient /home/sundb/data/rf_1/src/networking.c:2766
    #8 0x55f04597eb74 in processInputBuffer /home/sundb/data/rf_1/src/networking.c:2960
    #9 0x55f04598ca77 in readQueryFromClient /home/sundb/data/rf_1/src/networking.c:3122
    #10 0x55f045d1461c in callHandler /home/sundb/data/rf_1/src/connhelpers.h:59
    #11 0x55f045d1461c in connSocketEventHandler /home/sundb/data/rf_1/src/socket.c:288
    #12 0x55f0458b70ec in aeProcessEvents /home/sundb/data/rf_1/src/ae.c:435
    #13 0x55f0458b70ec in aeProcessEvents /home/sundb/data/rf_1/src/ae.c:360
    #14 0x55f0458b70ec in aeMain /home/sundb/data/rf_1/src/ae.c:495
    #15 0x55f0458a8a53 in main /home/sundb/data/rf_1/src/server.c:7660
    #16 0x7ff14be2a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #17 0x7ff14be2a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #18 0x55f0458ab224 in _start (/home/sundb/data/rf_1/src/redis-server+0x150224) (BuildId: 35c15804eed53bbfa49d7f59f3b33ee7a0409286)

previously allocated by thread T0 here:
    #0 0x7ff14c6fd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x55f04593c4aa in ztrymalloc_usable_internal /home/sundb/data/rf_1/src/zmalloc.c:135
    #2 0x55f04593c4aa in zmalloc_usable /home/sundb/data/rf_1/src/zmalloc.c:183
    #3 0x55f0459a92fa in kvobjCreate /home/sundb/data/rf_1/src/object.c:56
    #4 0x55f0459abfbc in kvobjSet /home/sundb/data/rf_1/src/object.c:316
    #5 0x55f0459cb91b in dbAddInternal /home/sundb/data/rf_1/src/db.c:336
    #6 0x55f0459ce2de in dbAddByLink /home/sundb/data/rf_1/src/db.c:356
    #7 0x55f0459ce2de in moveCommand /home/sundb/data/rf_1/src/db.c:1976
    #8 0x55f0459109dd in call /home/sundb/data/rf_1/src/server.c:3754
    #9 0x55f04591aa0b in processCommand /home/sundb/data/rf_1/src/server.c:4419
    #10 0x55f04597eb74 in processCommandAndResetClient /home/sundb/data/rf_1/src/networking.c:2766
    #11 0x55f04597eb74 in processInputBuffer /home/sundb/data/rf_1/src/networking.c:2960
    #12 0x55f04598ca77 in readQueryFromClient /home/sundb/data/rf_1/src/networking.c:3122
    #13 0x55f045d1461c in callHandler /home/sundb/data/rf_1/src/connhelpers.h:59
    #14 0x55f045d1461c in connSocketEventHandler /home/sundb/data/rf_1/src/socket.c:288
    #15 0x55f0458b70ec in aeProcessEvents /home/sundb/data/rf_1/src/ae.c:435
    #16 0x55f0458b70ec in aeProcessEvents /home/sundb/data/rf_1/src/ae.c:360
    #17 0x55f0458b70ec in aeMain /home/sundb/data/rf_1/src/ae.c:495
    #18 0x55f0458a8a53 in main /home/sundb/data/rf_1/src/server.c:7660
    #19 0x7ff14be2a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #20 0x7ff14be2a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #21 0x55f0458ab224 in _start (/home/sundb/data/rf_1/src/redis-server+0x150224) (BuildId: 35c15804eed53bbfa49d7f59f3b33ee7a0409286)

SUMMARY: AddressSanitizer: heap-use-after-free /home/sundb/data/rf_1/src/t_hash.c:2021 in hashTypeAddToExpires
Shadow bytes around the buggy address:
  0x50300000f480: fa fa fd fd fd fd fa fa fd fd fd fd fa fa fd fd
  0x50300000f500: fd fa fa fa fd fd fd fa fa fa fd fd fd fd fa fa
  0x50300000f580: fd fd fd fa fa fa fd fd fd fd fa fa fd fd fd fd
  0x50300000f600: fa fa 00 00 00 fa fa fa fd fd fd fd fa fa fd fd
  0x50300000f680: fd fd fa fa fd fd fd fd fa fa 00 00 00 fa fa fa
=>0x50300000f700: 00 00 00 02 fa fa 00 00 06 fa fa fa[fd]fd fd fd
  0x50300000f780: fa fa 00 00 00 00 fa fa fd fd fd fa fa fa 00 00
  0x50300000f800: 00 00 fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x50300000f880: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x50300000f900: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x50300000f980: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==133231==ABORTING


Logged sanitizer errors (pid 133231):
=================================================================
==133231==ERROR: AddressSanitizer: heap-use-after-free on address 0x50300000f760 at pc 0x55f045aa1565 bp 0x7ffd72709e30 sp 0x7ffd72709e20
READ of size 1 at 0x50300000f760 thread T0
    #0 0x55f045aa1564 in hashTypeAddToExpires /home/sundb/data/rf_1/src/t_hash.c:2021
    #1 0x55f0459ce3b1 in moveCommand /home/sundb/data/rf_1/src/db.c:1983
    #2 0x55f0459109dd in call /home/sundb/data/rf_1/src/server.c:3754
    #3 0x55f04591aa0b in processCommand /home/sundb/data/rf_1/src/server.c:4419
    #4 0x55f04597eb74 in processCommandAndResetClient /home/sundb/data/rf_1/src/networking.c:2766
    #5 0x55f04597eb74 in processInputBuffer /home/sundb/data/rf_1/src/networking.c:2960
    #6 0x55f04598ca77 in readQueryFromClient /home/sundb/data/rf_1/src/networking.c:3122
    #7 0x55f045d1461c in callHandler /home/sundb/data/rf_1/src/connhelpers.h:59
    #8 0x55f045d1461c in connSocketEventHandler /home/sundb/data/rf_1/src/socket.c:288
    #9 0x55f0458b70ec in aeProcessEvents /home/sundb/data/rf_1/src/ae.c:435
    #10 0x55f0458b70ec in aeProcessEvents /home/sundb/data/rf_1/src/ae.c:360
    #11 0x55f0458b70ec in aeMain /home/sundb/data/rf_1/src/ae.c:495
    #12 0x55f0458a8a53 in main /home/sundb/data/rf_1/src/server.c:7660
    #13 0x7ff14be2a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #14 0x7ff14be2a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #15 0x55f0458ab224 in _start (/home/sundb/data/rf_1/src/redis-server+0x150224) (BuildId: 35c15804eed53bbfa49d7f59f3b33ee7a0409286)

0x50300000f760 is located 0 bytes inside of 25-byte region [0x50300000f760,0x50300000f779)
freed by thread T0 here:
    #0 0x7ff14c6fc4d8 in free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x55f0459ac00e in kvobjSet /home/sundb/data/rf_1/src/object.c:319
    #2 0x55f0459cb4df in kvobjSetExpire /home/sundb/data/rf_1/src/object.c:266
    #3 0x55f0459cb4df in setExpireByLink /home/sundb/data/rf_1/src/db.c:2353
    #4 0x55f0459ce36f in moveCommand /home/sundb/data/rf_1/src/db.c:1978
    #5 0x55f0459109dd in call /home/sundb/data/rf_1/src/server.c:3754
    #6 0x55f04591aa0b in processCommand /home/sundb/data/rf_1/src/server.c:4419
    #7 0x55f04597eb74 in processCommandAndResetClient /home/sundb/data/rf_1/src/networking.c:2766
    #8 0x55f04597eb74 in processInputBuffer /home/sundb/data/rf_1/src/networking.c:2960
    #9 0x55f04598ca77 in readQueryFromClient /home/sundb/data/rf_1/src/networking.c:3122
    #10 0x55f045d1461c in callHandler /home/sundb/data/rf_1/src/connhelpers.h:59
    #11 0x55f045d1461c in connSocketEventHandler /home/sundb/data/rf_1/src/socket.c:288
    #12 0x55f0458b70ec in aeProcessEvents /home/sundb/data/rf_1/src/ae.c:435
    #13 0x55f0458b70ec in aeProcessEvents /home/sundb/data/rf_1/src/ae.c:360
    #14 0x55f0458b70ec in aeMain /home/sundb/data/rf_1/src/ae.c:495
    #15 0x55f0458a8a53 in main /home/sundb/data/rf_1/src/server.c:7660
    #16 0x7ff14be2a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #17 0x7ff14be2a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #18 0x55f0458ab224 in _start (/home/sundb/data/rf_1/src/redis-server+0x150224) (BuildId: 35c15804eed53bbfa49d7f59f3b33ee7a0409286)

previously allocated by thread T0 here:
    #0 0x7ff14c6fd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x55f04593c4aa in ztrymalloc_usable_internal /home/sundb/data/rf_1/src/zmalloc.c:135
    #2 0x55f04593c4aa in zmalloc_usable /home/sundb/data/rf_1/src/zmalloc.c:183
    #3 0x55f0459a92fa in kvobjCreate /home/sundb/data/rf_1/src/object.c:56
    #4 0x55f0459abfbc in kvobjSet /home/sundb/data/rf_1/src/object.c:316
    #5 0x55f0459cb91b in dbAddInternal /home/sundb/data/rf_1/src/db.c:336
    #6 0x55f0459ce2de in dbAddByLink /home/sundb/data/rf_1/src/db.c:356
    #7 0x55f0459ce2de in moveCommand /home/sundb/data/rf_1/src/db.c:1976
    #8 0x55f0459109dd in call /home/sundb/data/rf_1/src/server.c:3754
    #9 0x55f04591aa0b in processCommand /home/sundb/data/rf_1/src/server.c:4419
    #10 0x55f04597eb74 in processCommandAndResetClient /home/sundb/data/rf_1/src/networking.c:2766
    #11 0x55f04597eb74 in processInputBuffer /home/sundb/data/rf_1/src/networking.c:2960
    #12 0x55f04598ca77 in readQueryFromClient /home/sundb/data/rf_1/src/networking.c:3122
    #13 0x55f045d1461c in callHandler /home/sundb/data/rf_1/src/connhelpers.h:59
    #14 0x55f045d1461c in connSocketEventHandler /home/sundb/data/rf_1/src/socket.c:288
    #15 0x55f0458b70ec in aeProcessEvents /home/sundb/data/rf_1/src/ae.c:435
    #16 0x55f0458b70ec in aeProcessEvents /home/sundb/data/rf_1/src/ae.c:360
    #17 0x55f0458b70ec in aeMain /home/sundb/data/rf_1/src/ae.c:495
    #18 0x55f0458a8a53 in main /home/sundb/data/rf_1/src/server.c:7660
    #19 0x7ff14be2a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #20 0x7ff14be2a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #21 0x55f0458ab224 in _start (/home/sundb/data/rf_1/src/redis-server+0x150224) (BuildId: 35c15804eed53bbfa49d7f59f3b33ee7a0409286)

SUMMARY: AddressSanitizer: heap-use-after-free /home/sundb/data/rf_1/src/t_hash.c:2021 in hashTypeAddToExpires
Shadow bytes around the buggy address:
  0x50300000f480: fa fa fd fd fd fd fa fa fd fd fd fd fa fa fd fd
  0x50300000f500: fd fa fa fa fd fd fd fa fa fa fd fd fd fd fa fa
  0x50300000f580: fd fd fd fa fa fa fd fd fd fd fa fa fd fd fd fd
  0x50300000f600: fa fa 00 00 00 fa fa fa fd fd fd fd fa fa fd fd
  0x50300000f680: fd fd fa fa fd fd fd fd fa fa 00 00 00 fa fa fa
=>0x50300000f700: 00 00 00 02 fa fa 00 00 06 fa fa fa[fd]fd fd fd
  0x50300000f780: fa fa 00 00 00 00 fa fa fd fd fd fa fa fa 00 00
  0x50300000f800: 00 00 fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x50300000f880: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x50300000f900: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x50300000f980: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==133231==ABORTING
```