### PR TITLE
Fix missing expires_cursor check when existing defrag cycle

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1040,7 +1040,7 @@ void activeDefragCycle(void) {
                 server.stat_active_defrag_hits - prev_defragged > 512 ||
                 server.stat_active_defrag_scanned - prev_scanned > 64)
             {
-                if (!cursor || ustime() > endtime) {
+                if (!(cursor || expires_cursor) || ustime() > endtime) {
                     quit = 1;
                     break;
                 }


### PR DESCRIPTION
Fix https://github.com/redis/redis/issues/13612
This bug was introduced by https://github.com/redis/redis/issues/11465

This PR added the incremental defragmentation for db->expires.
If the time for the defragmentation cycle has not arrived, it will exit unless both cursor and expires_cursor are 0, meaning both keys and expires have been fragmented.
However, the expires_cursor check has now been overlooked, which leads to we will exit immediately even if the defragmentation doesn't reach the end time, which will cause the efficiency of defragmentation to become very low.

Note that this bug was already fixed in version 7.4(https://github.com/redis/redis/pull/13058)