### PR TITLE
sending large string by reference

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3299,7 +3299,8 @@ standardConfig static_configs[] = {
     createSpecialConfig("bind", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigBindOption, getConfigBindOption, rewriteConfigBindOption, applyBind),
     createSpecialConfig("replicaof", "slaveof", IMMUTABLE_CONFIG | MULTI_ARG_CONFIG, setConfigReplicaOfOption, getConfigReplicaOfOption, rewriteConfigReplicaOfOption, NULL),
     createSpecialConfig("latency-tracking-info-percentiles", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigLatencyTrackingInfoPercentilesOutputOption, getConfigLatencyTrackingInfoPercentilesOutputOption, rewriteConfigLatencyTrackingInfoPercentilesOutputOption, NULL),
-
+    createSizeTConfig("send-by-reference-min-size", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, server.send_by_reference_min_size, 1024, INTEGER_CONFIG, NULL, NULL),
+	
     /* NULL Terminator, this is dropped when we convert to the runtime array. */
     {NULL}
 };

--- a/src/networking.c
+++ b/src/networking.c
@@ -84,6 +84,11 @@ void *dupClientReplyValue(void *o) {
 }
 
 void freeClientReplyValue(void *o) {
+    clientReplyBlock *cb = o;
+	if (cb->sendByRef) {
+		void **b = (void **)cb->buf;
+		decrRefCount(b[1]);
+	}
     zfree(o);
 }
 
@@ -370,6 +375,7 @@ void _addReplyProtoToList(client *c, list *reply_list, const char *s, size_t len
         size_t size = len < PROTO_REPLY_CHUNK_BYTES? PROTO_REPLY_CHUNK_BYTES: len;
         tail = zmalloc_usable(size + sizeof(clientReplyBlock), &usable_size);
         /* take over the allocation's internal fragmentation */
+		tail->sendByRef = 0;
         tail->size = usable_size - sizeof(clientReplyBlock);
         tail->used = len;
         memcpy(tail->buf, s, len);
@@ -439,16 +445,102 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
     if (len > reply_len) _addReplyProtoToList(c,c->reply,s+reply_len,len-reply_len);
 }
 
+
 /* -----------------------------------------------------------------------------
  * Higher level functions to queue data on the client output buffer.
  * The following functions are the ones that commands implementations will call.
  * -------------------------------------------------------------------------- */
 
