### PR TITLE
Add support to decode json empty array as lua array

### DIFF
--- a/deps/lua/src/lua_cjson.c
+++ b/deps/lua/src/lua_cjson.c
@@ -1230,6 +1230,7 @@ static void json_parse_array_context(lua_State *l, json_parse_t *json)
         lua_newtable(l);
         lua_pushboolean(l, 1);
         lua_setfield(l, -2, "__is_cjson_array");
+        lua_enablereadonlytable(l, -1, 1); /* protect the metatable. */
         lua_setmetatable(l, -2); /* set metatable for the array table */
     }
 

--- a/deps/lua/src/lua_cjson.c
+++ b/deps/lua/src/lua_cjson.c
@@ -692,7 +692,7 @@ static void json_append_data(lua_State *l, json_config_t *cfg,
         current_depth++;
         json_check_encode_depth(l, cfg, current_depth, json);
 
-        /* Check if this is a array */
+        /* Check if this is an array */
         int as_array = 0;
         if (!lua_checkstack(l, 2))
             luaL_error(l, "max lua stack reached");

--- a/deps/lua/src/lua_cjson.c
+++ b/deps/lua/src/lua_cjson.c
@@ -692,13 +692,10 @@ static void json_append_data(lua_State *l, json_config_t *cfg,
         current_depth++;
         json_check_encode_depth(l, cfg, current_depth, json);
 
-        if (!lua_checkstack(l, 2)) {
-            luaL_error(l, "Stack overflow while creating metatable");
-            break;
-        }
-
         /* Check if this is a array */
         int as_array = 0;
+        if (!lua_checkstack(l, 2))
+            luaL_error(l, "max lua stack reached");
         if (lua_getmetatable(l, -1)) {
             lua_getfield(l, -1, "__is_cjson_array");
             as_array = lua_toboolean(l, -1);
@@ -708,13 +705,14 @@ static void json_append_data(lua_State *l, json_config_t *cfg,
         if (as_array) {
             len = lua_objlen(l, -1);
             json_append_array(l, cfg, current_depth, json, len);
-        } else {
-            len = lua_array_length(l, cfg, json);
-            if (len > 0)
-                json_append_array(l, cfg, current_depth, json, len);
-            else
-                json_append_object(l, cfg, current_depth, json);
+            break;
         }
+        
+        len = lua_array_length(l, cfg, json);
+        if (len > 0)
+            json_append_array(l, cfg, current_depth, json, len);
+        else
+            json_append_object(l, cfg, current_depth, json);
         break;
     case LUA_TNIL:
         strbuf_append_mem(json, "null", 4);

--- a/deps/lua/src/lua_cjson.c
+++ b/deps/lua/src/lua_cjson.c
@@ -1226,6 +1226,9 @@ static void json_parse_array_context(lua_State *l, json_parse_t *json)
 
     /* set array_mt on the table at the top of the stack */
     if (json->cfg->decode_array_with_array_mt) {
+        /* Ensure sufficient stack space for metatable creation (metatable + boolean) */
+        if (!lua_checkstack(l, 2))
+            luaL_error(l, "max lua stack reached");
         /* Mark this table so encoder can emit [] for empty arrays */
         lua_newtable(l);
         lua_pushboolean(l, 1);

--- a/deps/lua/src/lua_cjson.c
+++ b/deps/lua/src/lua_cjson.c
@@ -71,6 +71,7 @@
 #define DEFAULT_DECODE_INVALID_NUMBERS 1
 #define DEFAULT_ENCODE_KEEP_BUFFER 1
 #define DEFAULT_ENCODE_NUMBER_PRECISION 14
+#define DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT 0
 
 #ifdef DISABLE_INVALID_NUMBERS
 #undef DEFAULT_DECODE_INVALID_NUMBERS
@@ -130,6 +131,7 @@ typedef struct {
 
     int decode_invalid_numbers;
     int decode_max_depth;
+    int decode_array_with_array_mt;
 } json_config_t;
 
 typedef struct {
@@ -303,6 +305,14 @@ static int json_cfg_encode_number_precision(lua_State *l)
     return json_integer_option(l, 1, &cfg->encode_number_precision, 1, 14);
 }
 
+/* Configures how to decode arrays */
+static int json_cfg_decode_array_with_array_mt(lua_State *l)
+{
+    json_config_t *cfg = json_arg_init(l, 1);
+
+    return json_enum_option(l, 1, &cfg->decode_array_with_array_mt, NULL, 1);
+}
+
 /* Configures JSON encoding buffer persistence */
 static int json_cfg_encode_keep_buffer(lua_State *l)
 {
@@ -393,6 +403,7 @@ static void json_create_config(lua_State *l)
     cfg->decode_invalid_numbers = DEFAULT_DECODE_INVALID_NUMBERS;
     cfg->encode_keep_buffer = DEFAULT_ENCODE_KEEP_BUFFER;
     cfg->encode_number_precision = DEFAULT_ENCODE_NUMBER_PRECISION;
+    cfg->decode_array_with_array_mt = DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT;
 
 #if DEFAULT_ENCODE_KEEP_BUFFER > 0
     strbuf_init(&cfg->encode_buf, 0);
@@ -680,11 +691,30 @@ static void json_append_data(lua_State *l, json_config_t *cfg,
     case LUA_TTABLE:
         current_depth++;
         json_check_encode_depth(l, cfg, current_depth, json);
-        len = lua_array_length(l, cfg, json);
-        if (len > 0)
+
+        if (!lua_checkstack(l, 2)) {
+            luaL_error(l, "Stack overflow while creating metatable");
+            break;
+        }
+
+        /* Check if this is a array */
+        int as_array = 0;
+        if (lua_getmetatable(l, -1)) {
+            lua_getfield(l, -1, "__is_cjson_array");
+            as_array = lua_toboolean(l, -1);
+            lua_pop(l, 2); /* pop value and metatable */
+        }
+
+        if (as_array) {
+            len = lua_objlen(l, -1);
             json_append_array(l, cfg, current_depth, json, len);
-        else
-            json_append_object(l, cfg, current_depth, json);
+        } else {
+            len = lua_array_length(l, cfg, json);
+            if (len > 0)
+                json_append_array(l, cfg, current_depth, json, len);
+            else
+                json_append_object(l, cfg, current_depth, json);
+        }
         break;
     case LUA_TNIL:
         strbuf_append_mem(json, "null", 4);
@@ -1196,6 +1226,15 @@ static void json_parse_array_context(lua_State *l, json_parse_t *json)
 
     lua_newtable(l);
 
+    /* set array_mt on the table at the top of the stack */
+    if (json->cfg->decode_array_with_array_mt) {
+        /* Mark this table so encoder can emit [] for empty arrays */
+        lua_newtable(l);
+        lua_pushboolean(l, 1);
+        lua_setfield(l, -2, "__is_cjson_array");
+        lua_setmetatable(l, -2); /* set metatable for the array table */
+    }
+
     json_next_token(json, &token);
 
     /* Handle empty arrays */
@@ -1348,6 +1387,7 @@ static int lua_cjson_new(lua_State *l)
     luaL_Reg reg[] = {
         { "encode", json_encode },
         { "decode", json_decode },
+        { "decode_array_with_array_mt", json_cfg_decode_array_with_array_mt },
         { "encode_sparse_array", json_cfg_encode_sparse_array },
         { "encode_max_depth", json_cfg_encode_max_depth },
         { "decode_max_depth", json_cfg_decode_max_depth },

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -379,6 +379,43 @@ start_server {tags {"scripting"}} {
         } 0
     } {a b}
 
+    test {EVAL - JSON empty array decoding} {
+        assert_equal "{}" [run_script {
+            return cjson.encode(cjson.decode('[]'))
+        } 0]
+
+        assert_equal "\[\]" [run_script {
+            cjson.decode_array_with_array_mt(true)
+            return cjson.encode(cjson.decode('[]'))
+        } 0]
+
+        assert_equal "{}" [run_script {
+            cjson.decode_array_with_array_mt(false)
+            return cjson.encode(cjson.decode('[]'))
+        } 0]
+    }
+
+    test {EVAL - JSON empty array decoding after element removal} {
+        # Default: emptied array becomes object
+        assert_equal "{}" [run_script {
+            local t = cjson.decode('[1, 2]')
+            -- emptying the array
+            t[1] = nil
+            t[2] = nil
+            return cjson.encode(t)
+        } 0]
+
+        # With array metatable: emptied array stays array
+        assert_equal "\[\]" [run_script {
+            cjson.decode_array_with_array_mt(true)
+            local t = cjson.decode('[1, 2]')
+            -- emptying the array
+            t[1] = nil
+            t[2] = nil
+            return cjson.encode(t)
+        } 0]
+    }
+
     test {EVAL - JSON smoke test} {
         run_script {
             local some_map = {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -426,6 +426,18 @@ start_server {tags {"scripting"}} {
         } 0]
     }
 
+    test {EVAL - cjson array metatable modification should be readonly} {
+        catch {
+            run_script {
+                cjson.decode_array_with_array_mt(true)
+                local t = cjson.decode('[]')
+                getmetatable(t).__is_cjson_array = function() return 1 end
+                return cjson.encode(t)
+            } 0
+        } e
+        set _ $e
+    } {*Attempt to modify a readonly table*}
+
     test {EVAL - JSON smoke test} {
         run_script {
             local some_map = {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -380,24 +380,34 @@ start_server {tags {"scripting"}} {
     } {a b}
 
     test {EVAL - JSON empty array decoding} {
+        # Default behavior
         assert_equal "{}" [run_script {
             return cjson.encode(cjson.decode('[]'))
         } 0]
+        assert_equal "{}" [run_script {
+            cjson.decode_array_with_array_mt(false)
+            return cjson.encode(cjson.decode('[]'))
+        } 0]
+        assert_equal "{\"item\":{}}" [run_script {
+            cjson.decode_array_with_array_mt(false)
+            return cjson.encode(cjson.decode('{"item": []}'))
+        } 0]
 
+        # With array metatable
         assert_equal "\[\]" [run_script {
             cjson.decode_array_with_array_mt(true)
             return cjson.encode(cjson.decode('[]'))
         } 0]
-
-        assert_equal "{}" [run_script {
-            cjson.decode_array_with_array_mt(false)
-            return cjson.encode(cjson.decode('[]'))
+        assert_equal "{\"item\":\[\]}" [run_script {
+            cjson.decode_array_with_array_mt(true)
+            return cjson.encode(cjson.decode('{"item": []}'))
         } 0]
     }
 
     test {EVAL - JSON empty array decoding after element removal} {
         # Default: emptied array becomes object
         assert_equal "{}" [run_script {
+            cjson.decode_array_with_array_mt(false)
             local t = cjson.decode('[1, 2]')
             -- emptying the array
             t[1] = nil


### PR DESCRIPTION
## Summary
This PR adds a new configuration option `decode_array_with_array_mt` to lua_cjson that allows users to control how empty JSON arrays are handled during encoding/decoding.

## Problem
Currently, lua_cjson has an ambiguity when handling empty tables:
- When decoding an empty JSON array `[]`, it becomes an empty Lua table.
   This is mainly because both {} (object) and [] (array) are represented as tables. The Lua cjson library then decides whether to encode a table as a JSON object or as a JSON array, depending on its length. If the length is not 0, it becomes a JSON array; otherwise, it is treated as a JSON object.

## Solution
Added a new configuration option `decode_array_with_array_mt` (default: `false` for backward compatibility):

- **When `false` (default)**: Maintains current behavior - empty arrays decode to Lua table
- **When `true`**: Empty JSON arrays decode to tables with a special metatable marker `__is_cjson_array`

```lua
-- Usage Example
-- Default behavior without decode_array_with_array_mt  (backward compatible)
local arr = cjson.decode("[]")  -- plain table {}
cjson.encode(arr)  -- produces "{}"

-- Default behavior (backward compatible)
cjson.decode_array_with_array_mt(false)
local arr = cjson.decode("[]")  -- plain table {}
cjson.encode(arr)  -- produces "{}"

-- New behavior
cjson.decode_array_with_array_mt(true)
local arr = cjson.decode("[]")  -- table with __is_cjson_array metatable
cjson.encode(arr)  -- produces "[]"
```

## Note
this new Lua cjson API(decode_array_with_array_mt) references from https://github.com/openresty/lua-cjson