### PR TITLE
redis-cli: Add word-jump navigation (Alt/Option + ←/→, Ctrl + ←/→)

### DIFF
--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -1066,7 +1066,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
 
                     /* If first param is digit or ';', read more until we see a final in @~ */
                     char additionalChar;
-                    while (i < seqBufferMaxLength-1 && read(l.ifd, &additionalChar, 1) != -1) {
+                    while (i < seqBufferMaxLength-1 && read(l.ifd, &additionalChar, 1) == 1) {
                         seqBuffer[i++] = additionalChar;
                         if (additionalChar >= '@' && additionalChar <= '~') break; /* CSI final byte */
                     }

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -1037,13 +1037,14 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
              * chars at different times. */
             if (read(l.ifd,seq,1) == -1) break;
 
-            /* Handle Meta-b / Meta-f directly */
-            if (seq[0] == 'b') {                 /* ESC b → word left */
-                linenoiseEditMoveWordLeft(&l);
-                break;
-            }
-            if (seq[0] == 'f') {                 /* ESC f → word right */
-                linenoiseEditMoveWordRight(&l);
+            /* Handle Meta-b / Meta-f directly because it's a 2-byte sequence */
+            if (seq[0] == 'b' || seq[0] == 'f') {
+                if (reverse_search_mode_enabled) {
+                    disableReverseSearchMode(&l, buf, buflen, 1);
+                    break;
+                }
+                if (seq[0] == 'b') linenoiseEditMoveWordLeft(&l);   /* ESC b → word left */
+                else linenoiseEditMoveWordRight(&l);                /* ESC f → word right */
                 break;
             }
 

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -811,12 +811,11 @@ static void linenoiseEditMoveWordLeft(struct linenoiseState *l) {
 static void linenoiseEditMoveWordRight(struct linenoiseState *l) {
     if (l->pos == l->len) return;
     /* Move cursor to the right over any delimiters */
-    while (l->pos < l->len &&  isWordChar(l->buf[l->pos])) l->pos++;
+    while (l->pos < l->len && isWordChar(l->buf[l->pos])) l->pos++;
     /* Then continue moving over a word */
     while (l->pos < l->len && !isWordChar(l->buf[l->pos])) l->pos++;
     refreshLine(l);
 }
-
 
 /* Move cursor to the start of the line. */
 void linenoiseEditMoveHome(struct linenoiseState *l) {
@@ -1075,14 +1074,32 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                         }
                     }
 
+                    /* The exact key mapping behavior depends on your keyboard/terminal setup.
+                     * For example, in MacOS terminal you can go to the profile keyboard setting
+                     * to see or configure the current mapping.
+                     *
+                     * Take action `[1;5C` as an illustration:
+                     * [ indicates a CSI (Control Sequence Introducer), telling the terminal
+                     *    "What follows is a control command, not text"
+                     * 1 is how many units to move (default is 1 if omitted)
+                     * ; is the separator between parameters
+                     * 5 is the modifier mask for Ctrl. Other possible values include 1 (no modifier),
+                     *     2 (Shift), 3 (Alt), 4 (Shift + Alt), 6 (Shift + Ctrl), 7 (Alt + Ctrl), etc.
+                     * C is the cursor right command. Other commands include A (cursor up), B (cursor
+                     *     down), D (cursor left).
+                     */
+
+                    /* This branch is usually triggered by pressing Alt/Ctrl + ← */
                     if (strstr(seqBuffer, "1;5D") || strstr(seqBuffer, "5D")) {
                         linenoiseEditMoveWordLeft(&l);
                         break;
                     }
+                    /* Usually Alt/Ctrl + → */
                     if (strstr(seqBuffer, "1;5C") || strstr(seqBuffer, "5C")) {
                         linenoiseEditMoveWordRight(&l);
                         break;
                     }
+                    /* Usually the `delete` key */
                     if (strstr(seqBuffer, "3~")) {
                         linenoiseEditDelete(&l);
                         break;

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -1060,25 +1060,25 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                 if (seq[1] >= '0' && seq[1] <= '9') {
                     /* Extended escape, read additional bytes.
                      * Examples: ESC [1;5C  ESC [3~ */
-                    const int seqBufferMaxLength = 8;
-                    char seqBuffer[seqBufferMaxLength];
+                    const int seq_buffer_max_length = 8;
+                    char seq_buffer[seq_buffer_max_length];
                     int i = 0;
-                    seqBuffer[i++] = seq[1];
+                    seq_buffer[i++] = seq[1];
 
                     /* Read more bytes until we see a CSI final byte (range @..~).
-                     * Use seqBufferMaxLength-1 to reserve one position for '\0'. */
-                    char additionalChar;
-                    while (i < seqBufferMaxLength-1 && read(l.ifd, &additionalChar, 1) == 1) {
-                        seqBuffer[i++] = additionalChar;
-                        if (additionalChar >= '@' && additionalChar <= '~') break; /* CSI final byte */
+                     * Use seq_buffer_max_length-1 to reserve one position for '\0'. */
+                    char seq_char;
+                    while (i < seq_buffer_max_length-1 && read(l.ifd, &seq_char, 1) == 1) {
+                        seq_buffer[i++] = seq_char;
+                        if (seq_char >= '@' && seq_char <= '~') break; /* CSI final byte */
                     }
-                    seqBuffer[i] = '\0';
+                    seq_buffer[i] = '\0';
 
                     /* The exact key mapping behavior depends on your keyboard/terminal setup.
                      * For example, in MacOS terminal you can go to the profile keyboard setting
                      * to see or configure the current mapping.
                      *
-                     * Take action `[1;5C` as an illustration:
+                     * Take action `[1;5C` (Ctrl + →) or `[1;3D` (Alt + ←) as examples:
                      * [ indicates a CSI (Control Sequence Introducer), telling the terminal
                      *    "What follows is a control command, not text"
                      * 1 is how many units to move (default is 1 if omitted)
@@ -1090,19 +1090,17 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                      */
 
                     /* Word left: Ctrl + ← (modifier 5) or Alt + ← (modifier 3) */
-                    if (strcmp(seqBuffer, "1;5D") == 0 || strcmp(seqBuffer, "1;3D") == 0 ||
-                        strcmp(seqBuffer, "5D") == 0 || strcmp(seqBuffer, "3D") == 0) {
+                    if (strcmp(seq_buffer, "1;5D") == 0 || strcmp(seq_buffer, "1;3D") == 0) {
                         linenoiseEditMoveWordLeft(&l);
                         break;
                     }
                     /* Word right: Ctrl + → (modifier 5) or Alt + → (modifier 3) */
-                    if (strcmp(seqBuffer, "1;5C") == 0 || strcmp(seqBuffer, "1;3C") == 0 ||
-                        strcmp(seqBuffer, "5C") == 0 || strcmp(seqBuffer, "3C") == 0) {
+                    if (strcmp(seq_buffer, "1;5C") == 0 || strcmp(seq_buffer, "1;3C") == 0) {
                         linenoiseEditMoveWordRight(&l);
                         break;
                     }
-                    /* Usually the `delete` key */
-                    if (strcmp(seqBuffer, "3~") == 0) {
+                    /* Delete key */
+                    if (strcmp(seq_buffer, "3~") == 0) {
                         linenoiseEditDelete(&l);
                         break;
                     }

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -1068,11 +1068,9 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                     char additionalChar;
                     while (i < seqBufferMaxLength-1 && read(l.ifd, &additionalChar, 1) != -1) {
                         seqBuffer[i++] = additionalChar;
-                        if (additionalChar >= '@' && additionalChar <= '~') {    /* CSI final byte */
-                            seqBuffer[i] = '\0';
-                            break;
-                        }
+                        if (additionalChar >= '@' && additionalChar <= '~') break; /* CSI final byte */
                     }
+                    seqBuffer[i] = '\0';
 
                     /* The exact key mapping behavior depends on your keyboard/terminal setup.
                      * For example, in MacOS terminal you can go to the profile keyboard setting
@@ -1090,17 +1088,17 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                      */
 
                     /* This branch is usually triggered by pressing Alt/Ctrl + ← */
-                    if (strstr(seqBuffer, "1;5D") || strstr(seqBuffer, "5D")) {
+                    if (strcmp(seqBuffer, "1;5D") == 0 || strcmp(seqBuffer, "5D") == 0) {
                         linenoiseEditMoveWordLeft(&l);
                         break;
                     }
                     /* Usually Alt/Ctrl + → */
-                    if (strstr(seqBuffer, "1;5C") || strstr(seqBuffer, "5C")) {
+                    if (strcmp(seqBuffer, "1;5C") == 0 || strcmp(seqBuffer, "5C") == 0) {
                         linenoiseEditMoveWordRight(&l);
                         break;
                     }
                     /* Usually the `delete` key */
-                    if (strstr(seqBuffer, "3~")) {
+                    if (strcmp(seqBuffer, "3~") == 0) {
                         linenoiseEditDelete(&l);
                         break;
                     }

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -1089,13 +1089,15 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                      *     down), D (cursor left).
                      */
 
-                    /* This branch is usually triggered by pressing Alt/Ctrl + ← */
-                    if (strcmp(seqBuffer, "1;5D") == 0 || strcmp(seqBuffer, "5D") == 0) {
+                    /* Word left: Ctrl + ← (modifier 5) or Alt + ← (modifier 3) */
+                    if (strcmp(seqBuffer, "1;5D") == 0 || strcmp(seqBuffer, "1;3D") == 0 ||
+                        strcmp(seqBuffer, "5D") == 0 || strcmp(seqBuffer, "3D") == 0) {
                         linenoiseEditMoveWordLeft(&l);
                         break;
                     }
-                    /* Usually Alt/Ctrl + → */
-                    if (strcmp(seqBuffer, "1;5C") == 0 || strcmp(seqBuffer, "5C") == 0) {
+                    /* Word right: Ctrl + → (modifier 5) or Alt + → (modifier 3) */
+                    if (strcmp(seqBuffer, "1;5C") == 0 || strcmp(seqBuffer, "1;3C") == 0 ||
+                        strcmp(seqBuffer, "5C") == 0 || strcmp(seqBuffer, "3C") == 0) {
                         linenoiseEditMoveWordRight(&l);
                         break;
                     }

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -801,18 +801,18 @@ static int isWordChar(char c) {
 
 static void linenoiseEditMoveWordLeft(struct linenoiseState *l) {
     if (l->pos == 0) return;
-    /* Move cursor to the left over any delimiters */
+    /* Skip any delimiters, then move left over the previous word */
     while (l->pos > 0 && !isWordChar(l->buf[l->pos - 1])) l->pos--;
-    /* Then continue moving over a word */
+    /* Then move to the start of that word */
     while (l->pos > 0 && isWordChar(l->buf[l->pos - 1])) l->pos--;
     refreshLine(l);
 }
 
 static void linenoiseEditMoveWordRight(struct linenoiseState *l) {
     if (l->pos == l->len) return;
-    /* Move cursor to the right over any delimiters */
+    /* Skip the current word to the right */
     while (l->pos < l->len && isWordChar(l->buf[l->pos])) l->pos++;
-    /* Then continue moving over a word */
+    /* Then skip any delimiters to reach the next word */
     while (l->pos < l->len && !isWordChar(l->buf[l->pos])) l->pos++;
     refreshLine(l);
 }

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -1065,7 +1065,8 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                     int i = 0;
                     seqBuffer[i++] = seq[1];
 
-                    /* If first param is digit or ';', read more until we see a final in @~ */
+                    /* Read more bytes until we see a CSI final byte (range @..~).
+                     * Use seqBufferMaxLength-1 to reserve one position for '\0'. */
                     char additionalChar;
                     while (i < seqBufferMaxLength-1 && read(l.ifd, &additionalChar, 1) == 1) {
                         seqBuffer[i++] = additionalChar;

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -793,6 +793,31 @@ void linenoiseEditMoveRight(struct linenoiseState *l) {
     }
 }
 
+/* Consider letters/digits/underscore as “word”; others as delimiters. */
+static int isWordChar(char c) {
+    return (c == '_' || (c >= '0' && c <= '9') ||
+            (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'));
+}
+
+static void linenoiseEditMoveWordLeft(struct linenoiseState *l) {
+    if (l->pos == 0) return;
+    /* Move cursor to the left over any delimiters */
+    while (l->pos > 0 && !isWordChar(l->buf[l->pos - 1])) l->pos--;
+    /* Then continue moving over a word */
+    while (l->pos > 0 && isWordChar(l->buf[l->pos - 1])) l->pos--;
+    refreshLine(l);
+}
+
+static void linenoiseEditMoveWordRight(struct linenoiseState *l) {
+    if (l->pos == l->len) return;
+    /* Move cursor to the right over any delimiters */
+    while (l->pos < l->len &&  isWordChar(l->buf[l->pos])) l->pos++;
+    /* Then continue moving over a word */
+    while (l->pos < l->len && !isWordChar(l->buf[l->pos])) l->pos++;
+    refreshLine(l);
+}
+
+
 /* Move cursor to the start of the line. */
 void linenoiseEditMoveHome(struct linenoiseState *l) {
     if (l->pos != 0) {
@@ -1012,6 +1037,17 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
              * Use two calls to handle slow terminals returning the two
              * chars at different times. */
             if (read(l.ifd,seq,1) == -1) break;
+
+            /* Handle Meta-b / Meta-f directly */
+            if (seq[0] == 'b') {                 /* ESC b → word left */
+                linenoiseEditMoveWordLeft(&l);
+                break;
+            }
+            if (seq[0] == 'f') {                 /* ESC f → word right */
+                linenoiseEditMoveWordRight(&l);
+                break;
+            }
+
             if (read(l.ifd,seq+1,1) == -1) break;
 
             if (reverse_search_mode_enabled) {
@@ -1022,14 +1058,34 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
             /* ESC [ sequences. */
             if (seq[0] == '[') {
                 if (seq[1] >= '0' && seq[1] <= '9') {
-                    /* Extended escape, read additional byte. */
-                    if (read(l.ifd,seq+2,1) == -1) break;
-                    if (seq[2] == '~') {
-                        switch(seq[1]) {
-                        case '3': /* Delete key. */
-                            linenoiseEditDelete(&l);
+                    /* Extended escape, read additional bytes.
+                     * Examples: ESC [1;5C  ESC [3~ */
+                    const int seqBufferMaxLength = 8;
+                    char seqBuffer[seqBufferMaxLength];
+                    int i = 0;
+                    seqBuffer[i++] = seq[1];
+
+                    /* If first param is digit or ';', read more until we see a final in @~ */
+                    char additionalChar;
+                    while (i < seqBufferMaxLength-1 && read(l.ifd, &additionalChar, 1) != -1) {
+                        seqBuffer[i++] = additionalChar;
+                        if (additionalChar >= '@' && additionalChar <= '~') {    /* CSI final byte */
+                            seqBuffer[i] = '\0';
                             break;
                         }
+                    }
+
+                    if (strstr(seqBuffer, "1;5D") || strstr(seqBuffer, "5D")) {
+                        linenoiseEditMoveWordLeft(&l);
+                        break;
+                    }
+                    if (strstr(seqBuffer, "1;5C") || strstr(seqBuffer, "5C")) {
+                        linenoiseEditMoveWordRight(&l);
+                        break;
+                    }
+                    if (strstr(seqBuffer, "3~")) {
+                        linenoiseEditDelete(&l);
+                        break;
                     }
                 } else {
                     switch(seq[1]) {


### PR DESCRIPTION
solves issue #14322 

# summary

Interactive use of redis-cli often involves working with long keys (e.g. MY:INCREDIBLY:LONG:keythattakesalongtimetotype). In shells like bash, zsh, or psql, users can quickly move the cursor word by word with **Alt/Option+Left/Right** or **Ctrl+Left/Right**. This makes editing long commands much more efficient.

Until now, redis-cli (via linenoise) only supported single-character cursor moves, which is painful for frequent key editing.

This patch adds such support, with simple code changes in linenoise. It now suppports both the Meta (Alt/Option) styles and CSI (control sequence introducer) style:

|                 | Meta style | CSI style | Alt style |
| --------------- | ---------- | --------- | --------- |
| move word left  | ESC b      | ESC [1;5D | ESC [1;3D |
| move word right | ESC f      | ESC [1;5C | ESC [1;3C |



# How I verified

I'm using MacOS default terminal (`$TERM = xterm-256color`). I customized the terminal keyboard setting to map option + left to `\033b` , and  ctrl + left to `\033[1;5D`  so that I can produce both the Meta tyles and CSI style. This code change should also work for Linux/BSD/other terminal users.

Now the redis-cli works like the following if I push keyboard ctrl+left. `|` shows where the cursor is currently at:

```
set cache:item itemid
                   |

set cache:item itemid
               |

set cache:item itemid
          |

set cache:item itemid
    |

set cache:item itemid
|
```



Also works great for ctrl+right:

```
set cache:item itemid
|

set cache:item itemid
    |

set cache:item itemid
          |	

set cache:item itemid
               |

set cache:item itemid
                     |
```