### PR TITLE
Change `ps` command options to work on Solaris

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -689,16 +689,26 @@ proc get_system_name {} {
     return [string tolower [exec uname -s]]
 }
 
+proc get_proc_state {pid} {
+    if {[get_system_name] eq {sunos}} {
+        return "ps -o s= -p $pid"
+    } else {
+        return "ps -o state= -p $pid"
+    }
+}
+
+proc get_proc_job {pid} {
+    if {[get_system_name] eq {sunos}} {
+        return "ps -l -p $pid"
+    } else {
+        return "ps j $pid"
+    }
+}
+
 proc pause_process pid {
     exec kill -SIGSTOP $pid
-
-    if {[get_system_name] eq {sunos}} {
-        set proc_state_cmd "ps -o s= -p $pid"
-        set proc_job_cmd "ps -l -p $pid"
-    } else {
-        set proc_state_cmd "ps -o state= -p $pid"
-        set proc_job_cmd "ps j $pid"
-    }
+    set proc_state_cmd [get_proc_state $pid]
+    set proc_job_cmd [get_proc_job $pid]
 
     wait_for_condition 50 100 {
         [string match "T*" [exec {*}$proc_state_cmd]]
@@ -709,13 +719,9 @@ proc pause_process pid {
 }
 
 proc resume_process pid {
-    if {[get_system_name] eq {sunos}} {
-        set proc_state_cmd "ps -o s= -p $pid"
-        set proc_job_cmd "ps -l -p $pid"
-    } else {
-        set proc_state_cmd "ps -o state= -p $pid"
-        set proc_job_cmd "ps j $pid"
-    }
+    set proc_state_cmd [get_proc_state $pid]
+    set proc_job_cmd [get_proc_job $pid]
+
     wait_for_condition 50 1000 {
         [string match "T*" [exec {*}$proc_state_cmd]]
     } else {

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -687,20 +687,40 @@ proc process_is_alive pid {
 
 proc pause_process pid {
     exec kill -SIGSTOP $pid
-    wait_for_condition 50 100 {
-        [string match {*T*} [lindex [exec ps -l -p $pid] 15]]
+    set system_name [string tolower [exec uname -s]]
+    if {$system_name eq {sunos}} {
+        wait_for_condition 50 100 {
+            [string match {*T*} [lindex [exec ps -l -p $pid] 15]]
+        } else {
+            puts [exec ps -l -p $pid]
+            fail "process didn't stop"
+        }
     } else {
-        puts [exec ps -l -p $pid]
-        fail "process didn't stop"
+        wait_for_condition 50 100 {
+            [string match {*T*} [lindex [exec ps j $pid] 16]]
+        } else {
+            puts [exec ps j $pid]
+            fail "process didn't stop"
+        }
     }
 }
 
 proc resume_process pid {
-    wait_for_condition 50 1000 {
-        [string match "T*" [exec ps -o s= -p $pid]]
+    set system_name [string tolower [exec uname -s]]
+    if {$system_name eq {sunos}} {
+        wait_for_condition 50 1000 {
+            [string match "T*" [exec ps -o s= -p $pid]]
+        } else {
+            puts [exec ps -l -p $pid]
+            fail "process was not stopped"
+        }
     } else {
-        puts [exec ps -l -p $pid]
-        fail "process was not stopped"
+        wait_for_condition 50 1000 {
+            [string match "T*" [exec ps -o state= -p $pid]]
+        } else {
+            puts [exec ps j $pid]
+            fail "process was not stopped"
+        }
     }
     exec kill -SIGCONT $pid
 }

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -688,18 +688,18 @@ proc process_is_alive pid {
 proc pause_process pid {
     exec kill -SIGSTOP $pid
     wait_for_condition 50 100 {
-        [string match {*T*} [lindex [exec ps j $pid] 16]]
+        [string match {*T*} [lindex [exec ps -l -p $pid] 15]]
     } else {
-        puts [exec ps j $pid]
+        puts [exec ps -l -p $pid]
         fail "process didn't stop"
     }
 }
 
 proc resume_process pid {
     wait_for_condition 50 1000 {
-        [string match "T*" [exec ps -o state= -p $pid]]
+        [string match "T*" [exec ps -o s= -p $pid]]
     } else {
-        puts [exec ps j $pid]
+        puts [exec ps -l -p $pid]
         fail "process was not stopped"
     }
     exec kill -SIGCONT $pid

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -691,37 +691,35 @@ proc get_system_name {} {
 
 proc pause_process pid {
     exec kill -SIGSTOP $pid
-    set system_name [get_system_name]
 
-    if {$system_name eq {sunos}} {
-        set ps_cmd "ps -o s= -p $pid"
-        set debug_cmd "ps -l -p $pid"
+    if {[get_system_name] eq {sunos}} {
+        set proc_state_cmd "ps -o s= -p $pid"
+        set proc_job_cmd "ps -l -p $pid"
     } else {
-        set ps_cmd "ps -o state= -p $pid"
-        set debug_cmd "ps j $pid"
+        set proc_state_cmd "ps -o state= -p $pid"
+        set proc_job_cmd "ps j $pid"
     }
 
     wait_for_condition 50 100 {
-        [string match "T*" [exec {*}$ps_cmd]]
+        [string match "T*" [exec {*}$proc_state_cmd]]
     } else {
-        puts [exec {*}$debug_cmd]
+        puts [exec {*}$proc_job_cmd]
         fail "process didn't stop"
     }
 }
 
 proc resume_process pid {
-    set system_name [get_system_name]
-    if {$system_name eq {sunos}} {
-        set ps_cmd "ps -o s= -p $pid"
-        set debug_cmd "ps -l -p $pid"
+    if {[get_system_name] eq {sunos}} {
+        set proc_state_cmd "ps -o s= -p $pid"
+        set proc_job_cmd "ps -l -p $pid"
     } else {
-        set ps_cmd "ps -o state= -p $pid"
-        set debug_cmd "ps j $pid"
+        set proc_state_cmd "ps -o state= -p $pid"
+        set proc_job_cmd "ps j $pid"
     }
     wait_for_condition 50 1000 {
-        [string match "T*" [exec {*}$ps_cmd]]
+        [string match "T*" [exec {*}$proc_state_cmd]]
     } else {
-        puts [exec {*}$debug_cmd]
+        puts [exec {*}$proc_job_cmd]
         fail "process was not stopped"
     }
     exec kill -SIGCONT $pid

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -691,41 +691,35 @@ proc get_system_name {} {
 
 proc get_proc_state {pid} {
     if {[get_system_name] eq {sunos}} {
-        return "ps -o s= -p $pid"
+        return [exec ps -o s= -p $pid]
     } else {
-        return "ps -o state= -p $pid"
+        return [exec ps -o state= -p $pid]
     }
 }
 
 proc get_proc_job {pid} {
     if {[get_system_name] eq {sunos}} {
-        return "ps -l -p $pid"
+        return [exec ps -l -p $pid]
     } else {
-        return "ps j $pid"
+        return [exec ps j $pid]
     }
 }
 
-proc pause_process pid {
+proc pause_process {pid} {
     exec kill -SIGSTOP $pid
-    set proc_state_cmd [get_proc_state $pid]
-    set proc_job_cmd [get_proc_job $pid]
-
     wait_for_condition 50 100 {
-        [string match "T*" [exec {*}$proc_state_cmd]]
+        [string match "T*" [get_proc_state $pid]]
     } else {
-        puts [exec {*}$proc_job_cmd]
+        puts [get_proc_job $pid]
         fail "process didn't stop"
     }
 }
 
-proc resume_process pid {
-    set proc_state_cmd [get_proc_state $pid]
-    set proc_job_cmd [get_proc_job $pid]
-
+proc resume_process {pid} {
     wait_for_condition 50 1000 {
-        [string match "T*" [exec {*}$proc_state_cmd]]
+        [string match "T*" [get_proc_state $pid]]
     } else {
-        puts [exec {*}$proc_job_cmd]
+        puts [get_proc_job $pid]
         fail "process was not stopped"
     }
     exec kill -SIGCONT $pid

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -685,42 +685,44 @@ proc process_is_alive pid {
     }
 }
 
+proc get_system_name {} {
+    return [string tolower [exec uname -s]]
+}
+
 proc pause_process pid {
     exec kill -SIGSTOP $pid
-    set system_name [string tolower [exec uname -s]]
+    set system_name [get_system_name]
+
     if {$system_name eq {sunos}} {
-        wait_for_condition 50 100 {
-            [string match {*T*} [lindex [exec ps -l -p $pid] 15]]
-        } else {
-            puts [exec ps -l -p $pid]
-            fail "process didn't stop"
-        }
+        set ps_cmd "ps -o s= -p $pid"
+        set debug_cmd "ps -l -p $pid"
     } else {
-        wait_for_condition 50 100 {
-            [string match {*T*} [lindex [exec ps j $pid] 16]]
-        } else {
-            puts [exec ps j $pid]
-            fail "process didn't stop"
-        }
+        set ps_cmd "ps -o state= -p $pid"
+        set debug_cmd "ps j $pid"
+    }
+
+    wait_for_condition 50 100 {
+        [string match "T*" [exec {*}$ps_cmd]]
+    } else {
+        puts [exec {*}$debug_cmd]
+        fail "process didn't stop"
     }
 }
 
 proc resume_process pid {
-    set system_name [string tolower [exec uname -s]]
+    set system_name [get_system_name]
     if {$system_name eq {sunos}} {
-        wait_for_condition 50 1000 {
-            [string match "T*" [exec ps -o s= -p $pid]]
-        } else {
-            puts [exec ps -l -p $pid]
-            fail "process was not stopped"
-        }
+        set ps_cmd "ps -o s= -p $pid"
+        set debug_cmd "ps -l -p $pid"
     } else {
-        wait_for_condition 50 1000 {
-            [string match "T*" [exec ps -o state= -p $pid]]
-        } else {
-            puts [exec ps j $pid]
-            fail "process was not stopped"
-        }
+        set ps_cmd "ps -o state= -p $pid"
+        set debug_cmd "ps j $pid"
+    }
+    wait_for_condition 50 1000 {
+        [string match "T*" [exec {*}$ps_cmd]]
+    } else {
+        puts [exec {*}$debug_cmd]
+        fail "process was not stopped"
     }
     exec kill -SIGCONT $pid
 }
@@ -1228,7 +1230,7 @@ proc system_backtrace_supported {} {
         return 0
     }
 
-    set system_name [string tolower [exec uname -s]]
+    set system_name [get_system_name]
     if {$system_name eq {darwin}} {
         return 1
     } elseif {$system_name ne {linux}} {


### PR DESCRIPTION
Fix https://github.com/redis/redis/issues/14304
`ps` command options in tcl tests are adjusted to work on both Linux and Solaris.