### PR TITLE
Expose "touches-arbitrary-keys" flag to Redis modules

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1255,8 +1255,7 @@ RedisModuleCommand *moduleCreateCommandProxy(struct RedisModule *module, sds dec
  *                   For example, module commands that are called by the modules,
  *                   commands that do not perform ACL validations (relying on earlier checks)
  * * **"touches-arbitrary-keys"**: This command may modify arbitrary keys (i.e. not provided via argv).
- *                   This flag is used so we don't wrap the replicated commands with MULTI/EXEC, because it
- *                   might result in a CROSSSLOT violation in Redis-Enterprise
+ *                   This flag is used so we don't wrap the replicated commands with MULTI/EXEC.
  *
  * The last three parameters specify which arguments of the new command are
  * Redis keys. See https://redis.io/commands/command for more information.

--- a/src/module.c
+++ b/src/module.c
@@ -1165,7 +1165,8 @@ int64_t commandFlagsFromString(char *s) {
         else if (!strcasecmp(t,"no-cluster")) flags |= CMD_MODULE_NO_CLUSTER;
         else if (!strcasecmp(t,"no-mandatory-keys")) flags |= CMD_NO_MANDATORY_KEYS;
         else if (!strcasecmp(t,"allow-busy")) flags |= CMD_ALLOW_BUSY;
-        else if (!strcasecmp(t, "internal")) flags |= (CMD_INTERNAL|CMD_NOSCRIPT); /* We also disallow internal commands in scripts. */
+        else if (!strcasecmp(t,"internal")) flags |= (CMD_INTERNAL|CMD_NOSCRIPT); /* We also disallow internal commands in scripts. */
+        else if (!strcasecmp(t,"touches-arbitrary-keys")) flags |= CMD_TOUCHES_ARBITRARY_KEYS;
         else break;
     }
     sdsfreesplitres(tokens,count);
@@ -1253,6 +1254,9 @@ RedisModuleCommand *moduleCreateCommandProxy(struct RedisModule *module, sds dec
  * * **"internal"**: Internal command, one that should not be exposed to the user connections.
  *                   For example, module commands that are called by the modules,
  *                   commands that do not perform ACL validations (relying on earlier checks)
+ * * **"touches-arbitrary-keys"**: This command may modify arbitrary keys (i.e. not provided via argv).
+ *                   This flag is used so we don't wrap the replicated commands with MULTI/EXEC, because it
+ *                   might result in a CROSSSLOT violation in Redis-Enterprise
  *
  * The last three parameters specify which arguments of the new command are
  * Redis keys. See https://redis.io/commands/command for more information.

--- a/tests/modules/zset.c
+++ b/tests/modules/zset.c
@@ -69,6 +69,72 @@ int zset_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return RedisModule_ReplyWithError(ctx, "ERR ZsetIncrby failed");
 }
 
+/* Structure to hold data for the delall scan callback */
+typedef struct {
+    RedisModuleCtx *ctx;
+    size_t deleted_count;
+} zset_delall_data;
+
+/* Callback function for scanning keys and deleting zsets */
+void zset_delall_callback(RedisModuleCtx *ctx, RedisModuleString *keyname, RedisModuleKey *key, void *privdata) {
+    zset_delall_data *data = privdata;
+    int was_opened = 0;
+
+    /* Open the key if it wasn't already opened */
+    if (!key) {
+        key = RedisModule_OpenKey(ctx, keyname, REDISMODULE_READ);
+        was_opened = 1;
+    }
+
+    /* Check if the key is a zset and delete it immediately */
+    if (RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_ZSET) {
+        /* Close the key first if we opened it */
+        if (was_opened) {
+            RedisModule_CloseKey(key);
+            was_opened = 0;
+        }
+
+        /* Delete the key using DEL command */
+        RedisModuleCallReply *reply = RedisModule_Call(ctx, "DEL", "s!", keyname);
+        if (reply && RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_INTEGER) {
+            long long del_result = RedisModule_CallReplyInteger(reply);
+            if (del_result > 0) {
+                data->deleted_count++;
+            }
+        }
+        if (reply) {
+            RedisModule_FreeCallReply(reply);
+        }
+    }
+
+    /* Close the key if we opened it and haven't closed it yet */
+    if (was_opened) {
+        RedisModule_CloseKey(key);
+    }
+}
+
+/* ZSET.DELALL
+ *
+ * Iterates through the keyspace and deletes all keys of type "zset".
+ * Returns the number of deleted keys.
+ */
+int zset_delall(RedisModuleCtx *ctx, REDISMODULE_ATTR_UNUSED RedisModuleString **argv, int argc) {
+    if (argc != 1) return RedisModule_WrongArity(ctx);
+    RedisModule_AutoMemory(ctx);
+
+    zset_delall_data data = {
+        .ctx = ctx,
+        .deleted_count = 0
+    };
+
+    /* Create a scan cursor and iterate through all keys */
+    RedisModuleScanCursor *cursor = RedisModule_ScanCursorCreate();
+    while (RedisModule_Scan(ctx, cursor, zset_delall_callback, &data));
+    RedisModule_ScanCursorDestroy(cursor);
+
+    return RedisModule_ReplyWithLongLong(ctx, data.deleted_count);
+}
+
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
@@ -85,6 +151,10 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     if (RedisModule_CreateCommand(ctx, "zset.incrby", zset_incrby, "write",
                                   1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "zset.delall", zset_delall, "write touches-arbitrary-keys",
+                                  0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     return REDISMODULE_OK;

--- a/tests/modules/zset.c
+++ b/tests/modules/zset.c
@@ -72,10 +72,12 @@ int zset_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 /* Structure to hold data for the delall scan callback */
 typedef struct {
     RedisModuleCtx *ctx;
-    size_t deleted_count;
+    RedisModuleString **keys_to_delete;
+    size_t keys_capacity;
+    size_t keys_count;
 } zset_delall_data;
 
-/* Callback function for scanning keys and deleting zsets */
+/* Callback function for scanning keys and collecting zset keys to delete */
 void zset_delall_callback(RedisModuleCtx *ctx, RedisModuleString *keyname, RedisModuleKey *key, void *privdata) {
     zset_delall_data *data = privdata;
     int was_opened = 0;
@@ -86,28 +88,22 @@ void zset_delall_callback(RedisModuleCtx *ctx, RedisModuleString *keyname, Redis
         was_opened = 1;
     }
 
-    /* Check if the key is a zset and delete it immediately */
+    /* Check if the key is a zset and add it to the list */
     if (RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_ZSET) {
-        /* Close the key first if we opened it */
-        if (was_opened) {
-            RedisModule_CloseKey(key);
-            was_opened = 0;
+        /* Expand the array if needed */
+        if (data->keys_count >= data->keys_capacity) {
+            data->keys_capacity = data->keys_capacity ? data->keys_capacity * 2 : 16;
+            data->keys_to_delete = RedisModule_Realloc(data->keys_to_delete,
+                                                       data->keys_capacity * sizeof(RedisModuleString*));
         }
 
-        /* Delete the key using DEL command */
-        RedisModuleCallReply *reply = RedisModule_Call(ctx, "DEL", "s!", keyname);
-        if (reply && RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_INTEGER) {
-            long long del_result = RedisModule_CallReplyInteger(reply);
-            if (del_result > 0) {
-                data->deleted_count++;
-            }
-        }
-        if (reply) {
-            RedisModule_FreeCallReply(reply);
-        }
+        /* Store the key name (retain it so it doesn't get freed) */
+        data->keys_to_delete[data->keys_count] = keyname;
+        RedisModule_RetainString(ctx, keyname);
+        data->keys_count++;
     }
 
-    /* Close the key if we opened it and haven't closed it yet */
+    /* Close the key if we opened it */
     if (was_opened) {
         RedisModule_CloseKey(key);
     }
@@ -124,7 +120,9 @@ int zset_delall(RedisModuleCtx *ctx, REDISMODULE_ATTR_UNUSED RedisModuleString *
 
     zset_delall_data data = {
         .ctx = ctx,
-        .deleted_count = 0
+        .keys_to_delete = NULL,
+        .keys_capacity = 0,
+        .keys_count = 0
     };
 
     /* Create a scan cursor and iterate through all keys */
@@ -132,7 +130,28 @@ int zset_delall(RedisModuleCtx *ctx, REDISMODULE_ATTR_UNUSED RedisModuleString *
     while (RedisModule_Scan(ctx, cursor, zset_delall_callback, &data));
     RedisModule_ScanCursorDestroy(cursor);
 
-    return RedisModule_ReplyWithLongLong(ctx, data.deleted_count);
+    /* Delete all the collected zset keys after scan is complete */
+    size_t deleted_count = 0;
+    for (size_t i = 0; i < data.keys_count; i++) {
+        RedisModuleCallReply *reply = RedisModule_Call(ctx, "DEL", "s!", data.keys_to_delete[i]);
+        if (reply && RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_INTEGER) {
+            long long del_result = RedisModule_CallReplyInteger(reply);
+            if (del_result > 0) {
+                deleted_count++;
+            }
+        }
+        if (reply) {
+            RedisModule_FreeCallReply(reply);
+        }
+        RedisModule_FreeString(ctx, data.keys_to_delete[i]);
+    }
+
+    /* Free the keys array */
+    if (data.keys_to_delete) {
+        RedisModule_Free(data.keys_to_delete);
+    }
+
+    return RedisModule_ReplyWithLongLong(ctx, deleted_count);
 }
 
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {


### PR DESCRIPTION
This commit adds support for the "touches-arbitrary-keys" command flag in Redis modules, allowing module commands to be properly marked when they modify keys not explicitly provided as arguments, to avoid wrapping replicated commands with MULTI/EXEC.

Changes:
- Added "touches-arbitrary-keys" flag parsing in commandFlagsFromString()
- Updated module command documentation to describe the new flag
- Added test implementation in zset module with zset.delall command to demonstrate and verify the flag functionality

The zset.delall command serves as a test case that scans the keyspace and deletes all zset-type keys, properly using the new flag since it modifies keys not provided via argv.

This commit adds a new `zset.delall` command to the zset test module that iterates through the keyspace and deletes all keys of type "zset".

Key changes:
- Added zset_delall() function that uses RedisModule_Scan to iterate through all keys in the keyspace
- Added zset_delall_callback() that checks each key's type and deletes zset keys using RedisModule_Call with "DEL" command
- Registered the new command with "write touches-arbitrary-keys" flags since it modifies arbitrary keys not provided via argv
- Added support for "touches-arbitrary-keys" flag in module command parsing
- Added comprehensive tests for the new functionality

The command returns the number of deleted zset keys and properly handles replication by using the "s!" format specifier with RedisModule_Call to ensure DEL commands are replicated to slaves and AOF.

Usage: ZSET.DELALL
Returns: Integer count of deleted zset keys