### PR TITLE
Fix memory leak in RM_GetCommandKeysWithFlags

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -14176,6 +14176,7 @@ int *RM_GetCommandKeysWithFlags(RedisModuleCtx *ctx, RedisModuleString **argv, i
             (*out_flags)[i] = moduleConvertKeySpecsFlags(result.keys[i].flags, 0);
     }
 
+    getKeysFreeResult(&result);
     return res;
 }
 

--- a/tests/unit/moduleapi/getkeys.tcl
+++ b/tests/unit/moduleapi/getkeys.tcl
@@ -58,6 +58,18 @@ start_server {tags {"modules"}} {
         set _ $e
     } {*EINVAL*}
 
+    test "introspect with > MAX_KEYS_BUFFER keys triggers RM_GetCommandKeysWithFlags heap alloc" {
+        set args {}
+        for {set i 0} {$i < 7} {incr i} {
+            lappend args key k$i
+        }
+        set reply [r getkeys.introspect 1 getkeys.command_with_flags {*}$args]
+        assert {[llength $reply] == 7}
+        foreach pair $reply {
+            assert {[llength $pair] == 2}
+        }
+    }
+
     # user that can only read from "read" keys, write to "write" keys, and read+write to "RW" keys
     r ACL setuser testuser +@all %R~read* %W~write* %RW~rw*
 

--- a/tests/unit/moduleapi/getkeys.tcl
+++ b/tests/unit/moduleapi/getkeys.tcl
@@ -64,10 +64,7 @@ start_server {tags {"modules"}} {
             lappend args key k$i
         }
         set reply [r getkeys.introspect 1 getkeys.command_with_flags {*}$args]
-        assert {[llength $reply] == 7}
-        foreach pair $reply {
-            assert {[llength $pair] == 2}
-        }
+        assert_equal {{k0 RO} {k1 RO} {k2 RO} {k3 RO} {k4 RO} {k5 RO} {k6 RO}} $reply
     }
 
     # user that can only read from "read" keys, write to "write" keys, and read+write to "RW" keys


### PR DESCRIPTION
Fix https://github.com/redis/redis/issues/14208
As mentioned in above issue, RM_GetCommandKeysWithFlags could have memory leak when the number of keys is larger than MAX_KEYS_BUFFER. This PR fixes it by calling getKeysFreeResult before the function's return. A TCL testcase is created to verify the fix.