### PR TITLE
Add -fno-sanitize=function for Clang UBSAN

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -114,6 +114,13 @@ ifeq ($(SANITIZER),undefined)
 	MALLOC=libc
 	CFLAGS+=-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer
 	LDFLAGS+=-fsanitize=undefined
+
+	# Clang emits many "call to function through pointer to incorrect function type"
+	# warnings. Temporarily disable this check until a broader cleanup lands,
+	# after which we can re-enable it safely.
+	ifeq ($(CLANG),clang)
+		CFLAGS+=-fno-sanitize=function
+	endif
 else
 ifeq ($(SANITIZER),thread)
 	CFLAGS+=-fsanitize=thread -fno-sanitize-recover=all -fno-omit-frame-pointer

--- a/src/Makefile
+++ b/src/Makefile
@@ -118,7 +118,7 @@ ifeq ($(SANITIZER),undefined)
 	# Clang emits many "call to function through pointer to incorrect function type"
 	# warnings. Temporarily disable this check until a broader cleanup lands,
 	# after which we can re-enable it safely.
-	ifeq ($(CLANG),clang)
+	ifeq (clang, $(CLANG))
 		CFLAGS+=-fno-sanitize=function
 	endif
 else


### PR DESCRIPTION
Clang (18.1.3) emits many "call to function through pointer to incorrect function type" warnings:

```
module.c:12736:9: runtime error: call to function VectorSets_OnLoad through pointer to incorrect function type 'int (*)(void *, void **, int)'
/home/ozan/Desktop/redis/src/../modules/vector-sets/vset.c:2585: note: VectorSets_OnLoad defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior module.c:12736:9 
```

Unfortunately, after fixing it, there is another one: 

```
../modules/vector-sets/../../src/redismodule.h:1431:5: runtime error: call to function RM_GetApi through pointer to incorrect function type 'int (*)(const char *, void *)'
/home/ozan/Desktop/redis/src/module.c:800: note: RM_GetApi defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../modules/vector-sets/../../src/redismodule.h:1431:5 
```

It seems like we need to do some cleanup especially in module.c. Until then, we can temporarily disable this check by passing `-fno-sanitize=function` to clang UBSAN builds. 