### PR TITLE
Optimize `BITCOUNT` with AVX2 and AVX512 popcount implementations. 

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -57,9 +57,6 @@ static const uint8_t bitsinbyte[256] = {
     #undef B4
     #undef B2
 };
-
-
-
 /* Count number of bits set in the binary array pointed by 's' and long
  * 'count' bytes. The implementation of this function is required to
  * work with an input string length up to 512 MB or more (server.proto_max_bulk_len) */
@@ -150,7 +147,6 @@ remain:
     while(count--) bits += bitsinbyte[*p++];
     return bits;
 }
-
 
 #ifdef HAVE_AARCH64_NEON
 /* AArch64 optimized popcount implementation.

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -48,7 +48,11 @@
 #define BITOP_USE_AARCH64_NEON 0
 #endif
 
-/* Shared lookup table for bit counting - maps each byte value to its popcount */
+/* -----------------------------------------------------------------------------
+ * Helpers and low level bit functions.
+ * -------------------------------------------------------------------------- */
+
+ /* Shared lookup table for bit counting - maps each byte value to its popcount */
 static const uint8_t bitsinbyte[256] = {
     #define B2(n) n, n+1, n+1, n+2
     #define B4(n) B2(n), B2(n+1), B2(n+1), B2(n+2)
@@ -59,11 +63,25 @@ static const uint8_t bitsinbyte[256] = {
     #undef B2
 };
 
-
-
-/* -----------------------------------------------------------------------------
- * Helpers and low level bit functions.
- * -------------------------------------------------------------------------- */
+/* Automatically select the best available popcount implementation */
+static inline long long redisPopcountAuto(const unsigned char *p, long count) {
+#ifdef HAVE_AVX512
+    if (BITOP_USE_AVX512) {
+        return redisPopCountAvx512((void*)p, count);
+    }
+#endif
+#ifdef HAVE_AVX2
+    if (BITOP_USE_AVX2) {
+        return redisPopCountAvx2((void*)p, count);
+    }
+#endif
+#ifdef HAVE_AARCH64_NEON
+    if (BITOP_USE_AARCH64_NEON) {
+        return redisPopCountAarch64((void*)p, count);
+    }
+#endif
+    return redisPopcount((void*)p, count);
+}
 
 /* Count number of bits set in the binary array pointed by 's' and long
  * 'count' bytes. The implementation of this function is required to
@@ -1520,24 +1538,7 @@ void bitcountCommand(client *c) {
         long long count;
 
         /* Use the best available popcount implementation */
-#ifdef HAVE_AVX512
-        if (BITOP_USE_AVX512) {
-            count = redisPopCountAvx512(p+start,bytes);
-        } else
-#endif
-#ifdef HAVE_AVX2
-        if (BITOP_USE_AVX2) {
-            count = redisPopCountAvx2(p+start,bytes);
-        } else
-#endif
-#ifdef HAVE_AARCH64_NEON
-        if (BITOP_USE_AARCH64_NEON) {
-            count = redisPopCountAarch64(p+start,bytes);
-        } else
-#endif
-        {
-            count = redisPopcount(p+start,bytes);
-        }
+        count = redisPopcountAuto(p+start, bytes);
 
         if (first_byte_neg_mask != 0 || last_byte_neg_mask != 0) {
             unsigned char firstlast[2] = {0, 0};
@@ -1548,24 +1549,7 @@ void bitcountCommand(client *c) {
             if (last_byte_neg_mask != 0) firstlast[1] = p[end] & last_byte_neg_mask;
 
             /* Use the same popcount implementation for consistency */
-#ifdef HAVE_AVX512
-            if (BITOP_USE_AVX512) {
-                count -= redisPopCountAvx512(firstlast,2);
-            } else
-#endif
-#ifdef HAVE_AVX2
-            if (BITOP_USE_AVX2) {
-                count -= redisPopCountAvx2(firstlast,2);
-            } else
-#endif
-#ifdef HAVE_AARCH64_NEON
-            if (BITOP_USE_AARCH64_NEON) {
-                count -= redisPopCountAarch64(firstlast,2);
-            } else
-#endif
-            {
-                count -= redisPopcount(firstlast,2);
-            }
+            count -= redisPopcountAuto(firstlast, 2);
         }
         addReplyLongLong(c,count);
     }

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -57,6 +57,7 @@ static const uint8_t bitsinbyte[256] = {
     #undef B4
     #undef B2
 };
+
 /* Count number of bits set in the binary array pointed by 's' and long
  * 'count' bytes. The implementation of this function is required to
  * work with an input string length up to 512 MB or more (server.proto_max_bulk_len) */

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -25,6 +25,10 @@
 #include <immintrin.h>
 #endif
 
+#ifdef HAVE_AARCH64_NEON
+#include <arm_neon.h>
+#endif
+
 #ifdef HAVE_AVX2
 #define BITOP_USE_AVX2 (__builtin_cpu_supports("avx2"))
 #else
@@ -36,6 +40,15 @@
 #else
 #define BITOP_USE_AVX512 0
 #endif
+
+#ifdef HAVE_AARCH64_NEON
+/* AArch64 always has NEON, but check for specific features */
+#define BITOP_USE_AARCH64_NEON 1
+#else
+#define BITOP_USE_AARCH64_NEON 0
+#endif
+
+
 
 /* -----------------------------------------------------------------------------
  * Helpers and low level bit functions.
@@ -230,6 +243,93 @@ long long redisPopCountAvx2(void *s, long count) {
     return bits;
 }
 #endif
+
+#ifdef HAVE_AARCH64_NEON
+/* AArch64 NEON optimized version of redisPopcount.
+ * This function uses NEON 128-bit vectors with lookup table approach. */
+ATTRIBUTE_TARGET_AARCH64_NEON
+long long redisPopCountAarch64(void *s, long count) {
+    long long bits = 0;
+    unsigned char *p = s;
+    static const unsigned char bitsinbyte[256] = {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,4,5,5,6,5,6,6,7,5,6,6,7,6,7,7,8};
+
+    /* 4-bit popcount lookup table */
+    static const uint8_t popcount_table[16] = {
+        0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4
+    };
+
+    /* Align to 16-byte boundary for optimal NEON performance */
+    while ((unsigned long)p & 15 && count) {
+        bits += bitsinbyte[*p++];
+        count--;
+    }
+
+    uint8x16_t lookup_tbl = vld1q_u8(popcount_table);
+    uint64x2_t accumulator = vdupq_n_u64(0);
+
+    /* Process 32 bytes at a time using dual 128-bit registers */
+    while (count >= 32) {
+        /* Load two 128-bit chunks */
+        uint8x16_t data1 = vld1q_u8(p);
+        uint8x16_t data2 = vld1q_u8(p + 16);
+
+        /* Process first chunk */
+        uint8x16_t low1 = vandq_u8(data1, vdupq_n_u8(0x0F));
+        uint8x16_t high1 = vshrq_n_u8(data1, 4);
+        uint8x16_t count1 = vaddq_u8(
+            vqtbl1q_u8(lookup_tbl, low1),
+            vqtbl1q_u8(lookup_tbl, high1)
+        );
+
+        /* Process second chunk */
+        uint8x16_t low2 = vandq_u8(data2, vdupq_n_u8(0x0F));
+        uint8x16_t high2 = vshrq_n_u8(data2, 4);
+        uint8x16_t count2 = vaddq_u8(
+            vqtbl1q_u8(lookup_tbl, low2),
+            vqtbl1q_u8(lookup_tbl, high2)
+        );
+
+        /* Accumulate counts efficiently */
+        uint16x8_t sum16_1 = vpaddlq_u8(count1);
+        uint16x8_t sum16_2 = vpaddlq_u8(count2);
+        uint32x4_t sum32 = vpaddlq_u16(vaddq_u16(sum16_1, sum16_2));
+        accumulator = vpadalq_u32(accumulator, sum32);
+
+        p += 32;
+        count -= 32;
+        redis_prefetch_read(p + 2048);
+    }
+
+    /* Extract final sum */
+    bits += vgetq_lane_u64(accumulator, 0) + vgetq_lane_u64(accumulator, 1);
+
+    /* Handle remaining 16-byte chunks */
+    while (count >= 16) {
+        uint8x16_t data = vld1q_u8(p);
+        uint8x16_t low = vandq_u8(data, vdupq_n_u8(0x0F));
+        uint8x16_t high = vshrq_n_u8(data, 4);
+        uint8x16_t counts = vaddq_u8(
+            vqtbl1q_u8(lookup_tbl, low),
+            vqtbl1q_u8(lookup_tbl, high)
+        );
+
+        uint64x2_t sum_pairs = vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(counts)));
+        bits += vgetq_lane_u64(sum_pairs, 0) + vgetq_lane_u64(sum_pairs, 1);
+
+        p += 16;
+        count -= 16;
+    }
+
+    /* Handle remaining bytes */
+    while (count--) {
+        bits += bitsinbyte[*p++];
+    }
+
+    return bits;
+}
+#endif
+
+
 
 /* Return the position of the first bit set to one (if 'bit' is 1) or
  * zero (if 'bit' is 0) in the bitmap starting at 's' and long 'count' bytes.
@@ -1391,6 +1491,11 @@ void bitcountCommand(client *c) {
             count = redisPopCountAvx2(p+start,bytes);
         } else
 #endif
+#ifdef HAVE_AARCH64_NEON
+        if (BITOP_USE_AARCH64_NEON) {
+            count = redisPopCountAarch64(p+start,bytes);
+        } else
+#endif
         {
             count = redisPopcount(p+start,bytes);
         }
@@ -1412,6 +1517,11 @@ void bitcountCommand(client *c) {
 #ifdef HAVE_AVX2
             if (BITOP_USE_AVX2) {
                 count -= redisPopCountAvx2(firstlast,2);
+            } else
+#endif
+#ifdef HAVE_AARCH64_NEON
+            if (BITOP_USE_AARCH64_NEON) {
+                count -= redisPopCountAarch64(firstlast,2);
             } else
 #endif
             {
@@ -1887,6 +1997,24 @@ int popcountTest(int argc, char **argv, int flags) {
 #else
     printf("AVX512 not compiled in\n");
 #endif
+
+#ifdef HAVE_AARCH64_NEON
+    if (BITOP_USE_AARCH64_NEON) {
+        long long result_aarch64 = redisPopCountAarch64(test_data, sizeof(test_data));
+        printf("AArch64 NEON popcount: %lld (expected: %d)\n", result_aarch64, expected_bits);
+
+        if (result_aarch64 != expected_bits) {
+            printf("FAIL: AArch64 NEON popcount mismatch\n");
+            return 1;
+        }
+    } else {
+        printf("AArch64 NEON not available\n");
+    }
+#else
+    printf("AArch64 NEON not compiled in\n");
+#endif
+
+
 
     printf("All popcount tests passed!\n");
     return 0;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -48,6 +48,17 @@
 #define BITOP_USE_AARCH64_NEON 0
 #endif
 
+/* Shared lookup table for bit counting - maps each byte value to its popcount */
+static const uint8_t bitsinbyte[256] = {
+    #define B2(n) n, n+1, n+1, n+2
+    #define B4(n) B2(n), B2(n+1), B2(n+1), B2(n+2)
+    #define B6(n) B4(n), B4(n+1), B4(n+1), B4(n+2)
+    B6(0), B6(1), B6(1), B6(2)
+    #undef B6
+    #undef B4
+    #undef B2
+};
+
 
 
 /* -----------------------------------------------------------------------------
@@ -68,8 +79,7 @@ long long redisPopcount(void *s, long count) {
     int use_popcnt = 0; /* Assume CPU does not support POPCNT if
                          * __builtin_cpu_supports() is not available. */
 #endif
