### PR TITLE
Fix shutdown blocked client not being properly reset after shutdown cancellation

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -122,6 +122,18 @@ void processUnblockedClients(void) {
         listDelNode(server.unblocked_clients,ln);
         c->flags &= ~CLIENT_UNBLOCKED;
 
+        /* Reset the client for a new query, unless the client has pending command to process
+         * or in case a shutdown operation was canceled and we are still in the processCommand sequence  */
+        if (!(c->flags & CLIENT_PENDING_COMMAND)) {
+            freeClientOriginalArgv(c);
+            /* Clients that are not blocked on keys are not reprocessed so we must
+             * call reqresAppendResponse here (for clients blocked on key,
+             * unblockClientOnKey is called, which eventually calls processCommand,
+             * which calls reqresAppendResponse) */
+            reqresAppendResponse(c);
+            resetClient(c);
+        }
+
         if (c->flags & CLIENT_MODULE) {
             if (!(c->flags & CLIENT_BLOCKED)) {
                 moduleCallCommandUnblockedHandler(c);
@@ -191,17 +203,6 @@ void unblockClient(client *c, int queue_for_reprocessing) {
         serverPanic("Unknown btype in unblockClient().");
     }
 
-    /* Reset the client for a new query, unless the client has pending command to process
-     * or in case a shutdown operation was canceled and we are still in the processCommand sequence  */
-    if (!(c->flags & CLIENT_PENDING_COMMAND) && c->bstate.btype != BLOCKED_SHUTDOWN) {
-        freeClientOriginalArgv(c);
-        /* Clients that are not blocked on keys are not reprocessed so we must
-         * call reqresAppendResponse here (for clients blocked on key,
-         * unblockClientOnKey is called, which eventually calls processCommand,
-         * which calls reqresAppendResponse) */
-        reqresAppendResponse(c);
-        resetClient(c);
-    }
 
     /* Clear the flags, and put the client in the unblocked list so that
      * we'll process new commands in its query buffer ASAP. */
@@ -266,6 +267,7 @@ void replyToClientsBlockedOnShutdown(void) {
     while((ln = listNext(&li))) {
         client *c = listNodeValue(ln);
         if (c->flags & CLIENT_BLOCKED && c->bstate.btype == BLOCKED_SHUTDOWN) {
+            c->duration = 0;
             addReplyError(c, "Errors trying to SHUTDOWN. Check logs.");
             unblockClient(c, 1);
         }

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -122,8 +122,7 @@ void processUnblockedClients(void) {
         listDelNode(server.unblocked_clients,ln);
         c->flags &= ~CLIENT_UNBLOCKED;
 
-        /* Reset the client for a new query, unless the client has pending command to process
-         * or in case a shutdown operation was canceled and we are still in the processCommand sequence  */
+        /* Reset the client for a new query, unless the client has pending command to process. */
         if (!(c->flags & CLIENT_PENDING_COMMAND)) {
             freeClientOriginalArgv(c);
             /* Clients that are not blocked on keys are not reprocessed so we must

--- a/src/networking.c
+++ b/src/networking.c
@@ -2893,7 +2893,7 @@ int processInputBuffer(client *c) {
     /* Keep processing while there is something in the input buffer */
     while(c->qb_pos < sdslen(c->querybuf)) {
         /* Immediately abort if the client is in the middle of something. */
-        if (c->flags & CLIENT_BLOCKED) break;
+        if (c->flags & CLIENT_BLOCKED && c->flags & CLIENT_UNBLOCKED) break;
 
         /* Don't process more buffers from clients that have already pending
          * commands to execute in c->argv. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -2893,7 +2893,7 @@ int processInputBuffer(client *c) {
     /* Keep processing while there is something in the input buffer */
     while(c->qb_pos < sdslen(c->querybuf)) {
         /* Immediately abort if the client is in the middle of something. */
-        if (c->flags & CLIENT_BLOCKED && c->flags & CLIENT_UNBLOCKED) break;
+        if (c->flags & CLIENT_BLOCKED || c->flags & CLIENT_UNBLOCKED) break;
 
         /* Don't process more buffers from clients that have already pending
          * commands to execute in c->argv. */

--- a/tests/integration/shutdown.tcl
+++ b/tests/integration/shutdown.tcl
@@ -177,6 +177,12 @@ test "Shutting down master waits for replica then fails" {
             catch { $rd2 read } e2
             assert_match "*Errors trying to SHUTDOWN. Check logs*" $e1
             assert_match "*Errors trying to SHUTDOWN. Check logs*" $e2
+
+            # Verify that after shutdown is cancelled, the client is properly
+            # reset and can handle other commands normally.
+            $rd1 PING
+            assert_equal "PONG" [$rd1 read]
+
             $rd1 close
             $rd2 close
 


### PR DESCRIPTION
This issue was introduced by https://github.com/redis/redis/pull/10440
In that PR, we avoided resetting the current user during processCommand, but overlooked the fact that this client might not be the current one, it could be a client that was previously blocked due to shutdown.
If we don’t reset these clients, and the shutdown is canceled, then when these clients continue executing other commands, they will trigger an assertion.

This PR delays the operation of resetting the client to processUnblockedClients and no longer skips SHUTDOWN_BLOCKED clients.
