### PR TITLE
Fix nested function on bitopsTest

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1981,7 +1981,6 @@ int bitopsTest(int argc, char **argv, int flags) {
         return 1;
     }
 
-int popcountTest(int argc, char **argv, int flags) {
 #ifdef HAVE_AVX2
     if (BITOP_USE_AVX2) {
         long long result_avx2 = redisPopCountAvx2(test_data, sizeof(test_data));


### PR DESCRIPTION
Fix for extended ci after https://github.com/redis/redis/pull/14309
Raised by @sundb via https://github.com/redis/redis-extra-ci/actions/runs/18481782747/job/52657741179

Confirmation that extended CI passes afterwards:  https://github.com/redis/redis-extra-ci/actions/runs/18491273965