### PR TITLE
Add API RedisModule_ClusterKeySlotC

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -61,7 +61,7 @@ typedef struct clusterSlotStat {
  * However, if the key contains the {...} pattern, only the part between
  * { and } is hashed. This may be useful in the future to force certain
  * keys to be in the same node (assuming no resharding is in progress). */
-static inline unsigned int keyHashSlot(char *key, int keylen) {
+static inline unsigned int keyHashSlot(const char *key, int keylen) {
     int s, e; /* start-end indexes of { and } */
 
     for (s = 0; s < keylen; s++)

--- a/src/module.c
+++ b/src/module.c
@@ -9286,6 +9286,13 @@ unsigned int RM_ClusterKeySlot(RedisModuleString *key) {
     return keyHashSlot(key->ptr, sdslen(key->ptr));
 }
 
+/* Like `RM_ClusterKeySlot`, but gets a char pointer and a length.
+ * Returns the cluster slot of a key, similar to the `CLUSTER KEYSLOT` command.
+ * This function works even if cluster mode is not enabled. */
+unsigned int RM_ClusterKeySlotC(const char *keystr, size_t keylen) {
+    return keyHashSlot(keystr, keylen);
+}
+
 /* Returns a short string that can be used as a key or as a hash tag in a key,
  * such that the key maps to the given cluster slot. Returns NULL if slot is not
  * a valid slot. */
@@ -14785,6 +14792,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(GetBlockedClientHandle);
     REGISTER_API(SetClusterFlags);
     REGISTER_API(ClusterKeySlot);
+    REGISTER_API(ClusterKeySlotC);
     REGISTER_API(ClusterCanonicalKeyNameInSlot);
     REGISTER_API(CreateDict);
     REGISTER_API(FreeDict);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1275,6 +1275,7 @@ REDISMODULE_API void (*RedisModule_GetRandomHexChars)(char *dst, size_t len) RED
 REDISMODULE_API void (*RedisModule_SetDisconnectCallback)(RedisModuleBlockedClient *bc, RedisModuleDisconnectFunc callback) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetClusterFlags)(RedisModuleCtx *ctx, uint64_t flags) REDISMODULE_ATTR;
 REDISMODULE_API unsigned int (*RedisModule_ClusterKeySlot)(RedisModuleString *key) REDISMODULE_ATTR;
+REDISMODULE_API unsigned int (*RedisModule_ClusterKeySlotC)(const char *keystr, size_t keylen) REDISMODULE_ATTR;
 REDISMODULE_API const char *(*RedisModule_ClusterCanonicalKeyNameInSlot)(unsigned int slot) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExportSharedAPI)(RedisModuleCtx *ctx, const char *apiname, void *func) REDISMODULE_ATTR;
 REDISMODULE_API void * (*RedisModule_GetSharedAPI)(RedisModuleCtx *ctx, const char *apiname) REDISMODULE_ATTR;
@@ -1663,6 +1664,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(GetRandomHexChars);
     REDISMODULE_GET_API(SetClusterFlags);
     REDISMODULE_GET_API(ClusterKeySlot);
+    REDISMODULE_GET_API(ClusterKeySlotC);
     REDISMODULE_GET_API(ClusterCanonicalKeyNameInSlot);
     REDISMODULE_GET_API(ExportSharedAPI);
     REDISMODULE_GET_API(GetSharedAPI);

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -525,12 +525,15 @@ int test_malloc_api(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 }
 
 int test_keyslot(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    /* Static check of the ClusterKeySlot + ClusterCanonicalKeyNameInSlot
+    /* Static check of the ClusterKeySlot + ClusterKeySlotC + ClusterCanonicalKeyNameInSlot
      * round-trip for all slots. */
     for (unsigned int slot = 0; slot < 16384; slot++) {
         const char *tag = RedisModule_ClusterCanonicalKeyNameInSlot(slot);
         RedisModuleString *key = RedisModule_CreateStringPrintf(ctx, "x{%s}y", tag);
         assert(slot == RedisModule_ClusterKeySlot(key));
+        size_t len;
+        const char *key_c = RedisModule_StringPtrLen(key, &len);
+        assert(slot == RedisModule_ClusterKeySlotC(key_c, len));
         RedisModule_FreeString(ctx, key);
     }
     if (argc != 2){


### PR DESCRIPTION
Enhancing #13069, by adding a more direct API for getting the slot of a string

Introduces new module API: 

```c
/* Like `RM_ClusterKeySlot`, but gets a char pointer and a length.
 * Returns the cluster slot of a key, similar to the `CLUSTER KEYSLOT` command.
 * This function works even if cluster mode is not enabled. */
 unsigned int RM_ClusterKeySlotC(const char *keystr, size_t keylen)
```