### PR TITLE
enable unaligned access optimizations for RISC-V with Zicclsm​

### DIFF
--- a/src/siphash.c
+++ b/src/siphash.c
@@ -68,7 +68,8 @@ int siptlw(int c) {
  * Two interesting conditions to speedup the function that happen to be
  * in most of x86 servers. */
 #if defined(__X86_64__) || defined(__x86_64__) || defined (__i386__) \
-	|| defined (__aarch64__) || defined (__arm64__)
+	|| defined (__aarch64__) || defined (__arm64__) \
+    || (defined(__riscv) && defined(__riscv_zicclsm))
 #define UNALIGNED_LE_CPU
 #endif
 


### PR DESCRIPTION
While reviewing the Redis code, we discovered that optimizations for unaligned memory accesses are not enabled on RISC-V. After testing siphash separately, we found some performance improvements in this area and hope to add them.

The zicclsm extension, which includes unaligned memory accesses, is required on RISC-V, as specified in the [RVA20U64 specification](https://github.com/riscv/riscv-profiles/blob/5879c13c924ec5636995c5883f40337e83f6049a/src/profiles.adoc#L658). GCC also provides the macro [zicclsm](https://gcc.gnu.org/pipermail/gcc-patches/2024-February/644655.html) to detect the zicclsm extension.

Supported versions: GCC 14.1.0 and above

## **Test data**
environment information
```shell
[root@localhost root]# dmidecode -t processor | grep "Version"
        Version: SG2044
[root@localhost root]# uname -a
Linux localhost.localdomain 6.12.21-0.0.0.0.riscv64 #1 SMP Tue Apr  1 03:58:14 CST 2025 riscv64 riscv64 riscv64 GNU/Linux
```
Test Configuration​​
​​Test Iterations:​​ 10,000,000 hashes per run
Test Runs:​​ 10 consecutive runs

Improvement
6482733.40  -->  10732524.90  (​​+65.5%​)

### Disable UNALIGNED_LE_CPU
```shell
[root@fedora-riscv root]# ./siphash_test_aligned
Running performance test (10 runs)...
Run 1: 6491958.63 hashes/sec
Run 2: 6487366.83 hashes/sec
Run 3: 6481576.94 hashes/sec
Run 4: 6484129.18 hashes/sec
Run 5: 6486451.34 hashes/sec
Run 6: 6476159.22 hashes/sec
Run 7: 6479075.32 hashes/sec
Run 8: 6476821.02 hashes/sec
Run 9: 6482822.05 hashes/sec
Run 10: 6480973.47 hashes/sec

Average performance: 6482733.40 hashes/sec
```
### Enable UNALIGNED_LE_CPU
```shell
[root@fedora-riscv root]# ./siphash_test_unaligned
Running performance test (10 runs)...
Run 1: 10724141.20 hashes/sec
Run 2: 10736134.67 hashes/sec
Run 3: 10733149.45 hashes/sec
Run 4: 10732901.09 hashes/sec
Run 5: 10731710.56 hashes/sec
Run 6: 10734029.89 hashes/sec
Run 7: 10733342.07 hashes/sec
Run 8: 10732782.90 hashes/sec
Run 9: 10733797.15 hashes/sec
Run 10: 10733260.05 hashes/sec

Average performance: 10732524.90 hashes/sec
```