-/* Add the object 'obj' string representation to the client output buffer. */
+/* Add the object 'obj' by reference
+   allow for partial data to be sent 
+   this method increase the ref count and when the send is done it decreases it back
+   
+ */
+static inline void _addReplyLongLongSharedHdr(client *c, long long ll, char prefix,
+                                              robj *shared_hdr[OBJ_SHARED_BULKHDR_LEN])
+{
+    char buf[128];
+    int len;
+    const int opt_hdr = ll < OBJ_SHARED_BULKHDR_LEN && ll >= 0;
+
+    if (opt_hdr) {
+        _addReplyToBufferOrList(c, shared_hdr[ll]->ptr, OBJ_SHARED_HDR_STRLEN(ll));
+        return;
+    }
+
+    buf[0] = prefix;
+    len = ll2string(buf + 1, sizeof(buf) - 1, ll);
+    buf[len + 1] = '\r';
+    buf[len + 2] = '\n';
+    _addReplyToBufferOrList(c, buf, len + 3);
+}
+
+
+static inline void _addReplyLongLongMBulk(client *c, long long ll) {
+    _addReplyLongLongSharedHdr(c, ll, '*', shared.mbulkhdr);
+}
+
+/* Add a long long as integer reply or bulk len / multi bulk count.
+ * Basically this is used to output <prefix><long long><crlf>. */
+static void _addReplyLongLongWithPrefix(client *c, long long ll, char prefix) {
+    char buf[128];
+    int len;
+
+    /* Things like $3\r\n or *2\r\n are emitted very often by the protocol
+     * so we have a few shared objects to use if the integer is small
+     * like it is most of the times. */
+    const int opt_hdr = ll < OBJ_SHARED_BULKHDR_LEN && ll >= 0;
+    const size_t hdr_len = OBJ_SHARED_HDR_STRLEN(ll);
+    if (prefix == '*' && opt_hdr) {
+        _addReplyToBufferOrList(c, shared.mbulkhdr[ll]->ptr, hdr_len);
+        return;
+    } else if (prefix == '$' && opt_hdr) {
+        _addReplyToBufferOrList(c, shared.bulkhdr[ll]->ptr, hdr_len);
+        return;
+    } else if (prefix == '%' && opt_hdr) {
+        _addReplyToBufferOrList(c, shared.maphdr[ll]->ptr, hdr_len);
+        return;
+    } else if (prefix == '~' && opt_hdr) {
+        _addReplyToBufferOrList(c, shared.sethdr[ll]->ptr, hdr_len);
+        return;
+    }
+
+    buf[0] = prefix;
+    len = ll2string(buf + 1, sizeof(buf) - 1, ll);
+    buf[len + 1] = '\r';
+    buf[len + 2] = '\n';
+    _addReplyToBufferOrList(c, buf, len + 3);
+}
+
+static inline void _addReplyLongLongBulk(client *c, long long ll) {
+    _addReplyLongLongSharedHdr(c, ll, '$', shared.bulkhdr);
+}
+
+
+void sendByReference(client *c, void *data, size_t len, robj *obj)
+{
+    if (_prepareClientToWrite(c) != C_OK) return;
+	
+	_addReplyLongLongBulk(c, len);
+	
+	incrRefCount(obj);
+	clientReplyBlock *msg = zmalloc(sizeof(void *) *2 + sizeof(clientReplyBlock));
+	msg->sendByRef = 1;
+	msg->size = len;
+	msg->used = len;
+	void ** tmp = (void **)msg->buf;
+	*tmp = data;
+	*(tmp+1) = obj;
+	listAddNodeTail(c->reply, msg);
+	c->reply_bytes += msg->size;
+	_addReplyToBufferOrList(c,"\r\n",2);
+		
+	closeClientOnOutputBufferLimitReached(c, 1);	
+}
+
 void addReply(client *c, robj *obj) {
     if (_prepareClientToWrite(c) != C_OK) return;
-
-    if (sdsEncodedObject(obj)) {
+	if (sdsEncodedObject(obj)) {
         _addReplyToBufferOrList(c,obj->ptr,sdslen(obj->ptr));
     } else if (obj->encoding == OBJ_ENCODING_INT) {
         /* For integer encoded strings we just convert it into a string
@@ -482,9 +574,12 @@ void addReplySds(client *c, sds s) {
  * if not needed. The object will only be created by calling
  * _addReplyProtoToList() if we fail to extend the existing tail object
  * in the list of objects. */
+/* (Hilik) this method accept an object if the object is not null it assume the
+   data has to be sent by reference (and not been copied) and that the object
+   referce count increases */
 void addReplyProto(client *c, const char *s, size_t len) {
     if (_prepareClientToWrite(c) != C_OK) return;
-    _addReplyToBufferOrList(c,s,len);
+	_addReplyToBufferOrList(c,s,len);
 }
 
 /* Low level function called by the addReplyError...() functions.
@@ -727,7 +822,8 @@ void trimReplyUnusedTailSpace(client *c) {
      * allocation), otherwise there's a high chance realloc will NOP.
      * Also, to avoid large memmove which happens as part of realloc, we only do
      * that if the used part is small.  */
-    if (tail->size - tail->used > tail->size / 4 &&
+    if (!tail->sendByRef && 
+		tail->size - tail->used > tail->size / 4 &&
         tail->used < PROTO_REPLY_CHUNK_BYTES)
     {
         size_t usable_size;
@@ -820,6 +916,7 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
         size_t usable_size;
         clientReplyBlock *buf = zmalloc_usable(length + sizeof(clientReplyBlock), &usable_size);
         /* Take over the allocation's internal fragmentation */
+		buf->sendByRef = 0;
         buf->size = usable_size - sizeof(clientReplyBlock);
         buf->used = length;
         memcpy(buf->buf, s, length);
@@ -950,64 +1047,6 @@ void addReplyHumanLongDouble(client *c, long double d) {
     }
 }
 
-static inline void _addReplyLongLongSharedHdr(client *c, long long ll, char prefix,
-                                              robj *shared_hdr[OBJ_SHARED_BULKHDR_LEN])
-{
-    char buf[128];
-    int len;
-    const int opt_hdr = ll < OBJ_SHARED_BULKHDR_LEN && ll >= 0;
-
-    if (opt_hdr) {
-        _addReplyToBufferOrList(c, shared_hdr[ll]->ptr, OBJ_SHARED_HDR_STRLEN(ll));
-        return;
-    }
-
-    buf[0] = prefix;
-    len = ll2string(buf + 1, sizeof(buf) - 1, ll);
-    buf[len + 1] = '\r';
-    buf[len + 2] = '\n';
-    _addReplyToBufferOrList(c, buf, len + 3);
-}
-
-static inline void _addReplyLongLongBulk(client *c, long long ll) {
-    _addReplyLongLongSharedHdr(c, ll, '$', shared.bulkhdr);
-}
-
-static inline void _addReplyLongLongMBulk(client *c, long long ll) {
-    _addReplyLongLongSharedHdr(c, ll, '*', shared.mbulkhdr);
-}
-
-/* Add a long long as integer reply or bulk len / multi bulk count.
- * Basically this is used to output <prefix><long long><crlf>. */
-static void _addReplyLongLongWithPrefix(client *c, long long ll, char prefix) {
-    char buf[128];
-    int len;
-
-    /* Things like $3\r\n or *2\r\n are emitted very often by the protocol
-     * so we have a few shared objects to use if the integer is small
-     * like it is most of the times. */
-    const int opt_hdr = ll < OBJ_SHARED_BULKHDR_LEN && ll >= 0;
-    const size_t hdr_len = OBJ_SHARED_HDR_STRLEN(ll);
-    if (prefix == '*' && opt_hdr) {
-        _addReplyToBufferOrList(c, shared.mbulkhdr[ll]->ptr, hdr_len);
-        return;
-    } else if (prefix == '$' && opt_hdr) {
-        _addReplyToBufferOrList(c, shared.bulkhdr[ll]->ptr, hdr_len);
-        return;
-    } else if (prefix == '%' && opt_hdr) {
-        _addReplyToBufferOrList(c, shared.maphdr[ll]->ptr, hdr_len);
-        return;
-    } else if (prefix == '~' && opt_hdr) {
-        _addReplyToBufferOrList(c, shared.sethdr[ll]->ptr, hdr_len);
-        return;
-    }
-
-    buf[0] = prefix;
-    len = ll2string(buf + 1, sizeof(buf) - 1, ll);
-    buf[len + 1] = '\r';
-    buf[len + 2] = '\n';
-    _addReplyToBufferOrList(c, buf, len + 3);
-}
 
 void addReplyLongLong(client *c, long long ll) {
     if (ll == 0)
@@ -2033,9 +2072,11 @@ static int _writevToClient(client *c, ssize_t *nwritten) {
             listDelNode(c->reply, next);
             offset = 0;
             continue;
-        }
-
-        iov[iovcnt].iov_base = o->buf + offset;
+        } if (o->sendByRef) {
+			iov[iovcnt].iov_base = *(void **)o->buf;			
+		} else {
+			iov[iovcnt].iov_base = o->buf + offset;
+		}
         iov[iovcnt].iov_len = o->used - offset;
         iov_bytes_len += iov[iovcnt++].iov_len;
         offset = 0;

--- a/src/object.c
+++ b/src/object.c
@@ -576,26 +576,25 @@ void freeStreamObject(robj *o) {
 
 void incrRefCount(robj *o) {
     if (o->refcount < OBJ_FIRST_SPECIAL_REFCOUNT) {
-        o->refcount++;
-    } else {
-        if (o->refcount == OBJ_SHARED_REFCOUNT) {
-            /* Nothing to do: this refcount is immutable. */
-        } else if (o->refcount == OBJ_STATIC_REFCOUNT) {
-            serverPanic("You tried to retain an object allocated in the stack");
-        }
-    }
+		unsigned short ref_count = __atomic_add_fetch(&o->refcount, 1,__ATOMIC_RELAXED);
+		serverAssert(ref_count < OBJ_FIRST_SPECIAL_REFCOUNT);
+    } else if (o->refcount == OBJ_SHARED_REFCOUNT) {
+		/* Nothing to do: this refcount is immutable. */
+	} else if (o->refcount == OBJ_STATIC_REFCOUNT) {
+		serverPanic("You tried to retain an object allocated in the stack");
+	}
 }
-
+int shouldSendObjectByReference(int type, size_t len) {
+	return type == OBJ_STRING && len >= server.send_by_reference_min_size;
+}
 void decrRefCount(robj *o) {
-    if (o->refcount == OBJ_SHARED_REFCOUNT)
+    if (o->refcount == OBJ_SHARED_REFCOUNT) {
         return; /* Nothing to do: this refcount is immutable. */
-
-    if (unlikely(o->refcount <= 0)) {
-        serverPanic("illegal decrRefCount for object with: type %u, encoding %u, refcount %d",
-            o->type, o->encoding, o->refcount);
-    }
-
-    if (--(o->refcount) == 0) {
+	}
+	
+	unsigned short ref_count = __atomic_sub_fetch(&o->refcount, 1,__ATOMIC_RELAXED);
+	serverAssert(ref_count < OBJ_FIRST_SPECIAL_REFCOUNT);
+	if (ref_count == 0) {
         if (o->ptr != NULL) {
             switch(o->type) {
             case OBJ_STRING: freeStringObject(o); break;

--- a/src/server.h
+++ b/src/server.h
@@ -187,7 +187,7 @@ struct hdr_histogram;
 
 /* Protocol and I/O related defines */
 #define PROTO_IOBUF_LEN         (1024*16)  /* Generic I/O buffer size */
-#define PROTO_REPLY_CHUNK_BYTES (16*1024) /* 16k output buffer */
+#define PROTO_REPLY_CHUNK_BYTES (1024*16) /* 16k output buffer */
 #define PROTO_INLINE_MAX_SIZE   (1024*64) /* Max size of inline reads */
 #define PROTO_MBULK_BIG_ARG     (1024*32)
 #define PROTO_RESIZE_THRESHOLD  (1024*32) /* Threshold for determining whether to resize query buffer */
@@ -1034,7 +1034,7 @@ struct RedisModuleDigest {
 #define LRU_CLOCK_MAX ((1<<LRU_BITS)-1) /* Max value of obj->lru */
 #define LRU_CLOCK_RESOLUTION 1000 /* LRU clock resolution in ms */
 
-#define OBJ_REFCOUNT_BITS 30
+#define OBJ_REFCOUNT_BITS 16
 #define OBJ_SHARED_REFCOUNT ((1 << OBJ_REFCOUNT_BITS) - 1) /* Global object never destroyed. */
 #define OBJ_STATIC_REFCOUNT ((1 << OBJ_REFCOUNT_BITS) - 2) /* Object allocated in the stack. */
 #define OBJ_FIRST_SPECIAL_REFCOUNT OBJ_STATIC_REFCOUNT
@@ -1045,10 +1045,13 @@ struct redisObject {
     unsigned lru:LRU_BITS; /* LRU time (relative to global lru_clock) or
                             * LFU data (least significant 8 bits frequency
                             * and most significant 16 bits access time). */
+	unsigned short refcount; /* in order to make it thread safe it must be a known type */	
     unsigned iskvobj : 1;   /* 1 if this struct serves as a kvobj base */
     unsigned expirable : 1; /* 1 if this key has expiration time attached.
                              * If set, then this object is of type kvobj */
-    unsigned refcount : OBJ_REFCOUNT_BITS;
+	unsigned spares : 14;
+	
+	
     void *ptr;
 };
 
@@ -1075,7 +1078,9 @@ struct evictionPoolEntry; /* Defined in evict.c */
 /* This structure is used in order to represent the output buffer of a client,
  * which is actually a linked list of blocks like that, that is: client->reply. */
 typedef struct clientReplyBlock {
-    size_t size, used;
+	size_t sendByRef : 1;
+    size_t size : 63;
+	size_t used;
     char buf[];
 } clientReplyBlock;
 
@@ -2171,6 +2176,7 @@ struct redisServer {
     time_t repl_total_disconnect_time;       /* The total cumulative time we've been disconnected as a replica, visible when the link is up too. */
     /* Limits */
     unsigned int maxclients;            /* Max number of simultaneous clients */
+	size_t send_by_reference_min_size; /* send data by reference if data size exceeds this value */
     unsigned long long maxmemory;   /* Max number of memory bytes to use */
     ssize_t maxmemory_clients;       /* Memory limit for total client buffers */
     int maxmemory_policy;           /* Policy for key eviction */
@@ -2849,6 +2855,7 @@ void addReplyBulkCString(client *c, const char *s);
 void addReplyBulkCBuffer(client *c, const void *p, size_t len);
 void addReplyBulkLongLong(client *c, long long ll);
 void addReply(client *c, robj *obj);
+void sendByReference(client *c, void *data, size_t len, robj *obj);
 void addReplyStatusLength(client *c, const char *s, size_t len);
 void addReplySds(client *c, sds s);
 void addReplyBulkSds(client *c, sds s);
@@ -3033,6 +3040,9 @@ void execCommandAbort(client *c, sds error);
 /* Redis object implementation */
 void decrRefCount(robj *o);
 void incrRefCount(robj *o);
+/* sending object by reference for now only for large enough strings */
+int shouldSendObjectByReference(int type, size_t len);
+
 robj *makeObjectShared(robj *o);
 void freeStringObject(robj *o);
 void freeListObject(robj *o);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -328,6 +328,14 @@ int getGenericCommand(client *c) {
     if (checkType(c,o,OBJ_STRING)) {
         return C_ERR;
     }
+	if (sdsEncodedObject(o)) {
+		size_t len = sdslen(o->ptr);
+		if (shouldSendObjectByReference(o->type, len)) {
+			sendByReference(c, o->ptr, len, o);
+			return C_OK;
+		}						
+	} 
+		
 
     addReplyBulk(c,o);
     return C_OK;
@@ -380,7 +388,6 @@ void getexCommand(client *c) {
     if (expire && getExpireMillisecondsOrReply(c, expire, flags, unit, &milliseconds) != C_OK) {
         return;
     }
-
     /* We need to do this before we expire the key or delete it */
     addReplyBulk(c,o);
 
@@ -538,10 +545,16 @@ void getrangeCommand(client *c) {
 
     /* Precondition: end >= 0 && end < strlen, so the only condition where
      * nothing can be returned is: start > end. */
+	
     if (start > end || strlen == 0) {
         addReply(c,shared.emptybulk);
     } else {
-        addReplyBulkCBuffer(c,(char*)str+start,end-start+1);
+		size_t len = end-start+1;
+		if (shouldSendObjectByReference(o->type, len)) {
+			sendByReference(c, (char*)str+start,  len, o);
+		} else {			
+			addReplyBulkCBuffer(c,(char*)str+start, len);
+		}
     }
 }
 


### PR DESCRIPTION
https://github.com/redis/redis/issues/14390

This code is sending large string by reference. The code is not "production ready" and should be refereed as POC only. 

We need if possible to run performance testing on the code with large strings 
