### PR TITLE
Prevent crash when cgroups_ref is null in streamEntryIsReferenced() after reload

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2705,6 +2705,7 @@ int streamEntryIsReferenced(stream *s, streamID *id) {
         return 1;
 
     /* Check if the message is in any consumer group's PEL */
+    if (!s->cgroups_ref) return 0;
     unsigned char buf[sizeof(streamID)];
     streamEncodeID(buf, id);
     return raxFind(s->cgroups_ref, buf, sizeof(streamID), NULL);

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -244,6 +244,33 @@ start_server {
         assert {[r XLEN mystream] == 1} ;# Successfully trimmed to 1 entries
     }
 
+    test {XADD with ACKED option doesn't crash after DEBUG RELOAD} {
+        r DEL mystream
+        r XADD mystream 1-0 f v
+
+        # Create a consumer group and read one message
+        r XGROUP CREATE mystream mygroup 0
+        set records [r XREADGROUP GROUP mygroup consumer1 COUNT 1 STREAMS mystream >]
+        assert_equal [lindex [r XPENDING mystream mygroup] 0] 1
+
+        # After reload, the reference relationship between consumer groups and messages
+        # is correctly rebuilt, so the previously read but unacked message still cannot be deleted.
+        r DEBUG RELOAD
+        r XADD mystream MAXLEN = 1 ACKED 2-0 f v
+        assert_equal [r XLEN mystream] 2
+
+        # Acknowledge the read message so the PEL becomes empty
+        r XACK mystream mygroup [lindex [lindex [lindex [lindex $records 0] 1] 0] 0]
+        assert {[lindex [r XPENDING mystream mygroup] 0] == 0}
+
+        # After reload, since PEL is empty, no cgroup references will be recreated.
+        r DEBUG RELOAD
+
+        # ACKED option should work correctly even without cgroup references.
+        r XADD mystream MAXLEN = 1 ACKED 3-0 f v
+        assert_equal [r XLEN mystream] 2
+    }
+
     test {XADD with MAXLEN option and DELREF option} {
         r DEL mystream
         r XADD mystream 1-0 f v

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -269,7 +269,7 @@ start_server {
         # ACKED option should work correctly even without cgroup references.
         r XADD mystream MAXLEN = 1 ACKED 3-0 f v
         assert_equal [r XLEN mystream] 2
-    }
+    } {} {needs:debug}
 
     test {XADD with MAXLEN option and DELREF option} {
         r DEL mystream


### PR DESCRIPTION
This bug was introduced by https://github.com/redis/redis/pull/14130 found by @oranagra 

### Summary

Because `s->cgroup_ref` is created at runtime the first time a consumer group is linked with a message, but it is not released when all references are removed.

However, after `debug reload` or restart, if the PEL is empty (meaning no consumer group is referencing any message), `s->cgroup_ref` will not be recreated.

As a result, when executing XADD or XTRIM with `ACKED` option and checking whether a message that is being read but has not been ACKed can be deleted, the cgroup_ref being NULL will cause a crash.

### Code Path
```
xaddCommand -> streamTrim -> streamEntryIsReferenced
```

### Solution

Check if `s->cgroup_ref` is NULL in streamEntryIsReferenced().

### Crash Report

```
Logged crash report (pid 60922):
=== REDIS BUG REPORT START: Cut & paste starting from here ===
60922:M 14 Aug 2025 17:58:39.731 # Redis 255.255.255 crashed by signal: 11, si_code: 1
60922:M 14 Aug 2025 17:58:39.731 # Accessing address: (nil)
60922:M 14 Aug 2025 17:58:39.731 # Crashed running the instruction at: 0x55eb5ed7f974

------ STACK TRACE ------
EIP:
src/redis-server 127.0.0.1:21611(+0x260974)[0x55eb5ed7f974]

60924 bio_close_file
/lib/x86_64-linux-gnu/libc.so.6(+0x98d71)[0x7fb076498d71]
/lib/x86_64-linux-gnu/libc.so.6(pthread_cond_wait+0x20d)[0x7fb07649b7ed]
src/redis-server 127.0.0.1:21611(bioProcessBackgroundJobs+0x1ea)[0x55eb5ecb9a2a]
/lib/x86_64-linux-gnu/libc.so.6(+0x9caa4)[0x7fb07649caa4]
/lib/x86_64-linux-gnu/libc.so.6(+0x129c3c)[0x7fb076529c3c]

60925 bio_aof
/lib/x86_64-linux-gnu/libc.so.6(+0x98d71)[0x7fb076498d71]
/lib/x86_64-linux-gnu/libc.so.6(pthread_cond_wait+0x20d)[0x7fb07649b7ed]
src/redis-server 127.0.0.1:21611(bioProcessBackgroundJobs+0x1ea)[0x55eb5ecb9a2a]
/lib/x86_64-linux-gnu/libc.so.6(+0x9caa4)[0x7fb07649caa4]
/lib/x86_64-linux-gnu/libc.so.6(+0x129c3c)[0x7fb076529c3c]

60922 redis-server *
/lib/x86_64-linux-gnu/libc.so.6(+0x45330)[0x7fb076445330]
src/redis-server 127.0.0.1:21611(+0x260974)[0x55eb5ed7f974]
src/redis-server 127.0.0.1:21611(+0x2128a0)[0x55eb5ed318a0]
src/redis-server 127.0.0.1:21611(streamTrim+0x8d7)[0x55eb5ed24947]
src/redis-server 127.0.0.1:21611(xaddCommand+0x2fb)[0x55eb5ed2852b]
src/redis-server 127.0.0.1:21611(call+0x171)[0x55eb5ebd0bb1]
src/redis-server 127.0.0.1:21611(processCommand+0xae8)[0x55eb5ebde688]
src/redis-server 127.0.0.1:21611(processInputBuffer+0xd9)[0x55eb5ebf7729]
src/redis-server 127.0.0.1:21611(readQueryFromClient+0x358)[0x55eb5ebfc608]
src/redis-server 127.0.0.1:21611(+0x227914)[0x55eb5ed46914]
src/redis-server 127.0.0.1:21611(aeMain+0xf9)[0x55eb5ebb2a29]
src/redis-server 127.0.0.1:21611(main+0x4a7)[0x55eb5ebac8c7]
/lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca)[0x7fb07642a1ca]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b)[0x7fb07642a28b]
src/redis-server 127.0.0.1:21611(_start+0x25)[0x55eb5ebae145]

60926 bio_lazy_free
/lib/x86_64-linux-gnu/libc.so.6(+0x98d71)[0x7fb076498d71]
/lib/x86_64-linux-gnu/libc.so.6(pthread_cond_wait+0x20d)[0x7fb07649b7ed]
src/redis-server 127.0.0.1:21611(bioProcessBackgroundJobs+0x1ea)[0x55eb5ecb9a2a]
/lib/x86_64-linux-gnu/libc.so.6(+0x9caa4)[0x7fb07649caa4]
/lib/x86_64-linux-gnu/libc.so.6(+0x129c3c)[0x7fb076529c3c]

4/4 expected stacktraces.

------ STACK TRACE DONE ------

------ REGISTERS ------
60922:M 14 Aug 2025 17:58:39.733 # 
RAX:0000000000000000 RBX:00007fb076032310
RCX:0000000000000000 RDX:0000000000000000
RDI:0000000000000000 RSI:00007ffd390e20d0
RBP:00007ffd390e2110 RSP:00007ffd390e1ed8
R8 :0000000000000000 R9 :0000000000000000
R10:0000000000000000 R11:0000000000000000
R12:00007ffd390e21b0 R13:00007ffd390e20d0
R14:0000000000000002 R15:00007fb076032310
RIP:000055eb5ed7f974 EFL:0000000000010246
CSGSFS:002b000000000033
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1ee7) -> 0000000000000000
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1ee6) -> 0000000000000017
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1ee5) -> 0000001700000017
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1ee4) -> 00007fb07620d5f8
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1ee3) -> 00007fb07616b000
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1ee2) -> 00007fb0763ffe00
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1ee1) -> 00007fb0763ffe00
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1ee0) -> 000055eb5ee155fa
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1edf) -> 0070756f7267796d
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1ede) -> 0000000000000080
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1edd) -> 0000000000000007
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1edc) -> 00007fb07601b668
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1edb) -> 00007ffd390e1f10
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1eda) -> 00007fb07605f338
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1ed9) -> 00007fb000000002
60922:M 14 Aug 2025 17:58:39.733 # (00007ffd390e1ed8) -> 000055eb5ed318a0

------ INFO OUTPUT ------
# Server
redis_version:255.255.255
redis_git_sha1:8893d522
redis_git_dirty:1
redis_build_id:5db7de2abb8415da
redis_mode:standalone
os:Linux 6.8.0-71-generic x86_64
arch_bits:64
monotonic_clock:POSIX clock_gettime
multiplexing_api:epoll
atomicvar_api:c11-builtin
gcc_version:13.3.0
process_id:60922
process_supervised:no
run_id:f9d0bf58fe81988400b82fbe03cf9071b30642f5
tcp_port:21611
server_time_usec:1755165519731678
uptime_in_seconds:0
uptime_in_days:0
hz:10
configured_hz:10
lru_clock:10335055
executable:/home/sundb/data/rf_2/src/redis-server
config_file:/home/sundb/data/rf_2/./tests/tmp/redis.conf.60903.2
io_threads_active:0
listener0:name=tcp,bind=127.0.0.1,port=21611
listener1:name=unix,bind=/home/sundb/data/rf_2/tests/tmp/server.60903.1/socket

# Clients
connected_clients:1
cluster_connections:0
maxclients:10000
client_recent_max_input_buffer:0
client_recent_max_output_buffer:0
blocked_clients:0
tracking_clients:0
pubsub_clients:0
watching_clients:0
clients_in_timeout_table:0
total_watched_keys:0
total_blocking_keys:0
total_blocking_keys_on_nokey:0

# Memory
used_memory:944536
used_memory_human:922.40K
used_memory_rss:9961472
used_memory_rss_human:9.50M
used_memory_peak:944536
used_memory_peak_human:922.40K
used_memory_peak_time:1755165519
used_memory_peak_perc:100.22%
used_memory_overhead:719744
used_memory_startup:651872
used_memory_dataset:224792
used_memory_dataset_perc:76.81%
allocator_allocated:1488832
allocator_active:1667072
allocator_resident:9101312
allocator_muzzy:0
total_system_memory:66516324352
total_system_memory_human:61.95G
used_memory_lua:31744
used_memory_vm_eval:31744
used_memory_lua_human:31.00K
used_memory_scripts_eval:0
number_of_cached_scripts:0
number_of_functions:0
number_of_libraries:0
used_memory_vm_functions:32768
used_memory_vm_total:64512
used_memory_vm_total_human:63.00K
used_memory_functions:400
used_memory_scripts:400
used_memory_scripts_human:400B
maxmemory:0
maxmemory_human:0B
maxmemory_policy:noeviction
allocator_frag_ratio:1.10
allocator_frag_bytes:102208
allocator_rss_ratio:5.46
allocator_rss_bytes:7434240
rss_overhead_ratio:1.09
rss_overhead_bytes:860160
mem_fragmentation_ratio:15.28
mem_fragmentation_bytes:9309456
mem_not_counted_for_evict:0
mem_replication_backlog:0
mem_total_replication_buffers:0
mem_replica_full_sync_buffer:0
mem_clients_slaves:0
mem_clients_normal:0
mem_cluster_links:0
mem_aof_buffer:0
mem_allocator:jemalloc-5.3.0
mem_overhead_db_hashtable_rehashing:0
active_defrag_running:0
lazyfree_pending_objects:0
lazyfreed_objects:0

# Persistence
loading:0
async_loading:0
current_cow_peak:0
current_cow_size:0
current_cow_size_age:0
current_fork_perc:0.00
current_save_keys_processed:0
current_save_keys_total:0
rdb_changes_since_last_save:1
rdb_bgsave_in_progress:0
rdb_last_save_time:1755165519
rdb_last_bgsave_status:ok
rdb_last_bgsave_time_sec:-1
rdb_current_bgsave_time_sec:-1
rdb_saves:0
rdb_last_cow_size:0
rdb_last_load_keys_expired:0
rdb_last_load_keys_loaded:1
aof_enabled:0
aof_rewrite_in_progress:0
aof_rewrite_scheduled:0
aof_last_rewrite_time_sec:-1
aof_current_rewrite_time_sec:-1
aof_last_bgrewrite_status:ok
aof_rewrites:0
aof_rewrites_consecutive_failures:0
aof_last_write_status:ok
aof_last_cow_size:0
module_fork_in_progress:0
module_fork_last_cow_size:0

# Threads
io_thread_0:clients=1,reads=15,writes=13

# Stats
total_connections_received:2
total_commands_processed:13
instantaneous_ops_per_sec:0
total_net_input_bytes:680
total_net_output_bytes:193
total_net_repl_input_bytes:0
total_net_repl_output_bytes:0
instantaneous_input_kbps:0.00
instantaneous_output_kbps:0.00
instantaneous_input_repl_kbps:0.00
instantaneous_output_repl_kbps:0.00
rejected_connections:0
sync_full:0
sync_partial_ok:0
sync_partial_err:0
expired_subkeys:0
expired_keys:0
expired_stale_perc:0.00
expired_time_cap_reached_count:0
expire_cycle_cpu_milliseconds:0
evicted_keys:0
evicted_clients:0
evicted_scripts:0
total_eviction_exceeded_time:0
current_eviction_exceeded_time:0
keyspace_hits:6
keyspace_misses:0
pubsub_channels:0
pubsub_patterns:0
pubsubshard_channels:0
latest_fork_usec:0
total_forks:0
migrate_cached_sockets:0
slave_expires_tracked_keys:0
active_defrag_hits:0
active_defrag_misses:0
active_defrag_key_hits:0
active_defrag_key_misses:0
total_active_defrag_time:0
current_active_defrag_time:0
tracking_total_keys:0
tracking_total_items:0
tracking_total_prefixes:0
unexpected_error_replies:0
total_error_replies:0
dump_payload_sanitizations:0
total_reads_processed:15
total_writes_processed:13
io_threaded_reads_processed:0
io_threaded_writes_processed:0
io_threaded_total_prefetch_batches:0
io_threaded_total_prefetch_entries:0
client_query_buffer_limit_disconnections:0
client_output_buffer_limit_disconnections:0
reply_buffer_shrinks:0
reply_buffer_expands:0
eventloop_cycles:18
eventloop_duration_sum:25747
eventloop_duration_cmd_sum:25064
instantaneous_eventloop_cycles_per_sec:0
instantaneous_eventloop_duration_usec:0
acl_access_denied_auth:0
acl_access_denied_cmd:0
acl_access_denied_key:0
acl_access_denied_channel:0

# Replication
role:master
connected_slaves:0
master_failover_state:no-failover
master_replid:160c53fc9514f311a3abe7d487ec6de0151a89db
master_replid2:0000000000000000000000000000000000000000
master_repl_offset:0
second_repl_offset:-1
repl_backlog_active:0
repl_backlog_size:1048576
repl_backlog_first_byte_offset:0
repl_backlog_histlen:0

# CPU
used_cpu_sys:0.004854
used_cpu_user:0.002427
used_cpu_sys_children:0.000000
used_cpu_user_children:0.000000
used_cpu_sys_main_thread:0.004626
used_cpu_user_main_thread:0.002313

# Modules
module:name=vectorset,ver=1,api=1,filters=0,usedby=[],using=[],options=[handle-io-errors|handle-repl-async-load]

# Commandstats
cmdstat_ping:calls=1,usec=4,usec_per_call=4.00,rejected_calls=0,failed_calls=0
cmdstat_select:calls=1,usec=1,usec_per_call=1.00,rejected_calls=0,failed_calls=0
cmdstat_xadd:calls=2,usec=20,usec_per_call=10.00,rejected_calls=0,failed_calls=0
cmdstat_del:calls=1,usec=1,usec_per_call=1.00,rejected_calls=0,failed_calls=0
cmdstat_xgroup|create:calls=1,usec=2,usec_per_call=2.00,rejected_calls=0,failed_calls=0
cmdstat_debug:calls=2,usec=25020,usec_per_call=12510.00,rejected_calls=0,failed_calls=0
cmdstat_xreadgroup:calls=1,usec=13,usec_per_call=13.00,rejected_calls=0,failed_calls=0
cmdstat_xack:calls=1,usec=1,usec_per_call=1.00,rejected_calls=0,failed_calls=0
cmdstat_xpending:calls=2,usec=1,usec_per_call=0.50,rejected_calls=0,failed_calls=0
cmdstat_xlen:calls=1,usec=1,usec_per_call=1.00,rejected_calls=0,failed_calls=0

# Errorstats

# Latencystats
latency_percentiles_usec_ping:p50=4.015,p99=4.015,p99.9=4.015
latency_percentiles_usec_select:p50=1.003,p99=1.003,p99.9=1.003
latency_percentiles_usec_xadd:p50=6.015,p99=14.015,p99.9=14.015
latency_percentiles_usec_del:p50=1.003,p99=1.003,p99.9=1.003
latency_percentiles_usec_xgroup|create:p50=2.007,p99=2.007,p99.9=2.007
latency_percentiles_usec_debug:p50=12517.375,p99=12582.911,p99.9=12582.911
latency_percentiles_usec_xreadgroup:p50=13.055,p99=13.055,p99.9=13.055
latency_percentiles_usec_xack:p50=1.003,p99=1.003,p99.9=1.003
latency_percentiles_usec_xpending:p50=0.001,p99=1.003,p99.9=1.003
latency_percentiles_usec_xlen:p50=1.003,p99=1.003,p99.9=1.003

# Cluster
cluster_enabled:0

# Keyspace
db9:keys=1,expires=0,avg_ttl=0,subexpiry=0

# Keysizes

------ CLIENT LIST OUTPUT ------
id=5 addr=127.0.0.1:42039 laddr=127.0.0.1:21611 fd=12 name= age=0 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=88 qbuf-free=20386 argv-mem=30 multi-mem=0 rbs=16384 rbp=16384 obl=9 oll=0 omem=0 tot-mem=37862 events=r cmd=xadd user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0 tot-net-in=673 tot-net-out=186 tot-cmds=12

------ CURRENT CLIENT INFO ------
id=5 addr=127.0.0.1:42039 laddr=127.0.0.1:21611 fd=12 name= age=0 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=88 qbuf-free=20386 argv-mem=30 multi-mem=0 rbs=16384 rbp=16384 obl=9 oll=0 omem=0 tot-mem=37862 events=r cmd=xadd user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0 tot-net-in=673 tot-net-out=186 tot-cmds=12
argc: '9'
argv[0]: '"XADD"'
argv[1]: '"mystream"'
argv[2]: '"MAXLEN"'
argv[3]: '"="'
argv[4]: '"1"'
argv[5]: '"ACKED"'
argv[6]: '"3-0"'
argv[7]: '"f"'
argv[8]: '"v"'
60922:M 14 Aug 2025 17:58:39.734 # key 'mystream' found in DB containing the following object:
60922:M 14 Aug 2025 17:58:39.734 # Object type: 6
60922:M 14 Aug 2025 17:58:39.734 # Object encoding: 10
60922:M 14 Aug 2025 17:58:39.734 # Object refcount: 1

------ EXECUTING CLIENT INFO ------
id=5 addr=127.0.0.1:42039 laddr=127.0.0.1:21611 fd=12 name= age=0 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=88 qbuf-free=20386 argv-mem=30 multi-mem=0 rbs=16384 rbp=16384 obl=9 oll=0 omem=0 tot-mem=37862 events=r cmd=xadd user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0 tot-net-in=673 tot-net-out=186 tot-cmds=12
argc: '9'
argv[0]: '"XADD"'
argv[1]: '"mystream"'
argv[2]: '"MAXLEN"'
argv[3]: '"="'
argv[4]: '"1"'
argv[5]: '"ACKED"'
argv[6]: '"3-0"'
argv[7]: '"f"'
argv[8]: '"v"'
60922:M 14 Aug 2025 17:58:39.734 # key 'mystream' found in DB containing the following object:
60922:M 14 Aug 2025 17:58:39.734 # Object type: 6
60922:M 14 Aug 2025 17:58:39.734 # Object encoding: 10
60922:M 14 Aug 2025 17:58:39.734 # Object refcount: 1

------ MODULES INFO OUTPUT ------

------ CONFIG DEBUG OUTPUT ------
repl-diskless-load disabled
list-compress-depth 0
lazyfree-lazy-user-del no
lazyfree-lazy-server-del no
lazyfree-lazy-user-flush no
slave-read-only yes
repl-diskless-sync yes
activedefrag no
proto-max-bulk-len 512mb
client-query-buffer-limit 1gb
lazyfree-lazy-eviction no
io-threads 1
replica-read-only yes
lazyfree-lazy-expire no
sanitize-dump-payload no

------ FAST MEMORY TEST ------
60922:M 14 Aug 2025 17:58:39.734 # Bio worker thread #0 terminated
60922:M 14 Aug 2025 17:58:39.734 # Bio worker thread #1 terminated
60922:M 14 Aug 2025 17:58:39.734 # Bio worker thread #2 terminated
*** Preparing to test memory region 55eb5ef37000 (2322432 bytes)
*** Preparing to test memory region 55eb72bf7000 (135168 bytes)
*** Preparing to test memory region 7fb06c000000 (135168 bytes)
*** Preparing to test memory region 7fb0723fc000 (8388608 bytes)
*** Preparing to test memory region 7fb072bfd000 (8388608 bytes)
*** Preparing to test memory region 7fb0733fe000 (8388608 bytes)
*** Preparing to test memory region 7fb073bff000 (8388608 bytes)
*** Preparing to test memory region 7fb074400000 (8388608 bytes)
*** Preparing to test memory region 7fb074c00000 (10485760 bytes)
*** Preparing to test memory region 7fb075c00000 (8388608 bytes)
*** Preparing to test memory region 7fb076605000 (53248 bytes)
*** Preparing to test memory region 7fb076a7a000 (16384 bytes)
*** Preparing to test memory region 7fb076b76000 (28672 bytes)
*** Preparing to test memory region 7fb076cab000 (8192 bytes)
.O.O.O.O.O.O.O.O.O.O.O.O.O.O
Fast memory test PASSED, however your memory can still be broken. Please run a memory test for several hours if possible.

------ DUMPING CODE AROUND EIP ------
Symbol: (null) (base: (nil))
Module: src/redis-server 127.0.0.1:21611 (base 0x55eb5eb1f000)
$ xxd -r -p /tmp/dump.hex /tmp/dump.bin
$ objdump --adjust-vma=(nil) -D -b binary -m i386:x86-64 /tmp/dump.bin
------

=== REDIS BUG REPORT END. Make sure to include from START to END. ===

       Please report the crash by opening an issue on github:

           http://github.com/redis/redis/issues

  If a Redis module was involved, please open in the module's repo instead.

  Suspect RAM error? Use redis-server --test-memory to verify it.

  Some other issues could be detected by redis-server --check-system
```