-    static const unsigned char bitsinbyte[256] = {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,4,5,5,6,5,6,6,7,5,6,6,7,6,7,7,8};
-    
+
     /* Count initial bytes not aligned to 64-bit when using the POPCNT instruction,
      * otherwise align to 32-bit. */
     int align = use_popcnt ? 7 : 3;
@@ -165,16 +175,6 @@ remain:
 long long redisPopCountAarch64(void *s, long count) {
     long long bits = 0;
     const uint8_t *p = (const uint8_t*)s;
-
-    static const uint8_t bitsinbyte[256] = {
-        #define B2(n) n, n+1, n+1, n+2
-        #define B4(n) B2(n), B2(n+1), B2(n+1), B2(n+2)
-        #define B6(n) B4(n), B4(n+1), B4(n+1), B4(n+2)
-        B6(0), B6(1), B6(1), B6(2)
-        #undef B6
-        #undef B4
-        #undef B2
-    };
 
     /* Align */
     while (((uintptr_t)p & 15) && count) {
@@ -282,7 +282,6 @@ ATTRIBUTE_TARGET_AVX512
 long long redisPopCountAvx512(void *s, long count) {
     long long bits = 0;
     unsigned char *p = s;
-    static const unsigned char bitsinbyte[256] = {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,4,5,5,6,5,6,6,7,5,6,6,7,6,7,7,8};
 
     /* Align to 64-byte boundary for optimal AVX512 performance */
     while ((unsigned long)p & 63 && count) {
@@ -328,7 +327,6 @@ ATTRIBUTE_TARGET_AVX2
 long long redisPopCountAvx2(void *s, long count) {
     long long bits = 0;
     unsigned char *p = s;
-    static const unsigned char bitsinbyte[256] = {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,4,5,5,6,5,6,6,7,5,6,6,7,6,7,7,8};
 
     /* Align to 8-byte boundary for 64-bit operations */
     while ((unsigned long)p & 7 && count) {
@@ -371,10 +369,6 @@ long long redisPopCountAvx2(void *s, long count) {
     return bits;
 }
 #endif
-
-
-
-
 
 /* Return the position of the first bit set to one (if 'bit' is 1) or
  * zero (if 'bit' is 0) in the bitmap starting at 's' and long 'count' bytes.

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -35,18 +35,13 @@
 #define BITOP_USE_AVX2 0
 #endif
 
+/* AArch64 NEON support is determined at compile time via HAVE_AARCH64_NEON */
 #ifdef HAVE_AVX512
 #define BITOP_USE_AVX512 (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512vpopcntdq"))
 #else
 #define BITOP_USE_AVX512 0
 #endif
 
-#ifdef HAVE_AARCH64_NEON
-/* AArch64 always has NEON, but check for specific features */
-#define BITOP_USE_AARCH64_NEON 1
-#else
-#define BITOP_USE_AARCH64_NEON 0
-#endif
 
 /* -----------------------------------------------------------------------------
  * Helpers and low level bit functions.
@@ -63,25 +58,7 @@ static const uint8_t bitsinbyte[256] = {
     #undef B2
 };
 
-/* Automatically select the best available popcount implementation */
-static inline long long redisPopcountAuto(const unsigned char *p, long count) {
-#ifdef HAVE_AVX512
-    if (BITOP_USE_AVX512) {
-        return redisPopCountAvx512((void*)p, count);
-    }
-#endif
-#ifdef HAVE_AVX2
-    if (BITOP_USE_AVX2) {
-        return redisPopCountAvx2((void*)p, count);
-    }
-#endif
-#ifdef HAVE_AARCH64_NEON
-    if (BITOP_USE_AARCH64_NEON) {
-        return redisPopCountAarch64((void*)p, count);
-    }
-#endif
-    return redisPopcount((void*)p, count);
-}
+
 
 /* Count number of bits set in the binary array pointed by 's' and long
  * 'count' bytes. The implementation of this function is required to
@@ -387,6 +364,24 @@ long long redisPopCountAvx2(void *s, long count) {
     return bits;
 }
 #endif
+
+/* Automatically select the best available popcount implementation */
+static inline long long redisPopcountAuto(const unsigned char *p, long count) {
+#ifdef HAVE_AVX512
+    if (BITOP_USE_AVX512) {
+        return redisPopCountAvx512((void*)p, count);
+    }
+#endif
+#ifdef HAVE_AVX2
+    if (BITOP_USE_AVX2) {
+        return redisPopCountAvx2((void*)p, count);
+    }
+#endif
+#ifdef HAVE_AARCH64_NEON
+    return redisPopCountAarch64((void*)p, count);
+#endif
+    return redisPopcount((void*)p, count);
+}
 
 /* Return the position of the first bit set to one (if 'bit' is 1) or
  * zero (if 'bit' is 0) in the bitmap starting at 's' and long 'count' bytes.
@@ -2023,7 +2018,7 @@ int popcountTest(int argc, char **argv, int flags) {
 #endif
 
 #ifdef HAVE_AARCH64_NEON
-    if (BITOP_USE_AARCH64_NEON) {
+    {
         long long result_aarch64 = redisPopCountAarch64(test_data, sizeof(test_data));
         printf("AArch64 NEON popcount: %lld (expected: %d)\n", result_aarch64, expected_bits);
 
@@ -2031,11 +2026,9 @@ int popcountTest(int argc, char **argv, int flags) {
             printf("FAIL: AArch64 NEON popcount mismatch\n");
             return 1;
         }
-    } else {
-        printf("AArch64 NEON not supported on this CPU\n");
     }
 #else
-    printf("AArch64 NEON not compiled in\n");
+    printf("AArch64 NEON not available\n");
 #endif
     printf("All popcount tests passed!\n");
     return 0;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -18,10 +18,23 @@
 #include <immintrin.h>
 #endif
 
+#ifdef HAVE_AVX512
+/* Define __MM_MALLOC_H to prevent importing the memory aligned
+ * allocation functions, which we don't use. */
+#define __MM_MALLOC_H
+#include <immintrin.h>
+#endif
+
 #ifdef HAVE_AVX2
 #define BITOP_USE_AVX2 (__builtin_cpu_supports("avx2"))
 #else
 #define BITOP_USE_AVX2 0
+#endif
+
+#ifdef HAVE_AVX512
+#define BITOP_USE_AVX512 (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512vpopcntdq"))
+#else
+#define BITOP_USE_AVX512 0
 #endif
 
 /* -----------------------------------------------------------------------------
@@ -120,6 +133,103 @@ remain:
     while(count--) bits += bitsinbyte[*p++];
     return bits;
 }
+
+#ifdef HAVE_AVX512
+/* AVX512 optimized version of redisPopcount using VPOPCNTDQ instruction.
+ * This function requires AVX512F and AVX512VPOPCNTDQ support. */
+ATTRIBUTE_TARGET_AVX512
+long long redisPopCountAvx512(void *s, long count) {
+    long long bits = 0;
+    unsigned char *p = s;
+    static const unsigned char bitsinbyte[256] = {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,4,5,5,6,5,6,6,7,5,6,6,7,6,7,7,8};
+
+    /* Align to 64-byte boundary for optimal AVX512 performance */
+    while ((unsigned long)p & 63 && count) {
+        bits += bitsinbyte[*p++];
+        count--;
+    }
+
+    /* Process 64 bytes at a time using AVX512 */
+    while (count >= 64) {
+        __m512i data = _mm512_loadu_si512((__m512i*)p);
+        __m512i popcnt = _mm512_popcnt_epi64(data);
+
+        /* Sum all 8 64-bit popcount results */
+        bits += _mm512_reduce_add_epi64(popcnt);
+
+        p += 64;
+        count -= 64;
+
+        /* Prefetch next cache line */
+        redis_prefetch_read(p + 2048);
+    }
+
+    /* Handle remaining bytes with scalar popcount */
+    while (count >= 8) {
+        bits += __builtin_popcountll(*(uint64_t*)p);
+        p += 8;
+        count -= 8;
+    }
+
+    /* Handle final bytes */
+    while (count--) {
+        bits += bitsinbyte[*p++];
+    }
+
+    return bits;
+}
+#endif
+
+#ifdef HAVE_AVX2
+/* AVX2 optimized version of redisPopcount.
+ * This function requires AVX2 and POPCNT support. */
+ATTRIBUTE_TARGET_AVX2
+long long redisPopCountAvx2(void *s, long count) {
+    long long bits = 0;
+    unsigned char *p = s;
+    static const unsigned char bitsinbyte[256] = {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,4,5,5,6,5,6,6,7,5,6,6,7,6,7,7,8};
+
+    /* Align to 8-byte boundary for 64-bit operations */
+    while ((unsigned long)p & 7 && count) {
+        bits += bitsinbyte[*p++];
+        count--;
+    }
+
+    /* Use separate counters to avoid dependencies, similar to regular redisPopcount */
+    uint64_t cnt[4];
+    memset(cnt, 0, sizeof(cnt));
+
+    /* Process 32 bytes at a time using POPCNT on 64-bit chunks */
+    while (count >= 32) {
+        cnt[0] += __builtin_popcountll(*(uint64_t*)(p));
+        cnt[1] += __builtin_popcountll(*(uint64_t*)(p + 8));
+        cnt[2] += __builtin_popcountll(*(uint64_t*)(p + 16));
+        cnt[3] += __builtin_popcountll(*(uint64_t*)(p + 24));
+
+        p += 32;
+        count -= 32;
+
+        /* Prefetch next cache line */
+        redis_prefetch_read(p + 2048);
+    }
+
+    bits += cnt[0] + cnt[1] + cnt[2] + cnt[3];
+
+    /* Handle remaining bytes with scalar popcount */
+    while (count >= 8) {
+        bits += __builtin_popcountll(*(uint64_t*)p);
+        p += 8;
+        count -= 8;
+    }
+
+    /* Handle final bytes */
+    while (count--) {
+        bits += bitsinbyte[*p++];
+    }
+
+    return bits;
+}
+#endif
 
 /* Return the position of the first bit set to one (if 'bit' is 1) or
  * zero (if 'bit' is 0) in the bitmap starting at 's' and long 'count' bytes.
@@ -1268,7 +1378,23 @@ void bitcountCommand(client *c) {
         addReply(c,shared.czero);
     } else {
         long bytes = (long)(end-start+1);
-        long long count = redisPopcount(p+start,bytes);
+        long long count;
+
+        /* Use the best available popcount implementation */
+#ifdef HAVE_AVX512
+        if (BITOP_USE_AVX512) {
+            count = redisPopCountAvx512(p+start,bytes);
+        } else
+#endif
+#ifdef HAVE_AVX2
+        if (BITOP_USE_AVX2) {
+            count = redisPopCountAvx2(p+start,bytes);
+        } else
+#endif
+        {
+            count = redisPopcount(p+start,bytes);
+        }
+
         if (first_byte_neg_mask != 0 || last_byte_neg_mask != 0) {
             unsigned char firstlast[2] = {0, 0};
             /* We may count bits of first byte and last byte which are out of
@@ -1276,7 +1402,21 @@ void bitcountCommand(client *c) {
             * bits in the range to zero. So these bit will not be excluded. */
             if (first_byte_neg_mask != 0) firstlast[0] = p[start] & first_byte_neg_mask;
             if (last_byte_neg_mask != 0) firstlast[1] = p[end] & last_byte_neg_mask;
-            count -= redisPopcount(firstlast,2);
+
+            /* Use the same popcount implementation for consistency */
+#ifdef HAVE_AVX512
+            if (BITOP_USE_AVX512) {
+                count -= redisPopCountAvx512(firstlast,2);
+            } else
+#endif
+#ifdef HAVE_AVX2
+            if (BITOP_USE_AVX2) {
+                count -= redisPopCountAvx2(firstlast,2);
+            } else
+#endif
+            {
+                count -= redisPopcount(firstlast,2);
+            }
         }
         addReplyLongLong(c,count);
     }
@@ -1695,3 +1835,60 @@ void bitfieldCommand(client *c) {
 void bitfieldroCommand(client *c) {
     bitfieldGeneric(c, BITFIELD_FLAG_READONLY);
 }
+
+#ifdef REDIS_TEST
+/* Test function to verify popcount implementations */
+int popcountTest(int argc, char **argv, int flags) {
+    UNUSED(argc);
+    UNUSED(argv);
+    UNUSED(flags);
+
+    /* Test data with known popcount values */
+    unsigned char test_data[] = {0xFF, 0x00, 0xAA, 0x55, 0xF0, 0x0F, 0x33, 0xCC};
+    int expected_bits = 8 + 0 + 4 + 4 + 4 + 4 + 4 + 4; /* = 32 bits */
+
+    long long result_regular = redisPopcount(test_data, sizeof(test_data));
+
+    printf("Regular popcount: %lld (expected: %d)\n", result_regular, expected_bits);
+
+    if (result_regular != expected_bits) {
+        printf("FAIL: Regular popcount mismatch\n");
+        return 1;
+    }
+
+#ifdef HAVE_AVX2
+    if (BITOP_USE_AVX2) {
+        long long result_avx2 = redisPopCountAvx2(test_data, sizeof(test_data));
+        printf("AVX2 popcount: %lld (expected: %d)\n", result_avx2, expected_bits);
+
+        if (result_avx2 != expected_bits) {
+            printf("FAIL: AVX2 popcount mismatch\n");
+            return 1;
+        }
+    } else {
+        printf("AVX2 not supported on this CPU\n");
+    }
+#else
+    printf("AVX2 not compiled in\n");
+#endif
+
+#ifdef HAVE_AVX512
+    if (BITOP_USE_AVX512) {
+        long long result_avx512 = redisPopCountAvx512(test_data, sizeof(test_data));
+        printf("AVX512 popcount: %lld (expected: %d)\n", result_avx512, expected_bits);
+
+        if (result_avx512 != expected_bits) {
+            printf("FAIL: AVX512 popcount mismatch\n");
+            return 1;
+        }
+    } else {
+        printf("AVX512 not supported on this CPU\n");
+    }
+#else
+    printf("AVX512 not compiled in\n");
+#endif
+
+    printf("All popcount tests passed!\n");
+    return 0;
+}
+#endif

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -268,7 +268,7 @@ long long redisPopCountAarch64(void *s, long count) {
 #ifdef HAVE_AVX512
 /* AVX512 optimized version of redisPopcount using VPOPCNTDQ instruction.
  * This function requires AVX512F and AVX512VPOPCNTDQ support. */
-ATTRIBUTE_TARGET_AVX512
+ATTRIBUTE_TARGET_AVX512_POPCOUNT
 long long redisPopCountAvx512(void *s, long count) {
     long long bits = 0;
     unsigned char *p = s;
@@ -313,7 +313,7 @@ long long redisPopCountAvx512(void *s, long count) {
 #ifdef HAVE_AVX2
 /* AVX2 optimized version of redisPopcount.
  * This function requires AVX2 and POPCNT support. */
-ATTRIBUTE_TARGET_AVX2
+ATTRIBUTE_TARGET_AVX2_POPCOUNT
 long long redisPopCountAvx2(void *s, long count) {
     long long bits = 0;
     unsigned char *p = s;
@@ -916,7 +916,7 @@ void getbitCommand(client *c) {
  * 256-bit registers so if `minlen` is not a multiple of 32 some of the bytes
  * will be skipped. They will be taken care for in the unoptimized loop in the
  * main bitopCommand function. */
-ATTRIBUTE_TARGET_AVX2
+ATTRIBUTE_TARGET_AVX2_POPCOUNT
 unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res, 
                               unsigned long op, unsigned long numkeys,
                               unsigned long minlen)

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -18,11 +18,27 @@
 #include <immintrin.h>
 #endif
 
+#ifdef HAVE_AVX512
+/* Define __MM_MALLOC_H to prevent importing the memory aligned
+ * allocation functions, which we don't use. */
+#define __MM_MALLOC_H
+#include <immintrin.h>
+#endif
+
+
 #ifdef HAVE_AVX2
 #define BITOP_USE_AVX2 (__builtin_cpu_supports("avx2"))
 #else
 #define BITOP_USE_AVX2 0
 #endif
+
+#ifdef HAVE_AVX512
+#define BITOP_USE_AVX512 (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512vpopcntdq"))
+#else
+#define BITOP_USE_AVX512 0
+#endif
+
+
 
 /* -----------------------------------------------------------------------------
  * Helpers and low level bit functions.
@@ -42,7 +58,18 @@ long long redisPopcount(void *s, long count) {
     int use_popcnt = 0; /* Assume CPU does not support POPCNT if
                          * __builtin_cpu_supports() is not available. */
 #endif
-    static const unsigned char bitsinbyte[256] = {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,4,5,5,6,5,6,6,7,5,6,6,7,6,7,7,8};
+    /* Lookup table for counting set bits in a byte.
+     * bitsinbyte[i] contains the number of 1-bits in byte value i (0-255).
+     * Used as fallback when hardware bit counting instructions are not available/to align to 64-bit. */
+    static const uint8_t bitsinbyte[256] = {
+        #define B2(n) n, n+1, n+1, n+2
+        #define B4(n) B2(n), B2(n+1), B2(n+1), B2(n+2)
+        #define B6(n) B4(n), B4(n+1), B4(n+1), B4(n+2)
+        B6(0), B6(1), B6(1), B6(2)
+        #undef B6
+        #undef B4
+        #undef B2
+    };
     
     /* Count initial bytes not aligned to 64-bit when using the POPCNT instruction,
      * otherwise align to 32-bit. */
@@ -120,6 +147,121 @@ remain:
     while(count--) bits += bitsinbyte[*p++];
     return bits;
 }
+
+#ifdef HAVE_AVX512
+/* AVX512 optimized version of redisPopcount using VPOPCNTDQ instruction.
+ * This function requires AVX512F and AVX512VPOPCNTDQ support. */
+ATTRIBUTE_TARGET_AVX512
+long long redisPopCountAvx512(void *s, long count) {
+    long long bits = 0;
+    unsigned char *p = s;
+    /* Lookup table for counting set bits in a byte (see main function for details) */
+    static const uint8_t bitsinbyte[256] = {
+        #define B2(n) n, n+1, n+1, n+2
+        #define B4(n) B2(n), B2(n+1), B2(n+1), B2(n+2)
+        #define B6(n) B4(n), B4(n+1), B4(n+1), B4(n+2)
+        B6(0), B6(1), B6(1), B6(2)
+        #undef B6
+        #undef B4
+        #undef B2
+    };
+
+    /* Align to 64-byte boundary for optimal AVX512 performance */
+    while ((unsigned long)p & 63 && count) {
+        bits += bitsinbyte[*p++];
+        count--;
+    }
+
+    /* Process 64 bytes at a time using AVX512 */
+    while (count >= 64) {
+        __m512i data = _mm512_loadu_si512((__m512i*)p);
+        __m512i popcnt = _mm512_popcnt_epi64(data);
+
+        /* Sum all 8 64-bit popcount results */
+        bits += _mm512_reduce_add_epi64(popcnt);
+
+        p += 64;
+        count -= 64;
+
+        /* Prefetch next cache line */
+        redis_prefetch_read(p + 2048);
+    }
+
+    /* Handle remaining bytes with scalar popcount */
+    while (count >= 8) {
+        bits += __builtin_popcountll(*(uint64_t*)p);
+        p += 8;
+        count -= 8;
+    }
+
+    /* Handle final bytes */
+    while (count--) {
+        bits += bitsinbyte[*p++];
+    }
+
+    return bits;
+}
+#endif
+
+#ifdef HAVE_AVX2
+/* AVX2 optimized version of redisPopcount.
+ * This function requires AVX2 and POPCNT support. */
+ATTRIBUTE_TARGET_AVX2
+long long redisPopCountAvx2(void *s, long count) {
+    long long bits = 0;
+    unsigned char *p = s;
+    /* Lookup table for counting set bits in a byte (see main function for details) */
+    static const uint8_t bitsinbyte[256] = {
+        #define B2(n) n, n+1, n+1, n+2
+        #define B4(n) B2(n), B2(n+1), B2(n+1), B2(n+2)
+        #define B6(n) B4(n), B4(n+1), B4(n+1), B4(n+2)
+        B6(0), B6(1), B6(1), B6(2)
+        #undef B6
+        #undef B4
+        #undef B2
+    };
+
+    /* Align to 8-byte boundary for 64-bit operations */
+    while ((unsigned long)p & 7 && count) {
+        bits += bitsinbyte[*p++];
+        count--;
+    }
+
+    /* Use separate counters to avoid dependencies, similar to regular redisPopcount */
+    uint64_t cnt[4];
+    memset(cnt, 0, sizeof(cnt));
+
+    /* Process 32 bytes at a time using POPCNT on 64-bit chunks */
+    while (count >= 32) {
+        cnt[0] += __builtin_popcountll(*(uint64_t*)(p));
+        cnt[1] += __builtin_popcountll(*(uint64_t*)(p + 8));
+        cnt[2] += __builtin_popcountll(*(uint64_t*)(p + 16));
+        cnt[3] += __builtin_popcountll(*(uint64_t*)(p + 24));
+
+        p += 32;
+        count -= 32;
+
+        /* Prefetch next cache line */
+        redis_prefetch_read(p + 2048);
+    }
+
+    bits += cnt[0] + cnt[1] + cnt[2] + cnt[3];
+
+    /* Handle remaining bytes with scalar popcount */
+    while (count >= 8) {
+        bits += __builtin_popcountll(*(uint64_t*)p);
+        p += 8;
+        count -= 8;
+    }
+
+    /* Handle final bytes */
+    while (count--) {
+        bits += bitsinbyte[*p++];
+    }
+
+    return bits;
+}
+#endif
 
 /* Return the position of the first bit set to one (if 'bit' is 1) or
  * zero (if 'bit' is 0) in the bitmap starting at 's' and long 'count' bytes.
@@ -1268,7 +1410,23 @@ void bitcountCommand(client *c) {
         addReply(c,shared.czero);
     } else {
         long bytes = (long)(end-start+1);
-        long long count = redisPopcount(p+start,bytes);
+        long long count;
+
+        /* Use the best available popcount implementation */
+#ifdef HAVE_AVX512
+        if (BITOP_USE_AVX512) {
+            count = redisPopCountAvx512(p+start,bytes);
+        } else
+#endif
+#ifdef HAVE_AVX2
+        if (BITOP_USE_AVX2) {
+            count = redisPopCountAvx2(p+start,bytes);
+        } else
+#endif
+        {
+            count = redisPopcount(p+start,bytes);
+        }
+
         if (first_byte_neg_mask != 0 || last_byte_neg_mask != 0) {
             unsigned char firstlast[2] = {0, 0};
             /* We may count bits of first byte and last byte which are out of
@@ -1276,7 +1434,21 @@ void bitcountCommand(client *c) {
             * bits in the range to zero. So these bit will not be excluded. */
             if (first_byte_neg_mask != 0) firstlast[0] = p[start] & first_byte_neg_mask;
             if (last_byte_neg_mask != 0) firstlast[1] = p[end] & last_byte_neg_mask;
-            count -= redisPopcount(firstlast,2);
+
+            /* Use the same popcount implementation for consistency */
+#ifdef HAVE_AVX512
+            if (BITOP_USE_AVX512) {
+                count -= redisPopCountAvx512(firstlast,2);
+            } else
+#endif
+#ifdef HAVE_AVX2
+            if (BITOP_USE_AVX2) {
+                count -= redisPopCountAvx2(firstlast,2);
+            } else
+#endif
+            {
+                count -= redisPopcount(firstlast,2);
+            }
         }
         addReplyLongLong(c,count);
     }
@@ -1695,3 +1867,234 @@ void bitfieldCommand(client *c) {
 void bitfieldroCommand(client *c) {
     bitfieldGeneric(c, BITFIELD_FLAG_READONLY);
 }
+
+#ifdef REDIS_TEST
+#include <assert.h>
+
+static void test_basic_popcount(void) {
+    /* Test data with known popcount values */
+    unsigned char test_data[] = {0xFF, 0x00, 0xAA, 0x55, 0xF0, 0x0F, 0x33, 0xCC};
+    int expected_bits = 8 + 0 + 4 + 4 + 4 + 4 + 4 + 4; /* = 32 bits */
+
+    long long result_regular = redisPopcount(test_data, sizeof(test_data));
+    assert(result_regular == expected_bits);
+
+#ifdef HAVE_AVX2
+    if (BITOP_USE_AVX2) {
+        long long result_avx2 = redisPopCountAvx2(test_data, sizeof(test_data));
+        assert(result_avx2 == expected_bits);
+    }
+#endif
+
+#ifdef HAVE_AVX512
+    if (BITOP_USE_AVX512) {
+        long long result_avx512 = redisPopCountAvx512(test_data, sizeof(test_data));
+        assert(result_avx512 == expected_bits);
+    }
+#endif
+}
+
+static void test_large_buffer_popcount(void) {
+    /* Large buffer test (4KB) */
+    size_t large_size = 4096;
+    unsigned char *large_data = zmalloc(large_size);
+    assert(large_data != NULL);
+
+    /* Fill with alternating pattern */
+    for (size_t i = 0; i < large_size; i++) {
+        large_data[i] = (i % 2) ? 0xAA : 0x55; /* 4 bits each */
+    }
+    int expected_large = large_size * 4; /* 4 bits per byte */
+
+    long long result_large = redisPopcount(large_data, large_size);
+    assert(result_large == expected_large);
+
+#ifdef HAVE_AVX2
+    if (BITOP_USE_AVX2) {
+        long long result_large_avx2 = redisPopCountAvx2(large_data, large_size);
+        assert(result_large_avx2 == expected_large);
+    }
+#endif
+
+#ifdef HAVE_AVX512
+    if (BITOP_USE_AVX512) {
+        long long result_large_avx512 = redisPopCountAvx512(large_data, large_size);
+        assert(result_large_avx512 == expected_large);
+    }
+#endif
+
+    zfree(large_data);
+}
+
+static void test_unaligned_buffer_popcount(void) {
+    /* Unaligned buffer test */
+    unsigned char *aligned_buf = zmalloc(128 + 64); /* Extra space for alignment */
+    assert(aligned_buf != NULL);
+
+    /* Create unaligned pointer (offset by 1, 3, 5, 7 bytes) */
+    for (int offset = 1; offset <= 7; offset += 2) {
+        unsigned char *unaligned_data = aligned_buf + offset;
+        size_t unaligned_size = 64;
+
+        /* Fill with known pattern */
+        for (size_t i = 0; i < unaligned_size; i++) {
+            unaligned_data[i] = 0xF0; /* 4 bits each */
+        }
+        int expected_unaligned = unaligned_size * 4;
+
+        long long result_unaligned = redisPopcount(unaligned_data, unaligned_size);
+        assert(result_unaligned == expected_unaligned);
+
+#ifdef HAVE_AVX2
+        if (BITOP_USE_AVX2) {
+            long long result_unaligned_avx2 = redisPopCountAvx2(unaligned_data, unaligned_size);
+            assert(result_unaligned_avx2 == expected_unaligned);
+        }
+#endif
+
+#ifdef HAVE_AVX512
+        if (BITOP_USE_AVX512) {
+            long long result_unaligned_avx512 = redisPopCountAvx512(unaligned_data, unaligned_size);
+            assert(result_unaligned_avx512 == expected_unaligned);
+        }
+#endif
+    }
+
+    zfree(aligned_buf);
+}
+
+static void test_edge_case_sizes_popcount(void) {
+    /* Edge case sizes */
+    unsigned char edge_data[128];
+    for (int i = 0; i < 128; i++) edge_data[i] = 0x0F; /* 4 bits each */
+
+    /* Test various small sizes */
+    int edge_sizes[] = {1, 2, 3, 4, 5, 6, 7, 15, 16, 17, 31, 32, 33, 63, 64, 65};
+    int num_edge_sizes = sizeof(edge_sizes) / sizeof(edge_sizes[0]);
+
+    for (int i = 0; i < num_edge_sizes; i++) {
+        int size = edge_sizes[i];
+        int expected_edge = size * 4;
+
+        long long result_edge = redisPopcount(edge_data, size);
+        assert(result_edge == expected_edge);
+
+#ifdef HAVE_AVX2
+        if (BITOP_USE_AVX2) {
+            long long result_edge_avx2 = redisPopCountAvx2(edge_data, size);
+            assert(result_edge_avx2 == expected_edge);
+        }
+#endif
+
+#ifdef HAVE_AVX512
+        if (BITOP_USE_AVX512) {
+            long long result_edge_avx512 = redisPopCountAvx512(edge_data, size);
+            assert(result_edge_avx512 == expected_edge);
+        }
+#endif
+    }
+}
+
+static void test_zeros_and_ones_popcount(void) {
+    /* All zeros and all ones */
+    unsigned char zeros[256] = {0};
+    unsigned char ones[256];
+    memset(ones, 0xFF, 256);
+
+    /* Test all zeros */
+    long long result_zeros = redisPopcount(zeros, 256);
+    assert(result_zeros == 0);
+
+    /* Test all ones */
+    long long result_ones = redisPopcount(ones, 256);
+    assert(result_ones == 256 * 8);
+
+#ifdef HAVE_AVX2
+    if (BITOP_USE_AVX2) {
+        assert(redisPopCountAvx2(zeros, 256) == 0);
+        assert(redisPopCountAvx2(ones, 256) == 256 * 8);
+    }
+#endif
+
+#ifdef HAVE_AVX512
+    if (BITOP_USE_AVX512) {
+        assert(redisPopCountAvx512(zeros, 256) == 0);
+        assert(redisPopCountAvx512(ones, 256) == 256 * 8);
+    }
+#endif
+}
+
+static void test_random_pattern_popcount(void) {
+    /* Random pattern test */
+    unsigned char random_data[512];
+
+    /* Generate pseudo-random data with known seed for reproducibility */
+    unsigned int seed = 12345;
+    long long expected_random = 0;
+    for (int i = 0; i < 512; i++) {
+        seed = seed * 1103515245 + 12345; /* Simple LCG */
+        random_data[i] = (seed >> 16) & 0xFF;
+
+        /* Count bits manually for verification */
+        unsigned char byte = random_data[i];
+        for (int bit = 0; bit < 8; bit++) {
+            if (byte & (1 << bit)) expected_random++;
+        }
+    }
+
+    long long result_random = redisPopcount(random_data, 512);
+    assert(result_random == expected_random);
+
+#ifdef HAVE_AVX2
+    if (BITOP_USE_AVX2) {
+        long long result_random_avx2 = redisPopCountAvx2(random_data, 512);
+        assert(result_random_avx2 == expected_random);
+    }
+#endif
+
+#ifdef HAVE_AVX512
+    if (BITOP_USE_AVX512) {
+        long long result_random_avx512 = redisPopCountAvx512(random_data, 512);
+        assert(result_random_avx512 == expected_random);
+    }
+#endif
+}
+
+static void test_boundary_conditions_popcount(void) {
+    /* Boundary conditions */
+    unsigned char test_data[] = {0xFF, 0x00, 0xAA, 0x55};
+
+    /* Test zero length */
+    long long result_zero_len = redisPopcount(test_data, 0);
+    assert(result_zero_len == 0);
+
+#ifdef HAVE_AVX2
+    if (BITOP_USE_AVX2) {
+        assert(redisPopCountAvx2(test_data, 0) == 0);
+    }
+#endif
+
+#ifdef HAVE_AVX512
+    if (BITOP_USE_AVX512) {
+        assert(redisPopCountAvx512(test_data, 0) == 0);
+    }
+#endif
+}
+
+int bitopsTest(int argc, char **argv, int flags) {
+    UNUSED(argc);
+    UNUSED(argv);
+    UNUSED(flags);
+
+    test_basic_popcount();
+    test_large_buffer_popcount();
+    test_unaligned_buffer_popcount();
+    test_edge_case_sizes_popcount();
+    test_zeros_and_ones_popcount();
+    test_random_pattern_popcount();
+    test_boundary_conditions_popcount();
+
+    printf("All bitops tests passed!\n");
+    return 0;
+}
+#endif

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -374,8 +374,9 @@ static inline long long redisPopcountAuto(const unsigned char *p, long count) {
 #endif
 #ifdef HAVE_AARCH64_NEON
     return redisPopCountAarch64((void*)p, count);
-#endif
+#else
     return redisPopcount((void*)p, count);
+#endif
 }
 
 /* Return the position of the first bit set to one (if 'bit' is 1) or

--- a/src/config.h
+++ b/src/config.h
@@ -371,4 +371,17 @@ void setcpuaffinity(const char *cpulist);
 #define ATTRIBUTE_TARGET_AVX512
 #endif
 
+/* Check for AArch64 (ARM v8) specific optimizations */
+#if defined(__aarch64__) && ((defined(__GNUC__) && __GNUC__ >= 5) || defined(__clang__))
+#if defined(__has_attribute) && __has_attribute(target)
+#define HAVE_AARCH64_NEON
+#endif
+#endif
+
+#if defined(HAVE_AARCH64_NEON)
+#define ATTRIBUTE_TARGET_AARCH64_NEON __attribute__((target("+neon")))
+#else
+#define ATTRIBUTE_TARGET_AARCH64_NEON
+#endif
+
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -349,32 +349,17 @@ void setcpuaffinity(const char *cpulist);
 #if defined (__x86_64__) && ((defined(__GNUC__) && __GNUC__ >= 5) || (defined(__clang__) && __clang_major__ >= 4))
 #if defined(__has_attribute) && __has_attribute(target)
 #define HAVE_AVX2
-#endif
-#endif
-
-#if defined (HAVE_AVX2)
 #define ATTRIBUTE_TARGET_AVX2 __attribute__((target("avx2")))
-#else
-#define ATTRIBUTE_TARGET_AVX2
-#endif
-
-#if defined (HAVE_AVX2)
 #define ATTRIBUTE_TARGET_AVX2_POPCOUNT __attribute__((target("avx2,popcnt")))
-#else
-#define ATTRIBUTE_TARGET_AVX2_POPCOUNT
+#endif
 #endif
 
 /* Check if we can compile AVX512 code */
 #if defined (__x86_64__) && ((defined(__GNUC__) && __GNUC__ >= 5) || (defined(__clang__) && __clang_major__ >= 4))
 #if defined(__has_attribute) && __has_attribute(target)
 #define HAVE_AVX512
-#endif
-#endif
-
-#if defined (HAVE_AVX512)
 #define ATTRIBUTE_TARGET_AVX512_POPCOUNT __attribute__((target("avx512f,avx512vpopcntdq")))
-#else
-#define ATTRIBUTE_TARGET_AVX512_POPCOUNT
+#endif
 #endif
 
 /* Check for AArch64 (ARM v8) specific optimizations */

--- a/src/config.h
+++ b/src/config.h
@@ -353,9 +353,22 @@ void setcpuaffinity(const char *cpulist);
 #endif
 
 #if defined (HAVE_AVX2)
-#define ATTRIBUTE_TARGET_AVX2 __attribute__((target("avx2")))
+#define ATTRIBUTE_TARGET_AVX2 __attribute__((target("avx2,popcnt")))
 #else
 #define ATTRIBUTE_TARGET_AVX2
+#endif
+
+/* Check if we can compile AVX512 code */
+#if defined (__x86_64__) && ((defined(__GNUC__) && __GNUC__ >= 5) || (defined(__clang__) && __clang_major__ >= 4))
+#if defined(__has_attribute) && __has_attribute(target)
+#define HAVE_AVX512
+#endif
+#endif
+
+#if defined (HAVE_AVX512)
+#define ATTRIBUTE_TARGET_AVX512 __attribute__((target("avx512f,avx512vpopcntdq")))
+#else
+#define ATTRIBUTE_TARGET_AVX512
 #endif
 
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -353,9 +353,15 @@ void setcpuaffinity(const char *cpulist);
 #endif
 
 #if defined (HAVE_AVX2)
-#define ATTRIBUTE_TARGET_AVX2 __attribute__((target("avx2,popcnt")))
+#define ATTRIBUTE_TARGET_AVX2 __attribute__((target("avx2")))
 #else
 #define ATTRIBUTE_TARGET_AVX2
+#endif
+
+#if defined (HAVE_AVX2)
+#define ATTRIBUTE_TARGET_AVX2_POPCOUNT __attribute__((target("avx2,popcnt")))
+#else
+#define ATTRIBUTE_TARGET_AVX2_POPCOUNT
 #endif
 
 /* Check if we can compile AVX512 code */
@@ -366,9 +372,9 @@ void setcpuaffinity(const char *cpulist);
 #endif
 
 #if defined (HAVE_AVX512)
-#define ATTRIBUTE_TARGET_AVX512 __attribute__((target("avx512f,avx512vpopcntdq")))
+#define ATTRIBUTE_TARGET_AVX512_POPCOUNT __attribute__((target("avx512f,avx512vpopcntdq")))
 #else
-#define ATTRIBUTE_TARGET_AVX512
+#define ATTRIBUTE_TARGET_AVX512_POPCOUNT
 #endif
 
 /* Check for AArch64 (ARM v8) specific optimizations */

--- a/src/config.h
+++ b/src/config.h
@@ -378,11 +378,4 @@ void setcpuaffinity(const char *cpulist);
 #endif
 #endif
 
-#if defined(HAVE_AARCH64_NEON)
-/* AArch64 always has NEON, no target attribute needed */
-#define ATTRIBUTE_TARGET_AARCH64_NEON
-#else
-#define ATTRIBUTE_TARGET_AARCH64_NEON
-#endif
-
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -379,7 +379,8 @@ void setcpuaffinity(const char *cpulist);
 #endif
 
 #if defined(HAVE_AARCH64_NEON)
-#define ATTRIBUTE_TARGET_AARCH64_NEON __attribute__((target("+neon")))
+/* AArch64 always has NEON, no target attribute needed */
+#define ATTRIBUTE_TARGET_AARCH64_NEON
 #else
 #define ATTRIBUTE_TARGET_AARCH64_NEON
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -7285,6 +7285,7 @@ int __test_num = 0;
 * --accurate:     Runs tests with more iterations.
 * --large-memory: Enables tests that consume more than 100mb. */
 typedef int redisTestProc(int argc, char **argv, int flags);
+int bitopsTest(int argc, char **argv, int flags);
 struct redisTest {
     char *name;
     redisTestProc *proc;
@@ -7305,6 +7306,7 @@ struct redisTest {
     {"listpack", listpackTest},
     {"kvstore", kvstoreTest},
     {"ebuckets", ebucketsTest},
+    {"bitmap", bitopsTest},
 };
 redisTestProc *getTestProcByName(const char *name) {
     int numtests = sizeof(redisTests)/sizeof(struct redisTest);


### PR DESCRIPTION
This PR introduces **vectorized implementations of `BITCOUNT`** for x86_64 targets with AVX2 and AVX512 support.  

- **AVX2 path**: processes 32B at a time, using unrolled POPCNT on 64-bit lanes with independent accumulators to reduce data dependencies.  
- **AVX512 path**: leverages `VPOPCNTDQ` on 64B chunks with `_mm512_reduce_add_epi64` to efficiently aggregate results across 512-bit vectors.  
- Both paths include cache prefetching hints to better overlap memory fetches with computation.  This was proved to matter in https://github.com/redis/redis/pull/14103. 
- Fallbacks to the scalar implementation if hardware support is unavailable.  

The test suite has been expanded with unit tests that validate correctness across aligned/unaligned buffers, edge cases, random data, and large workloads, ensuring consistency between scalar, AVX2, and AVX512 implementations.  

---

## Performance Results on Intel Xeon SPR (single shard)

| Test Case | Baseline `/redis unstable` (median obs. ± std.dev) | Comparison `filipecosta90/redis optimize.bitcount.avx` (median obs. ± std.dev) | % change (lower-better) | Note |
|-----------|------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|--------------------------|------|
| [memtier_benchmark-1key-100M-bits-bitmap-bitcount](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-100M-bits-bitmap-bitcount.yml) | 6.239 ± 0.5% (7 datapoints) | 5.759 ± 0.3% (3 datapoints) | **−7.7%** | Better |
| [memtier_benchmark-1key-1Billion-bits-bitmap-bitcount](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-1Billion-bits-bitmap-bitcount.yml) | 59.647 ± 0.7% (7 datapoints) | 53.503 ± 0.3% (3 datapoints) | **−10.3%** | Better |
---

## Performance Results on AMD EPYC 9R14 (single shard)

| Test Case | Metric | Baseline `/redis unstable` (median obs. ± std.dev) | Comparison `filipecosta90/redis optimize.bitcount.avx` (median obs. ± std.dev) | % change (lower-better) |
|------------|---------|------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|--------------------------|
| [memtier_benchmark-1key-100M-bits-bitmap-bitcount](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-100M-bits-bitmap-bitcount.yml) | **Ops/sec (↑ better)** | 37,120.79 | 52,093.55 | **+40.2%** |
|  | **Latency (p50 / p99)** | 5.279 ms / 9.535 ms | 3.807 ms / 6.399 ms | **−27.9% / −33.0%** |

---

## Reproduce Benchmarks

```bash
pip3 install redis-benchmarks-specification
redis-benchmarks-spec-client-runner \
  --test memtier_benchmark-1key-1Billion-bits-bitmap-bitcount.yml \
  --db_server_host <...> --db_server_port <...> --db_server_password <...> \
  --flushall_on_every_test_start