### PR TITLE
Add VRANGE to ignored commands for schemas validator

### DIFF
--- a/utils/req-res-log-validator.py
+++ b/utils/req-res-log-validator.py
@@ -71,6 +71,7 @@ IGNORED_COMMANDS = {
     "VSETATTR",
     "VSIM",
     "VISMEMBER",
+    "VRANGE",
 }
 
 class Request(object):


### PR DESCRIPTION
In https://github.com/redis/redis/pull/14235 we forgot to skip vset module command `VRANGE` for schema validator

failed CI: https://github.com/redis/redis/actions/runs/18392425492/job/52405239744