### PR TITLE
[feature] support config set io-thread

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3180,7 +3180,7 @@ standardConfig static_configs[] = {
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */
-    createIntConfig("io-threads", NULL, DEBUG_CONFIG | IMMUTABLE_CONFIG, 1, 128, server.io_threads_num, 1, INTEGER_CONFIG, NULL, NULL), /* Single threaded by default */
+    createIntConfig("io-threads", NULL, MODIFIABLE_CONFIG, 1, 128, server.config_io_threads_num, 1, INTEGER_CONFIG, NULL, NULL), /* Single threaded by default */
     createIntConfig("prefetch-batch-max-size", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, 128, server.prefetch_batch_max_size, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_slave_validity_factor, 10, INTEGER_CONFIG, NULL, NULL), /* Slave max data age factor. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -1396,7 +1396,7 @@ void clientAcceptHandler(connection *conn) {
                           c);
 
     /* Assign the client to an IO thread */
-    if (server.io_threads_num > 1) assignClientToIOThread(c);
+    if (isMultiThreads()) assignClientToIOThread(c);
 }
 
 void acceptCommonHandler(connection *conn, int flags, char *ip) {
@@ -2262,7 +2262,7 @@ int handleClientsWithPendingWrites(void) {
         if (c->flags & CLIENT_CLOSE_ASAP) continue;
 
         /* Let IO thread handle the client if possible. */
-        if (server.io_threads_num > 1 &&
+        if (isMultiThreads() &&
             !(c->flags & CLIENT_CLOSE_AFTER_REPLY) &&
             !isClientMustHandledByMainThread(c))
         {
@@ -4710,4 +4710,9 @@ void evictClients(void) {
             listRewind(server.client_mem_usage_buckets[curr_bucket].clients, &bucket_iter);
         }
     }
+}
+
+void freeThreadReusableQb(void) {
+    serverAssert(thread_reusable_qb_used == 0);
+    if (thread_reusable_qb != NULL) sdsfree(thread_reusable_qb);
 }

--- a/tests/unit/io_thread.tcl
+++ b/tests/unit/io_thread.tcl
@@ -1,0 +1,258 @@
+proc get_info_field {info field} {
+    set fl [string length $field]
+    append field :
+    foreach line [split $info "\n"] {
+        set line [string trim $line "\r\n "]
+        if {[string range $line 0 $fl] eq $field} {
+            return [string range $line [expr {$fl+1}] end]
+        }
+    }
+    return {}
+}
+
+proc get_kv_value {input key} {
+    foreach pair [split $input ","] {
+        if {[regexp {^\s*([^=]+)\s*=\s*(.+?)\s*$} $pair -> k v]} {
+            if {$k eq $key} {
+                return $v
+            }
+        }
+    }
+    return ""
+}
+
+start_server {overrides {}} {
+    r set k v 
+
+    
+    test "threads 1 => n and n => 1" {
+        for {set thread_size 2} {$thread_size < 5} {incr thread_size} {
+            assert_equal [get_info_field [r info threads] io_thread_scale_status] "none"
+            assert {[get_info_field [r info threads] io_thread_1 ] eq ""}
+            # set io-threads n
+            # when client size < thread size , thread scale up task finish
+            if {!$::external} {
+                set lines [count_log_lines 0]
+            }
+            assert_equal [get_kv_value [get_info_field [r info threads] io_thread_0 ] clients] 1
+            r config set io-threads $thread_size 
+            if {!$::external} {
+                verify_log_message 0 "*IO threads scale-up end*" $lines
+            }
+            assert_equal [r get k] v 
+
+
+            # reset io-threads 1
+            if {!$::external} {
+                set lines [count_log_lines 0]
+            }
+            r config set io-threads 1
+            after 100
+            assert_equal [get_info_field [r info threads] io_thread_scale_status] "down"
+            wait_for_condition 100 50 {
+                [get_info_field [r info threads] io_thread_1 ] eq ""
+            } else {
+                fail "thread down n => 1 fail"
+            }
+            if {!$::external} {
+                verify_log_message 0 "*IO threads scale-down end*" $lines
+            }
+
+            # add clients
+            set clients []
+            for {set j 0} {$j < 100} {incr j} {
+                set cli [redis [srv 0 "host"] [srv 0 "port"] 0 $::tls]
+                if {!$::singledb} {
+                    $cli select 9
+                }
+                lappend clients $cli
+            }
+            assert_equal [get_kv_value [get_info_field [r info threads] io_thread_0 ] clients] 101
+            # set io-threads n
+            if {!$::external} {
+                set lines [count_log_lines 0]
+            }
+            r config set io-threads $thread_size 
+
+            if {!$::external} {
+                verify_log_message 0 "*IO threads scale-up end*" $lines
+            }
+            assert_equal [r get k] v
+            for {set j 0} {$j < 100} {incr j} {
+                set cli [lindex $clients $j]
+                assert_equal [$cli get k] v
+            }
+
+
+            # reset io-threads 1
+            if {!$::external} {
+                set lines [count_log_lines 0]
+            }
+            r config set io-threads 1
+            assert_equal [get_info_field [r info threads] io_thread_scale_status] "down"
+            wait_for_condition 100 50 {
+                [get_info_field [r info threads] io_thread_1 ] eq ""
+            } else {
+                fail "thread down n => 1 fail"
+            }
+            if {!$::external} {
+                verify_log_message 0 "*IO threads scale-down end*" $lines
+            }
+
+            # close all clients
+            for {set j 0} {$j < 100} {incr j} {
+                set cli [lindex $clients $j]
+                $cli close
+            }
+        }
+
+
+    }
+    
+    # test before set io-threads 2
+    r config set io-threads 2
+    
+    test "threads 2 => n and n => 2" {
+        for {set thread_size 3} {$thread_size < 5} {incr thread_size} {
+            assert_equal [get_info_field [r info threads] io_thread_scale_status] "none"
+            assert {[get_info_field [r info threads] io_thread_1 ] ne ""}
+            assert {[get_info_field [r info threads] io_thread_2 ] eq ""}
+
+            # set io-threads n
+            # when client size < thread size , thread scale up task finish
+            if {!$::external} {
+                set lines [count_log_lines 0]
+            }
+            assert_equal [get_kv_value [get_info_field [r info threads] io_thread_1 ] clients] 1
+            r config set io-threads $thread_size 
+            if {!$::external} {
+                verify_log_message 0 "*IO threads scale-up end*" $lines
+            }
+
+
+            # reset io-threads 2
+            if {!$::external} {
+                set lines [count_log_lines 0]
+            }
+            r config set io-threads 2
+            assert_equal [get_info_field [r info threads] io_thread_scale_status] "down"
+            wait_for_condition 100 50 {
+                [get_info_field [r info threads] io_thread_2 ] eq ""
+            } else {
+                fail "thread down n => 2 fail"
+            }
+            if {!$::external} {
+                verify_log_message 0 "*IO threads scale-down end*" $lines
+            }
+
+            # add clients
+            set clients []
+            for {set j 0} {$j < 100} {incr j} {
+                set cli [redis [srv 0 "host"] [srv 0 "port"] 0 $::tls]
+                if {!$::singledb} {
+                    $cli select 9
+                }
+                lappend clients $cli
+            }
+            assert_equal [get_kv_value [get_info_field [r info threads] io_thread_1 ] clients] 101
+
+            # set io-threads n
+            # wait CLIENT_IO_PENDING_CRON ,load balancing
+            if {!$::external} {
+                set lines [count_log_lines 0]
+            }
+            r config set io-threads $thread_size 
+            assert_equal [get_info_field [r info threads] io_thread_scale_status] "up"
+            wait_for_condition 100 50 {
+                [get_info_field [r info threads] io_thread_scale_status] eq  "none"
+            } else {
+                fail "thread up 2=>n fail"
+            }
+
+            if {!$::external} {
+                assert {[catch {verify_log_message 0 "*IO threads scale-up client num(1)< thread num*" $lines} errorMsg]}
+                assert {$errorMsg ne ""}
+                verify_log_message 0 "*IO threads scale-up end*" $lines
+            }
+
+            # reset io-threads 2
+            # wait CLIENT_IO_PENDING_CRON
+            if {!$::external} {
+                set lines [count_log_lines 0]
+            }
+            r config set io-threads 2
+            assert_equal [get_info_field [r info threads] io_thread_scale_status] "down"
+            wait_for_condition 100 50 {
+                [get_info_field [r info threads] io_thread_2 ] eq ""
+            } else {
+                fail "thread down n => 2 fail"
+            }
+            assert_equal [get_info_field [r info threads] io_thread_scale_status] "none"
+            if {!$::external} {
+                verify_log_message 0 "*IO threads scale-down end*" $lines
+            }
+
+            # set io-threads n
+            # client write, load balancing
+            if {!$::external} {
+                set lines [count_log_lines 0]
+            }
+            r config set io-threads $thread_size 
+            assert_equal [get_info_field [r info threads] io_thread_scale_status] "up"
+            for {set j 0} {$j < 100} {incr j} {
+                set cli [lindex $clients $j]
+                assert_equal [$cli get k] v
+            }
+            assert_equal [get_info_field [r info threads] io_thread_scale_status] "none"
+            if {!$::external} {
+                assert {[catch {verify_log_message 0 "*IO threads scale-up client num(1)< thread num*" $lines} errorMsg]}
+                assert {$errorMsg ne ""}
+                verify_log_message 0 "*IO threads scale-up end*" $lines
+            }
+
+
+            # reset io-threads 2
+            # client write 
+            if {!$::external} {
+                set lines [count_log_lines 0]
+            }
+            r config set io-threads 2
+            assert_equal [get_info_field [r info threads] io_thread_scale_status] "down"
+            assert_equal [r get k] v 
+            for {set j 0} {$j < 100} {incr j} {
+                set cli [lindex $clients $j]
+                assert_equal [$cli get k] v
+            }
+
+            set info [r info threads]
+            if {[get_info_field $info io_thread_2] ne ""} {
+                assert_equal [get_kv_value [get_info_field [r info threads] io_thread_2 ] clients] 0
+                # need wait thread_join
+                wait_for_condition 100 50 {
+                    [get_info_field [r info threads] io_thread_scale_status] eq "none"
+                } else {
+                    fail "thread down n => 2 fail"
+                }
+            } else {
+                assert_equal [get_info_field [r info threads] io_thread_scale_status] "none"
+            }
+
+            
+            if {!$::external} {
+                verify_log_message 0 "*IO threads scale-down end*" $lines
+            }
+
+
+
+            # close all clients
+            for {set j 0} {$j < 100} {incr j} {
+                set cli [lindex $clients $j]
+                $cli close
+            }
+
+        }
+
+    }
+    
+
+}


### PR DESCRIPTION
Rule: 
Load rebalancing and scaling both use a unified mechanism:
 1. Clients are first migrated back to the main thread.
 2. The main thread then reassigns them to the appropriate IO threads
   (based on current thread count and load distribution).
 
 This ensures:
 - Safe client transfer without connection loss.
 - Consistent handling during scale-up, scale-down, and rebalancing.
 - Centralized control in the main thread for simplicity and correctness.
 
Scenario:
1. Scaling up from 1 to N threads:
     Completion is triggered once the main thread offloads
     its first client to any IO thread. No load balancing
     is required (fast path for enabling threading).
 
 2. Scaling up from X to N (X > 1):
     Completion requires load balancing across all active
     IO threads (including existing ones).

 3. Scaling down (e.g., N to 1, N to X):
     Threads are stopped in reverse order (from last to first).
     A thread can be destroyed only when its client count reaches zero.