### PR TITLE
Fix Active Defrag HFE with large_ebrax test

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -534,7 +534,7 @@ run_solo {defrag} {
             r config set activedefrag no
             wait_for_defrag_stop 500 100
             r config resetstat
-            r config set active-defrag-threshold-lower 8
+            r config set active-defrag-threshold-lower 6
             r config set active-defrag-cycle-min 65
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 1000kb
@@ -577,7 +577,7 @@ run_solo {defrag} {
                 puts "frag [s allocator_frag_ratio]"
                 puts "frag_bytes [s allocator_frag_bytes]"
             }
-            assert_lessthan [s allocator_frag_ratio] 1.08
+            assert_lessthan [s allocator_frag_ratio] 1.06
 
             # Delete all the keys to create fragmentation
             for {set i 0} {$i < $n} {incr i} {
@@ -608,7 +608,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 500 100 1.08
+                wait_for_defrag_stop 500 100 1.06
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -527,14 +527,14 @@ run_solo {defrag} {
             $rd_pubsub close
         }
 
-        foreach {eb_container fields n} {eblist 16 3000 ebrax 30 1600 large_ebrax 1600 30} {
+        foreach {eb_container fields n} {eblist 16 3000 ebrax 30 1600 large_ebrax 500 100} {
         test "Active Defrag HFE with $eb_container: $type" {
             r flushdb
             r config set hz 100
             r config set activedefrag no
             wait_for_defrag_stop 500 100
             r config resetstat
-            r config set active-defrag-threshold-lower 8
+            r config set active-defrag-threshold-lower 6
             r config set active-defrag-cycle-min 65
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 1000kb
@@ -577,7 +577,7 @@ run_solo {defrag} {
                 puts "frag [s allocator_frag_ratio]"
                 puts "frag_bytes [s allocator_frag_bytes]"
             }
-            assert_lessthan [s allocator_frag_ratio] 1.08
+            assert_lessthan [s allocator_frag_ratio] 1.06
 
             # Delete all the keys to create fragmentation
             for {set i 0} {$i < $n} {incr i} {
@@ -608,7 +608,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 500 100 1.08
+                wait_for_defrag_stop 500 100 1.06
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -534,7 +534,7 @@ run_solo {defrag} {
             r config set activedefrag no
             wait_for_defrag_stop 500 100
             r config resetstat
-            r config set active-defrag-threshold-lower 6
+            r config set active-defrag-threshold-lower 8
             r config set active-defrag-cycle-min 65
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 1000kb
@@ -577,7 +577,7 @@ run_solo {defrag} {
                 puts "frag [s allocator_frag_ratio]"
                 puts "frag_bytes [s allocator_frag_bytes]"
             }
-            assert_lessthan [s allocator_frag_ratio] 1.06
+            assert_lessthan [s allocator_frag_ratio] 1.08
 
             # Delete all the keys to create fragmentation
             for {set i 0} {$i < $n} {incr i} {
@@ -608,7 +608,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 500 100 1.06
+                wait_for_defrag_stop 500 100 1.08
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -534,7 +534,7 @@ run_solo {defrag} {
             r config set activedefrag no
             wait_for_defrag_stop 500 100
             r config resetstat
-            r config set active-defrag-threshold-lower 6
+            r config set active-defrag-threshold-lower 7
             r config set active-defrag-cycle-min 65
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 1000kb
@@ -577,7 +577,7 @@ run_solo {defrag} {
                 puts "frag [s allocator_frag_ratio]"
                 puts "frag_bytes [s allocator_frag_bytes]"
             }
-            assert_lessthan [s allocator_frag_ratio] 1.06
+            assert_lessthan [s allocator_frag_ratio] 1.07
 
             # Delete all the keys to create fragmentation
             for {set i 0} {$i < $n} {incr i} {
@@ -608,7 +608,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 500 100 1.06
+                wait_for_defrag_stop 500 100 1.07
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -534,7 +534,7 @@ run_solo {defrag} {
             r config set activedefrag no
             wait_for_defrag_stop 500 100
             r config resetstat
-            r config set active-defrag-threshold-lower 5
+            r config set active-defrag-threshold-lower 6
             r config set active-defrag-cycle-min 65
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 1000kb
@@ -577,7 +577,7 @@ run_solo {defrag} {
                 puts "frag [s allocator_frag_ratio]"
                 puts "frag_bytes [s allocator_frag_bytes]"
             }
-            assert_lessthan [s allocator_frag_ratio] 1.05
+            assert_lessthan [s allocator_frag_ratio] 1.06
 
             # Delete all the keys to create fragmentation
             for {set i 0} {$i < $n} {incr i} {
@@ -608,7 +608,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 500 100 1.05
+                wait_for_defrag_stop 500 100 1.06
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms


### PR DESCRIPTION
From the malloc-stats reports of both failures and successes, we can see that the additional fragments mainly come from bin24.
By analyzing the fragments mainly from the entries of the dict, since `large_ebrax` test uses a dictionary with 1600 elements, it will move a large number of entries during the rehashing process, and we will not perform defragmentation on the dict entries.

In https://github.com/redis/redis/pull/13842 we changed to use two dicts alternately to generate frag. Normally, the entries should also alternate, but rehashing disrupted this, which resulted in bin24 frag that can't be defragged.

## Solution
In this PR, the length of a single dictionary was reduced from 1600 to 500 to avoid excessive rehashing, and the threshold was also lowered.

## The difference between the failed and the successful report:

total frag bytes: 567608 bytes (1335552 - 767944)
bin24 frag bytes: 529929 bytes((1253064 / 0.621) - (1261728 / 0.848))

failed log:
```
allocator_frag_ratio:1.05
allocator_frag_bytes:1335552

bins:           size ind    allocated      nmalloc (#/sec)      ndalloc (#/sec)    nrequests   (#/sec)  nshards      curregs     curslabs  nonfull_slabs regs pgs   util       nfills (#/sec)     nflushes (#/sec)       nslabs     nreslabs (#/sec)      n_lock_ops (#/sec)       n_waiting (#/sec)      n_spin_acq (#/sec)  n_owner_switch (#/sec)   total_wait_ns   (#/sec)     max_wait_ns  max_n_thds
                   8   0       390960       368833    6046       319963    5245       402688      6601        1        48870           99              5  512   1  0.964         3417      56         2425      39          562          292       4        96609896 1583768               0       0               0       0          168052    2754               0         0               0           0
                  16   1       237984        52164     855        37290     611      3271366     53628        1        14874           67             16  256   1  0.867          734      12          595       9          171          223       3         6656416  109121               0       0               0       0           23826     390               0         0               0           0
                  24   2      1253064       378673    6207       326462    5351      2127089     34870        1        52211          164            109  512   3  0.621         3650      59         2582      42          594          258       4       101280691 1660339               0       0               1       0          154680    2535               0         0               0           0

```

success log:
```
allocator_frag_ratio:1.03
allocator_frag_bytes:767944

bins:           size ind    allocated      nmalloc (#/sec)      ndalloc (#/sec)    nrequests   (#/sec)  nshards      curregs     curslabs  nonfull_slabs regs pgs   util       nfills (#/sec)     nflushes (#/sec)       nslabs     nreslabs (#/sec)      n_lock_ops (#/sec)       n_waiting (#/sec)      n_spin_acq (#/sec)  n_owner_switch (#/sec)   total_wait_ns   (#/sec)     max_wait_ns  max_n_thds
                   8   0       389344       369432   46179       320764   40095       402569     50321        1        48668          103             13  512   1  0.922         3464     433         1460     182          561          289      36          599955   74994               0       0               3       0          161405   20175               0         0               0           0
                  16   1       228384        50082    6260        35808    4476      3268897    408612        1        14274           63             14  256   1  0.885          745      93          465      58          164          226      28           58898    7362               0       0               0       0           11023    1377               0         0               0           0
                  24   2      1261728       391927   48990       339355   42419      1958980    244872        1        52572          121             31  512   3  0.848         3623     452         1578     197          592          294      36          625633   78204               0       0               4       0          166227   20778               0         0               0           0
```

failed CI: https://github.com/redis/redis/actions/runs/17567591780/job/49897482080