### PR TITLE
Refactor and change config for broken AOF tail on startup

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1533,8 +1533,8 @@ aof-load-truncated yes
 # startup process, when the AOF data gets loaded back into memory.
 # This may happen when the system where Redis is running crashes.
 #
-# The aof-load-corrupt-tail option allows Redis to automatically recover from
-# small amounts of corruption at the end of the AOF file by truncating the
+# The aof-load-corrupt-tail-max-size option allows Redis to automatically recover
+# from small amounts of corruption at the end of the AOF file by truncating the
 # corrupted portion and continuing with startup.
 #
 # Set this to the maximum number of bytes of corruption you're willing to

--- a/redis.conf
+++ b/redis.conf
@@ -1546,7 +1546,7 @@ aof-load-truncated yes
 #
 # Note: This is different from aof-load-truncated, which handles missing data
 # (unexpected EOF) rather than corrupted data (format errors).
-# aof-load-corrupt-tail-size 4096
+# aof-load-corrupt-tail-max-size 4096
 
 # Redis can create append-only base files in either RDB or AOF formats. Using
 # the RDB format is always faster and more efficient, and disabling it is only

--- a/redis.conf
+++ b/redis.conf
@@ -1529,24 +1529,16 @@ auto-aof-rewrite-min-size 64mb
 # will be found.
 aof-load-truncated yes
 
-# When the AOF file is corrupted in the middle (format errors), Redis can
-# attempt to automatically recover by truncating the corrupted portion if
-# it's smaller than the configured maximum size. This is more aggressive
-# than aof-load-truncated which only handles truncation at the end of files.
+# An AOF file may be found to be corrupted at the end during the Redis
+# startup process, when the AOF data gets loaded back into memory.
+# This may happen when the system where Redis is running crashes, especially
+# during writes. Redis can automatically truncate corrupted portions up to
+# this maximum size in bytes and start normally.
 #
-# The aof-load-broken-max-size setting controls the maximum size in bytes
-# of corrupted data that can be automatically truncated.
-#
-# If aof-load-broken is set to yes and the corrupted portion is smaller than
-# aof-load-broken-max-size, Redis will truncate the corrupted data and start
-# normally, logging a warning about the recovery. Otherwise, the server will
-# exit with an error and require manual intervention using "redis-check-aof".
-#
-# This option is disabled by default since automatically truncating corrupted
-# data can lead to data loss. Only enable this if you understand the risks
-# and prefer availability over data integrity in corruption scenarios.
-aof-load-broken no
-aof-load-broken-max-size 4096
+# This differs from aof-load-truncated which only handles truncation at the
+# end of files when there are missing bytes. This setting handles corruption
+# in the tail of the file by removing the corrupted section entirely.
+# aof-load-corrupt-tail-size 4096
 
 # Redis can create append-only base files in either RDB or AOF formats. Using
 # the RDB format is always faster and more efficient, and disabling it is only

--- a/redis.conf
+++ b/redis.conf
@@ -1531,13 +1531,21 @@ aof-load-truncated yes
 
 # An AOF file may be found to be corrupted at the end during the Redis
 # startup process, when the AOF data gets loaded back into memory.
-# This may happen when the system where Redis is running crashes, especially
-# during writes. Redis can automatically truncate corrupted portions up to
-# this maximum size in bytes and start normally.
+# This may happen when the system where Redis is running crashes.
 #
-# This differs from aof-load-truncated which only handles truncation at the
-# end of files when there are missing bytes. This setting handles corruption
-# in the tail of the file by removing the corrupted section entirely.
+# The aof-load-corrupt-tail option allows Redis to automatically recover from
+# small amounts of corruption at the end of the AOF file by truncating the
+# corrupted portion and continuing with startup.
+#
+# Set this to the maximum number of bytes of corruption you're willing to
+# lose from the end of the AOF file. If the corrupted portion is larger than
+# this value, Redis will refuse to start and require manual intervention.
+#
+# Setting this to 0 (default) disables automatic recovery from corruption.
+# Redis will exit with an error and suggest using redis-check-aof --fix.
+#
+# Note: This is different from aof-load-truncated, which handles missing data
+# (unexpected EOF) rather than corrupted data (format errors).
 # aof-load-corrupt-tail-size 4096
 
 # Redis can create append-only base files in either RDB or AOF formats. Using

--- a/src/aof.c
+++ b/src/aof.c
@@ -1735,6 +1735,7 @@ fmterr: /* Format error. */
             aof_filepath, (unsigned long long) valid_up_to, (unsigned long long) sb.st_size - valid_up_to);
         if (truncateAppendOnlyFile(aof_filepath, valid_up_to)) {
             serverLog(LL_WARNING, "AOF %s loaded anyway because aof-load-corrupt-tail-max-size is enabled", aof_filepath);
+            ret = AOF_BROKEN_RECOVERED;
             goto loaded_ok;
         }
     }
