### PR TITLE
Fix timing issue for sentinel master-reboot test

### DIFF
--- a/tests/sentinel/tests/12-master-reboot.tcl
+++ b/tests/sentinel/tests/12-master-reboot.tcl
@@ -40,7 +40,7 @@ test "Master reboot in very short time" {
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
     
-    R $master_id debug populate 10000
+    R $master_id debug populate 20000
     R $master_id bgsave
     R $master_id config set key-load-delay 1500
     R $master_id config set loading-process-events-interval-bytes 1024
@@ -62,6 +62,10 @@ test "Master reboot in very short time" {
             fail "At least one Sentinel did not receive failover info"
         }
     }
+
+    # Reset configuration to avoid unnecessary delays
+    R $master_id config set key-load-delay 0
+    R $master_id config rewrite
 
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     set master_id [get_instance_id_by_port redis [lindex $addr 1]]


### PR DESCRIPTION
From the following logs, if we are in a slow environment, the election process of sentinels may become very slow.
Even if the master instance that was restarted and is slowly loading RDB has already been loaded, the election just gets started. 

This PR makes the master load the RDB more slowly, and fixes the missing of reseting reset `key-load-delay` for the master node.

mymaster logs:
```
7033:M 28 Aug 2025 03:05:33.251 * Done loading RDB, keys loaded: 10000, keys expired: 0.
```

sentinel 1 logs:
```
2025-08-28T03:06:57.9619171Z 6570:X 28 Aug 2025 03:05:17.759 * Sentinel new configuration saved on disk
2025-08-28T03:06:57.9619627Z 6570:X 28 Aug 2025 03:05:17.759 # +vote-for-leader 186504e6fe96c12a389e2ca00ad67c304aee0402 9
2025-08-28T03:06:57.9620078Z 6570:X 28 Aug 2025 03:05:17.793 * +reboot master mymaster 127.0.0.1 30000
2025-08-28T03:06:57.9620463Z 6570:X 28 Aug 2025 03:05:17.844 # -sdown master mymaster 127.0.0.1 30000
2025-08-28T03:06:57.9620852Z 6570:X 28 Aug 2025 03:05:21.464 # +sdown master setmaster 10.0.0.1 30000
2025-08-28T03:06:57.9621227Z 6570:X 28 Aug 2025 03:05:22.820 # +sdown master mymaster 127.0.0.1 30000
2025-08-28T03:06:57.9621628Z 6570:X 28 Aug 2025 03:05:22.890 # +odown master mymaster 127.0.0.1 30000 #quorum 3/3
2025-08-28T03:06:57.9622163Z 6570:X 28 Aug 2025 03:05:22.890 * Next failover delay: I will not start a failover before Thu Aug 28 03:05:38 2025
2025-08-28T03:06:57.9622779Z 6570:X 28 Aug 2025 03:05:33.406 # -sdown master mymaster 127.0.0.1 30000
2025-08-28T03:06:57.9623171Z 6570:X 28 Aug 2025 03:05:33.406 # -odown master mymaster 127.0.0.1 30000
```

sentinel 2 logs:
```
2025-08-28T03:06:57.9826216Z 6578:X 28 Aug 2025 03:05:17.796 * +reboot master mymaster 127.0.0.1 30000
2025-08-28T03:06:57.9826367Z 6578:X 28 Aug 2025 03:05:17.866 # -sdown master mymaster 127.0.0.1 30000
2025-08-28T03:06:57.9826597Z 6578:X 28 Aug 2025 03:05:18.422 * +convert-to-slave slave 127.0.0.1:30003 127.0.0.1 30003 @ mymaster 127.0.0.1 30000
2025-08-28T03:06:57.9826732Z 6578:X 28 Aug 2025 03:05:21.565 # +sdown master setmaster 10.0.0.1 30000
2025-08-28T03:06:57.9826855Z 6578:X 28 Aug 2025 03:05:22.880 # +sdown master mymaster 127.0.0.1 30000
2025-08-28T03:06:57.9827140Z 6578:X 28 Aug 2025 03:05:22.973 # +odown master mymaster 127.0.0.1 30000 #quorum 4/3
2025-08-28T03:06:57.9827381Z 6578:X 28 Aug 2025 03:05:22.973 * Next failover delay: I will not start a failover before Thu Aug 28 03:05:38 2025
2025-08-28T03:06:57.9827509Z 6578:X 28 Aug 2025 03:05:33.450 # -sdown master mymaster 127.0.0.1 30000
2025-08-28T03:06:57.9827634Z 6578:X 28 Aug 2025 03:05:33.450 # -odown master mymaster 127.0.0.1 30000
```

Failed CI: 
https://github.com/redis/redis/actions/runs/17281840078/job/49051627047
https://github.com/redis/redis/actions/runs/17084800680/job/48446677834

CI just with ASAN (ran 10 times and didn't see this failure):
https://github.com/sundb/redis/actions/runs/17285732308