### PR TITLE
[RED-170693] Limit efSearch parameter to avoid heap overflow

### DIFF
--- a/modules/vector-sets/tests/vsim_limit_efsearch.py
+++ b/modules/vector-sets/tests/vsim_limit_efsearch.py
@@ -1,0 +1,32 @@
+from test import TestCase, generate_random_vector
+import struct
+
+class VSIMLimitEFSearch(TestCase):
+    def getname(self):
+        return "VSIM Limit EF Search"
+
+    def estimated_runtime(self):
+        return 0.2
+
+    def test(self):
+        dim = 32
+        vec = generate_random_vector(dim)
+        vec_bytes = struct.pack(f'{dim}f', *vec)
+
+        # Add test vector
+        self.redis.execute_command('VADD', self.test_key, 'FP32', vec_bytes, f'{self.test_key}:item:1')
+
+        query_vec = generate_random_vector(dim)
+
+        # Test EF upper bound (should accept 1000000)
+        result = self.redis.execute_command('VSIM', self.test_key, 'VALUES', dim,
+                                          *[str(x) for x in query_vec], 'EF', 1000000)
+        assert isinstance(result, list), "EF=1000000 should be accepted"
+
+        # Test EF over limit (should reject > 1000000)
+        try:
+            self.redis.execute_command('VSIM', self.test_key, 'VALUES', dim,
+                                     *[str(x) for x in query_vec], 'EF', 1000001)
+            assert False, "EF=1000001 should be rejected"
+        except Exception as e:
+            assert "invalid EF" in str(e), f"Expected EF validation error, got: {e}"

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -820,6 +820,9 @@ void VSIM_execute(RedisModuleCtx *ctx, struct vsetObject *vset,
     if (ef == 0) ef = VSET_DEFAULT_SEARCH_EF;
     if (count > ef) ef = count;
 
+    int slot = hnsw_acquire_read_slot(vset->hnsw);
+    if (ef > vset->hnsw->node_count) ef = vset->hnsw->node_count;
+
     /* Perform search */
     hnswNode **neighbors = RedisModule_Alloc(sizeof(hnswNode*)*ef);
     float *distances = RedisModule_Alloc(sizeof(float)*ef);
@@ -1075,7 +1078,7 @@ int VSIM_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             j += 2;
         } else if (!strcasecmp(opt, "EF") && j+1 < argc) {
             if (RedisModule_StringToLongLong(argv[j+1], &ef) !=
-                REDISMODULE_OK || ef <= 0)
+                REDISMODULE_OK || ef <= 0 || ef > 1000000)
             {
                 RedisModule_Free(vec);
                 return RedisModule_ReplyWithError(ctx, "ERR invalid EF");

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -826,7 +826,6 @@ void VSIM_execute(RedisModuleCtx *ctx, struct vsetObject *vset,
     /* Perform search */
     hnswNode **neighbors = RedisModule_Alloc(sizeof(hnswNode*)*ef);
     float *distances = RedisModule_Alloc(sizeof(float)*ef);
-    int slot = hnsw_acquire_read_slot(vset->hnsw);
     unsigned int found;
     if (ground_truth) {
         found = hnsw_ground_truth_with_filter(vset->hnsw, vec, ef, neighbors,


### PR DESCRIPTION
This PR aims to avoid the situation of a potential crash when efSearch is too large (and therefore the memory allocated could lead to a server crash or an integer overflow (where less memory is allocated than expected).

- Limit the accepted EF in the request o 100_000 as in VADD
- Limit the ef search to the number of nodes in the HNSW graph