### PR TITLE
RediSearch v8.2.1

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.2.0
+MODULE_VERSION = v8.2.1
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
* Protect cursors that are running in the background for FT.AGGREGATE command while running FLUSHDB and avoid server crash - https://github.com/RediSearch/RediSearch/pull/6601
* Fix performance regression in `info` command upon computing search indexes memory due to a change in Trie data structure implementation, and having it in O(1) again - https://github.com/RediSearch/RediSearch/pull/6621