### PR TITLE
Fix config parser to handle inline comments

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -454,6 +454,25 @@ void loadServerConfigFromString(char *config) {
         /* Skip comments and blank lines */
         if (lines[i][0] == '#' || lines[i][0] == '\0') continue;
 
+	/* Strip inline comments */
+	char *comment = strchr(lines[i], '#');
+	if (comment) {
+	    /* Check if # is inside quotes by counting quotes before it */
+	    char *p = lines[i];
+	    int in_quotes = 0;
+	    while (p < comment) {
+	    	if (*p == '"' || *p == '\''){
+	            in_quotes = !in_quotes;
+		}
+		p++;
+	    }
+	    /* Only treat as comment if not inside quotes */
+	    if (!in_quotes){
+	    	*comment = '\0';
+		lines[i] = sdstrim(lines[i], " \t\r\n");
+	    }
+	}
+
         /* Split into arguments */
         argv = sdssplitargs(lines[i],&argc);
         if (argv == NULL) {


### PR DESCRIPTION
# Fixes #14228

## Problem
  Redis fails to parse config lines with inline comments. For example:
  bind * -::* # this should work but fails

Results in: `Warning: Could not create server TCP listening socket #:6379`

## Solution
Modified `loadServerConfigFromString()` [config.c] to strip inline comments before parsing arguments, while preserving # characters inside quoted strings.

## Testing
- Tested with various bind configurations including inline comments
- All existing tests pass
- Added manual tests for edge cases (# inside quotes, etc.)

## Detailed Summary

The config parser now properly handles inline comments in configuration
directives. Previously, 'bind * -::* # comment' would fail because the
parser treated # and subsequent text as additional arguments.

This fix strips inline comments before parsing, while preserving any
\# characters that appear inside quoted strings.

Fixes the issue where Redis fails to start with:
Warning: Could not create server TCP listening socket #:6379

## Extra
A rare instance where this fix could be taken further is to handle escaped quotes or distinguishing between single or double quotes, but for most config file use cases i think that might be overkill.