### PR TITLE
Move getSlotOrReply() to cluster.c

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -58,6 +58,18 @@ int patternHashSlot(char *pattern, int length) {
     return crc16(pattern, length) & 0x3FFF;
 }
 
+int getSlotOrReply(client *c, robj *o) {
+    long long slot;
+
+    if (getLongLongFromObject(o,&slot) != C_OK ||
+        slot < 0 || slot >= CLUSTER_SLOTS)
+    {
+        addReplyError(c,"Invalid or out of range slot");
+        return -1;
+    }
+    return (int) slot;
+}
+
 ConnectionType *connTypeOfCluster(void) {
     if (server.tls_cluster) {
         return connectionTypeTls();

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5609,18 +5609,6 @@ const char *clusterGetMessageTypeString(int type) {
     return "unknown";
 }
 
-int getSlotOrReply(client *c, robj *o) {
-    long long slot;
-
-    if (getLongLongFromObject(o,&slot) != C_OK ||
-        slot < 0 || slot >= CLUSTER_SLOTS)
-    {
-        addReplyError(c,"Invalid or out of range slot");
-        return -1;
-    }
-    return (int) slot;
-}
-
 int checkSlotAssignmentsOrReply(client *c, unsigned char *slots, int del, int start_slot, int end_slot) {
     int slot;
     for (slot = start_slot; slot <= end_slot; slot++) {


### PR DESCRIPTION
getSlotOrReply() is used by the `CLUSTER SLOT-STATS` command but is defined
in cluster_legacy.c which might not be present in all build configurations.