### PR TITLE
Fix: Validate ENTRIESREAD in XGROUP command

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2979,6 +2979,11 @@ NULL
             s = o->ptr;
             signalModifiedKey(c,c->db,c->argv[2]);
         }
+        
+        if (entries_read != SCG_INVALID_ENTRIES_READ && (uint64_t)entries_read > s->entries_added) {
+            addReplyError(c, "The ENTRIESREAD counter cannot be greater than the total number of entries in the stream.");
+            return;
+        }
 
         streamCG *cg = streamCreateCG(s,grpname,sdslen(grpname),&id,entries_read);
         if (cg) {
@@ -2996,6 +3001,12 @@ NULL
         } else if (streamParseIDOrReply(c,c->argv[4],&id,0) != C_OK) {
             return;
         }
+
+        if (entries_read != SCG_INVALID_ENTRIES_READ && (uint64_t)entries_read > s->entries_added) {
+            addReplyError(c, "The ENTRIESREAD counter cannot be greater than the total number of entries in the stream.");
+            return;
+        }
+        
         streamUpdateCGroupLastId(s, cg, &id);
         cg->entries_read = entries_read;
         addReply(c,shared.ok);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2981,8 +2981,7 @@ NULL
         }
         
         if (entries_read != SCG_INVALID_ENTRIES_READ && (uint64_t)entries_read > s->entries_added) {
-            addReplyError(c, "The ENTRIESREAD counter cannot be greater than the total number of entries in the stream.");
-            return;
+            entries_read = s->entries_added;
         }
 
         streamCG *cg = streamCreateCG(s,grpname,sdslen(grpname),&id,entries_read);
@@ -3003,8 +3002,7 @@ NULL
         }
 
         if (entries_read != SCG_INVALID_ENTRIES_READ && (uint64_t)entries_read > s->entries_added) {
-            addReplyError(c, "The ENTRIESREAD counter cannot be greater than the total number of entries in the stream.");
-            return;
+            entries_read = s->entries_added;
         }
         
         streamUpdateCGroupLastId(s, cg, &id);

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -1630,5 +1630,33 @@ start_server {
             assert_equal {0 {} {} {}} [r XPENDING mystream group1]
             assert_equal {0 {} {} {}} [r XPENDING mystream group2]
         }
