### PR TITLE
Fix typo in thread status file path comment

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2665,7 +2665,7 @@ void debugDelay(int usec) {
  * If thread tid blocks or ignores sig_num returns 0 (thread is not ready to catch the signal).
  * also returns 0 if something is wrong and prints a warning message to the log file **/
 static int is_thread_ready_to_signal(const char *proc_pid_task_path, const char *tid, int sig_num) {
-    /* Open the threads status file path /proc/<pid>>/task/<tid>/status */
+    /* Open the threads status file path /proc/<pid>/task/<tid>/status */
     char path_buff[PATH_MAX];
     snprintf_async_signal_safe(path_buff, PATH_MAX, "%s/%s/status", proc_pid_task_path, tid);
 


### PR DESCRIPTION
The comment for the thread status file path contained an extra '>' character ("/proc/<pid>>/task/<tid>/status"). Fixed it to "/proc/<pid>/task/<tid>/status" for clarity and accuracy.
