### PR TITLE
Fix some flakiness tests

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -549,7 +549,8 @@ run_solo {defrag} {
                 for {set j 0} {$j < $fields} {incr j} {
                     $rd hset h$i $dummy_field$j v
                     $rd hexpire h$i 9999999 FIELDS 1 $dummy_field$j
-                    $rd set "k$i$j" $dummy_field
+                    $rd hset k$i $dummy_field$j v
+                    $rd hexpire k$i 9999999 FIELDS 1 $dummy_field$j
                 }
                 $rd expire h$i 9999999 ;# Ensure expire is updated after kvobj reallocation
             }
@@ -558,7 +559,8 @@ run_solo {defrag} {
                 for {set j 0} {$j < $fields} {incr j} {
                     $rd read ; # Discard hset replies
                     $rd read ; # Discard hexpire replies
-                    $rd read ; # Discard set replies
+                    $rd read ; # Discard hset replies
+                    $rd read ; # Discard hexpire replies
                 }
                 $rd read ; # Discard expire replies
             }
@@ -579,9 +581,7 @@ run_solo {defrag} {
 
             # Delete all the keys to create fragmentation
             for {set i 0} {$i < $n} {incr i} {
-                for {set j 0} {$j < $fields} {incr j} {
-                    r del "k$i$j"
-                }
+                r del k$i
             }
             $rd close
             after 120 ;# serverCron only updates the info once in 100ms

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -141,48 +141,36 @@ start_server {tags {"protocol network"}} {
         assert_equal [r rawread 5] "+OK\r\n"
         r get crlf
         assert_equal [r rawread 7] "\$1\r\n2\r\n"
-        r object encoding crlf
-        assert_equal [r rawread 9] "\$3\r\nint\r\n"
 
         # value=2147483647 (int encoding)
         r set crlf 2147483647
         assert_equal [r rawread 5] "+OK\r\n"
         r get crlf
         assert_equal [r rawread 17] "\$10\r\n2147483647\r\n"
-        r object encoding crlf
-        assert_equal [r rawread 9] "\$3\r\nint\r\n"
 
         # value=-2147483648 (int encoding)
         r set crlf -2147483648
         assert_equal [r rawread 5] "+OK\r\n"
         r get crlf
         assert_equal [r rawread 18] "\$11\r\n-2147483648\r\n"
-        r object encoding crlf
-        assert_equal [r rawread 9] "\$3\r\nint\r\n"
 
         # value=-9223372036854775809 (embstr encoding)
         r set crlf -9223372036854775809
         assert_equal [r rawread 5] "+OK\r\n"
         r get crlf
         assert_equal [r rawread 27] "\$20\r\n-9223372036854775809\r\n"
-        r object encoding crlf
-        assert_equal [r rawread 12] "\$6\r\nembstr\r\n"
 
         # value=9223372036854775808 (embstr encoding)
         r set crlf 9223372036854775808
         assert_equal [r rawread 5] "+OK\r\n"
         r get crlf
         assert_equal [r rawread 26] "\$19\r\n9223372036854775808\r\n"
-        r object encoding crlf
-        assert_equal [r rawread 12] "\$6\r\nembstr\r\n"
 
         # normal sds (embstr encoding)
         r set crlf aaaaaaaaaaaaaaaa
         assert_equal [r rawread 5] "+OK\r\n"
         r get crlf
         assert_equal [r rawread 23] "\$16\r\naaaaaaaaaaaaaaaa\r\n"
-        r object encoding crlf
-        assert_equal [r rawread 12] "\$6\r\nembstr\r\n"
 
         # normal sds (raw string encoding) with 45 'a'
         set rawstr [string repeat "a" 45]
@@ -190,8 +178,6 @@ start_server {tags {"protocol network"}} {
         assert_equal [r rawread 5] "+OK\r\n"
         r get crlf
         assert_equal [r rawread 52] "\$45\r\n$rawstr\r\n"
-        r object encoding crlf
-        assert_equal [r rawread 9] "\$3\r\nraw\r\n"
 
         r del crlf
         assert_equal [r rawread 4] ":1\r\n"


### PR DESCRIPTION
This PR mainly fixes two flakiness tests.
1. Fix the failure of `Active Defrag HFE with ebrax` test in `memefficiency.tcl`
    When `redisObject` structure size changes, the current test design becomes flakiness:
    In the current test, we will create 1 hash key + N string keys. When we delete this string key, these hash keys may be evenly distributed in robj 's slabs, resulting in the inability to perform defragmentation.

2. Fix `bulk reply protocol` test in `protocol.tcl` introduced by https://github.com/redis/redis/pull/13711
    When `OBJ_ENCODING_EMBSTR_SIZE_LIMIT` (currently 44) changes, it can cause this test to fail. This isn't necessarily a problem, but the main issue is that we use `rawread` to verify encoding correctness. If the reply length doesn't match exactly, it can cause the test to hang and become difficult to debug.