### PR TITLE
Fix RDB SLOT INFO doesn't work

### DIFF
--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -787,7 +787,7 @@ unsigned int kvstoreDictGetSomeKeys(kvstore *kvs, int didx, dictEntry **des, uns
 
 int kvstoreDictExpand(kvstore *kvs, int didx, unsigned long size)
 {
-    dict *d = kvstoreGetDict(kvs, didx);
+    dict *d = createDictIfNeeded(kvs, didx);
     if (!d)
         return DICT_ERR;
     return dictExpand(d, size);


### PR DESCRIPTION
In cluster mode, we create slot dicts on demand, so by default, there is no slot dicts, and `RDB_OPCODE_SLOT_INFO` doesn't resize dict actually.

https://github.com/redis/redis/blob/ecc3cbfde8c8c6e865b897d37fc1fd481397f069/src/rdb.c#L3438-L3440

not sure if it should be ported back old versions, we can fix in ASM PR if not cc @tezc @sundb 