### PR TITLE
Fix minor issues in the latency report

### DIFF
--- a/src/latency.c
+++ b/src/latency.c
@@ -262,7 +262,7 @@ sds createLatencyReport(void) {
             if (server.slowlog_log_slower_than < 0 || server.slowlog_max_len == 0) {
                 advise_slowlog_enabled = 1;
                 advices++;
-            } else if (server.slowlog_log_slower_than/1000 <
+            } else if (server.slowlog_log_slower_than/1000 >
                        server.latency_monitor_threshold)
             {
                 advise_slowlog_tuning = 1;
@@ -370,7 +370,7 @@ sds createLatencyReport(void) {
         }
 
         if (advise_slowlog_tuning) {
-            report = sdscatprintf(report,"- Your current Slow Log configuration only logs events that are slower than your configured latency monitor threshold. Please use 'CONFIG SET slowlog-log-slower-than %llu'.\n", (unsigned long long)server.latency_monitor_threshold*1000);
+            report = sdscatprintf(report,"- Your current Slow Log configuration can not log the events that greater than your configured latency monitor threshold but less than the Slow Log threshold. Please use 'CONFIG SET slowlog-log-slower-than %llu'.\n", (unsigned long long)server.latency_monitor_threshold*1000);
         }
 
         if (advise_slowlog_inspect) {

--- a/src/latency.c
+++ b/src/latency.c
@@ -262,7 +262,7 @@ sds createLatencyReport(void) {
             if (server.slowlog_log_slower_than < 0 || server.slowlog_max_len == 0) {
                 advise_slowlog_enabled = 1;
                 advices++;
-            } else if (server.slowlog_log_slower_than/1000 >
+            } else if (server.slowlog_log_slower_than/1000 <
                        server.latency_monitor_threshold)
             {
                 advise_slowlog_tuning = 1;


### PR DESCRIPTION
In the latency report, the suggestion words for optimizing the Slow Log threshold are incorrect. If the Slow Log threshold is greater than Latency Monitor threshold, the slowlog will be unable to log events that are greater than Latency Monitor threshold but less than the Slow Log threshold. 


I corrected the content of the report reply.