### PR TITLE
Fix divide-by-zero in redis-benchmark and redis-cli

### DIFF
--- a/deps/hdr_histogram/hdr_histogram.c
+++ b/deps/hdr_histogram/hdr_histogram.c
@@ -733,7 +733,7 @@ int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percen
 
 double hdr_mean(const struct hdr_histogram* h)
 {
-    if (!h || h->total_count == 0) {
+    if (h->total_count == 0) {
         return 0.0;
     }
 
@@ -755,7 +755,7 @@ double hdr_mean(const struct hdr_histogram* h)
 
 double hdr_stddev(const struct hdr_histogram* h)
 {
-    if (!h || h->total_count == 0) {
+    if (h->total_count == 0) {
         return 0.0;
     }
 

--- a/deps/hdr_histogram/hdr_histogram.c
+++ b/deps/hdr_histogram/hdr_histogram.c
@@ -733,10 +733,6 @@ int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percen
 
 double hdr_mean(const struct hdr_histogram* h)
 {
-    if (h->total_count == 0) {
-        return 0.0;
-    }
-
     struct hdr_iter iter;
     int64_t total = 0;
 
@@ -755,10 +751,6 @@ double hdr_mean(const struct hdr_histogram* h)
 
 double hdr_stddev(const struct hdr_histogram* h)
 {
-    if (h->total_count == 0) {
-        return 0.0;
-    }
-
     double mean = hdr_mean(h);
     double geometric_dev_total = 0.0;
 

--- a/deps/hdr_histogram/hdr_histogram.c
+++ b/deps/hdr_histogram/hdr_histogram.c
@@ -733,6 +733,10 @@ int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percen
 
 double hdr_mean(const struct hdr_histogram* h)
 {
+    if (!h || h->total_count == 0) {
+        return 0.0;
+    }
+
     struct hdr_iter iter;
     int64_t total = 0;
 
@@ -751,6 +755,10 @@ double hdr_mean(const struct hdr_histogram* h)
 
 double hdr_stddev(const struct hdr_histogram* h)
 {
+    if (!h || h->total_count == 0) {
+        return 0.0;
+    }
+
     double mean = hdr_mean(h);
     double geometric_dev_total = 0.0;
 

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -834,7 +834,7 @@ static void showLatencyReport(void) {
         return;
     }
 
-    const float reqpersec = (float)config.requests_finished/((float)config.totlatency/1000.0f);
+    const float reqpersec = config.totlatency > 0 ? (float)config.requests_finished/((float)config.totlatency/1000.0f) : 0.0f;
     const float p0 = ((float) hdr_min(config.latency_histogram))/1000.0f;
     const float p50 = hdr_value_at_percentile(config.latency_histogram, 50.0 )/1000.0f;
     const float p95 = hdr_value_at_percentile(config.latency_histogram, 95.0 )/1000.0f;
@@ -1680,16 +1680,8 @@ int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData
     config.previous_tick = current_tick;
     atomicSet(config.previous_requests_finished,requests_finished);
 
-    double avg_mean = 0.0;
-    double overall_mean = 0.0;
-    if (config.current_sec_latency_histogram->total_count > 0) {
-        avg_mean = hdr_mean(config.current_sec_latency_histogram)/1000.0f;
-    }
-    if (config.latency_histogram->total_count > 0) {
-        overall_mean = hdr_mean(config.latency_histogram)/1000.0f;
-    }
     printf("%*s\r", config.last_printed_bytes, " "); /* ensure there is a clean line */
-    int printed_bytes = printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)\r", config.title, instantaneous_rps, rps, avg_mean, overall_mean);
+    int printed_bytes = printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)\r", config.title, instantaneous_rps, rps, hdr_mean(config.current_sec_latency_histogram)/1000.0f, hdr_mean(config.latency_histogram)/1000.0f);
     config.last_printed_bytes = printed_bytes;
     hdr_reset(config.current_sec_latency_histogram);
     fflush(stdout);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -956,19 +956,16 @@ static void benchmark(const char *title, char *cmd, int len) {
     config.requests_finished = 0;
     config.previous_requests_finished = 0;
     config.last_printed_bytes = 0;
-    if (hdr_init(
-            CONFIG_LATENCY_HISTOGRAM_MIN_VALUE,  // Minimum value
-            CONFIG_LATENCY_HISTOGRAM_MAX_VALUE,  // Maximum value
-            config.precision,  // Number of significant figures
-            &config.latency_histogram) != 0 ||  // Pointer to initialise
-        hdr_init(
-            CONFIG_LATENCY_HISTOGRAM_MIN_VALUE,  // Minimum value
-            CONFIG_LATENCY_HISTOGRAM_INSTANT_MAX_VALUE,  // Maximum value
-            config.precision,  // Number of significant figures
-            &config.current_sec_latency_histogram) != 0) {  // Pointer to initialise
-        fprintf(stderr, "Failed to initialize latency histograms\n");
-        exit(1);
-    }
+    hdr_init(
+        CONFIG_LATENCY_HISTOGRAM_MIN_VALUE,  // Minimum value
+        CONFIG_LATENCY_HISTOGRAM_MAX_VALUE,  // Maximum value
+        config.precision,  // Number of significant figures
+        &config.latency_histogram);  // Pointer to initialise
+    hdr_init(
+        CONFIG_LATENCY_HISTOGRAM_MIN_VALUE,  // Minimum value
+        CONFIG_LATENCY_HISTOGRAM_INSTANT_MAX_VALUE,  // Maximum value
+        config.precision,  // Number of significant figures
+        &config.current_sec_latency_histogram);  // Pointer to initialise
 
     if (config.num_threads) initBenchmarkThreads();
 
@@ -1680,7 +1677,9 @@ int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData
     config.previous_tick = current_tick;
     atomicSet(config.previous_requests_finished,requests_finished);
     printf("%*s\r", config.last_printed_bytes, " "); /* ensure there is a clean line */
-    int printed_bytes = printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)\r", config.title, instantaneous_rps, rps, hdr_mean(config.current_sec_latency_histogram)/1000.0f, hdr_mean(config.latency_histogram)/1000.0f);
+    double avg_mean = config.current_sec_latency_histogram->total_count > 0 ? hdr_mean(config.current_sec_latency_histogram)/1000.0f : 0.0;
+    double overall_mean = config.latency_histogram->total_count > 0 ? hdr_mean(config.latency_histogram)/1000.0f : 0.0;
+    int printed_bytes = printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)\r", config.title, instantaneous_rps, rps, avg_mean, overall_mean);
     config.last_printed_bytes = printed_bytes;
     hdr_reset(config.current_sec_latency_histogram);
     fflush(stdout);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -829,8 +829,14 @@ static void createMissingClients(client c) {
 
 static void showLatencyReport(void) {
     if (config.latency_histogram->total_count == 0) {
-        printf("====== %s ======\n", config.title);
-        printf("No latency samples collected\n");
+        if (config.csv) {
+            printf("\"%s\",\"0.00\",\"0.000\",\"0.000\",\"0.000\",\"0.000\",\"0.000\",\"0.000\"\n", config.title);
+        } else if (config.quiet) {
+            printf("%s: 0.00 requests per second, p50=0.000 msec\n", config.title);
+        } else {
+            printf("====== %s ======\n", config.title);
+            printf("No latency samples collected\n");
+        }
         return;
     }
 

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1674,9 +1674,9 @@ int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData
         return SHOW_THROUGHPUT_INTERVAL;
     }
     const float dt = (float)(current_tick-config.start)/1000.0;
-    const float rps = (float)requests_finished/dt;
+    const float rps = dt > 0 ? (float)requests_finished/dt : 0.0f;
     const float instantaneous_dt = (float)(current_tick-config.previous_tick)/1000.0;
-    const float instantaneous_rps = (float)(requests_finished-previous_requests_finished)/instantaneous_dt;
+    const float instantaneous_rps = instantaneous_dt > 0 ? (float)(requests_finished-previous_requests_finished)/instantaneous_dt : 0.0f;
     config.previous_tick = current_tick;
     atomicSet(config.previous_requests_finished,requests_finished);
     printf("%*s\r", config.last_printed_bytes, " "); /* ensure there is a clean line */

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1679,7 +1679,6 @@ int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData
     const float instantaneous_rps = (float)(requests_finished-previous_requests_finished)/instantaneous_dt;
     config.previous_tick = current_tick;
     atomicSet(config.previous_requests_finished,requests_finished);
-
     printf("%*s\r", config.last_printed_bytes, " "); /* ensure there is a clean line */
     int printed_bytes = printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)\r", config.title, instantaneous_rps, rps, hdr_mean(config.current_sec_latency_histogram)/1000.0f, hdr_mean(config.latency_histogram)/1000.0f);
     config.last_printed_bytes = printed_bytes;

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -832,8 +832,10 @@ static void showLatencyReport(void) {
         if (config.csv) {
             printf("\"%s\",\"0.00\",\"0.000\",\"0.000\",\"0.000\",\"0.000\",\"0.000\",\"0.000\"\n", config.title);
         } else if (config.quiet) {
+            printf("%*s\r", config.last_printed_bytes, " "); // ensure there is a clean line
             printf("%s: 0.00 requests per second, p50=0.000 msec\n", config.title);
         } else {
+            printf("%*s\r", config.last_printed_bytes, " "); // ensure there is a clean line
             printf("====== %s ======\n", config.title);
             printf("No latency samples collected\n");
         }

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -828,6 +828,11 @@ static void createMissingClients(client c) {
 }
 
 static void showLatencyReport(void) {
+    if (config.latency_histogram->total_count == 0) {
+        printf("====== %s ======\n", config.title);
+        printf("No latency samples collected\n");
+        return;
+    }
 
     const float reqpersec = (float)config.requests_finished/((float)config.totlatency/1000.0f);
     const float p0 = ((float) hdr_min(config.latency_histogram))/1000.0f;
@@ -951,16 +956,19 @@ static void benchmark(const char *title, char *cmd, int len) {
     config.requests_finished = 0;
     config.previous_requests_finished = 0;
     config.last_printed_bytes = 0;
-    hdr_init(
-        CONFIG_LATENCY_HISTOGRAM_MIN_VALUE,  // Minimum value
-        CONFIG_LATENCY_HISTOGRAM_MAX_VALUE,  // Maximum value
-        config.precision,  // Number of significant figures
-        &config.latency_histogram);  // Pointer to initialise
-    hdr_init(
-        CONFIG_LATENCY_HISTOGRAM_MIN_VALUE,  // Minimum value
-        CONFIG_LATENCY_HISTOGRAM_INSTANT_MAX_VALUE,  // Maximum value
-        config.precision,  // Number of significant figures
-        &config.current_sec_latency_histogram);  // Pointer to initialise
+    if (hdr_init(
+            CONFIG_LATENCY_HISTOGRAM_MIN_VALUE,  // Minimum value
+            CONFIG_LATENCY_HISTOGRAM_MAX_VALUE,  // Maximum value
+            config.precision,  // Number of significant figures
+            &config.latency_histogram) != 0 ||  // Pointer to initialise
+        hdr_init(
+            CONFIG_LATENCY_HISTOGRAM_MIN_VALUE,  // Minimum value
+            CONFIG_LATENCY_HISTOGRAM_INSTANT_MAX_VALUE,  // Maximum value
+            config.precision,  // Number of significant figures
+            &config.current_sec_latency_histogram) != 0) {  // Pointer to initialise
+        fprintf(stderr, "Failed to initialize latency histograms\n");
+        exit(1);
+    }
 
     if (config.num_threads) initBenchmarkThreads();
 
@@ -1671,8 +1679,17 @@ int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData
     const float instantaneous_rps = (float)(requests_finished-previous_requests_finished)/instantaneous_dt;
     config.previous_tick = current_tick;
     atomicSet(config.previous_requests_finished,requests_finished);
+
+    double avg_mean = 0.0;
+    double overall_mean = 0.0;
+    if (config.current_sec_latency_histogram->total_count > 0) {
+        avg_mean = hdr_mean(config.current_sec_latency_histogram)/1000.0f;
+    }
+    if (config.latency_histogram->total_count > 0) {
+        overall_mean = hdr_mean(config.latency_histogram)/1000.0f;
+    }
     printf("%*s\r", config.last_printed_bytes, " "); /* ensure there is a clean line */
-    int printed_bytes = printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)\r", config.title, instantaneous_rps, rps, hdr_mean(config.current_sec_latency_histogram)/1000.0f, hdr_mean(config.latency_histogram)/1000.0f);
+    int printed_bytes = printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)\r", config.title, instantaneous_rps, rps, avg_mean, overall_mean);
     config.last_printed_bytes = printed_bytes;
     hdr_reset(config.current_sec_latency_histogram);
     fflush(stdout);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -10197,6 +10197,11 @@ static int displayKeyStatsSizeDist(struct hdr_histogram *keysize_histogram) {
     struct hdr_iter iter;
     int64_t last_displayed_cumulative_count = 0;
 
+    if (keysize_histogram->total_count == 0) {
+        line_count += cleanPrintfln("No key size samples collected");
+        return line_count;
+    }
+
     hdr_iter_percentile_init(&iter, keysize_histogram, 1);
 
     line_count += cleanPrintfln("Key size Percentile Total keys");

--- a/tests/integration/redis-benchmark.tcl
+++ b/tests/integration/redis-benchmark.tcl
@@ -134,6 +134,15 @@ tags {"benchmark network external:skip logreqres:skip"} {
             r get key
         } {arg}
 
+        test {benchmark: no NaN or Inf in latency report with fast requests} {
+            # With -n 1 on localhost, totlatency can round to 0 ms. Verify showLatencyReport() handles this gracefully.
+            set cmd [redisbenchmark $master_host $master_port "-c 1 -n 1 -t set"]
+            set output [exec {*}$cmd 2>@1]
+            if {[regexp -nocase {nan|(?:^|[^a-z])inf(?:[^o]|$)} $output]} {
+                fail "redis-benchmark output contains NaN or Inf: $output"
+            }
+        }
+
         # tls specific tests
         if {$::tls} {
             test {benchmark: specific tls-ciphers} {

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -857,7 +857,7 @@ start_server {tags {"cli external:skip"}} {
         catch {exec {*}$cmd 2>@1} result
         assert_match "*Scanning the entire keyspace*" $result
 
-        # The "Note:" line with Mean/ StdDeviation is only printed when displayKeyStatsSizeDist()
+        # The "Note:" line with Mean/StdDeviation is only printed when displayKeyStatsSizeDist()
         # compute stats. When keysize_histogram->total_count == 0, it should be skipped entirely.
         assert_match "*No key size samples collected*" $result
     }

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -849,4 +849,18 @@ start_server {tags {"cli external:skip"}} {
     }
 }
 
+start_server {tags {"cli external:skip"}} {
+    test "keystats on empty database should not produce garbage stats" {
+        # On an empty DB the keystats histogram has total_count = 0. Verify hdr_mean(), hdr_stddev(),
+        # and the percentile calculation handle this gracefully.
+        set cmd [rediscli [srv host] [srv port] [list --keystats]]
+        catch {exec {*}$cmd 2>@1} result
+        assert_match "*Scanning the entire keyspace*" $result
+
+        # The "Note:" line with Mean/ StdDeviation is only printed when displayKeyStatsSizeDist()
+        # compute stats. When keysize_histogram->total_count == 0, it should be skipped entirely.
+        assert_no_match "*Note: 0.01% size precision*" $result
+    }
+}
+
 file delete ./.rediscli_history_test

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -859,7 +859,7 @@ start_server {tags {"cli external:skip"}} {
 
         # The "Note:" line with Mean/ StdDeviation is only printed when displayKeyStatsSizeDist()
         # compute stats. When keysize_histogram->total_count == 0, it should be skipped entirely.
-        assert_no_match "*Note: 0.01% size precision*" $result
+        assert_match "*No key size samples collected*" $result
     }
 }
 


### PR DESCRIPTION
Resolve https://github.com/redis/redis/issues/14358 and https://github.com/redis/redis/issues/14359. Fix division by zero in redis-benchmark and redis-cli when histograms are empty or elapsed time is zero. Guard all affected divisions in showLatencyReport(), showThroughput(), and displayKeyStatsSizeDist(). Added integration tests for both cases.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix that adds zero-sample/zero-duration guards to CLI/benchmark reporting to prevent NaN/Inf output; behavior changes are limited to edge-case output formatting and stats calculations.
> 
> **Overview**
> Prevents divide-by-zero/NaN/Inf in `redis-benchmark` reporting by short-circuiting `showLatencyReport()` when no latency samples were recorded and guarding RPS/instantaneous RPS and mean-latency calculations when elapsed time or histogram counts are zero.
> 
> Updates `redis-cli --keystats` size distribution output to explicitly handle an empty histogram by printing `No key size samples collected` and skipping mean/stddev/percentile calculations, and adds integration tests covering both empty-keyspace keystats and fast/low-count benchmark runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b109323d868ed93859186de5490895d0d18f7471. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->