### PR TITLE
Use safe Iterator for modules

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3482,7 +3482,7 @@ static standardConfig *getMutableConfig(client *c, const sds name, const char **
 }
 
 dictIterator *moduleGetConfigIterator(void) {
-    return dictGetIterator(configs);
+    return dictGetSafeIterator(configs);
 }
 
 const char *moduleConfigIteratorNext(dictIterator **iter, sds pattern, int is_glob, configType *typehint) {


### PR DESCRIPTION
When modules create an iterator, they might trigger a rehash of the dictionary during iteration.
This can invalidate the iterator's fingerprint
and cause an assertion failure upon its release.