### PR TITLE
Fix timing issue for module defrag test

### DIFF
--- a/tests/unit/moduleapi/defrag.tcl
+++ b/tests/unit/moduleapi/defrag.tcl
@@ -54,14 +54,14 @@ start_server {tags {"modules"} overrides {{save ""}}} {
             r frag.create key2 10000 100 1000
 
             r config set activedefrag yes
-            wait_for_condition 200 50 {
-                [getInfoProperty [r info defragtest_stats] defragtest_defrag_ended] > 0
+            wait_for_condition 1000 50 {
+                [getInfoProperty [r info defragtest_stats] defragtest_defrag_ended] > 0 &&
+                [getInfoProperty [r info defragtest_stats] defragtest_datatype_resumes] > 10
             } else {
                 fail "Unable to wait for a complete defragmentation cycle to finish"
             }
 
             set info [r info defragtest_stats]
-            assert {[getInfoProperty $info defragtest_datatype_resumes] > 10}
             assert_equal 0 [getInfoProperty $info defragtest_datatype_wrong_cursor]
             assert_morethan [getInfoProperty $info defragtest_datatype_raw_defragged] 0
             assert_morethan [getInfoProperty $info defragtest_defrag_started] 0
@@ -81,7 +81,7 @@ start_server {tags {"modules"} overrides {{save ""}}} {
             r frag.create_frag_global 50000
             r config set activedefrag yes
 
-            wait_for_condition 200 50 {
+            wait_for_condition 1000 50 {
                 [getInfoProperty [r info defragtest_stats] defragtest_defrag_ended] > 0
             } else {
                 fail "Unable to wait for a complete defragmentation cycle to finish"


### PR DESCRIPTION
These two tests often fail in the slow environment.
1. `Module defrag: late defrag with cursor works` test
    `defragtest_datatype_resumes` in a defrag cycle does not always reach 10 times, so increase the threshold and move the assertion of `defragtest_datatype_resumes` to `wait_for_condition`.

    Failed CI: https://github.com/sundb/redis/actions/runs/17198264596/job/48882346784

2. `Module defrag: global defrag works` test
     Increase the waiting time for this test.

    Failed CI: https://github.com/sundb/redis/actions/runs/17198264596/job/48790675695

CI with this fix: https://github.com/sundb/redis/actions/runs/17198264596/job/48884301727