### PR TITLE
Skip AOF rewrite when a short write occurs

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -2590,6 +2590,27 @@ int rewriteAppendOnlyFileBackground(void) {
      * feedAppendOnlyFile() to issue a SELECT command. */
     server.aof_selected_db = -1;
     flushAppendOnlyFile(1);
+    /* If the flushAppendOnlyFile function fails to fully write all data from the 
+     * AOF buffer (i.e., a short write occurs), we should stop executing the AOF rewrite 
+     * operation. Otherwise, we might encounter the following two scenarios:
+     * 1) Successful ftruncate: The aof_buf contains complete commands that would be written 
+     *    to the next incremental AOF file (about to be generated). However, these commands 
+     *    should actually be written to the current incremental AOF file (which will become 
+     *    the history AOF). Otherwise, it could cause data duplication between the new base AOF 
+     *    and new incremental AOF (especially problematic for non-idempotent commands).
+     * 2) Failed ftruncate: The aof_buf might contain an incomplete command, potentially causing
+     *    both the current incremental AOF (about to become history AOF) and the next incremental 
+     *    AOF to each contain partial data. This would make all subsequent data appended to the 
+     *    new incremental AOF fail to load correctly due to this incomplete data.
+     */
+    if (server.aof_last_write_status == C_ERR) {
+        serverLog(LL_WARNING,
+            "Can't flush the AOF buffer on disk. "
+            "Background AOF rewrite may be unreliable: %s",
+            strerror(errno));
+        server.aof_lastbgrewrite_status = C_ERR;
+        return C_ERR;
+    }
     if (openNewIncrAofForAppend() != C_OK) {
         server.aof_lastbgrewrite_status = C_ERR;
         return C_ERR;

--- a/src/aof.c
+++ b/src/aof.c
@@ -2606,8 +2606,7 @@ int rewriteAppendOnlyFileBackground(void) {
     if (server.aof_last_write_status == C_ERR) {
         serverLog(LL_WARNING,
             "Can't flush the AOF buffer on disk. "
-            "Background AOF rewrite may be unreliable: %s",
-            strerror(errno));
+            "Background AOF rewrite aborted.");
         server.aof_lastbgrewrite_status = C_ERR;
         return C_ERR;
     }


### PR DESCRIPTION
If the flushAppendOnlyFile function fails to fully write all data from the AOF buffer (i.e., a short write occurs), we should stop executing the AOF rewrite operation. Otherwise, we might encounter the following two scenarios:

1) Successful ftruncate: The aof_buf contains complete commands that would be written to the next incremental AOF file (about to be generated). However, these commands should actually be written to the current incremental AOF file (which will become the history AOF). Otherwise, it could cause data duplication between the base AOF and incremental AOF (especially problematic for non-idempotent operations).    
<img width="696" height="872" alt="image" src="https://github.com/user-attachments/assets/16c1060f-cce6-4325-ad32-857c19bd0ab1" />

2) Failed ftruncate: The aof_buf might contain an incomplete command, potentially causing both the current incremental AOF (about to become history AOF) and the next incremental AOF to each contain partial data. This would make all subsequent data appended to the new incremental AOF fail to load correctly due to this incomplete data.   
<img width="728" height="750" alt="image" src="https://github.com/user-attachments/assets/44f723b8-13be-4c53-9df0-1e05b5303d75" />
