### PR TITLE
Fix MEMORY USAGE command

### DIFF
--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -43,7 +43,7 @@ start_server {tags {"hash"}} {
         create_hash myhash $contents
         assert_encoding $type myhash
 
-        # coverage for objectComputeSize
+        # coverage for kvobjComputeSize
         assert_morethan [memory_usage myhash] 0
 
         test "HRANDFIELD - $type" {

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -2241,7 +2241,7 @@ foreach {pop} {BLPOP BLMPOP_RIGHT} {
         set k [r lrange k 0 -1]
         set dump [r dump k]
 
-        # coverage for objectComputeSize
+        # coverage for kvobjComputeSize
         assert_morethan [memory_usage k] 0
 
         config_set sanitize-dump-payload no mayfail


### PR DESCRIPTION
After the key-value unification (kvobj), the MEMORY USAGE command may no longer account for the embedded key length stored within the kvobj. To fix this, replace sizeof(*o) with zmalloc_size((void *)o) to ensure the full allocated size is measured.

In this context, the function objectComputeSize() was renamed and modified to kvobjComputeSize(). From computing only the value size to compute the key and its value.