### PR TITLE
Avoid Accessing Arguments Out Of Bounds In handleDebugClusterCommand

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5897,9 +5897,9 @@ int clusterNodeIsMaster(clusterNode *n) {
 }
 
 int handleDebugClusterCommand(client *c) {
-    if (strcasecmp(c->argv[1]->ptr, "CLUSTERLINK") ||
-        strcasecmp(c->argv[2]->ptr, "KILL") ||
-        c->argc != 5) {
+    if (c->argc != 5 ||
+        strcasecmp(c->argv[1]->ptr, "CLUSTERLINK") ||
+        strcasecmp(c->argv[2]->ptr, "KILL")) {
         return 0;
     }
 


### PR DESCRIPTION
Noticed we assume there are at least 3 arguments since we access to index 2 in the if and only later check the argc.
Moved the argc check to the start of the if so the code will be a bit safer.