### PR TITLE
Fix numeric config boundry check

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2096,8 +2096,14 @@ static int numericBoundaryCheck(standardConfig *config, long long ll, const char
     if (config->data.numeric.numeric_type == NUMERIC_TYPE_ULONG_LONG ||
         config->data.numeric.numeric_type == NUMERIC_TYPE_UINT ||
         config->data.numeric.numeric_type == NUMERIC_TYPE_SIZE_T) {
-        /* Boundary check for unsigned types */
-        if (ll < 0) {
+        /* Boundary check for unsigned types
+         * The upper/lower bound check should suffice but for UINT type if
+         * negative value is passed that certainly means an error. This check
+         * is only here for the module config API - see moduleSetNumericConfig.
+         * If the numeric config was not set through a module, the codepath
+         * would be through numericConfigSet, which deals with wrong values
+         * via numericParseString. */
+        if (config->data.numeric.numeric_type == NUMERIC_TYPE_UINT && ll < 0) {
             *err = "argument must be greater or equal to 0";
             return 0;
         }

--- a/src/config.c
+++ b/src/config.c
@@ -2096,17 +2096,7 @@ static int numericBoundaryCheck(standardConfig *config, long long ll, const char
     if (config->data.numeric.numeric_type == NUMERIC_TYPE_ULONG_LONG ||
         config->data.numeric.numeric_type == NUMERIC_TYPE_UINT ||
         config->data.numeric.numeric_type == NUMERIC_TYPE_SIZE_T) {
-        /* Boundary check for unsigned types
-         * The upper/lower bound check should suffice but for UINT type if
-         * negative value is passed that certainly means an error. This check
-         * is only here for the module config API - see moduleSetNumericConfig.
-         * If the numeric config was not set through a module, the codepath
-         * would be through numericConfigSet, which deals with wrong values
-         * via numericParseString. */
-        if (config->data.numeric.numeric_type == NUMERIC_TYPE_UINT && ll < 0) {
-            *err = "argument must be greater or equal to 0";
-            return 0;
-        }
+        /* Boundary check for unsigned types */
         unsigned long long ull = ll;
         unsigned long long upper_bound = config->data.numeric.upper_bound;
         unsigned long long lower_bound = config->data.numeric.lower_bound;

--- a/src/module.c
+++ b/src/module.c
@@ -13863,6 +13863,8 @@ int RM_ConfigSetEnum(RedisModuleCtx *ctx, const char *name, RedisModuleString *v
 /* Set the value of a numeric config.
  * If the value passed is meant to be a percentage, it should be passed as a
  * negative value.
+ * For unsigned configs pass the value and cast to (long long) - internal type
+ * checks will handle it.
  *
  * See RedisModule_ConfigSet for return value. */
 int RM_ConfigSetNumeric(RedisModuleCtx *ctx, const char *name, long long value, RedisModuleString **err) {

--- a/tests/modules/configaccess.c
+++ b/tests/modules/configaccess.c
@@ -221,9 +221,17 @@ int TestSetNumericConfig_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **a
     const char *config_name = RedisModule_StringPtrLen(argv[1], &name_len);
 
     long long value;
-    if (RedisModule_StringToLongLong(argv[2], &value) != REDISMODULE_OK) {
-        RedisModule_ReplyWithError(ctx, "ERR Invalid numeric value");
-        return REDISMODULE_ERR;
+    const char *value_str= RedisModule_StringPtrLen(argv[2], NULL);
+    if (value_str[0] == '-') {
+        if (RedisModule_StringToLongLong(argv[2], &value) != REDISMODULE_OK) {
+            RedisModule_ReplyWithError(ctx, "ERR Invalid numeric value");
+            return REDISMODULE_ERR;
+        }
+    } else {
+        if (RedisModule_StringToULongLong(argv[2], (unsigned long long*)&value) != REDISMODULE_OK) {
+            RedisModule_ReplyWithError(ctx, "ERR Invalid numeric value");
+            return REDISMODULE_ERR;
+        }
     }
 
     RedisModuleString *error = NULL;

--- a/tests/unit/moduleapi/configaccess.tcl
+++ b/tests/unit/moduleapi/configaccess.tcl
@@ -134,10 +134,13 @@ start_server {tags {"modules"}} {
         catch {r configaccess.setnumeric moduleconfigs.numeric 5000} err
         assert_match "*ERR*" $err
         catch {r configaccess.setnumeric maxclients -1} err
-        assert_match "*argument must be greater or equal to 0*" $err
+        assert_match "*Failed to set numeric config maxclients: argument must be between*" $err
+        catch {r configaccess.setnumeric maxclients -9223372036854775808} err
+        assert_match "*Failed to set numeric config maxclients: argument must be between*" $err
 
         # Sanity check
         assert_equal [r configaccess.setnumeric maxmemory 18446744073709551615] "OK"
+        assert_equal [r configaccess.setnumeric maxmemory -1] "OK"
     }
 
     test {Test module get all configs} {

--- a/tests/unit/moduleapi/configaccess.tcl
+++ b/tests/unit/moduleapi/configaccess.tcl
@@ -133,6 +133,11 @@ start_server {tags {"modules"}} {
         # Test setting a numeric config with out-of-range value
         catch {r configaccess.setnumeric moduleconfigs.numeric 5000} err
         assert_match "*ERR*" $err
+        catch {r configaccess.setnumeric maxclients -1} err
+        assert_match "*argument must be greater or equal to 0*" $err
+
+        # Sanity check
+        assert_equal [r configaccess.setnumeric maxmemory 18446744073709551615] "OK"
     }
 
     test {Test module get all configs} {


### PR DESCRIPTION
Revert a breaking change introduced in #14051 described in this comment https://github.com/redis/redis/pull/14051#discussion_r2281765769

The non-negative check inside `checkNumericBoundaries` was ignoring that passing a big unsigned long long value (> 2^63-1) will be passed as negative value and will never reach the lower/upper boundary check.

The check is removed, reverting the breaking change.

Note that this allows the ambiguity of passing a negative value for unsigned long long configs as moduleSetNumericConfig has `long long` param for the value. The negative value would be implicitly converted to unsigned long long. Further discussion on how to resolve the ambiguity would be needed.