### PR TITLE
MOD-11572: Bump RediSearch to v8.2.5 for Redis 8.2.2

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.2.1
+MODULE_VERSION = v8.2.5
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
$ gitlog v8.2.1..v8.2.5

RediSearch/RediSearch#6867 Improve BUILD_INTEL_SVS_OPT flag validation
RediSearch/RediSearch#6845 Fix vector compression type reporting and rename SVS environment variable
RediSearch/RediSearch#6794 Fix rpcountFree casting
RediSearch/RediSearch#6825 Bump vecsim 8.2.4
RediSearch/RediSearch#6787 Fix deadlock while RDB loading and RM_Yield (#6763)
RediSearch/RediSearch#6723 Fix ACLUserMayAccessIndex
RediSearch/RediSearch#6701 Fix fd leak when OOM
RediSearch/RediSearch#6676 bump svs version
RediSearch/RediSearch#6671 Add SVS-VAMANA index to info fields telemetry
RediSearch/RediSearch#6665 Optimize rs_wall_clock_diff_ns by removing redundant if branch
RediSearch/RediSearch#6641 Update vectors memory in total index info memory
RediSearch/RediSearch#6634 Log DocTable capacity growth for memory diagnostics
RediSearch/RediSearch#6649 Bump minimal redis version
RediSearch/RediSearch#6648 Fix "has map" performance
RediSearch/RediSearch#6645 Trie: hide expensive memory usage computation behind a test-specific feature flag
