### PR TITLE
Add modules to make test

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -499,7 +499,7 @@ distclean: clean
 
 .PHONY: distclean
 
-test: $(REDIS_SERVER_NAME) $(REDIS_CHECK_AOF_NAME) $(REDIS_CLI_NAME) $(REDIS_BENCHMARK_NAME)
+test: $(REDIS_SERVER_NAME) $(REDIS_CHECK_AOF_NAME) $(REDIS_CLI_NAME) $(REDIS_BENCHMARK_NAME) module_tests
 	@(cd ..; ./runtest)
 
 test-modules: $(REDIS_SERVER_NAME)


### PR DESCRIPTION
This PR follows https://github.com/redis/redis/pull/14226.
make test fails on fresh checkout because test modules are not built by default when running tests.
error: 
[exception]: Executing test client: ERR Error loading the extension. Please check the server logs..
ERR Error loading the extension. Please check the server logs.
solution:
Add module_tests to the test target dependencies: