### PR TITLE
Optimize integer addition in setTypeAddAux with lpFindInteger

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -945,6 +945,28 @@ unsigned char *lpFind(unsigned char *lp, unsigned char *p, unsigned char *s,
     return lpFindCbInternal(lp, p, &arg, lpFindCmp, skip);
 }
 
+/* Comparator function to find Integer item */
+static inline int lpFindIntegerCmp(const unsigned char *lp, unsigned char *p,
+                                   void *user, unsigned char *s, long long ll) {
+    (void) lp;
+    (void) p;
+    if (s != NULL) return 1;  /* Skip if current entry is a string */
+	return (ll == *(long long *)user) ? 0 : 1;
+}
+
+/* Search for a specific long long integer value in the listpack.
+ *
+ * 'lp' is the pointer to the listpack.
+ * 'p' is the starting position within the listpack (if NULL, search starts from the first entry).
+ * 'value' is the target integer value to search for.
+ * 'skip' specifies the number of entries to skip between each comparison.
+ *
+ * Returns a pointer to the matching entry if found, otherwise NULL. */
+unsigned char *lpFindInteger(unsigned char *lp, unsigned char *p,
+                             long long value, unsigned int skip) {
+    return lpFindCbInternal(lp, p, &value, lpFindIntegerCmp, skip);
+}
+
 /* Insert, delete or replace the specified string element 'elestr' of length
  * 'size' or integer element 'eleint' at the specified position 'p', with 'p'
  * being a listpack element pointer obtained with lpFirst(), lpLast(), lpNext(),
@@ -3093,6 +3115,51 @@ int listpackTest(int argc, char *argv[], int flags) {
         assert(lpFind(lp, lpFirst(lp), (unsigned char*)"abc", 3, 0) == NULL);
         verifyEntry(lpFind(lp, lpFirst(lp), (unsigned char*)"hello", 5, 0), (unsigned char*)"hello", 5);
         verifyEntry(lpFind(lp, lpFirst(lp), (unsigned char*)"1024", 4, 0), (unsigned char*)"1024", 4);
+        lpFree(lp);
+    }
+
+    TEST("Test lpFindInteger") {
+        /* Create a listpack with a mix of integers and strings */
+        unsigned char *lp = lpNew(0);
+        lp = lpAppendInteger(lp, 100);
+        lp = lpAppend(lp, (unsigned char*)"hello", 5);
+        lp = lpAppendInteger(lp, -50);
+        lp = lpAppend(lp, (unsigned char*)"1024", 4);
+        unsigned char *p;
+        long long val;
+
+        /* Test: Find an existing integer (100) */
+        p = lpFindInteger(lp, NULL, 100, 0);
+        assert(p != NULL);
+        lpGetIntegerValue(p, &val);
+        assert(val == 100);
+
+        /* Test: Find an existing integer (-50) */
+        p = lpFindInteger(lp, NULL, -50, 0);
+        assert(p != NULL);
+        lpGetIntegerValue(p, &val);
+        assert(val == -50);
+
+        /* Test: Find an existing integer (100) with skip=1 */
+        p = lpFindInteger(lp, NULL, 100, 1);
+        assert(p != NULL);
+        lpGetIntegerValue(p, &val);
+        assert(val == 100);
+
+        /* Test: Find an existing integer (-50) with skip=1 */
+        p = lpFindInteger(lp, NULL, -50, 1);
+        assert(p != NULL);
+        lpGetIntegerValue(p, &val);
+        assert(val == -50);
+
+        /* Test: Find an existing integer (-50) with skip=2 */
+        p = lpFindInteger(lp, NULL, -50, 2);
+        assert(p == NULL);
+
+        /* Test: Find a non-existent integer (200) */
+        p = lpFindInteger(lp, NULL, 200, 0);
+        assert(p == NULL);
+
         lpFree(lp);
     }
 

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -61,6 +61,7 @@ unsigned char *lpGet(unsigned char *p, int64_t *count, unsigned char *intbuf);
 unsigned char *lpGetValue(unsigned char *p, unsigned int *slen, long long *lval);
 int lpGetIntegerValue(unsigned char *p, long long *lval);
 unsigned char *lpFind(unsigned char *lp, unsigned char *p, unsigned char *s, uint32_t slen, unsigned int skip);
+unsigned char *lpFindInteger(unsigned char *lp, unsigned char *p, long long value, unsigned int skip);
 typedef int (*lpCmp)(const unsigned char *lp, unsigned char *p, void *user, unsigned char *s, long long slen);
 unsigned char *lpFindCb(unsigned char *lp, unsigned char *p, void *user, lpCmp cmp, unsigned int skip);
 unsigned char *lpFirst(unsigned char *lp);

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -155,7 +155,8 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
             /* Not found.  */
             size_t addlen = input_is_integer ? lpEntrySizeInteger(llval) : len;
             if (lpLength(lp) < server.set_max_listpack_entries &&
-                (!input_is_integer || sdigits10(llval) <= server.set_max_listpack_value) &&
+                (input_is_integer ? sdigits10(llval) <= server.set_max_listpack_value
+                                  : len <= server.set_max_listpack_value) &&
                 lpSafeToAdd(lp, addlen))
             {
                 if (input_is_integer) {

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -119,13 +119,13 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
         return success;
     }
 
-    serverAssert(str || input_is_integer);
     if (set->encoding == OBJ_ENCODING_HT) {
         if (input_is_integer) {
             len = ll2string(tmpbuf, sizeof tmpbuf, llval);
             str = tmpbuf;
             str_is_sds = 0;
         }
+        serverAssert(str);
         /* Avoid duping the string if it is an sds string. */
         sds sdsval = str_is_sds ? (sds)str : sdsnewlen(str, len);
         dict *ht = set->ptr;
@@ -179,6 +179,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
             return 1;
         }
     } else if (set->encoding == OBJ_ENCODING_INTSET) {
+        serverAssert(str);
         long long value;
         if (string2ll(str, len, &value)) {
             uint8_t success = 0;

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -143,8 +143,13 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
     } else if (set->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *lp = set->ptr;
         unsigned char *p = lpFirst(lp);
-        if (p != NULL)
-            p = lpFind(lp, p, (unsigned char*)str, len, 0);
+        if (p != NULL) {
+            if (str == tmpbuf) {
+                p = lpFindInteger(lp, p, llval, 0);
+            } else {
+                p = lpFind(lp, p, (unsigned char*)str, len, 0);
+            }
+        }
         if (p == NULL) {
             /* Not found.  */
             if (lpLength(lp) < server.set_max_listpack_entries &&
@@ -152,8 +157,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
                 lpSafeToAdd(lp, len))
             {
                 if (str == tmpbuf) {
-                    /* This came in as integer so we can avoid parsing it again.
-                     * TODO: Create and use lpFindInteger; don't go via string. */
+                    /* This came in as integer so we can avoid parsing it again. */
                     lp = lpAppendInteger(lp, llval);
                 } else {
                     lp = lpAppend(lp, (unsigned char*)str, len);

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -110,21 +110,22 @@ int setTypeAdd(robj *subject, sds value) {
  * Returns 1 if the value was added and 0 if it was already a member. */
 int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sds) {
     char tmpbuf[LONG_STR_SIZE];
-    if (!str) {
-        if (set->encoding == OBJ_ENCODING_INTSET) {
-            uint8_t success = 0;
-            set->ptr = intsetAdd(set->ptr, llval, &success);
-            if (success) maybeConvertIntset(set);
-            return success;
-        }
-        /* Convert int to string. */
-        len = ll2string(tmpbuf, sizeof tmpbuf, llval);
-        str = tmpbuf;
-        str_is_sds = 0;
+    int input_is_integer = (str == NULL);
+
+    if (input_is_integer && set->encoding == OBJ_ENCODING_INTSET) {
+        uint8_t success = 0;
+        set->ptr = intsetAdd(set->ptr, llval, &success);
+        if (success) maybeConvertIntset(set);
+        return success;
     }
 
-    serverAssert(str);
+    serverAssert(str || input_is_integer);
     if (set->encoding == OBJ_ENCODING_HT) {
+        if (input_is_integer) {
+            len = ll2string(tmpbuf, sizeof tmpbuf, llval);
+            str = tmpbuf;
+            str_is_sds = 0;
+        }
         /* Avoid duping the string if it is an sds string. */
         sds sdsval = str_is_sds ? (sds)str : sdsnewlen(str, len);
         dict *ht = set->ptr;
@@ -144,7 +145,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
         unsigned char *lp = set->ptr;
         unsigned char *p = lpFirst(lp);
         if (p != NULL) {
-            if (str == tmpbuf) {
+            if (input_is_integer) {
                 p = lpFindInteger(lp, p, llval, 0);
             } else {
                 p = lpFind(lp, p, (unsigned char*)str, len, 0);
@@ -152,12 +153,12 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
         }
         if (p == NULL) {
             /* Not found.  */
+            size_t addlen = input_is_integer ? lpEntrySizeInteger(llval) : len;
             if (lpLength(lp) < server.set_max_listpack_entries &&
-                len <= server.set_max_listpack_value &&
-                lpSafeToAdd(lp, len))
+                (!input_is_integer || sdigits10(llval) <= server.set_max_listpack_value) &&
+                lpSafeToAdd(lp, addlen))
             {
-                if (str == tmpbuf) {
-                    /* This came in as integer so we can avoid parsing it again. */
+                if (input_is_integer) {
                     lp = lpAppendInteger(lp, llval);
                 } else {
                     lp = lpAppend(lp, (unsigned char*)str, len);
@@ -166,6 +167,10 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
             } else {
                 /* Size limit is reached. Convert to hashtable and add. */
                 setTypeConvertAndExpand(set, OBJ_ENCODING_HT, lpLength(lp) + 1, 1);
+                if (input_is_integer) {
+                    len = ll2string(tmpbuf, sizeof tmpbuf, llval);
+                    str = tmpbuf;
+                }
                 sds newval = sdsnewlen(str,len);
                 serverAssert(dictAdd(set->ptr,newval,NULL) == DICT_OK);
                 *htGetMetadataSize(set->ptr) += sdsAllocSize(newval);
@@ -635,7 +640,16 @@ void saddCommand(client *c) {
     if (server.memory_tracking_enabled)
         oldsize = kvobjAllocSize(set);
     for (j = 2; j < c->argc; j++) {
-        if (setTypeAdd(set,c->argv[j]->ptr)) added++;
+        long long llval;
+        sds ele = c->argv[j]->ptr;
+        size_t elen = sdslen(ele);
+        int added_this;
+        if (set->encoding != OBJ_ENCODING_HT && string2ll(ele, elen, &llval)) {
+            added_this = setTypeAddAux(set, NULL, 0, llval, 0);
+        } else {
+            added_this = setTypeAddAux(set, ele, elen, 0, 1);
+        }
+        if (added_this) added++;
     }
     if (server.memory_tracking_enabled)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), set, oldsize, kvobjAllocSize(set));


### PR DESCRIPTION
Changes proposed in this pull request:​​
- Code optimization
> Added integer pre-detection for set values to avoid string conversion overhead.  Introduced lpFindIntegerto directly handle integer values in listpack encoding, improving performance by passing integers straight to setTypeAddAux.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path set insertion logic and introduces a new listpack public API; incorrect integer detection or listpack search behavior could cause missed duplicates or encoding/size-threshold regressions.
> 
> **Overview**
> Optimizes `SADD`/`setTypeAddAux` for non-hashtable encodings by pre-detecting integer arguments and passing integers through the set insertion path without converting to strings.
> 
> Adds a new listpack API `lpFindInteger()` (with unit tests) to search listpacks for integer entries directly, and updates listpack-encoded set membership checks and listpack growth/threshold calculations to use integer-specific sizing and comparisons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b574ef4e62a26c59cedf2ae97346bed76f3e12d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->