### PR TITLE
Add per key memory accounting

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -885,9 +885,16 @@ void* defragStreamConsumerPendingEntry(raxIterator *ri, void *privdata) {
     return newnack;
 }
 
+typedef struct {
+    stream *s;
+    streamCG *cg;
+} StreamConsumerContext;
+
 void* defragStreamConsumer(raxIterator *ri, void *privdata) {
+    StreamConsumerContext *ctx = privdata;
+    stream *s = ctx->s;
+    streamCG *cg = ctx->cg;
     streamConsumer *c = ri->data;
-    streamCG *cg = privdata;
     void *newc = activeDefragAlloc(c);
     if (newc) {
         c = newc;
@@ -896,6 +903,9 @@ void* defragStreamConsumer(raxIterator *ri, void *privdata) {
     if (newsds)
         c->name = newsds;
     if (c->pel) {
+        /* Update pel back-pointer to new stream */
+        size_t **alloc_size = (size_t **)c->pel->metadata;
+        *alloc_size = &s->alloc_size;
         PendingEntryContext pel_ctx = {cg, c};
         defragRadixTree(&c->pel, 0, defragStreamConsumerPendingEntry, &pel_ctx);
     }
@@ -903,14 +913,23 @@ void* defragStreamConsumer(raxIterator *ri, void *privdata) {
 }
 
 void* defragStreamConsumerGroup(raxIterator *ri, void *privdata) {
+    stream *s = privdata;
     streamCG *newcg, *cg = ri->data;
-    UNUSED(privdata);
     if ((newcg = activeDefragAlloc(cg)))
         cg = newcg;
-    if (cg->consumers)
-        defragRadixTree(&cg->consumers, 0, defragStreamConsumer, cg);
-    if (cg->pel)
+    if (cg->pel) {
+        /* Update pel back-pointer to new stream */
+        size_t **alloc_size = (size_t **)cg->pel->metadata;
+        *alloc_size = &s->alloc_size;
         defragRadixTree(&cg->pel, 0, NULL, NULL);
+    }
+    if (cg->consumers) {
+        /* Update consumers back-pointer to new stream */
+        size_t **alloc_size = (size_t **)cg->consumers->metadata;
+        *alloc_size = &s->alloc_size;
+        StreamConsumerContext consumer_ctx = {s, cg};
+        defragRadixTree(&cg->consumers, 0, defragStreamConsumer, &consumer_ctx);
+    }
     return cg;
 }
 
@@ -922,6 +941,9 @@ void defragStream(defragKeysCtx *ctx, kvobj *ob) {
     if ((news = activeDefragAlloc(s)))
         ob->ptr = s = news;
 
+    /* Update rax back-pointer to new stream */
+    size_t **rax_alloc_size = (size_t **)s->rax->metadata;
+    *rax_alloc_size = &s->alloc_size;
     if (raxSize(s->rax) > server.active_defrag_max_scan_fields) {
         rax *newrax = activeDefragAlloc(s->rax);
         if (newrax)
@@ -930,8 +952,18 @@ void defragStream(defragKeysCtx *ctx, kvobj *ob) {
     } else
         defragRadixTree(&s->rax, 1, NULL, NULL);
 
-    if (s->cgroups)
-        defragRadixTree(&s->cgroups, 0, defragStreamConsumerGroup, NULL);
+    if (s->cgroups) {
+        /* Update cgroups back-pointer to new stream */
+        size_t **alloc_size = (size_t **)s->cgroups->metadata;
+        *alloc_size = &s->alloc_size;
+        defragRadixTree(&s->cgroups, 0, defragStreamConsumerGroup, s);
+    }
+
+    if (s->cgroups_ref) {
+        /* Update cgroups_ref back-pointer to new stream */
+        size_t **alloc_size = (size_t **)s->cgroups_ref->metadata;
+        *alloc_size = &s->alloc_size;
+    }
 }
 
 /* Defrag a module key. This is either done immediately or scheduled

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -921,6 +921,11 @@ void* defragStreamConsumerGroup(raxIterator *ri, void *privdata) {
         cg->pel->alloc_size = &s->alloc_size;
         defragRadixTree(&cg->pel, 0, NULL, NULL);
     }
+    if (cg->pel_by_time) {
+        /* Update pel_by_time back-pointer to new stream */
+        cg->pel_by_time->alloc_size = &s->alloc_size;
+        defragRadixTree(&cg->pel_by_time, 0, NULL, NULL);
+    }
     if (cg->consumers) {
         /* Update consumers back-pointer to new stream */
         cg->consumers->alloc_size = &s->alloc_size;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -904,8 +904,7 @@ void* defragStreamConsumer(raxIterator *ri, void *privdata) {
         c->name = newsds;
     if (c->pel) {
         /* Update pel back-pointer to new stream */
-        size_t **alloc_size = (size_t **)c->pel->metadata;
-        *alloc_size = &s->alloc_size;
+        c->pel->alloc_size = &s->alloc_size;
         PendingEntryContext pel_ctx = {cg, c};
         defragRadixTree(&c->pel, 0, defragStreamConsumerPendingEntry, &pel_ctx);
     }
@@ -919,14 +918,12 @@ void* defragStreamConsumerGroup(raxIterator *ri, void *privdata) {
         cg = newcg;
     if (cg->pel) {
         /* Update pel back-pointer to new stream */
-        size_t **alloc_size = (size_t **)cg->pel->metadata;
-        *alloc_size = &s->alloc_size;
+        cg->pel->alloc_size = &s->alloc_size;
         defragRadixTree(&cg->pel, 0, NULL, NULL);
     }
     if (cg->consumers) {
         /* Update consumers back-pointer to new stream */
-        size_t **alloc_size = (size_t **)cg->consumers->metadata;
-        *alloc_size = &s->alloc_size;
+        cg->consumers->alloc_size = &s->alloc_size;
         StreamConsumerContext consumer_ctx = {s, cg};
         defragRadixTree(&cg->consumers, 0, defragStreamConsumer, &consumer_ctx);
     }
@@ -942,8 +939,7 @@ void defragStream(defragKeysCtx *ctx, kvobj *ob) {
         ob->ptr = s = news;
 
     /* Update rax back-pointer to new stream */
-    size_t **rax_alloc_size = (size_t **)s->rax->metadata;
-    *rax_alloc_size = &s->alloc_size;
+    s->rax->alloc_size = &s->alloc_size;
     if (raxSize(s->rax) > server.active_defrag_max_scan_fields) {
         rax *newrax = activeDefragAlloc(s->rax);
         if (newrax)
@@ -954,15 +950,13 @@ void defragStream(defragKeysCtx *ctx, kvobj *ob) {
 
     if (s->cgroups) {
         /* Update cgroups back-pointer to new stream */
-        size_t **alloc_size = (size_t **)s->cgroups->metadata;
-        *alloc_size = &s->alloc_size;
+        s->cgroups->alloc_size = &s->alloc_size;
         defragRadixTree(&s->cgroups, 0, defragStreamConsumerGroup, s);
     }
 
     if (s->cgroups_ref) {
         /* Update cgroups_ref back-pointer to new stream */
-        size_t **alloc_size = (size_t **)s->cgroups_ref->metadata;
-        *alloc_size = &s->alloc_size;
+        s->cgroups_ref->alloc_size = &s->alloc_size;
     }
 }
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -204,8 +204,9 @@ dict *dictCreate(dictType *type)
 void dictTypeAddMeta(dict **d, dictType *typeWithMeta) {
     /* Verify new dictType is compatible with the old one */
     dictType toCmp = *typeWithMeta;
-    toCmp.dictMetadataBytes = NULL;                            /* Expected old one not to have metadata */
-    toCmp.onDictRelease = (*d)->type->onDictRelease;           /* Ignore 'onDictRelease' in comparison */
+    /* Ignore 'dictMetadataBytes' and 'onDictRelease' in comparison */
+    toCmp.dictMetadataBytes = (*d)->type->dictMetadataBytes;
+    toCmp.onDictRelease = (*d)->type->onDictRelease;
     assert(memcmp((*d)->type, &toCmp, sizeof(dictType)) == 0); /* The rest of the dictType fields must be the same */
 
     *d = zrealloc(*d, sizeof(dict) + typeWithMeta->dictMetadataBytes(*d));

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -543,7 +543,7 @@ static rax *ebConvertListToRax(eItem listHead, EbucketsType *type) {
     /* Use min expire-time for the first segment in rax */
     unsigned char raxKey[EB_KEY_SIZE];
     bucketKey2RaxKey(bucketKey, raxKey);
-    rax *rax = raxNewWithMetadata(sizeof(uint64_t));
+    rax *rax = raxNewWithMetadata(0, sizeof(uint64_t));
     *ebRaxNumItems(rax) = EB_LIST_MAX_ITEMS;
     raxInsert(rax, raxKey, EB_KEY_SIZE, firstSegHdr, NULL);
     return rax;

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -543,7 +543,7 @@ static rax *ebConvertListToRax(eItem listHead, EbucketsType *type) {
     /* Use min expire-time for the first segment in rax */
     unsigned char raxKey[EB_KEY_SIZE];
     bucketKey2RaxKey(bucketKey, raxKey);
-    rax *rax = raxNewWithMetadata(0, sizeof(uint64_t));
+    rax *rax = raxNewWithMetadata(sizeof(uint64_t), 0);
     *ebRaxNumItems(rax) = EB_LIST_MAX_ITEMS;
     raxInsert(rax, raxKey, EB_KEY_SIZE, firstSegHdr, NULL);
     return rax;

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -543,7 +543,7 @@ static rax *ebConvertListToRax(eItem listHead, EbucketsType *type) {
     /* Use min expire-time for the first segment in rax */
     unsigned char raxKey[EB_KEY_SIZE];
     bucketKey2RaxKey(bucketKey, raxKey);
-    rax *rax = raxNewWithMetadata(sizeof(uint64_t), 0, NULL);
+    rax *rax = raxNewWithMetadata(sizeof(uint64_t), NULL);
     *ebRaxNumItems(rax) = EB_LIST_MAX_ITEMS;
     raxInsert(rax, raxKey, EB_KEY_SIZE, firstSegHdr, NULL);
     return rax;

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -543,7 +543,7 @@ static rax *ebConvertListToRax(eItem listHead, EbucketsType *type) {
     /* Use min expire-time for the first segment in rax */
     unsigned char raxKey[EB_KEY_SIZE];
     bucketKey2RaxKey(bucketKey, raxKey);
-    rax *rax = raxNewWithMetadata(sizeof(uint64_t), 0);
+    rax *rax = raxNewWithMetadata(sizeof(uint64_t), 0, NULL);
     *ebRaxNumItems(rax) = EB_LIST_MAX_ITEMS;
     raxInsert(rax, raxKey, EB_KEY_SIZE, firstSegHdr, NULL);
     return rax;

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -239,9 +239,16 @@ void lpFreeGeneric(void *lp) {
 
 /* Shrink the memory to fit. */
 unsigned char* lpShrinkToFit(unsigned char *lp) {
+    return lpShrinkToFitUsable(lp, NULL, NULL);
+}
+
+unsigned char* lpShrinkToFitUsable(unsigned char *lp, size_t *usable, size_t *old_usable) {
     size_t size = lpGetTotalBytes(lp);
-    if (size < lp_malloc_size(lp)) {
-        return lp_realloc(lp, size);
+    size_t usable_size = lp_malloc_size(lp);
+    if (usable) *usable = usable_size;
+    if (old_usable) *old_usable = usable_size;
+    if (size < usable_size) {
+        return lp_realloc_usable(lp, size, usable, old_usable);
     } else {
         return lp;
     }
@@ -948,7 +955,8 @@ unsigned char *lpFind(unsigned char *lp, unsigned char *p, unsigned char *s,
  * set to the next element, on the right of the deleted one, or to NULL if the
  * deleted element was the last one. */
 unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char *eleint,
-                        uint32_t size, unsigned char *p, int where, unsigned char **newp)
+                        uint32_t size, unsigned char *p, int where, unsigned char **newp,
+                        size_t *usable, size_t *old_usable)
 {
     unsigned char intenc[LP_MAX_INT_ENCODING_LEN];
     unsigned char backlen[LP_MAX_BACKLEN_SIZE];
@@ -1017,13 +1025,17 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char 
      * make room for the new element if the final allocation will get
      * larger, or we do it after if the final allocation will get smaller. */
 
+    size_t newsize, oldsize;
     unsigned char *dst = lp + poff; /* May be updated after reallocation. */
 
     /* Realloc before: we need more room. */
+    size_t usable_size = lp_malloc_size(lp);
     if (new_listpack_bytes > old_listpack_bytes &&
-        new_listpack_bytes > lp_malloc_size(lp)) {
-        if ((lp = lp_realloc(lp,new_listpack_bytes)) == NULL) return NULL;
+        new_listpack_bytes > usable_size) {
+        if ((lp = lp_realloc_usable(lp,new_listpack_bytes,&newsize,&oldsize)) == NULL) return NULL;
         dst = lp + poff;
+    } else {
+        oldsize = newsize = usable_size;
     }
 
     /* Setup the listpack relocating the elements to make the exact room
@@ -1038,7 +1050,7 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char 
 
     /* Realloc after: we need to free space. */
     if (new_listpack_bytes < old_listpack_bytes) {
-        if ((lp = lp_realloc(lp,new_listpack_bytes)) == NULL) return NULL;
+        if ((lp = lp_realloc_usable(lp,new_listpack_bytes, &newsize, NULL)) == NULL) return NULL;
         dst = lp + poff;
     }
 
@@ -1092,7 +1104,8 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char 
     memset(oldlp,'A',new_listpack_bytes);
     lp_free(oldlp);
 #endif
-
+    if (usable) *usable = newsize;
+    if (old_usable) *old_usable = oldsize;
     return lp;
 }
 
@@ -1234,24 +1247,43 @@ unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
 unsigned char *lpInsertString(unsigned char *lp, unsigned char *s, uint32_t slen,
                               unsigned char *p, int where, unsigned char **newp)
 {
-    return lpInsert(lp, s, NULL, slen, p, where, newp);
+    return lpInsertStringUsable(lp,s,slen,p,where,newp,NULL,NULL);
+}
+
+unsigned char *lpInsertStringUsable(unsigned char *lp, unsigned char *s, uint32_t slen,
+                                    unsigned char *p, int where, unsigned char **newp,
+                                    size_t *usable, size_t *old_usable)
+{
+    return lpInsert(lp, s, NULL, slen, p, where, newp, usable, old_usable);
+}
+
+unsigned char *lpInsertIntegerUsable(unsigned char *lp, long long lval,
+                                     unsigned char *p, int where, unsigned char **newp,
+                                     size_t *usable, size_t *old_usable) {
+    uint64_t enclen; /* The length of the encoded element. */
+    unsigned char intenc[LP_MAX_INT_ENCODING_LEN];
+
+    lpEncodeIntegerGetType(lval, intenc, &enclen);
+    return lpInsert(lp, NULL, intenc, enclen, p, where, newp, usable, old_usable);
 }
 
 /* This is just a wrapper for lpInsert() to directly use a 64 bit integer
  * instead of a string. */
 unsigned char *lpInsertInteger(unsigned char *lp, long long lval, unsigned char *p, int where, unsigned char **newp) {
-    uint64_t enclen; /* The length of the encoded element. */
-    unsigned char intenc[LP_MAX_INT_ENCODING_LEN];
-
-    lpEncodeIntegerGetType(lval, intenc, &enclen);
-    return lpInsert(lp, NULL, intenc, enclen, p, where, newp);
+    return lpInsertIntegerUsable(lp, lval, p, where, newp, NULL, NULL);
 }
 
 /* Append the specified element 's' of length 'slen' at the head of the listpack. */
 unsigned char *lpPrepend(unsigned char *lp, unsigned char *s, uint32_t slen) {
+    return lpPrependUsable(lp,s,slen,NULL,NULL);
+}
+
+unsigned char *lpPrependUsable(unsigned char *lp, unsigned char *s, uint32_t slen,
+                               size_t *usable, size_t *old_usable)
+{
     unsigned char *p = lpFirst(lp);
-    if (!p) return lpAppend(lp, s, slen);
-    return lpInsert(lp, s, NULL, slen, p, LP_BEFORE, NULL);
+    if (!p) return lpAppendUsable(lp, s, slen, usable, old_usable);
+    return lpInsert(lp, s, NULL, slen, p, LP_BEFORE, NULL, usable, old_usable);
 }
 
 /* Append the specified integer element 'lval' at the head of the listpack. */
@@ -1265,16 +1297,27 @@ unsigned char *lpPrependInteger(unsigned char *lp, long long lval) {
  * listpack. It is implemented in terms of lpInsert(), so the return value is
  * the same as lpInsert(). */
 unsigned char *lpAppend(unsigned char *lp, unsigned char *ele, uint32_t size) {
+    return lpAppendUsable(lp, ele, size, NULL, NULL);
+}
+
+unsigned char *lpAppendUsable(unsigned char *lp, unsigned char *ele, uint32_t size,
+                              size_t *usable, size_t *old_usable)
+{
     uint64_t listpack_bytes = lpGetTotalBytes(lp);
     unsigned char *eofptr = lp + listpack_bytes - 1;
-    return lpInsert(lp,ele,NULL,size,eofptr,LP_BEFORE,NULL);
+    return lpInsert(lp,ele,NULL,size,eofptr,LP_BEFORE,NULL,usable,old_usable);
+}
+
+unsigned char *lpAppendIntegerUsable(unsigned char *lp, long long lval,
+                                     size_t *usable, size_t *old_usable) {
+    uint64_t listpack_bytes = lpGetTotalBytes(lp);
+    unsigned char *eofptr = lp + listpack_bytes - 1;
+    return lpInsertIntegerUsable(lp, lval, eofptr, LP_BEFORE, NULL, usable, old_usable);
 }
 
 /* Append the specified integer element 'lval' at the end of the listpack. */
 unsigned char *lpAppendInteger(unsigned char *lp, long long lval) {
-    uint64_t listpack_bytes = lpGetTotalBytes(lp);
-    unsigned char *eofptr = lp + listpack_bytes - 1;
-    return lpInsertInteger(lp, lval, eofptr, LP_BEFORE, NULL);
+    return lpAppendIntegerUsable(lp, lval, NULL, NULL);
 }
 
 /* Append batch of entries to the listpack.
@@ -1295,7 +1338,12 @@ unsigned char *lpBatchAppend(unsigned char *lp, listpackEntry *entries, unsigned
  * the current element. The function returns the new listpack as return
  * value, and also updates the current cursor by updating '*p'. */
 unsigned char *lpReplace(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen) {
-    return lpInsert(lp, s, NULL, slen, *p, LP_REPLACE, p);
+    return lpReplaceUsable(lp, p, s, slen, NULL, NULL);
+}
+
+unsigned char *lpReplaceUsable(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen,
+                               size_t *usable, size_t *old_usable) {
+    return lpInsert(lp, s, NULL, slen, *p, LP_REPLACE, p, usable, old_usable);
 }
 
 /* This is just a wrapper for lpInsertInteger() to directly use a 64 bit integer
@@ -1303,7 +1351,12 @@ unsigned char *lpReplace(unsigned char *lp, unsigned char **p, unsigned char *s,
  * the new listpack as return value, and also updates the current cursor
  * by updating '*p'. */
 unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long lval) {
-    return lpInsertInteger(lp, lval, *p, LP_REPLACE, p);
+    return lpReplaceIntegerUsable(lp, p, lval, NULL, NULL);
+}
+
+unsigned char *lpReplaceIntegerUsable(unsigned char *lp, unsigned char **p, long long lval,
+                                      size_t *usable, size_t *old_usable) {
+    return lpInsertIntegerUsable(lp, lval, *p, LP_REPLACE, p, usable, old_usable);
 }
 
 /* Remove the element pointed by 'p', and return the resulting listpack.
@@ -1311,11 +1364,21 @@ unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long 
  * deleted one) is returned by reference. If the deleted element was the
  * last one, '*newp' is set to NULL. */
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp) {
-    return lpInsert(lp,NULL,NULL,0,p,LP_REPLACE,newp);
+    return lpDeleteUsable(lp,p,newp,NULL,NULL);
+}
+
+unsigned char *lpDeleteUsable(unsigned char *lp, unsigned char *p, unsigned char **newp,
+                              size_t *usable, size_t *old_usable) {
+    return lpInsert(lp,NULL,NULL,0,p,LP_REPLACE,newp,usable,old_usable);
 }
 
 /* Delete a range of entries from the listpack start with the element pointed by 'p'. */
 unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsigned long num) {
+    return lpDeleteRangeWithEntryUsable(lp, p, num, NULL, NULL);
+}
+
+unsigned char *lpDeleteRangeWithEntryUsable(unsigned char *lp, unsigned char **p, unsigned long num,
+                                            size_t *usable, size_t *old_usable) {
     size_t bytes = lpBytes(lp);
     unsigned long deleted = 0;
     unsigned char *eofptr = lp + bytes - 1;
@@ -1344,7 +1407,7 @@ unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsi
     uint32_t numele = lpGetNumElements(lp);
     if (numele != LP_HDR_NUMELE_UNKNOWN)
         lpSetNumElements(lp, numele-deleted);
-    lp = lpShrinkToFit(lp);
+    lp = lpShrinkToFitUsable(lp, usable, old_usable);
 
     /* Store the entry. */
     *p = lp+poff;
@@ -1355,6 +1418,11 @@ unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsi
 
 /* Delete a range of entries from the listpack. */
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num) {
+    return lpDeleteRangeUsable(lp, index, num, NULL, NULL);
+}
+
+unsigned char *lpDeleteRangeUsable(unsigned char *lp, long index, unsigned long num,
+                                   size_t *usable, size_t *old_usable) {
     unsigned char *p;
     uint32_t numele = lpGetNumElements(lp);
 
@@ -1373,9 +1441,9 @@ unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num) {
         p[0] = LP_EOF;
         lpSetTotalBytes(lp, p - lp + 1);
         lpSetNumElements(lp, index);
-        lp = lpShrinkToFit(lp);
+        lp = lpShrinkToFitUsable(lp, usable, old_usable);
     } else {
-        lp = lpDeleteRangeWithEntry(lp, &p, num);
+        lp = lpDeleteRangeWithEntryUsable(lp, &p, num, usable, old_usable);
     }
 
     return lp;
@@ -1446,6 +1514,11 @@ unsigned char *lpBatchDelete(unsigned char *lp, unsigned char **ps, unsigned lon
  * 'first' or 'second', also frees the other unused input listpack, and sets the
  * input listpack argument equal to newly reallocated listpack return value. */
 unsigned char *lpMerge(unsigned char **first, unsigned char **second) {
+    return lpMergeUsable(first, second, NULL, NULL);
+}
+
+unsigned char *lpMergeUsable(unsigned char **first, unsigned char **second,
+                             size_t *usable, size_t *old_usable) {
     /* If any params are null, we can't merge, so NULL. */
     if (first == NULL || *first == NULL || second == NULL || *second == NULL)
         return NULL;
@@ -1491,7 +1564,8 @@ unsigned char *lpMerge(unsigned char **first, unsigned char **second) {
     lplength = lplength < UINT16_MAX ? lplength : UINT16_MAX;
 
     /* Extend target to new lpbytes then append or prepend source. */
-    target = lp_realloc(target, lpbytes);
+    size_t newsize, oldsize, oldsize2;
+    target = lp_realloc_usable(target, lpbytes, &newsize, &oldsize);
     if (append) {
         /* append == appending to target */
         /* Copy source after target (copying over original [END]):
@@ -1515,14 +1589,17 @@ unsigned char *lpMerge(unsigned char **first, unsigned char **second) {
 
     /* Now free and NULL out what we didn't realloc */
     if (append) {
-        lp_free(*second);
+        lp_free_usable(*second, &oldsize2);
         *second = NULL;
         *first = target;
     } else {
-        lp_free(*first);
+        lp_free_usable(*first, &oldsize2);
         *first = NULL;
         *second = target;
     }
+
+    if (usable) *usable = newsize;
+    if (old_usable) *old_usable = oldsize + oldsize2;
 
     return target;
 }

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -227,6 +227,11 @@ unsigned char *lpNew(size_t capacity) {
     return lp;
 }
 
+/* Similar to lpFree, '*usable' is set to the usable size being freed. */
+void lpFreeUsable(unsigned char *lp, size_t *usable) {
+    lp_free_usable(lp, usable);
+}
+
 /* Free the specified listpack. */
 void lpFree(unsigned char *lp) {
     lp_free(lp);

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -247,10 +247,10 @@ unsigned char* lpShrinkToFitUsable(unsigned char *lp, UsableSizes *usable) {
     size_t usable_size = lp_malloc_size(lp);
     UsableSizes dummy;
     if (!usable) usable = &dummy;
-    usable->val = usable_size;
-    usable->oldval = usable_size;
+    usable->newsize = usable_size;
+    usable->oldsize = usable_size;
     if (size < usable_size) {
-        return lp_realloc_usable(lp, size, &usable->val, &usable->oldval);
+        return lp_realloc_usable(lp, size, &usable->newsize, &usable->oldsize);
     } else {
         return lp;
     }
@@ -1107,8 +1107,8 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char 
     lp_free(oldlp);
 #endif
     if (usable) {
-        usable->val = newsize;
-        usable->oldval = oldsize;
+        usable->newsize = newsize;
+        usable->oldsize = oldsize;
     }
     return lp;
 }
@@ -1603,8 +1603,8 @@ unsigned char *lpMergeUsable(unsigned char **first, unsigned char **second,
     }
 
     if (usable) {
-        usable->val = newsize;
-        usable->oldval = oldsize + oldsize2;
+        usable->newsize = newsize;
+        usable->oldsize = oldsize + oldsize2;
     }
 
     return target;

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -244,16 +244,18 @@ void lpFreeGeneric(void *lp) {
 
 /* Shrink the memory to fit. */
 unsigned char* lpShrinkToFit(unsigned char *lp) {
-    return lpShrinkToFitUsable(lp, NULL, NULL);
+    return lpShrinkToFitUsable(lp, NULL);
 }
 
-unsigned char* lpShrinkToFitUsable(unsigned char *lp, size_t *usable, size_t *old_usable) {
+unsigned char* lpShrinkToFitUsable(unsigned char *lp, UsableSizes *usable) {
     size_t size = lpGetTotalBytes(lp);
     size_t usable_size = lp_malloc_size(lp);
-    if (usable) *usable = usable_size;
-    if (old_usable) *old_usable = usable_size;
+    UsableSizes dummy;
+    if (!usable) usable = &dummy;
+    usable->val = usable_size;
+    usable->oldval = usable_size;
     if (size < usable_size) {
-        return lp_realloc_usable(lp, size, usable, old_usable);
+        return lp_realloc_usable(lp, size, &usable->val, &usable->oldval);
     } else {
         return lp;
     }
@@ -961,7 +963,7 @@ unsigned char *lpFind(unsigned char *lp, unsigned char *p, unsigned char *s,
  * deleted element was the last one. */
 unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char *eleint,
                         uint32_t size, unsigned char *p, int where, unsigned char **newp,
-                        size_t *usable, size_t *old_usable)
+                        UsableSizes *usable)
 {
     unsigned char intenc[LP_MAX_INT_ENCODING_LEN];
     unsigned char backlen[LP_MAX_BACKLEN_SIZE];
@@ -1109,8 +1111,10 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char 
     memset(oldlp,'A',new_listpack_bytes);
     lp_free(oldlp);
 #endif
-    if (usable) *usable = newsize;
-    if (old_usable) *old_usable = oldsize;
+    if (usable) {
+        usable->val = newsize;
+        usable->oldval = oldsize;
+    }
     return lp;
 }
 
@@ -1252,43 +1256,43 @@ unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
 unsigned char *lpInsertString(unsigned char *lp, unsigned char *s, uint32_t slen,
                               unsigned char *p, int where, unsigned char **newp)
 {
-    return lpInsertStringUsable(lp,s,slen,p,where,newp,NULL,NULL);
+    return lpInsertStringUsable(lp,s,slen,p,where,newp,NULL);
 }
 
 unsigned char *lpInsertStringUsable(unsigned char *lp, unsigned char *s, uint32_t slen,
                                     unsigned char *p, int where, unsigned char **newp,
-                                    size_t *usable, size_t *old_usable)
+                                    UsableSizes *usable)
 {
-    return lpInsert(lp, s, NULL, slen, p, where, newp, usable, old_usable);
+    return lpInsert(lp, s, NULL, slen, p, where, newp, usable);
 }
 
 unsigned char *lpInsertIntegerUsable(unsigned char *lp, long long lval,
                                      unsigned char *p, int where, unsigned char **newp,
-                                     size_t *usable, size_t *old_usable) {
+                                     UsableSizes *usable) {
     uint64_t enclen; /* The length of the encoded element. */
     unsigned char intenc[LP_MAX_INT_ENCODING_LEN];
 
     lpEncodeIntegerGetType(lval, intenc, &enclen);
-    return lpInsert(lp, NULL, intenc, enclen, p, where, newp, usable, old_usable);
+    return lpInsert(lp, NULL, intenc, enclen, p, where, newp, usable);
 }
 
 /* This is just a wrapper for lpInsert() to directly use a 64 bit integer
  * instead of a string. */
 unsigned char *lpInsertInteger(unsigned char *lp, long long lval, unsigned char *p, int where, unsigned char **newp) {
-    return lpInsertIntegerUsable(lp, lval, p, where, newp, NULL, NULL);
+    return lpInsertIntegerUsable(lp, lval, p, where, newp, NULL);
 }
 
 /* Append the specified element 's' of length 'slen' at the head of the listpack. */
 unsigned char *lpPrepend(unsigned char *lp, unsigned char *s, uint32_t slen) {
-    return lpPrependUsable(lp,s,slen,NULL,NULL);
+    return lpPrependUsable(lp,s,slen,NULL);
 }
 
 unsigned char *lpPrependUsable(unsigned char *lp, unsigned char *s, uint32_t slen,
-                               size_t *usable, size_t *old_usable)
+                               UsableSizes *usable)
 {
     unsigned char *p = lpFirst(lp);
-    if (!p) return lpAppendUsable(lp, s, slen, usable, old_usable);
-    return lpInsert(lp, s, NULL, slen, p, LP_BEFORE, NULL, usable, old_usable);
+    if (!p) return lpAppendUsable(lp, s, slen, usable);
+    return lpInsert(lp, s, NULL, slen, p, LP_BEFORE, NULL, usable);
 }
 
 /* Append the specified integer element 'lval' at the head of the listpack. */
@@ -1302,27 +1306,27 @@ unsigned char *lpPrependInteger(unsigned char *lp, long long lval) {
  * listpack. It is implemented in terms of lpInsert(), so the return value is
  * the same as lpInsert(). */
 unsigned char *lpAppend(unsigned char *lp, unsigned char *ele, uint32_t size) {
-    return lpAppendUsable(lp, ele, size, NULL, NULL);
+    return lpAppendUsable(lp, ele, size, NULL);
 }
 
 unsigned char *lpAppendUsable(unsigned char *lp, unsigned char *ele, uint32_t size,
-                              size_t *usable, size_t *old_usable)
+                              UsableSizes *usable)
 {
     uint64_t listpack_bytes = lpGetTotalBytes(lp);
     unsigned char *eofptr = lp + listpack_bytes - 1;
-    return lpInsert(lp,ele,NULL,size,eofptr,LP_BEFORE,NULL,usable,old_usable);
+    return lpInsert(lp,ele,NULL,size,eofptr,LP_BEFORE,NULL,usable);
 }
 
 unsigned char *lpAppendIntegerUsable(unsigned char *lp, long long lval,
-                                     size_t *usable, size_t *old_usable) {
+                                     UsableSizes *usable) {
     uint64_t listpack_bytes = lpGetTotalBytes(lp);
     unsigned char *eofptr = lp + listpack_bytes - 1;
-    return lpInsertIntegerUsable(lp, lval, eofptr, LP_BEFORE, NULL, usable, old_usable);
+    return lpInsertIntegerUsable(lp, lval, eofptr, LP_BEFORE, NULL, usable);
 }
 
 /* Append the specified integer element 'lval' at the end of the listpack. */
 unsigned char *lpAppendInteger(unsigned char *lp, long long lval) {
-    return lpAppendIntegerUsable(lp, lval, NULL, NULL);
+    return lpAppendIntegerUsable(lp, lval, NULL);
 }
 
 /* Append batch of entries to the listpack.
@@ -1343,12 +1347,12 @@ unsigned char *lpBatchAppend(unsigned char *lp, listpackEntry *entries, unsigned
  * the current element. The function returns the new listpack as return
  * value, and also updates the current cursor by updating '*p'. */
 unsigned char *lpReplace(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen) {
-    return lpReplaceUsable(lp, p, s, slen, NULL, NULL);
+    return lpReplaceUsable(lp, p, s, slen, NULL);
 }
 
 unsigned char *lpReplaceUsable(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen,
-                               size_t *usable, size_t *old_usable) {
-    return lpInsert(lp, s, NULL, slen, *p, LP_REPLACE, p, usable, old_usable);
+                               UsableSizes *usable) {
+    return lpInsert(lp, s, NULL, slen, *p, LP_REPLACE, p, usable);
 }
 
 /* This is just a wrapper for lpInsertInteger() to directly use a 64 bit integer
@@ -1356,12 +1360,12 @@ unsigned char *lpReplaceUsable(unsigned char *lp, unsigned char **p, unsigned ch
  * the new listpack as return value, and also updates the current cursor
  * by updating '*p'. */
 unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long lval) {
-    return lpReplaceIntegerUsable(lp, p, lval, NULL, NULL);
+    return lpReplaceIntegerUsable(lp, p, lval, NULL);
 }
 
 unsigned char *lpReplaceIntegerUsable(unsigned char *lp, unsigned char **p, long long lval,
-                                      size_t *usable, size_t *old_usable) {
-    return lpInsertIntegerUsable(lp, lval, *p, LP_REPLACE, p, usable, old_usable);
+                                      UsableSizes *usable) {
+    return lpInsertIntegerUsable(lp, lval, *p, LP_REPLACE, p, usable);
 }
 
 /* Remove the element pointed by 'p', and return the resulting listpack.
@@ -1369,21 +1373,21 @@ unsigned char *lpReplaceIntegerUsable(unsigned char *lp, unsigned char **p, long
  * deleted one) is returned by reference. If the deleted element was the
  * last one, '*newp' is set to NULL. */
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp) {
-    return lpDeleteUsable(lp,p,newp,NULL,NULL);
+    return lpDeleteUsable(lp,p,newp,NULL);
 }
 
 unsigned char *lpDeleteUsable(unsigned char *lp, unsigned char *p, unsigned char **newp,
-                              size_t *usable, size_t *old_usable) {
-    return lpInsert(lp,NULL,NULL,0,p,LP_REPLACE,newp,usable,old_usable);
+                              UsableSizes *usable) {
+    return lpInsert(lp,NULL,NULL,0,p,LP_REPLACE,newp,usable);
 }
 
 /* Delete a range of entries from the listpack start with the element pointed by 'p'. */
 unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsigned long num) {
-    return lpDeleteRangeWithEntryUsable(lp, p, num, NULL, NULL);
+    return lpDeleteRangeWithEntryUsable(lp, p, num, NULL);
 }
 
 unsigned char *lpDeleteRangeWithEntryUsable(unsigned char *lp, unsigned char **p, unsigned long num,
-                                            size_t *usable, size_t *old_usable) {
+                                            UsableSizes *usable) {
     size_t bytes = lpBytes(lp);
     unsigned long deleted = 0;
     unsigned char *eofptr = lp + bytes - 1;
@@ -1412,7 +1416,7 @@ unsigned char *lpDeleteRangeWithEntryUsable(unsigned char *lp, unsigned char **p
     uint32_t numele = lpGetNumElements(lp);
     if (numele != LP_HDR_NUMELE_UNKNOWN)
         lpSetNumElements(lp, numele-deleted);
-    lp = lpShrinkToFitUsable(lp, usable, old_usable);
+    lp = lpShrinkToFitUsable(lp, usable);
 
     /* Store the entry. */
     *p = lp+poff;
@@ -1423,11 +1427,11 @@ unsigned char *lpDeleteRangeWithEntryUsable(unsigned char *lp, unsigned char **p
 
 /* Delete a range of entries from the listpack. */
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num) {
-    return lpDeleteRangeUsable(lp, index, num, NULL, NULL);
+    return lpDeleteRangeUsable(lp, index, num, NULL);
 }
 
 unsigned char *lpDeleteRangeUsable(unsigned char *lp, long index, unsigned long num,
-                                   size_t *usable, size_t *old_usable) {
+                                   UsableSizes *usable) {
     unsigned char *p;
     uint32_t numele = lpGetNumElements(lp);
 
@@ -1446,9 +1450,9 @@ unsigned char *lpDeleteRangeUsable(unsigned char *lp, long index, unsigned long 
         p[0] = LP_EOF;
         lpSetTotalBytes(lp, p - lp + 1);
         lpSetNumElements(lp, index);
-        lp = lpShrinkToFitUsable(lp, usable, old_usable);
+        lp = lpShrinkToFitUsable(lp, usable);
     } else {
-        lp = lpDeleteRangeWithEntryUsable(lp, &p, num, usable, old_usable);
+        lp = lpDeleteRangeWithEntryUsable(lp, &p, num, usable);
     }
 
     return lp;
@@ -1519,11 +1523,11 @@ unsigned char *lpBatchDelete(unsigned char *lp, unsigned char **ps, unsigned lon
  * 'first' or 'second', also frees the other unused input listpack, and sets the
  * input listpack argument equal to newly reallocated listpack return value. */
 unsigned char *lpMerge(unsigned char **first, unsigned char **second) {
-    return lpMergeUsable(first, second, NULL, NULL);
+    return lpMergeUsable(first, second, NULL);
 }
 
 unsigned char *lpMergeUsable(unsigned char **first, unsigned char **second,
-                             size_t *usable, size_t *old_usable) {
+                             UsableSizes *usable) {
     /* If any params are null, we can't merge, so NULL. */
     if (first == NULL || *first == NULL || second == NULL || *second == NULL)
         return NULL;
@@ -1603,8 +1607,10 @@ unsigned char *lpMergeUsable(unsigned char **first, unsigned char **second,
         *second = target;
     }
 
-    if (usable) *usable = newsize;
-    if (old_usable) *old_usable = oldsize + oldsize2;
+    if (usable) {
+        usable->val = newsize;
+        usable->oldval = oldsize + oldsize2;
+    }
 
     return target;
 }

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -227,11 +227,6 @@ unsigned char *lpNew(size_t capacity) {
     return lp;
 }
 
-/* Similar to lpFree, '*usable' is set to the usable size being freed. */
-void lpFreeUsable(unsigned char *lp, size_t *usable) {
-    lp_free_usable(lp, usable);
-}
-
 /* Free the specified listpack. */
 void lpFree(unsigned char *lp) {
     lp_free(lp);
@@ -239,18 +234,9 @@ void lpFree(unsigned char *lp) {
 
 /* Shrink the memory to fit. */
 unsigned char* lpShrinkToFit(unsigned char *lp) {
-    return lpShrinkToFitUsable(lp, NULL);
-}
-
-unsigned char* lpShrinkToFitUsable(unsigned char *lp, UsableSizes *usable) {
     size_t size = lpGetTotalBytes(lp);
-    size_t usable_size = lp_malloc_size(lp);
-    UsableSizes dummy;
-    if (!usable) usable = &dummy;
-    usable->newsize = usable_size;
-    usable->oldsize = usable_size;
-    if (size < usable_size) {
-        return lp_realloc_usable(lp, size, &usable->newsize, &usable->oldsize);
+    if (size < lp_malloc_size(lp)) {
+        return lp_realloc(lp, size);
     } else {
         return lp;
     }
@@ -957,8 +943,7 @@ unsigned char *lpFind(unsigned char *lp, unsigned char *p, unsigned char *s,
  * set to the next element, on the right of the deleted one, or to NULL if the
  * deleted element was the last one. */
 unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char *eleint,
-                        uint32_t size, unsigned char *p, int where, unsigned char **newp,
-                        UsableSizes *usable)
+                        uint32_t size, unsigned char *p, int where, unsigned char **newp)
 {
     unsigned char intenc[LP_MAX_INT_ENCODING_LEN];
     unsigned char backlen[LP_MAX_BACKLEN_SIZE];
@@ -1027,17 +1012,13 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char 
      * make room for the new element if the final allocation will get
      * larger, or we do it after if the final allocation will get smaller. */
 
-    size_t newsize, oldsize;
     unsigned char *dst = lp + poff; /* May be updated after reallocation. */
 
     /* Realloc before: we need more room. */
-    size_t usable_size = lp_malloc_size(lp);
     if (new_listpack_bytes > old_listpack_bytes &&
-        new_listpack_bytes > usable_size) {
-        if ((lp = lp_realloc_usable(lp,new_listpack_bytes,&newsize,&oldsize)) == NULL) return NULL;
+        new_listpack_bytes > lp_malloc_size(lp)) {
+        if ((lp = lp_realloc(lp,new_listpack_bytes)) == NULL) return NULL;
         dst = lp + poff;
-    } else {
-        oldsize = newsize = usable_size;
     }
 
     /* Setup the listpack relocating the elements to make the exact room
@@ -1052,7 +1033,7 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char 
 
     /* Realloc after: we need to free space. */
     if (new_listpack_bytes < old_listpack_bytes) {
-        if ((lp = lp_realloc_usable(lp,new_listpack_bytes, &newsize, NULL)) == NULL) return NULL;
+        if ((lp = lp_realloc(lp,new_listpack_bytes)) == NULL) return NULL;
         dst = lp + poff;
     }
 
@@ -1106,10 +1087,7 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char 
     memset(oldlp,'A',new_listpack_bytes);
     lp_free(oldlp);
 #endif
-    if (usable) {
-        usable->newsize = newsize;
-        usable->oldsize = oldsize;
-    }
+
     return lp;
 }
 
@@ -1251,43 +1229,24 @@ unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
 unsigned char *lpInsertString(unsigned char *lp, unsigned char *s, uint32_t slen,
                               unsigned char *p, int where, unsigned char **newp)
 {
-    return lpInsertStringUsable(lp,s,slen,p,where,newp,NULL);
-}
-
-unsigned char *lpInsertStringUsable(unsigned char *lp, unsigned char *s, uint32_t slen,
-                                    unsigned char *p, int where, unsigned char **newp,
-                                    UsableSizes *usable)
-{
-    return lpInsert(lp, s, NULL, slen, p, where, newp, usable);
-}
-
-unsigned char *lpInsertIntegerUsable(unsigned char *lp, long long lval,
-                                     unsigned char *p, int where, unsigned char **newp,
-                                     UsableSizes *usable) {
-    uint64_t enclen; /* The length of the encoded element. */
-    unsigned char intenc[LP_MAX_INT_ENCODING_LEN];
-
-    lpEncodeIntegerGetType(lval, intenc, &enclen);
-    return lpInsert(lp, NULL, intenc, enclen, p, where, newp, usable);
+    return lpInsert(lp, s, NULL, slen, p, where, newp);
 }
 
 /* This is just a wrapper for lpInsert() to directly use a 64 bit integer
  * instead of a string. */
 unsigned char *lpInsertInteger(unsigned char *lp, long long lval, unsigned char *p, int where, unsigned char **newp) {
-    return lpInsertIntegerUsable(lp, lval, p, where, newp, NULL);
+    uint64_t enclen; /* The length of the encoded element. */
+    unsigned char intenc[LP_MAX_INT_ENCODING_LEN];
+
+    lpEncodeIntegerGetType(lval, intenc, &enclen);
+    return lpInsert(lp, NULL, intenc, enclen, p, where, newp);
 }
 
 /* Append the specified element 's' of length 'slen' at the head of the listpack. */
 unsigned char *lpPrepend(unsigned char *lp, unsigned char *s, uint32_t slen) {
-    return lpPrependUsable(lp,s,slen,NULL);
-}
-
-unsigned char *lpPrependUsable(unsigned char *lp, unsigned char *s, uint32_t slen,
-                               UsableSizes *usable)
-{
     unsigned char *p = lpFirst(lp);
-    if (!p) return lpAppendUsable(lp, s, slen, usable);
-    return lpInsert(lp, s, NULL, slen, p, LP_BEFORE, NULL, usable);
+    if (!p) return lpAppend(lp, s, slen);
+    return lpInsert(lp, s, NULL, slen, p, LP_BEFORE, NULL);
 }
 
 /* Append the specified integer element 'lval' at the head of the listpack. */
@@ -1301,27 +1260,16 @@ unsigned char *lpPrependInteger(unsigned char *lp, long long lval) {
  * listpack. It is implemented in terms of lpInsert(), so the return value is
  * the same as lpInsert(). */
 unsigned char *lpAppend(unsigned char *lp, unsigned char *ele, uint32_t size) {
-    return lpAppendUsable(lp, ele, size, NULL);
-}
-
-unsigned char *lpAppendUsable(unsigned char *lp, unsigned char *ele, uint32_t size,
-                              UsableSizes *usable)
-{
     uint64_t listpack_bytes = lpGetTotalBytes(lp);
     unsigned char *eofptr = lp + listpack_bytes - 1;
-    return lpInsert(lp,ele,NULL,size,eofptr,LP_BEFORE,NULL,usable);
-}
-
-unsigned char *lpAppendIntegerUsable(unsigned char *lp, long long lval,
-                                     UsableSizes *usable) {
-    uint64_t listpack_bytes = lpGetTotalBytes(lp);
-    unsigned char *eofptr = lp + listpack_bytes - 1;
-    return lpInsertIntegerUsable(lp, lval, eofptr, LP_BEFORE, NULL, usable);
+    return lpInsert(lp,ele,NULL,size,eofptr,LP_BEFORE,NULL);
 }
 
 /* Append the specified integer element 'lval' at the end of the listpack. */
 unsigned char *lpAppendInteger(unsigned char *lp, long long lval) {
-    return lpAppendIntegerUsable(lp, lval, NULL);
+    uint64_t listpack_bytes = lpGetTotalBytes(lp);
+    unsigned char *eofptr = lp + listpack_bytes - 1;
+    return lpInsertInteger(lp, lval, eofptr, LP_BEFORE, NULL);
 }
 
 /* Append batch of entries to the listpack.
@@ -1342,12 +1290,7 @@ unsigned char *lpBatchAppend(unsigned char *lp, listpackEntry *entries, unsigned
  * the current element. The function returns the new listpack as return
  * value, and also updates the current cursor by updating '*p'. */
 unsigned char *lpReplace(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen) {
-    return lpReplaceUsable(lp, p, s, slen, NULL);
-}
-
-unsigned char *lpReplaceUsable(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen,
-                               UsableSizes *usable) {
-    return lpInsert(lp, s, NULL, slen, *p, LP_REPLACE, p, usable);
+    return lpInsert(lp, s, NULL, slen, *p, LP_REPLACE, p);
 }
 
 /* This is just a wrapper for lpInsertInteger() to directly use a 64 bit integer
@@ -1355,12 +1298,7 @@ unsigned char *lpReplaceUsable(unsigned char *lp, unsigned char **p, unsigned ch
  * the new listpack as return value, and also updates the current cursor
  * by updating '*p'. */
 unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long lval) {
-    return lpReplaceIntegerUsable(lp, p, lval, NULL);
-}
-
-unsigned char *lpReplaceIntegerUsable(unsigned char *lp, unsigned char **p, long long lval,
-                                      UsableSizes *usable) {
-    return lpInsertIntegerUsable(lp, lval, *p, LP_REPLACE, p, usable);
+    return lpInsertInteger(lp, lval, *p, LP_REPLACE, p);
 }
 
 /* Remove the element pointed by 'p', and return the resulting listpack.
@@ -1368,21 +1306,11 @@ unsigned char *lpReplaceIntegerUsable(unsigned char *lp, unsigned char **p, long
  * deleted one) is returned by reference. If the deleted element was the
  * last one, '*newp' is set to NULL. */
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp) {
-    return lpDeleteUsable(lp,p,newp,NULL);
-}
-
-unsigned char *lpDeleteUsable(unsigned char *lp, unsigned char *p, unsigned char **newp,
-                              UsableSizes *usable) {
-    return lpInsert(lp,NULL,NULL,0,p,LP_REPLACE,newp,usable);
+    return lpInsert(lp,NULL,NULL,0,p,LP_REPLACE,newp);
 }
 
 /* Delete a range of entries from the listpack start with the element pointed by 'p'. */
 unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsigned long num) {
-    return lpDeleteRangeWithEntryUsable(lp, p, num, NULL);
-}
-
-unsigned char *lpDeleteRangeWithEntryUsable(unsigned char *lp, unsigned char **p, unsigned long num,
-                                            UsableSizes *usable) {
     size_t bytes = lpBytes(lp);
     unsigned long deleted = 0;
     unsigned char *eofptr = lp + bytes - 1;
@@ -1411,7 +1339,7 @@ unsigned char *lpDeleteRangeWithEntryUsable(unsigned char *lp, unsigned char **p
     uint32_t numele = lpGetNumElements(lp);
     if (numele != LP_HDR_NUMELE_UNKNOWN)
         lpSetNumElements(lp, numele-deleted);
-    lp = lpShrinkToFitUsable(lp, usable);
+    lp = lpShrinkToFit(lp);
 
     /* Store the entry. */
     *p = lp+poff;
@@ -1422,11 +1350,6 @@ unsigned char *lpDeleteRangeWithEntryUsable(unsigned char *lp, unsigned char **p
 
 /* Delete a range of entries from the listpack. */
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num) {
-    return lpDeleteRangeUsable(lp, index, num, NULL);
-}
-
-unsigned char *lpDeleteRangeUsable(unsigned char *lp, long index, unsigned long num,
-                                   UsableSizes *usable) {
     unsigned char *p;
     uint32_t numele = lpGetNumElements(lp);
 
@@ -1445,9 +1368,9 @@ unsigned char *lpDeleteRangeUsable(unsigned char *lp, long index, unsigned long 
         p[0] = LP_EOF;
         lpSetTotalBytes(lp, p - lp + 1);
         lpSetNumElements(lp, index);
-        lp = lpShrinkToFitUsable(lp, usable);
+        lp = lpShrinkToFit(lp);
     } else {
-        lp = lpDeleteRangeWithEntryUsable(lp, &p, num, usable);
+        lp = lpDeleteRangeWithEntry(lp, &p, num);
     }
 
     return lp;
@@ -1518,11 +1441,6 @@ unsigned char *lpBatchDelete(unsigned char *lp, unsigned char **ps, unsigned lon
  * 'first' or 'second', also frees the other unused input listpack, and sets the
  * input listpack argument equal to newly reallocated listpack return value. */
 unsigned char *lpMerge(unsigned char **first, unsigned char **second) {
-    return lpMergeUsable(first, second, NULL);
-}
-
-unsigned char *lpMergeUsable(unsigned char **first, unsigned char **second,
-                             UsableSizes *usable) {
     /* If any params are null, we can't merge, so NULL. */
     if (first == NULL || *first == NULL || second == NULL || *second == NULL)
         return NULL;
@@ -1568,8 +1486,7 @@ unsigned char *lpMergeUsable(unsigned char **first, unsigned char **second,
     lplength = lplength < UINT16_MAX ? lplength : UINT16_MAX;
 
     /* Extend target to new lpbytes then append or prepend source. */
-    size_t newsize, oldsize, oldsize2;
-    target = lp_realloc_usable(target, lpbytes, &newsize, &oldsize);
+    target = lp_realloc(target, lpbytes);
     if (append) {
         /* append == appending to target */
         /* Copy source after target (copying over original [END]):
@@ -1593,18 +1510,13 @@ unsigned char *lpMergeUsable(unsigned char **first, unsigned char **second,
 
     /* Now free and NULL out what we didn't realloc */
     if (append) {
-        lp_free_usable(*second, &oldsize2);
+        lp_free(*second);
         *second = NULL;
         *first = target;
     } else {
-        lp_free_usable(*first, &oldsize2);
+        lp_free(*first);
         *first = NULL;
         *second = target;
-    }
-
-    if (usable) {
-        usable->newsize = newsize;
-        usable->oldsize = oldsize + oldsize2;
     }
 
     return target;

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -237,11 +237,6 @@ void lpFree(unsigned char *lp) {
     lp_free(lp);
 }
 
-/* Generic version of lpFree. */
-void lpFreeGeneric(void *lp) {
-    lp_free((unsigned char *)lp);
-}
-
 /* Shrink the memory to fit. */
 unsigned char* lpShrinkToFit(unsigned char *lp) {
     return lpShrinkToFitUsable(lp, NULL);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -38,24 +38,49 @@ unsigned char *lpNew(size_t capacity);
 void lpFree(unsigned char *lp);
 void lpFreeGeneric(void *lp);
 unsigned char* lpShrinkToFit(unsigned char *lp);
+unsigned char* lpShrinkToFitUsable(unsigned char *lp, size_t *usable, size_t *old_usable);
 unsigned char *lpInsertString(unsigned char *lp, unsigned char *s, uint32_t slen,
                               unsigned char *p, int where, unsigned char **newp);
 unsigned char *lpInsertInteger(unsigned char *lp, long long lval,
                                unsigned char *p, int where, unsigned char **newp);
+unsigned char *lpInsertStringUsable(unsigned char *lp, unsigned char *s, uint32_t slen,
+                                    unsigned char *p, int where, unsigned char **newp,
+                                    size_t *usable, size_t *old_usable);
+unsigned char *lpInsertIntegerUsable(unsigned char *lp, long long lval,
+                                     unsigned char *p, int where, unsigned char **newp,
+                                     size_t *usable, size_t *old_usable);
 unsigned char *lpPrepend(unsigned char *lp, unsigned char *s, uint32_t slen);
 unsigned char *lpPrependInteger(unsigned char *lp, long long lval);
+unsigned char *lpPrependUsable(unsigned char *lp, unsigned char *s, uint32_t slen,
+                               size_t *usable, size_t *old_usable);
 unsigned char *lpAppend(unsigned char *lp, unsigned char *s, uint32_t slen);
 unsigned char *lpAppendInteger(unsigned char *lp, long long lval);
+unsigned char *lpAppendUsable(unsigned char *lp, unsigned char *ele, uint32_t size,
+                              size_t *usable, size_t *old_usable);
+unsigned char *lpAppendIntegerUsable(unsigned char *lp, long long lval,
+                                     size_t *usable, size_t *old_usable);
 unsigned char *lpReplace(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen);
 unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long lval);
+unsigned char *lpReplaceUsable(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen,
+                               size_t *usable, size_t *old_usable);
+unsigned char *lpReplaceIntegerUsable(unsigned char *lp, unsigned char **p, long long lval,
+                                      size_t *usable, size_t *old_usable);
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp);
+unsigned char *lpDeleteUsable(unsigned char *lp, unsigned char *p, unsigned char **newp,
+                              size_t *usable, size_t *old_usable);
 unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsigned long num);
+unsigned char *lpDeleteRangeWithEntryUsable(unsigned char *lp, unsigned char **p, unsigned long num,
+                                            size_t *usable, size_t *old_usable);
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num);
+unsigned char *lpDeleteRangeUsable(unsigned char *lp, long index, unsigned long num,
+                                   size_t *usable, size_t *old_usable);
 unsigned char *lpBatchAppend(unsigned char *lp, listpackEntry *entries, unsigned long len);
 unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
                              listpackEntry *entries, unsigned int len, unsigned char **newp);
 unsigned char *lpBatchDelete(unsigned char *lp, unsigned char **ps, unsigned long count);
 unsigned char *lpMerge(unsigned char **first, unsigned char **second);
+unsigned char *lpMergeUsable(unsigned char **first, unsigned char **second,
+                             size_t *usable, size_t *old_usable);
 unsigned char *lpDup(unsigned char *lp);
 unsigned long lpLength(unsigned char *lp);
 unsigned char *lpGet(unsigned char *p, int64_t *count, unsigned char *intbuf);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -36,6 +36,7 @@ typedef struct {
 
 unsigned char *lpNew(size_t capacity);
 void lpFree(unsigned char *lp);
+void lpFreeUsable(unsigned char *lp, size_t *usable);
 void lpFreeGeneric(void *lp);
 unsigned char* lpShrinkToFit(unsigned char *lp);
 unsigned char* lpShrinkToFitUsable(unsigned char *lp, size_t *usable, size_t *old_usable);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -42,7 +42,6 @@ typedef struct UsableSizes {
 unsigned char *lpNew(size_t capacity);
 void lpFree(unsigned char *lp);
 void lpFreeUsable(unsigned char *lp, size_t *usable);
-void lpFreeGeneric(void *lp);
 unsigned char* lpShrinkToFit(unsigned char *lp);
 unsigned char* lpShrinkToFitUsable(unsigned char *lp, UsableSizes *usable);
 unsigned char *lpInsertString(unsigned char *lp, unsigned char *s, uint32_t slen,

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -34,58 +34,27 @@ typedef struct {
     long long lval;
 } listpackEntry;
 
-typedef struct UsableSizes {
-    size_t newsize;
-    size_t oldsize;
-} UsableSizes;
-
 unsigned char *lpNew(size_t capacity);
 void lpFree(unsigned char *lp);
-void lpFreeUsable(unsigned char *lp, size_t *usable);
 unsigned char* lpShrinkToFit(unsigned char *lp);
-unsigned char* lpShrinkToFitUsable(unsigned char *lp, UsableSizes *usable);
 unsigned char *lpInsertString(unsigned char *lp, unsigned char *s, uint32_t slen,
                               unsigned char *p, int where, unsigned char **newp);
 unsigned char *lpInsertInteger(unsigned char *lp, long long lval,
                                unsigned char *p, int where, unsigned char **newp);
-unsigned char *lpInsertStringUsable(unsigned char *lp, unsigned char *s, uint32_t slen,
-                                    unsigned char *p, int where, unsigned char **newp,
-                                    UsableSizes *usable);
-unsigned char *lpInsertIntegerUsable(unsigned char *lp, long long lval,
-                                     unsigned char *p, int where, unsigned char **newp,
-                                     UsableSizes *usable);
 unsigned char *lpPrepend(unsigned char *lp, unsigned char *s, uint32_t slen);
 unsigned char *lpPrependInteger(unsigned char *lp, long long lval);
-unsigned char *lpPrependUsable(unsigned char *lp, unsigned char *s, uint32_t slen,
-                               UsableSizes *usable);
 unsigned char *lpAppend(unsigned char *lp, unsigned char *s, uint32_t slen);
 unsigned char *lpAppendInteger(unsigned char *lp, long long lval);
-unsigned char *lpAppendUsable(unsigned char *lp, unsigned char *ele, uint32_t size,
-                              UsableSizes *usable);
-unsigned char *lpAppendIntegerUsable(unsigned char *lp, long long lval,
-                                     UsableSizes *usable);
 unsigned char *lpReplace(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen);
 unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long lval);
-unsigned char *lpReplaceUsable(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen,
-                               UsableSizes *usable);
-unsigned char *lpReplaceIntegerUsable(unsigned char *lp, unsigned char **p, long long lval,
-                                      UsableSizes *usable);
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp);
-unsigned char *lpDeleteUsable(unsigned char *lp, unsigned char *p, unsigned char **newp,
-                              UsableSizes *usable);
 unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsigned long num);
-unsigned char *lpDeleteRangeWithEntryUsable(unsigned char *lp, unsigned char **p, unsigned long num,
-                                            UsableSizes *usable);
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num);
-unsigned char *lpDeleteRangeUsable(unsigned char *lp, long index, unsigned long num,
-                                   UsableSizes *usable);
 unsigned char *lpBatchAppend(unsigned char *lp, listpackEntry *entries, unsigned long len);
 unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
                              listpackEntry *entries, unsigned int len, unsigned char **newp);
 unsigned char *lpBatchDelete(unsigned char *lp, unsigned char **ps, unsigned long count);
 unsigned char *lpMerge(unsigned char **first, unsigned char **second);
-unsigned char *lpMergeUsable(unsigned char **first, unsigned char **second,
-                             UsableSizes *usable);
 unsigned char *lpDup(unsigned char *lp);
 unsigned long lpLength(unsigned char *lp);
 unsigned char *lpGet(unsigned char *p, int64_t *count, unsigned char *intbuf);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -34,54 +34,59 @@ typedef struct {
     long long lval;
 } listpackEntry;
 
+typedef struct UsableSizes {
+    size_t val;
+    size_t oldval;
+} UsableSizes;
+
 unsigned char *lpNew(size_t capacity);
 void lpFree(unsigned char *lp);
 void lpFreeUsable(unsigned char *lp, size_t *usable);
 void lpFreeGeneric(void *lp);
 unsigned char* lpShrinkToFit(unsigned char *lp);
-unsigned char* lpShrinkToFitUsable(unsigned char *lp, size_t *usable, size_t *old_usable);
+unsigned char* lpShrinkToFitUsable(unsigned char *lp, UsableSizes *usable);
 unsigned char *lpInsertString(unsigned char *lp, unsigned char *s, uint32_t slen,
                               unsigned char *p, int where, unsigned char **newp);
 unsigned char *lpInsertInteger(unsigned char *lp, long long lval,
                                unsigned char *p, int where, unsigned char **newp);
 unsigned char *lpInsertStringUsable(unsigned char *lp, unsigned char *s, uint32_t slen,
                                     unsigned char *p, int where, unsigned char **newp,
-                                    size_t *usable, size_t *old_usable);
+                                    UsableSizes *usable);
 unsigned char *lpInsertIntegerUsable(unsigned char *lp, long long lval,
                                      unsigned char *p, int where, unsigned char **newp,
-                                     size_t *usable, size_t *old_usable);
+                                     UsableSizes *usable);
 unsigned char *lpPrepend(unsigned char *lp, unsigned char *s, uint32_t slen);
 unsigned char *lpPrependInteger(unsigned char *lp, long long lval);
 unsigned char *lpPrependUsable(unsigned char *lp, unsigned char *s, uint32_t slen,
-                               size_t *usable, size_t *old_usable);
+                               UsableSizes *usable);
 unsigned char *lpAppend(unsigned char *lp, unsigned char *s, uint32_t slen);
 unsigned char *lpAppendInteger(unsigned char *lp, long long lval);
 unsigned char *lpAppendUsable(unsigned char *lp, unsigned char *ele, uint32_t size,
-                              size_t *usable, size_t *old_usable);
+                              UsableSizes *usable);
 unsigned char *lpAppendIntegerUsable(unsigned char *lp, long long lval,
-                                     size_t *usable, size_t *old_usable);
+                                     UsableSizes *usable);
 unsigned char *lpReplace(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen);
 unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long lval);
 unsigned char *lpReplaceUsable(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen,
-                               size_t *usable, size_t *old_usable);
+                               UsableSizes *usable);
 unsigned char *lpReplaceIntegerUsable(unsigned char *lp, unsigned char **p, long long lval,
-                                      size_t *usable, size_t *old_usable);
+                                      UsableSizes *usable);
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp);
 unsigned char *lpDeleteUsable(unsigned char *lp, unsigned char *p, unsigned char **newp,
-                              size_t *usable, size_t *old_usable);
+                              UsableSizes *usable);
 unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsigned long num);
 unsigned char *lpDeleteRangeWithEntryUsable(unsigned char *lp, unsigned char **p, unsigned long num,
-                                            size_t *usable, size_t *old_usable);
+                                            UsableSizes *usable);
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num);
 unsigned char *lpDeleteRangeUsable(unsigned char *lp, long index, unsigned long num,
-                                   size_t *usable, size_t *old_usable);
+                                   UsableSizes *usable);
 unsigned char *lpBatchAppend(unsigned char *lp, listpackEntry *entries, unsigned long len);
 unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
                              listpackEntry *entries, unsigned int len, unsigned char **newp);
 unsigned char *lpBatchDelete(unsigned char *lp, unsigned char **ps, unsigned long count);
 unsigned char *lpMerge(unsigned char **first, unsigned char **second);
 unsigned char *lpMergeUsable(unsigned char **first, unsigned char **second,
-                             size_t *usable, size_t *old_usable);
+                             UsableSizes *usable);
 unsigned char *lpDup(unsigned char *lp);
 unsigned long lpLength(unsigned char *lp);
 unsigned char *lpGet(unsigned char *p, int64_t *count, unsigned char *intbuf);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -35,8 +35,8 @@ typedef struct {
 } listpackEntry;
 
 typedef struct UsableSizes {
-    size_t val;
-    size_t oldval;
+    size_t newsize;
+    size_t oldsize;
 } UsableSizes;
 
 unsigned char *lpNew(size_t capacity);

--- a/src/listpack_malloc.h
+++ b/src/listpack_malloc.h
@@ -23,7 +23,7 @@
  * to ensure the safe invocation of 'zmalloc_usable_size().
  * See comment in zmalloc_usable_size(). */
 #define lp_malloc(sz) zmalloc_usable(sz,NULL)
-#define lp_realloc(ptr,sz) zrealloc_usable(ptr,sz,NULL)
+#define lp_realloc(ptr,sz) zrealloc_usable(ptr,sz,NULL,NULL)
 #define lp_free zfree
 #define lp_malloc_size zmalloc_usable_size
 #endif

--- a/src/listpack_malloc.h
+++ b/src/listpack_malloc.h
@@ -26,5 +26,6 @@
 #define lp_realloc(ptr,sz) zrealloc_usable(ptr,sz,NULL,NULL)
 #define lp_realloc_usable(ptr,sz,usable,old_usable) zrealloc_usable(ptr,sz,usable,old_usable)
 #define lp_free zfree
+#define lp_free_usable zfree_usable
 #define lp_malloc_size zmalloc_usable_size
 #endif

--- a/src/listpack_malloc.h
+++ b/src/listpack_malloc.h
@@ -24,6 +24,7 @@
  * See comment in zmalloc_usable_size(). */
 #define lp_malloc(sz) zmalloc_usable(sz,NULL)
 #define lp_realloc(ptr,sz) zrealloc_usable(ptr,sz,NULL,NULL)
+#define lp_realloc_usable(ptr,sz,usable,old_usable) zrealloc_usable(ptr,sz,usable,old_usable)
 #define lp_free zfree
 #define lp_malloc_size zmalloc_usable_size
 #endif

--- a/src/listpack_malloc.h
+++ b/src/listpack_malloc.h
@@ -24,8 +24,6 @@
  * See comment in zmalloc_usable_size(). */
 #define lp_malloc(sz) zmalloc_usable(sz,NULL)
 #define lp_realloc(ptr,sz) zrealloc_usable(ptr,sz,NULL,NULL)
-#define lp_realloc_usable(ptr,sz,usable,old_usable) zrealloc_usable(ptr,sz,usable,old_usable)
 #define lp_free zfree
-#define lp_free_usable zfree_usable
 #define lp_malloc_size zmalloc_usable_size
 #endif

--- a/src/module.c
+++ b/src/module.c
@@ -557,13 +557,13 @@ void *RM_TryCalloc(size_t nmemb, size_t size) {
 
 /* Use like realloc() for memory obtained with RedisModule_Alloc(). */
 void* RM_Realloc(void *ptr, size_t bytes) {
-    return zrealloc_usable(ptr,bytes,NULL);
+    return zrealloc_usable(ptr,bytes,NULL,NULL);
 }
 
 /* Similar to RM_Realloc, but returns NULL in case of allocation failure,
  * instead of panicking. */
 void *RM_TryRealloc(void *ptr, size_t bytes) {
-    return ztryrealloc_usable(ptr,bytes,NULL);
+    return ztryrealloc_usable(ptr,bytes,NULL,NULL);
 }
 
 /* Use like free() for memory obtained by RedisModule_Alloc() and

--- a/src/mstr.h
+++ b/src/mstr.h
@@ -188,15 +188,15 @@ struct __attribute__ ((__packed__)) mstrhdr64 {
     int metaSize[NUM_MSTR_FLAGS];
 } mstrKind;
 
-mstr mstrNew(const char *initStr, size_t lenStr, int trymalloc);
+mstr mstrNew(const char *initStr, size_t lenStr, int trymalloc, size_t *usable);
 
-mstr mstrNewWithMeta(struct mstrKind *kind, const char *initStr, size_t lenStr, mstrFlags flags, int trymalloc);
+mstr mstrNewWithMeta(struct mstrKind *kind, const char *initStr, size_t lenStr, mstrFlags flags, int trymalloc, size_t *usable);
 
-mstr mstrNewCopy(struct mstrKind *kind, mstr src, mstrFlags newFlags);
+mstr mstrNewCopy(struct mstrKind *kind, mstr src, mstrFlags newFlags, size_t *usable);
 
 void *mstrGetAllocPtr(struct mstrKind *kind, mstr str);
 
-void mstrFree(struct mstrKind *kind, mstr s);
+void mstrFree(struct mstrKind *kind, mstr s, size_t *usable);
 
 mstrFlags *mstrFlagsRef(mstr s);
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -732,7 +732,7 @@ void trimReplyUnusedTailSpace(client *c) {
     {
         size_t usable_size;
         size_t old_size = tail->size;
-        tail = zrealloc_usable(tail, tail->used + sizeof(clientReplyBlock), &usable_size);
+        tail = zrealloc_usable(tail, tail->used + sizeof(clientReplyBlock), &usable_size, NULL);
         /* take over the allocation's internal fragmentation (at least for
          * memory usage tracking) */
         tail->size = usable_size - sizeof(clientReplyBlock);

--- a/src/object.c
+++ b/src/object.c
@@ -1209,8 +1209,6 @@ size_t streamRadixTreeMemoryUsage(rax *rax) {
 #define OBJ_COMPUTE_SIZE_DEF_SAMPLES 5 /* Default sample size. */
 size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
     dict *d;
-    dictIterator di;
-    struct dictEntry *de;
     size_t elesize = 0, elecount = 0, samples = 0;
     
     /* All kv-objects has at least kvobj header and embedded key */
@@ -1245,15 +1243,8 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
     } else if (o->type == OBJ_SET) {
         if (o->encoding == OBJ_ENCODING_HT) {
             d = o->ptr;
-            dictInitIterator(&di, d);
-            asize += sizeof(dict) + (sizeof(struct dictEntry*) * dictBuckets(d));
-            while((de = dictNext(&di)) != NULL && samples < sample_size) {
-                sds ele = dictGetKey(de);
-                elesize += dictEntryMemUsage(0) + sdsZmallocSize(ele);
-                samples++;
-            }
-            dictResetIterator(&di);
-            if (samples) asize += (double)elesize/samples*dictSize(d);
+            size_t *alloc_size = (size_t *)dictMetadata(d);
+            asize += sizeof(dict) + dictMemUsage(d) + *alloc_size;
         } else if (o->encoding == OBJ_ENCODING_INTSET) {
             asize += zmalloc_size(o->ptr);
         } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
@@ -1280,17 +1271,8 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
             asize += zmalloc_size(lpt) + zmalloc_size(lpt->lp);
         } else if (o->encoding == OBJ_ENCODING_HT) {
             d = o->ptr;
-            dictInitIterator(&di, d);
-            asize += sizeof(dict) + (sizeof(struct dictEntry*) * dictBuckets(d));
-            while((de = dictNext(&di)) != NULL && samples < sample_size) {
-                hfield ele = dictGetKey(de);
-                sds ele2 = dictGetVal(de);
-                elesize += hfieldZmallocSize(ele) + sdsZmallocSize(ele2);
-                elesize += dictEntryMemUsage(0);
-                samples++;
-            }
-            dictResetIterator(&di);
-            if (samples) asize += (double)elesize/samples*dictSize(d);
+            size_t *alloc_size = (size_t *)dictMetadata(d);
+            asize += sizeof(dict) + dictMemUsage(d) + *alloc_size;
         } else {
             serverPanic("Unknown hash encoding");
         }

--- a/src/object.c
+++ b/src/object.c
@@ -1209,7 +1209,6 @@ size_t streamRadixTreeMemoryUsage(rax *rax) {
 #define OBJ_COMPUTE_SIZE_DEF_SAMPLES 5 /* Default sample size. */
 size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
     dict *d;
-    size_t elesize = 0, elecount = 0, samples = 0;
     
     /* All kv-objects has at least kvobj header and embedded key */
     size_t asize = zmalloc_size((void *)o);
@@ -1226,15 +1225,7 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
         }
     } else if (o->type == OBJ_LIST) {
         if (o->encoding == OBJ_ENCODING_QUICKLIST) {
-            quicklist *ql = o->ptr;
-            quicklistNode *node = ql->head;
-            asize += sizeof(quicklist);
-            do {
-                elesize += sizeof(quicklistNode)+zmalloc_size(node->entry);
-                elecount += node->count;
-                samples++;
-            } while ((node = node->next) && samples < sample_size);
-            asize += (double)elesize/elecount*ql->count;
+            asize += quicklistAllocSize(o->ptr);
         } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
             asize += zmalloc_size(o->ptr);
         } else {

--- a/src/object.c
+++ b/src/object.c
@@ -1267,17 +1267,8 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
         } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
             d = ((zset*)o->ptr)->dict;
             zskiplist *zsl = ((zset*)o->ptr)->zsl;
-            zskiplistNode *znode = zsl->header->level[0].forward;
-            asize += sizeof(zset) + sizeof(zskiplist) + sizeof(dict) +
-                    (sizeof(struct dictEntry*)*dictBuckets(d))+
-                    zmalloc_size(zsl->header);
-            while(znode != NULL && samples < sample_size) {
-                elesize += sdsZmallocSize(znode->ele);
-                elesize += dictEntryMemUsage(1)+zmalloc_size(znode);
-                samples++;
-                znode = znode->level[0].forward;
-            }
-            if (samples) asize += (double)elesize/samples*dictSize(d);
+            asize += sizeof(zset) + zslAllocSize(zsl) +
+                sizeof(dict) + dictMemUsage(d);
         } else {
             serverPanic("Unknown sorted set encoding");
         }

--- a/src/object.c
+++ b/src/object.c
@@ -1178,30 +1178,6 @@ char *strEncoding(int encoding) {
 
 /* =========================== Memory introspection ========================= */
 
-
-/* This is a helper function with the goal of estimating the memory
- * size of a radix tree that is used to store Stream IDs.
- *
- * Note: to guess the size of the radix tree is not trivial, so we
- * approximate it considering 16 bytes of data overhead for each
- * key (the ID), and then adding the number of bare nodes, plus some
- * overhead due by the data and child pointers. This secret recipe
- * was obtained by checking the average radix tree created by real
- * workloads, and then adjusting the constants to get numbers that
- * more or less match the real memory usage.
- *
- * Actually the number of nodes and keys may be different depending
- * on the insertion speed and thus the ability of the radix tree
- * to compress prefixes. */
-size_t streamRadixTreeMemoryUsage(rax *rax) {
-    size_t size = sizeof(*rax);
-    size = rax->numele * sizeof(streamID);
-    size += rax->numnodes * sizeof(raxNode);
-    /* Add a fixed overhead due to the aux data pointer, children, ... */
-    size += rax->numnodes * sizeof(long)*30;
-    return size;
-}
-
 /* Returns the size in bytes consumed by the object header, key and value in RAM.
  * Note that the returned value is just an approximation, especially in the
  * case of aggregated data types where only "sample_size" elements
@@ -1269,67 +1245,7 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
         }
     } else if (o->type == OBJ_STREAM) {
         stream *s = o->ptr;
-        asize += sizeof(*s);
-        asize += streamRadixTreeMemoryUsage(s->rax);
-
-        /* Now we have to add the listpacks. The last listpack is often non
-         * complete, so we estimate the size of the first N listpacks, and
-         * use the average to compute the size of the first N-1 listpacks, and
-         * finally add the real size of the last node. */
-        raxIterator ri;
-        raxStart(&ri,s->rax);
-        raxSeek(&ri,"^",NULL,0);
-        size_t lpsize = 0, samples = 0;
-        while(samples < sample_size && raxNext(&ri)) {
-            unsigned char *lp = ri.data;
-            /* Use the allocated size, since we overprovision the node initially. */
-            lpsize += zmalloc_size(lp);
-            samples++;
-        }
-        if (s->rax->numele <= samples) {
-            asize += lpsize;
-        } else {
-            if (samples) lpsize /= samples; /* Compute the average. */
-            asize += lpsize * (s->rax->numele-1);
-            /* No need to check if seek succeeded, we enter this branch only
-             * if there are a few elements in the radix tree. */
-            raxSeek(&ri,"$",NULL,0);
-            raxNext(&ri);
-            /* Use the allocated size, since we overprovision the node initially. */
-            asize += zmalloc_size(ri.data);
-        }
-        raxStop(&ri);
-
-        /* Consumer groups also have a non trivial memory overhead if there
-         * are many consumers and many groups, let's count at least the
-         * overhead of the pending entries in the groups and consumers
-         * PELs. */
-        if (s->cgroups) {
-            raxStart(&ri,s->cgroups);
-            raxSeek(&ri,"^",NULL,0);
-            while(raxNext(&ri)) {
-                streamCG *cg = ri.data;
-                asize += sizeof(*cg);
-                asize += streamRadixTreeMemoryUsage(cg->pel);
-                asize += sizeof(streamNACK)*raxSize(cg->pel);
-
-                /* For each consumer we also need to add the basic data
-                 * structures and the PEL memory usage. */
-                raxIterator cri;
-                raxStart(&cri,cg->consumers);
-                raxSeek(&cri,"^",NULL,0);
-                while(raxNext(&cri)) {
-                    streamConsumer *consumer = cri.data;
-                    asize += sizeof(*consumer);
-                    asize += sdslen(consumer->name);
-                    asize += streamRadixTreeMemoryUsage(consumer->pel);
-                    /* Don't count NACKs again, they are shared with the
-                     * consumer group PEL. */
-                }
-                raxStop(&cri);
-            }
-            raxStop(&ri);
-        }
+        asize += s->alloc_size;
     } else if (o->type == OBJ_MODULE) {
         asize += moduleGetMemUsage(key, o, sample_size, dbid);
     } else {

--- a/src/object.c
+++ b/src/object.c
@@ -533,9 +533,8 @@ void freeSetObject(robj *o) {
     switch (o->encoding) {
     case OBJ_ENCODING_HT:
 #ifdef REDIS_TEST
-        dictEmpty((dict *) o->ptr, NULL);
-        size_t *alloc_size = (size_t *)dictMetadata((dict *) o->ptr);
-        serverAssert(*alloc_size == 0);
+        dictEmpty(o->ptr, NULL);
+        serverAssert(*getMetadataSize(o->ptr) == 0);
 #endif
         dictRelease((dict*) o->ptr);
         break;
@@ -1215,8 +1214,8 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
     } else if (o->type == OBJ_SET) {
         if (o->encoding == OBJ_ENCODING_HT) {
             d = o->ptr;
-            size_t *alloc_size = (size_t *)dictMetadata(d);
-            asize += sizeof(dict) + dictMemUsage(d) + *alloc_size;
+            asize += sizeof(dict) + dictMemUsage(d) +
+                *getMetadataSize(d);
         } else if (o->encoding == OBJ_ENCODING_INTSET) {
             asize += zmalloc_size(o->ptr);
         } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
@@ -1243,8 +1242,8 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
             asize += zmalloc_size(lpt) + zmalloc_size(lpt->lp);
         } else if (o->encoding == OBJ_ENCODING_HT) {
             d = o->ptr;
-            size_t *alloc_size = (size_t *)dictMetadata(d);
-            asize += sizeof(dict) + dictMemUsage(d) + *alloc_size;
+            asize += sizeof(dict) + dictMemUsage(d) +
+                *getMetadataSize(d);
         } else {
             serverPanic("Unknown hash encoding");
         }

--- a/src/object.c
+++ b/src/object.c
@@ -14,7 +14,6 @@
 #include "server.h"
 #include "functions.h"
 #include "intset.h"  /* Compact integer set structure */
-#include "redisassert.h"
 #include <math.h>
 #include <ctype.h>
 
@@ -536,8 +535,7 @@ void freeSetObject(robj *o) {
 #ifdef REDIS_TEST
         dictEmpty((dict *) o->ptr, NULL);
         size_t *alloc_size = (size_t *)dictMetadata((dict *) o->ptr);
-        UNUSED(alloc_size);
-        debugAssert(*alloc_size == 0);
+        serverAssert(*alloc_size == 0);
 #endif
         dictRelease((dict*) o->ptr);
         break;

--- a/src/object.c
+++ b/src/object.c
@@ -534,7 +534,7 @@ void freeSetObject(robj *o) {
     case OBJ_ENCODING_HT:
 #ifdef REDIS_TEST
         dictEmpty(o->ptr, NULL);
-        serverAssert(*getMetadataSize(o->ptr) == 0);
+        serverAssert(*htGetMetadataSize(o->ptr) == 0);
 #endif
         dictRelease((dict*) o->ptr);
         break;
@@ -1215,7 +1215,7 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
         if (o->encoding == OBJ_ENCODING_HT) {
             d = o->ptr;
             asize += sizeof(dict) + dictMemUsage(d) +
-                *getMetadataSize(d);
+                *htGetMetadataSize(d);
         } else if (o->encoding == OBJ_ENCODING_INTSET) {
             asize += zmalloc_size(o->ptr);
         } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
@@ -1243,7 +1243,7 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
         } else if (o->encoding == OBJ_ENCODING_HT) {
             d = o->ptr;
             asize += sizeof(dict) + dictMemUsage(d) +
-                *getMetadataSize(d);
+                *htGetMetadataSize(d);
         } else {
             serverPanic("Unknown hash encoding");
         }

--- a/src/object.c
+++ b/src/object.c
@@ -536,6 +536,7 @@ void freeSetObject(robj *o) {
 #ifdef REDIS_TEST
         dictEmpty((dict *) o->ptr, NULL);
         size_t *alloc_size = (size_t *)dictMetadata((dict *) o->ptr);
+        UNUSED(alloc_size);
         debugAssert(*alloc_size == 0);
 #endif
         dictRelease((dict*) o->ptr);

--- a/src/object.c
+++ b/src/object.c
@@ -14,6 +14,7 @@
 #include "server.h"
 #include "functions.h"
 #include "intset.h"  /* Compact integer set structure */
+#include "redisassert.h"
 #include <math.h>
 #include <ctype.h>
 
@@ -532,6 +533,11 @@ void freeListObject(robj *o) {
 void freeSetObject(robj *o) {
     switch (o->encoding) {
     case OBJ_ENCODING_HT:
+#ifdef REDIS_TEST
+        dictEmpty((dict *) o->ptr, NULL);
+        size_t *alloc_size = (size_t *)dictMetadata((dict *) o->ptr);
+        debugAssert(*alloc_size == 0);
+#endif
         dictRelease((dict*) o->ptr);
         break;
     case OBJ_ENCODING_INTSET:

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -100,7 +100,8 @@ quicklistBookmark *_quicklistBookmarkFindByName(quicklist *ql, const char *name)
 quicklistBookmark *_quicklistBookmarkFindByNode(quicklist *ql, quicklistNode *node);
 void _quicklistBookmarkDelete(quicklist *ql, quicklistBookmark *bm);
 
-REDIS_STATIC quicklistNode *_quicklistSplitNode(quicklistNode *node, int offset, int after);
+REDIS_STATIC quicklistNode *_quicklistSplitNode(quicklist *quicklist, quicklistNode *node,
+                                                int offset, int after);
 REDIS_STATIC quicklistNode *_quicklistMergeNodes(quicklist *quicklist, quicklistNode *center);
 
 /* Simple way to give quicklistEntry structs default values with one call. */
@@ -122,15 +123,23 @@ REDIS_STATIC quicklistNode *_quicklistMergeNodes(quicklist *quicklist, quicklist
         (iter)->zi = NULL;                                                     \
     } while (0)
 
+#define quicklistUpdateAllocSize(ql, new, old)                                 \
+    do {                                                                       \
+        (ql)->alloc_size += (new);                                             \
+        (ql)->alloc_size -= (old);                                             \
+    } while (0)
+
 /* Create a new quicklist.
  * Free with quicklistRelease(). */
 quicklist *quicklistCreate(void) {
     struct quicklist *quicklist;
+    size_t quicklist_sz;
 
-    quicklist = zmalloc(sizeof(*quicklist));
+    quicklist = zmalloc_usable(sizeof(*quicklist), &quicklist_sz);
     quicklist->head = quicklist->tail = NULL;
     quicklist->len = 0;
     quicklist->count = 0;
+    quicklist->alloc_size = quicklist_sz;
     quicklist->compress = 0;
     quicklist->fill = -2;
     quicklist->bookmark_count = 0;
@@ -169,9 +178,11 @@ quicklist *quicklistNew(int fill, int compress) {
     return quicklist;
 }
 
-REDIS_STATIC quicklistNode *quicklistCreateNode(void) {
+REDIS_STATIC quicklistNode *quicklistCreateNode(quicklist *quicklist) {
+    size_t node_usable;
     quicklistNode *node;
-    node = zmalloc(sizeof(*node));
+    node = zmalloc_usable(sizeof(*node), &node_usable);
+    quicklist->alloc_size += node_usable;
     node->entry = NULL;
     node->count = 0;
     node->sz = 0;
@@ -186,6 +197,9 @@ REDIS_STATIC quicklistNode *quicklistCreateNode(void) {
 /* Return cached quicklist count */
 unsigned long quicklistCount(const quicklist *ql) { return ql->count; }
 
+/* Return cached quicklist total memory used (in bytes) */
+size_t quicklistAllocSize(const quicklist *ql) { return ql->alloc_size; }
+
 /* Free entire quicklist. */
 void quicklistRelease(quicklist *quicklist) {
     unsigned long len;
@@ -197,11 +211,8 @@ void quicklistRelease(quicklist *quicklist) {
         next = current->next;
 
         zfree(current->entry);
-        quicklist->count -= current->count;
-
         zfree(current);
 
-        quicklist->len--;
         current = next;
     }
     quicklistBookmarksClear(quicklist);
@@ -211,7 +222,7 @@ void quicklistRelease(quicklist *quicklist) {
 /* Compress the listpack in 'node' and update encoding details.
  * Returns 1 if listpack compressed successfully.
  * Returns 0 if compression failed or if listpack too small to compress. */
-REDIS_STATIC int __quicklistCompressNode(quicklistNode *node) {
+REDIS_STATIC int __quicklistCompressNode(quicklist *quicklist, quicklistNode *node) {
 #ifdef REDIS_TEST
     node->attempted_compress = 1;
 #endif
@@ -236,55 +247,59 @@ REDIS_STATIC int __quicklistCompressNode(quicklistNode *node) {
         zfree(lzf);
         return 0;
     }
-    lzf = zrealloc(lzf, sizeof(*lzf) + lzf->sz);
-    zfree(node->entry);
+    size_t new_entry_size, old_entry_size;
+    lzf = zrealloc_usable(lzf, sizeof(*lzf) + lzf->sz, &new_entry_size, NULL);
+    zfree_usable(node->entry, &old_entry_size);
     node->entry = (unsigned char *)lzf;
     node->encoding = QUICKLIST_NODE_ENCODING_LZF;
+    quicklistUpdateAllocSize(quicklist, new_entry_size, old_entry_size);
     return 1;
 }
 
 /* Compress only uncompressed nodes. */
-#define quicklistCompressNode(_node)                                           \
+#define quicklistCompressNode(_ql, _node)                                      \
     do {                                                                       \
         if ((_node) && (_node)->encoding == QUICKLIST_NODE_ENCODING_RAW) {     \
-            __quicklistCompressNode((_node));                                  \
+            __quicklistCompressNode((_ql), (_node));                           \
         }                                                                      \
     } while (0)
 
 /* Uncompress the listpack in 'node' and update encoding details.
  * Returns 1 on successful decode, 0 on failure to decode. */
-REDIS_STATIC int __quicklistDecompressNode(quicklistNode *node) {
+REDIS_STATIC int __quicklistDecompressNode(quicklist *quicklist, quicklistNode *node) {
 #ifdef REDIS_TEST
     node->attempted_compress = 0;
 #endif
     node->recompress = 0;
 
-    void *decompressed = zmalloc(node->sz);
+    size_t new_entry_size, old_entry_size;
+    void *decompressed = zmalloc_usable(node->sz, &new_entry_size);
     quicklistLZF *lzf = (quicklistLZF *)node->entry;
     if (lzf_decompress(lzf->compressed, lzf->sz, decompressed, node->sz) == 0) {
         /* Someone requested decompress, but we can't decompress.  Not good. */
         zfree(decompressed);
         return 0;
     }
-    zfree(lzf);
+    zfree_usable(lzf, &old_entry_size);
+    quicklistUpdateAllocSize(quicklist, new_entry_size, old_entry_size);
     node->entry = decompressed;
     node->encoding = QUICKLIST_NODE_ENCODING_RAW;
     return 1;
 }
 
 /* Decompress only compressed nodes. */
-#define quicklistDecompressNode(_node)                                         \
+#define quicklistDecompressNode(_ql, _node)                                    \
     do {                                                                       \
         if ((_node) && (_node)->encoding == QUICKLIST_NODE_ENCODING_LZF) {     \
-            __quicklistDecompressNode((_node));                                \
+            __quicklistDecompressNode((_ql), (_node));                         \
         }                                                                      \
     } while (0)
 
 /* Force node to not be immediately re-compressible */
-#define quicklistDecompressNodeForUse(_node)                                   \
+#define quicklistDecompressNodeForUse(_ql, _node)                              \
     do {                                                                       \
         if ((_node) && (_node)->encoding == QUICKLIST_NODE_ENCODING_LZF) {     \
-            __quicklistDecompressNode((_node));                                \
+            __quicklistDecompressNode((_ql), (_node));                         \
             (_node)->recompress = 1;                                           \
         }                                                                      \
     } while (0)
@@ -304,7 +319,7 @@ size_t quicklistGetLzf(const quicklistNode *node, void **data) {
  * The only way to guarantee interior nodes get compressed is to iterate
  * to our "interior" compress depth then compress the next node we find.
  * If compress depth is larger than the entire list, we return immediately. */
-REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
+REDIS_STATIC void __quicklistCompress(quicklist *quicklist,
                                       quicklistNode *node) {
     if (quicklist->len == 0) return;
 
@@ -321,26 +336,26 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
     /* Optimized cases for small depth counts */
     if (quicklist->compress == 1) {
         quicklistNode *h = quicklist->head, *t = quicklist->tail;
-        quicklistDecompressNode(h);
-        quicklistDecompressNode(t);
+        quicklistDecompressNode(quicklist, h);
+        quicklistDecompressNode(quicklist, t);
         if (h != node && t != node)
-            quicklistCompressNode(node);
+            quicklistCompressNode(quicklist, node);
         return;
     } else if (quicklist->compress == 2) {
         quicklistNode *h = quicklist->head, *hn = h->next, *hnn = hn->next;
         quicklistNode *t = quicklist->tail, *tp = t->prev, *tpp = tp->prev;
-        quicklistDecompressNode(h);
-        quicklistDecompressNode(hn);
-        quicklistDecompressNode(t);
-        quicklistDecompressNode(tp);
+        quicklistDecompressNode(quicklist, h);
+        quicklistDecompressNode(quicklist, hn);
+        quicklistDecompressNode(quicklist, t);
+        quicklistDecompressNode(quicklist, tp);
         if (h != node && hn != node && t != node && tp != node) {
-            quicklistCompressNode(node);
+            quicklistCompressNode(quicklist, node);
         }
         if (hnn != t) {
-            quicklistCompressNode(hnn);
+            quicklistCompressNode(quicklist, hnn);
         }
         if (tpp != h) {
-            quicklistCompressNode(tpp);
+            quicklistCompressNode(quicklist, tpp);
         }
         return;
     }
@@ -354,8 +369,8 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
     int depth = 0;
     int in_depth = 0;
     while (depth++ < quicklist->compress) {
-        quicklistDecompressNode(forward);
-        quicklistDecompressNode(reverse);
+        quicklistDecompressNode(quicklist, forward);
+        quicklistDecompressNode(quicklist, reverse);
 
         if (forward == node || reverse == node)
             in_depth = 1;
@@ -370,11 +385,11 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
     }
 
     if (!in_depth)
-        quicklistCompressNode(node);
+        quicklistCompressNode(quicklist, node);
 
     /* At this point, forward and reverse are one node beyond depth */
-    quicklistCompressNode(forward);
-    quicklistCompressNode(reverse);
+    quicklistCompressNode(quicklist, forward);
+    quicklistCompressNode(quicklist, reverse);
 }
 
 /* This macro is used to compress a node.
@@ -389,16 +404,16 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
 #define quicklistCompress(_ql, _node)                                          \
     do {                                                                       \
         if ((_node)->recompress)                                               \
-            quicklistCompressNode((_node));                                    \
+            quicklistCompressNode((_ql), (_node));                             \
         else                                                                   \
             __quicklistCompress((_ql), (_node));                               \
     } while (0)
 
 /* If we previously used quicklistDecompressNodeForUse(), just recompress. */
-#define quicklistRecompressOnly(_node)                                         \
+#define quicklistRecompressOnly(_ql, _node)                                    \
     do {                                                                       \
         if ((_node)->recompress)                                               \
-            quicklistCompressNode((_node));                                    \
+            quicklistCompressNode((_ql), (_node));                             \
     } while (0)
 
 /* Insert 'new_node' after 'old_node' if 'after' is 1.
@@ -554,15 +569,17 @@ REDIS_STATIC int _quicklistNodeAllowMerge(const quicklistNode *a,
         (node)->sz = lpBytes((node)->entry);                                   \
     } while (0)
 
-static quicklistNode* __quicklistCreateNode(int container, void *value, size_t sz) {
-    quicklistNode *new_node = quicklistCreateNode();
+static quicklistNode* __quicklistCreateNode(quicklist *quicklist, int container, void *value, size_t sz) {
+    size_t entry_usable;
+    quicklistNode *new_node = quicklistCreateNode(quicklist);
     new_node->container = container;
     if (container == QUICKLIST_NODE_CONTAINER_PLAIN) {
-        new_node->entry = zmalloc(sz);
+        new_node->entry = zmalloc_usable(sz, &entry_usable);
         memcpy(new_node->entry, value, sz);
     } else {
-        new_node->entry = lpPrepend(lpNew(0), value, sz);
+        new_node->entry = lpPrependUsable(lpNew(0), value, sz, &entry_usable, NULL);
     }
+    quicklist->alloc_size += entry_usable;
     new_node->sz = sz;
     new_node->count++;
     return new_node;
@@ -571,7 +588,7 @@ static quicklistNode* __quicklistCreateNode(int container, void *value, size_t s
 static void __quicklistInsertPlainNode(quicklist *quicklist, quicklistNode *old_node,
                                        void *value, size_t sz, int after)
 {
-    quicklistNode *new_node = __quicklistCreateNode(QUICKLIST_NODE_CONTAINER_PLAIN, value, sz);
+    quicklistNode *new_node = __quicklistCreateNode(quicklist, QUICKLIST_NODE_CONTAINER_PLAIN, value, sz);
     __quicklistInsertNode(quicklist, old_node, new_node, after);
     quicklist->count++;
 }
@@ -582,6 +599,7 @@ static void __quicklistInsertPlainNode(quicklist *quicklist, quicklistNode *old_
  * Returns 1 if new head created. */
 int quicklistPushHead(quicklist *quicklist, void *value, size_t sz) {
     quicklistNode *orig_head = quicklist->head;
+    size_t usable, old_usable;
 
     if (unlikely(isLargeElement(sz, quicklist->fill))) {
         __quicklistInsertPlainNode(quicklist, quicklist->head, value, sz, 0);
@@ -590,12 +608,13 @@ int quicklistPushHead(quicklist *quicklist, void *value, size_t sz) {
 
     if (likely(
             _quicklistNodeAllowInsert(quicklist->head, quicklist->fill, sz))) {
-        quicklist->head->entry = lpPrepend(quicklist->head->entry, value, sz);
+        quicklist->head->entry = lpPrependUsable(quicklist->head->entry, value, sz, &usable, &old_usable);
+        quicklistUpdateAllocSize(quicklist, usable, old_usable);
         quicklistNodeUpdateSz(quicklist->head);
     } else {
-        quicklistNode *node = quicklistCreateNode();
-        node->entry = lpPrepend(lpNew(0), value, sz);
-
+        quicklistNode *node = quicklistCreateNode(quicklist);
+        node->entry = lpPrependUsable(lpNew(0), value, sz, &usable, NULL);
+        quicklistUpdateAllocSize(quicklist, usable, 0);
         quicklistNodeUpdateSz(node);
         _quicklistInsertNodeBefore(quicklist, quicklist->head, node);
     }
@@ -615,14 +634,17 @@ int quicklistPushTail(quicklist *quicklist, void *value, size_t sz) {
         return 1;
     }
 
+    size_t usable, old_usable;
     if (likely(
             _quicklistNodeAllowInsert(quicklist->tail, quicklist->fill, sz))) {
-        quicklist->tail->entry = lpAppend(quicklist->tail->entry, value, sz);
+        quicklist->tail->entry = lpAppendUsable(quicklist->tail->entry, value, sz,
+                                                &usable, &old_usable);
+        quicklistUpdateAllocSize(quicklist, usable, old_usable);
         quicklistNodeUpdateSz(quicklist->tail);
     } else {
-        quicklistNode *node = quicklistCreateNode();
-        node->entry = lpAppend(lpNew(0), value, sz);
-
+        quicklistNode *node = quicklistCreateNode(quicklist);
+        node->entry = lpAppendUsable(lpNew(0), value, sz, &usable, NULL);
+        quicklistUpdateAllocSize(quicklist, usable, 0);
         quicklistNodeUpdateSz(node);
         _quicklistInsertNodeAfter(quicklist, quicklist->tail, node);
     }
@@ -635,12 +657,13 @@ int quicklistPushTail(quicklist *quicklist, void *value, size_t sz) {
  * Used for loading RDBs where entire listpacks have been stored
  * to be retrieved later. */
 void quicklistAppendListpack(quicklist *quicklist, unsigned char *zl) {
-    quicklistNode *node = quicklistCreateNode();
+    quicklistNode *node = quicklistCreateNode(quicklist);
 
     node->entry = zl;
     node->count = lpLength(node->entry);
     node->sz = lpBytes(zl);
 
+    quicklist->alloc_size += zmalloc_usable_size(node->entry);
     _quicklistInsertNodeAfter(quicklist, quicklist->tail, node);
     quicklist->count += node->count;
 }
@@ -650,13 +673,14 @@ void quicklistAppendListpack(quicklist *quicklist, unsigned char *zl) {
  * to be retrieved later.
  * data - the data to add (pointer becomes the responsibility of quicklist) */
 void quicklistAppendPlainNode(quicklist *quicklist, unsigned char *data, size_t sz) {
-    quicklistNode *node = quicklistCreateNode();
+    quicklistNode *node = quicklistCreateNode(quicklist);
 
     node->entry = data;
     node->count = 1;
     node->sz = sz;
     node->container = QUICKLIST_NODE_CONTAINER_PLAIN;
 
+    quicklist->alloc_size += zmalloc_usable_size(node->entry);
     _quicklistInsertNodeAfter(quicklist, quicklist->tail, node);
     quicklist->count += node->count;
 }
@@ -701,8 +725,11 @@ REDIS_STATIC void __quicklistDelNode(quicklist *quicklist,
      * now have compressed nodes needing to be decompressed. */
     __quicklistCompress(quicklist, NULL);
 
-    zfree(node->entry);
-    zfree(node);
+    size_t usable;
+    zfree_usable(node->entry, &usable);
+    quicklist->alloc_size -= usable;
+    zfree_usable(node, &usable);
+    quicklist->alloc_size -= usable;
 }
 
 /* Delete one entry from list given the node for the entry and a pointer
@@ -716,12 +743,14 @@ REDIS_STATIC void __quicklistDelNode(quicklist *quicklist,
 REDIS_STATIC int quicklistDelIndex(quicklist *quicklist, quicklistNode *node,
                                    unsigned char **p) {
     int gone = 0;
+    size_t usable, old_usable;
 
     if (unlikely(QL_NODE_IS_PLAIN(node))) {
         __quicklistDelNode(quicklist, node);
         return 1;
     }
-    node->entry = lpDelete(node->entry, *p, p);
+    node->entry = lpDeleteUsable(node->entry, *p, p, &usable, &old_usable);
+    quicklistUpdateAllocSize(quicklist, usable, old_usable);
     node->count--;
     if (node->count == 0) {
         gone = 1;
@@ -774,18 +803,21 @@ void quicklistReplaceEntry(quicklistIter *iter, quicklistEntry *entry,
     quicklist* quicklist = iter->quicklist;
     quicklistNode *node = entry->node;
     unsigned char *newentry;
+    size_t usable, old_usable;
 
     if (likely(!QL_NODE_IS_PLAIN(entry->node) && !isLargeElement(sz, quicklist->fill) &&
-        (newentry = lpReplace(entry->node->entry, &entry->zi, data, sz)) != NULL))
+        (newentry = lpReplaceUsable(entry->node->entry, &entry->zi, data, sz, &usable, &old_usable)) != NULL))
     {
         entry->node->entry = newentry;
+        quicklistUpdateAllocSize(quicklist, usable, old_usable);
         quicklistNodeUpdateSz(entry->node);
         /* quicklistNext() and quicklistGetIteratorEntryAtIdx() provide an uncompressed node */
         quicklistCompress(quicklist, entry->node);
     } else if (QL_NODE_IS_PLAIN(entry->node)) {
         if (isLargeElement(sz, quicklist->fill)) {
-            zfree(entry->node->entry);
-            entry->node->entry = zmalloc(sz);
+            zfree_usable(entry->node->entry, &old_usable);
+            entry->node->entry = zmalloc_usable(sz, &usable);
+            quicklistUpdateAllocSize(quicklist, usable, old_usable);
             entry->node->sz = sz;
             memcpy(entry->node->entry, data, sz);
             quicklistCompress(quicklist, entry->node);
@@ -799,11 +831,11 @@ void quicklistReplaceEntry(quicklistIter *iter, quicklistEntry *entry,
 
         /* If the entry is not at the tail, split the node at the entry's offset. */
         if (entry->offset != node->count - 1 && entry->offset != -1)
-            split_node = _quicklistSplitNode(node, entry->offset, 1);
+            split_node = _quicklistSplitNode(quicklist, node, entry->offset, 1);
 
         /* Create a new node and insert it after the original node.
          * If the original node was split, insert the split node after the new node. */
-        new_node = __quicklistCreateNode(isLargeElement(sz, quicklist->fill) ?
+        new_node = __quicklistCreateNode(quicklist, isLargeElement(sz, quicklist->fill) ?
             QUICKLIST_NODE_CONTAINER_PLAIN : QUICKLIST_NODE_CONTAINER_PACKED, data, sz);
         __quicklistInsertNode(quicklist, node, new_node, 1);
         if (split_node) __quicklistInsertNode(quicklist, new_node, split_node, 1);
@@ -865,11 +897,12 @@ int quicklistReplaceAtIndex(quicklist *quicklist, long index, void *data,
 REDIS_STATIC quicklistNode *_quicklistListpackMerge(quicklist *quicklist,
                                                     quicklistNode *a,
                                                     quicklistNode *b) {
+    size_t usable, old_usable;
     D("Requested merge (a,b) (%u, %u)", a->count, b->count);
 
-    quicklistDecompressNode(a);
-    quicklistDecompressNode(b);
-    if ((lpMerge(&a->entry, &b->entry))) {
+    quicklistDecompressNode(quicklist, a);
+    quicklistDecompressNode(quicklist, b);
+    if ((lpMergeUsable(&a->entry, &b->entry, &usable, &old_usable))) {
         /* We merged listpacks! Now remove the unused quicklistNode. */
         quicklistNode *keep = NULL, *nokeep = NULL;
         if (!a->entry) {
@@ -881,6 +914,7 @@ REDIS_STATIC quicklistNode *_quicklistListpackMerge(quicklist *quicklist,
         }
         keep->count = lpLength(keep->entry);
         quicklistNodeUpdateSz(keep);
+        quicklistUpdateAllocSize(quicklist, usable, old_usable);
         keep->recompress = 0; /* Prevent 'keep' from being recompressed if
                                * it becomes head or tail after merging. */
 
@@ -968,11 +1002,13 @@ REDIS_STATIC quicklistNode *_quicklistMergeNodes(quicklist *quicklist, quicklist
  * The input node keeps all elements not taken by the returned node.
  *
  * Returns newly created node or NULL if split not possible. */
-REDIS_STATIC quicklistNode *_quicklistSplitNode(quicklistNode *node, int offset,
-                                                int after) {
+REDIS_STATIC quicklistNode *_quicklistSplitNode(quicklist *quicklist, quicklistNode *node,
+                                                int offset, int after) {
     size_t zl_sz = node->sz;
 
-    quicklistNode *new_node = quicklistCreateNode();
+    /* New node is detached on return but all callers add it back to quicklist
+     * so we account its allocation here and below directly on quicklist. */
+    quicklistNode *new_node = quicklistCreateNode(quicklist);
     new_node->entry = zmalloc(zl_sz);
 
     /* Copy original listpack so we can split it */
@@ -990,11 +1026,14 @@ REDIS_STATIC quicklistNode *_quicklistSplitNode(quicklistNode *node, int offset,
     D("After %d (%d); ranges: [%d, %d], [%d, %d]", after, offset, orig_start,
       orig_extent, new_start, new_extent);
 
-    node->entry = lpDeleteRange(node->entry, orig_start, orig_extent);
+    size_t usable, old_usable;
+    node->entry = lpDeleteRangeUsable(node->entry, orig_start, orig_extent, &usable, &old_usable);
+    quicklistUpdateAllocSize(quicklist, usable, old_usable);
     node->count = lpLength(node->entry);
     quicklistNodeUpdateSz(node);
 
-    new_node->entry = lpDeleteRange(new_node->entry, new_start, new_extent);
+    new_node->entry = lpDeleteRangeUsable(new_node->entry, new_start, new_extent, &usable, NULL);
+    quicklistUpdateAllocSize(quicklist, usable, 0);
     new_node->count = lpLength(new_node->entry);
     quicklistNodeUpdateSz(new_node);
 
@@ -1014,6 +1053,7 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
     int fill = quicklist->fill;
     quicklistNode *node = entry->node;
     quicklistNode *new_node = NULL;
+    size_t usable, old_usable;
 
     if (!node) {
         /* we have no reference node, so let's create only node in the list */
@@ -1022,8 +1062,9 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
             __quicklistInsertPlainNode(quicklist, quicklist->tail, value, sz, after);
             return;
         }
-        new_node = quicklistCreateNode();
-        new_node->entry = lpPrepend(lpNew(0), value, sz);
+        new_node = quicklistCreateNode(quicklist);
+        new_node->entry = lpPrependUsable(lpNew(0), value, sz, &usable, NULL);
+        quicklistUpdateAllocSize(quicklist, usable, 0);
         __quicklistInsertNode(quicklist, NULL, new_node, after);
         new_node->count++;
         quicklist->count++;
@@ -1059,9 +1100,9 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         if (QL_NODE_IS_PLAIN(node) || (at_tail && after) || (at_head && !after)) {
             __quicklistInsertPlainNode(quicklist, node, value, sz, after);
         } else {
-            quicklistDecompressNodeForUse(node);
-            new_node = _quicklistSplitNode(node, entry->offset, after);
-            quicklistNode *entry_node = __quicklistCreateNode(QUICKLIST_NODE_CONTAINER_PLAIN, value, sz);
+            quicklistDecompressNodeForUse(quicklist, node);
+            new_node = _quicklistSplitNode(quicklist, node, entry->offset, after);
+            quicklistNode *entry_node = __quicklistCreateNode(quicklist, QUICKLIST_NODE_CONTAINER_PLAIN, value, sz);
             __quicklistInsertNode(quicklist, node, entry_node, after);
             __quicklistInsertNode(quicklist, entry_node, new_node, after);
             quicklist->count++;
@@ -1072,47 +1113,52 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
     /* Now determine where and how to insert the new element */
     if (!full && after) {
         D("Not full, inserting after current position.");
-        quicklistDecompressNodeForUse(node);
-        node->entry = lpInsertString(node->entry, value, sz, entry->zi, LP_AFTER, NULL);
+        quicklistDecompressNodeForUse(quicklist, node);
+        node->entry = lpInsertStringUsable(node->entry, value, sz, entry->zi, LP_AFTER, NULL, &usable, &old_usable);
+        quicklistUpdateAllocSize(quicklist, usable, old_usable);
         node->count++;
         quicklistNodeUpdateSz(node);
-        quicklistRecompressOnly(node);
+        quicklistRecompressOnly(quicklist, node);
     } else if (!full && !after) {
         D("Not full, inserting before current position.");
-        quicklistDecompressNodeForUse(node);
-        node->entry = lpInsertString(node->entry, value, sz, entry->zi, LP_BEFORE, NULL);
+        quicklistDecompressNodeForUse(quicklist, node);
+        node->entry = lpInsertStringUsable(node->entry, value, sz, entry->zi, LP_BEFORE, NULL, &usable, &old_usable);
+        quicklistUpdateAllocSize(quicklist, usable, old_usable);
         node->count++;
         quicklistNodeUpdateSz(node);
-        quicklistRecompressOnly(node);
+        quicklistRecompressOnly(quicklist, node);
     } else if (full && at_tail && avail_next && after) {
         /* If we are: at tail, next has free space, and inserting after:
          *   - insert entry at head of next node. */
         D("Full and tail, but next isn't full; inserting next node head");
         new_node = node->next;
-        quicklistDecompressNodeForUse(new_node);
-        new_node->entry = lpPrepend(new_node->entry, value, sz);
+        quicklistDecompressNodeForUse(quicklist, new_node);
+        new_node->entry = lpPrependUsable(new_node->entry, value, sz, &usable, &old_usable);
+        quicklistUpdateAllocSize(quicklist, usable, old_usable);
         new_node->count++;
         quicklistNodeUpdateSz(new_node);
-        quicklistRecompressOnly(new_node);
-        quicklistRecompressOnly(node);
+        quicklistRecompressOnly(quicklist, new_node);
+        quicklistRecompressOnly(quicklist, node);
     } else if (full && at_head && avail_prev && !after) {
         /* If we are: at head, previous has free space, and inserting before:
          *   - insert entry at tail of previous node. */
         D("Full and head, but prev isn't full, inserting prev node tail");
         new_node = node->prev;
-        quicklistDecompressNodeForUse(new_node);
-        new_node->entry = lpAppend(new_node->entry, value, sz);
+        quicklistDecompressNodeForUse(quicklist, new_node);
+        new_node->entry = lpAppendUsable(new_node->entry, value, sz, &usable, &old_usable);
+        quicklistUpdateAllocSize(quicklist, usable, old_usable);
         new_node->count++;
         quicklistNodeUpdateSz(new_node);
-        quicklistRecompressOnly(new_node);
-        quicklistRecompressOnly(node);
+        quicklistRecompressOnly(quicklist, new_node);
+        quicklistRecompressOnly(quicklist, node);
     } else if (full && ((at_tail && !avail_next && after) ||
                         (at_head && !avail_prev && !after))) {
         /* If we are: full, and our prev/next has no available space, then:
          *   - create new node and attach to quicklist */
         D("\tprovisioning new node...");
-        new_node = quicklistCreateNode();
-        new_node->entry = lpPrepend(lpNew(0), value, sz);
+        new_node = quicklistCreateNode(quicklist);
+        new_node->entry = lpPrependUsable(lpNew(0), value, sz, &usable, NULL);
+        quicklistUpdateAllocSize(quicklist, usable, 0);
         new_node->count++;
         quicklistNodeUpdateSz(new_node);
         __quicklistInsertNode(quicklist, node, new_node, after);
@@ -1120,12 +1166,13 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         /* else, node is full we need to split it. */
         /* covers both after and !after cases */
         D("\tsplitting node...");
-        quicklistDecompressNodeForUse(node);
-        new_node = _quicklistSplitNode(node, entry->offset, after);
+        quicklistDecompressNodeForUse(quicklist, node);
+        new_node = _quicklistSplitNode(quicklist, node, entry->offset, after);
         if (after)
-            new_node->entry = lpPrepend(new_node->entry, value, sz);
+            new_node->entry = lpPrependUsable(new_node->entry, value, sz, &usable, &old_usable);
         else
-            new_node->entry = lpAppend(new_node->entry, value, sz);
+            new_node->entry = lpAppendUsable(new_node->entry, value, sz, &usable, &old_usable);
+        quicklistUpdateAllocSize(quicklist, usable, old_usable);
         new_node->count++;
         quicklistNodeUpdateSz(new_node);
         __quicklistInsertNode(quicklist, node, new_node, after);
@@ -1216,21 +1263,23 @@ int quicklistDelRange(quicklist *quicklist, const long start,
             del = extent;
         }
 
-        D("[%ld]: asking to del: %ld because offset: %d; (ENTIRE NODE: %d), "
+        D("[%ld]: asking to del: %ld because offset: %ld; (ENTIRE NODE: %d), "
           "node count: %u",
           extent, del, offset, delete_entire_node, node->count);
 
         if (delete_entire_node || QL_NODE_IS_PLAIN(node)) {
             __quicklistDelNode(quicklist, node);
         } else {
-            quicklistDecompressNodeForUse(node);
-            node->entry = lpDeleteRange(node->entry, offset, del);
+            size_t usable, old_usable;
+            quicklistDecompressNodeForUse(quicklist, node);
+            node->entry = lpDeleteRangeUsable(node->entry, offset, del, &usable, &old_usable);
+            quicklistUpdateAllocSize(quicklist, usable, old_usable);
             quicklistNodeUpdateSz(node);
             node->count -= del;
             quicklist->count -= del;
             quicklistDeleteIfEmpty(quicklist, node);
             if (node)
-                quicklistRecompressOnly(node);
+                quicklistRecompressOnly(quicklist, node);
         }
 
         extent -= del;
@@ -1420,7 +1469,7 @@ int quicklistNext(quicklistIter *iter, quicklistEntry *entry) {
     int plain = QL_NODE_IS_PLAIN(iter->current);
     if (!iter->zi) {
         /* If !zi, use current index. */
-        quicklistDecompressNodeForUse(iter->current);
+        quicklistDecompressNodeForUse(iter->quicklist, iter->current);
         if (unlikely(plain))
             iter->zi = iter->current->entry;
         else
@@ -1492,23 +1541,25 @@ quicklist *quicklistDup(quicklist *orig) {
 
     for (quicklistNode *current = orig->head; current;
          current = current->next) {
-        quicklistNode *node = quicklistCreateNode();
+        quicklistNode *node = quicklistCreateNode(copy);
+        size_t entry_size = 0;
 
         if (current->encoding == QUICKLIST_NODE_ENCODING_LZF) {
             quicklistLZF *lzf = (quicklistLZF *)current->entry;
             size_t lzf_sz = sizeof(*lzf) + lzf->sz;
-            node->entry = zmalloc(lzf_sz);
+            node->entry = zmalloc_usable(lzf_sz, &entry_size);
             memcpy(node->entry, current->entry, lzf_sz);
         } else if (current->encoding == QUICKLIST_NODE_ENCODING_RAW) {
-            node->entry = zmalloc(current->sz);
+            node->entry = zmalloc_usable(current->sz, &entry_size);
             memcpy(node->entry, current->entry, current->sz);
         }
 
         node->count = current->count;
-        copy->count += node->count;
         node->sz = current->sz;
         node->encoding = current->encoding;
         node->container = current->container;
+        copy->count += node->count;
+        copy->alloc_size += entry_size;
 
         _quicklistInsertNodeAfter(copy, copy->tail, node);
     }
@@ -1729,7 +1780,7 @@ void quicklistRepr(unsigned char *ql, int full) {
                node->attempted_compress);
 
         if (full) {
-            quicklistDecompressNode(node);
+            quicklistDecompressNode(quicklist, node);
             if (node->container == QUICKLIST_NODE_CONTAINER_PACKED) {
                 printf("{ listpack:\n");
                 lpRepr(node->entry);
@@ -1739,7 +1790,7 @@ void quicklistRepr(unsigned char *ql, int full) {
                 printf("{ entry : %s }\n", node->entry);
             }
             printf("}\n");
-            quicklistRecompressOnly(node);
+            quicklistRecompressOnly(quicklist, node);
         }
         node = node->next;
     }
@@ -1762,11 +1813,15 @@ int quicklistBookmarkCreate(quicklist **ql_ref, const char *name, quicklistNode 
         bm->node = node;
         return 1;
     }
-    ql = zrealloc(ql, sizeof(quicklist) + (ql->bookmark_count+1) * sizeof(quicklistBookmark));
+    size_t new_size, old_size;
+    ql = zrealloc_usable(ql, sizeof(quicklist) + (ql->bookmark_count+1) * sizeof(quicklistBookmark),
+                          &new_size, &old_size);
     *ql_ref = ql;
     ql->bookmarks[ql->bookmark_count].node = node;
-    ql->bookmarks[ql->bookmark_count].name = zstrdup(name);
+    size_t name_sz;
+    ql->bookmarks[ql->bookmark_count].name = zstrdup_usable(name, &name_sz);
     ql->bookmark_count++;
+    quicklistUpdateAllocSize(ql, new_size + name_sz, old_size);
     return 1;
 }
 
@@ -1812,16 +1867,21 @@ quicklistBookmark *_quicklistBookmarkFindByNode(quicklist *ql, quicklistNode *no
 
 void _quicklistBookmarkDelete(quicklist *ql, quicklistBookmark *bm) {
     int index = bm - ql->bookmarks;
-    zfree(bm->name);
+    size_t name_sz;
+    zfree_usable(bm->name, &name_sz);
     ql->bookmark_count--;
+    ql->alloc_size -= name_sz;
     memmove(bm, bm+1, (ql->bookmark_count - index)* sizeof(*bm));
     /* NOTE: We do not shrink (realloc) the quicklist yet (to avoid resonance,
      * it may be re-used later (a call to realloc may NOP). */
 }
 
 void quicklistBookmarksClear(quicklist *ql) {
-    while (ql->bookmark_count)
-        zfree(ql->bookmarks[--ql->bookmark_count].name);
+    size_t name_sz;
+    while (ql->bookmark_count) {
+        zfree_usable(ql->bookmarks[--ql->bookmark_count].name, &name_sz);
+        ql->alloc_size -= name_sz;
+    }
     /* NOTE: We do not shrink (realloc) the quick list. main use case for this
      * function is just before releasing the allocation. */
 }
@@ -1955,6 +2015,29 @@ static int _ql_verify_compress(quicklist *ql) {
     return errors;
 }
 
+static int _ql_verify_alloc_size(quicklist *ql) {
+    int errors = 0;
+    size_t alloc_size = zmalloc_usable_size(ql);
+
+    quicklistNode* node = ql->head;
+    while (node != NULL) {
+        alloc_size += zmalloc_usable_size(node);
+        alloc_size += zmalloc_usable_size(node->entry);
+        node = node->next;
+    }
+
+    for (unsigned i = 0; i < ql->bookmark_count; i++) {
+        alloc_size += zmalloc_usable_size(ql->bookmarks[i].name);
+    }
+
+    if (ql->alloc_size != alloc_size) {
+        yell("quicklist alloc_size wrong: expected %zu, got %zu", alloc_size, ql->alloc_size);
+        errors++;
+    }
+
+    return errors;
+}
+
 /* Verify list metadata matches physical list contents. */
 static int _ql_verify(quicklist *ql, uint32_t len, uint32_t count,
                       uint32_t head_count, uint32_t tail_count) {
@@ -2007,6 +2090,7 @@ static int _ql_verify(quicklist *ql, uint32_t len, uint32_t count,
         errors++;
     }
 
+    errors += _ql_verify_alloc_size(ql);
     errors += _ql_verify_compress(ql);
     return errors;
 }
@@ -3475,13 +3559,14 @@ int quicklistTest(int argc, char *argv[], int flags) {
 
     if (flags & REDIS_TEST_LARGE_MEMORY) {
         TEST("compress and decompress quicklist listpack node") {
-            quicklistNode *node = quicklistCreateNode();
+            quicklist *ql = quicklistNew(1, 0);
+            quicklistNode *node = quicklistCreateNode(ql);
             node->entry = lpNew(0);
 
             /* Just to avoid triggering the assertion in __quicklistCompressNode(),
              * it disables the passing of quicklist head or tail node. */
-            node->prev = quicklistCreateNode();
-            node->next = quicklistCreateNode();
+            node->prev = quicklistCreateNode(ql);
+            node->next = quicklistCreateNode(ql);
             
             /* Create a rand string */
             size_t sz = (1 << 25); /* 32MB per one entry */
@@ -3490,12 +3575,15 @@ int quicklistTest(int argc, char *argv[], int flags) {
 
             /* Keep filling the node, until it reaches 1GB */
             for (int i = 0; i < 32; i++) {
-                node->entry = lpAppend(node->entry, s, sz);
+                size_t usable, old_usable;
+                node->entry = lpAppendUsable(node->entry, s, sz,
+                                             &usable, &old_usable);
+                quicklistUpdateAllocSize(ql, usable, old_usable);
                 quicklistNodeUpdateSz(node);
 
                 long long start = mstime();
-                assert(__quicklistCompressNode(node));
-                assert(__quicklistDecompressNode(node));
+                assert(__quicklistCompressNode(ql, node));
+                assert(__quicklistDecompressNode(ql, node));
                 printf("Compress and decompress: %zu MB in %.2f seconds.\n",
                        node->sz/1024/1024, (float)(mstime() - start) / 1000);
             }
@@ -3505,26 +3593,28 @@ int quicklistTest(int argc, char *argv[], int flags) {
             zfree(node->next);
             zfree(node->entry);
             zfree(node);
+            quicklistRelease(ql);
         }
 
 #if ULONG_MAX >= 0xffffffffffffffff
         TEST("compress and decompress quicklist plain node larger than UINT32_MAX") {
+            quicklist *ql = quicklistNew(1, 0);
             size_t sz = (1ull << 32);
             unsigned char *s = zmalloc(sz);
             randstring(s, sz);
             memcpy(s, "helloworld", 10);
             memcpy(s + sz - 10, "1234567890", 10);
 
-            quicklistNode *node = __quicklistCreateNode(QUICKLIST_NODE_CONTAINER_PLAIN, s, sz);
+            quicklistNode *node = __quicklistCreateNode(ql, QUICKLIST_NODE_CONTAINER_PLAIN, s, sz);
 
             /* Just to avoid triggering the assertion in __quicklistCompressNode(),
              * it disables the passing of quicklist head or tail node. */
-            node->prev = quicklistCreateNode();
-            node->next = quicklistCreateNode();
+            node->prev = quicklistCreateNode(ql);
+            node->next = quicklistCreateNode(ql);
 
             long long start = mstime();
-            assert(__quicklistCompressNode(node));
-            assert(__quicklistDecompressNode(node));
+            assert(__quicklistCompressNode(ql, node));
+            assert(__quicklistDecompressNode(ql, node));
             printf("Compress and decompress: %zu MB in %.2f seconds.\n",
                    node->sz/1024/1024, (float)(mstime() - start) / 1000);
 
@@ -3534,6 +3624,7 @@ int quicklistTest(int argc, char *argv[], int flags) {
             zfree(node->next);
             zfree(node->entry);
             zfree(node);
+            quicklistRelease(ql);
         }
 #endif
     }

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -204,18 +204,22 @@ size_t quicklistAllocSize(const quicklist *ql) { return ql->alloc_size; }
 void quicklistRelease(quicklist *quicklist) {
     unsigned long len;
     quicklistNode *current, *next;
+    size_t usable;
 
     current = quicklist->head;
     len = quicklist->len;
     while (len--) {
         next = current->next;
 
-        zfree(current->entry);
-        zfree(current);
+        zfree_usable(current->entry, &usable);
+        quicklist->alloc_size -= usable;
+        zfree_usable(current, &usable);
+        quicklist->alloc_size -= usable;
 
         current = next;
     }
     quicklistBookmarksClear(quicklist);
+    debugAssert(quicklist->alloc_size == zmalloc_usable_size(quicklist));
     zfree(quicklist);
 }
 

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -211,8 +211,10 @@ void quicklistRelease(quicklist *quicklist) {
     while (len--) {
         next = current->next;
 
-        zfree_usable(current->entry, &usable);
-        quicklist->alloc_size -= usable;
+        if (current->entry) {
+            zfree_usable(current->entry, &usable);
+            quicklist->alloc_size -= usable;
+        }
         zfree_usable(current, &usable);
         quicklist->alloc_size -= usable;
 

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -574,16 +574,16 @@ REDIS_STATIC int _quicklistNodeAllowMerge(const quicklistNode *a,
     } while (0)
 
 static quicklistNode* __quicklistCreateNode(quicklist *quicklist, int container, void *value, size_t sz) {
-    size_t entry_usable;
+    UsableSizes entry_usable;
     quicklistNode *new_node = quicklistCreateNode(quicklist);
     new_node->container = container;
     if (container == QUICKLIST_NODE_CONTAINER_PLAIN) {
-        new_node->entry = zmalloc_usable(sz, &entry_usable);
+        new_node->entry = zmalloc_usable(sz, &entry_usable.val);
         memcpy(new_node->entry, value, sz);
     } else {
-        new_node->entry = lpPrependUsable(lpNew(0), value, sz, &entry_usable, NULL);
+        new_node->entry = lpPrependUsable(lpNew(0), value, sz, &entry_usable);
     }
-    quicklist->alloc_size += entry_usable;
+    quicklist->alloc_size += entry_usable.val;
     new_node->sz = sz;
     new_node->count++;
     return new_node;
@@ -603,7 +603,7 @@ static void __quicklistInsertPlainNode(quicklist *quicklist, quicklistNode *old_
  * Returns 1 if new head created. */
 int quicklistPushHead(quicklist *quicklist, void *value, size_t sz) {
     quicklistNode *orig_head = quicklist->head;
-    size_t usable, old_usable;
+    UsableSizes usable;
 
     if (unlikely(isLargeElement(sz, quicklist->fill))) {
         __quicklistInsertPlainNode(quicklist, quicklist->head, value, sz, 0);
@@ -612,13 +612,13 @@ int quicklistPushHead(quicklist *quicklist, void *value, size_t sz) {
 
     if (likely(
             _quicklistNodeAllowInsert(quicklist->head, quicklist->fill, sz))) {
-        quicklist->head->entry = lpPrependUsable(quicklist->head->entry, value, sz, &usable, &old_usable);
-        quicklistUpdateAllocSize(quicklist, usable, old_usable);
+        quicklist->head->entry = lpPrependUsable(quicklist->head->entry, value, sz, &usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
         quicklistNodeUpdateSz(quicklist->head);
     } else {
         quicklistNode *node = quicklistCreateNode(quicklist);
-        node->entry = lpPrependUsable(lpNew(0), value, sz, &usable, NULL);
-        quicklistUpdateAllocSize(quicklist, usable, 0);
+        node->entry = lpPrependUsable(lpNew(0), value, sz, &usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, 0);
         quicklistNodeUpdateSz(node);
         _quicklistInsertNodeBefore(quicklist, quicklist->head, node);
     }
@@ -638,17 +638,17 @@ int quicklistPushTail(quicklist *quicklist, void *value, size_t sz) {
         return 1;
     }
 
-    size_t usable, old_usable;
+    UsableSizes usable;
     if (likely(
             _quicklistNodeAllowInsert(quicklist->tail, quicklist->fill, sz))) {
         quicklist->tail->entry = lpAppendUsable(quicklist->tail->entry, value, sz,
-                                                &usable, &old_usable);
-        quicklistUpdateAllocSize(quicklist, usable, old_usable);
+                                                &usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
         quicklistNodeUpdateSz(quicklist->tail);
     } else {
         quicklistNode *node = quicklistCreateNode(quicklist);
-        node->entry = lpAppendUsable(lpNew(0), value, sz, &usable, NULL);
-        quicklistUpdateAllocSize(quicklist, usable, 0);
+        node->entry = lpAppendUsable(lpNew(0), value, sz, &usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, 0);
         quicklistNodeUpdateSz(node);
         _quicklistInsertNodeAfter(quicklist, quicklist->tail, node);
     }
@@ -747,14 +747,14 @@ REDIS_STATIC void __quicklistDelNode(quicklist *quicklist,
 REDIS_STATIC int quicklistDelIndex(quicklist *quicklist, quicklistNode *node,
                                    unsigned char **p) {
     int gone = 0;
-    size_t usable, old_usable;
+    UsableSizes usable;
 
     if (unlikely(QL_NODE_IS_PLAIN(node))) {
         __quicklistDelNode(quicklist, node);
         return 1;
     }
-    node->entry = lpDeleteUsable(node->entry, *p, p, &usable, &old_usable);
-    quicklistUpdateAllocSize(quicklist, usable, old_usable);
+    node->entry = lpDeleteUsable(node->entry, *p, p, &usable);
+    quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
     node->count--;
     if (node->count == 0) {
         gone = 1;
@@ -807,21 +807,21 @@ void quicklistReplaceEntry(quicklistIter *iter, quicklistEntry *entry,
     quicklist* quicklist = iter->quicklist;
     quicklistNode *node = entry->node;
     unsigned char *newentry;
-    size_t usable, old_usable;
+    UsableSizes usable;
 
     if (likely(!QL_NODE_IS_PLAIN(entry->node) && !isLargeElement(sz, quicklist->fill) &&
-        (newentry = lpReplaceUsable(entry->node->entry, &entry->zi, data, sz, &usable, &old_usable)) != NULL))
+        (newentry = lpReplaceUsable(entry->node->entry, &entry->zi, data, sz, &usable)) != NULL))
     {
         entry->node->entry = newentry;
-        quicklistUpdateAllocSize(quicklist, usable, old_usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
         quicklistNodeUpdateSz(entry->node);
         /* quicklistNext() and quicklistGetIteratorEntryAtIdx() provide an uncompressed node */
         quicklistCompress(quicklist, entry->node);
     } else if (QL_NODE_IS_PLAIN(entry->node)) {
         if (isLargeElement(sz, quicklist->fill)) {
-            zfree_usable(entry->node->entry, &old_usable);
-            entry->node->entry = zmalloc_usable(sz, &usable);
-            quicklistUpdateAllocSize(quicklist, usable, old_usable);
+            zfree_usable(entry->node->entry, &usable.oldval);
+            entry->node->entry = zmalloc_usable(sz, &usable.val);
+            quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
             entry->node->sz = sz;
             memcpy(entry->node->entry, data, sz);
             quicklistCompress(quicklist, entry->node);
@@ -901,12 +901,12 @@ int quicklistReplaceAtIndex(quicklist *quicklist, long index, void *data,
 REDIS_STATIC quicklistNode *_quicklistListpackMerge(quicklist *quicklist,
                                                     quicklistNode *a,
                                                     quicklistNode *b) {
-    size_t usable, old_usable;
+    UsableSizes usable;
     D("Requested merge (a,b) (%u, %u)", a->count, b->count);
 
     quicklistDecompressNode(quicklist, a);
     quicklistDecompressNode(quicklist, b);
-    if ((lpMergeUsable(&a->entry, &b->entry, &usable, &old_usable))) {
+    if ((lpMergeUsable(&a->entry, &b->entry, &usable))) {
         /* We merged listpacks! Now remove the unused quicklistNode. */
         quicklistNode *keep = NULL, *nokeep = NULL;
         if (!a->entry) {
@@ -918,7 +918,7 @@ REDIS_STATIC quicklistNode *_quicklistListpackMerge(quicklist *quicklist,
         }
         keep->count = lpLength(keep->entry);
         quicklistNodeUpdateSz(keep);
-        quicklistUpdateAllocSize(quicklist, usable, old_usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
         keep->recompress = 0; /* Prevent 'keep' from being recompressed if
                                * it becomes head or tail after merging. */
 
@@ -1030,14 +1030,14 @@ REDIS_STATIC quicklistNode *_quicklistSplitNode(quicklist *quicklist, quicklistN
     D("After %d (%d); ranges: [%d, %d], [%d, %d]", after, offset, orig_start,
       orig_extent, new_start, new_extent);
 
-    size_t usable, old_usable;
-    node->entry = lpDeleteRangeUsable(node->entry, orig_start, orig_extent, &usable, &old_usable);
-    quicklistUpdateAllocSize(quicklist, usable, old_usable);
+    UsableSizes usable;
+    node->entry = lpDeleteRangeUsable(node->entry, orig_start, orig_extent, &usable);
+    quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
     node->count = lpLength(node->entry);
     quicklistNodeUpdateSz(node);
 
-    new_node->entry = lpDeleteRangeUsable(new_node->entry, new_start, new_extent, &usable, NULL);
-    quicklistUpdateAllocSize(quicklist, usable, 0);
+    new_node->entry = lpDeleteRangeUsable(new_node->entry, new_start, new_extent, &usable);
+    quicklistUpdateAllocSize(quicklist, usable.val, 0);
     new_node->count = lpLength(new_node->entry);
     quicklistNodeUpdateSz(new_node);
 
@@ -1057,7 +1057,7 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
     int fill = quicklist->fill;
     quicklistNode *node = entry->node;
     quicklistNode *new_node = NULL;
-    size_t usable, old_usable;
+    UsableSizes usable;
 
     if (!node) {
         /* we have no reference node, so let's create only node in the list */
@@ -1067,8 +1067,8 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
             return;
         }
         new_node = quicklistCreateNode(quicklist);
-        new_node->entry = lpPrependUsable(lpNew(0), value, sz, &usable, NULL);
-        quicklistUpdateAllocSize(quicklist, usable, 0);
+        new_node->entry = lpPrependUsable(lpNew(0), value, sz, &usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, 0);
         __quicklistInsertNode(quicklist, NULL, new_node, after);
         new_node->count++;
         quicklist->count++;
@@ -1118,16 +1118,16 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
     if (!full && after) {
         D("Not full, inserting after current position.");
         quicklistDecompressNodeForUse(quicklist, node);
-        node->entry = lpInsertStringUsable(node->entry, value, sz, entry->zi, LP_AFTER, NULL, &usable, &old_usable);
-        quicklistUpdateAllocSize(quicklist, usable, old_usable);
+        node->entry = lpInsertStringUsable(node->entry, value, sz, entry->zi, LP_AFTER, NULL, &usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
         node->count++;
         quicklistNodeUpdateSz(node);
         quicklistRecompressOnly(quicklist, node);
     } else if (!full && !after) {
         D("Not full, inserting before current position.");
         quicklistDecompressNodeForUse(quicklist, node);
-        node->entry = lpInsertStringUsable(node->entry, value, sz, entry->zi, LP_BEFORE, NULL, &usable, &old_usable);
-        quicklistUpdateAllocSize(quicklist, usable, old_usable);
+        node->entry = lpInsertStringUsable(node->entry, value, sz, entry->zi, LP_BEFORE, NULL, &usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
         node->count++;
         quicklistNodeUpdateSz(node);
         quicklistRecompressOnly(quicklist, node);
@@ -1137,8 +1137,8 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         D("Full and tail, but next isn't full; inserting next node head");
         new_node = node->next;
         quicklistDecompressNodeForUse(quicklist, new_node);
-        new_node->entry = lpPrependUsable(new_node->entry, value, sz, &usable, &old_usable);
-        quicklistUpdateAllocSize(quicklist, usable, old_usable);
+        new_node->entry = lpPrependUsable(new_node->entry, value, sz, &usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
         new_node->count++;
         quicklistNodeUpdateSz(new_node);
         quicklistRecompressOnly(quicklist, new_node);
@@ -1149,8 +1149,8 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         D("Full and head, but prev isn't full, inserting prev node tail");
         new_node = node->prev;
         quicklistDecompressNodeForUse(quicklist, new_node);
-        new_node->entry = lpAppendUsable(new_node->entry, value, sz, &usable, &old_usable);
-        quicklistUpdateAllocSize(quicklist, usable, old_usable);
+        new_node->entry = lpAppendUsable(new_node->entry, value, sz, &usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
         new_node->count++;
         quicklistNodeUpdateSz(new_node);
         quicklistRecompressOnly(quicklist, new_node);
@@ -1161,8 +1161,8 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
          *   - create new node and attach to quicklist */
         D("\tprovisioning new node...");
         new_node = quicklistCreateNode(quicklist);
-        new_node->entry = lpPrependUsable(lpNew(0), value, sz, &usable, NULL);
-        quicklistUpdateAllocSize(quicklist, usable, 0);
+        new_node->entry = lpPrependUsable(lpNew(0), value, sz, &usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, 0);
         new_node->count++;
         quicklistNodeUpdateSz(new_node);
         __quicklistInsertNode(quicklist, node, new_node, after);
@@ -1173,10 +1173,10 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         quicklistDecompressNodeForUse(quicklist, node);
         new_node = _quicklistSplitNode(quicklist, node, entry->offset, after);
         if (after)
-            new_node->entry = lpPrependUsable(new_node->entry, value, sz, &usable, &old_usable);
+            new_node->entry = lpPrependUsable(new_node->entry, value, sz, &usable);
         else
-            new_node->entry = lpAppendUsable(new_node->entry, value, sz, &usable, &old_usable);
-        quicklistUpdateAllocSize(quicklist, usable, old_usable);
+            new_node->entry = lpAppendUsable(new_node->entry, value, sz, &usable);
+        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
         new_node->count++;
         quicklistNodeUpdateSz(new_node);
         __quicklistInsertNode(quicklist, node, new_node, after);
@@ -1274,10 +1274,10 @@ int quicklistDelRange(quicklist *quicklist, const long start,
         if (delete_entire_node || QL_NODE_IS_PLAIN(node)) {
             __quicklistDelNode(quicklist, node);
         } else {
-            size_t usable, old_usable;
+            UsableSizes usable;
             quicklistDecompressNodeForUse(quicklist, node);
-            node->entry = lpDeleteRangeUsable(node->entry, offset, del, &usable, &old_usable);
-            quicklistUpdateAllocSize(quicklist, usable, old_usable);
+            node->entry = lpDeleteRangeUsable(node->entry, offset, del, &usable);
+            quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
             quicklistNodeUpdateSz(node);
             node->count -= del;
             quicklist->count -= del;
@@ -3579,10 +3579,10 @@ int quicklistTest(int argc, char *argv[], int flags) {
 
             /* Keep filling the node, until it reaches 1GB */
             for (int i = 0; i < 32; i++) {
-                size_t usable, old_usable;
+                UsableSizes usable;
                 node->entry = lpAppendUsable(node->entry, s, sz,
-                                             &usable, &old_usable);
-                quicklistUpdateAllocSize(ql, usable, old_usable);
+                                             &usable);
+                quicklistUpdateAllocSize(ql, usable.val, usable.oldval);
                 quicklistNodeUpdateSz(node);
 
                 long long start = mstime();

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -219,7 +219,9 @@ void quicklistRelease(quicklist *quicklist) {
         current = next;
     }
     quicklistBookmarksClear(quicklist);
-    debugAssert(quicklist->alloc_size == zmalloc_usable_size(quicklist));
+#ifdef REDIS_TEST
+    assert(quicklist->alloc_size == zmalloc_usable_size(quicklist));
+#endif
     zfree(quicklist);
 }
 

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -212,8 +212,13 @@ void quicklistRelease(quicklist *quicklist) {
         next = current->next;
 
         if (current->entry) {
-            zfree_usable(current->entry, &usable);
-            quicklist->alloc_size -= usable;
+            if (current->encoding == QUICKLIST_NODE_ENCODING_LZF) {
+                quicklistLZF *lzf = (quicklistLZF *)current->entry;
+                quicklist->alloc_size -= sizeof(*lzf) + lzf->sz;
+            } else {
+                quicklist->alloc_size -= current->sz;
+            }
+            zfree(current->entry);
         }
         zfree_usable(current, &usable);
         quicklist->alloc_size -= usable;
@@ -255,12 +260,11 @@ REDIS_STATIC int __quicklistCompressNode(quicklist *quicklist, quicklistNode *no
         zfree(lzf);
         return 0;
     }
-    size_t new_entry_size, old_entry_size;
-    lzf = zrealloc_usable(lzf, sizeof(*lzf) + lzf->sz, &new_entry_size, NULL);
-    zfree_usable(node->entry, &old_entry_size);
+    lzf = zrealloc(lzf, sizeof(*lzf) + lzf->sz);
+    zfree(node->entry);
     node->entry = (unsigned char *)lzf;
     node->encoding = QUICKLIST_NODE_ENCODING_LZF;
-    quicklistUpdateAllocSize(quicklist, new_entry_size, old_entry_size);
+    quicklistUpdateAllocSize(quicklist, sizeof(*lzf) + lzf->sz, node->sz);
     return 1;
 }
 
@@ -280,16 +284,16 @@ REDIS_STATIC int __quicklistDecompressNode(quicklist *quicklist, quicklistNode *
 #endif
     node->recompress = 0;
 
-    size_t new_entry_size, old_entry_size;
-    void *decompressed = zmalloc_usable(node->sz, &new_entry_size);
+    void *decompressed = zmalloc(node->sz);
     quicklistLZF *lzf = (quicklistLZF *)node->entry;
     if (lzf_decompress(lzf->compressed, lzf->sz, decompressed, node->sz) == 0) {
         /* Someone requested decompress, but we can't decompress.  Not good. */
         zfree(decompressed);
         return 0;
     }
-    zfree_usable(lzf, &old_entry_size);
-    quicklistUpdateAllocSize(quicklist, new_entry_size, old_entry_size);
+    size_t oldsize = sizeof(*lzf) + lzf->sz;
+    zfree(lzf);
+    quicklistUpdateAllocSize(quicklist, node->sz, oldsize);
     node->entry = decompressed;
     node->encoding = QUICKLIST_NODE_ENCODING_RAW;
     return 1;
@@ -578,17 +582,17 @@ REDIS_STATIC int _quicklistNodeAllowMerge(const quicklistNode *a,
     } while (0)
 
 static quicklistNode* __quicklistCreateNode(quicklist *quicklist, int container, void *value, size_t sz) {
-    UsableSizes entry_usable = {0};
     quicklistNode *new_node = quicklistCreateNode(quicklist);
     new_node->container = container;
     if (container == QUICKLIST_NODE_CONTAINER_PLAIN) {
-        new_node->entry = zmalloc_usable(sz, &entry_usable.newsize);
+        new_node->entry = zmalloc(sz);
         memcpy(new_node->entry, value, sz);
+        new_node->sz = sz;
     } else {
-        new_node->entry = lpPrependUsable(lpNew(0), value, sz, &entry_usable);
+        new_node->entry = lpPrepend(lpNew(0), value, sz);
+        quicklistNodeUpdateSz(new_node);
     }
-    quicklist->alloc_size += entry_usable.newsize;
-    new_node->sz = sz;
+    quicklist->alloc_size += new_node->sz;
     new_node->count++;
     return new_node;
 }
@@ -607,7 +611,6 @@ static void __quicklistInsertPlainNode(quicklist *quicklist, quicklistNode *old_
  * Returns 1 if new head created. */
 int quicklistPushHead(quicklist *quicklist, void *value, size_t sz) {
     quicklistNode *orig_head = quicklist->head;
-    UsableSizes usable = {0};
 
     if (unlikely(isLargeElement(sz, quicklist->fill))) {
         __quicklistInsertPlainNode(quicklist, quicklist->head, value, sz, 0);
@@ -616,14 +619,15 @@ int quicklistPushHead(quicklist *quicklist, void *value, size_t sz) {
 
     if (likely(
             _quicklistNodeAllowInsert(quicklist->head, quicklist->fill, sz))) {
-        quicklist->head->entry = lpPrependUsable(quicklist->head->entry, value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
+        size_t oldsize = quicklist->head->sz;
+        quicklist->head->entry = lpPrepend(quicklist->head->entry, value, sz);
         quicklistNodeUpdateSz(quicklist->head);
+        quicklistUpdateAllocSize(quicklist, quicklist->head->sz, oldsize);
     } else {
         quicklistNode *node = quicklistCreateNode(quicklist);
-        node->entry = lpPrependUsable(lpNew(0), value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.newsize, 0);
+        node->entry = lpPrepend(lpNew(0), value, sz);
         quicklistNodeUpdateSz(node);
+        quicklistUpdateAllocSize(quicklist, node->sz, 0);
         _quicklistInsertNodeBefore(quicklist, quicklist->head, node);
     }
     quicklist->count++;
@@ -642,18 +646,17 @@ int quicklistPushTail(quicklist *quicklist, void *value, size_t sz) {
         return 1;
     }
 
-    UsableSizes usable = {0};
     if (likely(
             _quicklistNodeAllowInsert(quicklist->tail, quicklist->fill, sz))) {
-        quicklist->tail->entry = lpAppendUsable(quicklist->tail->entry, value, sz,
-                                                &usable);
-        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
+        size_t oldsize = quicklist->tail->sz;
+        quicklist->tail->entry = lpAppend(quicklist->tail->entry, value, sz);
         quicklistNodeUpdateSz(quicklist->tail);
+        quicklistUpdateAllocSize(quicklist, quicklist->tail->sz, oldsize);
     } else {
         quicklistNode *node = quicklistCreateNode(quicklist);
-        node->entry = lpAppendUsable(lpNew(0), value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.newsize, 0);
+        node->entry = lpAppend(lpNew(0), value, sz);
         quicklistNodeUpdateSz(node);
+        quicklistUpdateAllocSize(quicklist, node->sz, 0);
         _quicklistInsertNodeAfter(quicklist, quicklist->tail, node);
     }
     quicklist->count++;
@@ -671,7 +674,7 @@ void quicklistAppendListpack(quicklist *quicklist, unsigned char *zl) {
     node->count = lpLength(node->entry);
     node->sz = lpBytes(zl);
 
-    quicklist->alloc_size += zmalloc_usable_size(node->entry);
+    quicklist->alloc_size += node->sz;
     _quicklistInsertNodeAfter(quicklist, quicklist->tail, node);
     quicklist->count += node->count;
 }
@@ -688,7 +691,7 @@ void quicklistAppendPlainNode(quicklist *quicklist, unsigned char *data, size_t 
     node->sz = sz;
     node->container = QUICKLIST_NODE_CONTAINER_PLAIN;
 
-    quicklist->alloc_size += zmalloc_usable_size(node->entry);
+    quicklist->alloc_size += sz;
     _quicklistInsertNodeAfter(quicklist, quicklist->tail, node);
     quicklist->count += node->count;
 }
@@ -733,9 +736,15 @@ REDIS_STATIC void __quicklistDelNode(quicklist *quicklist,
      * now have compressed nodes needing to be decompressed. */
     __quicklistCompress(quicklist, NULL);
 
+    if (node->encoding == QUICKLIST_NODE_ENCODING_LZF) {
+        quicklistLZF *lzf = (quicklistLZF *)node->entry;
+        size_t lzf_sz = sizeof(*lzf) + lzf->sz;
+        quicklist->alloc_size -= lzf_sz;
+    } else {
+        quicklist->alloc_size -= node->sz;
+    }
+    zfree(node->entry);
     size_t usable;
-    zfree_usable(node->entry, &usable);
-    quicklist->alloc_size -= usable;
     zfree_usable(node, &usable);
     quicklist->alloc_size -= usable;
 }
@@ -751,20 +760,19 @@ REDIS_STATIC void __quicklistDelNode(quicklist *quicklist,
 REDIS_STATIC int quicklistDelIndex(quicklist *quicklist, quicklistNode *node,
                                    unsigned char **p) {
     int gone = 0;
-    UsableSizes usable = {0};
 
     if (unlikely(QL_NODE_IS_PLAIN(node))) {
         __quicklistDelNode(quicklist, node);
         return 1;
     }
-    node->entry = lpDeleteUsable(node->entry, *p, p, &usable);
-    quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
+    size_t oldsize = node->sz;
+    node->entry = lpDelete(node->entry, *p, p);
+    quicklistNodeUpdateSz(node);
+    quicklistUpdateAllocSize(quicklist, node->sz, oldsize);
     node->count--;
     if (node->count == 0) {
         gone = 1;
         __quicklistDelNode(quicklist, node);
-    } else {
-        quicklistNodeUpdateSz(node);
     }
     quicklist->count--;
     /* If we deleted the node, the original node is no longer valid */
@@ -811,21 +819,22 @@ void quicklistReplaceEntry(quicklistIter *iter, quicklistEntry *entry,
     quicklist* quicklist = iter->quicklist;
     quicklistNode *node = entry->node;
     unsigned char *newentry;
-    UsableSizes usable = {0};
 
     if (likely(!QL_NODE_IS_PLAIN(entry->node) && !isLargeElement(sz, quicklist->fill) &&
-        (newentry = lpReplaceUsable(entry->node->entry, &entry->zi, data, sz, &usable)) != NULL))
+        (newentry = lpReplace(entry->node->entry, &entry->zi, data, sz)) != NULL))
     {
         entry->node->entry = newentry;
-        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
+        size_t oldsize = entry->node->sz;
         quicklistNodeUpdateSz(entry->node);
+        quicklistUpdateAllocSize(quicklist, entry->node->sz, oldsize);
         /* quicklistNext() and quicklistGetIteratorEntryAtIdx() provide an uncompressed node */
         quicklistCompress(quicklist, entry->node);
     } else if (QL_NODE_IS_PLAIN(entry->node)) {
         if (isLargeElement(sz, quicklist->fill)) {
-            zfree_usable(entry->node->entry, &usable.oldsize);
-            entry->node->entry = zmalloc_usable(sz, &usable.newsize);
-            quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
+            zfree(entry->node->entry);
+            entry->node->entry = zmalloc(sz);
+            size_t oldsize = entry->node->sz;
+            quicklistUpdateAllocSize(quicklist, sz, oldsize);
             entry->node->sz = sz;
             memcpy(entry->node->entry, data, sz);
             quicklistCompress(quicklist, entry->node);
@@ -905,12 +914,11 @@ int quicklistReplaceAtIndex(quicklist *quicklist, long index, void *data,
 REDIS_STATIC quicklistNode *_quicklistListpackMerge(quicklist *quicklist,
                                                     quicklistNode *a,
                                                     quicklistNode *b) {
-    UsableSizes usable = {0};
     D("Requested merge (a,b) (%u, %u)", a->count, b->count);
 
     quicklistDecompressNode(quicklist, a);
     quicklistDecompressNode(quicklist, b);
-    if ((lpMergeUsable(&a->entry, &b->entry, &usable))) {
+    if ((lpMerge(&a->entry, &b->entry))) {
         /* We merged listpacks! Now remove the unused quicklistNode. */
         quicklistNode *keep = NULL, *nokeep = NULL;
         if (!a->entry) {
@@ -921,8 +929,9 @@ REDIS_STATIC quicklistNode *_quicklistListpackMerge(quicklist *quicklist,
             keep = a;
         }
         keep->count = lpLength(keep->entry);
+        size_t oldsize = keep->sz;
         quicklistNodeUpdateSz(keep);
-        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
+        quicklistUpdateAllocSize(quicklist, keep->sz, oldsize);
         keep->recompress = 0; /* Prevent 'keep' from being recompressed if
                                * it becomes head or tail after merging. */
 
@@ -1034,16 +1043,16 @@ REDIS_STATIC quicklistNode *_quicklistSplitNode(quicklist *quicklist, quicklistN
     D("After %d (%d); ranges: [%d, %d], [%d, %d]", after, offset, orig_start,
       orig_extent, new_start, new_extent);
 
-    UsableSizes usable = {0};
-    node->entry = lpDeleteRangeUsable(node->entry, orig_start, orig_extent, &usable);
-    quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
+    size_t oldsize = node->sz;
+    node->entry = lpDeleteRange(node->entry, orig_start, orig_extent);
     node->count = lpLength(node->entry);
     quicklistNodeUpdateSz(node);
+    quicklistUpdateAllocSize(quicklist, node->sz, oldsize);
 
-    new_node->entry = lpDeleteRangeUsable(new_node->entry, new_start, new_extent, &usable);
-    quicklistUpdateAllocSize(quicklist, usable.newsize, 0);
+    new_node->entry = lpDeleteRange(new_node->entry, new_start, new_extent);
     new_node->count = lpLength(new_node->entry);
     quicklistNodeUpdateSz(new_node);
+    quicklistUpdateAllocSize(quicklist, new_node->sz, 0);
 
     D("After split lengths: orig (%d), new (%d)", node->count, new_node->count);
     return new_node;
@@ -1061,7 +1070,6 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
     int fill = quicklist->fill;
     quicklistNode *node = entry->node;
     quicklistNode *new_node = NULL;
-    UsableSizes usable = {0};
 
     if (!node) {
         /* we have no reference node, so let's create only node in the list */
@@ -1071,8 +1079,9 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
             return;
         }
         new_node = quicklistCreateNode(quicklist);
-        new_node->entry = lpPrependUsable(lpNew(0), value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.newsize, 0);
+        new_node->entry = lpPrepend(lpNew(0), value, sz);
+        quicklistNodeUpdateSz(new_node);
+        quicklistUpdateAllocSize(quicklist, new_node->sz, 0);
         __quicklistInsertNode(quicklist, NULL, new_node, after);
         new_node->count++;
         quicklist->count++;
@@ -1122,18 +1131,20 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
     if (!full && after) {
         D("Not full, inserting after current position.");
         quicklistDecompressNodeForUse(quicklist, node);
-        node->entry = lpInsertStringUsable(node->entry, value, sz, entry->zi, LP_AFTER, NULL, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
-        node->count++;
+        node->entry = lpInsertString(node->entry, value, sz, entry->zi, LP_AFTER, NULL);
+        size_t oldsize = node->sz;
         quicklistNodeUpdateSz(node);
+        quicklistUpdateAllocSize(quicklist, node->sz, oldsize);
+        node->count++;
         quicklistRecompressOnly(quicklist, node);
     } else if (!full && !after) {
         D("Not full, inserting before current position.");
         quicklistDecompressNodeForUse(quicklist, node);
-        node->entry = lpInsertStringUsable(node->entry, value, sz, entry->zi, LP_BEFORE, NULL, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
-        node->count++;
+        node->entry = lpInsertString(node->entry, value, sz, entry->zi, LP_BEFORE, NULL);
+        size_t oldsize = node->sz;
         quicklistNodeUpdateSz(node);
+        quicklistUpdateAllocSize(quicklist, node->sz, oldsize);
+        node->count++;
         quicklistRecompressOnly(quicklist, node);
     } else if (full && at_tail && avail_next && after) {
         /* If we are: at tail, next has free space, and inserting after:
@@ -1141,10 +1152,11 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         D("Full and tail, but next isn't full; inserting next node head");
         new_node = node->next;
         quicklistDecompressNodeForUse(quicklist, new_node);
-        new_node->entry = lpPrependUsable(new_node->entry, value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
-        new_node->count++;
+        new_node->entry = lpPrepend(new_node->entry, value, sz);
+        size_t oldsize = new_node->sz;
         quicklistNodeUpdateSz(new_node);
+        quicklistUpdateAllocSize(quicklist, new_node->sz, oldsize);
+        new_node->count++;
         quicklistRecompressOnly(quicklist, new_node);
         quicklistRecompressOnly(quicklist, node);
     } else if (full && at_head && avail_prev && !after) {
@@ -1153,10 +1165,11 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         D("Full and head, but prev isn't full, inserting prev node tail");
         new_node = node->prev;
         quicklistDecompressNodeForUse(quicklist, new_node);
-        new_node->entry = lpAppendUsable(new_node->entry, value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
-        new_node->count++;
+        new_node->entry = lpAppend(new_node->entry, value, sz);
+        size_t oldsize = new_node->sz;
         quicklistNodeUpdateSz(new_node);
+        quicklistUpdateAllocSize(quicklist, new_node->sz, oldsize);
+        new_node->count++;
         quicklistRecompressOnly(quicklist, new_node);
         quicklistRecompressOnly(quicklist, node);
     } else if (full && ((at_tail && !avail_next && after) ||
@@ -1165,10 +1178,10 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
          *   - create new node and attach to quicklist */
         D("\tprovisioning new node...");
         new_node = quicklistCreateNode(quicklist);
-        new_node->entry = lpPrependUsable(lpNew(0), value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.newsize, 0);
-        new_node->count++;
+        new_node->entry = lpPrepend(lpNew(0), value, sz);
         quicklistNodeUpdateSz(new_node);
+        quicklistUpdateAllocSize(quicklist, new_node->sz, 0);
+        new_node->count++;
         __quicklistInsertNode(quicklist, node, new_node, after);
     } else if (full) {
         /* else, node is full we need to split it. */
@@ -1177,12 +1190,13 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         quicklistDecompressNodeForUse(quicklist, node);
         new_node = _quicklistSplitNode(quicklist, node, entry->offset, after);
         if (after)
-            new_node->entry = lpPrependUsable(new_node->entry, value, sz, &usable);
+            new_node->entry = lpPrepend(new_node->entry, value, sz);
         else
-            new_node->entry = lpAppendUsable(new_node->entry, value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
-        new_node->count++;
+            new_node->entry = lpAppend(new_node->entry, value, sz);
+        size_t oldsize = new_node->sz;
         quicklistNodeUpdateSz(new_node);
+        quicklistUpdateAllocSize(quicklist, new_node->sz, oldsize);
+        new_node->count++;
         __quicklistInsertNode(quicklist, node, new_node, after);
         _quicklistMergeNodes(quicklist, node);
     }
@@ -1278,11 +1292,11 @@ int quicklistDelRange(quicklist *quicklist, const long start,
         if (delete_entire_node || QL_NODE_IS_PLAIN(node)) {
             __quicklistDelNode(quicklist, node);
         } else {
-            UsableSizes usable = {0};
             quicklistDecompressNodeForUse(quicklist, node);
-            node->entry = lpDeleteRangeUsable(node->entry, offset, del, &usable);
-            quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
+            node->entry = lpDeleteRange(node->entry, offset, del);
+            size_t oldsize = node->sz;
             quicklistNodeUpdateSz(node);
+            quicklistUpdateAllocSize(quicklist, node->sz, oldsize);
             node->count -= del;
             quicklist->count -= del;
             quicklistDeleteIfEmpty(quicklist, node);
@@ -1550,16 +1564,17 @@ quicklist *quicklistDup(quicklist *orig) {
     for (quicklistNode *current = orig->head; current;
          current = current->next) {
         quicklistNode *node = quicklistCreateNode(copy);
-        size_t entry_size = 0;
 
         if (current->encoding == QUICKLIST_NODE_ENCODING_LZF) {
             quicklistLZF *lzf = (quicklistLZF *)current->entry;
             size_t lzf_sz = sizeof(*lzf) + lzf->sz;
-            node->entry = zmalloc_usable(lzf_sz, &entry_size);
+            node->entry = zmalloc(lzf_sz);
             memcpy(node->entry, current->entry, lzf_sz);
+            copy->alloc_size += lzf_sz;
         } else if (current->encoding == QUICKLIST_NODE_ENCODING_RAW) {
-            node->entry = zmalloc_usable(current->sz, &entry_size);
+            node->entry = zmalloc(current->sz);
             memcpy(node->entry, current->entry, current->sz);
+            copy->alloc_size += current->sz;
         }
 
         node->count = current->count;
@@ -1567,7 +1582,6 @@ quicklist *quicklistDup(quicklist *orig) {
         node->encoding = current->encoding;
         node->container = current->container;
         copy->count += node->count;
-        copy->alloc_size += entry_size;
 
         _quicklistInsertNodeAfter(copy, copy->tail, node);
     }
@@ -2030,7 +2044,12 @@ static int _ql_verify_alloc_size(quicklist *ql) {
     quicklistNode* node = ql->head;
     while (node != NULL) {
         alloc_size += zmalloc_usable_size(node);
-        alloc_size += zmalloc_usable_size(node->entry);
+        if (node->encoding == QUICKLIST_NODE_ENCODING_LZF) {
+            quicklistLZF *lzf = (quicklistLZF *)node->entry;
+            alloc_size += sizeof(*lzf) + lzf->sz;
+        } else {
+            alloc_size += node->sz;
+        }
         node = node->next;
     }
 
@@ -3583,11 +3602,10 @@ int quicklistTest(int argc, char *argv[], int flags) {
 
             /* Keep filling the node, until it reaches 1GB */
             for (int i = 0; i < 32; i++) {
-                UsableSizes usable = {0};
-                node->entry = lpAppendUsable(node->entry, s, sz,
-                                             &usable);
-                quicklistUpdateAllocSize(ql, usable.newsize, usable.oldsize);
+                node->entry = lpAppend(node->entry, s, sz);
+                size_t oldsize = node->sz;
                 quicklistNodeUpdateSz(node);
+                quicklistUpdateAllocSize(ql, node->sz, oldsize);
 
                 long long start = mstime();
                 assert(__quicklistCompressNode(ql, node));

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -578,7 +578,7 @@ REDIS_STATIC int _quicklistNodeAllowMerge(const quicklistNode *a,
     } while (0)
 
 static quicklistNode* __quicklistCreateNode(quicklist *quicklist, int container, void *value, size_t sz) {
-    UsableSizes entry_usable;
+    UsableSizes entry_usable = {0};
     quicklistNode *new_node = quicklistCreateNode(quicklist);
     new_node->container = container;
     if (container == QUICKLIST_NODE_CONTAINER_PLAIN) {
@@ -607,7 +607,7 @@ static void __quicklistInsertPlainNode(quicklist *quicklist, quicklistNode *old_
  * Returns 1 if new head created. */
 int quicklistPushHead(quicklist *quicklist, void *value, size_t sz) {
     quicklistNode *orig_head = quicklist->head;
-    UsableSizes usable;
+    UsableSizes usable = {0};
 
     if (unlikely(isLargeElement(sz, quicklist->fill))) {
         __quicklistInsertPlainNode(quicklist, quicklist->head, value, sz, 0);
@@ -642,7 +642,7 @@ int quicklistPushTail(quicklist *quicklist, void *value, size_t sz) {
         return 1;
     }
 
-    UsableSizes usable;
+    UsableSizes usable = {0};
     if (likely(
             _quicklistNodeAllowInsert(quicklist->tail, quicklist->fill, sz))) {
         quicklist->tail->entry = lpAppendUsable(quicklist->tail->entry, value, sz,
@@ -751,7 +751,7 @@ REDIS_STATIC void __quicklistDelNode(quicklist *quicklist,
 REDIS_STATIC int quicklistDelIndex(quicklist *quicklist, quicklistNode *node,
                                    unsigned char **p) {
     int gone = 0;
-    UsableSizes usable;
+    UsableSizes usable = {0};
 
     if (unlikely(QL_NODE_IS_PLAIN(node))) {
         __quicklistDelNode(quicklist, node);
@@ -811,7 +811,7 @@ void quicklistReplaceEntry(quicklistIter *iter, quicklistEntry *entry,
     quicklist* quicklist = iter->quicklist;
     quicklistNode *node = entry->node;
     unsigned char *newentry;
-    UsableSizes usable;
+    UsableSizes usable = {0};
 
     if (likely(!QL_NODE_IS_PLAIN(entry->node) && !isLargeElement(sz, quicklist->fill) &&
         (newentry = lpReplaceUsable(entry->node->entry, &entry->zi, data, sz, &usable)) != NULL))
@@ -905,7 +905,7 @@ int quicklistReplaceAtIndex(quicklist *quicklist, long index, void *data,
 REDIS_STATIC quicklistNode *_quicklistListpackMerge(quicklist *quicklist,
                                                     quicklistNode *a,
                                                     quicklistNode *b) {
-    UsableSizes usable;
+    UsableSizes usable = {0};
     D("Requested merge (a,b) (%u, %u)", a->count, b->count);
 
     quicklistDecompressNode(quicklist, a);
@@ -1034,7 +1034,7 @@ REDIS_STATIC quicklistNode *_quicklistSplitNode(quicklist *quicklist, quicklistN
     D("After %d (%d); ranges: [%d, %d], [%d, %d]", after, offset, orig_start,
       orig_extent, new_start, new_extent);
 
-    UsableSizes usable;
+    UsableSizes usable = {0};
     node->entry = lpDeleteRangeUsable(node->entry, orig_start, orig_extent, &usable);
     quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
     node->count = lpLength(node->entry);
@@ -1061,7 +1061,7 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
     int fill = quicklist->fill;
     quicklistNode *node = entry->node;
     quicklistNode *new_node = NULL;
-    UsableSizes usable;
+    UsableSizes usable = {0};
 
     if (!node) {
         /* we have no reference node, so let's create only node in the list */
@@ -1278,7 +1278,7 @@ int quicklistDelRange(quicklist *quicklist, const long start,
         if (delete_entire_node || QL_NODE_IS_PLAIN(node)) {
             __quicklistDelNode(quicklist, node);
         } else {
-            UsableSizes usable;
+            UsableSizes usable = {0};
             quicklistDecompressNodeForUse(quicklist, node);
             node->entry = lpDeleteRangeUsable(node->entry, offset, del, &usable);
             quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
@@ -3583,7 +3583,7 @@ int quicklistTest(int argc, char *argv[], int flags) {
 
             /* Keep filling the node, until it reaches 1GB */
             for (int i = 0; i < 32; i++) {
-                UsableSizes usable;
+                UsableSizes usable = {0};
                 node->entry = lpAppendUsable(node->entry, s, sz,
                                              &usable);
                 quicklistUpdateAllocSize(ql, usable.newsize, usable.oldsize);

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -3582,7 +3582,7 @@ int quicklistTest(int argc, char *argv[], int flags) {
                 UsableSizes usable;
                 node->entry = lpAppendUsable(node->entry, s, sz,
                                              &usable);
-                quicklistUpdateAllocSize(ql, usable.val, usable.oldval);
+                quicklistUpdateAllocSize(ql, usable.newsize, usable.oldsize);
                 quicklistNodeUpdateSz(node);
 
                 long long start = mstime();

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -578,12 +578,12 @@ static quicklistNode* __quicklistCreateNode(quicklist *quicklist, int container,
     quicklistNode *new_node = quicklistCreateNode(quicklist);
     new_node->container = container;
     if (container == QUICKLIST_NODE_CONTAINER_PLAIN) {
-        new_node->entry = zmalloc_usable(sz, &entry_usable.val);
+        new_node->entry = zmalloc_usable(sz, &entry_usable.newsize);
         memcpy(new_node->entry, value, sz);
     } else {
         new_node->entry = lpPrependUsable(lpNew(0), value, sz, &entry_usable);
     }
-    quicklist->alloc_size += entry_usable.val;
+    quicklist->alloc_size += entry_usable.newsize;
     new_node->sz = sz;
     new_node->count++;
     return new_node;
@@ -613,12 +613,12 @@ int quicklistPushHead(quicklist *quicklist, void *value, size_t sz) {
     if (likely(
             _quicklistNodeAllowInsert(quicklist->head, quicklist->fill, sz))) {
         quicklist->head->entry = lpPrependUsable(quicklist->head->entry, value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
         quicklistNodeUpdateSz(quicklist->head);
     } else {
         quicklistNode *node = quicklistCreateNode(quicklist);
         node->entry = lpPrependUsable(lpNew(0), value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.val, 0);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, 0);
         quicklistNodeUpdateSz(node);
         _quicklistInsertNodeBefore(quicklist, quicklist->head, node);
     }
@@ -643,12 +643,12 @@ int quicklistPushTail(quicklist *quicklist, void *value, size_t sz) {
             _quicklistNodeAllowInsert(quicklist->tail, quicklist->fill, sz))) {
         quicklist->tail->entry = lpAppendUsable(quicklist->tail->entry, value, sz,
                                                 &usable);
-        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
         quicklistNodeUpdateSz(quicklist->tail);
     } else {
         quicklistNode *node = quicklistCreateNode(quicklist);
         node->entry = lpAppendUsable(lpNew(0), value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.val, 0);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, 0);
         quicklistNodeUpdateSz(node);
         _quicklistInsertNodeAfter(quicklist, quicklist->tail, node);
     }
@@ -754,7 +754,7 @@ REDIS_STATIC int quicklistDelIndex(quicklist *quicklist, quicklistNode *node,
         return 1;
     }
     node->entry = lpDeleteUsable(node->entry, *p, p, &usable);
-    quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+    quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
     node->count--;
     if (node->count == 0) {
         gone = 1;
@@ -813,15 +813,15 @@ void quicklistReplaceEntry(quicklistIter *iter, quicklistEntry *entry,
         (newentry = lpReplaceUsable(entry->node->entry, &entry->zi, data, sz, &usable)) != NULL))
     {
         entry->node->entry = newentry;
-        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
         quicklistNodeUpdateSz(entry->node);
         /* quicklistNext() and quicklistGetIteratorEntryAtIdx() provide an uncompressed node */
         quicklistCompress(quicklist, entry->node);
     } else if (QL_NODE_IS_PLAIN(entry->node)) {
         if (isLargeElement(sz, quicklist->fill)) {
-            zfree_usable(entry->node->entry, &usable.oldval);
-            entry->node->entry = zmalloc_usable(sz, &usable.val);
-            quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+            zfree_usable(entry->node->entry, &usable.oldsize);
+            entry->node->entry = zmalloc_usable(sz, &usable.newsize);
+            quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
             entry->node->sz = sz;
             memcpy(entry->node->entry, data, sz);
             quicklistCompress(quicklist, entry->node);
@@ -918,7 +918,7 @@ REDIS_STATIC quicklistNode *_quicklistListpackMerge(quicklist *quicklist,
         }
         keep->count = lpLength(keep->entry);
         quicklistNodeUpdateSz(keep);
-        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
         keep->recompress = 0; /* Prevent 'keep' from being recompressed if
                                * it becomes head or tail after merging. */
 
@@ -1032,12 +1032,12 @@ REDIS_STATIC quicklistNode *_quicklistSplitNode(quicklist *quicklist, quicklistN
 
     UsableSizes usable;
     node->entry = lpDeleteRangeUsable(node->entry, orig_start, orig_extent, &usable);
-    quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+    quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
     node->count = lpLength(node->entry);
     quicklistNodeUpdateSz(node);
 
     new_node->entry = lpDeleteRangeUsable(new_node->entry, new_start, new_extent, &usable);
-    quicklistUpdateAllocSize(quicklist, usable.val, 0);
+    quicklistUpdateAllocSize(quicklist, usable.newsize, 0);
     new_node->count = lpLength(new_node->entry);
     quicklistNodeUpdateSz(new_node);
 
@@ -1068,7 +1068,7 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         }
         new_node = quicklistCreateNode(quicklist);
         new_node->entry = lpPrependUsable(lpNew(0), value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.val, 0);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, 0);
         __quicklistInsertNode(quicklist, NULL, new_node, after);
         new_node->count++;
         quicklist->count++;
@@ -1119,7 +1119,7 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         D("Not full, inserting after current position.");
         quicklistDecompressNodeForUse(quicklist, node);
         node->entry = lpInsertStringUsable(node->entry, value, sz, entry->zi, LP_AFTER, NULL, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
         node->count++;
         quicklistNodeUpdateSz(node);
         quicklistRecompressOnly(quicklist, node);
@@ -1127,7 +1127,7 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         D("Not full, inserting before current position.");
         quicklistDecompressNodeForUse(quicklist, node);
         node->entry = lpInsertStringUsable(node->entry, value, sz, entry->zi, LP_BEFORE, NULL, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
         node->count++;
         quicklistNodeUpdateSz(node);
         quicklistRecompressOnly(quicklist, node);
@@ -1138,7 +1138,7 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         new_node = node->next;
         quicklistDecompressNodeForUse(quicklist, new_node);
         new_node->entry = lpPrependUsable(new_node->entry, value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
         new_node->count++;
         quicklistNodeUpdateSz(new_node);
         quicklistRecompressOnly(quicklist, new_node);
@@ -1150,7 +1150,7 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         new_node = node->prev;
         quicklistDecompressNodeForUse(quicklist, new_node);
         new_node->entry = lpAppendUsable(new_node->entry, value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
         new_node->count++;
         quicklistNodeUpdateSz(new_node);
         quicklistRecompressOnly(quicklist, new_node);
@@ -1162,7 +1162,7 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
         D("\tprovisioning new node...");
         new_node = quicklistCreateNode(quicklist);
         new_node->entry = lpPrependUsable(lpNew(0), value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.val, 0);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, 0);
         new_node->count++;
         quicklistNodeUpdateSz(new_node);
         __quicklistInsertNode(quicklist, node, new_node, after);
@@ -1176,7 +1176,7 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
             new_node->entry = lpPrependUsable(new_node->entry, value, sz, &usable);
         else
             new_node->entry = lpAppendUsable(new_node->entry, value, sz, &usable);
-        quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+        quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
         new_node->count++;
         quicklistNodeUpdateSz(new_node);
         __quicklistInsertNode(quicklist, node, new_node, after);
@@ -1277,7 +1277,7 @@ int quicklistDelRange(quicklist *quicklist, const long start,
             UsableSizes usable;
             quicklistDecompressNodeForUse(quicklist, node);
             node->entry = lpDeleteRangeUsable(node->entry, offset, del, &usable);
-            quicklistUpdateAllocSize(quicklist, usable.val, usable.oldval);
+            quicklistUpdateAllocSize(quicklist, usable.newsize, usable.oldsize);
             quicklistNodeUpdateSz(node);
             node->count -= del;
             quicklist->count -= del;

--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -68,7 +68,7 @@ typedef struct quicklistLZF {
     char compressed[];
 } quicklistLZF;
 
-/* Bookmarks are padded with realloc at the end of of the quicklist struct.
+/* Bookmarks are padded with realloc at the end of the quicklist struct.
  * They should only be used for very big lists if thousands of nodes were the
  * excess memory usage is negligible, and there's a real need to iterate on them
  * in portions.
@@ -109,6 +109,7 @@ typedef struct quicklist {
     quicklistNode *tail;
     unsigned long count;        /* total count of all entries in all listpacks */
     unsigned long len;          /* number of quicklistNodes */
+    size_t alloc_size;          /* total allocated memory (in bytes) */
     signed int fill : QL_FILL_BITS;       /* fill factor for individual nodes */
     unsigned int compress : QL_COMP_BITS; /* depth of end nodes not to compress;0=off */
     unsigned int bookmark_count: QL_BM_BITS;
@@ -174,7 +175,7 @@ void quicklistReplaceEntry(quicklistIter *iter, quicklistEntry *entry,
                            void *data, size_t sz);
 int quicklistReplaceAtIndex(quicklist *quicklist, long index, void *data,
                             const size_t sz);
-int quicklistDelRange(quicklist *quicklist, const long start, const long stop);
+int quicklistDelRange(quicklist *quicklist, const long start, const long count);
 quicklistIter *quicklistGetIterator(quicklist *quicklist, int direction);
 quicklistIter *quicklistGetIteratorAtIdx(quicklist *quicklist,
                                          int direction, const long long idx);
@@ -191,6 +192,7 @@ int quicklistPopCustom(quicklist *quicklist, int where, unsigned char **data,
 int quicklistPop(quicklist *quicklist, int where, unsigned char **data,
                  size_t *sz, long long *slong);
 unsigned long quicklistCount(const quicklist *ql);
+size_t quicklistAllocSize(const quicklist *ql);
 int quicklistCompare(quicklistEntry *entry, unsigned char *p2, const size_t p2_len,
                      long long *cached_longval, int *cached_valid);
 size_t quicklistGetLzf(const quicklistNode *node, void **data);

--- a/src/rax.c
+++ b/src/rax.c
@@ -158,32 +158,55 @@ static inline void raxStackFree(raxStack *ts) {
  * If datafield is true, the allocation is made large enough to hold the
  * associated data pointer.
  * Returns the new node pointer. On out of memory NULL is returned. */
-raxNode *raxNewNode(size_t children, int datafield) {
+raxNode *raxNewNode(rax *rax, size_t children, int datafield) {
     size_t nodesize = sizeof(raxNode)+children+raxPadding(children)+
                       sizeof(raxNode*)*children;
     if (datafield) nodesize += sizeof(void*);
-    raxNode *node = rax_malloc(nodesize);
+    size_t usable;
+    raxNode *node = rax_malloc_usable(nodesize,&usable);
     if (node == NULL) return NULL;
     node->iskey = 0;
     node->isnull = 0;
     node->iscompr = 0;
     node->size = children;
+    if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
+        size_t *alloc_size = (size_t *)rax->metadata;
+        *alloc_size += usable;
+    }
     return node;
+}
+
+/* Deallocate node */
+void raxFreeNode(rax *rax, raxNode *n) {
+    size_t usable;
+    rax_free_usable(n, &usable);
+    if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
+        size_t *alloc_size = (size_t *)rax->metadata;
+        *alloc_size -= usable;
+    }
 }
 
 /* Allocate a new rax and return its pointer. On out of memory the function
  * returns NULL. */
 rax *raxNew(void) {
-    return raxNewWithMetadata(0);
+    return raxNewWithMetadata(0, 0);
 }
 
 /* Allocate a new rax with metadata */
-rax *raxNewWithMetadata(int metaSize) {
-    rax *rax = rax_malloc(sizeof(*rax) + metaSize);
+rax *raxNewWithMetadata(int flags, int metaSize) {
+    assert(!(flags & RAX_ACCOUNT_ALLOC_SIZE) ||
+           (size_t)metaSize >= sizeof(size_t));
+    size_t usable;
+    rax *rax = rax_malloc_usable(sizeof(*rax) + metaSize, &usable);
     if (rax == NULL) return NULL;
+    rax->flags = flags & RAX_FLAGS_MASK;
     rax->numele = 0;
     rax->numnodes = 1;
-    rax->head = raxNewNode(0, 0);
+    if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
+        size_t *alloc_size = (size_t *)rax->metadata;
+        *alloc_size = usable;
+    }
+    rax->head = raxNewNode(rax, 0, 0);
     if (rax->head == NULL) {
         rax_free(rax);
         return NULL;
@@ -192,12 +215,25 @@ rax *raxNewWithMetadata(int metaSize) {
     }
 }
 
+/* realloc the node to have 'newsize'. On out of memory NULL is returned. */
+raxNode *raxNodeRealloc(rax *rax, raxNode *n, size_t newsize) {
+    size_t usable, old_usable;
+    raxNode *newn = rax_realloc_usable(n,newsize,&usable,&old_usable);
+    if (newn == NULL) return NULL;
+    if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
+        size_t *alloc_size = (size_t *)rax->metadata;
+        *alloc_size -= old_usable;
+        *alloc_size += usable;
+    }
+    return newn;
+}
+
 /* realloc the node to make room for auxiliary data in order
  * to store an item in that node. On out of memory NULL is returned. */
-raxNode *raxReallocForData(raxNode *n, void *data) {
+raxNode *raxReallocForData(rax *rax, raxNode *n, void *data) {
     if (data == NULL) return n; /* No reallocation needed, setting isnull=1 */
     size_t curlen = raxNodeCurrentLength(n);
-    return rax_realloc(n,curlen+sizeof(void*));
+    return raxNodeRealloc(rax,n,curlen+sizeof(void*));
 }
 
 /* Set the node auxiliary data to the specified pointer. */
@@ -231,7 +267,7 @@ void *raxGetData(raxNode *n) {
  * On success the new parent node pointer is returned (it may change because
  * of the realloc, so the caller should discard 'n' and use the new value).
  * On out of memory NULL is returned, and the old node is still valid. */
-raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode ***parentlink) {
+raxNode *raxAddChild(rax *rax, raxNode *n, unsigned char c, raxNode **childptr, raxNode ***parentlink) {
     assert(n->iscompr == 0);
 
     size_t curlen = raxNodeCurrentLength(n);
@@ -241,13 +277,13 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
                   success at the end. */
 
     /* Alloc the new child we will link to 'n'. */
-    raxNode *child = raxNewNode(0,0);
+    raxNode *child = raxNewNode(rax,0,0);
     if (child == NULL) return NULL;
 
     /* Make space in the original node. */
-    raxNode *newn = rax_realloc(n,newlen);
+    raxNode *newn = raxNodeRealloc(rax,n,newlen);
     if (newn == NULL) {
-        rax_free(child);
+        raxFreeNode(rax,child);
         return NULL;
     }
     n = newn;
@@ -372,7 +408,7 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
  * The function also returns a child node, since the last node of the
  * compressed chain cannot be part of the chain: it has zero children while
  * we can only compress inner nodes with exactly one child each. */
-raxNode *raxCompressNode(raxNode *n, unsigned char *s, size_t len, raxNode **child) {
+raxNode *raxCompressNode(rax *rax, raxNode *n, unsigned char *s, size_t len, raxNode **child) {
     assert(n->size == 0 && n->iscompr == 0);
     void *data = NULL; /* Initialized only to avoid warnings. */
     size_t newsize;
@@ -380,7 +416,7 @@ raxNode *raxCompressNode(raxNode *n, unsigned char *s, size_t len, raxNode **chi
     debugf("Compress node: %.*s\n", (int)len,s);
 
     /* Allocate the child to link to this node. */
-    *child = raxNewNode(0,0);
+    *child = raxNewNode(rax,0,0);
     if (*child == NULL) return NULL;
 
     /* Make space in the parent node. */
@@ -389,9 +425,9 @@ raxNode *raxCompressNode(raxNode *n, unsigned char *s, size_t len, raxNode **chi
         data = raxGetData(n); /* To restore it later. */
         if (!n->isnull) newsize += sizeof(void*);
     }
-    raxNode *newn = rax_realloc(n,newsize);
+    raxNode *newn = raxNodeRealloc(rax,n,newsize);
     if (newn == NULL) {
-        rax_free(*child);
+        raxFreeNode(rax, *child);
         return NULL;
     }
     n = newn;
@@ -485,7 +521,7 @@ static inline size_t raxLowWalk(rax *rax, unsigned char *s, size_t len, raxNode 
  * be set to 0.
  */
 int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old, int overwrite) {
-    size_t i;
+    size_t i, usable;
     int j = 0; /* Split position. If raxLowWalk() stops in a compressed
                   node, the index 'j' represents the char we stopped within the
                   compressed node, that is, the position where to split the
@@ -504,7 +540,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         debugf("### Insert: node representing key exists\n");
         /* Make space for the value pointer if needed. */
         if (!h->iskey || (h->isnull && overwrite)) {
-            h = raxReallocForData(h,data);
+            h = raxReallocForData(rax,h,data);
             if (h) memcpy(parentlink,&h,sizeof(h));
         }
         if (h == NULL) {
@@ -677,7 +713,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
 
         /* 2: Create the split node. Also allocate the other nodes we'll need
          *    ASAP, so that it will be simpler to handle OOM. */
-        raxNode *splitnode = raxNewNode(1, split_node_is_key);
+        raxNode *splitnode = raxNewNode(rax, 1, split_node_is_key);
         raxNode *trimmed = NULL;
         raxNode *postfix = NULL;
 
@@ -685,13 +721,21 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             nodesize = sizeof(raxNode)+trimmedlen+raxPadding(trimmedlen)+
                        sizeof(raxNode*);
             if (h->iskey && !h->isnull) nodesize += sizeof(void*);
-            trimmed = rax_malloc(nodesize);
+            trimmed = rax_malloc_usable(nodesize, &usable);
+            if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
+                size_t *alloc_size = (size_t *)rax->metadata;
+                *alloc_size += usable;
+            }
         }
 
         if (postfixlen) {
             nodesize = sizeof(raxNode)+postfixlen+raxPadding(postfixlen)+
                        sizeof(raxNode*);
-            postfix = rax_malloc(nodesize);
+            postfix = rax_malloc_usable(nodesize, &usable);
+            if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
+                size_t *alloc_size = (size_t *)rax->metadata;
+                *alloc_size += usable;
+            }
         }
 
         /* OOM? Abort now that the tree is untouched. */
@@ -699,9 +743,9 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             (trimmedlen && trimmed == NULL) ||
             (postfixlen && postfix == NULL))
         {
-            rax_free(splitnode);
-            rax_free(trimmed);
-            rax_free(postfix);
+            raxFreeNode(rax,splitnode);
+            raxFreeNode(rax,trimmed);
+            raxFreeNode(rax,postfix);
             errno = ENOMEM;
             return 0;
         }
@@ -756,7 +800,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         /* 6. Continue insertion: this will cause the splitnode to
          * get a new child (the non common character at the currently
          * inserted key). */
-        rax_free(h);
+        raxFreeNode(rax,h);
         h = splitnode;
     } else if (h->iscompr && i == len) {
     /* ------------------------- ALGORITHM 2 --------------------------- */
@@ -768,15 +812,23 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         size_t nodesize = sizeof(raxNode)+postfixlen+raxPadding(postfixlen)+
                           sizeof(raxNode*);
         if (data != NULL) nodesize += sizeof(void*);
-        raxNode *postfix = rax_malloc(nodesize);
+        raxNode *postfix = rax_malloc_usable(nodesize, &usable);
+        if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
+            size_t *alloc_size = (size_t *)rax->metadata;
+            *alloc_size += usable;
+        }
 
         nodesize = sizeof(raxNode)+j+raxPadding(j)+sizeof(raxNode*);
         if (h->iskey && !h->isnull) nodesize += sizeof(void*);
-        raxNode *trimmed = rax_malloc(nodesize);
+        raxNode *trimmed = rax_malloc_usable(nodesize, &usable);
+        if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
+            size_t *alloc_size = (size_t *)rax->metadata;
+            *alloc_size += usable;
+        }
 
         if (postfix == NULL || trimmed == NULL) {
-            rax_free(postfix);
-            rax_free(trimmed);
+            raxFreeNode(rax,postfix);
+            raxFreeNode(rax,trimmed);
             errno = ENOMEM;
             return 0;
         }
@@ -817,7 +869,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         /* Finish! We don't need to continue with the insertion
          * algorithm for ALGO 2. The key is already inserted. */
         rax->numele++;
-        rax_free(h);
+        raxFreeNode(rax,h);
         return 1; /* Key inserted. */
     }
 
@@ -834,7 +886,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             size_t comprsize = len-i;
             if (comprsize > RAX_NODE_MAX_SIZE)
                 comprsize = RAX_NODE_MAX_SIZE;
-            raxNode *newh = raxCompressNode(h,s+i,comprsize,&child);
+            raxNode *newh = raxCompressNode(rax,h,s+i,comprsize,&child);
             if (newh == NULL) goto oom;
             h = newh;
             memcpy(parentlink,&h,sizeof(h));
@@ -843,7 +895,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         } else {
             debugf("Inserting normal node\n");
             raxNode **new_parentlink;
-            raxNode *newh = raxAddChild(h,s[i],&child,&new_parentlink);
+            raxNode *newh = raxAddChild(rax,h,s[i],&child,&new_parentlink);
             if (newh == NULL) goto oom;
             h = newh;
             memcpy(parentlink,&h,sizeof(h));
@@ -853,7 +905,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         rax->numnodes++;
         h = child;
     }
-    raxNode *newh = raxReallocForData(h,data);
+    raxNode *newh = raxReallocForData(rax,h,data);
     if (newh == NULL) goto oom;
     h = newh;
     if (!h->iskey) rax->numele++;
@@ -925,7 +977,7 @@ raxNode **raxFindParentLink(raxNode *parent, raxNode *child) {
  * removal) is returned. Note that this function does not fix the pointer
  * of the parent node in its parent, so this task is up to the caller.
  * The function never fails for out of memory. */
-raxNode *raxRemoveChild(raxNode *parent, raxNode *child) {
+raxNode *raxRemoveChild(rax *rax, raxNode *parent, raxNode *child) {
     debugnode("raxRemoveChild before", parent);
     /* If parent is a compressed node (having a single child, as for definition
      * of the data structure), the removal of the child consists into turning
@@ -987,11 +1039,11 @@ raxNode *raxRemoveChild(raxNode *parent, raxNode *child) {
 
     /* realloc the node according to the theoretical memory usage, to free
      * data if we are over-allocating right now. */
-    raxNode *newnode = rax_realloc(parent,raxNodeCurrentLength(parent));
+    raxNode *newnode = raxNodeRealloc(rax,parent,raxNodeCurrentLength(parent));
     if (newnode) {
         debugnode("raxRemoveChild after", newnode);
     }
-    /* Note: if rax_realloc() fails we just return the old address, which
+    /* Note: if raxNodeRealloc() fails we just return the old address, which
      * is valid. */
     return newnode ? newnode : parent;
 }
@@ -1030,17 +1082,17 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
             child = h;
             debugf("Freeing child %p [%.*s] key:%d\n", (void*)child,
                 (int)child->size, (char*)child->data, child->iskey);
-            rax_free(child);
+            raxFreeNode(rax,child);
             rax->numnodes--;
             h = raxStackPop(&ts);
-             /* If this node has more then one child, or actually holds
+             /* If this node has more than one child, or actually holds
               * a key, stop here. */
             if (h->iskey || (!h->iscompr && h->size != 1)) break;
         }
         if (child) {
             debugf("Unlinking child %p from parent %p\n",
                 (void*)child, (void*)h);
-            raxNode *new = raxRemoveChild(h,child);
+            raxNode *new = raxRemoveChild(rax,h,child);
             if (new != h) {
                 raxNode *parent = raxStackPeek(&ts);
                 raxNode **parentlink;
@@ -1147,12 +1199,17 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
             /* If we can compress, create the new node and populate it. */
             size_t nodesize =
                 sizeof(raxNode)+comprsize+raxPadding(comprsize)+sizeof(raxNode*);
-            raxNode *new = rax_malloc(nodesize);
+            size_t usable;
+            raxNode *new = rax_malloc_usable(nodesize, &usable);
             /* An out of memory here just means we cannot optimize this
              * node, but the tree is left in a consistent state. */
             if (new == NULL) {
                 raxStackFree(&ts);
                 return 1;
+            }
+            if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
+                size_t *alloc_size = (size_t *)rax->metadata;
+                *alloc_size += usable;
             }
             new->iskey = 0;
             new->isnull = 0;
@@ -1171,7 +1228,8 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
                 raxNode **cp = raxNodeLastChildPtr(h);
                 raxNode *tofree = h;
                 memcpy(&h,cp,sizeof(h));
-                rax_free(tofree); rax->numnodes--;
+                raxFreeNode(rax,tofree);
+                rax->numnodes--;
                 if (h->iskey || (!h->iscompr && h->size != 1)) break;
             }
             debugnode("New node",new);
@@ -1212,7 +1270,7 @@ void raxRecursiveFree(rax *rax, raxNode *n, void (*free_callback)(void*)) {
     debugnode("free depth-first",n);
     if (free_callback && n->iskey && !n->isnull)
         free_callback(raxGetData(n));
-    rax_free(n);
+    raxFreeNode(rax,n);
     rax->numnodes--;
 }
 
@@ -1231,7 +1289,7 @@ void raxRecursiveFreeWithCtx(rax *rax, raxNode *n,
     debugnode("free depth-first",n);
     if (free_callback && n->iskey && !n->isnull)
         free_callback(raxGetData(n), ctx);
-    rax_free(n);
+    raxFreeNode(rax,n);
     rax->numnodes--;
 }
 
@@ -1809,6 +1867,13 @@ uint64_t raxSize(rax *rax) {
     return rax->numele;
 }
 
+/* Return cached total memory used (in bytes) */
+size_t raxAllocSize(rax *rax) {
+    assert(rax->flags & RAX_ACCOUNT_ALLOC_SIZE);
+    size_t *alloc_size = (size_t *)rax->metadata;
+    return *alloc_size;
+}
+
 /* ----------------------------- Introspection ------------------------------ */
 
 /* This function is mostly used for debugging and learning purposes.
@@ -1933,3 +1998,120 @@ unsigned long raxTouch(raxNode *n) {
     }
     return sum;
 }
+
+/* The rest of this file is test cases and test helpers. */
+#ifdef REDIS_TEST
+#include "testhelp.h"
+#include <stdlib.h>
+
+#define UNUSED(x) (void)(x)
+
+#define yell(str, ...) printf("ERROR! " str "\n\n", __VA_ARGS__)
+
+#define ERR(x, ...)                                                            \
+    do {                                                                       \
+        printf("%s:%s:%d:\t", __FILE__, __func__, __LINE__);                   \
+        printf("ERROR! " x "\n", __VA_ARGS__);                                 \
+        err++;                                                                 \
+    } while (0)
+
+#define TEST(name) printf("test — %s\n", name);
+
+/* Verify rax memory accounting by calculating actual memory usage */
+static int _rax_verify_alloc_size(rax *rax) {
+    int errors = 0;
+    size_t alloc_size = rax_malloc_usable_size(rax);
+    raxNode *node;
+    raxStack stack;
+
+    raxStackInit(&stack);
+    raxStackPush(&stack, rax->head);
+    while ((node = raxStackPop(&stack))) {
+        alloc_size += rax_malloc_usable_size(node);
+        if (!node->iscompr) {
+            /* Non-compressed node: add all children */
+            for (int i = 0; i < node->size; i++) {
+                raxNode **child = raxNodeLastChildPtr(node) - i;
+                if (*child) raxStackPush(&stack, *child);
+            }
+        } else {
+            /* Compressed node: add single child */
+            raxNode **child = raxNodeLastChildPtr(node);
+            if (*child) raxStackPush(&stack, *child);
+        }
+    }
+    raxStackFree(&stack);
+
+    if (raxAllocSize(rax) != alloc_size) {
+        yell("rax alloc_size is wrong: expected: %zu, got: %zu\n", alloc_size, raxAllocSize(rax));
+        errors++;
+    }
+
+    return errors;
+}
+
+static void *createTestValue(size_t size) {
+    size_t usable;
+    void *val = rax_malloc_usable(size, &usable);
+    memset(val, 'A', usable);
+    return val;
+}
+
+int raxTest(int argc, char **argv, int flags) {
+    UNUSED(argc);
+    UNUSED(argv);
+    UNUSED(flags);
+
+    int err = 0;
+
+    TEST("verify raxAllocSize() after raxInsert()/raxRemove()") {
+        rax *r = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+
+        /* Insert values and verify accounting */
+        void *val1 = createTestValue(100);
+        assert(raxInsert(r, (unsigned char*)"key1", 4, val1, NULL) == 1);
+        err += _rax_verify_alloc_size(r);
+
+        void *val2 = createTestValue(200);
+        assert(raxInsert(r, (unsigned char*)"key2", 4, val2, NULL) == 1);
+        err += _rax_verify_alloc_size(r);
+
+        void *val3 = createTestValue(10);
+        assert(raxInsert(r, (unsigned char*)"3yek", 4, val3, NULL) == 1);
+        err += _rax_verify_alloc_size(r);
+
+        /* Remove a value and verify */
+        void *removed;
+        assert(raxRemove(r, (unsigned char*)"key1", 4, &removed) == 1);
+        rax_free(removed);
+        err += _rax_verify_alloc_size(r);
+
+        raxFreeWithCallback(r, rax_free);
+    }
+
+    TEST("verify raxAllocSize() when replacing existing key") {
+        rax *r = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+
+        void *val1 = createTestValue(100);
+        assert(raxInsert(r, (unsigned char*)"key", 3, val1, NULL) == 1);
+        err += _rax_verify_alloc_size(r);
+
+        /* Update with different sized value */
+        void *val2 = createTestValue(300);
+        void *old;
+        assert(raxInsert(r, (unsigned char*)"key", 3, val2, &old) == 0);
+        rax_free(old);
+        err += _rax_verify_alloc_size(r);
+
+        raxFreeWithCallback(r, rax_free);
+    }
+
+    if (!err)
+        printf("ALL TESTS PASSED!\n");
+    else
+        ERR("Sorry, not all tests passed!  In fact, %d tests failed.", err);
+
+    return err;
+}
+
+#endif

--- a/src/rax.c
+++ b/src/rax.c
@@ -519,7 +519,9 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
                   compressed node, that is, the position where to split the
                   node for insertion. */
     raxNode *h, **parentlink;
+    size_t dummy, *alloc_size = &dummy;
 
+    if (rax->alloc_size) alloc_size = rax->alloc_size;
     debugf("### Insert %.*s with value %p\n", (int)len, s, data);
     i = raxLowWalk(rax,s,len,&h,&parentlink,&j,NULL);
 
@@ -714,14 +716,14 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
                        sizeof(raxNode*);
             if (h->iskey && !h->isnull) nodesize += sizeof(void*);
             trimmed = rax_malloc_usable(nodesize, &usable);
-            if (rax->alloc_size) *rax->alloc_size += usable;
+            *alloc_size += usable;
         }
 
         if (postfixlen) {
             nodesize = sizeof(raxNode)+postfixlen+raxPadding(postfixlen)+
                        sizeof(raxNode*);
             postfix = rax_malloc_usable(nodesize, &usable);
-            if (rax->alloc_size) *rax->alloc_size += usable;
+            *alloc_size += usable;
         }
 
         /* OOM? Abort now that the tree is untouched. */
@@ -799,12 +801,12 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
                           sizeof(raxNode*);
         if (data != NULL) nodesize += sizeof(void*);
         raxNode *postfix = rax_malloc_usable(nodesize, &usable);
-        if (rax->alloc_size) *rax->alloc_size += usable;
+        *alloc_size += usable;
 
         nodesize = sizeof(raxNode)+j+raxPadding(j)+sizeof(raxNode*);
         if (h->iskey && !h->isnull) nodesize += sizeof(void*);
         raxNode *trimmed = rax_malloc_usable(nodesize, &usable);
-        if (rax->alloc_size) *rax->alloc_size += usable;
+        *alloc_size += usable;
 
         if (postfix == NULL || trimmed == NULL) {
             raxFreeNode(rax,postfix);
@@ -812,6 +814,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             errno = ENOMEM;
             return 0;
         }
+
 
         /* 1: Save next pointer. */
         raxNode **childfield = raxNodeLastChildPtr(h);
@@ -1275,11 +1278,10 @@ void raxRecursiveFreeWithCtx(rax *rax, raxNode *n,
 void raxFreeWithCallback(rax *rax, void (*free_callback)(void*)) {
     raxRecursiveFree(rax,rax->head,free_callback);
     assert(rax->numnodes == 0);
-    size_t dummy, *alloc_size = &dummy;
-    if (rax->alloc_size) alloc_size = rax->alloc_size;
+    size_t *alloc_size = rax->alloc_size;
     size_t usable;
     rax_free_usable(rax, &usable);
-    *alloc_size -= usable;
+    if (alloc_size) *alloc_size -= usable;
 }
 
 /* Free a whole radix tree, calling the specified callback in order to
@@ -1288,11 +1290,10 @@ void raxFreeWithCbAndContext(rax *rax,
                              void (*free_callback)(void *item, void *ctx), void *ctx) {
     raxRecursiveFreeWithCtx(rax,rax->head,free_callback,ctx);
     assert(rax->numnodes == 0);
-    size_t dummy, *alloc_size = &dummy;
-    if (rax->alloc_size) alloc_size = rax->alloc_size;
+    size_t *alloc_size = rax->alloc_size;
     size_t usable;
     rax_free_usable(rax, &usable);
-    *alloc_size -= usable;
+    if (alloc_size) *alloc_size -= usable;
 }
 
 /* Free a whole radix tree. */

--- a/src/rax.c
+++ b/src/rax.c
@@ -15,12 +15,15 @@
 #include <math.h>
 #include "rax.h"
 #include "redisassert.h"
+#include "util.h"
 
 #ifndef RAX_MALLOC_INCLUDE
 #define RAX_MALLOC_INCLUDE "rax_malloc.h"
 #endif
 
 #include RAX_MALLOC_INCLUDE
+
+static_assert(sizeof(rax) == 16 + sizeof(void*), "unexpected rax size");
 
 /* -------------------------------- Debugging ------------------------------ */
 

--- a/src/rax.c
+++ b/src/rax.c
@@ -15,15 +15,12 @@
 #include <math.h>
 #include "rax.h"
 #include "redisassert.h"
-#include "util.h"
 
 #ifndef RAX_MALLOC_INCLUDE
 #define RAX_MALLOC_INCLUDE "rax_malloc.h"
 #endif
 
 #include RAX_MALLOC_INCLUDE
-
-static_assert(sizeof(rax) == 16 + sizeof(void*), "unexpected rax size");
 
 /* -------------------------------- Debugging ------------------------------ */
 
@@ -172,10 +169,7 @@ raxNode *raxNewNode(rax *rax, size_t children, int datafield) {
     node->isnull = 0;
     node->iscompr = 0;
     node->size = children;
-    if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-        size_t **alloc_size = (size_t **)rax->metadata;
-        **alloc_size += usable;
-    }
+    if (rax->alloc_size) *rax->alloc_size += usable;
     return node;
 }
 
@@ -183,40 +177,30 @@ raxNode *raxNewNode(rax *rax, size_t children, int datafield) {
 void raxFreeNode(rax *rax, raxNode *n) {
     size_t usable;
     rax_free_usable(n, &usable);
-    if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-        size_t **alloc_size = (size_t **)rax->metadata;
-        **alloc_size -= usable;
-    }
+    if (rax->alloc_size) *rax->alloc_size -= usable;
 }
 
 /* Allocate a new rax and return its pointer. On out of memory the function
  * returns NULL. */
 rax *raxNew(void) {
-    return raxNewWithMetadata(0, 0, NULL);
+    return raxNewWithMetadata(0, NULL);
 }
 
 /* Allocate a new rax with metadata.
  * When RAX_ACCOUNT_ALLOC_SIZE is set in flags radix tree will account for used
  * memory in passed `palloc_size` pointer. Note, that in this case the first
  * sizeof(size_t *) bytes of metadata will be used for storing the pointer. */
-rax *raxNewWithMetadata(int metaSize, int flags, size_t *palloc_size) {
-    assert(!(flags & RAX_ACCOUNT_ALLOC_SIZE) ||
-           (size_t)metaSize >= sizeof(size_t *));
+rax *raxNewWithMetadata(int metaSize, size_t *alloc_size) {
     size_t usable;
     rax *rax = rax_malloc_usable(sizeof(*rax) + metaSize, &usable);
     if (rax == NULL) return NULL;
-    rax->flags = flags & RAX_FLAGS_MASK;
     rax->numele = 0;
     rax->numnodes = 1;
-    if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-        size_t **alloc_size = (size_t **)rax->metadata;
-        *alloc_size = palloc_size;
-        *palloc_size += usable;
-    }
+    rax->alloc_size = alloc_size;
+    if (rax->alloc_size) *rax->alloc_size += usable;
     rax->head = raxNewNode(rax, 0, 0);
     if (rax->head == NULL) {
-        if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE)
-            *palloc_size -= usable;
+        if (rax->alloc_size) *rax->alloc_size -= usable;
         rax_free(rax);
         return NULL;
     } else {
@@ -229,10 +213,9 @@ raxNode *raxNodeRealloc(rax *rax, raxNode *n, size_t newsize) {
     size_t usable, old_usable;
     raxNode *newn = rax_realloc_usable(n,newsize,&usable,&old_usable);
     if (newn == NULL) return NULL;
-    if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-        size_t **alloc_size = (size_t **)rax->metadata;
-        **alloc_size -= old_usable;
-        **alloc_size += usable;
+    if (rax->alloc_size) {
+        *rax->alloc_size -= old_usable;
+        *rax->alloc_size += usable;
     }
     return newn;
 }
@@ -731,20 +714,14 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
                        sizeof(raxNode*);
             if (h->iskey && !h->isnull) nodesize += sizeof(void*);
             trimmed = rax_malloc_usable(nodesize, &usable);
-            if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-                size_t **alloc_size = (size_t **)rax->metadata;
-                **alloc_size += usable;
-            }
+            if (rax->alloc_size) *rax->alloc_size += usable;
         }
 
         if (postfixlen) {
             nodesize = sizeof(raxNode)+postfixlen+raxPadding(postfixlen)+
                        sizeof(raxNode*);
             postfix = rax_malloc_usable(nodesize, &usable);
-            if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-                size_t **alloc_size = (size_t **)rax->metadata;
-                **alloc_size += usable;
-            }
+            if (rax->alloc_size) *rax->alloc_size += usable;
         }
 
         /* OOM? Abort now that the tree is untouched. */
@@ -822,18 +799,12 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
                           sizeof(raxNode*);
         if (data != NULL) nodesize += sizeof(void*);
         raxNode *postfix = rax_malloc_usable(nodesize, &usable);
-        if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-            size_t **alloc_size = (size_t **)rax->metadata;
-            **alloc_size += usable;
-        }
+        if (rax->alloc_size) *rax->alloc_size += usable;
 
         nodesize = sizeof(raxNode)+j+raxPadding(j)+sizeof(raxNode*);
         if (h->iskey && !h->isnull) nodesize += sizeof(void*);
         raxNode *trimmed = rax_malloc_usable(nodesize, &usable);
-        if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-            size_t **alloc_size = (size_t **)rax->metadata;
-            **alloc_size += usable;
-        }
+        if (rax->alloc_size) *rax->alloc_size += usable;
 
         if (postfix == NULL || trimmed == NULL) {
             raxFreeNode(rax,postfix);
@@ -1216,10 +1187,7 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
                 raxStackFree(&ts);
                 return 1;
             }
-            if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-                size_t **alloc_size = (size_t **)rax->metadata;
-                **alloc_size += usable;
-            }
+            if (rax->alloc_size) *rax->alloc_size += usable;
             new->iskey = 0;
             new->isnull = 0;
             new->iscompr = 1;
@@ -1307,14 +1275,11 @@ void raxRecursiveFreeWithCtx(rax *rax, raxNode *n,
 void raxFreeWithCallback(rax *rax, void (*free_callback)(void*)) {
     raxRecursiveFree(rax,rax->head,free_callback);
     assert(rax->numnodes == 0);
-    size_t dummy, *palloc_size = &dummy;
-    if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-        size_t **alloc_size = (size_t **)rax->metadata;
-        palloc_size = *alloc_size;
-    }
+    size_t dummy, *alloc_size = &dummy;
+    if (rax->alloc_size) alloc_size = rax->alloc_size;
     size_t usable;
     rax_free_usable(rax, &usable);
-    *palloc_size -= usable;
+    *alloc_size -= usable;
 }
 
 /* Free a whole radix tree, calling the specified callback in order to
@@ -1323,14 +1288,11 @@ void raxFreeWithCbAndContext(rax *rax,
                              void (*free_callback)(void *item, void *ctx), void *ctx) {
     raxRecursiveFreeWithCtx(rax,rax->head,free_callback,ctx);
     assert(rax->numnodes == 0);
-    size_t dummy, *palloc_size = &dummy;
-    if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-        size_t **alloc_size = (size_t **)rax->metadata;
-        palloc_size = *alloc_size;
-    }
+    size_t dummy, *alloc_size = &dummy;
+    if (rax->alloc_size) alloc_size = rax->alloc_size;
     size_t usable;
     rax_free_usable(rax, &usable);
-    *palloc_size -= usable;
+    *alloc_size -= usable;
 }
 
 /* Free a whole radix tree. */
@@ -2082,7 +2044,7 @@ int raxTest(int argc, char **argv, int flags) {
 
     TEST("verify raxAllocSize() after raxInsert()/raxRemove()") {
         size_t alloc_size = 0;
-        rax *r = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &alloc_size);
+        rax *r = raxNewWithMetadata(0, &alloc_size);
 
         /* Insert values and verify accounting */
         void *val1 = createTestValue(100);
@@ -2108,7 +2070,7 @@ int raxTest(int argc, char **argv, int flags) {
 
     TEST("verify raxAllocSize() when replacing existing key") {
         size_t alloc_size = 0;
-        rax *r = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &alloc_size);
+        rax *r = raxNewWithMetadata(0, &alloc_size);
 
         void *val1 = createTestValue(100);
         assert(raxInsert(r, (unsigned char*)"key", 3, val1, NULL) == 1);

--- a/src/rax.c
+++ b/src/rax.c
@@ -14,7 +14,6 @@
 #include <errno.h>
 #include <math.h>
 #include "rax.h"
-#include "redisassert.h"
 
 #ifndef RAX_MALLOC_INCLUDE
 #define RAX_MALLOC_INCLUDE "rax_malloc.h"
@@ -1881,13 +1880,6 @@ int raxEOF(raxIterator *it) {
 /* Return the number of elements inside the radix tree. */
 uint64_t raxSize(rax *rax) {
     return rax->numele;
-}
-
-/* Return cached total memory used (in bytes) */
-size_t raxAllocSize(rax *rax) {
-    debugAssert(rax->flags & RAX_ACCOUNT_ALLOC_SIZE);
-    size_t *alloc_size = (size_t *)rax->metadata;
-    return *alloc_size;
 }
 
 /* ----------------------------- Introspection ------------------------------ */

--- a/src/rax.c
+++ b/src/rax.c
@@ -22,8 +22,6 @@
 
 #include RAX_MALLOC_INCLUDE
 
-#define UNUSED(x) (void)(x)
-
 /* -------------------------------- Debugging ------------------------------ */
 
 void raxDebugShowNode(const char *msg, raxNode *n);
@@ -2018,6 +2016,8 @@ unsigned long raxTouch(raxNode *n) {
 #ifdef REDIS_TEST
 #include "testhelp.h"
 #include <stdlib.h>
+
+#define UNUSED(x) (void)(x)
 
 #define yell(str, ...) printf("ERROR! " str "\n\n", __VA_ARGS__)
 

--- a/src/rax.c
+++ b/src/rax.c
@@ -22,6 +22,8 @@
 
 #include RAX_MALLOC_INCLUDE
 
+#define UNUSED(x) (void)(x)
+
 /* -------------------------------- Debugging ------------------------------ */
 
 void raxDebugShowNode(const char *msg, raxNode *n);
@@ -1301,6 +1303,7 @@ void raxFreeWithCallback(rax *rax, void (*free_callback)(void*)) {
 #ifdef REDIS_TEST
     if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
         size_t *alloc_size = (size_t *)rax->metadata;
+        UNUSED(alloc_size);
         debugAssert(*alloc_size == rax_malloc_usable_size(rax));
     }
 #endif
@@ -1316,6 +1319,7 @@ void raxFreeWithCbAndContext(rax *rax,
 #ifdef REDIS_TEST
     if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
         size_t *alloc_size = (size_t *)rax->metadata;
+        UNUSED(alloc_size);
         debugAssert(*alloc_size == rax_malloc_usable_size(rax));
     }
 #endif
@@ -2015,8 +2019,6 @@ unsigned long raxTouch(raxNode *n) {
 #ifdef REDIS_TEST
 #include "testhelp.h"
 #include <stdlib.h>
-
-#define UNUSED(x) (void)(x)
 
 #define yell(str, ...) printf("ERROR! " str "\n\n", __VA_ARGS__)
 

--- a/src/rax.c
+++ b/src/rax.c
@@ -172,8 +172,8 @@ raxNode *raxNewNode(rax *rax, size_t children, int datafield) {
     node->iscompr = 0;
     node->size = children;
     if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-        size_t *alloc_size = (size_t *)rax->metadata;
-        *alloc_size += usable;
+        size_t **alloc_size = (size_t **)rax->metadata;
+        **alloc_size += usable;
     }
     return node;
 }
@@ -183,21 +183,24 @@ void raxFreeNode(rax *rax, raxNode *n) {
     size_t usable;
     rax_free_usable(n, &usable);
     if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-        size_t *alloc_size = (size_t *)rax->metadata;
-        *alloc_size -= usable;
+        size_t **alloc_size = (size_t **)rax->metadata;
+        **alloc_size -= usable;
     }
 }
 
 /* Allocate a new rax and return its pointer. On out of memory the function
  * returns NULL. */
 rax *raxNew(void) {
-    return raxNewWithMetadata(0, 0);
+    return raxNewWithMetadata(0, 0, NULL);
 }
 
-/* Allocate a new rax with metadata */
-rax *raxNewWithMetadata(int metaSize, int flags) {
+/* Allocate a new rax with metadata.
+ * When RAX_ACCOUNT_ALLOC_SIZE is set in flags radix tree will account for used
+ * memory in passed `palloc_size` pointer. Note, that in this case the first
+ * sizeof(size_t *) bytes of metadata will be used for storing the pointer. */
+rax *raxNewWithMetadata(int metaSize, int flags, size_t *palloc_size) {
     assert(!(flags & RAX_ACCOUNT_ALLOC_SIZE) ||
-           (size_t)metaSize >= sizeof(size_t));
+           (size_t)metaSize >= sizeof(size_t *));
     size_t usable;
     rax *rax = rax_malloc_usable(sizeof(*rax) + metaSize, &usable);
     if (rax == NULL) return NULL;
@@ -205,11 +208,14 @@ rax *raxNewWithMetadata(int metaSize, int flags) {
     rax->numele = 0;
     rax->numnodes = 1;
     if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-        size_t *alloc_size = (size_t *)rax->metadata;
-        *alloc_size = usable;
+        size_t **alloc_size = (size_t **)rax->metadata;
+        *alloc_size = palloc_size;
+        *palloc_size += usable;
     }
     rax->head = raxNewNode(rax, 0, 0);
     if (rax->head == NULL) {
+        if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE)
+            *palloc_size -= usable;
         rax_free(rax);
         return NULL;
     } else {
@@ -223,9 +229,9 @@ raxNode *raxNodeRealloc(rax *rax, raxNode *n, size_t newsize) {
     raxNode *newn = rax_realloc_usable(n,newsize,&usable,&old_usable);
     if (newn == NULL) return NULL;
     if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-        size_t *alloc_size = (size_t *)rax->metadata;
-        *alloc_size -= old_usable;
-        *alloc_size += usable;
+        size_t **alloc_size = (size_t **)rax->metadata;
+        **alloc_size -= old_usable;
+        **alloc_size += usable;
     }
     return newn;
 }
@@ -725,8 +731,8 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             if (h->iskey && !h->isnull) nodesize += sizeof(void*);
             trimmed = rax_malloc_usable(nodesize, &usable);
             if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-                size_t *alloc_size = (size_t *)rax->metadata;
-                *alloc_size += usable;
+                size_t **alloc_size = (size_t **)rax->metadata;
+                **alloc_size += usable;
             }
         }
 
@@ -735,8 +741,8 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
                        sizeof(raxNode*);
             postfix = rax_malloc_usable(nodesize, &usable);
             if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-                size_t *alloc_size = (size_t *)rax->metadata;
-                *alloc_size += usable;
+                size_t **alloc_size = (size_t **)rax->metadata;
+                **alloc_size += usable;
             }
         }
 
@@ -816,16 +822,16 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         if (data != NULL) nodesize += sizeof(void*);
         raxNode *postfix = rax_malloc_usable(nodesize, &usable);
         if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-            size_t *alloc_size = (size_t *)rax->metadata;
-            *alloc_size += usable;
+            size_t **alloc_size = (size_t **)rax->metadata;
+            **alloc_size += usable;
         }
 
         nodesize = sizeof(raxNode)+j+raxPadding(j)+sizeof(raxNode*);
         if (h->iskey && !h->isnull) nodesize += sizeof(void*);
         raxNode *trimmed = rax_malloc_usable(nodesize, &usable);
         if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-            size_t *alloc_size = (size_t *)rax->metadata;
-            *alloc_size += usable;
+            size_t **alloc_size = (size_t **)rax->metadata;
+            **alloc_size += usable;
         }
 
         if (postfix == NULL || trimmed == NULL) {
@@ -1210,8 +1216,8 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
                 return 1;
             }
             if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-                size_t *alloc_size = (size_t *)rax->metadata;
-                *alloc_size += usable;
+                size_t **alloc_size = (size_t **)rax->metadata;
+                **alloc_size += usable;
             }
             new->iskey = 0;
             new->isnull = 0;
@@ -1300,14 +1306,14 @@ void raxRecursiveFreeWithCtx(rax *rax, raxNode *n,
 void raxFreeWithCallback(rax *rax, void (*free_callback)(void*)) {
     raxRecursiveFree(rax,rax->head,free_callback);
     assert(rax->numnodes == 0);
-#ifdef REDIS_TEST
+    size_t dummy, *palloc_size = &dummy;
     if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-        size_t *alloc_size = (size_t *)rax->metadata;
-        UNUSED(alloc_size);
-        debugAssert(*alloc_size == rax_malloc_usable_size(rax));
+        size_t **alloc_size = (size_t **)rax->metadata;
+        palloc_size = *alloc_size;
     }
-#endif
-    rax_free(rax);
+    size_t usable;
+    rax_free_usable(rax, &usable);
+    *palloc_size -= usable;
 }
 
 /* Free a whole radix tree, calling the specified callback in order to
@@ -1316,14 +1322,14 @@ void raxFreeWithCbAndContext(rax *rax,
                              void (*free_callback)(void *item, void *ctx), void *ctx) {
     raxRecursiveFreeWithCtx(rax,rax->head,free_callback,ctx);
     assert(rax->numnodes == 0);
-#ifdef REDIS_TEST
+    size_t dummy, *palloc_size = &dummy;
     if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
-        size_t *alloc_size = (size_t *)rax->metadata;
-        UNUSED(alloc_size);
-        debugAssert(*alloc_size == rax_malloc_usable_size(rax));
+        size_t **alloc_size = (size_t **)rax->metadata;
+        palloc_size = *alloc_size;
     }
-#endif
-    rax_free(rax);
+    size_t usable;
+    rax_free_usable(rax, &usable);
+    *palloc_size -= usable;
 }
 
 /* Free a whole radix tree. */
@@ -1883,13 +1889,6 @@ uint64_t raxSize(rax *rax) {
     return rax->numele;
 }
 
-/* Return cached total memory used (in bytes) */
-size_t raxAllocSize(rax *rax) {
-    debugAssert(rax->flags & RAX_ACCOUNT_ALLOC_SIZE);
-    size_t *alloc_size = (size_t *)rax->metadata;
-    return *alloc_size;
-}
-
 /* ----------------------------- Introspection ------------------------------ */
 
 /* This function is mostly used for debugging and learning purposes.
@@ -2032,16 +2031,16 @@ unsigned long raxTouch(raxNode *n) {
 #define TEST(name) printf("test — %s\n", name);
 
 /* Verify rax memory accounting by calculating actual memory usage */
-static int _rax_verify_alloc_size(rax *rax) {
+static int _rax_verify_alloc_size(rax *rax, size_t have) {
     int errors = 0;
-    size_t alloc_size = rax_malloc_usable_size(rax);
+    size_t want = rax_malloc_usable_size(rax);
     raxNode *node;
     raxStack stack;
 
     raxStackInit(&stack);
     raxStackPush(&stack, rax->head);
     while ((node = raxStackPop(&stack))) {
-        alloc_size += rax_malloc_usable_size(node);
+        want += rax_malloc_usable_size(node);
         if (!node->iscompr) {
             /* Non-compressed node: add all children */
             for (int i = 0; i < node->size; i++) {
@@ -2056,8 +2055,8 @@ static int _rax_verify_alloc_size(rax *rax) {
     }
     raxStackFree(&stack);
 
-    if (raxAllocSize(rax) != alloc_size) {
-        yell("rax alloc_size is wrong: expected: %zu, got: %zu\n", alloc_size, raxAllocSize(rax));
+    if (want != have) {
+        yell("rax alloc_size is wrong: want: %zu, have: %zu\n", want, have);
         errors++;
     }
 
@@ -2079,43 +2078,45 @@ int raxTest(int argc, char **argv, int flags) {
     int err = 0;
 
     TEST("verify raxAllocSize() after raxInsert()/raxRemove()") {
-        rax *r = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
+        size_t alloc_size = 0;
+        rax *r = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &alloc_size);
 
         /* Insert values and verify accounting */
         void *val1 = createTestValue(100);
         assert(raxInsert(r, (unsigned char*)"key1", 4, val1, NULL) == 1);
-        err += _rax_verify_alloc_size(r);
+        err += _rax_verify_alloc_size(r, alloc_size);
 
         void *val2 = createTestValue(200);
         assert(raxInsert(r, (unsigned char*)"key2", 4, val2, NULL) == 1);
-        err += _rax_verify_alloc_size(r);
+        err += _rax_verify_alloc_size(r, alloc_size);
 
         void *val3 = createTestValue(10);
         assert(raxInsert(r, (unsigned char*)"3yek", 4, val3, NULL) == 1);
-        err += _rax_verify_alloc_size(r);
+        err += _rax_verify_alloc_size(r, alloc_size);
 
         /* Remove a value and verify */
         void *removed;
         assert(raxRemove(r, (unsigned char*)"key1", 4, &removed) == 1);
         rax_free(removed);
-        err += _rax_verify_alloc_size(r);
+        err += _rax_verify_alloc_size(r, alloc_size);
 
         raxFreeWithCallback(r, rax_free);
     }
 
     TEST("verify raxAllocSize() when replacing existing key") {
-        rax *r = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
+        size_t alloc_size = 0;
+        rax *r = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &alloc_size);
 
         void *val1 = createTestValue(100);
         assert(raxInsert(r, (unsigned char*)"key", 3, val1, NULL) == 1);
-        err += _rax_verify_alloc_size(r);
+        err += _rax_verify_alloc_size(r, alloc_size);
 
         /* Update with different sized value */
         void *val2 = createTestValue(300);
         void *old;
         assert(raxInsert(r, (unsigned char*)"key", 3, val2, &old) == 0);
         rax_free(old);
-        err += _rax_verify_alloc_size(r);
+        err += _rax_verify_alloc_size(r, alloc_size);
 
         raxFreeWithCallback(r, rax_free);
     }

--- a/src/rax.c
+++ b/src/rax.c
@@ -193,7 +193,7 @@ rax *raxNew(void) {
 }
 
 /* Allocate a new rax with metadata */
-rax *raxNewWithMetadata(int flags, int metaSize) {
+rax *raxNewWithMetadata(int metaSize, int flags) {
     assert(!(flags & RAX_ACCOUNT_ALLOC_SIZE) ||
            (size_t)metaSize >= sizeof(size_t));
     size_t usable;
@@ -2065,7 +2065,7 @@ int raxTest(int argc, char **argv, int flags) {
     int err = 0;
 
     TEST("verify raxAllocSize() after raxInsert()/raxRemove()") {
-        rax *r = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+        rax *r = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
 
         /* Insert values and verify accounting */
         void *val1 = createTestValue(100);
@@ -2090,7 +2090,7 @@ int raxTest(int argc, char **argv, int flags) {
     }
 
     TEST("verify raxAllocSize() when replacing existing key") {
-        rax *r = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+        rax *r = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
 
         void *val1 = createTestValue(100);
         assert(raxInsert(r, (unsigned char*)"key", 3, val1, NULL) == 1);

--- a/src/rax.c
+++ b/src/rax.c
@@ -1298,6 +1298,12 @@ void raxRecursiveFreeWithCtx(rax *rax, raxNode *n,
 void raxFreeWithCallback(rax *rax, void (*free_callback)(void*)) {
     raxRecursiveFree(rax,rax->head,free_callback);
     assert(rax->numnodes == 0);
+#ifdef REDIS_TEST
+    if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
+        size_t *alloc_size = (size_t *)rax->metadata;
+        debugAssert(*alloc_size == rax_malloc_usable_size(rax));
+    }
+#endif
     rax_free(rax);
 }
 
@@ -1307,6 +1313,12 @@ void raxFreeWithCbAndContext(rax *rax,
                              void (*free_callback)(void *item, void *ctx), void *ctx) {
     raxRecursiveFreeWithCtx(rax,rax->head,free_callback,ctx);
     assert(rax->numnodes == 0);
+#ifdef REDIS_TEST
+    if (rax->flags & RAX_ACCOUNT_ALLOC_SIZE) {
+        size_t *alloc_size = (size_t *)rax->metadata;
+        debugAssert(*alloc_size == rax_malloc_usable_size(rax));
+    }
+#endif
     rax_free(rax);
 }
 
@@ -1869,7 +1881,7 @@ uint64_t raxSize(rax *rax) {
 
 /* Return cached total memory used (in bytes) */
 size_t raxAllocSize(rax *rax) {
-    assert(rax->flags & RAX_ACCOUNT_ALLOC_SIZE);
+    debugAssert(rax->flags & RAX_ACCOUNT_ALLOC_SIZE);
     size_t *alloc_size = (size_t *)rax->metadata;
     return *alloc_size;
 }

--- a/src/rax.c
+++ b/src/rax.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <math.h>
 #include "rax.h"
+#include "redisassert.h"
 
 #ifndef RAX_MALLOC_INCLUDE
 #define RAX_MALLOC_INCLUDE "rax_malloc.h"
@@ -1880,6 +1881,13 @@ int raxEOF(raxIterator *it) {
 /* Return the number of elements inside the radix tree. */
 uint64_t raxSize(rax *rax) {
     return rax->numele;
+}
+
+/* Return cached total memory used (in bytes) */
+size_t raxAllocSize(rax *rax) {
+    debugAssert(rax->flags & RAX_ACCOUNT_ALLOC_SIZE);
+    size_t *alloc_size = (size_t *)rax->metadata;
+    return *alloc_size;
 }
 
 /* ----------------------------- Introspection ------------------------------ */

--- a/src/rax.h
+++ b/src/rax.h
@@ -89,7 +89,7 @@ typedef struct raxNode {
      *
      * [header iscompr=0][abc][a-ptr][b-ptr][c-ptr](value-ptr?)
      *
-     * if node is compressed (iscompr bit is 1) the node has 1 children.
+     * if node is compressed (iscompr bit is 1) the node has 1 child.
      * In that case the 'size' bytes of the string stored immediately at
      * the start of the data section, represent a sequence of successive
      * nodes linked one after the other, for which only the last one in
@@ -110,9 +110,17 @@ typedef struct raxNode {
     unsigned char data[];
 } raxNode;
 
+/* Bit flags used by rax */
+#define RAX_FLAGS_BITS 1               /* Number of flags bits */
+#define RAX_ACCOUNT_ALLOC_SIZE (1U<<0) /* If set, total allocation size is
+                                        * stored in the first sizeof(size_t)
+                                        * bytes of the metadata */
+#define RAX_FLAGS_MASK ((1U<<RAX_FLAGS_BITS)-1)
+
 typedef struct rax {
     raxNode *head;
-    uint64_t numele;
+    uint8_t flags:RAX_FLAGS_BITS;
+    uint64_t numele:64-RAX_FLAGS_BITS;
     uint64_t numnodes;
     void *metadata[];
 } rax;
@@ -169,7 +177,7 @@ typedef struct raxIterator {
 
 /* Exported API. */
 rax *raxNew(void);
-rax *raxNewWithMetadata(int metaSize);
+rax *raxNewWithMetadata(int flags, int metaSize);
 int raxInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
 int raxTryInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
 int raxRemove(rax *rax, unsigned char *s, size_t len, void **old);
@@ -189,11 +197,16 @@ void raxStop(raxIterator *it);
 int raxEOF(raxIterator *it);
 void raxShow(rax *rax);
 uint64_t raxSize(rax *rax);
+size_t raxAllocSize(rax *rax);
 unsigned long raxTouch(raxNode *n);
 void raxSetDebugMsg(int onoff);
 
 /* Internal API. May be used by the node callback in order to access rax nodes
  * in a low level way, so this function is exported as well. */
 void raxSetData(raxNode *n, void *data);
+
+#ifdef REDIS_TEST
+int raxTest(int argc, char *argv[], int flags);
+#endif
 
 #endif

--- a/src/rax.h
+++ b/src/rax.h
@@ -185,7 +185,7 @@ typedef struct raxIterator {
 
 /* Exported API. */
 rax *raxNew(void);
-rax *raxNewWithMetadata(int metaSize, int flags);
+rax *raxNewWithMetadata(int metaSize, int flags, size_t *alloc_size);
 int raxInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
 int raxTryInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
 int raxRemove(rax *rax, unsigned char *s, size_t len, void **old);
@@ -205,7 +205,6 @@ void raxStop(raxIterator *it);
 int raxEOF(raxIterator *it);
 void raxShow(rax *rax);
 uint64_t raxSize(rax *rax);
-size_t raxAllocSize(rax *rax);
 unsigned long raxTouch(raxNode *n);
 void raxSetDebugMsg(int onoff);
 

--- a/src/rax.h
+++ b/src/rax.h
@@ -12,6 +12,7 @@
 #define RAX_H
 
 #include <stdint.h>
+#include "redisassert.h"
 
 /* Selective copy of ifndef from server.h instead of including it */
 #ifndef static_assert
@@ -205,13 +206,19 @@ void raxStop(raxIterator *it);
 int raxEOF(raxIterator *it);
 void raxShow(rax *rax);
 uint64_t raxSize(rax *rax);
-size_t raxAllocSize(rax *rax);
 unsigned long raxTouch(raxNode *n);
 void raxSetDebugMsg(int onoff);
 
 /* Internal API. May be used by the node callback in order to access rax nodes
  * in a low level way, so this function is exported as well. */
 void raxSetData(raxNode *n, void *data);
+
+/* Return cached total memory used (in bytes) */
+static inline size_t raxAllocSize(rax *rax) {
+    debugAssert(rax->flags & RAX_ACCOUNT_ALLOC_SIZE);
+    size_t *alloc_size = (size_t *)rax->metadata;
+    return *alloc_size;
+}
 
 #ifdef REDIS_TEST
 int raxTest(int argc, char *argv[], int flags);

--- a/src/rax.h
+++ b/src/rax.h
@@ -13,6 +13,11 @@
 
 #include <stdint.h>
 
+/* Selective copy of ifndef from server.h instead of including it */
+#ifndef static_assert
+#define static_assert(expr, lit) extern char __static_assert_failure[(expr) ? 1:-1]
+#endif
+
 /* Representation of a radix tree as implemented in this file, that contains
  * the strings "foo", "foobar" and "footer" after the insertion of each
  * word. When the node represents a key inside the radix tree, we write it
@@ -111,6 +116,7 @@ typedef struct raxNode {
 } raxNode;
 
 /* Bit flags used by rax */
+#define RAX_NUMELE_BITS 63             /* Number of bits for numele */
 #define RAX_FLAGS_BITS 1               /* Number of flags bits */
 #define RAX_ACCOUNT_ALLOC_SIZE (1U<<0) /* If set, total allocation size is
                                         * stored in the first sizeof(size_t)
@@ -119,11 +125,13 @@ typedef struct raxNode {
 
 typedef struct rax {
     raxNode *head;
-    __extension__ uint8_t flags:RAX_FLAGS_BITS;
-    __extension__ uint64_t numele:64-RAX_FLAGS_BITS;
+    __extension__ uint64_t flags:RAX_FLAGS_BITS;
+    __extension__ uint64_t numele:RAX_NUMELE_BITS;
     uint64_t numnodes;
     void *metadata[];
 } rax;
+
+static_assert(sizeof(rax) == 16 + sizeof(void*), "unexpected rax size");
 
 /* Stack data structure used by raxLowWalk() in order to, optionally, return
  * a list of parent nodes to the caller. The nodes do not have a "parent"

--- a/src/rax.h
+++ b/src/rax.h
@@ -13,11 +13,6 @@
 
 #include <stdint.h>
 
-/* Selective copy of ifndef from server.h instead of including it */
-#ifndef static_assert
-#define static_assert(expr, lit) extern char __static_assert_failure[(expr) ? 1:-1]
-#endif
-
 /* Representation of a radix tree as implemented in this file, that contains
  * the strings "foo", "foobar" and "footer" after the insertion of each
  * word. When the node represents a key inside the radix tree, we write it
@@ -130,8 +125,6 @@ typedef struct rax {
     uint64_t numnodes;
     void *metadata[];
 } rax;
-
-static_assert(sizeof(rax) == 16 + sizeof(void*), "unexpected rax size");
 
 /* Stack data structure used by raxLowWalk() in order to, optionally, return
  * a list of parent nodes to the caller. The nodes do not have a "parent"

--- a/src/rax.h
+++ b/src/rax.h
@@ -110,19 +110,11 @@ typedef struct raxNode {
     unsigned char data[];
 } raxNode;
 
-/* Bit flags used by rax */
-#define RAX_NUMELE_BITS 63             /* Number of bits for numele */
-#define RAX_FLAGS_BITS 1               /* Number of flags bits */
-#define RAX_ACCOUNT_ALLOC_SIZE (1U<<0) /* If set, total allocation size is
-                                        * stored in the first sizeof(size_t)
-                                        * bytes of the metadata */
-#define RAX_FLAGS_MASK ((1U<<RAX_FLAGS_BITS)-1)
-
 typedef struct rax {
     raxNode *head;
-    __extension__ uint64_t flags:RAX_FLAGS_BITS;
-    __extension__ uint64_t numele:RAX_NUMELE_BITS;
+    uint64_t numele;
     uint64_t numnodes;
+    size_t *alloc_size;
     void *metadata[];
 } rax;
 
@@ -178,7 +170,7 @@ typedef struct raxIterator {
 
 /* Exported API. */
 rax *raxNew(void);
-rax *raxNewWithMetadata(int metaSize, int flags, size_t *alloc_size);
+rax *raxNewWithMetadata(int metaSize, size_t *alloc_size);
 int raxInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
 int raxTryInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
 int raxRemove(rax *rax, unsigned char *s, size_t len, void **old);

--- a/src/rax.h
+++ b/src/rax.h
@@ -177,7 +177,7 @@ typedef struct raxIterator {
 
 /* Exported API. */
 rax *raxNew(void);
-rax *raxNewWithMetadata(int flags, int metaSize);
+rax *raxNewWithMetadata(int metaSize, int flags);
 int raxInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
 int raxTryInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
 int raxRemove(rax *rax, unsigned char *s, size_t len, void **old);

--- a/src/rax.h
+++ b/src/rax.h
@@ -12,7 +12,6 @@
 #define RAX_H
 
 #include <stdint.h>
-#include "redisassert.h"
 
 /* Selective copy of ifndef from server.h instead of including it */
 #ifndef static_assert
@@ -206,19 +205,13 @@ void raxStop(raxIterator *it);
 int raxEOF(raxIterator *it);
 void raxShow(rax *rax);
 uint64_t raxSize(rax *rax);
+size_t raxAllocSize(rax *rax);
 unsigned long raxTouch(raxNode *n);
 void raxSetDebugMsg(int onoff);
 
 /* Internal API. May be used by the node callback in order to access rax nodes
  * in a low level way, so this function is exported as well. */
 void raxSetData(raxNode *n, void *data);
-
-/* Return cached total memory used (in bytes) */
-static inline size_t raxAllocSize(rax *rax) {
-    debugAssert(rax->flags & RAX_ACCOUNT_ALLOC_SIZE);
-    size_t *alloc_size = (size_t *)rax->metadata;
-    return *alloc_size;
-}
 
 #ifdef REDIS_TEST
 int raxTest(int argc, char *argv[], int flags);

--- a/src/rax.h
+++ b/src/rax.h
@@ -119,8 +119,8 @@ typedef struct raxNode {
 
 typedef struct rax {
     raxNode *head;
-    uint8_t flags:RAX_FLAGS_BITS;
-    uint64_t numele:64-RAX_FLAGS_BITS;
+    __extension__ uint8_t flags:RAX_FLAGS_BITS;
+    __extension__ uint64_t numele:64-RAX_FLAGS_BITS;
     uint64_t numnodes;
     void *metadata[];
 } rax;

--- a/src/rax_malloc.h
+++ b/src/rax_malloc.h
@@ -21,4 +21,8 @@
 #define rax_malloc zmalloc
 #define rax_realloc zrealloc
 #define rax_free zfree
+#define rax_malloc_usable zmalloc_usable
+#define rax_realloc_usable zrealloc_usable
+#define rax_free_usable zfree_usable
+#define rax_malloc_usable_size zmalloc_usable_size
 #endif

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -311,7 +311,7 @@ void *rdbLoadIntegerObject(rio *rdb, int enctype, int flags, size_t *lenptr) {
         } else if (sdsFlag) {
             p = sdsnewlen(SDS_NOINIT,len);
         } else { /* hfldFlag */
-            p = hfieldNew(NULL, len, (flags&RDB_LOAD_HFLD) ? 0 : 1);
+            p = hfieldNew(NULL, len, (flags&RDB_LOAD_HFLD) ? 0 : 1, NULL);
         }
         memcpy(p,buf,len);
         return p;
@@ -403,7 +403,7 @@ void *rdbLoadLzfStringObject(rio *rdb, int flags, size_t *lenptr) {
     } else if (sdsFlag || robjFlag) {
         val = sdstrynewlen(SDS_NOINIT,len);
     } else { /* hfldFlag */
-        val = hfieldTryNew(NULL, len, (flags&RDB_LOAD_HFLD) ? 0 : 1);
+        val = hfieldTryNew(NULL, len, (flags&RDB_LOAD_HFLD) ? 0 : 1, NULL);
     }
 
     if (!val) {
@@ -430,7 +430,7 @@ err:
     } else if (sdsFlag || robjFlag) {
         sdsfree(val);
     } else { /* hfldFlag*/
-        hfieldFree(val);
+        hfieldFree(val, NULL);
     }
     return NULL;
 }
@@ -562,7 +562,7 @@ void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr) {
     } else if (sdsFlag) {
         buf = sdstrynewlen(SDS_NOINIT,len);
     }  else { /* hfldFlag */
-        buf = hfieldTryNew(NULL, len, (flags&RDB_LOAD_HFLD) ? 0 : 1);
+        buf = hfieldTryNew(NULL, len, (flags&RDB_LOAD_HFLD) ? 0 : 1, NULL);
     }
     if (!buf) {
         serverLog(isRestoreContext()? LL_VERBOSE: LL_WARNING, "rdbGenericLoadStringObject failed allocating %llu bytes", len);
@@ -576,7 +576,7 @@ void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr) {
         else if (sdsFlag) {
             sdsfree(buf);
         } else { /* hfldFlag */
-            hfieldFree(buf);
+            hfieldFree(buf, NULL);
         }
         return NULL;
     }
@@ -2068,6 +2068,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     sdsfree(sdsele);
                     return NULL;
                 }
+                size_t *alloc_size = (size_t *)dictMetadata((dict *)o->ptr);
+                *alloc_size += sdsAllocSize(sdsele);
             } else {
                 sdsfree(sdsele);
             }
@@ -2176,7 +2178,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 return NULL;
             }
             if ((value = rdbGenericLoadStringObject(rdb,RDB_LOAD_SDS,NULL)) == NULL) {
-                hfieldFree(field);
+                hfieldFree(field, NULL);
                 decrRefCount(o);
                 if (dupSearchDict) dictRelease(dupSearchDict);
                 return NULL;
@@ -2190,7 +2192,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     dictRelease(dupSearchDict);
                     decrRefCount(o);
                     sdsfree(field_dup);
-                    hfieldFree(field);
+                    hfieldFree(field, NULL);
                     sdsfree(value);
                     return NULL;
                 }
@@ -2209,10 +2211,12 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     rdbReportCorruptRDB("Duplicate hash fields detected");
                     if (dupSearchDict) dictRelease(dupSearchDict);
                     sdsfree(value);
-                    hfieldFree(field);
+                    hfieldFree(field, NULL);
                     decrRefCount(o);
                     return NULL;
                 }
+                size_t *alloc_size = (size_t *)dictMetadata((dict *)o->ptr);
+                *alloc_size += zmalloc_usable_size(mstrGetAllocPtr(&mstrFieldKind, field)) + sdsAllocSize(value);
                 break;
             }
 
@@ -2220,7 +2224,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             o->ptr = lpAppend(o->ptr, (unsigned char*)field, hfieldlen(field));
             o->ptr = lpAppend(o->ptr, (unsigned char*)value, sdslen(value));
 
-            hfieldFree(field);
+            hfieldFree(field, NULL);
             sdsfree(value);
         }
 
@@ -2248,7 +2252,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 return NULL;
             }
             if ((value = rdbGenericLoadStringObject(rdb,RDB_LOAD_SDS,NULL)) == NULL) {
-                hfieldFree(field);
+                hfieldFree(field, NULL);
                 decrRefCount(o);
                 return NULL;
             }
@@ -2261,10 +2265,12 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             if (ret == DICT_ERR) {
                 rdbReportCorruptRDB("Duplicate hash fields detected");
                 sdsfree(value);
-                hfieldFree(field);
+                hfieldFree(field, NULL);
                 decrRefCount(o);
                 return NULL;
             }
+            size_t *alloc_size = (size_t *)dictMetadata((dict *)o->ptr);
+            *alloc_size += zmalloc_usable_size(mstrGetAllocPtr(&mstrFieldKind, field)) + sdsAllocSize(value);
         }
 
         /* All pairs should be read by now */
@@ -2361,7 +2367,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 serverLog(LL_WARNING, "failed reading hash value");
                 decrRefCount(o);
                 if (dupSearchDict != NULL) dictRelease(dupSearchDict);
-                hfieldFree(field);
+                hfieldFree(field, NULL);
                 return NULL;
             }
 
@@ -2377,7 +2383,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                         decrRefCount(o);
                         sdsfree(field_dup);
                         sdsfree(value);
-                        hfieldFree(field);
+                        hfieldFree(field, NULL);
                         return NULL;
                     }
                 }
@@ -2396,7 +2402,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                             decrRefCount(o);
                             if (dupSearchDict != NULL) dictRelease(dupSearchDict);
                             sdsfree(value);
-                            hfieldFree(field);
+                            hfieldFree(field, NULL);
                             return NULL;
                         }
                     }
@@ -2405,7 +2411,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 } else {
                     listpackExAddNew(o, field, hfieldlen(field),
                                      value, sdslen(value), expireAt);
-                    hfieldFree(field);
+                    hfieldFree(field, NULL);
                     sdsfree(value);
                 }
             }
@@ -2426,10 +2432,12 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 if (ret == DICT_ERR) {
                     rdbReportCorruptRDB("Duplicate hash fields detected");
                     sdsfree(value);
-                    hfieldFree(field);
+                    hfieldFree(field, NULL);
                     decrRefCount(o);
                     return NULL;
                 }
+                size_t *alloc_size = (size_t *)dictMetadata(d);
+                *alloc_size += zmalloc_usable_size(mstrGetAllocPtr(&mstrFieldKind, field)) + sdsAllocSize(value);
             }
         }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2831,9 +2831,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             }
 
             /* Load the listpack. */
-            size_t lp_size, usable = 0;
+            size_t lp_size;
             unsigned char *lp =
-                rdbGenericLoadStringObjectUsable(rdb,RDB_LOAD_PLAIN,&lp_size,&usable);
+                rdbGenericLoadStringObject(rdb,RDB_LOAD_PLAIN,&lp_size);
             if (lp == NULL) {
                 rdbReportReadError("Stream listpacks loading failed.");
                 sdsfree(nodekey);
@@ -2871,7 +2871,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 zfree(lp);
                 return NULL;
             }
-            s->alloc_size += usable;
+            s->alloc_size += lpBytes(lp);
         }
         /* Load total number of items inside the stream. */
         s->length = rdbLoadLen(rdb,NULL);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2864,10 +2864,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             }
 
             /* Insert the key in the radix tree. */
-            s->alloc_size -= raxAllocSize(s->rax);
             int retval = raxTryInsert(s->rax,
                 (unsigned char*)nodekey,sizeof(streamID),lp,NULL);
-            s->alloc_size += raxAllocSize(s->rax);
             sdsfree(nodekey);
             if (!retval) {
                 rdbReportCorruptRDB("Listpack re-added with existing key");
@@ -2997,17 +2995,14 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, cgroup, rawid);
                 if (rioGetReadError(rdb)) {
                     rdbReportReadError("Stream PEL NACK loading failed.");
-                    streamFreeNACK(s,nack);
+                    streamFreeNACK(s, nack);
                     decrRefCount(o);
                     return NULL;
                 }
-                s->alloc_size -= raxAllocSize(cgroup->pel);
-                int retval = raxTryInsert(cgroup->pel,rawid,sizeof(rawid),nack,NULL);
-                s->alloc_size += raxAllocSize(cgroup->pel);
-                if (!retval) {
+                if (!raxTryInsert(cgroup->pel,rawid,sizeof(rawid),nack,NULL)) {
                     rdbReportCorruptRDB("Duplicated global PEL entry "
                                             "loading stream consumer group");
-                    streamFreeNACK(s,nack);
+                    streamFreeNACK(s, nack);
                     decrRefCount(o);
                     return NULL;
                 }
@@ -3091,14 +3086,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                      * loading the global PEL. Then set the same shared
                      * NACK structure also in the consumer-specific PEL. */
                     nack->consumer = consumer;
-                    s->alloc_size -= raxAllocSize(consumer->pel);
-                    int retval = raxTryInsert(consumer->pel,rawid,sizeof(rawid),nack,NULL);
-                    s->alloc_size += raxAllocSize(consumer->pel);
-                    if (!retval) {
+                    if (!raxTryInsert(consumer->pel,rawid,sizeof(rawid),nack,NULL)) {
                         rdbReportCorruptRDB("Duplicated consumer PEL entry "
                                                 " loading a stream consumer "
                                                 "group");
-                        streamFreeNACK(s,nack);
+                        streamFreeNACK(s, nack);
                         decrRefCount(o);
                         return NULL;
                     }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2076,8 +2076,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     sdsfree(sdsele);
                     return NULL;
                 }
-                size_t *alloc_size = (size_t *)dictMetadata((dict *)o->ptr);
-                *alloc_size += sdsAllocSize(sdsele);
+                *getMetadataSize(o->ptr) += sdsAllocSize(sdsele);
             } else {
                 sdsfree(sdsele);
             }
@@ -2224,8 +2223,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     decrRefCount(o);
                     return NULL;
                 }
-                size_t *alloc_size = (size_t *)dictMetadata((dict *)o->ptr);
-                *alloc_size += usable + sdsAllocSize(value);
+                *getMetadataSize(o->ptr) += usable + sdsAllocSize(value);
                 break;
             }
 
@@ -2279,8 +2277,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 decrRefCount(o);
                 return NULL;
             }
-            size_t *alloc_size = (size_t *)dictMetadata((dict *)o->ptr);
-            *alloc_size += usable + sdsAllocSize(value);
+            *getMetadataSize(o->ptr) += usable + sdsAllocSize(value);
         }
 
         /* All pairs should be read by now */
@@ -2436,7 +2433,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
 
                 /* Attach expiry to the hash field and register in hash private HFE DS */
                 if ((ret != DICT_ERR) && expireAt) {
-                    htExpireMetadata *m = (htExpireMetadata *) dictMetadata(d);
+                    htExpireMetadata *m = getMetadataEx(d);
                     ret = ebAdd(&m->hfe, &hashFieldExpireBucketsType, field, expireAt);
                 }
 
@@ -2447,8 +2444,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     decrRefCount(o);
                     return NULL;
                 }
-                size_t *alloc_size = (size_t *)dictMetadata(d);
-                *alloc_size += usable + sdsAllocSize(value);
+                *getMetadataSize(d) += usable + sdsAllocSize(value);
             }
         }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2076,7 +2076,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     sdsfree(sdsele);
                     return NULL;
                 }
-                *getMetadataSize(o->ptr) += sdsAllocSize(sdsele);
+                *htGetMetadataSize(o->ptr) += sdsAllocSize(sdsele);
             } else {
                 sdsfree(sdsele);
             }
@@ -2223,7 +2223,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     decrRefCount(o);
                     return NULL;
                 }
-                *getMetadataSize(o->ptr) += usable + sdsAllocSize(value);
+                *htGetMetadataSize(o->ptr) += usable + sdsAllocSize(value);
                 break;
             }
 
@@ -2277,7 +2277,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 decrRefCount(o);
                 return NULL;
             }
-            *getMetadataSize(o->ptr) += usable + sdsAllocSize(value);
+            *htGetMetadataSize(o->ptr) += usable + sdsAllocSize(value);
         }
 
         /* All pairs should be read by now */
@@ -2433,7 +2433,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
 
                 /* Attach expiry to the hash field and register in hash private HFE DS */
                 if ((ret != DICT_ERR) && expireAt) {
-                    htExpireMetadata *m = getMetadataEx(d);
+                    htMetadataEx *m = htGetMetadataEx(d);
                     ret = ebAdd(&m->hfe, &hashFieldExpireBucketsType, field, expireAt);
                 }
 
@@ -2444,7 +2444,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     decrRefCount(o);
                     return NULL;
                 }
-                *getMetadataSize(d) += usable + sdsAllocSize(value);
+                *htGetMetadataSize(d) += usable + sdsAllocSize(value);
             }
         }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -587,7 +587,6 @@ void *rdbGenericLoadStringObjectUsable(rio *rdb, int flags, size_t *lenptr, size
     return buf;
 }
 
-
 void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr) {
     return rdbGenericLoadStringObjectUsable(rdb,flags,lenptr,NULL);
 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2436,7 +2436,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
 
                 /* Attach expiry to the hash field and register in hash private HFE DS */
                 if ((ret != DICT_ERR) && expireAt) {
-                    dictExpireMetadata *m = (dictExpireMetadata *) dictMetadata(d);
+                    htExpireMetadata *m = (htExpireMetadata *) dictMetadata(d);
                     ret = ebAdd(&m->hfe, &hashFieldExpireBucketsType, field, expireAt);
                 }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -273,7 +273,7 @@ int rdbEncodeInteger(long long value, unsigned char *enc) {
 /* Loads an integer-encoded object with the specified encoding type "enctype".
  * The returned value changes according to the flags, see
  * rdbGenericLoadStringObject() for more info. */
-void *rdbLoadIntegerObject(rio *rdb, int enctype, int flags, size_t *lenptr) {
+void *rdbLoadIntegerObject(rio *rdb, int enctype, int flags, size_t *lenptr, size_t *usable) {
     int plainFlag = flags & RDB_LOAD_PLAIN;
     int sdsFlag = flags & RDB_LOAD_SDS;
     int hfldFlag = flags & (RDB_LOAD_HFLD|RDB_LOAD_HFLD_TTL);
@@ -307,11 +307,12 @@ void *rdbLoadIntegerObject(rio *rdb, int enctype, int flags, size_t *lenptr) {
         int len = ll2string(buf,sizeof(buf),val);
         if (lenptr) *lenptr = len;
         if (plainFlag) {
-            p = zmalloc(len);
+            p = zmalloc_usable(len, usable);
         } else if (sdsFlag) {
             p = sdsnewlen(SDS_NOINIT,len);
+            if (usable) *usable = sdsAllocSize(buf);
         } else { /* hfldFlag */
-            p = hfieldNew(NULL, len, (flags&RDB_LOAD_HFLD) ? 0 : 1, NULL);
+            p = hfieldNew(NULL, len, (flags&RDB_LOAD_HFLD) ? 0 : 1, usable);
         }
         memcpy(p,buf,len);
         return p;
@@ -380,7 +381,7 @@ ssize_t rdbSaveLzfStringObject(rio *rdb, unsigned char *s, size_t len) {
 /* Load an LZF compressed string in RDB format. The returned value
  * changes according to 'flags'. For more info check the
  * rdbGenericLoadStringObject() function. */
-void *rdbLoadLzfStringObject(rio *rdb, int flags, size_t *lenptr) {
+void *rdbLoadLzfStringObject(rio *rdb, int flags, size_t *lenptr, size_t *usable) {
     int plainFlag = flags & RDB_LOAD_PLAIN;
     int sdsFlag = flags & RDB_LOAD_SDS;
     int hfldFlag = flags & (RDB_LOAD_HFLD | RDB_LOAD_HFLD_TTL);
@@ -399,11 +400,12 @@ void *rdbLoadLzfStringObject(rio *rdb, int flags, size_t *lenptr) {
 
     /* Allocate our target according to the uncompressed size. */
     if (plainFlag) {
-        val = ztrymalloc(len);
+        val = ztrymalloc_usable(len, usable);
     } else if (sdsFlag || robjFlag) {
         val = sdstrynewlen(SDS_NOINIT,len);
+        if (usable) *usable = sdsAllocSize(val);
     } else { /* hfldFlag */
-        val = hfieldTryNew(NULL, len, (flags&RDB_LOAD_HFLD) ? 0 : 1, NULL);
+        val = hfieldTryNew(NULL, len, (flags&RDB_LOAD_HFLD) ? 0 : 1, usable);
     }
 
     if (!val) {
@@ -533,9 +535,9 @@ void *rdbGenericLoadStringObjectUsable(rio *rdb, int flags, size_t *lenptr, size
         case RDB_ENC_INT8:
         case RDB_ENC_INT16:
         case RDB_ENC_INT32:
-            return rdbLoadIntegerObject(rdb,len,flags,lenptr);
+            return rdbLoadIntegerObject(rdb,len,flags,lenptr,usable);
         case RDB_ENC_LZF:
-            return rdbLoadLzfStringObject(rdb,flags,lenptr);
+            return rdbLoadLzfStringObject(rdb,flags,lenptr,usable);
         default:
             rdbReportCorruptRDB("Unknown RDB string encoding type %llu",len);
             return NULL;
@@ -2812,7 +2814,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             return NULL;
         }
 
-        s->alloc_size -= raxAllocSize(s->rax);
         while(listpacks--) {
             /* Get the master ID, the one we'll use as key of the radix tree
              * node: the entries inside the listpack itself are delta-encoded
@@ -2849,7 +2850,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 zfree(lp);
                 return NULL;
             }
-            s->alloc_size += usable;
 
             unsigned char *first = lpFirst(lp);
             if (first == NULL) {
@@ -2864,8 +2864,10 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             }
 
             /* Insert the key in the radix tree. */
+            s->alloc_size -= raxAllocSize(s->rax);
             int retval = raxTryInsert(s->rax,
                 (unsigned char*)nodekey,sizeof(streamID),lp,NULL);
+            s->alloc_size += raxAllocSize(s->rax);
             sdsfree(nodekey);
             if (!retval) {
                 rdbReportCorruptRDB("Listpack re-added with existing key");
@@ -2873,8 +2875,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 zfree(lp);
                 return NULL;
             }
+            s->alloc_size += usable;
         }
-        s->alloc_size += raxAllocSize(s->rax);
         /* Load total number of items inside the stream. */
         s->length = rdbLoadLen(rdb,NULL);
 
@@ -2982,7 +2984,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 decrRefCount(o);
                 return NULL;
             }
-            s->alloc_size -= raxAllocSize(cgroup->pel);
             while(pel_size--) {
                 unsigned char rawid[sizeof(streamID)];
                 if (rioRead(rdb,rawid,sizeof(rawid)) == 0) {
@@ -3000,7 +3001,10 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     decrRefCount(o);
                     return NULL;
                 }
-                if (!raxTryInsert(cgroup->pel,rawid,sizeof(rawid),nack,NULL)) {
+                s->alloc_size -= raxAllocSize(cgroup->pel);
+                int retval = raxTryInsert(cgroup->pel,rawid,sizeof(rawid),nack,NULL);
+                s->alloc_size += raxAllocSize(cgroup->pel);
+                if (!retval) {
                     rdbReportCorruptRDB("Duplicated global PEL entry "
                                             "loading stream consumer group");
                     streamFreeNACK(s,nack);
@@ -3012,7 +3016,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 streamDecodeID(rawid, &id);
                 raxInsertPelByTime(cgroup->pel_by_time, nack->delivery_time, &id);
             }
-            s->alloc_size += raxAllocSize(cgroup->pel);
 
             /* Now that we loaded our global PEL, we need to load the
              * consumers and their local PELs. */
@@ -3067,7 +3070,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     decrRefCount(o);
                     return NULL;
                 }
-                s->alloc_size -= raxAllocSize(consumer->pel);
                 while(pel_size--) {
                     unsigned char rawid[sizeof(streamID)];
                     if (rioRead(rdb,rawid,sizeof(rawid)) == 0) {
@@ -3089,7 +3091,10 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                      * loading the global PEL. Then set the same shared
                      * NACK structure also in the consumer-specific PEL. */
                     nack->consumer = consumer;
-                    if (!raxTryInsert(consumer->pel,rawid,sizeof(rawid),nack,NULL)) {
+                    s->alloc_size -= raxAllocSize(consumer->pel);
+                    int retval = raxTryInsert(consumer->pel,rawid,sizeof(rawid),nack,NULL);
+                    s->alloc_size += raxAllocSize(consumer->pel);
+                    if (!retval) {
                         rdbReportCorruptRDB("Duplicated consumer PEL entry "
                                                 " loading a stream consumer "
                                                 "group");
@@ -3098,7 +3103,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                         return NULL;
                     }
                 }
-                s->alloc_size += raxAllocSize(consumer->pel);
             }
 
             /* Verify that each PEL eventually got a consumer assigned to it. */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2996,15 +2996,15 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, cgroup, rawid);
                 if (rioGetReadError(rdb)) {
                     rdbReportReadError("Stream PEL NACK loading failed.");
-                    decrRefCount(o);
                     streamFreeNACK(s,nack);
+                    decrRefCount(o);
                     return NULL;
                 }
                 if (!raxTryInsert(cgroup->pel,rawid,sizeof(rawid),nack,NULL)) {
                     rdbReportCorruptRDB("Duplicated global PEL entry "
                                             "loading stream consumer group");
-                    decrRefCount(o);
                     streamFreeNACK(s,nack);
+                    decrRefCount(o);
                     return NULL;
                 }
 
@@ -3093,8 +3093,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                         rdbReportCorruptRDB("Duplicated consumer PEL entry "
                                                 " loading a stream consumer "
                                                 "group");
-                        decrRefCount(o);
                         streamFreeNACK(s,nack);
+                        decrRefCount(o);
                         return NULL;
                     }
                 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2181,7 +2181,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
         while (o->encoding == OBJ_ENCODING_LISTPACK && len > 0) {
             len--;
             /* Load raw strings */
-            if ((field = rdbGenericLoadStringObject(rdb,RDB_LOAD_HFLD,NULL)) == NULL) {
+            size_t usable;
+            if ((field = rdbGenericLoadStringObjectUsable(rdb,RDB_LOAD_HFLD,NULL,&usable)) == NULL) {
                 decrRefCount(o);
                 if (dupSearchDict) dictRelease(dupSearchDict);
                 return NULL;
@@ -2225,7 +2226,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     return NULL;
                 }
                 size_t *alloc_size = (size_t *)dictMetadata((dict *)o->ptr);
-                *alloc_size += zmalloc_usable_size(mstrGetAllocPtr(&mstrFieldKind, field)) + sdsAllocSize(value);
+                *alloc_size += usable + sdsAllocSize(value);
                 break;
             }
 
@@ -2256,7 +2257,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
         while (o->encoding == OBJ_ENCODING_HT && len > 0) {
             len--;
             /* Load encoded strings */
-            if ((field = rdbGenericLoadStringObject(rdb,RDB_LOAD_HFLD,NULL)) == NULL) {
+            size_t usable;
+            if ((field = rdbGenericLoadStringObjectUsable(rdb,RDB_LOAD_HFLD,NULL,&usable)) == NULL) {
                 decrRefCount(o);
                 return NULL;
             }
@@ -2279,7 +2281,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 return NULL;
             }
             size_t *alloc_size = (size_t *)dictMetadata((dict *)o->ptr);
-            *alloc_size += zmalloc_usable_size(mstrGetAllocPtr(&mstrFieldKind, field)) + sdsAllocSize(value);
+            *alloc_size += usable + sdsAllocSize(value);
         }
 
         /* All pairs should be read by now */
@@ -2359,10 +2361,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             }
 
             /* if needed create field with TTL metadata  */
+            size_t usable;
             if (expireAt !=0)
-                field = rdbGenericLoadStringObject(rdb, RDB_LOAD_HFLD_TTL, NULL);
+                field = rdbGenericLoadStringObjectUsable(rdb, RDB_LOAD_HFLD_TTL, NULL, &usable);
             else
-                field = rdbGenericLoadStringObject(rdb, RDB_LOAD_HFLD, NULL);
+                field = rdbGenericLoadStringObjectUsable(rdb, RDB_LOAD_HFLD, NULL, &usable);
 
             if (field == NULL) {
                 serverLog(LL_WARNING, "failed reading hash field");
@@ -2446,7 +2449,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     return NULL;
                 }
                 size_t *alloc_size = (size_t *)dictMetadata(d);
-                *alloc_size += zmalloc_usable_size(mstrGetAllocPtr(&mstrFieldKind, field)) + sdsAllocSize(value);
+                *alloc_size += usable + sdsAllocSize(value);
             }
         }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -515,7 +515,7 @@ ssize_t rdbSaveStringObject(rio *rdb, robj *obj) {
  *
  * On I/O error NULL is returned.
  */
-void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr) {
+void *rdbGenericLoadStringObjectUsable(rio *rdb, int flags, size_t *lenptr, size_t *usable) {
     void *buf;
     int plainFlag = flags & RDB_LOAD_PLAIN;
     int sdsFlag = flags & RDB_LOAD_SDS;
@@ -544,6 +544,7 @@ void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr) {
 
     /* return robj */
     if (robjFlag) {
+        if (usable) *usable = 0;
         robj *o = tryCreateStringObject(SDS_NOINIT,len);
         if (!o) {
             serverLog(isRestoreContext()? LL_VERBOSE: LL_WARNING, "rdbGenericLoadStringObject failed allocating %llu bytes", len);
@@ -558,11 +559,12 @@ void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr) {
 
     /* plain/sds/hfld */
     if (plainFlag) {
-        buf = ztrymalloc(len);
+        buf = ztrymalloc_usable(len, usable);
     } else if (sdsFlag) {
         buf = sdstrynewlen(SDS_NOINIT,len);
+        if (usable) *usable = sdsAllocSize(buf);
     }  else { /* hfldFlag */
-        buf = hfieldTryNew(NULL, len, (flags&RDB_LOAD_HFLD) ? 0 : 1, NULL);
+        buf = hfieldTryNew(NULL, len, (flags&RDB_LOAD_HFLD) ? 0 : 1, usable);
     }
     if (!buf) {
         serverLog(isRestoreContext()? LL_VERBOSE: LL_WARNING, "rdbGenericLoadStringObject failed allocating %llu bytes", len);
@@ -581,6 +583,11 @@ void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr) {
         return NULL;
     }
     return buf;
+}
+
+
+void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr) {
+    return rdbGenericLoadStringObjectUsable(rdb,flags,lenptr,NULL);
 }
 
 robj *rdbLoadStringObject(rio *rdb) {
@@ -2805,6 +2812,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             return NULL;
         }
 
+        s->alloc_size -= raxAllocSize(s->rax);
         while(listpacks--) {
             /* Get the master ID, the one we'll use as key of the radix tree
              * node: the entries inside the listpack itself are delta-encoded
@@ -2824,9 +2832,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             }
 
             /* Load the listpack. */
-            size_t lp_size;
+            size_t lp_size, usable = 0;
             unsigned char *lp =
-                rdbGenericLoadStringObject(rdb,RDB_LOAD_PLAIN,&lp_size);
+                rdbGenericLoadStringObjectUsable(rdb,RDB_LOAD_PLAIN,&lp_size,&usable);
             if (lp == NULL) {
                 rdbReportReadError("Stream listpacks loading failed.");
                 sdsfree(nodekey);
@@ -2841,6 +2849,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 zfree(lp);
                 return NULL;
             }
+            s->alloc_size += usable;
 
             unsigned char *first = lpFirst(lp);
             if (first == NULL) {
@@ -2865,6 +2874,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 return NULL;
             }
         }
+        s->alloc_size += raxAllocSize(s->rax);
         /* Load total number of items inside the stream. */
         s->length = rdbLoadLen(rdb,NULL);
 
@@ -2972,6 +2982,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 decrRefCount(o);
                 return NULL;
             }
+            s->alloc_size -= raxAllocSize(cgroup->pel);
             while(pel_size--) {
                 unsigned char rawid[sizeof(streamID)];
                 if (rioRead(rdb,rawid,sizeof(rawid)) == 0) {
@@ -2979,21 +2990,21 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     decrRefCount(o);
                     return NULL;
                 }
-                streamNACK *nack = streamCreateNACK(NULL);
+                streamNACK *nack = streamCreateNACK(s, NULL);
                 nack->delivery_time = rdbLoadMillisecondTime(rdb,RDB_VERSION);
                 nack->delivery_count = rdbLoadLen(rdb,NULL);
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, cgroup, rawid);
                 if (rioGetReadError(rdb)) {
                     rdbReportReadError("Stream PEL NACK loading failed.");
                     decrRefCount(o);
-                    streamFreeNACK(nack);
+                    streamFreeNACK(s,nack);
                     return NULL;
                 }
                 if (!raxTryInsert(cgroup->pel,rawid,sizeof(rawid),nack,NULL)) {
                     rdbReportCorruptRDB("Duplicated global PEL entry "
                                             "loading stream consumer group");
                     decrRefCount(o);
-                    streamFreeNACK(nack);
+                    streamFreeNACK(s,nack);
                     return NULL;
                 }
 
@@ -3001,6 +3012,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 streamDecodeID(rawid, &id);
                 raxInsertPelByTime(cgroup->pel_by_time, nack->delivery_time, &id);
             }
+            s->alloc_size += raxAllocSize(cgroup->pel);
 
             /* Now that we loaded our global PEL, we need to load the
              * consumers and their local PELs. */
@@ -3018,7 +3030,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     decrRefCount(o);
                     return NULL;
                 }
-                streamConsumer *consumer = streamCreateConsumer(cgroup,cname,NULL,0,
+                streamConsumer *consumer = streamCreateConsumer(s,cgroup,cname,NULL,0,
                                                         SCC_NO_NOTIFY|SCC_NO_DIRTIFY);
                 sdsfree(cname);
                 if (!consumer) {
@@ -3055,6 +3067,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     decrRefCount(o);
                     return NULL;
                 }
+                s->alloc_size -= raxAllocSize(consumer->pel);
                 while(pel_size--) {
                     unsigned char rawid[sizeof(streamID)];
                     if (rioRead(rdb,rawid,sizeof(rawid)) == 0) {
@@ -3081,10 +3094,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                                                 " loading a stream consumer "
                                                 "group");
                         decrRefCount(o);
-                        streamFreeNACK(nack);
+                        streamFreeNACK(s,nack);
                         return NULL;
                     }
                 }
+                s->alloc_size += raxAllocSize(consumer->pel);
             }
 
             /* Verify that each PEL eventually got a consumer assigned to it. */

--- a/src/sds.c
+++ b/src/sds.c
@@ -295,7 +295,7 @@ sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
     assert(hdrlen + newlen + 1 > reqlen);  /* Catch size_t overflow */
     use_realloc = (oldtype == type);
     if (use_realloc) {
-        newsh = s_realloc_usable(sh, hdrlen + newlen + 1, &bufsize);
+        newsh = s_realloc_usable(sh, hdrlen + newlen + 1, &bufsize, NULL);
         if (newsh == NULL) return NULL;
         s = (char*)newsh + hdrlen;
         if (adjustTypeIfNeeded(&type, &hdrlen, bufsize)) {
@@ -395,7 +395,7 @@ sds sdsResize(sds s, size_t size, int would_regrow) {
         alloc_already_optimal = (je_nallocx(newlen, 0) == bufsize);
         #endif
         if (!alloc_already_optimal) {
-            newsh = s_realloc_usable(sh, newlen, &bufsize);
+            newsh = s_realloc_usable(sh, newlen, &bufsize, NULL);
             if (newsh == NULL) return NULL;
             s = (char *)newsh + oldhdrlen;
 

--- a/src/sds.c
+++ b/src/sds.c
@@ -216,6 +216,16 @@ void sdsfree(sds s) {
     s_free((char*)s-sdsHdrSize(s[-1]));
 }
 
+/* Free an sds string. No operation is performed if 's' is NULL.
+ * '*usable' is set to the usable size if non NULL */
+void sdsfreeusable(sds s, size_t *usable) {
+    if (s == NULL) {
+        if (usable) *usable = 0;
+        return;
+    }
+    s_free_usable((char*)s-sdsHdrSize(s[-1]), usable);
+}
+
 /* Generic version of sdsfree. */
 void sdsfreegeneric(void *s) {
     sdsfree((sds)s);

--- a/src/sds.c
+++ b/src/sds.c
@@ -216,16 +216,6 @@ void sdsfree(sds s) {
     s_free((char*)s-sdsHdrSize(s[-1]));
 }
 
-/* Free an sds string. No operation is performed if 's' is NULL.
- * '*usable' is set to the usable size if non NULL */
-void sdsfreeusable(sds s, size_t *usable) {
-    if (s == NULL) {
-        if (usable) *usable = 0;
-        return;
-    }
-    s_free_usable((char*)s-sdsHdrSize(s[-1]), usable);
-}
-
 /* Generic version of sdsfree. */
 void sdsfreegeneric(void *s) {
     sdsfree((sds)s);

--- a/src/sds.c
+++ b/src/sds.c
@@ -435,18 +435,6 @@ sds sdsResize(sds s, size_t size, int would_regrow) {
     return s;
 }
 
-/* Return the total size of the allocation of the specified sds string,
- * including:
- * 1) The sds header before the pointer.
- * 2) The string.
- * 3) The free buffer at the end if any.
- * 4) The implicit null term.
- */
-size_t sdsAllocSize(sds s) {
-    size_t alloc = sdsalloc(s);
-    return sdsHdrSize(s[-1])+alloc+1;
-}
-
 /* Return the pointer of the actual SDS allocation (normally SDS strings
  * are referenced by the start of the string buffer). */
 void *sdsAllocPtr(sds s) {

--- a/src/sds.h
+++ b/src/sds.h
@@ -218,6 +218,7 @@ sds sdsnewplacement(char *buf, size_t bufsize, char type, const char *init, size
 sds sdsempty(void);
 sds sdsdup(const sds s);
 void sdsfree(sds s);
+void sdsfreeusable(sds s, size_t *usable);
 void sdsfreegeneric(void *s);
 sds sdsgrowzero(sds s, size_t len);
 sds sdscatlen(sds s, const void *t, size_t len);

--- a/src/sds.h
+++ b/src/sds.h
@@ -157,6 +157,29 @@ static inline void sdsinclen(sds s, size_t inc) {
     }
 }
 
+/* Return the total size of the allocation of the specified sds string,
+ * including:
+ * 1) The sds header before the pointer.
+ * 2) The string.
+ * 3) The free buffer at the end if any.
+ * 4) The implicit null term.
+ */
+static inline size_t sdsAllocSize(sds s) {
+    switch(sdsType(s)) {
+        case SDS_TYPE_5:
+            return SDS_TYPE_5_LEN(s) + sizeof(struct sdshdr5);
+        case SDS_TYPE_8:
+            return SDS_HDR(8,s)->alloc + sizeof(struct sdshdr8);
+        case SDS_TYPE_16:
+            return SDS_HDR(16,s)->alloc + sizeof(struct sdshdr16);
+        case SDS_TYPE_32:
+            return SDS_HDR(32,s)->alloc + sizeof(struct sdshdr32);
+        case SDS_TYPE_64:
+            return SDS_HDR(64,s)->alloc + sizeof(struct sdshdr64);
+    }
+    return 0;
+}
+
 /* sdsalloc() = sdsavail() + sdslen() */
 static inline size_t sdsalloc(const sds s) {
     switch(sdsType(s)) {
@@ -269,7 +292,6 @@ sds sdsMakeRoomForNonGreedy(sds s, size_t addlen);
 void sdsIncrLen(sds s, ssize_t incr);
 sds sdsRemoveFreeSpace(sds s, int would_regrow);
 sds sdsResize(sds s, size_t size, int would_regrow);
-size_t sdsAllocSize(sds s);
 void *sdsAllocPtr(sds s);
 
 /* Returns the minimum required size to store an sds string of the given length

--- a/src/sds.h
+++ b/src/sds.h
@@ -241,7 +241,6 @@ sds sdsnewplacement(char *buf, size_t bufsize, char type, const char *init, size
 sds sdsempty(void);
 sds sdsdup(const sds s);
 void sdsfree(sds s);
-void sdsfreeusable(sds s, size_t *usable);
 void sdsfreegeneric(void *s);
 sds sdsgrowzero(sds s, size_t len);
 sds sdscatlen(sds s, const void *t, size_t len);

--- a/src/server.c
+++ b/src/server.c
@@ -400,6 +400,17 @@ void dictSdsDestructor(dict *d, void *val)
     sdsfree(val);
 }
 
+void setSdsDestructor(dict *d, void *val) {
+    size_t usable, *alloc_size = (size_t *)dictMetadata(d);
+    sdsfreeusable(val, &usable);
+    *alloc_size -= usable;
+}
+
+size_t setDictMetadataBytes(dict *d) {
+    UNUSED(d);
+    return sizeof(size_t);
+}
+
 void *dictSdsDup(dict *d, const void *key) {
     UNUSED(d);
     return sdsdup((const sds) key);
@@ -551,11 +562,12 @@ dictType setDictType = {
     NULL,                      /* key dup */
     NULL,                      /* val dup */
     dictSdsKeyCompare,         /* key compare */
-    dictSdsDestructor,         /* key destructor */
+    setSdsDestructor,          /* key destructor */
     NULL,                      /* val destructor */
     NULL,                      /* allow to expand */
     .no_value = 1,             /* no values in this dict */
-    .keys_are_odd = 1          /* an SDS string is always an odd pointer */
+    .keys_are_odd = 1,         /* an SDS string is always an odd pointer */
+    .dictMetadataBytes = setDictMetadataBytes,
 };
 
 /* Sorted sets hash (note: a skiplist is used in addition to the hash table) */

--- a/src/server.c
+++ b/src/server.c
@@ -401,9 +401,9 @@ void dictSdsDestructor(dict *d, void *val)
 }
 
 void setSdsDestructor(dict *d, void *val) {
-    size_t usable, *alloc_size = (size_t *)dictMetadata(d);
-    sdsfreeusable(val, &usable);
-    *alloc_size -= usable;
+    size_t *alloc_size = (size_t *)dictMetadata(d);
+    *alloc_size -= sdsAllocSize(val);
+    sdsfree(val);
 }
 
 size_t setDictMetadataBytes(dict *d) {

--- a/src/server.c
+++ b/src/server.c
@@ -401,7 +401,7 @@ void dictSdsDestructor(dict *d, void *val)
 }
 
 void setSdsDestructor(dict *d, void *val) {
-    *getMetadataSize(d) -= sdsAllocSize(val);
+    *htGetMetadataSize(d) -= sdsAllocSize(val);
     sdsfree(val);
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -401,8 +401,7 @@ void dictSdsDestructor(dict *d, void *val)
 }
 
 void setSdsDestructor(dict *d, void *val) {
-    size_t *alloc_size = (size_t *)dictMetadata(d);
-    *alloc_size -= sdsAllocSize(val);
+    *getMetadataSize(d) -= sdsAllocSize(val);
     sdsfree(val);
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -7325,6 +7325,7 @@ struct redisTest {
     {"estore", estoreTest},
     {"ebuckets", ebucketsTest},
     {"bitmap", bitopsTest},
+    {"rax", raxTest},
 };
 redisTestProc *getTestProcByName(const char *name) {
     int numtests = sizeof(redisTests)/sizeof(struct redisTest);

--- a/src/server.h
+++ b/src/server.h
@@ -3883,10 +3883,6 @@ void dictSdsDestructor(dict *d, void *val);
 void dictListDestructor(dict *d, void *val);
 void *dictSdsDup(dict *d, const void *key);
 
-/* Keys destructor for sets accounting allocated memory in dict's metadata. */
-void setSdsDestructor(dict *d, void *val);
-size_t setDictMetadataBytes(dict *d);
-
 /* Git SHA1 */
 char *redisGitSHA1(void);
 char *redisGitDirty(void);

--- a/src/server.h
+++ b/src/server.h
@@ -3463,7 +3463,9 @@ typedef struct listpackEx {
 } listpackEx;
 
 /* Each dict of hash object that has fields with time-Expiration will have the
- * following metadata attached to dict header */
+ * following metadata attached to dict header.
+ * Note that alloc_size field must be first because hash objects without expre
+ * already use sizeof(size_t) bytes of metadata for memory accounting. */
 typedef struct dictExpireMetadata {
     size_t alloc_size;       /* Total memory used for keys and values */
     ExpireMeta expireMeta;   /* embedded ExpireMeta in dict.

--- a/src/server.h
+++ b/src/server.h
@@ -3476,6 +3476,15 @@ typedef struct htExpireMetadata {
     ebuckets hfe;            /* DS of Hash Fields Expiration, associated to each hash */
 } htExpireMetadata;
 
+/* hash metadata helpers */
+static inline htExpireMetadata *getMetadataEx(dict *d) {
+    return (htExpireMetadata *)dictMetadata(d);
+}
+
+static inline size_t *getMetadataSize(dict *d) {
+    return (size_t *)dictMetadata(d);
+}
+
 /* Hash data type */
 #define HASH_SET_TAKE_FIELD (1<<0)
 #define HASH_SET_TAKE_VALUE (1<<1)

--- a/src/server.h
+++ b/src/server.h
@@ -3466,7 +3466,7 @@ typedef struct listpackEx {
  * following metadata attached to dict header.
  * Note that alloc_size field must be first because hash objects without expre
  * already use sizeof(size_t) bytes of metadata for memory accounting. */
-typedef struct dictExpireMetadata {
+typedef struct htExpireMetadata {
     size_t alloc_size;       /* Total memory used for keys and values */
     ExpireMeta expireMeta;   /* embedded ExpireMeta in dict.
                                 To be used in order to register the hash in the
@@ -3474,7 +3474,7 @@ typedef struct dictExpireMetadata {
                                 TTL value might be inaccurate up-to few seconds due
                                 to optimization consideration. */
     ebuckets hfe;            /* DS of Hash Fields Expiration, associated to each hash */
-} dictExpireMetadata;
+} htExpireMetadata;
 
 /* Hash data type */
 #define HASH_SET_TAKE_FIELD (1<<0)

--- a/src/server.h
+++ b/src/server.h
@@ -3466,7 +3466,7 @@ typedef struct listpackEx {
  * following metadata attached to dict header.
  * Note that alloc_size field must be first because hash objects without expre
  * already use sizeof(size_t) bytes of metadata for memory accounting. */
-typedef struct htExpireMetadata {
+typedef struct htMetadataEx {
     size_t alloc_size;       /* Total memory used for keys and values */
     ExpireMeta expireMeta;   /* embedded ExpireMeta in dict.
                                 To be used in order to register the hash in the
@@ -3474,14 +3474,14 @@ typedef struct htExpireMetadata {
                                 TTL value might be inaccurate up-to few seconds due
                                 to optimization consideration. */
     ebuckets hfe;            /* DS of Hash Fields Expiration, associated to each hash */
-} htExpireMetadata;
+} htMetadataEx;
 
 /* hash metadata helpers */
-static inline htExpireMetadata *getMetadataEx(dict *d) {
-    return (htExpireMetadata *)dictMetadata(d);
+static inline htMetadataEx *htGetMetadataEx(dict *d) {
+    return (htMetadataEx *)dictMetadata(d);
 }
 
-static inline size_t *getMetadataSize(dict *d) {
+static inline size_t *htGetMetadataSize(dict *d) {
     return (size_t *)dictMetadata(d);
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -1559,6 +1559,7 @@ typedef struct zskiplist {
     struct zskiplistNode *header, *tail;
     unsigned long length;
     int level;
+    size_t alloc_size;
 } zskiplist;
 
 typedef struct zset {
@@ -3299,6 +3300,7 @@ typedef struct {
 
 zskiplist *zslCreate(void);
 void zslFree(zskiplist *zsl);
+size_t zslAllocSize(const zskiplist *zsl);
 zskiplistNode *zslInsert(zskiplist *zsl, double score, sds ele);
 unsigned char *zzlInsert(unsigned char *zl, sds ele, double score);
 int zslDelete(zskiplist *zsl, double score, sds ele, zskiplistNode **node);

--- a/src/server.h
+++ b/src/server.h
@@ -3465,6 +3465,7 @@ typedef struct listpackEx {
 /* Each dict of hash object that has fields with time-Expiration will have the
  * following metadata attached to dict header */
 typedef struct dictExpireMetadata {
+    size_t alloc_size;       /* Total memory used for keys and values */
     ExpireMeta expireMeta;   /* embedded ExpireMeta in dict.
                                 To be used in order to register the hash in the
                                 subexpires DB with next minimum hash-field to expire.
@@ -3507,7 +3508,7 @@ void hashTypeCurrentFromHashTable(hashTypeIterator *hi, int what, char **str,
 void hashTypeCurrentObject(hashTypeIterator *hi, int what, unsigned char **vstr,
                            unsigned int *vlen, long long *vll, uint64_t *expireTime);
 sds hashTypeCurrentObjectNewSds(hashTypeIterator *hi, int what);
-hfield hashTypeCurrentObjectNewHfield(hashTypeIterator *hi);
+hfield hashTypeCurrentObjectNewHfield(hashTypeIterator *hi, size_t *usable);
 int hashTypeGetValueObject(redisDb *db, kvobj *kv, sds field, int hfeFlags,
                            robj **val, uint64_t *expireTime, int *isHashDeleted);
 int hashTypeSet(redisDb *db, kvobj *kv, sds field, sds value, int flags);
@@ -3524,12 +3525,12 @@ void listpackExAddNew(robj *o, char *field, size_t flen,
                       char *value, size_t vlen, uint64_t expireAt);
 
 /* Hash-Field data type (of t_hash.c) */
-hfield hfieldNew(const void *field, size_t fieldlen, int withExpireMeta);
-hfield hfieldTryNew(const void *field, size_t fieldlen, int withExpireMeta);
+hfield hfieldNew(const void *field, size_t fieldlen, int withExpireMeta, size_t *usable);
+hfield hfieldTryNew(const void *field, size_t fieldlen, int withExpireMeta, size_t *usable);
 int hfieldIsExpireAttached(hfield field);
 int hfieldIsExpired(hfield field);
 uint64_t hfieldGetExpireTime(hfield field);
-static inline void hfieldFree(hfield field) { mstrFree(&mstrFieldKind, field); }
+static inline void hfieldFree(hfield field, size_t *usable) { mstrFree(&mstrFieldKind, field, usable); }
 static inline void *hfieldGetAllocPtr(hfield field) { return mstrGetAllocPtr(&mstrFieldKind, field); }
 static inline size_t hfieldlen(hfield field) { return mstrlen(field);}
 
@@ -3879,6 +3880,10 @@ int dictSdsKeyCaseCompare(dictCmpCache *cache, const void *key1, const void *key
 void dictSdsDestructor(dict *d, void *val);
 void dictListDestructor(dict *d, void *val);
 void *dictSdsDup(dict *d, const void *key);
+
+/* Keys destructor for sets accounting allocated memory in dict's metadata. */
+void setSdsDestructor(dict *d, void *val);
+size_t setDictMetadataBytes(dict *d);
 
 /* Git SHA1 */
 char *redisGitSHA1(void);

--- a/src/stream.h
+++ b/src/stream.h
@@ -24,7 +24,7 @@ typedef struct stream {
     rax *cgroups_ref;       /* Index mapping message IDs to their consumer groups. */
     streamID min_cgroup_last_id;  /* The minimum ID of consume group. */
     unsigned int min_cgroup_last_id_valid: 1;
-    size_t alloc_size:63;   /* Total allocated memory (in bytes) by this stream. */
+    size_t alloc_size:8*sizeof(size_t)-1; /* Total allocated memory (in bytes) by this stream. */
 } stream;
 
 /* We define an iterator to iterate stream items in an abstract way, without

--- a/src/stream.h
+++ b/src/stream.h
@@ -20,11 +20,11 @@ typedef struct stream {
     streamID first_id;      /* The first non-tombstone entry, zero if empty. */
     streamID max_deleted_entry_id;  /* The maximal ID that was deleted. */
     uint64_t entries_added; /* All time count of elements added. */
+    size_t alloc_size;      /* Total allocated memory (in bytes) by this stream. */
     rax *cgroups;           /* Consumer groups dictionary: name -> streamCG */
     rax *cgroups_ref;       /* Index mapping message IDs to their consumer groups. */
     streamID min_cgroup_last_id;  /* The minimum ID of consume group. */
     unsigned int min_cgroup_last_id_valid: 1;
-    size_t alloc_size:8*sizeof(size_t)-1; /* Total allocated memory (in bytes) by this stream. */
 } stream;
 
 /* We define an iterator to iterate stream items in an abstract way, without

--- a/src/stream.h
+++ b/src/stream.h
@@ -24,6 +24,7 @@ typedef struct stream {
     rax *cgroups_ref;       /* Index mapping message IDs to their consumer groups. */
     streamID min_cgroup_last_id;  /* The minimum ID of consume group. */
     unsigned int min_cgroup_last_id_valid: 1;
+    size_t alloc_size:63;   /* Total allocated memory (in bytes) by this stream. */
 } stream;
 
 /* We define an iterator to iterate stream items in an abstract way, without
@@ -139,12 +140,12 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current);
 void streamIteratorStop(streamIterator *si);
 streamCG *streamLookupCG(stream *s, sds groupname);
 streamConsumer *streamLookupConsumer(streamCG *cg, sds name);
-streamConsumer *streamCreateConsumer(streamCG *cg, sds name, robj *key, int dbid, int flags);
+streamConsumer *streamCreateConsumer(stream *s, streamCG *cg, sds name, robj *key, int dbid, int flags);
 streamCG *streamCreateCG(stream *s, char *name, size_t namelen, streamID *id, long long entries_read);
-streamNACK *streamCreateNACK(streamConsumer *consumer);
+streamNACK *streamCreateNACK(stream *s, streamConsumer *consumer);
 void streamDecodeID(void *buf, streamID *id);
 int streamCompareID(streamID *a, streamID *b);
-void streamFreeNACK(streamNACK *na);
+void streamFreeNACK(stream *s, streamNACK *na);
 int streamIncrID(streamID *id);
 int streamDecrID(streamID *id);
 void streamPropagateConsumerCreation(client *c, robj *key, robj *groupname, sds consumername);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -109,7 +109,7 @@ EbucketsType subexpiresBucketsType = {
     .itemsAddrAreOdd = 0,                 /* Addresses of dict are even */
 };
 
-/* dictExpireMetadata - ebuckets-type for hash fields with time-Expiration. ebuckets
+/* htExpireMetadata - ebuckets-type for hash fields with time-Expiration. ebuckets
  * instance Will be attached to each hash that has at least one field with expiry
  * time. */
 EbucketsType hashFieldExpireBucketsType = {
@@ -242,7 +242,7 @@ static void dictHfieldDestructor(dict *d, void *field) {
 
     /* If attached TTL to the field, then remove it from hash's private ebuckets. */
     if (hfieldGetExpireTime(field) != EB_EXPIRE_TIME_INVALID) {
-        dictExpireMetadata *dictExpireMeta = (dictExpireMetadata *) dictMetadata(d);
+        htExpireMetadata *dictExpireMeta = (htExpireMetadata *) dictMetadata(d);
         ebRemove(&dictExpireMeta->hfe, &hashFieldExpireBucketsType, field);
     }
 
@@ -270,12 +270,12 @@ static size_t hashDictMetadataBytes(dict *d) {
 static size_t hashDictWithExpireMetadataBytes(dict *d) {
     UNUSED(d);
     /* expireMeta of the hash, ref to ebuckets and pointer to hash's key */
-    return sizeof(dictExpireMetadata);
+    return sizeof(htExpireMetadata);
 }
 
 static void hashDictWithExpireOnRelease(dict *d) {
     /* for sure allocated with metadata. Otherwise, this func won't be registered */
-    dictExpireMetadata *dictExpireMeta = (dictExpireMetadata *) dictMetadata(d);
+    htExpireMetadata *dictExpireMeta = (htExpireMetadata *) dictMetadata(d);
     ebDestroy(&dictExpireMeta->hfe, &hashFieldExpireBucketsType, NULL);
 }
 
@@ -1070,7 +1070,7 @@ SetExRes hashTypeSetExpiryHT(HashTypeSetEx *exInfo, sds field, uint64_t expireAt
                 return HSETEX_NO_CONDITION_MET;
 
             /* remove old expiry time from hash's private ebuckets */
-            dictExpireMetadata *dm = (dictExpireMetadata *) dictMetadata(ht);
+            htExpireMetadata *dm = (htExpireMetadata *) dictMetadata(ht);
             ebRemove(&dm->hfe, &hashFieldExpireBucketsType, hfOld);
 
             /* Track of minimum expiration time (only later update global HFE DS) */
@@ -1105,7 +1105,7 @@ SetExRes hashTypeSetExpiryHT(HashTypeSetEx *exInfo, sds field, uint64_t expireAt
     if (exInfo->minExpireFields > expireAt)
         exInfo->minExpireFields = expireAt;
 
-    dictExpireMetadata *dm = (dictExpireMetadata *) dictMetadata(ht);
+    htExpireMetadata *dm = (htExpireMetadata *) dictMetadata(ht);
     ebAdd(&dm->hfe, &hashFieldExpireBucketsType, hfNew, expireAt);
     return HSETEX_OK;
 }
@@ -1153,7 +1153,7 @@ SetExRes hashTypeSetEx(robj *o, sds field, uint64_t expireAt, HashTypeSetEx *exI
 void initDictExpireMetadata(robj *o) {
     dict *ht = o->ptr;
 
-    dictExpireMetadata *m = (dictExpireMetadata *) dictMetadata(ht);
+    htExpireMetadata *m = (htExpireMetadata *) dictMetadata(ht);
     m->hfe = ebCreate();     /* Allocate HFE DS */
     m->expireMeta.trash = 1; /* mark as trash (as long it wasn't ebAdd()) */
 }
@@ -1179,7 +1179,7 @@ int hashTypeSetExInit(robj *key, kvobj *o, client *c, redisDb *db,
         if (!isDictWithMetaHFE(ht)) {
             /* Realloc (only header of dict) with metadata for hash-field expiration */
             dictTypeAddMeta(&ht, &mstrHashDictTypeWithHFE);
-            dictExpireMetadata *m = (dictExpireMetadata *) dictMetadata(ht);
+            htExpireMetadata *m = (htExpireMetadata *) dictMetadata(ht);
             o->ptr = ht;
 
             /* Find the key in the keyspace. Need to keep reference to the key for
@@ -1309,7 +1309,7 @@ unsigned long hashTypeLength(const robj *o, int subtractExpiredFields) {
         uint64_t expiredItems = 0;
         dict *d = (dict*)o->ptr;
         if (subtractExpiredFields && isDictWithMetaHFE(d)) {
-            dictExpireMetadata *meta = (dictExpireMetadata *) dictMetadata(d);
+            htExpireMetadata *meta = (htExpireMetadata *) dictMetadata(d);
             /* If dict registered in global HFE DS */
             if (meta->expireMeta.trash == 0)
                 expiredItems = ebExpireDryRun(meta->hfe,
@@ -1634,7 +1634,7 @@ void hashTypeConvertListpackEx(redisDb *db, robj *o, int enc) {
         int ret, slot = -1;
         hashTypeIterator *hi;
         dict *dict;
-        dictExpireMetadata *dictExpireMeta;
+        htExpireMetadata *dictExpireMeta;
         listpackEx *lpt = o->ptr;
 
         if (db && lpt->meta.trash != 1) {
@@ -1645,7 +1645,7 @@ void hashTypeConvertListpackEx(redisDb *db, robj *o, int enc) {
 
         dict = dictCreate(&mstrHashDictTypeWithHFE);
         dictExpand(dict,hashTypeLength(o, 0));
-        dictExpireMeta = (dictExpireMetadata *) dictMetadata(dict);
+        dictExpireMeta = (htExpireMetadata *) dictMetadata(dict);
 
         /* Fillup dict HFE metadata */
         dictExpireMeta->hfe = ebCreate();     /* Allocate HFE DS */
@@ -1731,7 +1731,7 @@ robj *hashTypeDup(kvobj *o, uint64_t *minHashExpire) {
         hobj = createObject(OBJ_HASH, dup);
         hobj->encoding = OBJ_ENCODING_LISTPACK_EX;
     } else if(o->encoding == OBJ_ENCODING_HT) {
-        dictExpireMetadata *dictExpireMetaSrc, *dictExpireMetaDst = NULL;
+        htExpireMetadata *dictExpireMetaSrc, *dictExpireMetaDst = NULL;
         dict *d;
 
         /* If dict doesn't have HFE metadata, then create a new dict without it */
@@ -1740,8 +1740,8 @@ robj *hashTypeDup(kvobj *o, uint64_t *minHashExpire) {
         } else {
             /* Create a new dict with HFE metadata */
             d = dictCreate(&mstrHashDictTypeWithHFE);
-            dictExpireMetaSrc = (dictExpireMetadata *) dictMetadata((dict *) o->ptr);
-            dictExpireMetaDst = (dictExpireMetadata *) dictMetadata(d);
+            dictExpireMetaSrc = (htExpireMetadata *) dictMetadata((dict *) o->ptr);
+            dictExpireMetaDst = (htExpireMetadata *) dictMetadata(d);
             dictExpireMetaDst->hfe = ebCreate();     /* Allocate HFE DS */
             dictExpireMetaDst->expireMeta.trash = 1; /* mark as trash (as long it wasn't ebAdd()) */
 
@@ -1849,7 +1849,7 @@ uint64_t hashTypeActiveExpire(redisDb *db, kvobj *o, uint32_t *quota, int update
         serverAssert(o->encoding == OBJ_ENCODING_HT);
 
         dict *d = o->ptr;
-        dictExpireMetadata *dictExpireMeta = (dictExpireMetadata *) dictMetadata(d);
+        htExpireMetadata *dictExpireMeta = (htExpireMetadata *) dictMetadata(d);
 
         OnFieldExpireCtx onFieldExpireCtx = { .hashObj = o, .db = db };
 
@@ -1949,7 +1949,7 @@ uint64_t hashTypeGetMinExpire(robj *o, int accurate) {
             if (!isDictWithMetaHFE(d))
                 return EB_EXPIRE_TIME_INVALID;
 
-            expireMeta = &((dictExpireMetadata *) dictMetadata(d))->expireMeta;
+            expireMeta = &((htExpireMetadata *) dictMetadata(d))->expireMeta;
         }
 
         /* Keep aside next hash-field expiry before updating HFE DS. Verify it is not trash */
@@ -1972,7 +1972,7 @@ uint64_t hashTypeGetMinExpire(robj *o, int accurate) {
         if (!isDictWithMetaHFE(d))
             return EB_EXPIRE_TIME_INVALID;
 
-        dictExpireMetadata *expireMeta = (dictExpireMetadata *) dictMetadata(d);
+        htExpireMetadata *expireMeta = (htExpireMetadata *) dictMetadata(d);
         return ebGetNextTimeToExpire(expireMeta->hfe, &hashFieldExpireBucketsType);
     }
 }
@@ -1987,7 +1987,7 @@ int hashTypeIsFieldsWithExpire(robj *o) {
         /* If dict doesn't holds HFE metadata */
         if (!isDictWithMetaHFE(d))
             return 0;
-        dictExpireMetadata *meta = (dictExpireMetadata *) dictMetadata(d);
+        htExpireMetadata *meta = (htExpireMetadata *) dictMetadata(d);
         return ebGetTotalItems(meta->hfe, &hashFieldExpireBucketsType) != 0;
     }
 }
@@ -1997,7 +1997,7 @@ void hashTypeFree(robj *o) {
         case OBJ_ENCODING_HT:
             /* Verify hash is not registered in global HFE ds */
             if (isDictWithMetaHFE((dict*)o->ptr)) {
-                dictExpireMetadata *m = (dictExpireMetadata *)dictMetadata((dict*)o->ptr);
+                htExpireMetadata *m = (htExpireMetadata *)dictMetadata((dict*)o->ptr);
                 serverAssert(m->expireMeta.trash == 1);
             }
 #ifdef REDIS_TEST
@@ -2022,7 +2022,7 @@ void hashTypeFree(robj *o) {
 }
 
 ebuckets *hashTypeGetDictMetaHFE(dict *d) {
-    dictExpireMetadata *dictExpireMeta = (dictExpireMetadata *) dictMetadata(d);
+    htExpireMetadata *dictExpireMeta = (htExpireMetadata *) dictMetadata(d);
     return &dictExpireMeta->hfe;
 }
 
@@ -3368,7 +3368,7 @@ static void hfieldPersist(robj *hashObj, hfield field) {
 
     /* if field is set with expire, then dict must has HFE metadata attached */
     dict *d = hashObj->ptr;
-    dictExpireMetadata *dictExpireMeta = (dictExpireMetadata *)dictMetadata(d);
+    htExpireMetadata *dictExpireMeta = (htExpireMetadata *)dictMetadata(d);
 
     /* If field has valid expiry then dict must have valid metadata as well */
     serverAssert(dictExpireMeta->expireMeta.trash == 0);
@@ -3442,7 +3442,7 @@ ExpireMeta *hashGetExpireMeta(const eItem hash) {
         return &lpt->meta;
     } else if (hashObj->encoding == OBJ_ENCODING_HT) {
         dict *d = hashObj->ptr;
-        dictExpireMetadata *dictExpireMeta = (dictExpireMetadata *) dictMetadata(d);
+        htExpireMetadata *dictExpireMeta = (htExpireMetadata *) dictMetadata(d);
         return &dictExpireMeta->expireMeta;
     } else {
         serverPanic("Unknown encoding: %d", hashObj->encoding);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -242,12 +242,12 @@ static void dictHfieldDestructor(dict *d, void *field) {
 
     /* If attached TTL to the field, then remove it from hash's private ebuckets. */
     if (hfieldGetExpireTime(field) != EB_EXPIRE_TIME_INVALID) {
-        htExpireMetadata *dictExpireMeta = getMetadataEx(d);
+        htMetadataEx *dictExpireMeta = htGetMetadataEx(d);
         ebRemove(&dictExpireMeta->hfe, &hashFieldExpireBucketsType, field);
     }
 
     hfieldFree(field, &usable);
-    *getMetadataSize(d) -= usable;
+    *htGetMetadataSize(d) -= usable;
 
     /* Don't have to update global HFE DS. It's unnecessary. Implementing this
      * would introduce significant complexity and overhead for an operation that
@@ -257,7 +257,7 @@ static void dictHfieldDestructor(dict *d, void *field) {
 }
 
 static void hashSdsDestructor(dict *d, void *val) {
-    *getMetadataSize(d) -= sdsAllocSize(val);
+    *htGetMetadataSize(d) -= sdsAllocSize(val);
     sdsfree(val);
 }
 
@@ -269,12 +269,12 @@ static size_t hashDictMetadataBytes(dict *d) {
 static size_t hashDictWithExpireMetadataBytes(dict *d) {
     UNUSED(d);
     /* expireMeta of the hash, ref to ebuckets and pointer to hash's key */
-    return sizeof(htExpireMetadata);
+    return sizeof(htMetadataEx);
 }
 
 static void hashDictWithExpireOnRelease(dict *d) {
     /* for sure allocated with metadata. Otherwise, this func won't be registered */
-    htExpireMetadata *dictExpireMeta = getMetadataEx(d);
+    htMetadataEx *dictExpireMeta = htGetMetadataEx(d);
     ebDestroy(&dictExpireMeta->hfe, &hashFieldExpireBucketsType, NULL);
 }
 
@@ -983,7 +983,7 @@ int hashTypeSet(redisDb *db, kvobj *o, sds field, sds value, int flags) {
         dictEntry *de;
         /* check if field already exists */
         dictEntryLink bucket, link = dictFindLink(ht, field, &bucket);
-        size_t usable, *alloc_size = getMetadataSize(ht);
+        size_t usable, *alloc_size = htGetMetadataSize(ht);
         /* check if field already exists */
         if (link == NULL) {
             hfield newField = hfieldNew(field, sdslen(field), 0, &usable);
@@ -1046,7 +1046,7 @@ SetExRes hashTypeSetExpiryHT(HashTypeSetEx *exInfo, sds field, uint64_t expireAt
 
     /* If field doesn't have expiry metadata attached */
     if (!hfieldIsExpireAttached(hfOld)) {
-        size_t usable, *alloc_size = getMetadataSize(ht);
+        size_t usable, *alloc_size = htGetMetadataSize(ht);
 
         /* For fields without expiry, LT condition is considered valid */
         if (exInfo->expireSetCond & (HFE_XX | HFE_GT))
@@ -1069,7 +1069,7 @@ SetExRes hashTypeSetExpiryHT(HashTypeSetEx *exInfo, sds field, uint64_t expireAt
                 return HSETEX_NO_CONDITION_MET;
 
             /* remove old expiry time from hash's private ebuckets */
-            htExpireMetadata *dm = getMetadataEx(ht);
+            htMetadataEx *dm = htGetMetadataEx(ht);
             ebRemove(&dm->hfe, &hashFieldExpireBucketsType, hfOld);
 
             /* Track of minimum expiration time (only later update global HFE DS) */
@@ -1104,7 +1104,7 @@ SetExRes hashTypeSetExpiryHT(HashTypeSetEx *exInfo, sds field, uint64_t expireAt
     if (exInfo->minExpireFields > expireAt)
         exInfo->minExpireFields = expireAt;
 
-    htExpireMetadata *dm = getMetadataEx(ht);
+    htMetadataEx *dm = htGetMetadataEx(ht);
     ebAdd(&dm->hfe, &hashFieldExpireBucketsType, hfNew, expireAt);
     return HSETEX_OK;
 }
@@ -1152,7 +1152,7 @@ SetExRes hashTypeSetEx(robj *o, sds field, uint64_t expireAt, HashTypeSetEx *exI
 void initDictExpireMetadata(robj *o) {
     dict *ht = o->ptr;
 
-    htExpireMetadata *m = getMetadataEx(ht);
+    htMetadataEx *m = htGetMetadataEx(ht);
     m->hfe = ebCreate();     /* Allocate HFE DS */
     m->expireMeta.trash = 1; /* mark as trash (as long it wasn't ebAdd()) */
 }
@@ -1178,7 +1178,7 @@ int hashTypeSetExInit(robj *key, kvobj *o, client *c, redisDb *db,
         if (!isDictWithMetaHFE(ht)) {
             /* Realloc (only header of dict) with metadata for hash-field expiration */
             dictTypeAddMeta(&ht, &mstrHashDictTypeWithHFE);
-            htExpireMetadata *m = getMetadataEx(ht);
+            htMetadataEx *m = htGetMetadataEx(ht);
             o->ptr = ht;
 
             /* Find the key in the keyspace. Need to keep reference to the key for
@@ -1308,7 +1308,7 @@ unsigned long hashTypeLength(const robj *o, int subtractExpiredFields) {
         uint64_t expiredItems = 0;
         dict *d = (dict*)o->ptr;
         if (subtractExpiredFields && isDictWithMetaHFE(d)) {
-            htExpireMetadata *meta = getMetadataEx(d);
+            htMetadataEx *meta = htGetMetadataEx(d);
             /* If dict registered in global HFE DS */
             if (meta->expireMeta.trash == 0)
                 expiredItems = ebExpireDryRun(meta->hfe,
@@ -1596,7 +1596,7 @@ void hashTypeConvertListpack(robj *o, int enc) {
         /* Presize the dict to avoid rehashing */
         dictExpand(dict,hashTypeLength(o, 0));
 
-        size_t usable, *alloc_size = getMetadataSize(dict);
+        size_t usable, *alloc_size = htGetMetadataSize(dict);
         while (hashTypeNext(hi, 0) != C_ERR) {
 
             hfield key = hashTypeCurrentObjectNewHfield(hi, &usable);
@@ -1633,7 +1633,7 @@ void hashTypeConvertListpackEx(redisDb *db, robj *o, int enc) {
         int ret, slot = -1;
         hashTypeIterator *hi;
         dict *dict;
-        htExpireMetadata *dictExpireMeta;
+        htMetadataEx *dictExpireMeta;
         listpackEx *lpt = o->ptr;
 
         if (db && lpt->meta.trash != 1) {
@@ -1644,7 +1644,7 @@ void hashTypeConvertListpackEx(redisDb *db, robj *o, int enc) {
 
         dict = dictCreate(&mstrHashDictTypeWithHFE);
         dictExpand(dict,hashTypeLength(o, 0));
-        dictExpireMeta = getMetadataEx(dict);
+        dictExpireMeta = htGetMetadataEx(dict);
 
         /* Fillup dict HFE metadata */
         dictExpireMeta->hfe = ebCreate();     /* Allocate HFE DS */
@@ -1730,7 +1730,7 @@ robj *hashTypeDup(kvobj *o, uint64_t *minHashExpire) {
         hobj = createObject(OBJ_HASH, dup);
         hobj->encoding = OBJ_ENCODING_LISTPACK_EX;
     } else if(o->encoding == OBJ_ENCODING_HT) {
-        htExpireMetadata *dictExpireMetaSrc, *dictExpireMetaDst = NULL;
+        htMetadataEx *dictExpireMetaSrc, *dictExpireMetaDst = NULL;
         dict *d;
 
         /* If dict doesn't have HFE metadata, then create a new dict without it */
@@ -1739,8 +1739,8 @@ robj *hashTypeDup(kvobj *o, uint64_t *minHashExpire) {
         } else {
             /* Create a new dict with HFE metadata */
             d = dictCreate(&mstrHashDictTypeWithHFE);
-            dictExpireMetaSrc = getMetadataEx((dict *) o->ptr);
-            dictExpireMetaDst = getMetadataEx(d);
+            dictExpireMetaSrc = htGetMetadataEx((dict *) o->ptr);
+            dictExpireMetaDst = htGetMetadataEx(d);
             dictExpireMetaDst->hfe = ebCreate();     /* Allocate HFE DS */
             dictExpireMetaDst->expireMeta.trash = 1; /* mark as trash (as long it wasn't ebAdd()) */
 
@@ -1751,7 +1751,7 @@ robj *hashTypeDup(kvobj *o, uint64_t *minHashExpire) {
         }
         dictExpand(d, dictSize((const dict*)o->ptr));
 
-        size_t usable, *alloc_size = getMetadataSize(d);
+        size_t usable, *alloc_size = htGetMetadataSize(d);
         hi = hashTypeInitIterator(o);
         while (hashTypeNext(hi, 0) != C_ERR) {
             uint64_t expireTime;
@@ -1848,7 +1848,7 @@ uint64_t hashTypeActiveExpire(redisDb *db, kvobj *o, uint32_t *quota, int update
         serverAssert(o->encoding == OBJ_ENCODING_HT);
 
         dict *d = o->ptr;
-        htExpireMetadata *dictExpireMeta = getMetadataEx(d);
+        htMetadataEx *dictExpireMeta = htGetMetadataEx(d);
 
         OnFieldExpireCtx onFieldExpireCtx = { .hashObj = o, .db = db };
 
@@ -1948,7 +1948,7 @@ uint64_t hashTypeGetMinExpire(robj *o, int accurate) {
             if (!isDictWithMetaHFE(d))
                 return EB_EXPIRE_TIME_INVALID;
 
-            expireMeta = &getMetadataEx(d)->expireMeta;
+            expireMeta = &htGetMetadataEx(d)->expireMeta;
         }
 
         /* Keep aside next hash-field expiry before updating HFE DS. Verify it is not trash */
@@ -1971,7 +1971,7 @@ uint64_t hashTypeGetMinExpire(robj *o, int accurate) {
         if (!isDictWithMetaHFE(d))
             return EB_EXPIRE_TIME_INVALID;
 
-        htExpireMetadata *expireMeta = getMetadataEx(d);
+        htMetadataEx *expireMeta = htGetMetadataEx(d);
         return ebGetNextTimeToExpire(expireMeta->hfe, &hashFieldExpireBucketsType);
     }
 }
@@ -1986,7 +1986,7 @@ int hashTypeIsFieldsWithExpire(robj *o) {
         /* If dict doesn't holds HFE metadata */
         if (!isDictWithMetaHFE(d))
             return 0;
-        htExpireMetadata *meta = getMetadataEx(d);
+        htMetadataEx *meta = htGetMetadataEx(d);
         return ebGetTotalItems(meta->hfe, &hashFieldExpireBucketsType) != 0;
     }
 }
@@ -1996,12 +1996,12 @@ void hashTypeFree(robj *o) {
         case OBJ_ENCODING_HT:
             /* Verify hash is not registered in global HFE ds */
             if (isDictWithMetaHFE((dict*)o->ptr)) {
-                htExpireMetadata *m = getMetadataEx((dict*)o->ptr);
+                htMetadataEx *m = htGetMetadataEx((dict*)o->ptr);
                 serverAssert(m->expireMeta.trash == 1);
             }
 #ifdef REDIS_TEST
             dictEmpty(o->ptr, NULL);
-            serverAssert(*getMetadataSize(o->ptr) == 0);
+            serverAssert(*htGetMetadataSize(o->ptr) == 0);
 #endif
             dictRelease((dict*) o->ptr);
             break;
@@ -2020,7 +2020,7 @@ void hashTypeFree(robj *o) {
 }
 
 ebuckets *hashTypeGetDictMetaHFE(dict *d) {
-    htExpireMetadata *dictExpireMeta = getMetadataEx(d);
+    htMetadataEx *dictExpireMeta = htGetMetadataEx(d);
     return &dictExpireMeta->hfe;
 }
 
@@ -3366,7 +3366,7 @@ static void hfieldPersist(robj *hashObj, hfield field) {
 
     /* if field is set with expire, then dict must has HFE metadata attached */
     dict *d = hashObj->ptr;
-    htExpireMetadata *dictExpireMeta = getMetadataEx(d);
+    htMetadataEx *dictExpireMeta = htGetMetadataEx(d);
 
     /* If field has valid expiry then dict must have valid metadata as well */
     serverAssert(dictExpireMeta->expireMeta.trash == 0);
@@ -3440,7 +3440,7 @@ ExpireMeta *hashGetExpireMeta(const eItem hash) {
         return &lpt->meta;
     } else if (hashObj->encoding == OBJ_ENCODING_HT) {
         dict *d = hashObj->ptr;
-        htExpireMetadata *dictExpireMeta = getMetadataEx(d);
+        htMetadataEx *dictExpireMeta = htGetMetadataEx(d);
         return &dictExpireMeta->expireMeta;
     } else {
         serverPanic("Unknown encoding: %d", hashObj->encoding);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -257,9 +257,9 @@ static void dictHfieldDestructor(dict *d, void *field) {
 }
 
 static void hashSdsDestructor(dict *d, void *val) {
-    size_t usable, *alloc_size = (size_t *)dictMetadata(d);
-    sdsfreeusable(val, &usable);
-    *alloc_size -= usable;
+    size_t *alloc_size = (size_t *)dictMetadata(d);
+    *alloc_size -= sdsAllocSize(val);
+    sdsfree(val);
 }
 
 static size_t hashDictMetadataBytes(dict *d) {
@@ -999,8 +999,9 @@ int hashTypeSet(redisDb *db, kvobj *o, sds field, sds value, int flags) {
                 hfieldPersist(o, oldField);
             }
             /* Free the old value */
-            sdsfreeusable(dictGetVal(*link), &usable);
-            *alloc_size -= usable;
+            sds val = dictGetVal(*link);
+            *alloc_size -= sdsAllocSize(val);
+            sdsfree(val);
             update = 1;
             de = *link;
         }
@@ -1999,6 +2000,11 @@ void hashTypeFree(robj *o) {
                 dictExpireMetadata *m = (dictExpireMetadata *)dictMetadata((dict*)o->ptr);
                 serverAssert(m->expireMeta.trash == 1);
             }
+#ifdef REDIS_TEST
+            dictEmpty((dict *) o->ptr, NULL);
+            size_t *alloc_size = (size_t *)dictMetadata((dict *) o->ptr);
+            debugAssert(*alloc_size == 0);
+#endif
             dictRelease((dict*) o->ptr);
             break;
         case OBJ_ENCODING_LISTPACK:

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -238,16 +238,16 @@ static uint64_t dictMstrHash(const void *key) {
 }
 
 static void dictHfieldDestructor(dict *d, void *field) {
-    size_t usable, *alloc_size = (size_t *)dictMetadata(d);
+    size_t usable;
 
     /* If attached TTL to the field, then remove it from hash's private ebuckets. */
     if (hfieldGetExpireTime(field) != EB_EXPIRE_TIME_INVALID) {
-        htExpireMetadata *dictExpireMeta = (htExpireMetadata *) dictMetadata(d);
+        htExpireMetadata *dictExpireMeta = getMetadataEx(d);
         ebRemove(&dictExpireMeta->hfe, &hashFieldExpireBucketsType, field);
     }
 
     hfieldFree(field, &usable);
-    *alloc_size -= usable;
+    *getMetadataSize(d) -= usable;
 
     /* Don't have to update global HFE DS. It's unnecessary. Implementing this
      * would introduce significant complexity and overhead for an operation that
@@ -257,8 +257,7 @@ static void dictHfieldDestructor(dict *d, void *field) {
 }
 
 static void hashSdsDestructor(dict *d, void *val) {
-    size_t *alloc_size = (size_t *)dictMetadata(d);
-    *alloc_size -= sdsAllocSize(val);
+    *getMetadataSize(d) -= sdsAllocSize(val);
     sdsfree(val);
 }
 
@@ -275,7 +274,7 @@ static size_t hashDictWithExpireMetadataBytes(dict *d) {
 
 static void hashDictWithExpireOnRelease(dict *d) {
     /* for sure allocated with metadata. Otherwise, this func won't be registered */
-    htExpireMetadata *dictExpireMeta = (htExpireMetadata *) dictMetadata(d);
+    htExpireMetadata *dictExpireMeta = getMetadataEx(d);
     ebDestroy(&dictExpireMeta->hfe, &hashFieldExpireBucketsType, NULL);
 }
 
@@ -984,7 +983,7 @@ int hashTypeSet(redisDb *db, kvobj *o, sds field, sds value, int flags) {
         dictEntry *de;
         /* check if field already exists */
         dictEntryLink bucket, link = dictFindLink(ht, field, &bucket);
-        size_t usable, *alloc_size = (size_t *)dictMetadata(ht);
+        size_t usable, *alloc_size = getMetadataSize(ht);
         /* check if field already exists */
         if (link == NULL) {
             hfield newField = hfieldNew(field, sdslen(field), 0, &usable);
@@ -1047,7 +1046,7 @@ SetExRes hashTypeSetExpiryHT(HashTypeSetEx *exInfo, sds field, uint64_t expireAt
 
     /* If field doesn't have expiry metadata attached */
     if (!hfieldIsExpireAttached(hfOld)) {
-        size_t usable, *alloc_size = (size_t *)dictMetadata(ht);
+        size_t usable, *alloc_size = getMetadataSize(ht);
 
         /* For fields without expiry, LT condition is considered valid */
         if (exInfo->expireSetCond & (HFE_XX | HFE_GT))
@@ -1070,7 +1069,7 @@ SetExRes hashTypeSetExpiryHT(HashTypeSetEx *exInfo, sds field, uint64_t expireAt
                 return HSETEX_NO_CONDITION_MET;
 
             /* remove old expiry time from hash's private ebuckets */
-            htExpireMetadata *dm = (htExpireMetadata *) dictMetadata(ht);
+            htExpireMetadata *dm = getMetadataEx(ht);
             ebRemove(&dm->hfe, &hashFieldExpireBucketsType, hfOld);
 
             /* Track of minimum expiration time (only later update global HFE DS) */
@@ -1105,7 +1104,7 @@ SetExRes hashTypeSetExpiryHT(HashTypeSetEx *exInfo, sds field, uint64_t expireAt
     if (exInfo->minExpireFields > expireAt)
         exInfo->minExpireFields = expireAt;
 
-    htExpireMetadata *dm = (htExpireMetadata *) dictMetadata(ht);
+    htExpireMetadata *dm = getMetadataEx(ht);
     ebAdd(&dm->hfe, &hashFieldExpireBucketsType, hfNew, expireAt);
     return HSETEX_OK;
 }
@@ -1153,7 +1152,7 @@ SetExRes hashTypeSetEx(robj *o, sds field, uint64_t expireAt, HashTypeSetEx *exI
 void initDictExpireMetadata(robj *o) {
     dict *ht = o->ptr;
 
-    htExpireMetadata *m = (htExpireMetadata *) dictMetadata(ht);
+    htExpireMetadata *m = getMetadataEx(ht);
     m->hfe = ebCreate();     /* Allocate HFE DS */
     m->expireMeta.trash = 1; /* mark as trash (as long it wasn't ebAdd()) */
 }
@@ -1179,7 +1178,7 @@ int hashTypeSetExInit(robj *key, kvobj *o, client *c, redisDb *db,
         if (!isDictWithMetaHFE(ht)) {
             /* Realloc (only header of dict) with metadata for hash-field expiration */
             dictTypeAddMeta(&ht, &mstrHashDictTypeWithHFE);
-            htExpireMetadata *m = (htExpireMetadata *) dictMetadata(ht);
+            htExpireMetadata *m = getMetadataEx(ht);
             o->ptr = ht;
 
             /* Find the key in the keyspace. Need to keep reference to the key for
@@ -1309,7 +1308,7 @@ unsigned long hashTypeLength(const robj *o, int subtractExpiredFields) {
         uint64_t expiredItems = 0;
         dict *d = (dict*)o->ptr;
         if (subtractExpiredFields && isDictWithMetaHFE(d)) {
-            htExpireMetadata *meta = (htExpireMetadata *) dictMetadata(d);
+            htExpireMetadata *meta = getMetadataEx(d);
             /* If dict registered in global HFE DS */
             if (meta->expireMeta.trash == 0)
                 expiredItems = ebExpireDryRun(meta->hfe,
@@ -1597,7 +1596,7 @@ void hashTypeConvertListpack(robj *o, int enc) {
         /* Presize the dict to avoid rehashing */
         dictExpand(dict,hashTypeLength(o, 0));
 
-        size_t usable, *alloc_size = (size_t *)dictMetadata(dict);
+        size_t usable, *alloc_size = getMetadataSize(dict);
         while (hashTypeNext(hi, 0) != C_ERR) {
 
             hfield key = hashTypeCurrentObjectNewHfield(hi, &usable);
@@ -1645,7 +1644,7 @@ void hashTypeConvertListpackEx(redisDb *db, robj *o, int enc) {
 
         dict = dictCreate(&mstrHashDictTypeWithHFE);
         dictExpand(dict,hashTypeLength(o, 0));
-        dictExpireMeta = (htExpireMetadata *) dictMetadata(dict);
+        dictExpireMeta = getMetadataEx(dict);
 
         /* Fillup dict HFE metadata */
         dictExpireMeta->hfe = ebCreate();     /* Allocate HFE DS */
@@ -1653,7 +1652,7 @@ void hashTypeConvertListpackEx(redisDb *db, robj *o, int enc) {
 
         hi = hashTypeInitIterator(o);
 
-        size_t usable, *alloc_size = (size_t *)dictMetadata(dict);
+        size_t usable, *alloc_size = &dictExpireMeta->alloc_size;
         while (hashTypeNext(hi, 0) != C_ERR) {
             hfield key = hashTypeCurrentObjectNewHfield(hi, &usable);
             sds value = hashTypeCurrentObjectNewSds(hi,OBJ_HASH_VALUE);
@@ -1740,8 +1739,8 @@ robj *hashTypeDup(kvobj *o, uint64_t *minHashExpire) {
         } else {
             /* Create a new dict with HFE metadata */
             d = dictCreate(&mstrHashDictTypeWithHFE);
-            dictExpireMetaSrc = (htExpireMetadata *) dictMetadata((dict *) o->ptr);
-            dictExpireMetaDst = (htExpireMetadata *) dictMetadata(d);
+            dictExpireMetaSrc = getMetadataEx((dict *) o->ptr);
+            dictExpireMetaDst = getMetadataEx(d);
             dictExpireMetaDst->hfe = ebCreate();     /* Allocate HFE DS */
             dictExpireMetaDst->expireMeta.trash = 1; /* mark as trash (as long it wasn't ebAdd()) */
 
@@ -1752,7 +1751,7 @@ robj *hashTypeDup(kvobj *o, uint64_t *minHashExpire) {
         }
         dictExpand(d, dictSize((const dict*)o->ptr));
 
-        size_t usable, *alloc_size = (size_t *)dictMetadata(d);
+        size_t usable, *alloc_size = getMetadataSize(d);
         hi = hashTypeInitIterator(o);
         while (hashTypeNext(hi, 0) != C_ERR) {
             uint64_t expireTime;
@@ -1849,7 +1848,7 @@ uint64_t hashTypeActiveExpire(redisDb *db, kvobj *o, uint32_t *quota, int update
         serverAssert(o->encoding == OBJ_ENCODING_HT);
 
         dict *d = o->ptr;
-        htExpireMetadata *dictExpireMeta = (htExpireMetadata *) dictMetadata(d);
+        htExpireMetadata *dictExpireMeta = getMetadataEx(d);
 
         OnFieldExpireCtx onFieldExpireCtx = { .hashObj = o, .db = db };
 
@@ -1949,7 +1948,7 @@ uint64_t hashTypeGetMinExpire(robj *o, int accurate) {
             if (!isDictWithMetaHFE(d))
                 return EB_EXPIRE_TIME_INVALID;
 
-            expireMeta = &((htExpireMetadata *) dictMetadata(d))->expireMeta;
+            expireMeta = &getMetadataEx(d)->expireMeta;
         }
 
         /* Keep aside next hash-field expiry before updating HFE DS. Verify it is not trash */
@@ -1972,7 +1971,7 @@ uint64_t hashTypeGetMinExpire(robj *o, int accurate) {
         if (!isDictWithMetaHFE(d))
             return EB_EXPIRE_TIME_INVALID;
 
-        htExpireMetadata *expireMeta = (htExpireMetadata *) dictMetadata(d);
+        htExpireMetadata *expireMeta = getMetadataEx(d);
         return ebGetNextTimeToExpire(expireMeta->hfe, &hashFieldExpireBucketsType);
     }
 }
@@ -1987,7 +1986,7 @@ int hashTypeIsFieldsWithExpire(robj *o) {
         /* If dict doesn't holds HFE metadata */
         if (!isDictWithMetaHFE(d))
             return 0;
-        htExpireMetadata *meta = (htExpireMetadata *) dictMetadata(d);
+        htExpireMetadata *meta = getMetadataEx(d);
         return ebGetTotalItems(meta->hfe, &hashFieldExpireBucketsType) != 0;
     }
 }
@@ -1997,13 +1996,12 @@ void hashTypeFree(robj *o) {
         case OBJ_ENCODING_HT:
             /* Verify hash is not registered in global HFE ds */
             if (isDictWithMetaHFE((dict*)o->ptr)) {
-                htExpireMetadata *m = (htExpireMetadata *)dictMetadata((dict*)o->ptr);
+                htExpireMetadata *m = getMetadataEx((dict*)o->ptr);
                 serverAssert(m->expireMeta.trash == 1);
             }
 #ifdef REDIS_TEST
-            dictEmpty((dict *) o->ptr, NULL);
-            size_t *alloc_size = (size_t *)dictMetadata((dict *) o->ptr);
-            serverAssert(*alloc_size == 0);
+            dictEmpty(o->ptr, NULL);
+            serverAssert(*getMetadataSize(o->ptr) == 0);
 #endif
             dictRelease((dict*) o->ptr);
             break;
@@ -2022,7 +2020,7 @@ void hashTypeFree(robj *o) {
 }
 
 ebuckets *hashTypeGetDictMetaHFE(dict *d) {
-    htExpireMetadata *dictExpireMeta = (htExpireMetadata *) dictMetadata(d);
+    htExpireMetadata *dictExpireMeta = getMetadataEx(d);
     return &dictExpireMeta->hfe;
 }
 
@@ -3368,7 +3366,7 @@ static void hfieldPersist(robj *hashObj, hfield field) {
 
     /* if field is set with expire, then dict must has HFE metadata attached */
     dict *d = hashObj->ptr;
-    htExpireMetadata *dictExpireMeta = (htExpireMetadata *)dictMetadata(d);
+    htExpireMetadata *dictExpireMeta = getMetadataEx(d);
 
     /* If field has valid expiry then dict must have valid metadata as well */
     serverAssert(dictExpireMeta->expireMeta.trash == 0);
@@ -3442,7 +3440,7 @@ ExpireMeta *hashGetExpireMeta(const eItem hash) {
         return &lpt->meta;
     } else if (hashObj->encoding == OBJ_ENCODING_HT) {
         dict *d = hashObj->ptr;
-        htExpireMetadata *dictExpireMeta = (htExpireMetadata *) dictMetadata(d);
+        htExpireMetadata *dictExpireMeta = getMetadataEx(d);
         return &dictExpireMeta->expireMeta;
     } else {
         serverPanic("Unknown encoding: %d", hashObj->encoding);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2003,8 +2003,7 @@ void hashTypeFree(robj *o) {
 #ifdef REDIS_TEST
             dictEmpty((dict *) o->ptr, NULL);
             size_t *alloc_size = (size_t *)dictMetadata((dict *) o->ptr);
-            UNUSED(alloc_size);
-            debugAssert(*alloc_size == 0);
+            serverAssert(*alloc_size == 0);
 #endif
             dictRelease((dict*) o->ptr);
             break;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2003,6 +2003,7 @@ void hashTypeFree(robj *o) {
 #ifdef REDIS_TEST
             dictEmpty((dict *) o->ptr, NULL);
             size_t *alloc_size = (size_t *)dictMetadata((dict *) o->ptr);
+            UNUSED(alloc_size);
             debugAssert(*alloc_size == 0);
 #endif
             dictRelease((dict*) o->ptr);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -51,6 +51,8 @@ static void propagateHashFieldDeletion(redisDb *db, sds key, char *field, size_t
 static int dictHfieldKeyCompare(dictCmpCache *cache, const void *key1, const void *key2);
 static uint64_t dictMstrHash(const void *key);
 static void dictHfieldDestructor(dict *d, void *field);
+static void hashSdsDestructor(dict *d, void *val);
+static size_t hashDictMetadataBytes(dict *d);
 static size_t hashDictWithExpireMetadataBytes(dict *d);
 static void hashDictWithExpireOnRelease(dict *d);
 static kvobj* hashTypeLookupWriteOrCreate(client *c, robj *key);
@@ -70,9 +72,10 @@ dictType mstrHashDictType = {
     NULL,                                       /* val dup */
     dictSdsMstrKeyCompare,                      /* lookup key compare */
     dictHfieldDestructor,                       /* key destructor */
-    dictSdsDestructor,                          /* val destructor */
+    hashSdsDestructor,                          /* val destructor */
     .storedHashFunction = dictMstrHash,         /* stored hash function */
     .storedKeyCompare = dictHfieldKeyCompare,   /* stored key compare */
+    .dictMetadataBytes = hashDictMetadataBytes,
 };
 
 /* Define alternative dictType of hash with hash-field expiration (HFE) support */
@@ -82,7 +85,7 @@ dictType mstrHashDictTypeWithHFE = {
     NULL,                                       /* val dup */
     dictSdsMstrKeyCompare,                      /* lookup key compare */
     dictHfieldDestructor,                       /* key destructor */
-    dictSdsDestructor,                          /* val destructor */
+    hashSdsDestructor,                          /* val destructor */
     .storedHashFunction = dictMstrHash,         /* stored hash function */
     .storedKeyCompare = dictHfieldKeyCompare,   /* stored key compare */
     .dictMetadataBytes = hashDictWithExpireMetadataBytes,
@@ -235,6 +238,7 @@ static uint64_t dictMstrHash(const void *key) {
 }
 
 static void dictHfieldDestructor(dict *d, void *field) {
+    size_t usable, *alloc_size = (size_t *)dictMetadata(d);
 
     /* If attached TTL to the field, then remove it from hash's private ebuckets. */
     if (hfieldGetExpireTime(field) != EB_EXPIRE_TIME_INVALID) {
@@ -242,13 +246,25 @@ static void dictHfieldDestructor(dict *d, void *field) {
         ebRemove(&dictExpireMeta->hfe, &hashFieldExpireBucketsType, field);
     }
 
-    hfieldFree(field);
+    hfieldFree(field, &usable);
+    *alloc_size -= usable;
 
     /* Don't have to update global HFE DS. It's unnecessary. Implementing this
      * would introduce significant complexity and overhead for an operation that
      * isn't critical. In the worst case scenario, the hash will be efficiently
      * updated later by an active-expire operation, or it will be removed by the
      * hash's dbGenericDelete() function. */
+}
+
+static void hashSdsDestructor(dict *d, void *val) {
+    size_t usable, *alloc_size = (size_t *)dictMetadata(d);
+    sdsfreeusable(val, &usable);
+    *alloc_size -= usable;
+}
+
+static size_t hashDictMetadataBytes(dict *d) {
+    UNUSED(d);
+    return sizeof(size_t);
 }
 
 static size_t hashDictWithExpireMetadataBytes(dict *d) {
@@ -968,10 +984,12 @@ int hashTypeSet(redisDb *db, kvobj *o, sds field, sds value, int flags) {
         dictEntry *de;
         /* check if field already exists */
         dictEntryLink bucket, link = dictFindLink(ht, field, &bucket);
+        size_t usable, *alloc_size = (size_t *)dictMetadata(ht);
         /* check if field already exists */
         if (link == NULL) {
-            hfield newField = hfieldNew(field, sdslen(field), 0);
+            hfield newField = hfieldNew(field, sdslen(field), 0, &usable);
             dictSetKeyAtLink(ht, newField, &bucket, 1);
+            *alloc_size += usable;
             de = *bucket;
         } else {
             /* If attached TTL to the old field, then remove it from hash's
@@ -981,16 +999,20 @@ int hashTypeSet(redisDb *db, kvobj *o, sds field, sds value, int flags) {
                 hfieldPersist(o, oldField);
             }
             /* Free the old value */
-            sdsfree(dictGetVal(*link));
+            sdsfreeusable(dictGetVal(*link), &usable);
+            *alloc_size -= usable;
             update = 1;
             de = *link;
         }
 
         if (flags & HASH_SET_TAKE_VALUE) {
             dictSetVal(ht, de, value);
+            *alloc_size += sdsAllocSize(value);
             flags &= ~HASH_SET_TAKE_VALUE;
         } else {
-            dictSetVal(ht, de, sdsdup(value));
+            sds newval = sdsdup(value);
+            dictSetVal(ht, de, newval);
+            *alloc_size += sdsAllocSize(newval);
         }
     } else {
         serverPanic("Unknown hash encoding");
@@ -1024,14 +1046,18 @@ SetExRes hashTypeSetExpiryHT(HashTypeSetEx *exInfo, sds field, uint64_t expireAt
 
     /* If field doesn't have expiry metadata attached */
     if (!hfieldIsExpireAttached(hfOld)) {
+        size_t usable, *alloc_size = (size_t *)dictMetadata(ht);
+
         /* For fields without expiry, LT condition is considered valid */
         if (exInfo->expireSetCond & (HFE_XX | HFE_GT))
             return HSETEX_NO_CONDITION_MET;
 
         /* Delete old field. Below goanna dictSetKey(..,hfNew) */
-        hfieldFree(hfOld);
+        hfieldFree(hfOld, &usable);
+        *alloc_size -= usable;
         /* New field with expiration metadata */
-        hfNew = hfieldNew(field, sdslen(field), 1);
+        hfNew = hfieldNew(field, sdslen(field), 1, &usable);
+        *alloc_size += usable;
     } else { /* field has ExpireMeta struct attached */
         uint64_t prevExpire = hfieldGetExpireTime(hfOld);
 
@@ -1504,7 +1530,7 @@ sds hashTypeCurrentObjectNewSds(hashTypeIterator *hi, int what) {
 }
 
 /* Return the key at the current iterator position as a new hfield string. */
-hfield hashTypeCurrentObjectNewHfield(hashTypeIterator *hi) {
+hfield hashTypeCurrentObjectNewHfield(hashTypeIterator *hi, size_t *usable) {
     char buf[LONG_STR_SIZE];
     unsigned char *vstr;
     unsigned int vlen;
@@ -1519,7 +1545,7 @@ hfield hashTypeCurrentObjectNewHfield(hashTypeIterator *hi) {
         vstr = (unsigned char *) buf;
     }
 
-    hf = hfieldNew(vstr,vlen, expireTime != EB_EXPIRE_TIME_INVALID);
+    hf = hfieldNew(vstr,vlen, expireTime != EB_EXPIRE_TIME_INVALID, usable);
     return hf;
 }
 
@@ -1570,20 +1596,22 @@ void hashTypeConvertListpack(robj *o, int enc) {
         /* Presize the dict to avoid rehashing */
         dictExpand(dict,hashTypeLength(o, 0));
 
+        size_t usable, *alloc_size = (size_t *)dictMetadata(dict);
         while (hashTypeNext(hi, 0) != C_ERR) {
 
-            hfield key = hashTypeCurrentObjectNewHfield(hi);
+            hfield key = hashTypeCurrentObjectNewHfield(hi, &usable);
             sds value = hashTypeCurrentObjectNewSds(hi,OBJ_HASH_VALUE);
             dictUseStoredKeyApi(dict, 1);
             ret = dictAdd(dict, key, value);
             dictUseStoredKeyApi(dict, 0);
             if (ret != DICT_OK) {
-                hfieldFree(key); sdsfree(value); /* Needed for gcc ASAN */
+                hfieldFree(key, NULL); sdsfree(value); /* Needed for gcc ASAN */
                 hashTypeReleaseIterator(hi);  /* Needed for gcc ASAN */
                 serverLogHexDump(LL_WARNING,"listpack with dup elements dump",
                     o->ptr,lpBytes(o->ptr));
                 serverPanic("Listpack corruption detected");
             }
+            *alloc_size += usable + sdsAllocSize(value);
         }
         hashTypeReleaseIterator(hi);
         zfree(o->ptr);
@@ -1624,19 +1652,21 @@ void hashTypeConvertListpackEx(redisDb *db, robj *o, int enc) {
 
         hi = hashTypeInitIterator(o);
 
+        size_t usable, *alloc_size = (size_t *)dictMetadata(dict);
         while (hashTypeNext(hi, 0) != C_ERR) {
-            hfield key = hashTypeCurrentObjectNewHfield(hi);
+            hfield key = hashTypeCurrentObjectNewHfield(hi, &usable);
             sds value = hashTypeCurrentObjectNewSds(hi,OBJ_HASH_VALUE);
             dictUseStoredKeyApi(dict, 1);
             ret = dictAdd(dict, key, value);
             dictUseStoredKeyApi(dict, 0);
             if (ret != DICT_OK) {
-                hfieldFree(key); sdsfree(value); /* Needed for gcc ASAN */
+                hfieldFree(key, NULL); sdsfree(value); /* Needed for gcc ASAN */
                 hashTypeReleaseIterator(hi);  /* Needed for gcc ASAN */
                 serverLogHexDump(LL_WARNING,"listpack with dup elements dump",
                                  lpt->lp,lpBytes(lpt->lp));
                 serverPanic("Listpack corruption detected");
             }
+            *alloc_size += usable + sdsAllocSize(value);
 
             if (hi->expire_time != EB_EXPIRE_TIME_INVALID)
                 ebAdd(&dictExpireMeta->hfe, &hashFieldExpireBucketsType, key, hi->expire_time);
@@ -1721,6 +1751,7 @@ robj *hashTypeDup(kvobj *o, uint64_t *minHashExpire) {
         }
         dictExpand(d, dictSize((const dict*)o->ptr));
 
+        size_t usable, *alloc_size = (size_t *)dictMetadata(d);
         hi = hashTypeInitIterator(o);
         while (hashTypeNext(hi, 0) != C_ERR) {
             uint64_t expireTime;
@@ -1730,9 +1761,9 @@ robj *hashTypeDup(kvobj *o, uint64_t *minHashExpire) {
             size_t fieldLen, valueLen;
             hashTypeCurrentFromHashTable(hi, OBJ_HASH_KEY, &field, &fieldLen, &expireTime);
             if (expireTime == EB_EXPIRE_TIME_INVALID) {
-                newfield = hfieldNew(field, fieldLen, 0);
+                newfield = hfieldNew(field, fieldLen, 0, &usable);
             } else {
-                newfield = hfieldNew(field, fieldLen, 1);
+                newfield = hfieldNew(field, fieldLen, 1, &usable);
                 ebAdd(&dictExpireMetaDst->hfe, &hashFieldExpireBucketsType, newfield, expireTime);
             }
 
@@ -1743,6 +1774,7 @@ robj *hashTypeDup(kvobj *o, uint64_t *minHashExpire) {
             dictUseStoredKeyApi(d, 1);
             dictAdd(d,newfield,newvalue);
             dictUseStoredKeyApi(d, 0);
+            *alloc_size += usable + sdsAllocSize(newvalue);
         }
         hashTypeReleaseIterator(hi);
 
@@ -3274,13 +3306,14 @@ void hrandfieldCommand(client *c) {
  * Hash Field with optional expiry (based on mstr)
  *----------------------------------------------------------------------------*/
 static hfield _hfieldNew(const void *field, size_t fieldlen, int withExpireMeta,
-                         int trymalloc)
+                         int trymalloc, size_t *usable)
 {
     if (!withExpireMeta)
-        return mstrNew(field, fieldlen, trymalloc);
+        return mstrNew(field, fieldlen, trymalloc, usable);
 
     hfield hf = mstrNewWithMeta(&mstrFieldKind, field, fieldlen,
-                                (mstrFlags) 1 << HFIELD_META_EXPIRE, trymalloc);
+                                (mstrFlags) 1 << HFIELD_META_EXPIRE,
+                                trymalloc, usable);
 
     if (!hf) return NULL;
 
@@ -3292,12 +3325,12 @@ static hfield _hfieldNew(const void *field, size_t fieldlen, int withExpireMeta,
 }
 
 /* if expireAt is 0, then expireAt is ignored and no metadata is attached */
-hfield hfieldNew(const void *field, size_t fieldlen, int withExpireMeta) {
-    return _hfieldNew(field, fieldlen, withExpireMeta, 0);
+hfield hfieldNew(const void *field, size_t fieldlen, int withExpireMeta, size_t *usable) {
+    return _hfieldNew(field, fieldlen, withExpireMeta, 0, usable);
 }
 
-hfield hfieldTryNew(const void *field, size_t fieldlen, int withExpireMeta) {
-    return _hfieldNew(field, fieldlen, withExpireMeta, 1);
+hfield hfieldTryNew(const void *field, size_t fieldlen, int withExpireMeta, size_t *usable) {
+    return _hfieldNew(field, fieldlen, withExpireMeta, 1, usable);
 }
 
 int hfieldIsExpireAttached(hfield field) {

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -90,7 +90,7 @@ static void listTypeTryConvertQuicklist(robj *o, int shrinking, beforeConvertCB 
      * then reset it and release the quicklist. */
     o->ptr = ql->head->entry;
     ql->head->entry = NULL;
-    ql->alloc_size -= zmalloc_usable_size(o->ptr);
+    ql->alloc_size -= ql->head->sz;
     quicklistRelease(ql);
     o->encoding = OBJ_ENCODING_LISTPACK;
 }

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -90,6 +90,7 @@ static void listTypeTryConvertQuicklist(robj *o, int shrinking, beforeConvertCB 
      * then reset it and release the quicklist. */
     o->ptr = ql->head->entry;
     ql->head->entry = NULL;
+    ql->alloc_size -= zmalloc_usable_size(o->ptr);
     quicklistRelease(ql);
     o->encoding = OBJ_ENCODING_LISTPACK;
 }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -132,6 +132,8 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
             /* Key doesn't already exist in the set. Add it but dup the key. */
             if (sdsval == str) sdsval = sdsdup(sdsval);
             dictSetKeyAtLink(ht, sdsval, &bucket, 1);
+            size_t *alloc_size = (size_t *)dictMetadata(ht);
+            *alloc_size += sdsAllocSize(sdsval);
             return 1;
         } else if (sdsval != str) {
             /* String is already a member. Free our temporary sds copy. */
@@ -160,7 +162,10 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
             } else {
                 /* Size limit is reached. Convert to hashtable and add. */
                 setTypeConvertAndExpand(set, OBJ_ENCODING_HT, lpLength(lp) + 1, 1);
-                serverAssert(dictAdd(set->ptr,sdsnewlen(str,len),NULL) == DICT_OK);
+                sds newval = sdsnewlen(str,len);
+                serverAssert(dictAdd(set->ptr,newval,NULL) == DICT_OK);
+                size_t *alloc_size = (size_t *)dictMetadata((dict *)set->ptr);
+                *alloc_size += sdsAllocSize(newval);
             }
             return 1;
         }
@@ -204,7 +209,10 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
                                         intsetLen(set->ptr) + 1, 1);
                 /* The set *was* an intset and this value is not integer
                  * encodable, so dictAdd should always work. */
-                serverAssert(dictAdd(set->ptr,sdsnewlen(str,len),NULL) == DICT_OK);
+                sds newval = sdsnewlen(str,len);
+                serverAssert(dictAdd(set->ptr,newval,NULL) == DICT_OK);
+                size_t *alloc_size = (size_t *)dictMetadata((dict *)set->ptr);
+                *alloc_size += sdsAllocSize(newval);
                 return 1;
             }
         }
@@ -503,9 +511,11 @@ int setTypeConvertAndExpand(robj *setobj, int enc, unsigned long cap, int panic)
         }
 
         /* To add the elements we extract integers and create redis objects */
+        size_t *alloc_size = (size_t *)dictMetadata(d);
         si = setTypeInitIterator(setobj);
         while ((element = setTypeNextObject(si)) != NULL) {
             serverAssert(dictAdd(d,element,NULL) == DICT_OK);
+            *alloc_size += sdsAllocSize(element);
         }
         setTypeReleaseIterator(si);
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -132,8 +132,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
             /* Key doesn't already exist in the set. Add it but dup the key. */
             if (sdsval == str) sdsval = sdsdup(sdsval);
             dictSetKeyAtLink(ht, sdsval, &bucket, 1);
-            size_t *alloc_size = (size_t *)dictMetadata(ht);
-            *alloc_size += sdsAllocSize(sdsval);
+            *getMetadataSize(ht) += sdsAllocSize(sdsval);
             return 1;
         } else if (sdsval != str) {
             /* String is already a member. Free our temporary sds copy. */
@@ -164,8 +163,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
                 setTypeConvertAndExpand(set, OBJ_ENCODING_HT, lpLength(lp) + 1, 1);
                 sds newval = sdsnewlen(str,len);
                 serverAssert(dictAdd(set->ptr,newval,NULL) == DICT_OK);
-                size_t *alloc_size = (size_t *)dictMetadata((dict *)set->ptr);
-                *alloc_size += sdsAllocSize(newval);
+                *getMetadataSize(set->ptr) += sdsAllocSize(newval);
             }
             return 1;
         }
@@ -211,8 +209,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
                  * encodable, so dictAdd should always work. */
                 sds newval = sdsnewlen(str,len);
                 serverAssert(dictAdd(set->ptr,newval,NULL) == DICT_OK);
-                size_t *alloc_size = (size_t *)dictMetadata((dict *)set->ptr);
-                *alloc_size += sdsAllocSize(newval);
+                *getMetadataSize(set->ptr) += sdsAllocSize(newval);
                 return 1;
             }
         }
@@ -511,7 +508,7 @@ int setTypeConvertAndExpand(robj *setobj, int enc, unsigned long cap, int panic)
         }
 
         /* To add the elements we extract integers and create redis objects */
-        size_t *alloc_size = (size_t *)dictMetadata(d);
+        size_t *alloc_size = getMetadataSize(d);
         si = setTypeInitIterator(setobj);
         while ((element = setTypeNextObject(si)) != NULL) {
             serverAssert(dictAdd(d,element,NULL) == DICT_OK);

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -132,7 +132,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
             /* Key doesn't already exist in the set. Add it but dup the key. */
             if (sdsval == str) sdsval = sdsdup(sdsval);
             dictSetKeyAtLink(ht, sdsval, &bucket, 1);
-            *getMetadataSize(ht) += sdsAllocSize(sdsval);
+            *htGetMetadataSize(ht) += sdsAllocSize(sdsval);
             return 1;
         } else if (sdsval != str) {
             /* String is already a member. Free our temporary sds copy. */
@@ -163,7 +163,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
                 setTypeConvertAndExpand(set, OBJ_ENCODING_HT, lpLength(lp) + 1, 1);
                 sds newval = sdsnewlen(str,len);
                 serverAssert(dictAdd(set->ptr,newval,NULL) == DICT_OK);
-                *getMetadataSize(set->ptr) += sdsAllocSize(newval);
+                *htGetMetadataSize(set->ptr) += sdsAllocSize(newval);
             }
             return 1;
         }
@@ -209,7 +209,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
                  * encodable, so dictAdd should always work. */
                 sds newval = sdsnewlen(str,len);
                 serverAssert(dictAdd(set->ptr,newval,NULL) == DICT_OK);
-                *getMetadataSize(set->ptr) += sdsAllocSize(newval);
+                *htGetMetadataSize(set->ptr) += sdsAllocSize(newval);
                 return 1;
             }
         }
@@ -508,7 +508,7 @@ int setTypeConvertAndExpand(robj *setobj, int enc, unsigned long cap, int panic)
         }
 
         /* To add the elements we extract integers and create redis objects */
-        size_t *alloc_size = getMetadataSize(d);
+        size_t *alloc_size = htGetMetadataSize(d);
         si = setTypeInitIterator(setobj);
         while ((element = setTypeNextObject(si)) != NULL) {
             serverAssert(dictAdd(d,element,NULL) == DICT_OK);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -573,8 +573,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
             /* Shrink extra pre-allocated memory */
             UsableSizes usable;
             lp = lpShrinkToFitUsable(lp, &usable);
-            s->alloc_size -= usable.oldval;
-            s->alloc_size += usable.val;
+            s->alloc_size -= usable.oldsize;
+            s->alloc_size += usable.newsize;
             if (ri.data != lp)
                 raxSetData(ri.node, lp);
             lp = NULL;
@@ -605,7 +605,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
             lp = lpAppend(lp,(unsigned char*)field,sdslen(field));
         }
         lp = lpAppendIntegerUsable(lp,0,&usable); /* Master entry zero terminator. */
-        s->alloc_size += usable.val;
+        s->alloc_size += usable.newsize;
         s->alloc_size -= raxAllocSize(s->rax);
         raxInsert(s->rax,(unsigned char*)&rax_key,sizeof(rax_key),lp,NULL);
         s->alloc_size += raxAllocSize(s->rax);
@@ -691,8 +691,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
         lp_count += numfields+1;
     }
     lp = lpAppendIntegerUsable(lp,lp_count,&usable);
-    s->alloc_size += usable.val;
-    s->alloc_size -= old_usable.oldval;
+    s->alloc_size += usable.newsize;
+    s->alloc_size -= old_usable.oldsize;
 
     /* Insert back into the tree in order to update the listpack pointer. */
     if (ri.data != lp)
@@ -933,7 +933,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         UsableSizes usable;
         lp = lpReplaceIntegerUsable(lp,&p,marked_deleted+deleted_from_lp,&usable);
         p = lpNext(lp,p); /* Skip num-of-fields in the master entry. */
-        s->alloc_size += usable.val;
+        s->alloc_size += usable.newsize;
         s->alloc_size -= old_usable;
 
         /* Here we should perform garbage collection in case at this point
@@ -1475,8 +1475,8 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
         p = lpNext(lp,p); /* Seek deleted field. */
         aux = lpGetInteger(p);
         lp = lpReplaceIntegerUsable(lp,&p,aux+1,&usable);
-        s->alloc_size += usable.val;
-        s->alloc_size -= old_usable.oldval;
+        s->alloc_size += usable.newsize;
+        s->alloc_size -= old_usable.oldsize;
 
         /* Update the listpack with the new pointer. */
         if (si->lp != lp)

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -10,6 +10,7 @@
 #include "server.h"
 #include "endianconv.h"
 #include "stream.h"
+#include "redisassert.h"
 
 /* Every stream item inside the listpack, has a flags field that is used to
  * mark the entry as deleted, or having the same field as the "master"
@@ -71,13 +72,26 @@ stream *streamNew(void) {
     return s;
 }
 
+static void streamLpFreeGeneric(void *lp, void *str) {
+    stream *s = str;
+    size_t usable = 0;
+    lpFreeUsable(lp, &usable);
+    s->alloc_size -= usable;
+}
+
 /* Free a stream, including the listpacks stored inside the radix tree. */
 void freeStream(stream *s) {
-    raxFreeWithCallback(s->rax, lpFreeGeneric);
-    if (s->cgroups)
+    s->alloc_size -= raxAllocSize(s->rax);
+    raxFreeWithCbAndContext(s->rax, streamLpFreeGeneric, s);
+    if (s->cgroups) {
+        s->alloc_size -= raxAllocSize(s->cgroups);
         raxFreeWithCbAndContext(s->cgroups, streamFreeCGGeneric, s);
-    if (s->cgroups_ref)
+    }
+    if (s->cgroups_ref) {
+        s->alloc_size -= raxAllocSize(s->cgroups_ref);
         raxFreeWithCallback(s->cgroups_ref, listReleaseGeneric);
+    }
+    debugAssert(s->alloc_size == zmalloc_usable_size(s));
     zfree(s);
 }
 
@@ -557,7 +571,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 
         if (new_node) {
             /* Shrink extra pre-allocated memory */
-            size_t usable, old_usable;
+            size_t usable = 0, old_usable = 0;
             lp = lpShrinkToFitUsable(lp, &usable, &old_usable);
             s->alloc_size -= old_usable;
             s->alloc_size += usable;
@@ -1431,7 +1445,7 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     stream *s = si->stream;
     unsigned char *lp = si->lp;
     int64_t aux;
-    size_t usable, old_usable;
+    size_t usable = 0, old_usable = 0;
 
     /* We do not really delete the entry here. Instead we mark it as
      * deleted by flagging it, and also incrementing the count of the
@@ -3049,8 +3063,8 @@ void streamFreeConsumer(stream *s, streamConsumer *sc) {
     s->alloc_size -= raxAllocSize(sc->pel);
     raxFree(sc->pel); /* No value free callback: the PEL entries are shared
                          between the consumer and the main stream PEL. */
-    sdsfreeusable(sc->name, &usable);
-    s->alloc_size -= usable;
+    s->alloc_size -= sdsAllocSize(sc->name);
+    sdsfree(sc->name);
     zfree_usable(sc, &usable);
     s->alloc_size -= usable;
 }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -72,8 +72,8 @@ stream *streamNew(void) {
     return s;
 }
 
-static void streamLpFreeGeneric(void *lp, void *str) {
-    stream *s = str;
+static void streamLpFreeGeneric(void *lp, void *stream_) {
+    stream *s = stream_;
     size_t usable = 0;
     lpFreeUsable(lp, &usable);
     s->alloc_size -= usable;
@@ -192,7 +192,7 @@ robj *streamDup(robj *o) {
         lp = ri.data;
         lp_bytes = lpBytes(lp);
         size_t usable;
-        unsigned char *new_lp = zmalloc_usable(lp_bytes,&usable);
+        unsigned char *new_lp = zmalloc_usable(lp_bytes, &usable);
         new_s->alloc_size += usable;
         memcpy(new_lp, lp, lp_bytes);
         raxInsert(new_s->rax, ri.key, ri.key_len,

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -54,8 +54,7 @@ stream *streamNew(void) {
     size_t usable;
     stream *s = zmalloc_usable(sizeof(*s), &usable);
     s->alloc_size = usable;
-    s->rax = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
-    s->alloc_size += raxAllocSize(s->rax);
+    s->rax = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
     s->length = 0;
     s->first_id.ms = 0;
     s->first_id.seq = 0;
@@ -81,16 +80,11 @@ static void streamLpFreeGeneric(void *lp, void *stream_) {
 
 /* Free a stream, including the listpacks stored inside the radix tree. */
 void freeStream(stream *s) {
-    s->alloc_size -= raxAllocSize(s->rax);
     raxFreeWithCbAndContext(s->rax, streamLpFreeGeneric, s);
-    if (s->cgroups) {
-        s->alloc_size -= raxAllocSize(s->cgroups);
+    if (s->cgroups)
         raxFreeWithCbAndContext(s->cgroups, streamFreeCGGeneric, s);
-    }
-    if (s->cgroups_ref) {
-        s->alloc_size -= raxAllocSize(s->cgroups_ref);
+    if (s->cgroups_ref)
         raxFreeWithCallback(s->cgroups_ref, listReleaseGeneric);
-    }
     debugAssert(s->alloc_size == zmalloc_usable_size(s));
     zfree(s);
 }
@@ -186,7 +180,6 @@ robj *streamDup(robj *o) {
     size_t lp_bytes = 0;      /* Total bytes in the listpack. */
     unsigned char *lp = NULL; /* listpack pointer. */
     /* Get a reference to the listpack node. */
-    new_s->alloc_size -= raxAllocSize(new_s->rax);
     while (raxNext(&ri)) {
         serverAssert(ri.key_len == sizeof(streamID));
         lp = ri.data;
@@ -198,7 +191,6 @@ robj *streamDup(robj *o) {
         raxInsert(new_s->rax, ri.key, ri.key_len,
                   new_lp, NULL);
     }
-    new_s->alloc_size += raxAllocSize(new_s->rax);
     new_s->length = s->length;
     new_s->first_id = s->first_id;
     new_s->last_id = s->last_id;
@@ -224,7 +216,6 @@ robj *streamDup(robj *o) {
         raxIterator ri_cg_pel;
         raxStart(&ri_cg_pel,cg->pel);
         raxSeek(&ri_cg_pel,"^",NULL,0);
-        new_s->alloc_size -= raxAllocSize(new_cg->pel);
         while(raxNext(&ri_cg_pel)){
             streamNACK *nack = ri_cg_pel.data;
             streamNACK *new_nack = streamCreateNACK(new_s, NULL);
@@ -237,14 +228,12 @@ robj *streamDup(robj *o) {
             streamDecodeID(ri_cg_pel.key, &id);
             raxInsertPelByTime(new_cg->pel_by_time, new_nack->delivery_time, &id);
         }
-        new_s->alloc_size += raxAllocSize(new_cg->pel);
         raxStop(&ri_cg_pel);
 
         /* Consumers */
         raxIterator ri_consumers;
         raxStart(&ri_consumers, cg->consumers);
         raxSeek(&ri_consumers, "^", NULL, 0);
-        new_s->alloc_size -= raxAllocSize(new_cg->consumers);
         while (raxNext(&ri_consumers)) {
             streamConsumer *consumer = ri_consumers.data;
             streamConsumer *new_consumer;
@@ -253,7 +242,7 @@ robj *streamDup(robj *o) {
             new_s->alloc_size += usable;
             new_consumer->name = sdsdup(consumer->name);
             new_s->alloc_size += sdsAllocSize(new_consumer->name);
-            new_consumer->pel = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
+            new_consumer->pel = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &new_s->alloc_size);
             raxInsert(new_cg->consumers,(unsigned char *)new_consumer->name,
                         sdslen(new_consumer->name), new_consumer, NULL);
             new_consumer->seen_time = consumer->seen_time;
@@ -273,10 +262,8 @@ robj *streamDup(robj *o) {
                 new_nack->consumer = new_consumer;
                 raxInsert(new_consumer->pel,ri_cpel.key,sizeof(streamID),new_nack,NULL);
             }
-            new_s->alloc_size += raxAllocSize(new_consumer->pel);
             raxStop(&ri_cpel);
         }
-        new_s->alloc_size += raxAllocSize(new_cg->consumers);
         raxStop(&ri_consumers);
     }
     raxStop(&ri_cgroups);
@@ -606,9 +593,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
         }
         lp = lpAppendIntegerUsable(lp,0,&usable); /* Master entry zero terminator. */
         s->alloc_size += usable.newsize;
-        s->alloc_size -= raxAllocSize(s->rax);
         raxInsert(s->rax,(unsigned char*)&rax_key,sizeof(rax_key),lp,NULL);
-        s->alloc_size += raxAllocSize(s->rax);
         /* The first entry we insert, has obviously the same fields of the
          * master entry. */
         flags |= STREAM_ITEM_FLAG_SAMEFIELDS;
@@ -818,9 +803,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
             size_t usable;
             lpFreeUsable(lp, &usable);
             s->alloc_size -= usable;
-            s->alloc_size -= raxAllocSize(s->rax);
             raxRemove(s->rax,ri.key,ri.key_len,NULL);
-            s->alloc_size += raxAllocSize(s->rax);
             raxSeek(&ri,">=",ri.key,ri.key_len);
             s->length -= entries;
             deleted += entries;
@@ -918,9 +901,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
             size_t usable;
             lpFreeUsable(lp, &usable);
             s->alloc_size -= usable;
-            s->alloc_size -= raxAllocSize(s->rax);
             raxRemove(s->rax,ri.key,ri.key_len,NULL);
-            s->alloc_size += raxAllocSize(s->rax);
             raxSeek(&ri,">=",ri.key,ri.key_len);
             continue;
         }
@@ -1466,9 +1447,7 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
          * node. */
         lpFreeUsable(lp, &usable_sz);
         s->alloc_size -= usable_sz;
-        s->alloc_size -= raxAllocSize(s->rax);
         raxRemove(s->rax,si->ri.key,si->ri.key_len,NULL);
-        s->alloc_size += raxAllocSize(s->rax);
     } else {
         /* In the base case we alter the counters of valid/deleted entries. */
         lp = lpReplaceInteger(lp,&p,aux-1);
@@ -2078,14 +2057,10 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
              * will not require extra lookups. We'll fix the problem later
              * if we find that there is already an entry for this ID. */
             streamNACK *nack = streamCreateNACK(s, consumer);
-            s->alloc_size -= raxAllocSize(group->pel);
             int group_inserted =
                 raxTryInsert(group->pel,buf,sizeof(buf),nack,NULL);
-            s->alloc_size += raxAllocSize(group->pel);
-            s->alloc_size -= raxAllocSize(consumer->pel);
             int consumer_inserted =
                 raxTryInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
-            s->alloc_size += raxAllocSize(consumer->pel);
 
             /* Now we can check if the entry was already busy, and
              * in that case reassign the entry to the new consumer,
@@ -2096,9 +2071,7 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
                 int found = raxFind(group->pel,buf,sizeof(buf),&result);
                 serverAssert(found);
                 nack = result;
-                s->alloc_size -= raxAllocSize(nack->consumer->pel);
                 raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
-                s->alloc_size += raxAllocSize(nack->consumer->pel);
                 /* Remove old entry from the PEL by time. */
                 raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &id);
                 /* Update the consumer and NACK metadata. */
@@ -2106,9 +2079,7 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
                 nack->delivery_time = commandTimeSnapshot();
                 nack->delivery_count = 1;
                 /* Add the entry in the new consumer local PEL. */
-                s->alloc_size -= raxAllocSize(consumer->pel);
                 raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
-                s->alloc_size += raxAllocSize(consumer->pel);
             } else if (group_inserted == 1 && consumer_inserted == 1) {
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, group, buf);
             } else if (group_inserted == 1 && consumer_inserted == 0) {
@@ -2905,17 +2876,13 @@ void streamUpdateCGroupLastId(stream *s, streamCG *cg, streamID *id) {
 listNode *streamLinkCGroupToEntry(stream *s, streamCG *cg, unsigned char *key) {
     list *cglist;
 
-    if (!s->cgroups_ref) {
-        s->cgroups_ref = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
-        s->alloc_size += raxAllocSize(s->cgroups_ref);
-    }
+    if (!s->cgroups_ref)
+        s->cgroups_ref = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
     
     /* Try to find the list for this stream ID, create it if it doesn't exist */
     if (!raxFind(s->cgroups_ref, key, sizeof(streamID), (void**)&cglist)) {
         cglist = listCreate();
-        s->alloc_size -= raxAllocSize(s->cgroups_ref);
         serverAssert(raxInsert(s->cgroups_ref, key, sizeof(streamID), cglist, NULL));
-        s->alloc_size += raxAllocSize(s->cgroups_ref);
     }
     
     /* Add the consumer group to the list and return the list node */
@@ -2933,9 +2900,7 @@ void streamUnlinkEntryFromCGroupRef(stream *s, streamNACK *na, unsigned char *ke
         
         /* If the list is now empty, remove it from the index. */
         if (listLength(cglist) == 0) {
-            s->alloc_size -= raxAllocSize(s->cgroups_ref);
             raxRemove(s->cgroups_ref, key, sizeof(streamID), NULL);
-            s->alloc_size += raxAllocSize(s->cgroups_ref);
             listRelease(cglist);
         }
     }
@@ -2963,21 +2928,15 @@ void streamCleanupEntryCGroupRefs(stream *s, streamID *id) {
         serverAssert(raxFind(group->pel, buf, sizeof(buf), (void **)&nack));
         
         /* Remove from group and consumer PELs */
-        s->alloc_size -= raxAllocSize(group->pel);
         raxRemove(group->pel, buf, sizeof(buf), NULL);
-        s->alloc_size += raxAllocSize(group->pel);
         raxRemovePelByTime(group->pel_by_time, nack->delivery_time, id);
-        s->alloc_size -= raxAllocSize(nack->consumer->pel);
         raxRemove(nack->consumer->pel, buf, sizeof(buf), NULL);
-        s->alloc_size += raxAllocSize(nack->consumer->pel);
         /* Since we're removing all references from the cgroups_ref, we can directly
          * free the NACK without unlinking it from the cgroups_ref. */
         streamFreeNACK(s, nack);
     }
 
-    s->alloc_size -= raxAllocSize(s->cgroups_ref);
     raxRemove(s->cgroups_ref, buf, sizeof(streamID), NULL);
-    s->alloc_size += raxAllocSize(s->cgroups_ref);
     listRelease(cglist);
 }
 
@@ -3061,7 +3020,6 @@ void streamFreeNACKGeneric(void *na, void *s) {
  * should do some work before. */
 void streamFreeConsumer(stream *s, streamConsumer *sc) {
     size_t usable;
-    s->alloc_size -= raxAllocSize(sc->pel);
     raxFree(sc->pel); /* No value free callback: the PEL entries are shared
                          between the consumer and the main stream PEL. */
     s->alloc_size -= sdsAllocSize(sc->name);
@@ -3080,37 +3038,29 @@ void streamFreeConsumerGeneric(void *sc, void *s) {
  * the same name already exists NULL is returned, otherwise the pointer to the
  * consumer group is returned. */
 streamCG *streamCreateCG(stream *s, char *name, size_t namelen, streamID *id, long long entries_read) {
-    if (s->cgroups == NULL) {
-        s->cgroups = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
-        s->alloc_size += raxAllocSize(s->cgroups);
-    }
+    if (s->cgroups == NULL)
+        s->cgroups = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
     if (raxFind(s->cgroups,(unsigned char*)name,namelen,NULL))
         return NULL;
 
     size_t usable;
     streamCG *cg = zmalloc_usable(sizeof(*cg), &usable);
     s->alloc_size += usable;
-    cg->pel = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
-    s->alloc_size += raxAllocSize(cg->pel);
-    cg->pel_by_time = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
-    cg->consumers = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
-    s->alloc_size += raxAllocSize(cg->consumers);
+    cg->pel = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
+    cg->pel_by_time = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
+    cg->consumers = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
     cg->last_id.ms = 0;
     cg->last_id.seq = 0;
     streamUpdateCGroupLastId(s, cg, id);
     cg->entries_read = entries_read;
-    s->alloc_size -= raxAllocSize(s->cgroups);
     raxInsert(s->cgroups,(unsigned char*)name,namelen,cg,NULL);
-    s->alloc_size += raxAllocSize(s->cgroups);
     return cg;
 }
 
 /* Free a consumer group and all its associated data. */
 static void streamFreeCG(stream *s, streamCG *cg) {
-    s->alloc_size -= raxAllocSize(cg->pel);
     raxFreeWithCbAndContext(cg->pel, streamFreeNACKGeneric, s);
     raxFree(cg->pel_by_time);
-    s->alloc_size -= raxAllocSize(cg->consumers);
     raxFreeWithCbAndContext(cg->consumers, streamFreeConsumerGeneric, s);
     size_t usable;
     zfree_usable(cg, &usable);
@@ -3155,7 +3105,6 @@ streamConsumer *streamCreateConsumer(stream *s, streamCG *cg, sds name, robj *ke
     int dirty = !(flags & SCC_NO_DIRTIFY);
     size_t usable;
     streamConsumer *consumer = zmalloc_usable(sizeof(*consumer), &usable);
-    size_t old_consumers_size = raxAllocSize(cg->consumers);
     int success = raxTryInsert(cg->consumers,(unsigned char*)name,
                                sdslen(name),consumer,NULL);
     if (!success) {
@@ -3163,12 +3112,9 @@ streamConsumer *streamCreateConsumer(stream *s, streamCG *cg, sds name, robj *ke
         return NULL;
     }
     s->alloc_size += usable;
-    s->alloc_size -= old_consumers_size;
-    s->alloc_size += raxAllocSize(cg->consumers);
     consumer->name = sdsdup(name);
     s->alloc_size += sdsAllocSize(consumer->name);
-    consumer->pel = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
-    s->alloc_size += raxAllocSize(consumer->pel);
+    consumer->pel = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
     consumer->active_time = -1;
     consumer->seen_time = commandTimeSnapshot();
     if (dirty) server.dirty++;
@@ -3206,10 +3152,8 @@ void streamDelConsumer(stream *s, streamCG *cg, streamConsumer *consumer) {
     raxStop(&ri);
 
     /* Deallocate the consumer. */
-    s->alloc_size -= raxAllocSize(cg->consumers);
     raxRemove(cg->consumers,(unsigned char*)consumer->name,
               sdslen(consumer->name),NULL);
-    s->alloc_size += raxAllocSize(cg->consumers);
     streamFreeConsumer(s,consumer);
 }
 
@@ -3361,9 +3305,7 @@ NULL
         notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-setid",c->argv[2],c->db->id);
     } else if (!strcasecmp(opt,"DESTROY") && c->argc == 4) {
         if (cg) {
-            s->alloc_size -= raxAllocSize(s->cgroups);
             raxRemove(s->cgroups,(unsigned char*)grpname,sdslen(grpname),NULL);
-            s->alloc_size += raxAllocSize(s->cgroups);
             streamDestroyCG(s, cg);
             addReply(c,shared.cone);
             server.dirty++;
@@ -3507,7 +3449,6 @@ void xackCommand(client *c) {
     }
 
     int acknowledged = 0;
-    stream *s = kv->ptr;
     for (int j = 3; j < c->argc; j++) {
         unsigned char buf[sizeof(streamID)];
         streamEncodeID(buf,&ids[j-3]);
@@ -3519,12 +3460,8 @@ void xackCommand(client *c) {
         if (raxFind(group->pel,buf,sizeof(buf),&result)) {
             streamNACK *nack = result;
             raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &ids[j-3]);
-            s->alloc_size -= raxAllocSize(group->pel);
             raxRemove(group->pel,buf,sizeof(buf),NULL);
-            s->alloc_size += raxAllocSize(group->pel);
-            s->alloc_size -= raxAllocSize(nack->consumer->pel);
             raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
-            s->alloc_size += raxAllocSize(nack->consumer->pel);
             streamDestroyNACK(kv->ptr, nack, buf);
             acknowledged++;
             server.dirty++;
@@ -3593,12 +3530,8 @@ void xackdelCommand(client *c) {
         if (raxFind(group->pel,buf,sizeof(buf),&result)) {
             streamNACK *nack = result;
             raxRemovePelByTime(group->pel_by_time, nack->delivery_time, id);
-            s->alloc_size -= raxAllocSize(group->pel);
             raxRemove(group->pel,buf,sizeof(buf),NULL);
-            s->alloc_size += raxAllocSize(group->pel);
-            s->alloc_size -= raxAllocSize(nack->consumer->pel);
             raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
-            s->alloc_size += raxAllocSize(nack->consumer->pel);
             streamDestroyNACK(s, nack, buf);
             server.dirty++;
 
@@ -4030,12 +3963,8 @@ void xclaimCommand(client *c) {
                 server.dirty++;
                 /* Release the NACK */
                 raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &id);
-                s->alloc_size -= raxAllocSize(group->pel);
                 raxRemove(group->pel,buf,sizeof(buf),NULL);
-                s->alloc_size += raxAllocSize(group->pel);
-                s->alloc_size -= raxAllocSize(nack->consumer->pel);
                 raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
-                s->alloc_size += raxAllocSize(nack->consumer->pel);
                 streamDestroyNACK(s, nack, buf);
             }
             continue;
@@ -4049,9 +3978,7 @@ void xclaimCommand(client *c) {
         if (force && nack == NULL) {
             /* Create the NACK. */
             nack = streamCreateNACK(s,NULL);
-            s->alloc_size -= raxAllocSize(group->pel);
             raxInsert(group->pel,buf,sizeof(buf),nack,NULL);
-            s->alloc_size += raxAllocSize(group->pel);
             raxInsertPelByTime(group->pel_by_time, nack->delivery_time, &id);
             nack->cgroup_ref_node = streamLinkCGroupToEntry(s, group, buf);
         }
@@ -4073,9 +4000,7 @@ void xclaimCommand(client *c) {
                  * Note that nack->consumer is NULL if we created the
                  * NACK above because of the FORCE option. */
                 if (nack->consumer) {
-                    s->alloc_size -= raxAllocSize(nack->consumer->pel);
                     raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
-                    s->alloc_size += raxAllocSize(nack->consumer->pel);
                 }
             }
 
@@ -4092,9 +4017,7 @@ void xclaimCommand(client *c) {
             }
             if (nack->consumer != consumer) {
                 /* Add the entry in the new consumer local PEL. */
-                s->alloc_size -= raxAllocSize(consumer->pel);
                 raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
-                s->alloc_size += raxAllocSize(consumer->pel);
                 nack->consumer = consumer;
             }
             /* Send the reply for this entry. */
@@ -4238,12 +4161,8 @@ void xautoclaimCommand(client *c) {
             server.dirty++;
             /* Clear this entry from the PEL, it no longer exists */
             raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &id);
-            s->alloc_size -= raxAllocSize(group->pel);
             raxRemove(group->pel,ri.key,ri.key_len,NULL);
-            s->alloc_size += raxAllocSize(group->pel);
-            s->alloc_size -= raxAllocSize(nack->consumer->pel);
             raxRemove(nack->consumer->pel,ri.key,ri.key_len,NULL);
-            s->alloc_size += raxAllocSize(nack->consumer->pel);
             streamDestroyNACK(s, nack, ri.key);
             /* Remember the ID for later */
             deleted_ids[deleted_id_num++] = id;
@@ -4263,9 +4182,7 @@ void xautoclaimCommand(client *c) {
              * Note that nack->consumer is NULL if we created the
              * NACK above because of the FORCE option. */
             if (nack->consumer) {
-                s->alloc_size -= raxAllocSize(nack->consumer->pel);
                 raxRemove(nack->consumer->pel,ri.key,ri.key_len,NULL);
-                s->alloc_size += raxAllocSize(nack->consumer->pel);
             }
         }
 
@@ -4280,9 +4197,7 @@ void xautoclaimCommand(client *c) {
 
         if (nack->consumer != consumer) {
             /* Add the entry in the new consumer local PEL. */
-            s->alloc_size -= raxAllocSize(consumer->pel);
             raxInsert(consumer->pel,ri.key,ri.key_len,nack,NULL);
-            s->alloc_size += raxAllocSize(consumer->pel);
             nack->consumer = consumer;
         }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -70,11 +70,10 @@ stream *streamNew(void) {
     return s;
 }
 
-static void streamLpFreeGeneric(void *lp, void *stream_) {
-    stream *s = stream_;
-    size_t usable = 0;
-    lpFreeUsable(lp, &usable);
-    s->alloc_size -= usable;
+static void streamLpFreeGeneric(void *lp, void *strm) {
+    stream *s = strm;
+    s->alloc_size -= lpBytes(lp);
+    lpFree(lp);
 }
 
 /* Free a stream, including the listpacks stored inside the radix tree. */
@@ -185,9 +184,8 @@ robj *streamDup(robj *o) {
         serverAssert(ri.key_len == sizeof(streamID));
         lp = ri.data;
         lp_bytes = lpBytes(lp);
-        size_t usable;
-        unsigned char *new_lp = zmalloc_usable(lp_bytes, &usable);
-        new_s->alloc_size += usable;
+        unsigned char *new_lp = zmalloc(lp_bytes);
+        new_s->alloc_size += lp_bytes;
         memcpy(new_lp, lp, lp_bytes);
         raxInsert(new_s->rax, ri.key, ri.key_len,
                   new_lp, NULL);
@@ -559,10 +557,9 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 
         if (new_node) {
             /* Shrink extra pre-allocated memory */
-            UsableSizes usable = {0};
-            lp = lpShrinkToFitUsable(lp, &usable);
-            s->alloc_size -= usable.oldsize;
-            s->alloc_size += usable.newsize;
+            lp = lpShrinkToFit(lp);
+            s->alloc_size -= lp_bytes;
+            s->alloc_size += lpBytes(lp);
             if (ri.data != lp)
                 raxSetData(ri.node, lp);
             lp = NULL;
@@ -571,7 +568,6 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 
     int flags = STREAM_ITEM_FLAG_NONE;
     if (lp == NULL) {
-        UsableSizes usable = {0};
         master_id = id;
         streamEncodeID(rax_key,&id);
         /* Create the listpack having the master entry ID and fields.
@@ -592,8 +588,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
             sds field = argv[i*2]->ptr;
             lp = lpAppend(lp,(unsigned char*)field,sdslen(field));
         }
-        lp = lpAppendIntegerUsable(lp,0,&usable); /* Master entry zero terminator. */
-        s->alloc_size += usable.newsize;
+        lp = lpAppendInteger(lp,0); /* Master entry zero terminator. */
+        s->alloc_size += lpBytes(lp);
         raxInsert(s->rax,(unsigned char*)&rax_key,sizeof(rax_key),lp,NULL);
         /* The first entry we insert, has obviously the same fields of the
          * master entry. */
@@ -608,7 +604,10 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 
         /* Update count and skip the deleted fields. */
         int64_t count = lpGetInteger(lp_ele);
+        size_t oldsize = lpBytes(lp);
         lp = lpReplaceInteger(lp,&lp_ele,count+1);
+        s->alloc_size -= oldsize;
+        s->alloc_size += lpBytes(lp);
         lp_ele = lpNext(lp,lp_ele); /* seek deleted. */
         lp_ele = lpNext(lp,lp_ele); /* seek master entry num fields. */
 
@@ -656,8 +655,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
      * in reverse order: we can just start from the end of the listpack, read
      * the entry, and jump back N times to seek the "flags" field to read
      * the stream full entry. */
-    UsableSizes usable = {0}, old_usable = {0};
-    lp = lpAppendIntegerUsable(lp,flags,&old_usable);
+    size_t oldsize = lpBytes(lp);
+    lp = lpAppendInteger(lp,flags);
     lp = lpAppendInteger(lp,id.ms - master_id.ms);
     lp = lpAppendInteger(lp,id.seq - master_id.seq);
     if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS))
@@ -676,9 +675,9 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
          * the values, and an additional num-fields field. */
         lp_count += numfields+1;
     }
-    lp = lpAppendIntegerUsable(lp,lp_count,&usable);
-    s->alloc_size += usable.newsize;
-    s->alloc_size -= old_usable.oldsize;
+    lp = lpAppendInteger(lp,lp_count);
+    s->alloc_size -= oldsize;
+    s->alloc_size += lpBytes(lp);
 
     /* Insert back into the tree in order to update the listpack pointer. */
     if (ri.data != lp)
@@ -801,9 +800,8 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         }
 
         if (remove_node) {
-            size_t usable;
-            lpFreeUsable(lp, &usable);
-            s->alloc_size -= usable;
+            s->alloc_size -= lpBytes(lp);
+            lpFree(lp);
             raxRemove(s->rax,ri.key,ri.key_len,NULL);
             raxSeek(&ri,">=",ri.key,ri.key_len);
             s->length -= entries;
@@ -816,7 +814,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         if (approx) break;
 
         /* Now we have to trim entries from within 'lp' */
-        size_t old_usable = zmalloc_usable_size(lp);
+        size_t oldsize = lpBytes(lp);
         int64_t deleted_from_lp = 0;
 
         p = lpNext(lp, p); /* Skip deleted field. */
@@ -899,9 +897,8 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
          * due to delete strategy constraints, and now we've processed and deleted all entries
          * in the node, we can finally remove the entire node. */
         if (node_eligible_for_remove && deleted_from_lp == entries) {
-            size_t usable;
-            lpFreeUsable(lp, &usable);
-            s->alloc_size -= usable;
+            s->alloc_size -= oldsize;
+            lpFree(lp);
             raxRemove(s->rax,ri.key,ri.key_len,NULL);
             raxSeek(&ri,">=",ri.key,ri.key_len);
             continue;
@@ -912,11 +909,10 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         lp = lpReplaceInteger(lp,&p,entries-deleted_from_lp);
         p = lpNext(lp,p); /* Skip deleted field. */
         int64_t marked_deleted = lpGetInteger(p);
-        UsableSizes usable = {0};
-        lp = lpReplaceIntegerUsable(lp,&p,marked_deleted+deleted_from_lp,&usable);
+        lp = lpReplaceInteger(lp,&p,marked_deleted+deleted_from_lp);
         p = lpNext(lp,p); /* Skip num-of-fields in the master entry. */
-        s->alloc_size += usable.newsize;
-        s->alloc_size -= old_usable;
+        s->alloc_size -= oldsize;
+        s->alloc_size += lpBytes(lp);
 
         /* Here we should perform garbage collection in case at this point
          * there are too many entries deleted inside the listpack. */
@@ -1426,8 +1422,8 @@ void streamIteratorGetField(streamIterator *si, unsigned char **fieldptr, unsign
 void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     stream *s = si->stream;
     unsigned char *lp = si->lp;
+    size_t oldsize = lpBytes(lp);
     int64_t aux;
-    UsableSizes usable = {0}, old_usable = {0};
 
     /* We do not really delete the entry here. Instead we mark it as
      * deleted by flagging it, and also incrementing the count of the
@@ -1436,27 +1432,26 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
      * We start flagging: */
     int64_t flags = lpGetInteger(si->lp_flags);
     flags |= STREAM_ITEM_FLAG_DELETED;
-    lp = lpReplaceIntegerUsable(lp,&si->lp_flags,flags,&old_usable);
+    lp = lpReplaceInteger(lp,&si->lp_flags,flags);
 
     /* Change the valid/deleted entries count in the master entry. */
     unsigned char *p = lpFirst(lp);
     aux = lpGetInteger(p);
 
     if (aux == 1) {
-        size_t usable_sz;
         /* If this is the last element in the listpack, we can remove the whole
          * node. */
-        lpFreeUsable(lp, &usable_sz);
-        s->alloc_size -= usable_sz;
+        s->alloc_size -= oldsize;
+        lpFree(lp);
         raxRemove(s->rax,si->ri.key,si->ri.key_len,NULL);
     } else {
         /* In the base case we alter the counters of valid/deleted entries. */
         lp = lpReplaceInteger(lp,&p,aux-1);
         p = lpNext(lp,p); /* Seek deleted field. */
         aux = lpGetInteger(p);
-        lp = lpReplaceIntegerUsable(lp,&p,aux+1,&usable);
-        s->alloc_size += usable.newsize;
-        s->alloc_size -= old_usable.oldsize;
+        lp = lpReplaceInteger(lp,&p,aux+1);
+        s->alloc_size -= oldsize;
+        s->alloc_size += lpBytes(lp);
 
         /* Update the listpack with the new pointer. */
         if (si->lp != lp)

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -559,7 +559,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 
         if (new_node) {
             /* Shrink extra pre-allocated memory */
-            UsableSizes usable;
+            UsableSizes usable = {0};
             lp = lpShrinkToFitUsable(lp, &usable);
             s->alloc_size -= usable.oldsize;
             s->alloc_size += usable.newsize;
@@ -571,7 +571,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 
     int flags = STREAM_ITEM_FLAG_NONE;
     if (lp == NULL) {
-        UsableSizes usable;
+        UsableSizes usable = {0};
         master_id = id;
         streamEncodeID(rax_key,&id);
         /* Create the listpack having the master entry ID and fields.
@@ -656,7 +656,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
      * in reverse order: we can just start from the end of the listpack, read
      * the entry, and jump back N times to seek the "flags" field to read
      * the stream full entry. */
-    UsableSizes usable, old_usable;
+    UsableSizes usable = {0}, old_usable = {0};
     lp = lpAppendIntegerUsable(lp,flags,&old_usable);
     lp = lpAppendInteger(lp,id.ms - master_id.ms);
     lp = lpAppendInteger(lp,id.seq - master_id.seq);
@@ -912,7 +912,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         lp = lpReplaceInteger(lp,&p,entries-deleted_from_lp);
         p = lpNext(lp,p); /* Skip deleted field. */
         int64_t marked_deleted = lpGetInteger(p);
-        UsableSizes usable;
+        UsableSizes usable = {0};
         lp = lpReplaceIntegerUsable(lp,&p,marked_deleted+deleted_from_lp,&usable);
         p = lpNext(lp,p); /* Skip num-of-fields in the master entry. */
         s->alloc_size += usable.newsize;
@@ -1427,7 +1427,7 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     stream *s = si->stream;
     unsigned char *lp = si->lp;
     int64_t aux;
-    UsableSizes usable, old_usable;
+    UsableSizes usable = {0}, old_usable = {0};
 
     /* We do not really delete the entry here. Instead we mark it as
      * deleted by flagging it, and also incrementing the count of the

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -53,7 +53,7 @@ stream *streamNew(void) {
     size_t usable;
     stream *s = zmalloc_usable(sizeof(*s), &usable);
     s->alloc_size = usable;
-    s->rax = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+    s->rax = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
     s->alloc_size += raxAllocSize(s->rax);
     s->length = 0;
     s->first_id.ms = 0;
@@ -239,7 +239,7 @@ robj *streamDup(robj *o) {
             new_s->alloc_size += usable;
             new_consumer->name = sdsdup(consumer->name);
             new_s->alloc_size += sdsAllocSize(new_consumer->name);
-            new_consumer->pel = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+            new_consumer->pel = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
             raxInsert(new_cg->consumers,(unsigned char *)new_consumer->name,
                         sdslen(new_consumer->name), new_consumer, NULL);
             new_consumer->seen_time = consumer->seen_time;
@@ -2891,7 +2891,7 @@ listNode *streamLinkCGroupToEntry(stream *s, streamCG *cg, unsigned char *key) {
     list *cglist;
 
     if (!s->cgroups_ref) {
-        s->cgroups_ref = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+        s->cgroups_ref = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
         s->alloc_size += raxAllocSize(s->cgroups_ref);
     }
     
@@ -3066,7 +3066,7 @@ void streamFreeConsumerGeneric(void *sc, void *s) {
  * consumer group is returned. */
 streamCG *streamCreateCG(stream *s, char *name, size_t namelen, streamID *id, long long entries_read) {
     if (s->cgroups == NULL) {
-        s->cgroups = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+        s->cgroups = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
         s->alloc_size += raxAllocSize(s->cgroups);
     }
     if (raxFind(s->cgroups,(unsigned char*)name,namelen,NULL))
@@ -3075,10 +3075,10 @@ streamCG *streamCreateCG(stream *s, char *name, size_t namelen, streamID *id, lo
     size_t usable;
     streamCG *cg = zmalloc_usable(sizeof(*cg), &usable);
     s->alloc_size += usable;
-    cg->pel = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+    cg->pel = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
     s->alloc_size += raxAllocSize(cg->pel);
-    cg->pel_by_time = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
-    cg->consumers = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+    cg->pel_by_time = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
+    cg->consumers = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
     s->alloc_size += raxAllocSize(cg->consumers);
     cg->last_id.ms = 0;
     cg->last_id.seq = 0;
@@ -3152,7 +3152,7 @@ streamConsumer *streamCreateConsumer(stream *s, streamCG *cg, sds name, robj *ke
     s->alloc_size += raxAllocSize(cg->consumers);
     consumer->name = sdsdup(name);
     s->alloc_size += sdsAllocSize(consumer->name);
-    consumer->pel = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+    consumer->pel = raxNewWithMetadata(sizeof(size_t), RAX_ACCOUNT_ALLOC_SIZE);
     s->alloc_size += raxAllocSize(consumer->pel);
     consumer->active_time = -1;
     consumer->seen_time = commandTimeSnapshot();

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -571,10 +571,10 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 
         if (new_node) {
             /* Shrink extra pre-allocated memory */
-            size_t usable = 0, old_usable = 0;
-            lp = lpShrinkToFitUsable(lp, &usable, &old_usable);
-            s->alloc_size -= old_usable;
-            s->alloc_size += usable;
+            UsableSizes usable;
+            lp = lpShrinkToFitUsable(lp, &usable);
+            s->alloc_size -= usable.oldval;
+            s->alloc_size += usable.val;
             if (ri.data != lp)
                 raxSetData(ri.node, lp);
             lp = NULL;
@@ -583,7 +583,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 
     int flags = STREAM_ITEM_FLAG_NONE;
     if (lp == NULL) {
-        size_t usable;
+        UsableSizes usable;
         master_id = id;
         streamEncodeID(rax_key,&id);
         /* Create the listpack having the master entry ID and fields.
@@ -604,8 +604,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
             sds field = argv[i*2]->ptr;
             lp = lpAppend(lp,(unsigned char*)field,sdslen(field));
         }
-        lp = lpAppendIntegerUsable(lp,0,&usable,NULL); /* Master entry zero terminator. */
-        s->alloc_size += usable;
+        lp = lpAppendIntegerUsable(lp,0,&usable); /* Master entry zero terminator. */
+        s->alloc_size += usable.val;
         s->alloc_size -= raxAllocSize(s->rax);
         raxInsert(s->rax,(unsigned char*)&rax_key,sizeof(rax_key),lp,NULL);
         s->alloc_size += raxAllocSize(s->rax);
@@ -670,8 +670,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
      * in reverse order: we can just start from the end of the listpack, read
      * the entry, and jump back N times to seek the "flags" field to read
      * the stream full entry. */
-    size_t usable, old_usable;
-    lp = lpAppendIntegerUsable(lp,flags, NULL, &old_usable);
+    UsableSizes usable, old_usable;
+    lp = lpAppendIntegerUsable(lp,flags,&old_usable);
     lp = lpAppendInteger(lp,id.ms - master_id.ms);
     lp = lpAppendInteger(lp,id.seq - master_id.seq);
     if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS))
@@ -690,9 +690,9 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
          * the values, and an additional num-fields field. */
         lp_count += numfields+1;
     }
-    lp = lpAppendIntegerUsable(lp,lp_count,&usable,NULL);
-    s->alloc_size += usable;
-    s->alloc_size -= old_usable;
+    lp = lpAppendIntegerUsable(lp,lp_count,&usable);
+    s->alloc_size += usable.val;
+    s->alloc_size -= old_usable.oldval;
 
     /* Insert back into the tree in order to update the listpack pointer. */
     if (ri.data != lp)
@@ -930,10 +930,10 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         lp = lpReplaceInteger(lp,&p,entries-deleted_from_lp);
         p = lpNext(lp,p); /* Skip deleted field. */
         int64_t marked_deleted = lpGetInteger(p);
-        size_t usable;
-        lp = lpReplaceIntegerUsable(lp,&p,marked_deleted+deleted_from_lp,&usable,NULL);
+        UsableSizes usable;
+        lp = lpReplaceIntegerUsable(lp,&p,marked_deleted+deleted_from_lp,&usable);
         p = lpNext(lp,p); /* Skip num-of-fields in the master entry. */
-        s->alloc_size += usable;
+        s->alloc_size += usable.val;
         s->alloc_size -= old_usable;
 
         /* Here we should perform garbage collection in case at this point
@@ -1445,7 +1445,7 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     stream *s = si->stream;
     unsigned char *lp = si->lp;
     int64_t aux;
-    size_t usable = 0, old_usable = 0;
+    UsableSizes usable, old_usable;
 
     /* We do not really delete the entry here. Instead we mark it as
      * deleted by flagging it, and also incrementing the count of the
@@ -1454,17 +1454,18 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
      * We start flagging: */
     int64_t flags = lpGetInteger(si->lp_flags);
     flags |= STREAM_ITEM_FLAG_DELETED;
-    lp = lpReplaceIntegerUsable(lp,&si->lp_flags,flags,NULL,&old_usable);
+    lp = lpReplaceIntegerUsable(lp,&si->lp_flags,flags,&old_usable);
 
     /* Change the valid/deleted entries count in the master entry. */
     unsigned char *p = lpFirst(lp);
     aux = lpGetInteger(p);
 
     if (aux == 1) {
+        size_t usable_sz;
         /* If this is the last element in the listpack, we can remove the whole
          * node. */
-        lpFreeUsable(lp, &usable);
-        s->alloc_size -= usable;
+        lpFreeUsable(lp, &usable_sz);
+        s->alloc_size -= usable_sz;
         s->alloc_size -= raxAllocSize(s->rax);
         raxRemove(s->rax,si->ri.key,si->ri.key_len,NULL);
         s->alloc_size += raxAllocSize(s->rax);
@@ -1473,9 +1474,9 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
         lp = lpReplaceInteger(lp,&p,aux-1);
         p = lpNext(lp,p); /* Seek deleted field. */
         aux = lpGetInteger(p);
-        lp = lpReplaceIntegerUsable(lp,&p,aux+1,&usable,NULL);
-        s->alloc_size += usable;
-        s->alloc_size -= old_usable;
+        lp = lpReplaceIntegerUsable(lp,&p,aux+1,&usable);
+        s->alloc_size += usable.val;
+        s->alloc_size -= old_usable.oldval;
 
         /* Update the listpack with the new pointer. */
         if (si->lp != lp)

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -53,7 +53,7 @@ stream *streamNew(void) {
     size_t usable;
     stream *s = zmalloc_usable(sizeof(*s), &usable);
     s->alloc_size = usable;
-    s->rax = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
+    s->rax = raxNewWithMetadata(0, &s->alloc_size);
     s->length = 0;
     s->first_id.ms = 0;
     s->first_id.seq = 0;
@@ -243,7 +243,7 @@ robj *streamDup(robj *o) {
             new_s->alloc_size += usable;
             new_consumer->name = sdsdup(consumer->name);
             new_s->alloc_size += sdsAllocSize(new_consumer->name);
-            new_consumer->pel = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &new_s->alloc_size);
+            new_consumer->pel = raxNewWithMetadata(0, &new_s->alloc_size);
             raxInsert(new_cg->consumers,(unsigned char *)new_consumer->name,
                         sdslen(new_consumer->name), new_consumer, NULL);
             new_consumer->seen_time = consumer->seen_time;
@@ -2878,7 +2878,7 @@ listNode *streamLinkCGroupToEntry(stream *s, streamCG *cg, unsigned char *key) {
     list *cglist;
 
     if (!s->cgroups_ref)
-        s->cgroups_ref = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
+        s->cgroups_ref = raxNewWithMetadata(0, &s->alloc_size);
     
     /* Try to find the list for this stream ID, create it if it doesn't exist */
     if (!raxFind(s->cgroups_ref, key, sizeof(streamID), (void**)&cglist)) {
@@ -3040,16 +3040,16 @@ void streamFreeConsumerGeneric(void *sc, void *s) {
  * consumer group is returned. */
 streamCG *streamCreateCG(stream *s, char *name, size_t namelen, streamID *id, long long entries_read) {
     if (s->cgroups == NULL)
-        s->cgroups = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
+        s->cgroups = raxNewWithMetadata(0, &s->alloc_size);
     if (raxFind(s->cgroups,(unsigned char*)name,namelen,NULL))
         return NULL;
 
     size_t usable;
     streamCG *cg = zmalloc_usable(sizeof(*cg), &usable);
     s->alloc_size += usable;
-    cg->pel = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
-    cg->pel_by_time = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
-    cg->consumers = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
+    cg->pel = raxNewWithMetadata(0, &s->alloc_size);
+    cg->pel_by_time = raxNewWithMetadata(0, &s->alloc_size);
+    cg->consumers = raxNewWithMetadata(0, &s->alloc_size);
     cg->last_id.ms = 0;
     cg->last_id.seq = 0;
     streamUpdateCGroupLastId(s, cg, id);
@@ -3115,7 +3115,7 @@ streamConsumer *streamCreateConsumer(stream *s, streamCG *cg, sds name, robj *ke
     s->alloc_size += usable;
     consumer->name = sdsdup(name);
     s->alloc_size += sdsAllocSize(consumer->name);
-    consumer->pel = raxNewWithMetadata(sizeof(size_t *), RAX_ACCOUNT_ALLOC_SIZE, &s->alloc_size);
+    consumer->pel = raxNewWithMetadata(0, &s->alloc_size);
     consumer->active_time = -1;
     consumer->seen_time = commandTimeSnapshot();
     if (dirty) server.dirty++;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -10,7 +10,6 @@
 #include "server.h"
 #include "endianconv.h"
 #include "stream.h"
-#include "redisassert.h"
 
 /* Every stream item inside the listpack, has a flags field that is used to
  * mark the entry as deleted, or having the same field as the "master"
@@ -85,7 +84,9 @@ void freeStream(stream *s) {
         raxFreeWithCbAndContext(s->cgroups, streamFreeCGGeneric, s);
     if (s->cgroups_ref)
         raxFreeWithCallback(s->cgroups_ref, listReleaseGeneric);
-    debugAssert(s->alloc_size == zmalloc_usable_size(s));
+#ifdef REDIS_TEST
+    serverAssert(s->alloc_size == zmalloc_usable_size(s));
+#endif
     zfree(s);
 }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -33,8 +33,8 @@
  * will return NULL. */
 #define STREAM_LISTPACK_MAX_SIZE (1<<30)
 
-void streamFreeCGGeneric(void *cg);
-void streamFreeNACK(streamNACK *na);
+void streamFreeCGGeneric(void *cg, void *s);
+void streamFreeNACK(stream *s, streamNACK *na);
 size_t streamReplyWithRangeFromConsumerPEL(client *c, stream *s, streamID *start, streamID *end, size_t count, streamCG *group, streamConsumer *consumer);
 int streamParseStrictIDOrReply(client *c, robj *o, streamID *id, uint64_t missing_seq, int *seq_given);
 int streamParseIDOrReply(client *c, robj *o, streamID *id, uint64_t missing_seq);
@@ -50,8 +50,11 @@ void trackStreamClaimTimeouts(client *c, robj **keys, int numkeys, uint64_t expi
 
 /* Create a new stream data structure. */
 stream *streamNew(void) {
-    stream *s = zmalloc(sizeof(*s));
-    s->rax = raxNew();
+    size_t usable;
+    stream *s = zmalloc_usable(sizeof(*s), &usable);
+    s->alloc_size = usable;
+    s->rax = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+    s->alloc_size += raxAllocSize(s->rax);
     s->length = 0;
     s->first_id.ms = 0;
     s->first_id.seq = 0;
@@ -72,7 +75,7 @@ stream *streamNew(void) {
 void freeStream(stream *s) {
     raxFreeWithCallback(s->rax, lpFreeGeneric);
     if (s->cgroups)
-        raxFreeWithCallback(s->cgroups, streamFreeCGGeneric);
+        raxFreeWithCbAndContext(s->cgroups, streamFreeCGGeneric, s);
     if (s->cgroups_ref)
         raxFreeWithCallback(s->cgroups_ref, listReleaseGeneric);
     zfree(s);
@@ -169,15 +172,19 @@ robj *streamDup(robj *o) {
     size_t lp_bytes = 0;      /* Total bytes in the listpack. */
     unsigned char *lp = NULL; /* listpack pointer. */
     /* Get a reference to the listpack node. */
+    new_s->alloc_size -= raxAllocSize(new_s->rax);
     while (raxNext(&ri)) {
         serverAssert(ri.key_len == sizeof(streamID));
         lp = ri.data;
         lp_bytes = lpBytes(lp);
-        unsigned char *new_lp = zmalloc(lp_bytes);
+        size_t usable;
+        unsigned char *new_lp = zmalloc_usable(lp_bytes,&usable);
+        new_s->alloc_size += usable;
         memcpy(new_lp, lp, lp_bytes);
         raxInsert(new_s->rax, ri.key, ri.key_len,
                   new_lp, NULL);
     }
+    new_s->alloc_size += raxAllocSize(new_s->rax);
     new_s->length = s->length;
     new_s->first_id = s->first_id;
     new_s->last_id = s->last_id;
@@ -203,9 +210,10 @@ robj *streamDup(robj *o) {
         raxIterator ri_cg_pel;
         raxStart(&ri_cg_pel,cg->pel);
         raxSeek(&ri_cg_pel,"^",NULL,0);
+        new_s->alloc_size -= raxAllocSize(new_cg->pel);
         while(raxNext(&ri_cg_pel)){
             streamNACK *nack = ri_cg_pel.data;
-            streamNACK *new_nack = streamCreateNACK(NULL);
+            streamNACK *new_nack = streamCreateNACK(new_s, NULL);
             new_nack->delivery_time = nack->delivery_time;
             new_nack->delivery_count = nack->delivery_count;
             new_nack->cgroup_ref_node = streamLinkCGroupToEntry(new_s, new_cg, ri_cg_pel.key);
@@ -215,18 +223,23 @@ robj *streamDup(robj *o) {
             streamDecodeID(ri_cg_pel.key, &id);
             raxInsertPelByTime(new_cg->pel_by_time, new_nack->delivery_time, &id);
         }
+        new_s->alloc_size += raxAllocSize(new_cg->pel);
         raxStop(&ri_cg_pel);
 
         /* Consumers */
         raxIterator ri_consumers;
         raxStart(&ri_consumers, cg->consumers);
         raxSeek(&ri_consumers, "^", NULL, 0);
+        new_s->alloc_size -= raxAllocSize(new_cg->consumers);
         while (raxNext(&ri_consumers)) {
             streamConsumer *consumer = ri_consumers.data;
             streamConsumer *new_consumer;
-            new_consumer = zmalloc(sizeof(*new_consumer));
+            size_t usable;
+            new_consumer = zmalloc_usable(sizeof(*new_consumer), &usable);
+            new_s->alloc_size += usable;
             new_consumer->name = sdsdup(consumer->name);
-            new_consumer->pel = raxNew();
+            new_s->alloc_size += sdsAllocSize(new_consumer->name);
+            new_consumer->pel = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
             raxInsert(new_cg->consumers,(unsigned char *)new_consumer->name,
                         sdslen(new_consumer->name), new_consumer, NULL);
             new_consumer->seen_time = consumer->seen_time;
@@ -246,8 +259,10 @@ robj *streamDup(robj *o) {
                 new_nack->consumer = new_consumer;
                 raxInsert(new_consumer->pel,ri_cpel.key,sizeof(streamID),new_nack,NULL);
             }
+            new_s->alloc_size += raxAllocSize(new_consumer->pel);
             raxStop(&ri_cpel);
         }
+        new_s->alloc_size += raxAllocSize(new_cg->consumers);
         raxStop(&ri_consumers);
     }
     raxStop(&ri_cgroups);
@@ -542,7 +557,10 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 
         if (new_node) {
             /* Shrink extra pre-allocated memory */
-            lp = lpShrinkToFit(lp);
+            size_t usable, old_usable;
+            lp = lpShrinkToFitUsable(lp, &usable, &old_usable);
+            s->alloc_size -= old_usable;
+            s->alloc_size += usable;
             if (ri.data != lp)
                 raxSetData(ri.node, lp);
             lp = NULL;
@@ -551,6 +569,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 
     int flags = STREAM_ITEM_FLAG_NONE;
     if (lp == NULL) {
+        size_t usable;
         master_id = id;
         streamEncodeID(rax_key,&id);
         /* Create the listpack having the master entry ID and fields.
@@ -571,8 +590,11 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
             sds field = argv[i*2]->ptr;
             lp = lpAppend(lp,(unsigned char*)field,sdslen(field));
         }
-        lp = lpAppendInteger(lp,0); /* Master entry zero terminator. */
+        lp = lpAppendIntegerUsable(lp,0,&usable,NULL); /* Master entry zero terminator. */
+        s->alloc_size += usable;
+        s->alloc_size -= raxAllocSize(s->rax);
         raxInsert(s->rax,(unsigned char*)&rax_key,sizeof(rax_key),lp,NULL);
+        s->alloc_size += raxAllocSize(s->rax);
         /* The first entry we insert, has obviously the same fields of the
          * master entry. */
         flags |= STREAM_ITEM_FLAG_SAMEFIELDS;
@@ -634,7 +656,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
      * in reverse order: we can just start from the end of the listpack, read
      * the entry, and jump back N times to seek the "flags" field to read
      * the stream full entry. */
-    lp = lpAppendInteger(lp,flags);
+    size_t usable, old_usable;
+    lp = lpAppendIntegerUsable(lp,flags, NULL, &old_usable);
     lp = lpAppendInteger(lp,id.ms - master_id.ms);
     lp = lpAppendInteger(lp,id.seq - master_id.seq);
     if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS))
@@ -653,7 +676,9 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
          * the values, and an additional num-fields field. */
         lp_count += numfields+1;
     }
-    lp = lpAppendInteger(lp,lp_count);
+    lp = lpAppendIntegerUsable(lp,lp_count,&usable,NULL);
+    s->alloc_size += usable;
+    s->alloc_size -= old_usable;
 
     /* Insert back into the tree in order to update the listpack pointer. */
     if (ri.data != lp)
@@ -776,8 +801,12 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         }
 
         if (remove_node) {
-            lpFree(lp);
+            size_t usable;
+            lpFreeUsable(lp, &usable);
+            s->alloc_size -= usable;
+            s->alloc_size -= raxAllocSize(s->rax);
             raxRemove(s->rax,ri.key,ri.key_len,NULL);
+            s->alloc_size += raxAllocSize(s->rax);
             raxSeek(&ri,">=",ri.key,ri.key_len);
             s->length -= entries;
             deleted += entries;
@@ -789,6 +818,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         if (approx) break;
 
         /* Now we have to trim entries from within 'lp' */
+        size_t old_usable = zmalloc_usable_size(lp);
         int64_t deleted_from_lp = 0;
 
         p = lpNext(lp, p); /* Skip deleted field. */
@@ -871,8 +901,12 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
          * due to delete strategy constraints, and now we've processed and deleted all entries
          * in the node, we can finally remove the entire node. */
         if (node_eligible_for_remove && deleted_from_lp == entries) {
-            lpFree(lp);
+            size_t usable;
+            lpFreeUsable(lp, &usable);
+            s->alloc_size -= usable;
+            s->alloc_size -= raxAllocSize(s->rax);
             raxRemove(s->rax,ri.key,ri.key_len,NULL);
+            s->alloc_size += raxAllocSize(s->rax);
             raxSeek(&ri,">=",ri.key,ri.key_len);
             continue;
         }
@@ -882,8 +916,11 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         lp = lpReplaceInteger(lp,&p,entries-deleted_from_lp);
         p = lpNext(lp,p); /* Skip deleted field. */
         int64_t marked_deleted = lpGetInteger(p);
-        lp = lpReplaceInteger(lp,&p,marked_deleted+deleted_from_lp);
+        size_t usable;
+        lp = lpReplaceIntegerUsable(lp,&p,marked_deleted+deleted_from_lp,&usable,NULL);
         p = lpNext(lp,p); /* Skip num-of-fields in the master entry. */
+        s->alloc_size += usable;
+        s->alloc_size -= old_usable;
 
         /* Here we should perform garbage collection in case at this point
          * there are too many entries deleted inside the listpack. */
@@ -1391,8 +1428,10 @@ void streamIteratorGetField(streamIterator *si, unsigned char **fieldptr, unsign
  * automatically re-seek to the next entry, so the caller should continue
  * with GetID(). */
 void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
+    stream *s = si->stream;
     unsigned char *lp = si->lp;
     int64_t aux;
+    size_t usable, old_usable;
 
     /* We do not really delete the entry here. Instead we mark it as
      * deleted by flagging it, and also incrementing the count of the
@@ -1401,7 +1440,7 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
      * We start flagging: */
     int64_t flags = lpGetInteger(si->lp_flags);
     flags |= STREAM_ITEM_FLAG_DELETED;
-    lp = lpReplaceInteger(lp,&si->lp_flags,flags);
+    lp = lpReplaceIntegerUsable(lp,&si->lp_flags,flags,NULL,&old_usable);
 
     /* Change the valid/deleted entries count in the master entry. */
     unsigned char *p = lpFirst(lp);
@@ -1410,22 +1449,27 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     if (aux == 1) {
         /* If this is the last element in the listpack, we can remove the whole
          * node. */
-        lpFree(lp);
-        raxRemove(si->stream->rax,si->ri.key,si->ri.key_len,NULL);
+        lpFreeUsable(lp, &usable);
+        s->alloc_size -= usable;
+        s->alloc_size -= raxAllocSize(s->rax);
+        raxRemove(s->rax,si->ri.key,si->ri.key_len,NULL);
+        s->alloc_size += raxAllocSize(s->rax);
     } else {
         /* In the base case we alter the counters of valid/deleted entries. */
         lp = lpReplaceInteger(lp,&p,aux-1);
         p = lpNext(lp,p); /* Seek deleted field. */
         aux = lpGetInteger(p);
-        lp = lpReplaceInteger(lp,&p,aux+1);
+        lp = lpReplaceIntegerUsable(lp,&p,aux+1,&usable,NULL);
+        s->alloc_size += usable;
+        s->alloc_size -= old_usable;
 
         /* Update the listpack with the new pointer. */
         if (si->lp != lp)
-            raxInsert(si->stream->rax,si->ri.key,si->ri.key_len,lp,NULL);
+            raxInsert(s->rax,si->ri.key,si->ri.key_len,lp,NULL);
     }
 
     /* Update the number of entries counter. */
-    si->stream->length--;
+    s->length--;
 
     /* Re-seek the iterator to fix the now messed up state. */
     streamID start, end;
@@ -1437,7 +1481,7 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
         streamDecodeID(si->end_key,&end);
     }
     streamIteratorStop(si);
-    streamIteratorStart(si,si->stream,&start,&end,si->rev);
+    streamIteratorStart(si,s,&start,&end,si->rev);
 
     /* TODO: perform a garbage collection here if the ratio between
      * deleted and valid goes over a certain limit. */
@@ -2018,22 +2062,28 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
             /* Try to add a new NACK. Most of the time this will work and
              * will not require extra lookups. We'll fix the problem later
              * if we find that there is already an entry for this ID. */
-            streamNACK *nack = streamCreateNACK(consumer);
+            streamNACK *nack = streamCreateNACK(s, consumer);
+            s->alloc_size -= raxAllocSize(group->pel);
             int group_inserted =
                 raxTryInsert(group->pel,buf,sizeof(buf),nack,NULL);
+            s->alloc_size += raxAllocSize(group->pel);
+            s->alloc_size -= raxAllocSize(consumer->pel);
             int consumer_inserted =
                 raxTryInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
+            s->alloc_size += raxAllocSize(consumer->pel);
 
             /* Now we can check if the entry was already busy, and
              * in that case reassign the entry to the new consumer,
              * or update it if the consumer is the same as before. */
             if (group_inserted == 0) {
-                streamFreeNACK(nack);
+                streamFreeNACK(s,nack);
                 void *result;
                 int found = raxFind(group->pel,buf,sizeof(buf),&result);
                 serverAssert(found);
                 nack = result;
+                s->alloc_size -= raxAllocSize(nack->consumer->pel);
                 raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
+                s->alloc_size += raxAllocSize(nack->consumer->pel);
                 /* Remove old entry from the PEL by time. */
                 raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &id);
                 /* Update the consumer and NACK metadata. */
@@ -2041,7 +2091,9 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
                 nack->delivery_time = commandTimeSnapshot();
                 nack->delivery_count = 1;
                 /* Add the entry in the new consumer local PEL. */
+                s->alloc_size -= raxAllocSize(consumer->pel);
                 raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
+                s->alloc_size += raxAllocSize(consumer->pel);
             } else if (group_inserted == 1 && consumer_inserted == 1) {
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, group, buf);
             } else if (group_inserted == 1 && consumer_inserted == 0) {
@@ -2698,7 +2750,7 @@ void xreadCommand(client *c) {
             }
             consumer = streamLookupConsumer(groups[i],consumername->ptr);
             if (consumer == NULL) {
-                consumer = streamCreateConsumer(groups[i],consumername->ptr,
+                consumer = streamCreateConsumer(s,groups[i],consumername->ptr,
                                                 c->argv[streams_arg+i],
                                                 c->db->id,SCC_DEFAULT);
                 if (noack)
@@ -2838,13 +2890,17 @@ void streamUpdateCGroupLastId(stream *s, streamCG *cg, streamID *id) {
 listNode *streamLinkCGroupToEntry(stream *s, streamCG *cg, unsigned char *key) {
     list *cglist;
 
-    if (!s->cgroups_ref)
-        s->cgroups_ref = raxNew();
+    if (!s->cgroups_ref) {
+        s->cgroups_ref = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+        s->alloc_size += raxAllocSize(s->cgroups_ref);
+    }
     
     /* Try to find the list for this stream ID, create it if it doesn't exist */
     if (!raxFind(s->cgroups_ref, key, sizeof(streamID), (void**)&cglist)) {
         cglist = listCreate();
+        s->alloc_size -= raxAllocSize(s->cgroups_ref);
         serverAssert(raxInsert(s->cgroups_ref, key, sizeof(streamID), cglist, NULL));
+        s->alloc_size += raxAllocSize(s->cgroups_ref);
     }
     
     /* Add the consumer group to the list and return the list node */
@@ -2862,7 +2918,9 @@ void streamUnlinkEntryFromCGroupRef(stream *s, streamNACK *na, unsigned char *ke
         
         /* If the list is now empty, remove it from the index. */
         if (listLength(cglist) == 0) {
+            s->alloc_size -= raxAllocSize(s->cgroups_ref);
             raxRemove(s->cgroups_ref, key, sizeof(streamID), NULL);
+            s->alloc_size += raxAllocSize(s->cgroups_ref);
             listRelease(cglist);
         }
     }
@@ -2890,15 +2948,21 @@ void streamCleanupEntryCGroupRefs(stream *s, streamID *id) {
         serverAssert(raxFind(group->pel, buf, sizeof(buf), (void **)&nack));
         
         /* Remove from group and consumer PELs */
+        s->alloc_size -= raxAllocSize(group->pel);
         raxRemove(group->pel, buf, sizeof(buf), NULL);
+        s->alloc_size += raxAllocSize(group->pel);
         raxRemovePelByTime(group->pel_by_time, nack->delivery_time, id);
+        s->alloc_size -= raxAllocSize(nack->consumer->pel);
         raxRemove(nack->consumer->pel, buf, sizeof(buf), NULL);
+        s->alloc_size += raxAllocSize(nack->consumer->pel);
         /* Since we're removing all references from the cgroups_ref, we can directly
          * free the NACK without unlinking it from the cgroups_ref. */
-        streamFreeNACK(nack);
+        streamFreeNACK(s, nack);
     }
 
+    s->alloc_size -= raxAllocSize(s->cgroups_ref);
     raxRemove(s->cgroups_ref, buf, sizeof(streamID), NULL);
+    s->alloc_size += raxAllocSize(s->cgroups_ref);
     listRelease(cglist);
 }
 
@@ -2943,8 +3007,10 @@ int streamEntryIsReferenced(stream *s, streamID *id) {
 /* Create a NACK entry setting the delivery count to 1 and the delivery
  * time to the current time. The NACK consumer will be set to the one
  * specified as argument of the function. */
-streamNACK *streamCreateNACK(streamConsumer *consumer) {
-    streamNACK *nack = zmalloc(sizeof(*nack));
+streamNACK *streamCreateNACK(stream *s, streamConsumer *consumer) {
+    size_t usable;
+    streamNACK *nack = zmalloc_usable(sizeof(*nack), &usable);
+    s->alloc_size += usable;
     nack->delivery_time = commandTimeSnapshot();
     nack->delivery_count = 1;
     nack->consumer = consumer;
@@ -2953,20 +3019,24 @@ streamNACK *streamCreateNACK(streamConsumer *consumer) {
 }
 
 /* Free a NACK entry. */
-void streamFreeNACK(streamNACK *na) {
-    zfree(na);
+void streamFreeNACK(stream *s, streamNACK *na) {
+    size_t usable;
+    zfree_usable(na, &usable);
+    s->alloc_size -= usable;
 }
 
 /* Free a NACK entry and remove its reference from the cgroups_ref.
  * This ensures proper cleanup of the consumer group list associated with the message ID. */
 void streamDestroyNACK(stream *s, streamNACK *na, unsigned char *key) {
+    size_t usable;
     streamUnlinkEntryFromCGroupRef(s, na, key);
-    zfree(na);
+    zfree_usable(na, &usable);
+    s->alloc_size -= usable;
 }
 
 /* Generic version of streamFreeNACK. */
-void streamFreeNACKGeneric(void *na) {
-    streamFreeNACK((streamNACK *)na);
+void streamFreeNACKGeneric(void *na, void *s) {
+    streamFreeNACK((stream *)s, (streamNACK *)na);
 }
 
 /* Free a consumer and associated data structures. Note that this function
@@ -2974,16 +3044,20 @@ void streamFreeNACKGeneric(void *na) {
  * nor will delete them from the stream, so when this function is called
  * to delete a consumer, and not when the whole stream is destroyed, the caller
  * should do some work before. */
-void streamFreeConsumer(streamConsumer *sc) {
+void streamFreeConsumer(stream *s, streamConsumer *sc) {
+    size_t usable;
+    s->alloc_size -= raxAllocSize(sc->pel);
     raxFree(sc->pel); /* No value free callback: the PEL entries are shared
                          between the consumer and the main stream PEL. */
-    sdsfree(sc->name);
-    zfree(sc);
+    sdsfreeusable(sc->name, &usable);
+    s->alloc_size -= usable;
+    zfree_usable(sc, &usable);
+    s->alloc_size -= usable;
 }
 
 /* Generic version of streamFreeConsumer. */
-void streamFreeConsumerGeneric(void *sc) {
-    streamFreeConsumer((streamConsumer *)sc);
+void streamFreeConsumerGeneric(void *sc, void *s) {
+    streamFreeConsumer((stream *)s, (streamConsumer *)sc);
 }
 
 /* Create a new consumer group in the context of the stream 's', having the
@@ -2991,28 +3065,41 @@ void streamFreeConsumerGeneric(void *sc) {
  * the same name already exists NULL is returned, otherwise the pointer to the
  * consumer group is returned. */
 streamCG *streamCreateCG(stream *s, char *name, size_t namelen, streamID *id, long long entries_read) {
-    if (s->cgroups == NULL) s->cgroups = raxNew();
+    if (s->cgroups == NULL) {
+        s->cgroups = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+        s->alloc_size += raxAllocSize(s->cgroups);
+    }
     if (raxFind(s->cgroups,(unsigned char*)name,namelen,NULL))
         return NULL;
 
-    streamCG *cg = zmalloc(sizeof(*cg));
-    cg->pel = raxNew();
-    cg->pel_by_time = raxNew();
-    cg->consumers = raxNew();
+    size_t usable;
+    streamCG *cg = zmalloc_usable(sizeof(*cg), &usable);
+    s->alloc_size += usable;
+    cg->pel = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+    s->alloc_size += raxAllocSize(cg->pel);
+    cg->pel_by_time = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+    cg->consumers = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+    s->alloc_size += raxAllocSize(cg->consumers);
     cg->last_id.ms = 0;
     cg->last_id.seq = 0;
     streamUpdateCGroupLastId(s, cg, id);
     cg->entries_read = entries_read;
+    s->alloc_size -= raxAllocSize(s->cgroups);
     raxInsert(s->cgroups,(unsigned char*)name,namelen,cg,NULL);
+    s->alloc_size += raxAllocSize(s->cgroups);
     return cg;
 }
 
 /* Free a consumer group and all its associated data. */
-static void streamFreeCG(streamCG *cg) {
-    raxFreeWithCallback(cg->pel, streamFreeNACKGeneric);
+static void streamFreeCG(stream *s, streamCG *cg) {
+    s->alloc_size -= raxAllocSize(cg->pel);
+    raxFreeWithCbAndContext(cg->pel, streamFreeNACKGeneric, s);
     raxFree(cg->pel_by_time);
-    raxFreeWithCallback(cg->consumers, streamFreeConsumerGeneric);
-    zfree(cg);
+    s->alloc_size -= raxAllocSize(cg->consumers);
+    raxFreeWithCbAndContext(cg->consumers, streamFreeConsumerGeneric, s);
+    size_t usable;
+    zfree_usable(cg, &usable);
+    s->alloc_size -= usable;
 }
 
 /* Destroy a consumer group and clean up all associated references. */
@@ -3026,12 +3113,12 @@ void streamDestroyCG(stream *s, streamCG *cg) {
     }
     raxStop(&it);
 
-    streamFreeCG(cg);
+    streamFreeCG(s, cg);
 }
 
 /* Generic version of streamFreeCG. */
-void streamFreeCGGeneric(void *cg) {
-    streamFreeCG((streamCG *)cg);
+void streamFreeCGGeneric(void *cg, void *s) {
+    streamFreeCG((stream *)s, (streamCG *)cg);
 }
 
 /* Lookup the consumer group in the specified stream and returns its
@@ -3047,19 +3134,26 @@ streamCG *streamLookupCG(stream *s, sds groupname) {
  * If the consumer exists, return NULL. As a side effect, when the consumer
  * is successfully created, the key space will be notified and dirty++ unless
  * the SCC_NO_NOTIFY or SCC_NO_DIRTIFY flags is specified. */
-streamConsumer *streamCreateConsumer(streamCG *cg, sds name, robj *key, int dbid, int flags) {
+streamConsumer *streamCreateConsumer(stream *s, streamCG *cg, sds name, robj *key, int dbid, int flags) {
     if (cg == NULL) return NULL;
     int notify = !(flags & SCC_NO_NOTIFY);
     int dirty = !(flags & SCC_NO_DIRTIFY);
-    streamConsumer *consumer = zmalloc(sizeof(*consumer));
+    size_t usable;
+    streamConsumer *consumer = zmalloc_usable(sizeof(*consumer), &usable);
+    size_t old_consumers_size = raxAllocSize(cg->consumers);
     int success = raxTryInsert(cg->consumers,(unsigned char*)name,
                                sdslen(name),consumer,NULL);
     if (!success) {
         zfree(consumer);
         return NULL;
     }
+    s->alloc_size += usable;
+    s->alloc_size -= old_consumers_size;
+    s->alloc_size += raxAllocSize(cg->consumers);
     consumer->name = sdsdup(name);
-    consumer->pel = raxNew();
+    s->alloc_size += sdsAllocSize(consumer->name);
+    consumer->pel = raxNewWithMetadata(RAX_ACCOUNT_ALLOC_SIZE, sizeof(size_t));
+    s->alloc_size += raxAllocSize(consumer->pel);
     consumer->active_time = -1;
     consumer->seen_time = commandTimeSnapshot();
     if (dirty) server.dirty++;
@@ -3092,14 +3186,16 @@ void streamDelConsumer(stream *s, streamCG *cg, streamConsumer *consumer) {
         raxRemovePelByTime(cg->pel_by_time, nack->delivery_time, &id);
         raxRemove(cg->pel,ri.key,ri.key_len,NULL);
 
-        streamFreeNACK(nack);
+        streamFreeNACK(s, nack);
     }
     raxStop(&ri);
 
     /* Deallocate the consumer. */
+    s->alloc_size -= raxAllocSize(cg->consumers);
     raxRemove(cg->consumers,(unsigned char*)consumer->name,
               sdslen(consumer->name),NULL);
-    streamFreeConsumer(consumer);
+    s->alloc_size += raxAllocSize(cg->consumers);
+    streamFreeConsumer(s,consumer);
 }
 
 /* -----------------------------------------------------------------------
@@ -3250,7 +3346,9 @@ NULL
         notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-setid",c->argv[2],c->db->id);
     } else if (!strcasecmp(opt,"DESTROY") && c->argc == 4) {
         if (cg) {
+            s->alloc_size -= raxAllocSize(s->cgroups);
             raxRemove(s->cgroups,(unsigned char*)grpname,sdslen(grpname),NULL);
+            s->alloc_size += raxAllocSize(s->cgroups);
             streamDestroyCG(s, cg);
             addReply(c,shared.cone);
             server.dirty++;
@@ -3262,7 +3360,7 @@ NULL
             addReply(c,shared.czero);
         }
     } else if (!strcasecmp(opt,"CREATECONSUMER") && c->argc == 5) {
-        streamConsumer *created = streamCreateConsumer(cg,c->argv[4]->ptr,c->argv[2],
+        streamConsumer *created = streamCreateConsumer(s,cg,c->argv[4]->ptr,c->argv[2],
                                                        c->db->id,SCC_DEFAULT);
         addReplyLongLong(c,created ? 1 : 0);
     } else if (!strcasecmp(opt,"DELCONSUMER") && c->argc == 5) {
@@ -3394,6 +3492,7 @@ void xackCommand(client *c) {
     }
 
     int acknowledged = 0;
+    stream *s = kv->ptr;
     for (int j = 3; j < c->argc; j++) {
         unsigned char buf[sizeof(streamID)];
         streamEncodeID(buf,&ids[j-3]);
@@ -3405,8 +3504,12 @@ void xackCommand(client *c) {
         if (raxFind(group->pel,buf,sizeof(buf),&result)) {
             streamNACK *nack = result;
             raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &ids[j-3]);
+            s->alloc_size -= raxAllocSize(group->pel);
             raxRemove(group->pel,buf,sizeof(buf),NULL);
+            s->alloc_size += raxAllocSize(group->pel);
+            s->alloc_size -= raxAllocSize(nack->consumer->pel);
             raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
+            s->alloc_size += raxAllocSize(nack->consumer->pel);
             streamDestroyNACK(kv->ptr, nack, buf);
             acknowledged++;
             server.dirty++;
@@ -3475,8 +3578,12 @@ void xackdelCommand(client *c) {
         if (raxFind(group->pel,buf,sizeof(buf),&result)) {
             streamNACK *nack = result;
             raxRemovePelByTime(group->pel_by_time, nack->delivery_time, id);
+            s->alloc_size -= raxAllocSize(group->pel);
             raxRemove(group->pel,buf,sizeof(buf),NULL);
+            s->alloc_size += raxAllocSize(group->pel);
+            s->alloc_size -= raxAllocSize(nack->consumer->pel);
             raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
+            s->alloc_size += raxAllocSize(nack->consumer->pel);
             streamDestroyNACK(s, nack, buf);
             server.dirty++;
 
@@ -3881,10 +3988,11 @@ void xclaimCommand(client *c) {
     /* Do the actual claiming. */
     streamConsumer *consumer = streamLookupConsumer(group,c->argv[3]->ptr);
     if (consumer == NULL) {
-        consumer = streamCreateConsumer(group,c->argv[3]->ptr,c->argv[1],c->db->id,SCC_DEFAULT);
+        consumer = streamCreateConsumer(o->ptr,group,c->argv[3]->ptr,c->argv[1],c->db->id,SCC_DEFAULT);
     }
     consumer->seen_time = commandTimeSnapshot();
 
+    stream *s = o->ptr;
     void *arraylenptr = addReplyDeferredLen(c);
     size_t arraylen = 0;
     for (int j = 5; j <= last_id_arg; j++) {
@@ -3898,7 +4006,7 @@ void xclaimCommand(client *c) {
         streamNACK *nack = result;
 
         /* Item must exist for us to transfer it to another consumer. */
-        if (!streamEntryExists(o->ptr,&id)) {
+        if (!streamEntryExists(s,&id)) {
             /* Clear this entry from the PEL, it no longer exists */
             if (nack != NULL) {
                 /* Propagate this change (we are going to delete the NACK). */
@@ -3907,9 +4015,13 @@ void xclaimCommand(client *c) {
                 server.dirty++;
                 /* Release the NACK */
                 raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &id);
-                raxRemove(group->pel, buf,sizeof(buf),NULL);
+                s->alloc_size -= raxAllocSize(group->pel);
+                raxRemove(group->pel,buf,sizeof(buf),NULL);
+                s->alloc_size += raxAllocSize(group->pel);
+                s->alloc_size -= raxAllocSize(nack->consumer->pel);
                 raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
-                streamDestroyNACK(o->ptr, nack, buf);
+                s->alloc_size += raxAllocSize(nack->consumer->pel);
+                streamDestroyNACK(s, nack, buf);
             }
             continue;
         }
@@ -3921,10 +4033,12 @@ void xclaimCommand(client *c) {
          * and replication of consumer groups. */
         if (force && nack == NULL) {
             /* Create the NACK. */
-            nack = streamCreateNACK(NULL);
+            nack = streamCreateNACK(s,NULL);
+            s->alloc_size -= raxAllocSize(group->pel);
             raxInsert(group->pel,buf,sizeof(buf),nack,NULL);
+            s->alloc_size += raxAllocSize(group->pel);
             raxInsertPelByTime(group->pel_by_time, nack->delivery_time, &id);
-            nack->cgroup_ref_node = streamLinkCGroupToEntry(o->ptr, group, buf);
+            nack->cgroup_ref_node = streamLinkCGroupToEntry(s, group, buf);
         }
 
         if (nack != NULL) {
@@ -3943,8 +4057,11 @@ void xclaimCommand(client *c) {
                 /* Remove the entry from the old consumer.
                  * Note that nack->consumer is NULL if we created the
                  * NACK above because of the FORCE option. */
-                if (nack->consumer)
+                if (nack->consumer) {
+                    s->alloc_size -= raxAllocSize(nack->consumer->pel);
                     raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
+                    s->alloc_size += raxAllocSize(nack->consumer->pel);
+                }
             }
 
             raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &id);
@@ -3960,7 +4077,9 @@ void xclaimCommand(client *c) {
             }
             if (nack->consumer != consumer) {
                 /* Add the entry in the new consumer local PEL. */
+                s->alloc_size -= raxAllocSize(consumer->pel);
                 raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
+                s->alloc_size += raxAllocSize(consumer->pel);
                 nack->consumer = consumer;
             }
             /* Send the reply for this entry. */
@@ -4070,7 +4189,7 @@ void xautoclaimCommand(client *c) {
     /* Do the actual claiming. */
     streamConsumer *consumer = streamLookupConsumer(group,c->argv[3]->ptr);
     if (consumer == NULL) {
-        consumer = streamCreateConsumer(group,c->argv[3]->ptr,c->argv[1],c->db->id,SCC_DEFAULT);
+        consumer = streamCreateConsumer(o->ptr,group,c->argv[3]->ptr,c->argv[1],c->db->id,SCC_DEFAULT);
     }
     consumer->seen_time = commandTimeSnapshot();
 
@@ -4080,6 +4199,7 @@ void xautoclaimCommand(client *c) {
     void *endidptr = addReplyDeferredLen(c); /* reply[0] */
     void *arraylenptr = addReplyDeferredLen(c); /* reply[1] */
 
+    stream *s = o->ptr;
     unsigned char startkey[sizeof(streamID)];
     streamEncodeID(startkey,&startid);
     raxIterator ri;
@@ -4095,7 +4215,7 @@ void xautoclaimCommand(client *c) {
         streamDecodeID(ri.key, &id);
 
         /* Item must exist for us to transfer it to another consumer. */
-        if (!streamEntryExists(o->ptr,&id)) {
+        if (!streamEntryExists(s,&id)) {
             /* Propagate this change (we are going to delete the NACK). */
             robj *idstr = createObjectFromStreamID(&id);
             streamPropagateXCLAIM(c,c->argv[1],group,c->argv[2],idstr,nack);
@@ -4103,9 +4223,13 @@ void xautoclaimCommand(client *c) {
             server.dirty++;
             /* Clear this entry from the PEL, it no longer exists */
             raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &id);
+            s->alloc_size -= raxAllocSize(group->pel);
             raxRemove(group->pel,ri.key,ri.key_len,NULL);
+            s->alloc_size += raxAllocSize(group->pel);
+            s->alloc_size -= raxAllocSize(nack->consumer->pel);
             raxRemove(nack->consumer->pel,ri.key,ri.key_len,NULL);
-            streamDestroyNACK(o->ptr, nack, ri.key);
+            s->alloc_size += raxAllocSize(nack->consumer->pel);
+            streamDestroyNACK(s, nack, ri.key);
             /* Remember the ID for later */
             deleted_ids[deleted_id_num++] = id;
             raxSeek(&ri,">=",ri.key,ri.key_len);
@@ -4123,8 +4247,11 @@ void xautoclaimCommand(client *c) {
             /* Remove the entry from the old consumer.
              * Note that nack->consumer is NULL if we created the
              * NACK above because of the FORCE option. */
-            if (nack->consumer)
+            if (nack->consumer) {
+                s->alloc_size -= raxAllocSize(nack->consumer->pel);
                 raxRemove(nack->consumer->pel,ri.key,ri.key_len,NULL);
+                s->alloc_size += raxAllocSize(nack->consumer->pel);
+            }
         }
 
         /* Update the consumer and idle time. */
@@ -4138,7 +4265,9 @@ void xautoclaimCommand(client *c) {
 
         if (nack->consumer != consumer) {
             /* Add the entry in the new consumer local PEL. */
+            s->alloc_size -= raxAllocSize(consumer->pel);
             raxInsert(consumer->pel,ri.key,ri.key_len,nack,NULL);
+            s->alloc_size += raxAllocSize(consumer->pel);
             nack->consumer = consumer;
         }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -544,7 +544,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
             /* Shrink extra pre-allocated memory */
             lp = lpShrinkToFit(lp);
             if (ri.data != lp)
-                raxInsert(s->rax,ri.key,ri.key_len,lp,NULL);
+                raxSetData(ri.node, lp);
             lp = NULL;
         }
     }
@@ -893,8 +893,8 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
             /* TODO: perform a garbage collection. */
         }
 
-        /* Update the listpack with the new pointer. */
-        raxInsert(s->rax,ri.key,ri.key_len,lp,NULL);
+        /* Update the node with the new pointer. */
+        raxSetData(ri.node,lp);
 
         /* If the node is eligible for removal but we couldn't remove it due to delete strategy
          * constraints (we need to check each entry individually), continue to the next node

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -164,19 +164,18 @@ robj *streamDup(robj *o) {
     new_s = sobj->ptr;
 
     raxIterator ri;
-    uint64_t rax_key[2];
     raxStart(&ri, s->rax);
     raxSeek(&ri, "^", NULL, 0);
     size_t lp_bytes = 0;      /* Total bytes in the listpack. */
     unsigned char *lp = NULL; /* listpack pointer. */
     /* Get a reference to the listpack node. */
     while (raxNext(&ri)) {
+        serverAssert(ri.key_len == sizeof(streamID));
         lp = ri.data;
         lp_bytes = lpBytes(lp);
         unsigned char *new_lp = zmalloc(lp_bytes);
         memcpy(new_lp, lp, lp_bytes);
-        memcpy(rax_key, ri.key, sizeof(rax_key));
-        raxInsert(new_s->rax, (unsigned char *)&rax_key, sizeof(rax_key),
+        raxInsert(new_s->rax, ri.key, ri.key_len,
                   new_lp, NULL);
     }
     new_s->length = s->length;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -57,11 +57,14 @@ zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank);
 
 /* Create a skiplist node with the specified number of levels.
  * The SDS string 'ele' is referenced by the node after the call. */
-zskiplistNode *zslCreateNode(int level, double score, sds ele) {
+zskiplistNode *zslCreateNode(zskiplist *zsl, int level, double score, sds ele) {
+    size_t usable;
     zskiplistNode *zn =
-        zmalloc(sizeof(*zn)+level*sizeof(struct zskiplistLevel));
+        zmalloc_usable(sizeof(*zn)+level*sizeof(struct zskiplistLevel), &usable);
     zn->score = score;
     zn->ele = ele;
+    zsl->alloc_size += usable;
+    if (ele) zsl->alloc_size += sdsAllocSize(ele);
     return zn;
 }
 
@@ -69,11 +72,13 @@ zskiplistNode *zslCreateNode(int level, double score, sds ele) {
 zskiplist *zslCreate(void) {
     int j;
     zskiplist *zsl;
+    size_t zsl_size;
 
-    zsl = zmalloc(sizeof(*zsl));
+    zsl = zmalloc_usable(sizeof(*zsl), &zsl_size);
     zsl->level = 1;
     zsl->length = 0;
-    zsl->header = zslCreateNode(ZSKIPLIST_MAXLEVEL,0,NULL);
+    zsl->alloc_size = zsl_size;
+    zsl->header = zslCreateNode(zsl,ZSKIPLIST_MAXLEVEL,0,NULL);
     for (j = 0; j < ZSKIPLIST_MAXLEVEL; j++) {
         zsl->header->level[j].forward = NULL;
         zsl->header->level[j].span = 0;
@@ -86,9 +91,12 @@ zskiplist *zslCreate(void) {
 /* Free the specified skiplist node. The referenced SDS string representation
  * of the element is freed too, unless node->ele is set to NULL before calling
  * this function. */
-void zslFreeNode(zskiplistNode *node) {
-    sdsfree(node->ele);
-    zfree(node);
+void zslFreeNode(zskiplist *zsl, zskiplistNode *node) {
+    size_t usable;
+    sdsfreeusable(node->ele, &usable);
+    zsl->alloc_size -= usable;
+    zfree_usable(node, &usable);
+    zsl->alloc_size -= usable;
 }
 
 /* Free a whole skiplist. */
@@ -98,11 +106,14 @@ void zslFree(zskiplist *zsl) {
     zfree(zsl->header);
     while(node) {
         next = node->level[0].forward;
-        zslFreeNode(node);
+        zslFreeNode(zsl, node);
         node = next;
     }
     zfree(zsl);
 }
+
+/* Return cached total memory used (in bytes) */
+size_t zslAllocSize(const zskiplist *zsl) { return zsl->alloc_size; }
 
 /* Returns a random level for the new skiplist node we are going to create.
  * The return value of this function is between 1 and ZSKIPLIST_MAXLEVEL
@@ -152,7 +163,7 @@ zskiplistNode *zslInsert(zskiplist *zsl, double score, sds ele) {
         }
         zsl->level = level;
     }
-    x = zslCreateNode(level,score,ele);
+    x = zslCreateNode(zsl,level,score,ele);
     for (i = 0; i < level; i++) {
         x->level[i].forward = update[i]->level[i].forward;
         update[i]->level[i].forward = x;
@@ -227,7 +238,7 @@ int zslDelete(zskiplist *zsl, double score, sds ele, zskiplistNode **node) {
     if (x && score == x->score && sdscmp(x->ele,ele) == 0) {
         zslDeleteNode(zsl, x, update);
         if (!node)
-            zslFreeNode(x);
+            zslFreeNode(zsl, x);
         else
             *node = x;
         return 1;
@@ -286,7 +297,7 @@ zskiplistNode *zslUpdateScore(zskiplist *zsl, double curscore, sds ele, double n
     /* We reused the old node x->ele SDS string, free the node now
      * since zslInsert created a new one. */
     x->ele = NULL;
-    zslFreeNode(x);
+    zslFreeNode(zsl, x);
     return newnode;
 }
 
@@ -420,7 +431,7 @@ unsigned long zslDeleteRangeByScore(zskiplist *zsl, zrangespec *range, dict *dic
         zskiplistNode *next = x->level[0].forward;
         zslDeleteNode(zsl,x,update);
         dictDelete(dict,x->ele);
-        zslFreeNode(x); /* Here is where x->ele is actually released. */
+        zslFreeNode(zsl, x); /* Here is where x->ele is actually released. */
         removed++;
         x = next;
     }
@@ -449,7 +460,7 @@ unsigned long zslDeleteRangeByLex(zskiplist *zsl, zlexrangespec *range, dict *di
         zskiplistNode *next = x->level[0].forward;
         zslDeleteNode(zsl,x,update);
         dictDelete(dict,x->ele);
-        zslFreeNode(x); /* Here is where x->ele is actually released. */
+        zslFreeNode(zsl, x); /* Here is where x->ele is actually released. */
         removed++;
         x = next;
     }
@@ -478,7 +489,7 @@ unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned int start, unsigned 
         zskiplistNode *next = x->level[0].forward;
         zslDeleteNode(zsl,x,update);
         dictDelete(dict,x->ele);
-        zslFreeNode(x);
+        zslFreeNode(zsl, x);
         removed++;
         traversed++;
         x = next;
@@ -1310,15 +1321,15 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
         dictRelease(zs->dict);
         node = zs->zsl->header->level[0].forward;
         zfree(zs->zsl->header);
-        zfree(zs->zsl);
 
         while (node) {
             zl = zzlInsertAt(zl,NULL,node->ele,node->score);
             next = node->level[0].forward;
-            zslFreeNode(node);
+            zslFreeNode(zs->zsl, node);
             node = next;
         }
 
+        zfree(zs->zsl);
         zfree(zs);
         zobj->ptr = zl;
         zobj->encoding = OBJ_ENCODING_LISTPACK;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -43,6 +43,7 @@
 #include "fast_float_strtod.h"
 #include "server.h"
 #include "intset.h"  /* Compact integer set structure */
+#include "redisassert.h"
 #include <math.h>
 
 /*-----------------------------------------------------------------------------
@@ -93,8 +94,10 @@ zskiplist *zslCreate(void) {
  * this function. */
 void zslFreeNode(zskiplist *zsl, zskiplistNode *node) {
     size_t usable;
-    sdsfreeusable(node->ele, &usable);
-    zsl->alloc_size -= usable;
+    if (node->ele) {
+        zsl->alloc_size -= sdsAllocSize(node->ele);
+        sdsfree(node->ele);
+    }
     zfree_usable(node, &usable);
     zsl->alloc_size -= usable;
 }
@@ -102,13 +105,16 @@ void zslFreeNode(zskiplist *zsl, zskiplistNode *node) {
 /* Free a whole skiplist. */
 void zslFree(zskiplist *zsl) {
     zskiplistNode *node = zsl->header->level[0].forward, *next;
+    size_t usable;
 
-    zfree(zsl->header);
+    zfree_usable(zsl->header, &usable);
+    zsl->alloc_size -= usable;
     while(node) {
         next = node->level[0].forward;
         zslFreeNode(zsl, node);
         node = next;
     }
+    debugAssert(zsl->alloc_size == zmalloc_usable_size(zsl));
     zfree(zsl);
 }
 
@@ -296,6 +302,7 @@ zskiplistNode *zslUpdateScore(zskiplist *zsl, double curscore, sds ele, double n
     zskiplistNode *newnode = zslInsert(zsl,newscore,x->ele);
     /* We reused the old node x->ele SDS string, free the node now
      * since zslInsert created a new one. */
+    if (x->ele) zsl->alloc_size -= sdsAllocSize(x->ele);
     x->ele = NULL;
     zslFreeNode(zsl, x);
     return newnode;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -43,7 +43,6 @@
 #include "fast_float_strtod.h"
 #include "server.h"
 #include "intset.h"  /* Compact integer set structure */
-#include "redisassert.h"
 #include <math.h>
 
 /*-----------------------------------------------------------------------------
@@ -114,7 +113,9 @@ void zslFree(zskiplist *zsl) {
         zslFreeNode(zsl, node);
         node = next;
     }
-    debugAssert(zsl->alloc_size == zmalloc_usable_size(zsl));
+#ifdef REDIS_TEST
+    serverAssert(zsl->alloc_size == zmalloc_usable_size(zsl));
+#endif
     zfree(zsl);
 }
 

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -482,28 +482,29 @@ void zfree(void *ptr) {
 
 /* Similar to zfree, '*usable' is set to the usable size being freed. */
 void zfree_usable(void *ptr, size_t *usable) {
+    size_t oldsize;
 #ifndef HAVE_MALLOC_SIZE
     void *realptr;
-    size_t oldsize;
 #endif
 
     if (ptr == NULL) {
-        *usable = 0;
+        if (usable) *usable = 0;
         return;
     }
 
 #ifdef HAVE_ALLOC_WITH_USIZE
-    free_with_usize(ptr, usable);
-    update_zmalloc_stat_free(*usable);
+    free_with_usize(ptr, &oldsize);
+    update_zmalloc_stat_free(oldsize);
 #elif HAVE_MALLOC_SIZE
-    update_zmalloc_stat_free(*usable = zmalloc_size(ptr));
+    update_zmalloc_stat_free(oldsize = zmalloc_size(ptr));
     free(ptr);
 #else
     realptr = (char*)ptr-PREFIX_SIZE;
-    *usable = oldsize = *((size_t*)realptr);
+    oldsize = *((size_t*)realptr);
     update_zmalloc_stat_free(oldsize+PREFIX_SIZE);
     free(realptr);
 #endif
+    if (usable) *usable = oldsize;
 }
 
 char *zstrdup_usable(const char *s, size_t *usable) {

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -336,8 +336,9 @@ void *zcalloc_usable(size_t size, size_t *usable) {
 }
 
 /* Try reallocating memory, and return NULL if failed.
- * '*usable' is set to the usable size if non NULL. */
-static inline void *ztryrealloc_usable_internal(void *ptr, size_t size, size_t *usable) {
+ * '*usable' is set to the usable size if non NULL
+ * '*old_usable' is set to the previous usable size if non NULL. */
+static inline void *ztryrealloc_usable_internal(void *ptr, size_t size, size_t *usable, size_t *old_usable) {
 #ifndef HAVE_MALLOC_SIZE
     void *realptr;
 #endif
@@ -346,35 +347,42 @@ static inline void *ztryrealloc_usable_internal(void *ptr, size_t size, size_t *
 
     /* not allocating anything, just redirect to free. */
     if (size == 0 && ptr != NULL) {
-        zfree(ptr);
+        zfree_usable(ptr, &oldsize);
         if (usable) *usable = 0;
+        if (old_usable) *old_usable = oldsize;
         return NULL;
     }
     /* Not freeing anything, just redirect to malloc. */
-    if (ptr == NULL)
+    if (ptr == NULL) {
+        if (old_usable) *old_usable = 0;
         return ztrymalloc_usable(size, usable);
+    }
 
     /* Possible overflow, return NULL, so that the caller can panic or handle a failed allocation. */
     if (size >= SIZE_MAX/2) {
-        zfree(ptr);
+        zfree_usable(ptr, &oldsize);
         if (usable) *usable = 0;
+        if (old_usable) *usable = oldsize;
         return NULL;
     }
 #ifdef HAVE_ALLOC_WITH_USIZE
     newptr = realloc_with_usize(ptr, size, &oldsize, &size);
     if (newptr == NULL) {
         if (usable) *usable = 0;
+        if (old_usable) *old_usable = oldsize;
         return NULL;
     }
     update_zmalloc_stat_free(oldsize);
     update_zmalloc_stat_alloc(size);
     if (usable) *usable = size;
+    if (old_usable) *old_usable = oldsize;
     return newptr;
 #elif HAVE_MALLOC_SIZE
     oldsize = zmalloc_size(ptr);
     newptr = realloc(ptr,size);
     if (newptr == NULL) {
         if (usable) *usable = 0;
+        if (old_usable) *old_usable = oldsize;
         return NULL;
     }
 
@@ -382,6 +390,7 @@ static inline void *ztryrealloc_usable_internal(void *ptr, size_t size, size_t *
     size = zmalloc_size(newptr);
     update_zmalloc_stat_alloc(size);
     if (usable) *usable = size;
+    if (old_usable) *old_usable = oldsize;
     return newptr;
 #else
     realptr = (char*)ptr-PREFIX_SIZE;
@@ -396,13 +405,14 @@ static inline void *ztryrealloc_usable_internal(void *ptr, size_t size, size_t *
     update_zmalloc_stat_free(oldsize);
     update_zmalloc_stat_alloc(size);
     if (usable) *usable = size;
+    if (old_usable) *old_usable = oldsize;
     return (char*)newptr+PREFIX_SIZE;
 #endif
 }
 
-void *ztryrealloc_usable(void *ptr, size_t size, size_t *usable) {
+void *ztryrealloc_usable(void *ptr, size_t size, size_t *usable, size_t *old_usable) {
     size_t usable_size = 0;
-    ptr = ztryrealloc_usable_internal(ptr, size, &usable_size);
+    ptr = ztryrealloc_usable_internal(ptr, size, &usable_size, old_usable);
 #ifdef HAVE_MALLOC_SIZE
     ptr = extend_to_usable(ptr, usable_size);
 #endif
@@ -412,22 +422,23 @@ void *ztryrealloc_usable(void *ptr, size_t size, size_t *usable) {
 
 /* Reallocate memory and zero it or panic */
 void *zrealloc(void *ptr, size_t size) {
-    ptr = ztryrealloc_usable_internal(ptr, size, NULL);
+    ptr = ztryrealloc_usable_internal(ptr, size, NULL, NULL);
     if (!ptr && size != 0) zmalloc_oom_handler(size);
     return ptr;
 }
 
 /* Try Reallocating memory, and return NULL if failed. */
 void *ztryrealloc(void *ptr, size_t size) {
-    ptr = ztryrealloc_usable_internal(ptr, size, NULL);
+    ptr = ztryrealloc_usable_internal(ptr, size, NULL, NULL);
     return ptr;
 }
 
 /* Reallocate memory or panic.
+ * '*old_usable' is set to the previous usable size if non NULL
  * '*usable' is set to the usable size if non NULL. */
-void *zrealloc_usable(void *ptr, size_t size, size_t *usable) {
+void *zrealloc_usable(void *ptr, size_t size, size_t *usable, size_t *old_usable) {
     size_t usable_size = 0;
-    ptr = ztryrealloc_usable(ptr, size, &usable_size);
+    ptr = ztryrealloc_usable(ptr, size, &usable_size, old_usable);
     if (!ptr && size != 0) zmalloc_oom_handler(size);
 #ifdef HAVE_MALLOC_SIZE
     ptr = extend_to_usable(ptr, usable_size);
@@ -476,7 +487,10 @@ void zfree_usable(void *ptr, size_t *usable) {
     size_t oldsize;
 #endif
 
-    if (ptr == NULL) return;
+    if (ptr == NULL) {
+        *usable = 0;
+        return;
+    }
 
 #ifdef HAVE_ALLOC_WITH_USIZE
     free_with_usize(ptr, usable);
@@ -492,12 +506,16 @@ void zfree_usable(void *ptr, size_t *usable) {
 #endif
 }
 
-char *zstrdup(const char *s) {
+char *zstrdup_usable(const char *s, size_t *usable) {
     size_t l = strlen(s)+1;
-    char *p = zmalloc(l);
+    char *p = zmalloc_usable(l, usable);
 
     memcpy(p,s,l);
     return p;
+}
+
+char *zstrdup(const char *s) {
+    return zstrdup_usable(s, NULL);
 }
 
 size_t zmalloc_used_memory(void) {

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -342,70 +342,74 @@ static inline void *ztryrealloc_usable_internal(void *ptr, size_t size, size_t *
 #ifndef HAVE_MALLOC_SIZE
     void *realptr;
 #endif
-    size_t oldsize;
+    size_t oldsize, dummy;
     void *newptr;
+
+    if (!usable) usable = &dummy;
+    if (!old_usable) old_usable = &dummy;
 
     /* not allocating anything, just redirect to free. */
     if (size == 0 && ptr != NULL) {
         zfree_usable(ptr, &oldsize);
-        if (usable) *usable = 0;
-        if (old_usable) *old_usable = oldsize;
+        *usable = 0;
+        *old_usable = oldsize;
         return NULL;
     }
     /* Not freeing anything, just redirect to malloc. */
     if (ptr == NULL) {
-        if (old_usable) *old_usable = 0;
+        *old_usable = 0;
         return ztrymalloc_usable(size, usable);
     }
 
     /* Possible overflow, return NULL, so that the caller can panic or handle a failed allocation. */
     if (size >= SIZE_MAX/2) {
         zfree_usable(ptr, &oldsize);
-        if (usable) *usable = 0;
-        if (old_usable) *usable = oldsize;
+        *usable = 0;
+        *old_usable = oldsize;
         return NULL;
     }
 #ifdef HAVE_ALLOC_WITH_USIZE
     newptr = realloc_with_usize(ptr, size, &oldsize, &size);
     if (newptr == NULL) {
-        if (usable) *usable = 0;
-        if (old_usable) *old_usable = oldsize;
+        *usable = 0;
+        *old_usable = oldsize;
         return NULL;
     }
     update_zmalloc_stat_free(oldsize);
     update_zmalloc_stat_alloc(size);
-    if (usable) *usable = size;
-    if (old_usable) *old_usable = oldsize;
+    *usable = size;
+    *old_usable = oldsize;
     return newptr;
 #elif HAVE_MALLOC_SIZE
     oldsize = zmalloc_size(ptr);
     newptr = realloc(ptr,size);
     if (newptr == NULL) {
-        if (usable) *usable = 0;
-        if (old_usable) *old_usable = oldsize;
+        *usable = 0;
+        *old_usable = oldsize;
         return NULL;
     }
 
     update_zmalloc_stat_free(oldsize);
     size = zmalloc_size(newptr);
     update_zmalloc_stat_alloc(size);
-    if (usable) *usable = size;
-    if (old_usable) *old_usable = oldsize;
+    *usable = size;
+    *old_usable = oldsize;
     return newptr;
 #else
     realptr = (char*)ptr-PREFIX_SIZE;
     oldsize = *((size_t*)realptr);
     newptr = realloc(realptr,size+PREFIX_SIZE);
     if (newptr == NULL) {
-        if (usable) *usable = 0;
+        *usable = 0;
+        *old_usable = oldsize;
         return NULL;
     }
 
     *((size_t*)newptr) = size;
     update_zmalloc_stat_free(oldsize);
     update_zmalloc_stat_alloc(size);
-    if (usable) *usable = size;
-    if (old_usable) *old_usable = oldsize;
+    *usable = size;
+    *old_usable = oldsize;
     return (char*)newptr+PREFIX_SIZE;
 #endif
 }

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -100,12 +100,13 @@ __attribute__((alloc_size(2),noinline)) void *ztryrealloc(void *ptr, size_t size
 void zfree(void *ptr);
 void *zmalloc_usable(size_t size, size_t *usable);
 void *zcalloc_usable(size_t size, size_t *usable);
-void *zrealloc_usable(void *ptr, size_t size, size_t *usable);
+void *zrealloc_usable(void *ptr, size_t size, size_t *usable, size_t *old_usable);
 void *ztrymalloc_usable(size_t size, size_t *usable);
 void *ztrycalloc_usable(size_t size, size_t *usable);
-void *ztryrealloc_usable(void *ptr, size_t size, size_t *usable);
+void *ztryrealloc_usable(void *ptr, size_t size, size_t *usable, size_t *old_usable);
 void zfree_usable(void *ptr, size_t *usable);
 __attribute__((malloc)) char *zstrdup(const char *s);
+__attribute__((malloc)) char *zstrdup_usable(const char *s, size_t *usable);
 size_t zmalloc_used_memory(void);
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t));
 size_t zmalloc_get_rss(void);

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -272,7 +272,7 @@ foreach {type large} [array get largevalue] {
 }
 
     foreach type {intset listpack hashtable} {
-        test {COPY basic usage for $type set} {
+        test "COPY basic usage for $type set" {
             r del set1{t} newset1{t}
             r sadd set1{t} 1 2 3
             if {$type ne "intset"} {


### PR DESCRIPTION
Add O(1) memory accounting per key for all robj types.

This is part 1 of adding slot level memory accounting #10472 (discussed in #10411 and #14119) for redis.

Currently the tracked allocation sizes are used in the `MEMORY USAGE` command and replace previous approximation in `kvobjComputeSize()`. In part 2, this is extended to provide per slot memory accounting.

Note that we're accounting for usable memory size (not requested memory size). This is consistent with current `MEMORY USAGE` semantics and is also provides more realistic metric than requested memory size.

Since asking for usable size of an allocation with `zmalloc_usable_size()` is not free, care is taken no to call it when possible and rely on usable sizes reported from `zmalloc_usable()`/`zmalloc_free_usable()` et al.

Quicklists, skiplists and streams track allocated size in `alloc_size` field costing additional 8 bytes per instance.

Since dicts and rax are generic data structures where most uses don't care about memory accounting, having additional 8 bytes per instance would be overkill and instead allocated size is tracked in metadata only where it's necessary (currently only for hashes and sets with hashtable encoding and raxs used in streams).

Dict's allocation size is easily approximated by `dictMemUsage()` and the metadata `alloc_size` accumulates allocation sizes of associated keys/values only.

Rax users that want memory accounting provide `size_t *` pointer where this should be done and supply `RAX_ACCOUNT_ALLOC_SIZE` flag on rax creation. One bit of 64-bit `rax.numele` is used for rax flags. For memory accounting `rax`es, the user provided `size_t *` pointer is stored at the start of the metadata. 

Correctness is enforced in unit tests that compare O(1) accounted allocations sizes with the result of O(n) memory accounted version (e.g. `_rax_verify_alloc_size()`, `_ql_verify_alloc_size()`). Additionally for REDIS_TEST builds correct `alloc_size` is asserted on robj deallocation.