### PR TITLE
Sentinel: Verify replication ID before promoting slave during failover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ Makefile.dep
 .ccls-cache/*
 compile_commands.json
 redis.code-workspace
+.DS_Store

--- a/sentinel.conf
+++ b/sentinel.conf
@@ -145,14 +145,14 @@ sentinel down-after-milliseconds mymaster 30000
 #   user worker +@admin +@connection ~* on >ffa9203c493aa99
 #
 # For more information about ACL configuration please refer to the Redis
-# website at https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/ and redis server configuration 
+# website at https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/ and redis server configuration
 # template redis.conf.
 
 # ACL LOG
 #
 # The ACL Log tracks failed commands and authentication events associated
-# with ACLs. The ACL Log is useful to troubleshoot failed commands blocked 
-# by ACLs. The ACL Log is stored in memory. You can reclaim memory with 
+# with ACLs. The ACL Log is useful to troubleshoot failed commands blocked
+# by ACLs. The ACL Log is stored in memory. You can reclaim memory with
 # ACL LOG RESET. Define the maximum entry length of the ACL Log below.
 acllog-max-len 128
 
@@ -184,7 +184,7 @@ acllog-max-len 128
 #
 # New config files are advised to use separate authentication control for
 # incoming connections (via ACL), and for outgoing connections (via
-# sentinel-user and sentinel-pass) 
+# sentinel-user and sentinel-pass)
 #
 # The requirepass is not compatible with aclfile option and the ACL LOAD
 # command, these will cause requirepass to be ignored.
@@ -192,7 +192,7 @@ acllog-max-len 128
 # sentinel sentinel-user <username>
 #
 # You can configure Sentinel to authenticate with other Sentinels with specific
-# user name. 
+# user name.
 
 # sentinel sentinel-pass <password>
 #
@@ -254,7 +254,7 @@ sentinel failover-timeout mymaster 180000
 # NOTIFICATION SCRIPT
 #
 # sentinel notification-script <master-name> <script-path>
-# 
+#
 # Call the specified notification script for any sentinel event that is
 # generated in the WARNING level (for instance -sdown, -odown, and so forth).
 # This script should notify the system administrator via email, SMS, or any

--- a/src/replication.c
+++ b/src/replication.c
@@ -1862,6 +1862,7 @@ void updateSlavesWaitingBgsave(int bgsaveerr, int type) {
 void changeReplicationId(void) {
     getRandomHexChars(server.replid,CONFIG_RUN_ID_SIZE);
     server.replid[CONFIG_RUN_ID_SIZE] = '\0';
+    serverLog(LL_NOTICE, "Changed replication ID to %s", server.port, server.replid);
 }
 
 /* Clear (invalidate) the secondary replication ID. This happens, for

--- a/src/replication.c
+++ b/src/replication.c
@@ -1862,7 +1862,7 @@ void updateSlavesWaitingBgsave(int bgsaveerr, int type) {
 void changeReplicationId(void) {
     getRandomHexChars(server.replid,CONFIG_RUN_ID_SIZE);
     server.replid[CONFIG_RUN_ID_SIZE] = '\0';
-    serverLog(LL_NOTICE, "Changed replication ID to %s", server.port, server.replid);
+    serverLog(LL_NOTICE, "Changed replication ID to %s", server.replid);
 }
 
 /* Clear (invalidate) the secondary replication ID. This happens, for

--- a/src/sds.c
+++ b/src/sds.c
@@ -221,6 +221,13 @@ void sdsfreegeneric(void *s) {
     sdsfree((sds)s);
 }
 
+/* A helper function to free a not-NULL sds string and reassign
+ * a new sds string. */
+void sdsReplace(sds *dest, sds new_str) {
+    if (*dest != NULL) sdsfree(*dest);
+    *dest = new_str;
+}
+
 /* Set the sds string length to the length as obtained with strlen(), so
  * considering as content only up to the first null term character.
  *

--- a/src/sds.h
+++ b/src/sds.h
@@ -225,6 +225,7 @@ sds sdscat(sds s, const char *t);
 sds sdscatsds(sds s, const sds t);
 sds sdscpylen(sds s, const char *t, size_t len);
 sds sdscpy(sds s, const char *t);
+void sdsReplace(sds *dest, sds new_str);
 
 sds sdscatvprintf(sds s, const char *fmt, va_list ap);
 #ifdef __GNUC__

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3024,7 +3024,7 @@ void sentinelProcessHelloMessage(char *hello, int hello_len) {
 
                 sentinelEvent(LL_WARNING,"+config-update-from",si,"%@");
                 sentinelEvent(LL_WARNING,"+switch-master",
-                    master,"%s %s %d %s %d",
+                    master,"%s from %s %d to %s %d",
                     master->name,
                     announceSentinelAddr(master->addr), master->addr->port,
                     token[5], master_port);
@@ -3600,6 +3600,10 @@ void addReplySentinelRedisInstance(client *c, sentinelRedisInstance *ri) {
         addReplyBulkLongLong(c,ri->quorum);
         fields++;
 
+        addReplyBulkCString(c, "master-replid");
+        addReplyBulkCString(c, ri->master_replid);
+        fields++;
+
         addReplyBulkCString(c,"failover-timeout");
         addReplyBulkLongLong(c,ri->failover_timeout);
         fields++;
@@ -3640,6 +3644,10 @@ void addReplySentinelRedisInstance(client *c, sentinelRedisInstance *ri) {
 
         addReplyBulkCString(c,"master-port");
         addReplyBulkLongLong(c,ri->slave_master_port);
+        fields++;
+
+        addReplyBulkCString(c, "master-replid");
+        addReplyBulkCString(c, ri->slave_master_replid);
         fields++;
 
         addReplyBulkCString(c,"slave-priority");
@@ -5172,7 +5180,7 @@ sentinelRedisInstance *sentinelSelectSlave(sentinelRedisInstance *master) {
         if (slave->slave_priority == 0) continue;
 
         /* It's possible that the sentinel has just detected the slave
-         * instance and hasn't got the chance to verify its replciation
+         * instance and hasn't got the chance to verify its replication
          * ID before the failover process starts. */
         if (slave->is_relevant_to_master == REPLID_UNVERIFIED) {
             slave->is_relevant_to_master = isSlaveRelevant(slave, master);

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -118,6 +118,11 @@ static mstime_t sentinel_default_failover_timeout = 60*3*1000;
 #define SENTINEL_SIMFAILURE_CRASH_AFTER_ELECTION (1<<0)
 #define SENTINEL_SIMFAILURE_CRASH_AFTER_PROMOTION (1<<1)
 
+/* Flags used to verify slaves' replication lineage */
+#define REPLID_UNVERIFIED 0
+#define REPLID_RELEVANT 1
+#define REPLID_NOT_RELEVANT 2
+
 /* The link to a sentinelRedisInstance. When we have the same set of Sentinels
  * monitoring many masters, we have different instances representing the
  * same Sentinels, one per master, and we need to share the hiredis connections
@@ -199,6 +204,9 @@ typedef struct sentinelRedisInstance {
     int parallel_syncs; /* How many slaves to reconfigure at same time. */
     char *auth_pass;    /* Password to use for AUTH against master & replica. */
     char *auth_user;    /* Username for ACLs AUTH against master & replica. */
+    char *master_replid; /* Master's current replication ID */
+    char *master_replid2; /* Master's previous replication ID */
+    long long second_repl_offset; /* Master accepts offsets up to this for replid2 */
 
     /* Slave specific. */
     mstime_t master_link_down_time; /* Slave replication link down time. */
@@ -209,7 +217,10 @@ typedef struct sentinelRedisInstance {
     char *slave_master_host;    /* Master host as reported by INFO */
     int slave_master_port;      /* Master port as reported by INFO */
     int slave_master_link_status; /* Master link status as reported by INFO */
-    unsigned long long slave_repl_offset; /* Slave replication offset. */
+    char *slave_master_replid; /* Master's current replication ID from slave's view */
+    long long slave_repl_offset; /* Slave replication offset */
+    int is_relevant_to_master; /* A flag shows whether the replication lineage matches */
+
     /* Failover */
     char *leader;       /* If this is a master instance, this is the runid of
                            the Sentinel that should perform the failover. If
@@ -446,7 +457,7 @@ void sentinelConfigSetCommand(client *c);
 
 /* this array is used for sentinel config lookup, which need to be loaded
  * before monitoring masters config to avoid dependency issues */
-const char *preMonitorCfgName[] = { 
+const char *preMonitorCfgName[] = {
     "announce-ip",
     "announce-port",
     "deny-scripts-reconfig",
@@ -599,7 +610,7 @@ int sentinelAddrEqualsHostname(sentinelAddr *a, char *hostname) {
                     sentinel.resolve_hostnames ? ANET_NONE : ANET_IP_ONLY) == ANET_ERR) {
 
         /* If failed resolve then compare based on hostnames. That is our best effort as
-         * long as the server is unavailable for some reason. It is fine since Redis 
+         * long as the server is unavailable for some reason. It is fine since Redis
          * instance cannot have multiple hostnames for a given setup */
         return !strcasecmp(sentinel.resolve_hostnames ? a->hostname : a->ip, hostname);
     }
@@ -1124,7 +1135,7 @@ void dropInstanceConnections(sentinelRedisInstance *ri) {
     /* Disconnect with the master. */
     instanceLinkCloseConnection(ri->link, ri->link->cc);
     instanceLinkCloseConnection(ri->link, ri->link->pc);
-    
+
     /* Disconnect with all replicas. */
     dictIterator di;
     dictEntry *de;
@@ -1315,23 +1326,33 @@ sentinelRedisInstance *createSentinelRedisInstance(char *name, int flags, char *
     ri->o_down_since_time = 0;
     ri->down_after_period = master ? master->down_after_period : sentinel_default_down_after;
     ri->master_reboot_down_after_period = 0;
-    ri->master_link_down_time = 0;
+    ri->master_reboot_since_time = 0;
+    ri->info_refresh = 0;
+    ri->renamed_commands = dictCreate(&renamedCommandsDictType);
+
+    /* Master specific */
+    ri->sentinels = dictCreate(&instancesDictType);
+    ri->slaves = dictCreate(&instancesDictType);
+    ri->quorum = quorum;
+    ri->parallel_syncs = SENTINEL_DEFAULT_PARALLEL_SYNCS;
     ri->auth_pass = NULL;
     ri->auth_user = NULL;
+    ri->master_replid = NULL;
+    ri->master_replid2 = NULL;
+    ri->second_repl_offset = 0;
+
+    /* Slave specific. */
+    ri->master_link_down_time = 0;
     ri->slave_priority = SENTINEL_DEFAULT_SLAVE_PRIORITY;
     ri->replica_announced = 1;
     ri->slave_reconf_sent_time = 0;
+    ri->master = master;
     ri->slave_master_host = NULL;
     ri->slave_master_port = 0;
     ri->slave_master_link_status = SENTINEL_MASTER_LINK_STATUS_DOWN;
+    ri->slave_master_replid = NULL;
     ri->slave_repl_offset = 0;
-    ri->sentinels = dictCreate(&instancesDictType);
-    ri->quorum = quorum;
-    ri->parallel_syncs = SENTINEL_DEFAULT_PARALLEL_SYNCS;
-    ri->master = master;
-    ri->slaves = dictCreate(&instancesDictType);
-    ri->info_refresh = 0;
-    ri->renamed_commands = dictCreate(&renamedCommandsDictType);
+    ri->is_relevant_to_master = REPLID_UNVERIFIED;
 
     /* Failover state. */
     ri->leader = NULL;
@@ -1379,6 +1400,9 @@ void releaseSentinelRedisInstance(sentinelRedisInstance *ri) {
     sdsfree(ri->auth_pass);
     sdsfree(ri->auth_user);
     sdsfree(ri->info);
+    sdsfree(ri->master_replid);
+    sdsfree(ri->master_replid2);
+    sdsfree(ri->slave_master_replid);
     releaseSentinelAddr(ri->addr);
     dictRelease(ri->renamed_commands);
 
@@ -1536,6 +1560,7 @@ void sentinelResetMaster(sentinelRedisInstance *ri, int flags) {
     sdsfree(ri->slave_master_host);
     ri->runid = NULL;
     ri->slave_master_host = NULL;
+    ri->is_relevant_to_master = REPLID_UNVERIFIED;
     ri->link->act_ping_time = mstime();
     ri->link->last_ping_time = 0;
     ri->link->last_avail_time = mstime();
@@ -1589,7 +1614,7 @@ int sentinelResetMasterAndChangeAddress(sentinelRedisInstance *master, char *hos
      * and It can add old master 1 more slave. 
      * so It allocates dictSize(master->slaves) + 1          */
     slaves = zmalloc(sizeof(sentinelAddr*)*(dictSize(master->slaves) + 1));
-    
+
     /* Don't include the one having the address we are switching to. */
     dictInitIterator(&di, master->slaves);
     while((de = dictNext(&di)) != NULL) {
@@ -1630,6 +1655,44 @@ int sentinelResetMasterAndChangeAddress(sentinelRedisInstance *master, char *hos
     releaseSentinelAddr(oldaddr);
     sentinelFlushConfig();
     return C_OK;
+}
+
+/* Helper function to check whether the slave is actually relevant
+ * (if both of the following conditions are true) to the master.
+ * [1] slave's master address is the same as the provided master
+ * [2] slave's replication lineage matches with provided master's
+ *     current lineage.
+ *
+ * Notes: A slave can become irrelevant. For example, users can
+ * manually send command `replicaof` to ask a slave to follow a
+ * different master. Or, a slave instance gets assigned a rotating
+ * IP address previously owned by another slave, and thus another
+ * cluster discovers this slave mistakenly.
+ */
+int isSlaveRelevant(sentinelRedisInstance *slave, sentinelRedisInstance *master) {
+    /* Check address */
+    if (slave->slave_master_host) {
+        if (strcasecmp(slave->slave_master_host, master->addr->hostname) != 0 &&
+            strcasecmp(slave->slave_master_host, master->addr->ip) != 0) {
+            return 0;
+        }
+        if (slave->slave_master_port != master->addr->port) {
+            return 0;
+        }
+    }
+
+    /* Check replication lineage */
+    if (slave->slave_master_replid && master->master_replid) {
+        /* Compare against master's current replication lineage */
+        if (!strcasecmp(slave->slave_master_replid, master->master_replid)) {
+            return 1;
+        }
+        if (!strcasecmp(slave->slave_master_replid, master->master_replid2) &&
+            slave->slave_repl_offset <= master->second_repl_offset) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 /* Return non-zero if there was no SDOWN or ODOWN error associated to this
@@ -2490,7 +2553,7 @@ int sentinelMasterLooksSane(sentinelRedisInstance *master) {
         (mstime() - master->info_refresh) < sentinel_info_period*2;
 }
 
-/* Process the INFO output from masters. */
+/* Process the INFO output from masters and slaves. */
 void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
     sds *lines;
     int numlines, j;
@@ -2518,7 +2581,7 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
                 if (strncmp(ri->runid,l+7,40) != 0) {
                     sentinelEvent(LL_NOTICE,"+reboot",ri,"%@");
 
-                    if (ri->flags & SRI_MASTER && ri->master_reboot_down_after_period != 0) {
+                    if (ri->flags & SRI_MASTER) {
                         ri->flags |= SRI_MASTER_REBOOT;
                         ri->master_reboot_since_time = mstime();
                     }
@@ -2580,6 +2643,18 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
         if (sdslen(l) >= 11 && !memcmp(l,"role:master",11)) role = SRI_MASTER;
         else if (sdslen(l) >= 10 && !memcmp(l,"role:slave",10)) role = SRI_SLAVE;
 
+        if (role == SRI_MASTER) {
+            if (sdslen(l) >= 14 && !memcmp(l, "master_replid:", 14)) {
+                sdsReplace(&ri->master_replid, sdsnew(l+14));
+            }
+            if (sdslen(l) >= 15 && !memcmp(l, "master_replid2:", 15)) {
+                sdsReplace(&ri->master_replid2, sdsnew(l+15));
+            }
+            if (sdslen(l) >= 19 && !memcmp(l, "second_repl_offset:", 19)) {
+                ri->second_repl_offset = strtoll(l + 19, NULL, 10);
+            }
+        }
+
         if (role == SRI_SLAVE) {
             /* master_host:<host> */
             if (sdslen(l) >= 12 && !memcmp(l,"master_host:",12)) {
@@ -2614,9 +2689,14 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
             if (sdslen(l) >= 15 && !memcmp(l,"slave_priority:",15))
                 ri->slave_priority = atoi(l+15);
 
+            /* slave reported replication ID */
+            if (sdslen(l) >= 14 && !memcmp(l, "master_replid:", 14)) {
+                sdsReplace(&ri->slave_master_replid, sdsnew(l+14));
+            }
+
             /* slave_repl_offset:<offset> */
             if (sdslen(l) >= 18 && !memcmp(l,"slave_repl_offset:",18))
-                ri->slave_repl_offset = strtoull(l+18,NULL,10);
+                ri->slave_repl_offset = strtoll(l+18,NULL,10);
 
             /* replica_announced:<announcement> */
             if (sdslen(l) >= 18 && !memcmp(l,"replica_announced:",18))
@@ -2625,6 +2705,19 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
     }
     ri->info_refresh = mstime();
     sdsfreesplitres(lines,numlines);
+    if (ri->flags & SRI_SLAVE) {
+        /* We should not claim a slave irrelevant immediately after the
+         * master reboots and gets a new replid. */
+        mstime_t wait_time = sentinel_publish_period*4;
+        if (isSlaveRelevant(ri, ri->master)) {
+            ri->is_relevant_to_master = REPLID_RELEVANT;
+        } else if (sentinelMasterLooksSane(ri->master) &&
+            sentinelRedisInstanceNoDownFor(ri->master, wait_time) &&
+            (ri->master->master_reboot_since_time == 0 ||
+                mstime() - ri->master->master_reboot_since_time > wait_time)) {
+            ri->is_relevant_to_master = REPLID_NOT_RELEVANT;
+        }
+    }
 
     /* ---------------------------- Acting half -----------------------------
      * Some things will not happen if sentinel.tilt is true, but some will
@@ -2664,7 +2757,7 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
             (ri->master->failover_state ==
                 SENTINEL_FAILOVER_STATE_WAIT_PROMOTION))
         {
-            /* Now that we are sure the slave was reconfigured as a master
+            /* Now that we are sure the slave was reconfigured as a master,
              * set the master configuration epoch to the epoch we won the
              * election to perform this failover. This will force the other
              * Sentinels to update their config (assuming there is not
@@ -3126,7 +3219,10 @@ void sentinelSendPeriodicCommands(sentinelRedisInstance *ri) {
         ((ri->master->flags & (SRI_O_DOWN|SRI_FAILOVER_IN_PROGRESS)) ||
          (ri->master_link_down_time != 0)))
     {
-        info_period = 1000;
+        /* If the user-defined info period is even more frequent than every
+         * second, we're willing to accept it. This is usually seen in the
+         * sentinel tests where we set info period to 500 or even 100ms. */
+        info_period = sentinel_info_period < 1000 ? sentinel_info_period : 1000;
     } else {
         info_period = sentinel_info_period;
     }
@@ -4010,6 +4106,8 @@ NULL
         if (c->argc != 3) goto numargserr;
         if ((ri = sentinelGetMasterByNameOrReplyError(c,c->argv[2])) == NULL)
             return;
+        serverLog(LL_NOTICE,"Accepted user requested FAILOVER of '%s'",
+            ri->name);
         if (ri->flags & SRI_FAILOVER_IN_PROGRESS) {
             addReplyError(c,"-INPROG Failover already in progress");
             return;
@@ -4573,7 +4671,8 @@ void sentinelCheckSubjectivelyDown(sentinelRedisInstance *ri) {
          ri->role_reported == SRI_SLAVE &&
          mstime() - ri->role_reported_time >
           (ri->down_after_period+sentinel_info_period*2)) ||
-          (ri->flags & SRI_MASTER_REBOOT && 
+          (ri->flags & SRI_MASTER_REBOOT &&
+           ri->master_reboot_down_after_period != 0 &&
            mstime()-ri->master_reboot_since_time > ri->master_reboot_down_after_period))
     {
         /* Is subjectively down */
@@ -5049,10 +5148,10 @@ int compareSlavesForPromotion(const void *a, const void *b) {
 }
 
 sentinelRedisInstance *sentinelSelectSlave(sentinelRedisInstance *master) {
-    sentinelRedisInstance **instance =
-        zmalloc(sizeof(instance[0])*dictSize(master->slaves));
+    sentinelRedisInstance **instances =
+        zmalloc(sizeof(instances[0])*dictSize(master->slaves));
     sentinelRedisInstance *selected = NULL;
-    int instances = 0;
+    int num_instances = 0;
     dictIterator di;
     dictEntry *de;
     mstime_t max_master_down_time = 0;
@@ -5072,6 +5171,14 @@ sentinelRedisInstance *sentinelSelectSlave(sentinelRedisInstance *master) {
         if (mstime() - slave->link->last_avail_time > sentinel_ping_period*5) continue;
         if (slave->slave_priority == 0) continue;
 
+        /* It's possible that the sentinel has just detected the slave
+         * instance and hasn't got the chance to verify its replciation
+         * ID before the failover process starts. */
+        if (slave->is_relevant_to_master == REPLID_UNVERIFIED) {
+            slave->is_relevant_to_master = isSlaveRelevant(slave, master);
+        }
+        if (slave->is_relevant_to_master == REPLID_NOT_RELEVANT) continue;
+
         /* If the master is in SDOWN state we get INFO for slaves every second.
          * Otherwise we get it with the usual period so we need to account for
          * a larger delay. */
@@ -5081,15 +5188,15 @@ sentinelRedisInstance *sentinelSelectSlave(sentinelRedisInstance *master) {
             info_validity_time = sentinel_info_period*3;
         if (mstime() - slave->info_refresh > info_validity_time) continue;
         if (slave->master_link_down_time > max_master_down_time) continue;
-        instance[instances++] = slave;
+        instances[num_instances++] = slave;
     }
     dictResetIterator(&di);
-    if (instances) {
-        qsort(instance,instances,sizeof(sentinelRedisInstance*),
+    if (num_instances) {
+        qsort(instances,num_instances,sizeof(sentinelRedisInstance*),
             compareSlavesForPromotion);
-        selected = instance[0];
+        selected = instances[0];
     }
-    zfree(instance);
+    zfree(instances);
     return selected;
 }
 
@@ -5119,7 +5226,7 @@ void sentinelFailoverWaitStart(sentinelRedisInstance *ri) {
         }
         return;
     }
-    sentinelEvent(LL_WARNING,"+elected-leader",ri,"%@");
+    sentinelEvent(LL_WARNING,"+elected-leader",ri,"%@ in epoch %d", ri->failover_epoch);
     if (sentinel.simfailure_flags & SENTINEL_SIMFAILURE_CRASH_AFTER_ELECTION)
         sentinelSimFailureCrash();
     ri->failover_state = SENTINEL_FAILOVER_STATE_SELECT_SLAVE;
@@ -5295,6 +5402,8 @@ void sentinelFailoverReconfNextSlave(sentinelRedisInstance *master) {
             slave->slave_reconf_sent_time = mstime();
             sentinelEvent(LL_NOTICE,"+slave-reconf-sent",slave,"%@");
             in_progress++;
+        } else {
+            sentinelEvent(LL_WARNING,"-slave-reconf-sent-failed",slave,"%@");
         }
     }
     dictResetIterator(&di);
@@ -5310,7 +5419,7 @@ void sentinelFailoverSwitchToPromotedSlave(sentinelRedisInstance *master) {
     sentinelRedisInstance *ref = master->promoted_slave ?
                                  master->promoted_slave : master;
 
-    sentinelEvent(LL_WARNING,"+switch-master",master,"%s %s %d %s %d",
+    sentinelEvent(LL_WARNING,"+switch-master",master,"%s from %s %d to %s %d",
         master->name, announceSentinelAddr(master->addr), master->addr->port,
         announceSentinelAddr(ref->addr), ref->addr->port);
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -121,7 +121,7 @@ static mstime_t sentinel_default_failover_timeout = 60*3*1000;
 /* Flags used to verify slaves' replication lineage */
 #define REPLID_UNVERIFIED 0
 #define REPLID_RELEVANT 1
-#define REPLID_NOT_RELEVANT 2
+#define REPLID_IRRELEVANT 2
 
 /* The link to a sentinelRedisInstance. When we have the same set of Sentinels
  * monitoring many masters, we have different instances representing the
@@ -2706,16 +2706,19 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
     ri->info_refresh = mstime();
     sdsfreesplitres(lines,numlines);
     if (ri->flags & SRI_SLAVE) {
-        /* We should not claim a slave irrelevant immediately after the
-         * master reboots and gets a new replid. */
         mstime_t wait_time = sentinel_publish_period*4;
         if (isSlaveRelevant(ri, ri->master)) {
             ri->is_relevant_to_master = REPLID_RELEVANT;
-        } else if (sentinelMasterLooksSane(ri->master) &&
+        } else if (ri->is_relevant_to_master == REPLID_UNVERIFIED) {
+            ri->is_relevant_to_master = REPLID_IRRELEVANT;
+        }
+        /* We should not claim a slave irrelevant immediately after the
+         * master reboots and gets a new replid. */
+        else if (sentinelMasterLooksSane(ri->master) &&
             sentinelRedisInstanceNoDownFor(ri->master, wait_time) &&
             (ri->master->master_reboot_since_time == 0 ||
                 mstime() - ri->master->master_reboot_since_time > wait_time)) {
-            ri->is_relevant_to_master = REPLID_NOT_RELEVANT;
+            ri->is_relevant_to_master = REPLID_IRRELEVANT;
         }
     }
 
@@ -5179,13 +5182,12 @@ sentinelRedisInstance *sentinelSelectSlave(sentinelRedisInstance *master) {
         if (mstime() - slave->link->last_avail_time > sentinel_ping_period*5) continue;
         if (slave->slave_priority == 0) continue;
 
-        /* It's possible that the sentinel has just detected the slave
-         * instance and hasn't got the chance to verify its replication
-         * ID before the failover process starts. */
-        if (slave->is_relevant_to_master == REPLID_UNVERIFIED) {
-            slave->is_relevant_to_master = isSlaveRelevant(slave, master);
-        }
-        if (slave->is_relevant_to_master == REPLID_NOT_RELEVANT) continue;
+        /* The flag might be uninitialized, because it's possible that
+         * the sentinel has just discovered the slave instance and hasn't
+         * got the chance to verify its replication ID before the failover
+         * process starts. The flag could also be set irrelevant. Either
+         * way we shouldn't consider this slave instance qualified. */
+        if (slave->is_relevant_to_master != REPLID_RELEVANT) continue;
 
         /* If the master is in SDOWN state we get INFO for slaves every second.
          * Otherwise we get it with the usual period so we need to account for

--- a/src/server.c
+++ b/src/server.c
@@ -7079,6 +7079,7 @@ void loadDataFromDisk(void) {
                 rsi_is_valid = 1;
                 if (!iAmMaster()) {
                     memcpy(server.replid,rsi.repl_id,sizeof(server.replid));
+                    serverLog(LL_NOTICE, "replid restored to %s from RDB file", server.replid);
                     server.master_repl_offset = rsi.repl_offset;
                     /* If this is a replica, create a cached master from this
                      * information, in order to allow partial resynchronizations
@@ -7090,6 +7091,7 @@ void loadDataFromDisk(void) {
                      * as secondary ID and offset, in order to allow replicas
                      * to partial resynchronizations with masters. */
                     memcpy(server.replid2,rsi.repl_id,sizeof(server.replid));
+                    serverLog(LL_NOTICE, "replid2 restored to %s from RDB file", server.replid2);
                     server.second_replid_offset = rsi.repl_offset+1;
                     /* Rebase master_repl_offset from rsi.repl_offset. */
                     server.master_repl_offset += rsi.repl_offset;

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -69,12 +69,14 @@ proc exec_instance {type dirname cfgfile} {
 
 # Spawn a redis or sentinel instance, depending on 'type'.
 proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
+    set current_instances_count [llength [set ::${type}_instances]]
     for {set j 0} {$j < $count} {incr j} {
+        set instance_id [expr $current_instances_count + $j]
         set port [find_available_port $base_port $::redis_port_count]
         # plaintext port (only used for TLS cluster)
         set pport 0
         # Create a directory for this instance.
-        set dirname "${type}_${j}"
+        set dirname "${type}_${instance_id}"
         lappend ::dirs $dirname
         catch {exec rm -rf $dirname}
         file mkdir $dirname
@@ -136,7 +138,7 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
 
             # Check availability
             if {[server_is_up 127.0.0.1 $port 100] == 0} {
-                puts "Starting $type #$j at port $port failed, try another"
+                puts "Starting $type #$instance_id at port $port failed, try another"
                 incr retry -1
                 set port [find_available_port $base_port $::redis_port_count]
                 set cfg [open $cfgfile a+]
@@ -149,7 +151,7 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
                 }
                 close $cfg
             } else {
-                puts "Starting $type #$j at port $port"
+                puts "Starting $type #$instance_id at port $port"
                 lappend ::pids $pid
                 break
             }
@@ -159,7 +161,7 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
         if {[server_is_up $::host $port 100] == 0} {
             set logfile [file join $dirname log.txt]
             puts [exec tail $logfile]
-            abort_sentinel_test "Problems starting $type #$j: ping timeout, maybe server start failed, check $logfile"
+            abort_sentinel_test "Problems starting $type #$instance_id: ping timeout, maybe server start failed, check $logfile"
         }
 
         # Push the instance into the right list
@@ -256,9 +258,11 @@ proc cleanup {} {
     if {$::dont_clean} {
         return
     }
-    foreach dir $::dirs {
-        catch {exec rm -rf $dir}
-    }
+#    if {$::failed == 0} {
+#        foreach dir $::dirs {
+#            catch {exec rm -rf $dir}
+#        }
+#    }
 }
 
 proc abort_sentinel_test msg {
@@ -610,28 +614,38 @@ proc set_instance_attrib {type id attrib newval} {
 }
 
 # Create a master-slave cluster of the given number of total instances.
-# The first instance "0" is the master, all others are configured as
-# slaves.
-proc create_redis_master_slave_cluster n {
-    foreach_redis_id id {
-        if {$id == 0} {
-            # Our master.
+# The first instance (default ID is 0) is the master, all others are
+# configured as slaves.
+proc create_redis_master_slave_cluster { n {master_id 0} } {
+    for {set id $master_id} {$id < [expr $master_id + $n]} {incr id} {
+        if {$id == $master_id} {
             R $id slaveof no one
             R $id flushall
-        } elseif {$id < $n} {
-            R $id slaveof [get_instance_attrib redis 0 host] \
-                          [get_instance_attrib redis 0 port]
         } else {
-            # Instances not part of the cluster.
-            R $id slaveof no one
+            R $id slaveof [get_instance_attrib redis $master_id host] \
+                          [get_instance_attrib redis $master_id port]
         }
     }
+#    foreach_redis_id id {
+#        if {$id == $master_id} {
+#            # Our master.
+#            R $id slaveof no one
+#            R $id flushall
+#        } elseif { $id < [expr $master_id + $n] } {
+#            R $id slaveof [get_instance_attrib redis $master_id host] \
+#                          [get_instance_attrib redis $master_id port]
+#        } else {
+#            # Instances not part of the cluster.
+#            R $id slaveof no one
+#        }
+#    }
     # Wait for all the slaves to sync.
-    wait_for_condition 1000 50 {
-        [RI 0 connected_slaves] == ($n-1)
+    wait_for_condition 100 50 {
+        [RI $master_id connected_slaves] == ($n-1)
     } else {
-        fail "Unable to create a master-slaves cluster."
+        fail "Unable to create a master-slaves cluster. Only connected [RI $master_id connected_slaves] slaves. Expected [expr $n-1]"
     }
+    puts "Successfully created a master-slave cluster of $n instances with master ID $master_id"
 }
 
 proc get_instance_id_by_port {type port} {

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -168,6 +168,7 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
         set link [redis $::host $port 0 $::tls]
         $link reconnect 1
         lappend ::${type}_instances [list \
+            instance_id $instance_id \
             pid $pid \
             host $::host \
             port $port \
@@ -175,6 +176,23 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
             link $link \
         ]
     }
+}
+
+proc remove_redis_instance { ids } {
+    set ids [lsort -unique $ids]
+    set new {}
+    foreach instance $::redis_instances {
+        # Treats the flat list entry {pid 93770 host 127.0.0.1 port 30000 ...}
+        # as alternating key/value pairs.
+        array set inst $instance
+        # Found the target instance
+        if { [lsearch -exact $ids $inst(instance_id)] >= 0} {
+            kill_instance "redis" $inst(instance_id)
+        } else {
+            lappend new $instance
+        }
+    }
+    set ::redis_instances $new
 }
 
 proc log_crashes {} {
@@ -258,11 +276,9 @@ proc cleanup {} {
     if {$::dont_clean} {
         return
     }
-#    if {$::failed == 0} {
-#        foreach dir $::dirs {
-#            catch {exec rm -rf $dir}
-#        }
-#    }
+    # Don't clean up the log files. We often need to examine the
+    # logs regardless of whether the test fail or not.
+    # The logs will be cleaned up in run.tcl prior to running tests
 }
 
 proc abort_sentinel_test msg {
@@ -441,7 +457,8 @@ proc test {descr code} {
 # Check memory leaks when running on OSX using the "leaks" utility.
 proc check_leaks instance_types {
     if {[string match {*Darwin*} [exec uname -a]]} {
-        puts -nonewline "Testing for memory leaks..."; flush stdout
+        set ts [clock format [clock seconds] -format %H:%M:%S]
+        puts -nonewline "$ts> Testing for memory leaks..."; flush stdout
         foreach type $instance_types {
             foreach_instance_id [set ::${type}_instances] id {
                 if {[instance_is_killed $type $id]} continue
@@ -484,7 +501,7 @@ while 1 {
             continue
         }
         if {[file isdirectory $test]} continue
-        puts [colorstr yellow "Testing unit: [lindex [file split $test] end]"]
+        puts [colorstr yellow "\nTesting unit: [lindex [file split $test] end]"]
         if {[catch { source $test } err]} {
             puts "FAILED: caught an error in the test $err"
             puts $::errorInfo
@@ -616,34 +633,21 @@ proc set_instance_attrib {type id attrib newval} {
 # Create a master-slave cluster of the given number of total instances.
 # The first instance (default ID is 0) is the master, all others are
 # configured as slaves.
-proc create_redis_master_slave_cluster { n {master_id 0} } {
+proc create_redis_master_slave_cluster { n master_id } {
     for {set id $master_id} {$id < [expr $master_id + $n]} {incr id} {
         if {$id == $master_id} {
             R $id slaveof no one
             R $id flushall
         } else {
-            R $id slaveof [get_instance_attrib redis $master_id host] \
-                          [get_instance_attrib redis $master_id port]
+            R $id slaveof [get_instance_attrib redis $master_id host] [get_instance_attrib redis $master_id port]
         }
     }
-#    foreach_redis_id id {
-#        if {$id == $master_id} {
-#            # Our master.
-#            R $id slaveof no one
-#            R $id flushall
-#        } elseif { $id < [expr $master_id + $n] } {
-#            R $id slaveof [get_instance_attrib redis $master_id host] \
-#                          [get_instance_attrib redis $master_id port]
-#        } else {
-#            # Instances not part of the cluster.
-#            R $id slaveof no one
-#        }
-#    }
     # Wait for all the slaves to sync.
     wait_for_condition 100 50 {
         [RI $master_id connected_slaves] == ($n-1)
     } else {
-        fail "Unable to create a master-slaves cluster. Only connected [RI $master_id connected_slaves] slaves. Expected [expr $n-1]"
+        fail "Unable to create a master-slaves cluster. Connected [RI $master_id connected_slaves] \
+              slaves but expected [expr $n-1]"
     }
     puts "Successfully created a master-slave cluster of $n instances with master ID $master_id"
 }

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -30,14 +30,12 @@ proc main {} {
         "sentinel deny-scripts-reconfig no"
         "enable-protected-configs yes"
         "enable-debug-command yes"
-        "loglevel debug"
     } "../tests/includes/sentinel.conf"
 
     spawn_instance redis $::redis_base_port $::instances_count {
         "enable-protected-configs yes"
         "enable-debug-command yes"
         "save ''"
-        "loglevel debug"
     }
     run_tests
     cleanup

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -12,7 +12,6 @@ source ../instances.tcl
 
 set ::instances_count 5 ; # How many instances we use at max.
 set ::tlsdir "../../tls"
-set ::setup_second_master 0
 
 proc main {} {
     set start [clock milliseconds]

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -15,6 +15,13 @@ set ::tlsdir "../../tls"
 set ::setup_second_master 0
 
 proc main {} {
+    set start [clock milliseconds]
+    # Clean up log files from previous test run
+    foreach name [glob -tails -directory [pwd] * .*] {
+        if {$name in { . .. .gitignore }} continue
+        file delete -force -- $name
+    }
+
     parse_options
     if {$::leaked_fds_file != ""} {
         set ::env(LEAKED_FDS_FILE) $::leaked_fds_file
@@ -34,6 +41,9 @@ proc main {} {
     }
     run_tests
     cleanup
+    set end [clock milliseconds]
+    set duration [expr {($end - $start) / 1000}]
+    puts "Total test duration: ${duration} seconds"
     end_tests
 }
 

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -12,6 +12,7 @@ source ../instances.tcl
 
 set ::instances_count 5 ; # How many instances we use at max.
 set ::tlsdir "../../tls"
+set ::setup_second_master 0
 
 proc main {} {
     parse_options
@@ -22,12 +23,14 @@ proc main {} {
         "sentinel deny-scripts-reconfig no"
         "enable-protected-configs yes"
         "enable-debug-command yes"
+        "loglevel debug"
     } "../tests/includes/sentinel.conf"
 
     spawn_instance redis $::redis_base_port $::instances_count {
         "enable-protected-configs yes"
         "enable-debug-command yes"
         "save ''"
+        "loglevel debug"
     }
     run_tests
     cleanup

--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -4,6 +4,12 @@ source "../tests/includes/init-tests.tcl"
 
 foreach_sentinel_id id {
     S $id sentinel debug default-down-after 1000
+    # In this test suite, the newly promoted master will be
+    # killed multiple times during tests. We need to send
+    # INFO commands frequently to sync with the master's
+    # latest replication ID, so that slaves' replication
+    # lineage is in sync.
+    S $id sentinel debug info-period 500
 }
 
 if {$::simulate_error} {
@@ -111,11 +117,7 @@ test "All the other slaves now point to the new master" {
 }
 
 test "The old master eventually gets reconfigured as a slave" {
-    wait_for_condition 1000 50 {
-        [RI 0 master_port] == [lindex $addr 1]
-    } else {
-        fail "Old master not reconfigured as slave of new master"
-    }
+    wait_for_master_reconfigured_as_slave 0 "mymaster" "Old master not reconfigured as slave of new master"
 }
 
 test "ODOWN is not possible without N (quorum) Sentinels reports" {
@@ -164,12 +166,23 @@ test "Failover works if we configure for absolute agreement" {
         S $id SENTINEL SET mymaster quorum $sentinels
     }
 
-    # Wait for Sentinels to monitor the master again
+    # Wait for sentinels to monitor the master again
     foreach_sentinel_id id {
         wait_for_condition 1000 100 {
             [dict get [S $id SENTINEL MASTER mymaster] info-refresh] < 100000
         } else {
             fail "At least one Sentinel is not monitoring the master"
+        }
+    }
+
+    # Wait for all sentinels (both the crashed and not-crashed ones)
+    # to detect master is now back on, and thus sync with it to
+    # update replid.
+    foreach_sentinel_id id {
+        wait_for_condition 100 100 {
+            [RI $master_id "master_replid"] == [get_info_field [S $id SENTINEL INFO-CACHE mymaster] "master_replid"]
+        } else {
+            fail "Sentinel $id could not retrieve master's latest replid"
         }
     }
 
@@ -196,7 +209,7 @@ test "New master [join $addr {:}] role matches" {
     assert {[RI $master_id role] eq {master}}
 }
 
-test "SENTINEL RESET can resets the master" {
+test "SENTINEL RESET can reset the master" {
     # After SENTINEL RESET, sometimes the sentinel can sense the master again,
     # causing the test to fail. Here we give it a few more chances.
     for {set j 0} {$j < 10} {incr j} {

--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -119,6 +119,7 @@ test "The old master eventually gets reconfigured as a slave" {
 }
 
 test "ODOWN is not possible without N (quorum) Sentinels reports" {
+    set sentinels [llength $::sentinel_instances]
     foreach_sentinel_id id {
         S $id SENTINEL SET mymaster quorum [expr $sentinels+1]
     }
@@ -127,13 +128,14 @@ test "ODOWN is not possible without N (quorum) Sentinels reports" {
     assert {[lindex $addr 1] == $old_port}
     kill_instance redis $master_id
 
-    # Make sure failover did not happened.
+    # Make sure failover did not happen.
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
     restart_instance redis $master_id
 }
 
 test "Failover is not possible without majority agreement" {
+    set quorum [expr {$sentinels/2 + 1}]
     foreach_sentinel_id id {
         S $id SENTINEL SET mymaster quorum $quorum
     }
@@ -146,7 +148,7 @@ test "Failover is not possible without majority agreement" {
     # Kill the current master
     kill_instance redis $master_id
 
-    # Make sure failover did not happened.
+    # Make sure failover did not happen.
     set addr [S $quorum SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
     restart_instance redis $master_id

--- a/tests/sentinel/tests/04-slave-selection.tcl
+++ b/tests/sentinel/tests/04-slave-selection.tcl
@@ -4,31 +4,33 @@
 # 1) That when there are no suitable slaves no failover is performed.
 # 2) That among the available slaves, the one with better offset is picked.
 
-# Pass the flag as a global variable to the init script
-set ::setup_second_master 1
 source ../tests/includes/init-tests.tcl
-# Now we have two master-slave clusters. In this test we will mainly operate
-# on the second master.
+# This unit is the only one in the whole sentinel test suite that
+# requires two clusters. Here we will mainly operate on the second cluster.
 
-set master_a_id $master_id
+# Spawn 1 master with only 1 slave
+set num_instances 2
+spawn_instance redis $::redis_base_port $num_instances {
+    "enable-protected-configs yes"
+    "enable-debug-command yes"
+    "save ''"
+}
+
+set master_a_id 0
 set master_a_name "mymaster"
-set master_b_id 5
+# The first 5 IDs belong to the default master-slave cluster
+set master_b_id $::instances_count
 set master_b_name "another_master"
 set slave_id [expr $master_b_id + 1]
-set slave_port [RPort $slave_id]
+
+# Create the second cluster
+init_cluster $master_b_name $master_b_id $num_instances
 
 foreach_sentinel_id id {
-    S $id sentinel debug ping-period 500
-    S $id sentinel debug ask-period 500
-    S $id sentinel debug info-period 500
-    S $id sentinel debug default-down-after 1000
-
-    # This is kinda hacky. The sentinels will periodically check
-    # whether any slave now follows a different master, and if so,
-    # convert it back via a +fix-slave-config event.
-    # Here we make the failover-timeout (sentinel's wait time before
-    # converting slaves back) very long to avoid such event.
-    S $id SENTINEL SET $master_b_name failover-timeout 20000
+    S $id SENTINEL DEBUG ping-period 500
+    S $id SENTINEL DEBUG ask-period 500
+    S $id SENTINEL DEBUG info-period 500
+    S $id SENTINEL DEBUG default-down-after 1000
 }
 
 proc change_master { slave_id new_master_id } {
@@ -36,7 +38,24 @@ proc change_master { slave_id new_master_id } {
                         [get_instance_attrib redis $new_master_id port]
 }
 
+proc wait_for_sentinel_confirm_new_master { master_name master_port } {
+    foreach_sentinel_id id {
+        wait_for_condition 200 100 {
+            [lindex [S $id SENTINEL GET-MASTER-ADDR-BY-NAME $master_name] 1] == $master_port
+        } else {
+            fail "Sentinel $id did not see the new master"
+        }
+    }
+}
+
+# TODO(zhijun): This test has flakiness. The correct ordering is:
+# 1. the slave in the second cluster updates replid after following
+#    the master in the first cluster;
+# 2. sentinels monitoring this slave instance notices the new replid
+# 3. manual failover starts
+# If step 3 happens before 2, this test case would fail.
 test "Cannot failover when there's no good slave" {
+    set old_port [RPort $master_b_id]
     # Put a simple string into the database
     R $master_b_id SET "mykey" "myvalue"
 
@@ -45,14 +64,14 @@ test "Cannot failover when there's no good slave" {
     # replication ID.
     change_master $slave_id $master_a_id
 
-    # The default master had 4 slaves. Now it should discover this new slave
     foreach_sentinel_id id {
         wait_for_condition 100 50 {
-            [llength [S $id SENTINEL replicas $master_a_name]] == 5
+            [get_info_field [S $id SENTINEL INFO-CACHE $master_b_name] "connected_slaves"] == 0
         } else {
-            fail "mymaster should now have 5 slaves from sentinel $id's view"
+            fail "Sentinel $id should see the only slave in the second cluster gone by now"
         }
     }
+
     # The original data should be gone by now
     assert_equal [R $slave_id GET "mykey"] {}
 
@@ -68,17 +87,57 @@ test "Failover should work now that the slave's replication ID is reverted back"
     # Reconfigure the slave again to bring the slave back to the original
     # master to revert its replication ID.
     change_master $slave_id $master_b_id
+    wait_for_condition 100 100 {
+        [RI $slave_id master_replid] == [RI $master_b_id master_replid]
+    } else {
+        fail "Slave couldn't sync with its original master"
+    }
+
+    # Since slave b temporarily follows mymaster, sentinels will continue
+    # believing it's a slave of the first cluster. We need to reset sentinels' views.
+    foreach_sentinel_id id {
+        S $id SENTINEL RESET $master_a_name
+    }
 
     # This time the failover should succeed.
     kill_instance redis $master_b_id
-    foreach_sentinel_id id {
-        wait_for_condition 200 100 {
-            [lindex [S $id SENTINEL GET-MASTER-ADDR-BY-NAME $master_b_name] 1] == $slave_port
-        } else {
-            fail "Sentinel $id did not see the new master"
-        }
-    }
+    wait_for_sentinel_confirm_new_master $master_b_name [RPort $slave_id]
 
     # The new master should contain the original data
     assert_equal [R $slave_id GET "mykey"] "myvalue"
 }
+
+test "The old master eventually gets reconfigured as a slave" {
+    restart_instance redis $master_b_id
+    wait_for_master_reconfigured_as_slave $master_b_id $master_b_name "Old master not reconfigured as slave of new master"
+}
+
+test "Original master (now slave) gets promoted after the new master (previous slave) goes down" {
+    kill_instance redis $slave_id
+    wait_for_sentinel_confirm_new_master $master_b_name $old_port
+
+    # The original slave is now slave again
+    restart_instance redis $slave_id
+    wait_for_master_reconfigured_as_slave $slave_id $master_b_name "The original slave not reconfigured as slave again"
+}
+
+# After the master goes down and reboots, it gets assigned a new
+# replid different its slave's. We make sure the failover still
+# works in such situation.
+test "Slave selection works when the master reboots immediately" {
+    # Turn the master into reboot state with a new replid
+    kill_instance redis $master_b_id
+    restart_instance redis $master_b_id
+
+    # Now crash it to trigger failover process
+    kill_instance redis $master_b_id
+    wait_for_sentinel_confirm_new_master $master_b_name [RPort $slave_id]
+    restart_instance redis $master_b_id
+}
+
+# Now that we have two clusters, we need to do proper cleanup
+# to avoid messing up other test suites.
+foreach_sentinel_id id {
+    S $id SENTINEL REMOVE $master_b_name
+}
+remove_redis_instance [list $master_b_id $slave_id]

--- a/tests/sentinel/tests/04-slave-selection.tcl
+++ b/tests/sentinel/tests/04-slave-selection.tcl
@@ -69,11 +69,10 @@ test "The second cluster works" {
     R $master_b_id SET "mykey" "myvalue"
 
     wait_for_condition 100 50 {
-        [get_info_field [S 0 SENTINEL INFO-CACHE $master_b_name] "connected_slaves"] == 1
+        assert_equal [R $slave_id GET "mykey"] "myvalue"
     } else {
         fail "The slave and master in the second cluster cannot sync"
     }
-    assert_equal [R $slave_id GET "mykey"] "myvalue"
 }
 
 test "Cannot failover when there's no good slave" {

--- a/tests/sentinel/tests/04-slave-selection.tcl
+++ b/tests/sentinel/tests/04-slave-selection.tcl
@@ -38,6 +38,21 @@ proc change_master { slave_id new_master_id } {
                         [get_instance_attrib redis $new_master_id port]
 }
 
+# After a slave finishes syncing data with the new master,
+# we need to wait for sentinels to fully observe such change.
+# At this point, sentinels should have two copies of this slave,
+# one under the new cluster and the other under the old cluster,
+# because sentinels won't prune any slaves and thus they still
+# believe the slave is following the old master.
+# So we need to wait for sentinels to see the slave's new replid
+# matches with the new master.
+proc is_change_master_finished { sentinel_id new_master_name old_master_name } {
+    set slave [lindex [S $sentinel_id SENTINEL REPLICAS $old_master_name] 0]
+    set slave_master_replid [dict get $slave "master-replid"]
+    set new_master_replid [get_info_field [S $sentinel_id SENTINEL INFO-CACHE $new_master_name] "master_replid"]
+    return [expr {$new_master_replid eq $slave_master_replid}]
+}
+
 proc wait_for_sentinel_confirm_new_master { master_name master_port } {
     foreach_sentinel_id id {
         wait_for_condition 200 100 {
@@ -48,27 +63,37 @@ proc wait_for_sentinel_confirm_new_master { master_name master_port } {
     }
 }
 
-# TODO(zhijun): This test has flakiness. The correct ordering is:
-# 1. the slave in the second cluster updates replid after following
-#    the master in the first cluster;
-# 2. sentinels monitoring this slave instance notices the new replid
-# 3. manual failover starts
-# If step 3 happens before 2, this test case would fail.
-test "Cannot failover when there's no good slave" {
-    set old_port [RPort $master_b_id]
+test "The second cluster works" {
     # Put a simple string into the database
     R $master_b_id SET "mykey" "myvalue"
+
+    wait_for_condition 100 50 {
+        [get_info_field [S 0 SENTINEL INFO-CACHE $master_b_name] "connected_slaves"] == 1
+    } else {
+        fail "The slave and master in the second cluster cannot sync"
+    }
+    assert_equal [R $slave_id GET "mykey"] "myvalue"
+}
+
+test "Cannot failover when there's no good slave" {
+    set old_port [RPort $master_b_id]
 
     # This cluster has only one slave. Let's reconfigure the slave to
     # follow the default master instead, so that it will update its
     # replication ID.
     change_master $slave_id $master_a_id
 
+    # The correct order of events is:
+    # 1. the slave in the second cluster updates replid after following
+    #    the master in the first cluster;
+    # 2. sentinels sees the new replid
+    # 3. manual failover starts
+    # The following wait condition is to strictly guarantee such order.
     foreach_sentinel_id id {
-        wait_for_condition 100 50 {
-            [get_info_field [S $id SENTINEL INFO-CACHE $master_b_name] "connected_slaves"] == 0
+        wait_for_condition 200 50 {
+            [is_change_master_finished $id $master_a_name $master_b_name] == 1
         } else {
-            fail "Sentinel $id should see the only slave in the second cluster gone by now"
+            fail "Sentinel $id should see the slave has new replid now"
         }
     }
 
@@ -122,7 +147,7 @@ test "Original master (now slave) gets promoted after the new master (previous s
 }
 
 # After the master goes down and reboots, it gets assigned a new
-# replid different its slave's. We make sure the failover still
+# replid different from its slave's. We make sure the failover still
 # works in such situation.
 test "Slave selection works when the master reboots immediately" {
     # Turn the master into reboot state with a new replid

--- a/tests/sentinel/tests/04-slave-selection.tcl
+++ b/tests/sentinel/tests/04-slave-selection.tcl
@@ -5,6 +5,14 @@
 # 2) That among the available slaves, the one with better offset is picked.
 
 source ../tests/includes/init-tests.tcl
+
+foreach_sentinel_id id {
+    S $id SENTINEL DEBUG ping-period 500
+    S $id SENTINEL DEBUG ask-period 500
+    S $id SENTINEL DEBUG info-period 500
+    S $id SENTINEL DEBUG default-down-after 1000
+}
+
 # This unit is the only one in the whole sentinel test suite that
 # requires two clusters. Here we will mainly operate on the second cluster.
 
@@ -25,13 +33,6 @@ set slave_id [expr $master_b_id + 1]
 
 # Create the second cluster
 init_cluster $master_b_name $master_b_id $num_instances
-
-foreach_sentinel_id id {
-    S $id SENTINEL DEBUG ping-period 500
-    S $id SENTINEL DEBUG ask-period 500
-    S $id SENTINEL DEBUG info-period 500
-    S $id SENTINEL DEBUG default-down-after 1000
-}
 
 proc change_master { slave_id new_master_id } {
     R $slave_id slaveof [get_instance_attrib redis $new_master_id host] \

--- a/tests/sentinel/tests/04-slave-selection.tcl
+++ b/tests/sentinel/tests/04-slave-selection.tcl
@@ -3,3 +3,82 @@
 # This unit should test:
 # 1) That when there are no suitable slaves no failover is performed.
 # 2) That among the available slaves, the one with better offset is picked.
+
+# Pass the flag as a global variable to the init script
+set ::setup_second_master 1
+source ../tests/includes/init-tests.tcl
+# Now we have two master-slave clusters. In this test we will mainly operate
+# on the second master.
+
+set master_a_id $master_id
+set master_a_name "mymaster"
+set master_b_id 5
+set master_b_name "another_master"
+set slave_id [expr $master_b_id + 1]
+set slave_port [RPort $slave_id]
+
+foreach_sentinel_id id {
+    S $id sentinel debug ping-period 500
+    S $id sentinel debug ask-period 500
+    S $id sentinel debug info-period 500
+    S $id sentinel debug default-down-after 1000
+
+    # This is kinda hacky. The sentinels will periodically check
+    # whether any slave now follows a different master, and if so,
+    # convert it back via a +fix-slave-config event.
+    # Here we make the failover-timeout (sentinel's wait time before
+    # converting slaves back) very long to avoid such event.
+    S $id SENTINEL SET $master_b_name failover-timeout 20000
+}
+
+proc change_master { slave_id new_master_id } {
+    R $slave_id slaveof [get_instance_attrib redis $new_master_id host] \
+                        [get_instance_attrib redis $new_master_id port]
+}
+
+test "Cannot failover when there's no good slave" {
+    # Put a simple string into the database
+    R $master_b_id SET "mykey" "myvalue"
+
+    # This cluster has only one slave. Let's reconfigure the slave to
+    # follow the default master instead, so that it will update its
+    # replication ID.
+    change_master $slave_id $master_a_id
+
+    # The default master had 4 slaves. Now it should discover this new slave
+    foreach_sentinel_id id {
+        wait_for_condition 100 50 {
+            [llength [S $id SENTINEL replicas $master_a_name]] == 5
+        } else {
+            fail "mymaster should now have 5 slaves from sentinel $id's view"
+        }
+    }
+    # The original data should be gone by now
+    assert_equal [R $slave_id GET "mykey"] {}
+
+    # We expect the manual failover to fail now that there is no
+    # good slave to promote.
+    set result [catch { S 0 SENTINEL FAILOVER $master_b_name } err]
+    if {$result == 0 || [string match "*NOGOODSLAVE*" $err] == 0} {
+        fail "Manual failover did not error with NOGOODSLAVE. Instead, it got: $err"
+    }
+}
+
+test "Failover should work now that the slave's replication ID is reverted back" {
+    # Reconfigure the slave again to bring the slave back to the original
+    # master to revert its replication ID.
+    change_master $slave_id $master_b_id
+
+    # This time the failover should succeed.
+    kill_instance redis $master_b_id
+    foreach_sentinel_id id {
+        wait_for_condition 200 100 {
+            [lindex [S $id SENTINEL GET-MASTER-ADDR-BY-NAME $master_b_name] 1] == $slave_port
+        } else {
+            fail "Sentinel $id did not see the new master"
+        }
+    }
+
+    # The new master should contain the original data
+    assert_equal [R $slave_id GET "mykey"] "myvalue"
+}

--- a/tests/sentinel/tests/04-slave-selection.tcl
+++ b/tests/sentinel/tests/04-slave-selection.tcl
@@ -69,7 +69,7 @@ test "The second cluster works" {
     R $master_b_id SET "mykey" "myvalue"
 
     wait_for_condition 100 50 {
-        assert_equal [R $slave_id GET "mykey"] "myvalue"
+        [R $slave_id GET "mykey"] == "myvalue"
     } else {
         fail "The slave and master in the second cluster cannot sync"
     }

--- a/tests/sentinel/tests/12-master-reboot.tcl
+++ b/tests/sentinel/tests/12-master-reboot.tcl
@@ -48,14 +48,14 @@ test "Master reboot in very short time" {
 
     foreach_sentinel_id id {
         S $id SENTINEL SET mymaster master-reboot-down-after-period 5000
-        S $id sentinel debug ping-period 500
-        S $id sentinel debug ask-period 500 
+        S $id SENTINEL debug ping-period 500
+        S $id SENTINEL debug ask-period 500
     }
 
     kill_instance redis $master_id
     reboot_instance redis $master_id
-    
-    foreach_sentinel_id id {        
+
+    foreach_sentinel_id id {
         wait_for_condition 1000 100 {
             [lindex [S $id SENTINEL GET-MASTER-ADDR-BY-NAME mymaster] 1] != $old_port
         } else {

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -1,6 +1,47 @@
 # Initialization tests -- most units will start including this.
 source "../tests/includes/utils.tcl"
 
+proc sentinel_monitor_master { master_name master_id } {
+    set sentinels [llength $::sentinel_instances]
+    set quorum [expr {$sentinels/2+1}]
+    foreach_sentinel_id id {
+        S $id SENTINEL MONITOR $master_name \
+              [get_instance_attrib redis $master_id host] \
+              [get_instance_attrib redis $master_id port] $quorum
+    }
+    foreach_sentinel_id id {
+        assert {[S $id sentinel master $master_name] ne {}}
+        S $id SENTINEL SET $master_name down-after-milliseconds 2000
+        S $id SENTINEL SET $master_name failover-timeout 10000
+        S $id SENTINEL debug tilt-period 5000
+        S $id SENTINEL SET $master_name parallel-syncs 10
+        if {$::leaked_fds_file != "" && [exec uname] == "Linux"} {
+            S $id SENTINEL SET $master_name notification-script ../../tests/helpers/check_leaked_fds.tcl
+            S $id SENTINEL SET $master_name client-reconfig-script ../../tests/helpers/check_leaked_fds.tcl
+        }
+    }
+}
+
+proc verify_sentinel_connect_to_master { master_name } {
+    foreach_sentinel_id id {
+        wait_for_condition 1000 50 {
+            [catch {S $id SENTINEL GET-MASTER-ADDR-BY-NAME $master_name}] == 0
+        } else {
+            fail "Sentinel $id can't talk with the master $master_name"
+        }
+    }
+}
+
+proc verify_sentinel_discover_slaves { master_name expected_slaves } {
+    foreach_sentinel_id id {
+        wait_for_condition 1000 50 {
+            [dict get [S $id SENTINEL MASTER $master_name] num-slaves] == $expected_slaves
+        } else {
+            fail "For master $master_name, at least some sentinel can't detect some slaves"
+        }
+    }
+}
+
 test "(init) Restart killed instances" {
     restart_killed_instances
 }
@@ -18,34 +59,11 @@ test "(init) Create a master-slaves cluster of [expr $redis_slaves+1] instances"
 set master_id 0
 
 test "(init) Sentinels can start monitoring a master" {
-    set sentinels [llength $::sentinel_instances]
-    set quorum [expr {$sentinels/2+1}]
-    foreach_sentinel_id id {
-        S $id SENTINEL MONITOR mymaster \
-              [get_instance_attrib redis $master_id host] \
-              [get_instance_attrib redis $master_id port] $quorum
-    }
-    foreach_sentinel_id id {
-        assert {[S $id sentinel master mymaster] ne {}}
-        S $id SENTINEL SET mymaster down-after-milliseconds 2000
-        S $id SENTINEL SET mymaster failover-timeout 10000
-        S $id SENTINEL debug tilt-period 5000
-        S $id SENTINEL SET mymaster parallel-syncs 10
-        if {$::leaked_fds_file != "" && [exec uname] == "Linux"} {
-            S $id SENTINEL SET mymaster notification-script ../../tests/helpers/check_leaked_fds.tcl
-            S $id SENTINEL SET mymaster client-reconfig-script ../../tests/helpers/check_leaked_fds.tcl
-        }
-    }
+    sentinel_monitor_master "mymaster" 0
 }
 
 test "(init) Sentinels can talk with the master" {
-    foreach_sentinel_id id {
-        wait_for_condition 1000 50 {
-            [catch {S $id SENTINEL GET-MASTER-ADDR-BY-NAME mymaster}] == 0
-        } else {
-            fail "Sentinel $id can't talk with the master."
-        }
-    }
+    verify_sentinel_connect_to_master "mymaster"
 }
 
 test "(init) Sentinels are able to auto-discover other sentinels" {
@@ -53,11 +71,29 @@ test "(init) Sentinels are able to auto-discover other sentinels" {
 }
 
 test "(init) Sentinels are able to auto-discover slaves" {
-    foreach_sentinel_id id {
-        wait_for_condition 1000 50 {
-            [dict get [S $id SENTINEL MASTER mymaster] num-slaves] == $redis_slaves
-        } else {
-            fail "At least some sentinel can't detect some slave"
+    verify_sentinel_discover_slaves "mymaster" $redis_slaves
+}
+
+# Most of the time we only need just one master-slave cluster
+if {$::setup_second_master} {
+    test "(init) Setting up the second master" {
+        # Create 1 master with only 1 slave
+        set num_additional_instances 2
+        spawn_instance redis $::redis_base_port $num_additional_instances {
+            "enable-protected-configs yes"
+            "enable-debug-command yes"
+            "save ''"
         }
+        create_redis_master_slave_cluster $num_additional_instances $::instances_count
+
+        # The first 5 IDs belong to the default master-slave cluster
+        set second_master_id 5
+        set second_master_name "another_master"
+
+        # Verify the setup
+        sentinel_monitor_master $second_master_name $second_master_id
+        verify_sentinel_connect_to_master $second_master_name
+        verify_sentinel_auto_discovery $second_master_name
+        verify_sentinel_discover_slaves $second_master_name [expr $num_additional_instances - 1]
     }
 }

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -6,8 +6,7 @@ proc sentinel_monitor_master { master_name master_id } {
     set quorum [expr {$sentinels/2+1}]
     foreach_sentinel_id id {
         S $id SENTINEL MONITOR $master_name \
-              [get_instance_attrib redis $master_id host] \
-              [get_instance_attrib redis $master_id port] $quorum
+          [get_instance_attrib redis $master_id host] [get_instance_attrib redis $master_id port] $quorum
     }
     foreach_sentinel_id id {
         assert {[S $id sentinel master $master_name] ne {}}
@@ -42,58 +41,39 @@ proc verify_sentinel_discover_slaves { master_name expected_slaves } {
     }
 }
 
-test "(init) Restart killed instances" {
-    restart_killed_instances
-}
+proc init_cluster { master_name master_id num_instances } {
+    puts "Initializing test setup for cluster: master $master_name with $num_instances instances"
 
-test "(init) Remove old master entry from sentinels" {
-    foreach_sentinel_id id {
-        catch {S $id SENTINEL REMOVE mymaster}
+    test "(init) Restart killed instances" {
+        restart_killed_instances
     }
-}
 
-set redis_slaves [expr $::instances_count - 1]
-test "(init) Create a master-slaves cluster of [expr $redis_slaves+1] instances" {
-    create_redis_master_slave_cluster [expr {$redis_slaves+1}]
-}
-set master_id 0
-
-test "(init) Sentinels can start monitoring a master" {
-    sentinel_monitor_master "mymaster" 0
-}
-
-test "(init) Sentinels can talk with the master" {
-    verify_sentinel_connect_to_master "mymaster"
-}
-
-test "(init) Sentinels are able to auto-discover other sentinels" {
-    verify_sentinel_auto_discovery
-}
-
-test "(init) Sentinels are able to auto-discover slaves" {
-    verify_sentinel_discover_slaves "mymaster" $redis_slaves
-}
-
-# Most of the time we only need just one master-slave cluster
-if {$::setup_second_master} {
-    test "(init) Setting up the second master" {
-        # Create 1 master with only 1 slave
-        set num_additional_instances 2
-        spawn_instance redis $::redis_base_port $num_additional_instances {
-            "enable-protected-configs yes"
-            "enable-debug-command yes"
-            "save ''"
+    test "(init) Remove old master entry from sentinels" {
+        foreach_sentinel_id id {
+            catch {S $id SENTINEL REMOVE $master_name}
         }
-        create_redis_master_slave_cluster $num_additional_instances $::instances_count
+    }
 
-        # The first 5 IDs belong to the default master-slave cluster
-        set second_master_id 5
-        set second_master_name "another_master"
+    test "(init) Create a master-slaves cluster of $num_instances instances" {
+        create_redis_master_slave_cluster $num_instances $master_id
+    }
 
-        # Verify the setup
-        sentinel_monitor_master $second_master_name $second_master_id
-        verify_sentinel_connect_to_master $second_master_name
-        verify_sentinel_auto_discovery $second_master_name
-        verify_sentinel_discover_slaves $second_master_name [expr $num_additional_instances - 1]
+    test "(init) Sentinels can start monitoring a master" {
+        sentinel_monitor_master $master_name $master_id
+    }
+
+    test "(init) Sentinels can talk with the master" {
+        verify_sentinel_connect_to_master $master_name
+    }
+
+    test "(init) Sentinels are able to auto-discover other sentinels" {
+        verify_sentinel_auto_discovery $master_name
+    }
+
+    test "(init) Sentinels are able to auto-discover slaves" {
+        verify_sentinel_discover_slaves $master_name [expr $num_instances - 1]
     }
 }
+
+set master_id 0
+init_cluster "mymaster" $master_id $::instances_count

--- a/tests/sentinel/tests/includes/utils.tcl
+++ b/tests/sentinel/tests/includes/utils.tcl
@@ -10,13 +10,17 @@ proc restart_killed_instances {} {
     }
 }
 
-proc verify_sentinel_auto_discovery {} {
+proc verify_sentinel_auto_discovery { {master_name {}} } {
+    if {$master_name eq {}} {
+        set master_name "mymaster"
+    }
+
     set sentinels [llength $::sentinel_instances]
     foreach_sentinel_id id {
         wait_for_condition 1000 50 {
-            [dict get [S $id SENTINEL MASTER mymaster] num-other-sentinels] == ($sentinels-1)
+            [dict get [S $id SENTINEL MASTER $master_name] num-other-sentinels] == ($sentinels-1)
         } else {
-            fail "At least some sentinel can't detect some other sentinel"
+            fail "For master $master_name, at least some sentinel can't detect some other sentinel"
         }
     }
 }

--- a/tests/sentinel/tests/includes/utils.tcl
+++ b/tests/sentinel/tests/includes/utils.tcl
@@ -1,3 +1,15 @@
+# Everytime a master goes down and sentinels promote a slave to
+# be the new master, sentinels wait for a while (publish-period * 4,
+# that's 8s by default) before sending slaveof command in a +convert-to-slave
+# event to force the rebooted master to reconfigure as slave.
+proc wait_for_master_reconfigured_as_slave { instance_id master_name err_msg} {
+    wait_for_condition 100 100 {
+        [RI $instance_id "master_port"] == [lindex [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME $master_name] 1]
+    } else {
+        fail $err_msg
+    }
+}
+
 proc restart_killed_instances {} {
     foreach type {redis sentinel} {
         foreach_${type}_id id {

--- a/tests/sentinel/tests/includes/utils.tcl
+++ b/tests/sentinel/tests/includes/utils.tcl
@@ -1,4 +1,4 @@
-# Everytime a master goes down and sentinels promote a slave to
+# Every time a master goes down and sentinels promote a slave to
 # be the new master, sentinels wait for a while (publish-period * 4,
 # that's 8s by default) before sending slaveof command in a +convert-to-slave
 # event to force the rebooted master to reconfigure as slave.

--- a/tests/sentinel/tests/includes/utils.tcl
+++ b/tests/sentinel/tests/includes/utils.tcl
@@ -3,7 +3,7 @@
 # that's 8s by default) before sending slaveof command in a +convert-to-slave
 # event to force the rebooted master to reconfigure as slave.
 proc wait_for_master_reconfigured_as_slave { instance_id master_name err_msg} {
-    wait_for_condition 100 100 {
+    wait_for_condition 200 50 {
         [RI $instance_id "master_port"] == [lindex [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME $master_name] 1]
     } else {
         fail $err_msg


### PR DESCRIPTION

Solves issue https://github.com/redis/redis/issues/14313. 


##  How to reproduce the issue

We need to run two clusters and have two sentinel instances monitoring each one.

Duplicate the file `sentinel.conf` as `sentinel-a.conf` and `sentinel-b.conf`.  Add `sentinel monitor cluster-a 127.0.0.1 6379 1` to `sentinel-a.conf`, and `sentinel monitor cluster-b 127.0.0.1 6380 1` to `sentinel-a.conf`. Then replace all occurrence of "mymaster" to "cluster-a"/"cluster-b" correspondingly.

At the root directory of the repo:

```bash
# Set up the Redis server clusters
./src/redis-server --port 6379  # this is cluster A
./src/redis-server --port 6380  # this is cluster B
./src/redis-server --port 6381 --replicaof 127.0.0.1 6379  # slave in cluster A

# Set up the sentinel instances
./src/redis-server sentinel-a.conf --sentinel --port 26379
./src/redis-server sentinel-b.conf --sentinel --port 26380

# Insert data
./src/redis-cli -p 6379 set "key-cluster-a" "value-a"
./src/redis-cli -p 6380 set "key-cluster-b" "value-b"

# Verify that the slave has replicated the data
./src/redis-cli -p 6381 get "key-cluster-a"

# Manually ask the slave to follow a diffrent master
./src/redis-cli -p 6381 replicaof 127.0.0.1 6380
```

Now shut down the master server (port 6379) in cluster A and we will see sentinel A starting failover trying to promote a candidate slave. Since the only slave 6381now belongs to a diffrent cluster (cluster B), the failover should fail with an event `-failover-abort-no-good-slave`, but the sentinel A still thinks slave 6381 is following master A 6379 and thus promotes 6381 to become the new master in cluster A.

This patch will fix the issue.



## Changes I made

The logic of verifying replication ID is pretty straightforward. I add a new flag `is_relevant_to_master` to the `sentinelRedisInstance` object and update it during each run of `sentinelRefreshInstanceInfo`. Both the master and slaves servers would send the output of `INFO` command periodically, which contains the replication IDs and replciation offset.

If a slave is relevant to the master, then its claimed master address will be the same as the master server, and its replication ID is the same as the master's (the logic here is identical to checking whether partial resync is feasible - check out function `masterTryPartialResynchronization` in `src/replication.c` ).

The challenging part of this patch is to set up tests and most of my development time was spent on it. The entire sentinel test suite is designed to have only one master-slave cluster with the master named "mymaster", but my code changes would require spinning up two clusters so I had to refactor the `tests/sentinel/tests/includes/init-tests.tcl` file to support so.

All my test logic is in `tests/04-slave-selection.tcl`.  Interestingly, this file was intended to test the slave selection procedure but the test was never implemented since 2014.

There were a couple race conditions I had to fight with. Fundamentally they were due to the way sentinels work - sentinels observe the master-slave cluster by sending PING and INFO commands periodically to get the latest status of the running servers, and will always lag behind the actual reality of the cluster. For example, a server has a new replication ID, but sentinels can only find this out after a later INFO command, and sentinels might start the failover process before that, which would cause unexpected behaviors. So I had to decide strict wait for conditions in my tests to ensure the correct ordering of events.

Another tricky issue is that the master server might crash and reboot immediately (like, after 20ms). It will be assigned a brand new replication ID, which doesn't match with any running slave server. However, apparently the master and the slaves are still in sync, and we don't want to mark all slaves as "no longer relevant to the master", so I have additional logic to avoid setting the flag `is_relevant_to_master` to irrelevant too soon.