### PR TITLE
Move cluster stats state out of cluster_legacy.c

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -39,6 +39,13 @@
 typedef struct _clusterNode clusterNode;
 struct clusterState;
 
+/* Struct used for storing slot statistics. */
+typedef struct clusterSlotStat {
+    uint64_t cpu_usec;          /* CPU time (in microseconds) spent on given slot */
+    uint64_t network_bytes_in;  /* Network ingress (in bytes) received for given slot */
+    uint64_t network_bytes_out; /* Network egress (in bytes) sent for given slot */
+} clusterSlotStat;
+
 /* Flags that a module can set in order to prevent certain Redis Cluster
  * features to be enabled. Useful when implementing a different distributed
  * system on top of Redis Cluster message bus, using modules. */

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -331,13 +331,6 @@ struct _clusterNode {
     list *fail_reports;         /* List of nodes signaling this as failing */
 };
 
-/* Struct used for storing slot statistics. */
-typedef struct slotStat {
-    uint64_t cpu_usec;          /* CPU time (in microseconds) spent on given slot */
-    uint64_t network_bytes_in;  /* Network ingress (in bytes) received for given slot */
-    uint64_t network_bytes_out; /* Network egress (in bytes) sent for given slot */
-} slotStat;
-
 struct clusterState {
     clusterNode *myself;  /* This node */
     uint64_t currentEpoch;
@@ -385,8 +378,6 @@ struct clusterState {
      * stops claiming the slot. This prevents spreading incorrect information (that
      * source still owns the slot) using UPDATE messages. */
     unsigned char owner_not_claiming_slot[CLUSTER_SLOTS / 8];
-    /* Struct used for storing slot statistics, for all slots owned by the current shard. */
-    slotStat slot_stats[CLUSTER_SLOTS];
 };
 
 

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -203,7 +203,7 @@ void clusterSlotStatReset(int slot) {
 }
 
 void clusterSlotStatResetAll(void) {
-    memset(server.cluster_slot_stats, 0, CLUSTER_SLOTS * sizeof(*server.cluster_slot_stats));
+    memset(server.cluster_slot_stats, 0, CLUSTER_SLOTS * sizeof(clusterSlotStat));
 }
 
 /* For cpu-usec accumulation, nested commands within EXEC, EVAL, FCALL are skipped.

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -13,6 +13,7 @@
  */
 
 #include "cluster_slot_stats.h"
+#include "cluster.h"
 
 typedef enum {
     KEY_COUNT,
@@ -47,9 +48,9 @@ static int markSlotsAssignedToMyShard(unsigned char *assigned_slots, int start_s
 static uint64_t getSlotStat(int slot, slotStatType stat_type) {
     switch (stat_type) {
     case KEY_COUNT: return countKeysInSlot(slot);
-    case CPU_USEC: return server.cluster->slot_stats[slot].cpu_usec;
-    case NETWORK_BYTES_IN: return server.cluster->slot_stats[slot].network_bytes_in;
-    case NETWORK_BYTES_OUT: return server.cluster->slot_stats[slot].network_bytes_out;
+    case CPU_USEC: return server.cluster_slot_stats[slot].cpu_usec;
+    case NETWORK_BYTES_IN: return server.cluster_slot_stats[slot].network_bytes_in;
+    case NETWORK_BYTES_OUT: return server.cluster_slot_stats[slot].network_bytes_out;
     default: serverPanic("Invalid slot stat type %d was found.", stat_type);
     }
 }
@@ -99,11 +100,11 @@ static void addReplySlotStat(client *c, int slot) {
      * and are aggregated and returned based on its server config. */
     if (server.cluster_slot_stats_enabled) {
         addReplyBulkCString(c, "cpu-usec");
-        addReplyLongLong(c, server.cluster->slot_stats[slot].cpu_usec);
+        addReplyLongLong(c, server.cluster_slot_stats[slot].cpu_usec);
         addReplyBulkCString(c, "network-bytes-in");
-        addReplyLongLong(c, server.cluster->slot_stats[slot].network_bytes_in);
+        addReplyLongLong(c, server.cluster_slot_stats[slot].network_bytes_in);
         addReplyBulkCString(c, "network-bytes-out");
-        addReplyLongLong(c, server.cluster->slot_stats[slot].network_bytes_out);
+        addReplyLongLong(c, server.cluster_slot_stats[slot].network_bytes_out);
     }
 }
 
@@ -136,7 +137,7 @@ void clusterSlotStatsAddNetworkBytesOutForUserClient(client *c) {
     if (!canAddNetworkBytesOut(c)) return;
 
     serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
-    server.cluster->slot_stats[c->slot].network_bytes_out += c->net_output_bytes_curr_cmd;
+    server.cluster_slot_stats[c->slot].network_bytes_out += c->net_output_bytes_curr_cmd;
 }
 
 /* Accumulates egress bytes upon sending replication stream. This only applies for primary nodes. */
@@ -147,11 +148,11 @@ static void clusterSlotStatsUpdateNetworkBytesOutForReplication(long long len) {
     /* We multiply the bytes len by the number of replicas to account for us broadcasting to multiple replicas at once. */
     len *= (long long)listLength(server.slaves);
     serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
-    serverAssert(nodeIsMaster(server.cluster->myself));
+    serverAssert(clusterNodeIsMaster(getMyClusterNode()));
     /* We sometimes want to adjust the counter downwards (for example when we want to undo accounting for
      * SELECT commands that don't belong to any slot) so let's make sure we don't underflow the counter. */
-    serverAssert(len >= 0 || server.cluster->slot_stats[c->slot].network_bytes_out >= (uint64_t)-len);
-    server.cluster->slot_stats[c->slot].network_bytes_out += len;
+    serverAssert(len >= 0 || server.cluster_slot_stats[c->slot].network_bytes_out >= (uint64_t)-len);
+    server.cluster_slot_stats[c->slot].network_bytes_out += len;
 }
 
 /* Increment network bytes out for replication stream. This method will increment `len` value times the active replica
@@ -179,7 +180,7 @@ void clusterSlotStatsAddNetworkBytesOutForShardedPubSubInternalPropagation(clien
     c->slot = slot;
     if (canAddNetworkBytesOut(c)) {
         serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
-        server.cluster->slot_stats[c->slot].network_bytes_out += c->net_output_bytes_curr_cmd;
+        server.cluster_slot_stats[c->slot].network_bytes_out += c->net_output_bytes_curr_cmd;
     }
     /* For sharded pubsub, the client's network bytes metrics must be reset here,
      * as resetClient() is not called until subscription ends. */
@@ -198,11 +199,11 @@ static void addReplyOrderBy(client *c, slotStatType order_by, long limit, int de
 /* Resets applicable slot statistics. */
 void clusterSlotStatReset(int slot) {
     /* key-count is exempt, as it is queried separately through `countKeysInSlot()`. */
-    memset(&server.cluster->slot_stats[slot], 0, sizeof(slotStat));
+    memset(&server.cluster_slot_stats[slot], 0, sizeof(clusterSlotStat));
 }
 
 void clusterSlotStatResetAll(void) {
-    memset(server.cluster->slot_stats, 0, sizeof(server.cluster->slot_stats));
+    memset(server.cluster_slot_stats, 0, CLUSTER_SLOTS * sizeof(*server.cluster_slot_stats));
 }
 
 /* For cpu-usec accumulation, nested commands within EXEC, EVAL, FCALL are skipped.
@@ -223,7 +224,7 @@ void clusterSlotStatsAddCpuDuration(client *c, ustime_t duration) {
     if (!canAddCpuDuration(c)) return;
 
     serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
-    server.cluster->slot_stats[c->slot].cpu_usec += duration;
+    server.cluster_slot_stats[c->slot].cpu_usec += duration;
 }
 
 /* For cross-slot scripting, its caller client's slot must be invalidated,
@@ -258,7 +259,7 @@ void clusterSlotStatsAddNetworkBytesInForUserClient(client *c) {
         c->net_input_bytes_curr_cmd += 15;
     }
 
-    server.cluster->slot_stats[c->slot].network_bytes_in += c->net_input_bytes_curr_cmd;
+    server.cluster_slot_stats[c->slot].network_bytes_in += c->net_input_bytes_curr_cmd;
 }
 
 void clusterSlotStatsCommand(client *c) {

--- a/src/cluster_slot_stats.h
+++ b/src/cluster_slot_stats.h
@@ -13,9 +13,7 @@
  */
 
 #include "server.h"
-#include "cluster.h"
 #include "script.h"
-#include "cluster_legacy.h"
 
 /* General use-cases. */
 void clusterSlotStatReset(int slot);

--- a/src/server.c
+++ b/src/server.c
@@ -7600,7 +7600,7 @@ int main(int argc, char **argv) {
     redisAsciiArt();
     checkTcpBacklogSettings();
     if (server.cluster_enabled) {
-        server.cluster_slot_stats = zmalloc(CLUSTER_SLOTS*sizeof(*server.cluster_slot_stats));
+        server.cluster_slot_stats = zmalloc(CLUSTER_SLOTS*sizeof(clusterSlotStat));
         clusterInit();
     }
     if (!server.sentinel_mode) {

--- a/src/server.c
+++ b/src/server.c
@@ -7600,6 +7600,7 @@ int main(int argc, char **argv) {
     redisAsciiArt();
     checkTcpBacklogSettings();
     if (server.cluster_enabled) {
+        server.cluster_slot_stats = zmalloc(CLUSTER_SLOTS*sizeof(*server.cluster_slot_stats));
         clusterInit();
     }
     if (!server.sentinel_mode) {

--- a/src/server.h
+++ b/src/server.h
@@ -839,6 +839,7 @@ struct moduleLoadQueueEntry;
 struct RedisModuleKeyOptCtx;
 struct RedisModuleCommand;
 struct clusterState;
+struct clusterSlotStat;
 
 /* Each module type implementation should export a set of methods in order
  * to serialize and deserialize the value in the RDB file, rewrite the AOF
@@ -2236,6 +2237,7 @@ struct redisServer {
     mstime_t cluster_ping_interval;    /* A debug configuration for setting how often cluster nodes send ping messages. */
     char *cluster_configfile; /* Cluster auto-generated config file name. */
     struct clusterState *cluster;  /* State of the cluster */
+    struct clusterSlotStat *cluster_slot_stats; /* Struct used for storing slot statistics, for all slots owned by the current shard. */
     int cluster_migration_barrier; /* Cluster replicas migration barrier. */
     int cluster_allow_replica_migration; /* Automatic replica migrations to orphaned masters and from empty masters */
     int cluster_slave_validity_factor; /* Slave max data age for failover. */


### PR DESCRIPTION
In certain build configurations cluster_legacy.c is not being linked in.

To handle this cluster slots stats state is referenced from the global `server` state instead.