### PR TITLE
Fix module_tests dependency to resolve parallel build issues

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -398,7 +398,7 @@ endif
 
 .PHONY: all
 
-module_tests:
+module_tests: $(REDIS_SERVER_NAME)
 	$(MAKE) -C ../tests/modules
 
 .PHONY: module_tests


### PR DESCRIPTION
This PR follows https://github.com/redis/redis/issues/14226.
When using parallel compilation with `make -j`, the `module_tests` target and `REDIS_SERVER_NAME` may compile concurrently, leading to build failures. This appears to be caused by both targets having a shared dependency on `redismodule.h`, creating a race condition during parallel execution.

Solution:
Add explicit dependency of `module_tests` on `$(REDIS_SERVER_NAME)` to enforce build order.

part of the failed output:
`make distclean && make -j 10` is easier to reproduce this issue in my local.
```
ar crs lib/libjemalloc.a src/jemalloc.o src/arena.o src/background_thread.o src/base.o src/bin.o src/bin_info.o src/bitmap.o src/buf_writer.o src/cache_bin.o src/ckh.o src/counter.o src/ctl.o src/decay.o src/div.o src/ecache.o src/edata.o src/edata_cache.o src/ehooks.o src/emap.o src/eset.o src/exp_grow.o src/extent.o src/extent_dss.o src/extent_mmap.o src/fxp.o src/san.o src/san_bump.o src/hook.o src/hpa.o src/hpa_hooks.o src/hpdata.o src/inspect.o src/large.o src/log.o src/malloc_io.o src/mutex.o src/nstime.o src/pa.o src/pa_extra.o src/pai.o src/pac.o src/pages.o src/peak_event.o src/prof.o src/prof_data.o src/prof_log.o src/prof_recent.o src/prof_stats.o src/prof_sys.o src/psset.o src/rtree.o src/safety_check.o src/sc.o src/sec.o src/stats.o src/sz.o src/tcache.o src/test_hooks.o src/thread_event.o src/ticker.o src/tsd.o src/witness.o
make[3]: Leaving directory '/home/sundb/data/redis_fork_6/deps/jemalloc'
make[2]: Leaving directory '/home/sundb/data/redis_fork_6/deps'
make[1]: Leaving directory '/home/sundb/data/redis_fork_6/src'
make: *** [Makefile:11: all] Error 2
```
