### PR TITLE
Fix heap-buffer-overflow in CLUSTER FORGET with invalid node ID length

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1852,8 +1852,8 @@ void clusterBlacklistAddNode(clusterNode *node) {
 /* Return non-zero if the specified node ID exists in the blacklist.
  * You don't need to pass an sds string here, any pointer to 40 bytes
  * will work. */
-int clusterBlacklistExists(char *nodeid) {
-    sds id = sdsnewlen(nodeid,CLUSTER_NAMELEN);
+int clusterBlacklistExists(char *nodeid, size_t len) {
+    sds id = sdsnewlen(nodeid,len);
     int retval;
 
     clusterBlacklistCleanup();
@@ -2208,7 +2208,7 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
              * joining another cluster. */
             if (sender &&
                 !(flags & CLUSTER_NODE_NOADDR) &&
-                !clusterBlacklistExists(g->nodename))
+                !clusterBlacklistExists(g->nodename, CLUSTER_NAMELEN))
             {
                 clusterNode *node;
                 node = createClusterNode(g->nodename, flags);
@@ -6223,7 +6223,7 @@ int clusterCommandSpecial(client *c) {
         /* CLUSTER FORGET <NODE ID> */
         clusterNode *n = clusterLookupNode(c->argv[2]->ptr, sdslen(c->argv[2]->ptr));
         if (!n) {
-            if (clusterBlacklistExists((char*)c->argv[2]->ptr))
+            if (clusterBlacklistExists((char*)c->argv[2]->ptr, sdslen(c->argv[2]->ptr)))
                 /* Already forgotten. The deletion may have been gossipped by
                  * another node, so we pretend it succeeded. */
                 addReply(c,shared.ok);

--- a/tests/cluster/tests/00-base.tcl
+++ b/tests/cluster/tests/00-base.tcl
@@ -87,3 +87,7 @@ test "CLUSTER SLAVES and CLUSTER REPLICAS with zero replicas" {
     assert_equal {} [R 0 cluster slaves [R 0 CLUSTER MYID]]
     assert_equal {} [R 0 cluster replicas [R 0 CLUSTER MYID]]
 }
+
+test "CLUSTER FORGET with invalid node ID" {
+    assert_error {*ERR Unknown node*} {r cluster forget 1}
+}


### PR DESCRIPTION
## Description

Fix a heap-buffer-overflow vulnerability in the `CLUSTER FORGET` command when provided with a node ID shorter than the expected 40 bytes.

### The Issue

When `CLUSTER FORGET` is called with a node ID that has a length smaller than `CLUSTER_NAMELEN` (40 bytes), the `clusterBlacklistExists()` function would read beyond the allocated string buffer. This occurs because the function always attempted to read exactly 40 bytes via `sdsnewlen(nodeid, CLUSTER_NAMELEN)`.

This primarily impacts memory inspection tools (e.g., AddressSanitizer) and could potentially cause issues in production environments.

### Changes

- Added a `size_t len` parameter to `clusterBlacklistExists()` to use the actual string length
- Updated all call sites to pass the appropriate length
- Added a test case to verify the fix
- Test added to verify that `CLUSTER FORGET` with an invalid short node ID returns an appropriate error.

This PR is based on:
    valkey-io/valkey#2108

Co-authored-by: Ran Shidlansik <ranshid@amazon.com>