### PR TITLE
Fix issues with server.allow_access_expired

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2494,7 +2494,7 @@ void propagateDeletion(redisDb *db, robj *key, int lazy) {
  */
 int keyIsExpired(redisDb *db, sds key, kvobj *kv) {
     /* Don't expire anything while loading. It will be done later. */
-    if (server.loading) return 0;
+    if (server.loading || server.allow_access_expired) return 0;
     mstime_t when = getExpire(db, key, kv);
     if (when < 0) return 0; /* No expire for this key */
     const mstime_t now = commandTimeSnapshot();
@@ -2550,8 +2550,7 @@ int confAllowsExpireDel(void) {
  */
 keyStatus expireIfNeeded(redisDb *db, robj *key, kvobj *kv, int flags) {
     debugAssert(key != NULL || kv != NULL);
-    if ((server.allow_access_expired) ||
-        (flags & EXPIRE_ALLOW_ACCESS_EXPIRED) ||
+    if ((flags & EXPIRE_ALLOW_ACCESS_EXPIRED) ||
         (!keyIsExpired(db,  key ? key->ptr : NULL, kv)))
         return KEY_VALID;
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -465,6 +465,10 @@ void debugCommand(client *c) {
 "    Setting it to 0 disables expiring keys (and hash-fields) in background ",
 "    when they are not accessed (otherwise the Redis behavior). Setting it",
 "    to 1 reenables back the default.",
+"SET-ALLOW-ACCESS-EXPIRED <0|1>",
+"    Setting it to 0 prevents access to expired keys (and hash-fields),",
+"    simulating the standard Redis behavior. Setting it to 1 allows",
+"    access to expired keys (and hash-fields) without triggering deletion.",
 "QUICKLIST-PACKED-THRESHOLD <size>",
 "    Sets the threshold for elements to be inserted as plain vs packed nodes",
 "    Default value is 1GB, allows values up to 4GB. Setting to 0 restores to default.",
@@ -875,6 +879,11 @@ NULL
                c->argc == 3)
     {
         server.active_expire_enabled = atoi(c->argv[2]->ptr);
+        addReply(c,shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr,"set-allow-access-expired") &&
+               c->argc == 3)
+    {
+        server.allow_access_expired = atoi(c->argv[2]->ptr);
         addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"quicklist-packed-threshold") &&
                c->argc == 3)

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1266,9 +1266,9 @@ int hashTypeDelete(robj *o, void *field, int isSdsField) {
  */
 unsigned long hashTypeLength(const robj *o, int subtractExpiredFields) {
     unsigned long length = ULONG_MAX;
-    if (server.allow_access_expired) {
+    /* If expired field access is allowed, don't subtract expired fields from the count. */
+    if (server.allow_access_expired)
         subtractExpiredFields = 0;
-    }
 
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
         length = lpLength(o->ptr) / 2;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1266,7 +1266,9 @@ int hashTypeDelete(robj *o, void *field, int isSdsField) {
  */
 unsigned long hashTypeLength(const robj *o, int subtractExpiredFields) {
     unsigned long length = ULONG_MAX;
-    subtractExpiredFields &= !server.allow_access_expired;
+    if (server.allow_access_expired) {
+        subtractExpiredFields = 0;
+    }
 
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
         length = lpLength(o->ptr) / 2;
@@ -1323,7 +1325,9 @@ void hashTypeReleaseIterator(hashTypeIterator *hi) {
 /* Move to the next entry in the hash. Return C_OK when the next entry
  * could be found and C_ERR when the iterator reaches the end. */
 int hashTypeNext(hashTypeIterator *hi, int skipExpiredFields) {
-    skipExpiredFields &= !server.allow_access_expired;
+    if (server.allow_access_expired) {
+        skipExpiredFields = 0;
+    }
 
     hi->expire_time = EB_EXPIRE_TIME_INVALID;
     if (hi->encoding == OBJ_ENCODING_LISTPACK) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1325,9 +1325,9 @@ void hashTypeReleaseIterator(hashTypeIterator *hi) {
 /* Move to the next entry in the hash. Return C_OK when the next entry
  * could be found and C_ERR when the iterator reaches the end. */
 int hashTypeNext(hashTypeIterator *hi, int skipExpiredFields) {
-    if (server.allow_access_expired) {
+    /* If expired field access is allowed, don't skip expired fields during iteration */
+    if (server.allow_access_expired)
         skipExpiredFields = 0;
-    }
 
     hi->expire_time = EB_EXPIRE_TIME_INVALID;
     if (hi->encoding == OBJ_ENCODING_LISTPACK) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -560,6 +560,8 @@ SetExRes hashTypeSetExpiryListpack(HashTypeSetEx *ex, sds field,
 
 /* Returns 1 if expired */
 int hashTypeIsExpired(const robj *o, uint64_t expireAt) {
+    if (server.allow_access_expired) return 0;
+
     if (o->encoding == OBJ_ENCODING_LISTPACK_EX) {
         if (expireAt == HASH_LP_NO_TTL)
             return 0;
@@ -738,7 +740,8 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
         serverPanic("Unknown hash encoding");
     }
 
-    if ((*expiredAt >= (uint64_t) commandTimeSnapshot()) || 
+    if ((server.allow_access_expired) ||
+        (*expiredAt >= (uint64_t) commandTimeSnapshot()) ||
         (hfeFlags & HFE_LAZY_ACCESS_EXPIRED))
         return GETF_OK;
 
@@ -752,7 +755,6 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
     }
 
     if ((server.loading) ||
-        (server.allow_access_expired) ||
         (hfeFlags & HFE_LAZY_AVOID_FIELD_DEL) ||
         (isPausedActionsWithUpdate(PAUSE_ACTION_EXPIRE)))
         return GETF_EXPIRED;
@@ -1264,6 +1266,7 @@ int hashTypeDelete(robj *o, void *field, int isSdsField) {
  */
 unsigned long hashTypeLength(const robj *o, int subtractExpiredFields) {
     unsigned long length = ULONG_MAX;
+    subtractExpiredFields &= !server.allow_access_expired;
 
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
         length = lpLength(o->ptr) / 2;
@@ -1320,6 +1323,8 @@ void hashTypeReleaseIterator(hashTypeIterator *hi) {
 /* Move to the next entry in the hash. Return C_OK when the next entry
  * could be found and C_ERR when the iterator reaches the end. */
 int hashTypeNext(hashTypeIterator *hi, int skipExpiredFields) {
+    skipExpiredFields &= !server.allow_access_expired;
+
     hi->expire_time = EB_EXPIRE_TIME_INVALID;
     if (hi->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl;
@@ -3336,6 +3341,8 @@ static void hfieldPersist(robj *hashObj, hfield field) {
 }
 
 int hfieldIsExpired(hfield field) {
+    if (server.allow_access_expired) return 0;
+
     /* Condition remains valid even if hfieldGetExpireTime() returns EB_EXPIRE_TIME_INVALID,
      * as the constant is equivalent to (EB_EXPIRE_TIME_MAX + 1). */
     return ( (mstime_t)hfieldGetExpireTime(field) < commandTimeSnapshot());

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -1280,6 +1280,40 @@ start_server {tags {"external:skip needs:debug"}} {
             assert_equal [r hsetex myhash EXAT [expr {[clock seconds] - 1}] FIELDS 2 f1 v1 f2 v2] 1
             assert_equal [r hexists myhash field1] 0
         }
+
+        test "Hash field expire - test allow-access-expired parameter enabled" {
+            r debug set-active-expire 0
+            r debug set-allow-access-expired 1
+            r del H1
+            r hset H1 f1 1
+            r hpexpire H1 1 FIELDS 1 f1
+            after 2
+            # With allow-access-expired 1, expired fields should be accessible
+            assert_equal {1} [r hexists H1 f1]
+            # Test hget with allow-access-expired enabled
+            assert_equal {1} [r hget H1 f1]
+            # Test hscan with allow-access-expired enabled
+            assert_equal {1 f1} [lsort [lindex [r hscan H1 0] 1]]
+            # Test hgetall with allow-access-expired enabled
+            assert_equal {f1 1} [r hgetall H1]
+            # Test hlen with allow-access-expired enabled
+            assert_equal {1} [r hlen H1]
+            # Test hmget with allow-access-expired enabled
+            assert_equal {1} [r hmget H1 f1]
+            # Test hkeys and hvals with allow-access-expired enabled
+            assert_equal {f1} [r hkeys H1]
+            assert_equal {1} [r hvals H1]
+            # Test hincrby with allow-access-expired enabled
+            assert_equal {2} [r hincrby H1 f1 1]
+            # Test hincrbyfloat with allow-access-expired enabled
+            assert_equal {3.5} [r hincrbyfloat H1 f1 1.5]
+            # Test hrandfield with allow-access-expired enabled
+            assert_equal {f1} [r hrandfield H1]
+            assert_equal {f1 3.5} [r hrandfield H1 1 withvalues]
+            # Reset to default
+            r debug set-allow-access-expired 0
+            r debug set-active-expire 1
+        }
     }
 
     test "Statistics - Hashes with HFEs ($type)" {
@@ -1384,6 +1418,33 @@ start_server {tags {"external:skip needs:debug"}} {
         after 50
         assert_equal [lsort [r hgetall myhash]] [lsort "f1 f3 f5 f6 f7 f8 f9 f10 v1 v3 v5 v6 v7 v8 v9 v10"]
         r config set hash-max-listpack-entries $prev
+        r debug set-active-expire 1
+    }
+
+    test "Test listpack converts to ht with allow-access-expired enabled" {
+        set prev [lindex [r config get hash-max-listpack-entries] 1]
+        r debug set-active-expire 0
+        r debug set-allow-access-expired 1
+        r config set hash-max-listpack-entries 5
+        r del myhash
+
+        r hset myhash f1 v1 f2 v2 f3 v3 f4 v4
+        r hpexpire myhash 1 FIELDS 2 f1 f2
+        after 2
+
+        assert_equal {f1 f2 f3 f4 v1 v2 v3 v4} [lsort [r hgetall myhash]]
+        assert_equal {1} [r hexists myhash f1]
+
+        for {set i 5} {$i <= 10} {incr i} {
+            r hset myhash f$i v$i
+        }
+
+        assert_equal {hashtable} [r object encoding myhash]
+        assert_equal {v1} [r hget myhash f1]
+        assert_equal {10} [r hlen myhash]
+
+        r config set hash-max-listpack-entries $prev
+        r debug set-allow-access-expired 0
         r debug set-active-expire 1
     }
 

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -1422,10 +1422,9 @@ start_server {tags {"external:skip needs:debug"}} {
     }
 
     test "Test listpack converts to ht with allow-access-expired enabled" {
-        set prev [lindex [r config get hash-max-listpack-entries] 1]
         r debug set-active-expire 0
         r debug set-allow-access-expired 1
-        r config set hash-max-listpack-entries 5
+        set prev [config_get_set hash-max-listpack-entries 5]
         r del myhash
 
         r hset myhash f1 v1 f2 v2 f3 v3 f4 v4

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -940,6 +940,18 @@ start_server {tags {"hash"}} {
         set _ $k
     } {ZIP_INT_8B 127 ZIP_INT_16B 32767 ZIP_INT_32B 2147483647 ZIP_INT_64B 9223372036854775808 ZIP_INT_IMM_MIN 0 ZIP_INT_IMM_MAX 12}
 
+    test {KEYS command return expired keys when allow_access_expired is 1} {
+        r flushall
+        r debug set-allow-access-expired 1
+        r debug set-active-expire 0
+        r set key1 value1
+        r pexpire key1 1
+        after 2
+        assert_equal {key1} [r keys *]
+        r debug set-allow-access-expired 0
+        r debug set-active-expire 1
+    } {OK} {needs:debug}
+
     # On some platforms strtold("+inf") with valgrind returns a non-inf result
     if {!$::valgrind} {
         test {HINCRBYFLOAT does not allow NaN or Infinity} {


### PR DESCRIPTION
Close  https://github.com/redis/redis/issues/14214

1. When the server.allow_access_expired flag is set to 1, it allows access to expired keys that have not yet been evicted. All places involving access to expired keys should consider the impact of this parameter.
2. The modifications involve five methods: hfieldIsExpired, hashTypeNext, hashTypeLength, keyIsExpired, and hashTypeIsExpired. When the server.allow_access_expired flag is set to 1, these methods will not skip expired keys, otherwise they follow the normal logic execution.