+
+        test "XGROUP CREATE with ENTRIESREAD larger than stream entries should cap the value" {
+            r DEL mystream
+            r xadd mystream * field value
+            r xgroup create mystream mygroup $ entriesread 9999
+
+            set reply [r XINFO STREAM mystream FULL]
+            set group [lindex [dict get $reply groups] 0]
+
+            # Lag must be 0 and entries-read must be 1.
+            assert_equal [dict get $group lag] 0
+            assert_equal [dict get $group entries-read] 1
+        }
+
+        test "XGROUP SETID with ENTRIESREAD larger than stream entries should cap the value" {
+            r DEL mystream
+            r xadd mystream * field value
+            r xgroup create mystream mygroup $
+
+            r xgroup setid mystream mygroup $ entriesread 9999
+
+            set reply [r XINFO STREAM mystream FULL]
+            set group [lindex [dict get $reply groups] 0]
+
+            # Lag must be 0 and entries-read must be 1.
+            assert_equal [dict get $group lag] 0
+            assert_equal [dict get $group entries-read] 1
+        }
     }
 }

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -52,45 +52,6 @@ set content {} ;# Will be populated with Tcl side copy of the stream content.
 start_server {
     tags {"stream"}
 } {
-    test "XGROUP CREATE with ENTRIESREAD larger than stream entries should cap the value" {
-        r DEL mystream
-        r xadd mystream * field value
-        assert_equal [r xlen mystream] 1
-
-        r xgroup create mystream mygroup $ entriesread 9999
-
-        set group_info [lindex [r xinfo groups mystream] 0]
-
-        # Find the value of 'lag' and 'entries-read' in the XINFO reply.
-        set lag_idx [lsearch -exact $group_info lag]
-        set lag_val [lindex $group_info [expr {$lag_idx + 1}]]
-
-        set entries_read_idx [lsearch -exact $group_info entries-read]
-        set entries_read_val [lindex $group_info [expr {$entries_read_idx + 1}]]
-        
-        # Lag must be 0 and entries-read must be 1.
-        assert_equal $lag_val 0
-        assert_equal $entries_read_val 1
-    }
-
-    test "XGROUP SETID with ENTRIESREAD larger than stream entries should cap the value" {
-        r DEL mystream
-        r xadd mystream * field value
-        r xgroup create mystream mygroup $
-
-        r xgroup setid mystream mygroup $ entriesread 9999
-
-        set group_info [lindex [r xinfo groups mystream] 0]
-        set lag_idx [lsearch -exact $group_info lag]
-        set lag_val [lindex $group_info [expr {$lag_idx + 1}]]
-        set entries_read_idx [lsearch -exact $group_info entries-read]
-        set entries_read_val [lindex $group_info [expr {$entries_read_idx + 1}]]
-
-        # Lag must be 0 and entries-read must be 1.
-        assert_equal $lag_val 0
-        assert_equal $entries_read_val 1
-    } 
-
     test "XADD wrong number of args" {
         assert_error {*wrong number of arguments for 'xadd' command} {r XADD mystream}
         assert_error {*wrong number of arguments for 'xadd' command} {r XADD mystream *}

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -52,6 +52,45 @@ set content {} ;# Will be populated with Tcl side copy of the stream content.
 start_server {
     tags {"stream"}
 } {
+    test "XGROUP CREATE with ENTRIESREAD larger than stream entries should cap the value" {
+        r DEL mystream
+        r xadd mystream * field value
+        assert_equal [r xlen mystream] 1
+
+        r xgroup create mystream mygroup $ entriesread 9999
+
+        set group_info [lindex [r xinfo groups mystream] 0]
+
+        # Find the value of 'lag' and 'entries-read' in the XINFO reply.
+        set lag_idx [lsearch -exact $group_info lag]
+        set lag_val [lindex $group_info [expr {$lag_idx + 1}]]
+
+        set entries_read_idx [lsearch -exact $group_info entries-read]
+        set entries_read_val [lindex $group_info [expr {$entries_read_idx + 1}]]
+        
+        # Lag must be 0 and entries-read must be 1.
+        assert_equal $lag_val 0
+        assert_equal $entries_read_val 1
+    }
+
+    test "XGROUP SETID with ENTRIESREAD larger than stream entries should cap the value" {
+        r DEL mystream
+        r xadd mystream * field value
+        r xgroup create mystream mygroup $
+
+        r xgroup setid mystream mygroup $ entriesread 9999
+
+        set group_info [lindex [r xinfo groups mystream] 0]
+        set lag_idx [lsearch -exact $group_info lag]
+        set lag_val [lindex $group_info [expr {$lag_idx + 1}]]
+        set entries_read_idx [lsearch -exact $group_info entries-read]
+        set entries_read_val [lindex $group_info [expr {$entries_read_idx + 1}]]
+
+        # Lag must be 0 and entries-read must be 1.
+        assert_equal $lag_val 0
+        assert_equal $entries_read_val 1
+    } 
+
     test "XADD wrong number of args" {
         assert_error {*wrong number of arguments for 'xadd' command} {r XADD mystream}
         assert_error {*wrong number of arguments for 'xadd' command} {r XADD mystream *}


### PR DESCRIPTION
Fixes #14257

The XGROUP CREATE and SETID subcommands allowed setting an ENTRIESREAD value greater than the stream's total `entries_added` counter. This could lead to a logically inconsistent state.

This commit adds a check to ensure the provided ENTRIESREAD value is not greater than the number of entries ever added to the stream. If ENTRIESREAD is too large, it gets set to the total number of entries in the stream, i.e. `s->entries_added`.