### PR TITLE
Check clusterManagerSetSlot return value in redis-cli migration

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5191,11 +5191,10 @@ static int clusterManagerMigrateKeysInSlot(clusterManagerNode *source,
                     clusterManagerLogWarn("*** Slot was not served, setting "
                                           "owner to node %s:%d.\n",
                                           target->ip, target->port);
-                    int setslot_ok = clusterManagerSetSlot(source, target, slot, "node", NULL);
-                    if (!setslot_ok) {
-                    clusterManagerLogErr("*** Failed to set slot owner for slot%d", slot);
-                    success = 0;
-                    goto next;
+                    if (!clusterManagerSetSlot(source, target, slot, "node", NULL)) {
+                        clusterManagerLogErr("*** Failed to set slot owner for slot%d", slot);
+                        success = 0;
+                        goto next;
                     }  
                 }
                 /* If the key already exists in the target node (BUSYKEY),

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5191,7 +5191,12 @@ static int clusterManagerMigrateKeysInSlot(clusterManagerNode *source,
                     clusterManagerLogWarn("*** Slot was not served, setting "
                                           "owner to node %s:%d.\n",
                                           target->ip, target->port);
-                    clusterManagerSetSlot(source, target, slot, "node", NULL);
+                    int setslot_ok = clusterManagerSetSlot(source, target, slot, "node", NULL);
+                    if (!setslot_ok) {
+                    clusterManagerLogErr("*** Failed to set slot owner for slot%d", slot);
+                    success = 0;
+                    goto next;
+                    }  
                 }
                 /* If the key already exists in the target node (BUSYKEY),
                  * check whether its value is the same in both nodes.


### PR DESCRIPTION
### Context
During cluster slot migration, redis-cli invokes `clusterManagerSetSlot`
to assign slots to target nodes. Currently, the return value is not checked.

### Problem
If `clusterManagerSetSlot` fails, migration continues as if the operation
succeeded. This can cause inconsistent slot allocation and compromise
cluster integrity.

### Fix
- Added explicit return value check for `clusterManagerSetSlot`.
- On failure:
  - log an error message,
  - set `success = 0`,
  - and propagate the failure state.

### Rationale
This ensures that migration stops cleanly if slot assignment fails, avoiding
partial or inconsistent cluster states.

Fixes #14308
