### PR TITLE
Fix defrag issues for pubsub and lua

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1050,7 +1050,7 @@ void defragPubsubScanCallback(void *privdata, const dictEntry *de, dictEntryLink
             client *c = dictGetKey(clientde);
             dict *client_channels = ctx->getPubSubChannels(c);
             uint64_t hash = dictGetHash(client_channels, newchannel);
-            dictEntry *pubsub_channel = dictFindByHashAndPtr(client_channels, newchannel, hash);
+            dictEntry *pubsub_channel = dictFindByHashAndPtr(client_channels, channel, hash);
             serverAssert(pubsub_channel);
             dictSetKey(ctx->getPubSubChannels(c), pubsub_channel, newchannel);
         }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1049,7 +1049,8 @@ void defragPubsubScanCallback(void *privdata, const dictEntry *de, dictEntryLink
         while((clientde = dictNext(&di)) != NULL) {
             client *c = dictGetKey(clientde);
             dict *client_channels = ctx->getPubSubChannels(c);
-            dictEntry *pubsub_channel = dictFind(client_channels, newchannel);
+            uint64_t hash = dictGetHash(client_channels, newchannel);
+            dictEntry *pubsub_channel = dictFindByHashAndPtr(client_channels, newchannel, hash);
             serverAssert(pubsub_channel);
             dictSetKey(ctx->getPubSubChannels(c), pubsub_channel, newchannel);
         }

--- a/src/dict.h
+++ b/src/dict.h
@@ -226,6 +226,7 @@ dictEntryLink dictTwoPhaseUnlinkFind(dict *d, const void *key, int *table_index)
 void dictTwoPhaseUnlinkFree(dict *d, dictEntryLink llink, int table_index);
 void dictRelease(dict *d);
 dictEntry * dictFind(dict *d, const void *key);
+dictEntry *dictFindByHashAndPtr(dict *d, const void *oldptr, const uint64_t hash);
 int dictShrinkIfNeeded(dict *d);
 int dictExpandIfNeeded(dict *d);
 void *dictGetKey(const dictEntry *de);


### PR DESCRIPTION
This PR fixes two defrag issues.

1. Fix a use-after-free issue caused by updating dictionary keys after a pubsub channel is reallocated.
   This issue was introduced by https://github.com/redis/redis/pull/13058

1. Fix potential use-after-free for lua during AOF loading with defrag
   This issue was introduced by https://github.com/redis/redis/issues/13058
   This fix follows https://github.com/redis/redis/pull/14319
    This PR updates the LuaScript LRU list before script execution to prevent accessing a potentially invalidated pointer after long-running scripts.
 
Note that both of these issues were introduced since 7.4, so we can fix them together.