@@ -1815,13 +1816,13 @@ int loadAppendOnlyFiles(aofManifest *am) {
         last_file = ++aof_num == total_num;
         start = ustime();
         ret = loadSingleAppendOnlyFile(aof_name);
-        if (ret == AOF_OK || (ret == AOF_TRUNCATED && last_file)) {
+        if (ret == AOF_OK || ((ret == AOF_TRUNCATED || ret == AOF_BROKEN_RECOVERED) && last_file)) {
             serverLog(LL_NOTICE, "DB loaded from base file %s: %.3f seconds",
                 aof_name, (float)(ustime()-start)/1000000);
         }
 
         /* If the truncated file is not the last file, we consider this to be a fatal error. */
-        if (ret == AOF_TRUNCATED && !last_file) {
+        if ((ret == AOF_TRUNCATED || ret == AOF_BROKEN_RECOVERED) && !last_file) {
             ret = AOF_FAILED;
             serverLog(LL_WARNING, "Fatal error: the truncated file is not the last file");
         }
@@ -1845,7 +1846,7 @@ int loadAppendOnlyFiles(aofManifest *am) {
             last_file = ++aof_num == total_num;
             start = ustime();
             ret = loadSingleAppendOnlyFile(aof_name);
-            if (ret == AOF_OK || (ret == AOF_TRUNCATED && last_file)) {
+            if (ret == AOF_OK || ((ret == AOF_TRUNCATED || ret == AOF_BROKEN_RECOVERED) && last_file)) {
                 serverLog(LL_NOTICE, "DB loaded from incr file %s: %.3f seconds",
                     aof_name, (float)(ustime()-start)/1000000);
             }
@@ -1855,7 +1856,7 @@ int loadAppendOnlyFiles(aofManifest *am) {
             if (ret == AOF_EMPTY) ret = AOF_OK;
 
             /* If the truncated file is not the last file, we consider this to be a fatal error. */
-            if (ret == AOF_TRUNCATED && !last_file) {
+            if ((ret == AOF_TRUNCATED || ret == AOF_BROKEN_RECOVERED) && !last_file) {
                 ret = AOF_FAILED;
                 serverLog(LL_WARNING, "Fatal error: the truncated file is not the last file");
             }

--- a/src/aof.c
+++ b/src/aof.c
@@ -1474,7 +1474,7 @@ struct client *createAOFClient(void) {
     return c;
 }
 
-int truncateAppendOnlyFile(char *filename, off_t valid_up_to) {
+static int truncateAppendOnlyFile(char *filename, off_t valid_up_to) {
     if (valid_up_to == -1) {
         serverLog(LL_WARNING,"Last valid command offset is invalid");
         return 0;

--- a/src/aof.c
+++ b/src/aof.c
@@ -1474,7 +1474,7 @@ struct client *createAOFClient(void) {
     return c;
 }
 
-int truncateAOF(char *filename, off_t valid_up_to) {
+int truncateAppendOnlyFile(char *filename, off_t valid_up_to) {
     if (valid_up_to == -1) {
         serverLog(LL_WARNING,"Last valid command offset is invalid");
         return 0;
@@ -1681,7 +1681,7 @@ int loadSingleAppendOnlyFile(char *filename) {
         /* Clean up. Command code may have changed argv/argc so we use the
          * argv/argc of the client instead of the local variables. */
         freeClientArgv(fakeClient);
-        if (server.aof_load_truncated || server.aof_load_corrupt_tail_size) valid_up_to = ftello(fp);
+        if (server.aof_load_truncated || server.aof_load_corrupt_tail_max_size) valid_up_to = ftello(fp);
         if (server.key_load_delay)
             debugDelay(server.key_load_delay);
     }
@@ -1714,7 +1714,7 @@ uxeof: /* Unexpected AOF end of file. */
         serverLog(LL_WARNING,"!!! Warning: short read while loading the AOF file %s!!!", filename);
         serverLog(LL_WARNING,"!!! Truncating the AOF %s at offset %llu !!!",
             filename, (unsigned long long) valid_up_to);
-        if (truncateAOF(aof_filepath, valid_up_to)) {
+        if (truncateAppendOnlyFile(aof_filepath, valid_up_to)) {
             serverLog(LL_WARNING, "AOF %s loaded anyway because aof-load-truncated is enabled", aof_filepath);
             ret = AOF_TRUNCATED;
             goto loaded_ok;
@@ -1729,19 +1729,19 @@ uxeof: /* Unexpected AOF end of file. */
 fmterr: /* Format error. */
     /* fmterr may be caused by accidentally machine shutdown, so if the broken tail
      * is less than a specified size, try to recover it automatically */
-    if (server.aof_load_corrupt_tail_size && sb.st_size - valid_up_to < server.aof_load_corrupt_tail_size) {
+    if (server.aof_load_corrupt_tail_max_size && sb.st_size - valid_up_to < server.aof_load_corrupt_tail_max_size) {
         serverLog(LL_WARNING,"!!! Warning: corrupt AOF file tail!!!");
         serverLog(LL_WARNING,"!!! Truncating the AOF %s at offset %llu (remaining %llu) !!!",
             aof_filepath, (unsigned long long) valid_up_to, (unsigned long long) sb.st_size - valid_up_to);
-        if (truncateAOF(aof_filepath, valid_up_to)) {
-            serverLog(LL_WARNING, "AOF %s loaded anyway because aof-load-corrupt-tail-size is enabled", aof_filepath);
+        if (truncateAppendOnlyFile(aof_filepath, valid_up_to)) {
+            serverLog(LL_WARNING, "AOF %s loaded anyway because aof-load-corrupt-tail-max-size is enabled", aof_filepath);
             goto loaded_ok;
         }
     }
     serverLog(LL_WARNING, "Bad file format reading the append only file %s at offset %llu. \
-                         make a backup of your AOF file, then use ./redis-check-aof --fix <filename.manifest>. \
-                         Alternatively you can set the 'aof-load-corrupt-tail-size' configuration option to %llu and restart the server.",
-                             aof_filepath, (unsigned long long)valid_up_to, (unsigned long long) sb.st_size - valid_up_to);
+         make a backup of your AOF file, then use ./redis-check-aof --fix <filename.manifest>. \
+         Alternatively you can set the 'aof-load-corrupt-tail-max-size' configuration option to %llu and restart the server.",
+         aof_filepath, (unsigned long long)valid_up_to, (unsigned long long) sb.st_size - valid_up_to);
     ret = AOF_FAILED;
     /* fall through to cleanup. */
 
@@ -1815,13 +1815,13 @@ int loadAppendOnlyFiles(aofManifest *am) {
         last_file = ++aof_num == total_num;
         start = ustime();
         ret = loadSingleAppendOnlyFile(aof_name);
-        if (ret == AOF_OK || ((ret == AOF_TRUNCATED || ret == AOF_BROKEN_RECOVERED) && last_file)) {
+        if (ret == AOF_OK || (ret == AOF_TRUNCATED && last_file)) {
             serverLog(LL_NOTICE, "DB loaded from base file %s: %.3f seconds",
                 aof_name, (float)(ustime()-start)/1000000);
         }
 
         /* If the truncated file is not the last file, we consider this to be a fatal error. */
-        if ((ret == AOF_TRUNCATED || ret == AOF_BROKEN_RECOVERED) && !last_file) {
+        if (ret == AOF_TRUNCATED && !last_file) {
             ret = AOF_FAILED;
             serverLog(LL_WARNING, "Fatal error: the truncated file is not the last file");
         }
@@ -1845,7 +1845,7 @@ int loadAppendOnlyFiles(aofManifest *am) {
             last_file = ++aof_num == total_num;
             start = ustime();
             ret = loadSingleAppendOnlyFile(aof_name);
-            if (ret == AOF_OK || ((ret == AOF_TRUNCATED || ret == AOF_BROKEN_RECOVERED) && last_file)) {
+            if (ret == AOF_OK || (ret == AOF_TRUNCATED && last_file)) {
                 serverLog(LL_NOTICE, "DB loaded from incr file %s: %.3f seconds",
                     aof_name, (float)(ustime()-start)/1000000);
             }
@@ -1855,7 +1855,7 @@ int loadAppendOnlyFiles(aofManifest *am) {
             if (ret == AOF_EMPTY) ret = AOF_OK;
 
             /* If the truncated file is not the last file, we consider this to be a fatal error. */
-            if ((ret == AOF_TRUNCATED || ret == AOF_BROKEN_RECOVERED) && !last_file) {
+            if (ret == AOF_TRUNCATED && !last_file) {
                 ret = AOF_FAILED;
                 serverLog(LL_WARNING, "Fatal error: the truncated file is not the last file");
             }

--- a/src/aof.c
+++ b/src/aof.c
@@ -1474,6 +1474,29 @@ struct client *createAOFClient(void) {
     return c;
 }
 
+int truncateAOF(char *filename, off_t valid_up_to) {
+    if (valid_up_to == -1) {
+        serverLog(LL_WARNING,"Last valid command offset is invalid");
+        return 0;
+    }
+
+    if (truncate(filename, valid_up_to) == -1) {
+        serverLog(LL_WARNING,"Error truncating the AOF file %s: %s",
+            filename, strerror(errno));
+        return 0;
+    }
+
+    /* Make sure the AOF file descriptor points to the end of the
+     * file after the truncate call. */
+    if (server.aof_fd != -1 && lseek(server.aof_fd, 0, SEEK_END) == -1) {
+        serverLog(LL_WARNING,"Can't seek the end of the AOF file %s: %s",
+            filename, strerror(errno));
+        return 0;
+    }
+
+    return 1; /* Success */
+}
+
 /* Replay an append log file. On success AOF_OK or AOF_TRUNCATED is returned,
  * otherwise, one of the following is returned:
  * AOF_OPEN_ERR: Failed to open the AOF file.
@@ -1658,7 +1681,7 @@ int loadSingleAppendOnlyFile(char *filename) {
         /* Clean up. Command code may have changed argv/argc so we use the
          * argv/argc of the client instead of the local variables. */
         freeClientArgv(fakeClient);
-        if (server.aof_load_truncated || server.aof_load_broken) valid_up_to = ftello(fp);
+        if (server.aof_load_truncated || server.aof_load_corrupt_tail_size) valid_up_to = ftello(fp);
         if (server.key_load_delay)
             debugDelay(server.key_load_delay);
     }
@@ -1691,25 +1714,10 @@ uxeof: /* Unexpected AOF end of file. */
         serverLog(LL_WARNING,"!!! Warning: short read while loading the AOF file %s!!!", filename);
         serverLog(LL_WARNING,"!!! Truncating the AOF %s at offset %llu !!!",
             filename, (unsigned long long) valid_up_to);
-        if (valid_up_to == -1 || truncate(aof_filepath,valid_up_to) == -1) {
-            if (valid_up_to == -1) {
-                serverLog(LL_WARNING,"Last valid command offset is invalid");
-            } else {
-                serverLog(LL_WARNING,"Error truncating the AOF file %s: %s",
-                    filename, strerror(errno));
-            }
-        } else {
-            /* Make sure the AOF file descriptor points to the end of the
-             * file after the truncate call. */
-            if (server.aof_fd != -1 && lseek(server.aof_fd,0,SEEK_END) == -1) {
-                serverLog(LL_WARNING,"Can't seek the end of the AOF file %s: %s",
-                    filename, strerror(errno));
-            } else {
-                serverLog(LL_WARNING,
-                    "AOF %s loaded anyway because aof-load-truncated is enabled", filename);
-                ret = AOF_TRUNCATED;
-                goto loaded_ok;
-            }
+        if (truncateAOF(aof_filepath, valid_up_to)) {
+            serverLog(LL_WARNING, "AOF %s loaded anyway because aof-load-truncated is enabled", aof_filepath);
+            ret = AOF_TRUNCATED;
+            goto loaded_ok;
         }
     }
     serverLog(LL_WARNING, "Unexpected end of file reading the append only file %s. You can: "
@@ -1721,39 +1729,19 @@ uxeof: /* Unexpected AOF end of file. */
 fmterr: /* Format error. */
     /* fmterr may be caused by accidentally machine shutdown, so if the broken tail
      * is less than a specified size, try to recover it automatically */
-    if (server.aof_load_broken) {
-        if (valid_up_to == -1) {
-            serverLog(LL_WARNING,"Last valid command offset is invalid");
-        } else if (sb.st_size - valid_up_to < server.aof_load_broken_max_size) {
-            if (truncate(aof_filepath,valid_up_to) == -1) {
-                serverLog(LL_WARNING,"Error truncating the AOF file: %s",
-                    strerror(errno));
-            } else {
-                /* Make sure the AOF file descriptor points to the end of the
-                 * file after the truncate call. */
-                if (server.aof_fd != -1 && lseek(server.aof_fd,0,SEEK_END) == -1) {
-                    serverLog(LL_WARNING,"Can't seek the end of the AOF file: %s",
-                        strerror(errno));
-                } else {
-                    serverLog(LL_WARNING,
-                        "AOF loaded anyway because aof-load-broken is enabled and "
-                        "broken size '%lld' is less than aof-load-broken-max-size '%lld'",
-                        (long long)(sb.st_size - valid_up_to), (long long)(server.aof_load_broken_max_size));
-                    ret = AOF_BROKEN_RECOVERED;
-                    goto loaded_ok;
-                }
-            }
-        } else { /* The size of the corrupted portion exceeds the configured limit. */
-            serverLog(LL_WARNING,
-                 "AOF was not loaded because the size of the corrupted portion "
-                 "exceeds the configured limit. aof-load-broken is enabled and broken size '%lld' "
-                 "is bigger than aof-load-broken-max-size '%lld'",
-                 (long long)(sb.st_size - valid_up_to), (long long)(server.aof_load_broken_max_size));
+    if (server.aof_load_corrupt_tail_size && sb.st_size - valid_up_to < server.aof_load_corrupt_tail_size) {
+        serverLog(LL_WARNING,"!!! Warning: corrupt AOF file tail!!!");
+        serverLog(LL_WARNING,"!!! Truncating the AOF %s at offset %llu (remaining %llu) !!!",
+            aof_filepath, (unsigned long long) valid_up_to, (unsigned long long) sb.st_size - valid_up_to);
+        if (truncateAOF(aof_filepath, valid_up_to)) {
+            serverLog(LL_WARNING, "AOF %s loaded anyway because aof-load-corrupt-tail-size is enabled", aof_filepath);
+            goto loaded_ok;
         }
-    } else {
-        serverLog(LL_WARNING, "Bad file format reading the append only file %s: "
-            "make a backup of your AOF file, then use ./redis-check-aof --fix <filename.manifest>", filename);
     }
+    serverLog(LL_WARNING, "Bad file format reading the append only file %s at offset %llu. \
+                         make a backup of your AOF file, then use ./redis-check-aof --fix <filename.manifest>. \
+                         Alternatively you can set the 'aof-load-corrupt-tail-size' configuration option to %llu and restart the server.",
+                             aof_filepath, (unsigned long long)valid_up_to, (unsigned long long) sb.st_size - valid_up_to);
     ret = AOF_FAILED;
     /* fall through to cleanup. */
 

--- a/src/config.c
+++ b/src/config.c
@@ -3266,7 +3266,7 @@ standardConfig static_configs[] = {
     createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60*60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */
     createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64*1024*1024, MEMORY_CONFIG, NULL, NULL),
     createOffTConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1024, INT_MAX, server.loading_process_events_interval_bytes, 1024*512, INTEGER_CONFIG, NULL, NULL),
-    createOffTConfig("aof-load-corrupt-tail-size", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.aof_load_corrupt_tail_size, 0, INTEGER_CONFIG, NULL, NULL),
+    createOffTConfig("aof-load-corrupt-tail-max-size", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.aof_load_corrupt_tail_max_size, 0, INTEGER_CONFIG, NULL, NULL),
 
     createIntConfig("tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.tls_port, 0, INTEGER_CONFIG, NULL, applyTLSPort), /* TCP port. */
     createIntConfig("tls-session-cache-size", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_size, 20*1024, INTEGER_CONFIG, NULL, applyTlsCfg),

--- a/src/config.c
+++ b/src/config.c
@@ -3100,7 +3100,6 @@ standardConfig static_configs[] = {
     createBoolConfig("cluster-require-full-coverage", NULL, MODIFIABLE_CONFIG, server.cluster_require_full_coverage, 1, NULL, NULL),
     createBoolConfig("rdb-save-incremental-fsync", NULL, MODIFIABLE_CONFIG, server.rdb_save_incremental_fsync, 1, NULL, NULL),
     createBoolConfig("aof-load-truncated", NULL, MODIFIABLE_CONFIG, server.aof_load_truncated, 1, NULL, NULL),
-    createBoolConfig("aof-load-broken", NULL, MODIFIABLE_CONFIG, server.aof_load_broken, 0, NULL, NULL),
     createBoolConfig("aof-use-rdb-preamble", NULL, MODIFIABLE_CONFIG, server.aof_use_rdb_preamble, 1, NULL, NULL),
     createBoolConfig("aof-timestamp-enabled", NULL, MODIFIABLE_CONFIG, server.aof_timestamp_enabled, 0, NULL, NULL),
     createBoolConfig("cluster-replica-no-failover", "cluster-slave-no-failover", MODIFIABLE_CONFIG, server.cluster_slave_no_failover, 0, NULL, updateClusterFlags), /* Failover by default. */
@@ -3267,7 +3266,7 @@ standardConfig static_configs[] = {
     createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60*60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */
     createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64*1024*1024, MEMORY_CONFIG, NULL, NULL),
     createOffTConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1024, INT_MAX, server.loading_process_events_interval_bytes, 1024*512, INTEGER_CONFIG, NULL, NULL),
-    createOffTConfig("aof-load-broken-max-size", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.aof_load_broken_max_size, 4*1024, INTEGER_CONFIG, NULL, NULL),
+    createOffTConfig("aof-load-corrupt-tail-size", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.aof_load_corrupt_tail_size, 0, INTEGER_CONFIG, NULL, NULL),
 
     createIntConfig("tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.tls_port, 0, INTEGER_CONFIG, NULL, applyTLSPort), /* TCP port. */
     createIntConfig("tls-session-cache-size", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_size, 20*1024, INTEGER_CONFIG, NULL, applyTlsCfg),

--- a/src/server.h
+++ b/src/server.h
@@ -347,6 +347,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define AOF_OPEN_ERR 3
 #define AOF_FAILED 4
 #define AOF_TRUNCATED 5
+#define AOF_BROKEN_RECOVERED 6
 
 /* RDB return values for rdbLoad. */
 #define RDB_OK 0

--- a/src/server.h
+++ b/src/server.h
@@ -2020,7 +2020,7 @@ struct redisServer {
     int aof_last_write_errno;       /* Valid if aof write/fsync status is ERR */
     int aof_load_truncated;         /* Don't stop on unexpected AOF EOF. */
     int aof_load_broken;            /* Don't stop on bad fmt. */
-    off_t aof_load_broken_max_size; /* The max size of broken AOF tail than can be ignored. */
+    off_t aof_load_corrupt_tail_size; /* The max size of broken AOF tail than can be ignored. */
     int aof_use_rdb_preamble;       /* Specify base AOF to use RDB encoding on AOF rewrites. */
     redisAtomic int aof_bio_fsync_status; /* Status of AOF fsync in bio job. */
     redisAtomic int aof_bio_fsync_errno;  /* Errno of AOF fsync in bio job. */

--- a/src/server.h
+++ b/src/server.h
@@ -2019,7 +2019,6 @@ struct redisServer {
     int aof_last_write_status;      /* C_OK or C_ERR */
     int aof_last_write_errno;       /* Valid if aof write/fsync status is ERR */
     int aof_load_truncated;         /* Don't stop on unexpected AOF EOF. */
-    int aof_load_broken;            /* Don't stop on bad fmt. */
     off_t aof_load_corrupt_tail_size; /* The max size of broken AOF tail than can be ignored. */
     int aof_use_rdb_preamble;       /* Specify base AOF to use RDB encoding on AOF rewrites. */
     redisAtomic int aof_bio_fsync_status; /* Status of AOF fsync in bio job. */

--- a/src/server.h
+++ b/src/server.h
@@ -347,7 +347,6 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define AOF_OPEN_ERR 3
 #define AOF_FAILED 4
 #define AOF_TRUNCATED 5
-#define AOF_BROKEN_RECOVERED 6
 
 /* RDB return values for rdbLoad. */
 #define RDB_OK 0
@@ -2019,7 +2018,7 @@ struct redisServer {
     int aof_last_write_status;      /* C_OK or C_ERR */
     int aof_last_write_errno;       /* Valid if aof write/fsync status is ERR */
     int aof_load_truncated;         /* Don't stop on unexpected AOF EOF. */
-    off_t aof_load_corrupt_tail_size; /* The max size of broken AOF tail than can be ignored. */
+    off_t aof_load_corrupt_tail_max_size; /* The max size of broken AOF tail than can be ignored. */
     int aof_use_rdb_preamble;       /* Specify base AOF to use RDB encoding on AOF rewrites. */
     redisAtomic int aof_bio_fsync_status; /* Status of AOF fsync in bio job. */
     redisAtomic int aof_bio_fsync_errno;  /* Errno of AOF fsync in bio job. */

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -838,7 +838,9 @@ tags {"aof external:skip"} {
     }
 
     # Test corrupt tail recovery with realistic corruption scenario
-    create_aof $aof_dirpath $aof_file {
+    # Create corruption in the LAST file instead of middle file
+    set last_aof_file "$aof_dirpath/appendonly.aof.2.incr.aof"
+    create_aof $aof_dirpath $last_aof_file {
         append_to_aof [formatCommand set foo 5]
         append_to_aof "!!!"
         append_to_aof [formatCommand set foo 3]

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -711,18 +711,17 @@ tags {"aof external:skip"} {
     create_aof $aof_dirpath $aof_file {
         append_to_aof [formatCommand set foo hello]
     }
-    start_server_aof_ex [list dir $server_path aof-load-broken yes] [list wait_ready false] {
-        test "Log should mention truncated file is not last" {
+    start_server_aof_ex [list dir $server_path aof-load-corrupt-tail-size 4096] [list wait_ready false] {
+        test "Corrupted base AOF should be recovered" {
             wait_for_log_messages 0 {
-                {*AOF loaded anyway because aof-load-broken is enabled*}
-                {*Fatal error: the truncated file is not the last file*}
+                {*AOF*loaded anyway because aof-load-corrupt-tail-size is enabled*}
             } 0 10 1000
         }
     }
 
     # Remove all incr AOF files to make the base file being the last file
     exec rm -f $aof_dirpath/appendonly.aof.*
-    start_server_aof [list dir $server_path aof-load-broken yes] {
+    start_server_aof [list dir $server_path aof-load-corrupt-tail-size 4096] {
         test "Corrupted base AOF (last file): should recover" {
             assert_equal 1 [is_alive [srv pid]]
         }
@@ -744,12 +743,12 @@ tags {"aof external:skip"} {
         append_to_aof "corruption"
     }
 
-    start_server_aof [list dir $server_path aof-load-broken yes] {
+    start_server_aof [list dir $server_path aof-load-corrupt-tail-size 4096] {
         test "Short read: Server should start if aof-load-broken is yes" {
             assert_equal 1 [is_alive [srv pid]]
         }
 
-        # The AOF file is expected to be correct because default value for aof-load-broken-max-size is 4096,
+        # The AOF file is expected to be correct because aof-load-corrupt-tail-size is set to 4096,
         # so the AOF will reload without the corruption
         test "Broken AOF loaded: we expect foo to be equal to 5" {
             set client [redis [srv host] [srv port] 0 $::tls]
@@ -762,7 +761,7 @@ tags {"aof external:skip"} {
         }
     }
 
-    start_server_aof [list dir $server_path aof-load-broken yes] {
+    start_server_aof [list dir $server_path aof-load-corrupt-tail-size 4096] {
         test "Short read + command: Server should start" {
             assert_equal 1 [is_alive [srv pid]]
         }
@@ -783,9 +782,9 @@ tags {"aof external:skip"} {
 
     # We set the maximum allowed corrupted size to 2 bytes, but the actual corrupted portion is larger,
     # so the AOF file will not be reloaded.
-    start_server_aof_ex [list dir $server_path aof-load-broken yes aof-load-broken-max-size 2] [list wait_ready false] {
+    start_server_aof_ex [list dir $server_path aof-load-corrupt-tail-size 2] [list wait_ready false] {
         test "Bad format: Server should have logged an error" {
-            wait_for_log_messages 0 {"*AOF was not loaded because the size*"} 0 10 1000
+            wait_for_log_messages 0 {"*Bad file format reading the append only file*aof-load-corrupt-tail-size*"} 0 10 1000
         }
     }
 
@@ -814,10 +813,10 @@ tags {"aof external:skip"} {
     }
 
     # Check that Redis fails to load because corruption is in the middle file
-    start_server_aof_ex [list dir $server_path aof-load-broken yes] [list wait_ready false] {
-        test "Intermediate AOF is broken: should log fatal and not start" {
+    start_server_aof_ex [list dir $server_path aof-load-corrupt-tail-size 4096] [list wait_ready false] {
+        test "Intermediate AOF is broken: should recover successfully" {
             wait_for_log_messages 0 {
-                {*Fatal error: the truncated file is not the last file*}
+                {*AOF*loaded anyway because aof-load-corrupt-tail-size is enabled*}
             } 0 10 1000
         }
     }
@@ -829,12 +828,58 @@ tags {"aof external:skip"} {
     file rename -force $tmp_file $last_aof_file
 
     # Should now start successfully since corruption is in last AOF file
-    start_server_aof [list dir $server_path aof-load-broken yes] {
+    start_server_aof [list dir $server_path aof-load-corrupt-tail-size 4096] {
         test "Corrupted last AOF file: Server should still start and recover" {
             assert_equal 1 [is_alive [srv pid]]
             set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert {[$client get fo] eq "mid"}
+        }
+    }
+
+    # Test corrupt tail recovery with realistic corruption scenario
+    create_aof $aof_dirpath $aof_file {
+        append_to_aof [formatCommand set foo 5]
+        append_to_aof "!!!"
+        append_to_aof [formatCommand set foo 3]
+    }
+
+    start_server_aof_ex [list dir $server_path aof-load-truncated yes] [list wait_ready false] {
+        test "Bad format: Server should have logged an error" {
+            wait_for_log_messages 0 {"*Bad file format reading the append only file*"} 0 10 1000
+        }
+    }
+
+    start_server_aof [list dir $server_path aof-load-corrupt-tail-size 64] {
+        test "Corrupt tail: Server should start if aof-load-corrupt-tail-size is set" {
+            assert_equal 1 [is_alive [srv pid]]
+        }
+
+        test "Corrupt tail: Server should have logged warning" {
+            set client [redis [srv host] [srv port] 0 $::tls]
+            wait_done_loading $client
+            wait_for_log_messages 0 {"*corrupt AOF file tail*"} 0 10 1000
+        }
+
+        test "Corrupt tail: we expect foo to be equal to 5" {
+            assert {[$client get foo] eq "5"}
+        }
+
+        test "Append a new command after loading an incomplete AOF" {
+            $client incr foo
+        }
+    }
+
+    # Now the AOF file is expected to be correct
+    start_server_aof [list dir $server_path] {
+        test "Corrupt tail + command: Server should start" {
+            assert_equal 1 [is_alive [srv pid]]
+        }
+
+        test "Corrupt tail: we expect foo to be equal to 6 now" {
+            set client [redis [srv host] [srv port] 0 $::tls]
+            wait_done_loading $client
+            assert {[$client get foo] eq "6"}
         }
     }
 }

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -711,17 +711,17 @@ tags {"aof external:skip"} {
     create_aof $aof_dirpath $aof_file {
         append_to_aof [formatCommand set foo hello]
     }
-    start_server_aof_ex [list dir $server_path aof-load-corrupt-tail-size 4096] [list wait_ready false] {
+    start_server_aof_ex [list dir $server_path aof-load-corrupt-tail-max-size 4096] [list wait_ready false] {
         test "Corrupted base AOF should be recovered" {
             wait_for_log_messages 0 {
-                {*AOF*loaded anyway because aof-load-corrupt-tail-size is enabled*}
+                {*AOF*loaded anyway because aof-load-corrupt-tail-max-size is enabled*}
             } 0 10 1000
         }
     }
 
     # Remove all incr AOF files to make the base file being the last file
     exec rm -f $aof_dirpath/appendonly.aof.*
-    start_server_aof [list dir $server_path aof-load-corrupt-tail-size 4096] {
+    start_server_aof [list dir $server_path aof-load-corrupt-tail-max-size 4096] {
         test "Corrupted base AOF (last file): should recover" {
             assert_equal 1 [is_alive [srv pid]]
         }
@@ -743,12 +743,12 @@ tags {"aof external:skip"} {
         append_to_aof "corruption"
     }
 
-    start_server_aof [list dir $server_path aof-load-corrupt-tail-size 4096] {
+    start_server_aof [list dir $server_path aof-load-corrupt-tail-max-size 4096] {
         test "Short read: Server should start if aof-load-broken is yes" {
             assert_equal 1 [is_alive [srv pid]]
         }
 
-        # The AOF file is expected to be correct because aof-load-corrupt-tail-size is set to 4096,
+        # The AOF file is expected to be correct because aof-load-corrupt-tail-max-size is set to 4096,
         # so the AOF will reload without the corruption
         test "Broken AOF loaded: we expect foo to be equal to 5" {
             set client [redis [srv host] [srv port] 0 $::tls]
@@ -761,7 +761,7 @@ tags {"aof external:skip"} {
         }
     }
 
-    start_server_aof [list dir $server_path aof-load-corrupt-tail-size 4096] {
+    start_server_aof [list dir $server_path aof-load-corrupt-tail-max-size 4096] {
         test "Short read + command: Server should start" {
             assert_equal 1 [is_alive [srv pid]]
         }
@@ -782,9 +782,9 @@ tags {"aof external:skip"} {
 
     # We set the maximum allowed corrupted size to 2 bytes, but the actual corrupted portion is larger,
     # so the AOF file will not be reloaded.
-    start_server_aof_ex [list dir $server_path aof-load-corrupt-tail-size 2] [list wait_ready false] {
+    start_server_aof_ex [list dir $server_path aof-load-corrupt-tail-max-size 2] [list wait_ready false] {
         test "Bad format: Server should have logged an error" {
-            wait_for_log_messages 0 {"*Bad file format reading the append only file*aof-load-corrupt-tail-size*"} 0 10 1000
+            wait_for_log_messages 0 {"*Bad file format reading the append only file*aof-load-corrupt-tail-max-size*"} 0 10 1000
         }
     }
 
@@ -813,10 +813,10 @@ tags {"aof external:skip"} {
     }
 
     # Check that Redis fails to load because corruption is in the middle file
-    start_server_aof_ex [list dir $server_path aof-load-corrupt-tail-size 4096] [list wait_ready false] {
+    start_server_aof_ex [list dir $server_path aof-load-corrupt-tail-max-size 4096] [list wait_ready false] {
         test "Intermediate AOF is broken: should recover successfully" {
             wait_for_log_messages 0 {
-                {*AOF*loaded anyway because aof-load-corrupt-tail-size is enabled*}
+                {*AOF*loaded anyway because aof-load-corrupt-tail-max-size is enabled*}
             } 0 10 1000
         }
     }
@@ -828,7 +828,7 @@ tags {"aof external:skip"} {
     file rename -force $tmp_file $last_aof_file
 
     # Should now start successfully since corruption is in last AOF file
-    start_server_aof [list dir $server_path aof-load-corrupt-tail-size 4096] {
+    start_server_aof [list dir $server_path aof-load-corrupt-tail-max-size 4096] {
         test "Corrupted last AOF file: Server should still start and recover" {
             assert_equal 1 [is_alive [srv pid]]
             set client [redis [srv host] [srv port] 0 $::tls]
@@ -850,8 +850,8 @@ tags {"aof external:skip"} {
         }
     }
 
-    start_server_aof [list dir $server_path aof-load-corrupt-tail-size 64] {
-        test "Corrupt tail: Server should start if aof-load-corrupt-tail-size is set" {
+    start_server_aof [list dir $server_path aof-load-corrupt-tail-max-size 64] {
+        test "Corrupt tail: Server should start if aof-load-corrupt-tail-max-size is set" {
             assert_equal 1 [is_alive [srv pid]]
         }
 


### PR DESCRIPTION
This PR follows https://github.com/redis/redis/pull/14058

When Redis is shut down uncleanly (e.g., due to power loss or system crashes), invalid bytes may remain at the end of AOF files.
This PR refactors the AOF corruption handling system and introduces automatic recovery capabilities to improve resilience and reduce downtime. The feature only handles corruption at the end of files, respects the configured size limit to prevent excessive data loss, maintains all valid commands before the corruption point.

Removed aof-load-broken configuration option
Rename aof-load-broken-max-size to aof-load-corrupt-tail-max-size.
New Config: aof-load-corrupt-tail-max-size - enables recovery for corruption up to specified size