### PR TITLE
Enforce token presence for multiple_token in json schema

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1163,6 +1163,7 @@ static sds addHintForRepeatedArgument(sds hint, cliCommandArg *arg) {
     hint = sdscat(hint, "[");
 
     if (arg->flags & CMD_ARG_MULTIPLE_TOKEN) {
+        assert(arg->token);
         hint = sdscat_orempty(hint, arg->token);
         if (arg->type != ARG_TYPE_PURE_TOKEN) {
             hint = sdscat(hint, " ");

--- a/utils/generate-command-code.py
+++ b/utils/generate-command-code.py
@@ -207,7 +207,7 @@ class Argument(object):
                 s += "CMD_ARG_MULTIPLE|"
             if self.desc.get("multiple_token", False):
                 assert self.desc.get("multiple", False)  # Sanity
-                assert self.desc.get("token", None)
+                assert "token" in self.desc
                 s += "CMD_ARG_MULTIPLE_TOKEN|"
             return s[:-1] if s else "CMD_ARG_NONE"
 

--- a/utils/generate-command-code.py
+++ b/utils/generate-command-code.py
@@ -207,6 +207,7 @@ class Argument(object):
                 s += "CMD_ARG_MULTIPLE|"
             if self.desc.get("multiple_token", False):
                 assert self.desc.get("multiple", False)  # Sanity
+                assert self.desc.get("token", None)
                 s += "CMD_ARG_MULTIPLE_TOKEN|"
             return s[:-1] if s else "CMD_ARG_NONE"
 


### PR DESCRIPTION
Fix https://github.com/redis/redis/issues/14252

This PR enforces `token` presence validation for the `multiple_token` flag in the JSON schema generation and CLI hint. The change adds assertion checks to ensure that whenever `multiple_token` is set to true, a corresponding `token` value must also be provided.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds development-time assertions for an existing invariant; no runtime behavior change for valid command definitions.
> 
> **Overview**
> Command JSON with **`multiple_token`** must now include a **`token`** field, enforced at **codegen** and **CLI hint** build time instead of risking null use later.
> 
> **`utils/generate-command-code.py`** adds `assert "token" in self.desc` next to the existing `multiple` check when emitting **`CMD_ARG_MULTIPLE_TOKEN`**. **`src/redis-cli.c`** adds `assert(arg->token)` before appending the token into completion hints for the same flag.
> 
> Invalid definitions fail fast during command table generation or CLI builds; valid command JSON is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95dfcc8c3b9d41a55d69b3cbcd3aee239c5d5b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->