### PR TITLE
Fix span calculation in skiplist node deletion

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -182,7 +182,7 @@ void zslDeleteNode(zskiplist *zsl, zskiplistNode *x, zskiplistNode **update) {
     int i;
     for (i = 0; i < zsl->level; i++) {
         if (update[i]->level[i].forward == x) {
-            update[i]->level[i].span += x->level[i].span - 1;
+            update[i]->level[i].span = update[i]->level[i].span + x->level[i].span - 1;
             update[i]->level[i].forward = x->level[i].forward;
         } else {
             update[i]->level[i].span -= 1;


### PR DESCRIPTION
The deleted node x may be the last node with a span of 0. The original code will lead to an unsigned integer overflow bug, resulting in an incorrect calculated span.