### PR TITLE
Fix potential division by zero in LRU test mode in redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -9855,11 +9855,12 @@ static void LRUTestMode(void) {
             }
         }
         /* Print stats. */
+        long long total_gets = hits + misses;
         printf(
             "%lld Gets/sec | Hits: %lld (%.2f%%) | Misses: %lld (%.2f%%)\n",
             hits+misses,
-            hits, (double)hits/(hits+misses)*100,
-            misses, (double)misses/(hits+misses)*100);
+            hits, total_gets > 0 ? (double)hits/(hits+misses)*100 : 0.0,
+            misses, total_gets > 0 ? (double)misses/(hits+misses)*100 : 0.0);
     }
     exit(0);
 }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -9859,8 +9859,8 @@ static void LRUTestMode(void) {
         printf(
             "%lld Gets/sec | Hits: %lld (%.2f%%) | Misses: %lld (%.2f%%)\n",
             hits+misses,
-            hits, total_gets > 0 ? (double)hits/(hits+misses)*100 : 0.0,
-            misses, total_gets > 0 ? (double)misses/(hits+misses)*100 : 0.0);
+            hits, total_gets > 0 ? (double)hits/total_gets*100 : 0.0,
+            misses, total_gets > 0 ? (double)misses/total_gets*100 : 0.0);
     }
     exit(0);
 }


### PR DESCRIPTION
This PR resolves a potential division-by-zero issue in the `redis-cli` LRU test mode (`--lru-test`), as reported by the Linux Verification Center.

### Problem

When printing the statistics for the LRU test, the percentage calculation for hits and misses could result in a `0/0` division. This occurs if both the `hits` and `misses` counters are zero within a test cycle, which can happen if all GET operations fail or find no keys. This leads to `NaN` (Not a Number) being printed in the output.

### Solution

This change introduces a check to ensure the denominator is non-zero before performing the division.
The total number of gets (`hits + misses`) is calculated first and if it is zero, the percentage defaults to 0.0

This prevents the `NaN` output and ensures the statistics are always displayed cleanly.

Fixes #14361