### PR TITLE
Fix RedisModule_GetClusterNodeInfo API

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -9221,7 +9221,7 @@ size_t RM_GetClusterSize(void) {
 int RM_GetClusterNodeInfo(RedisModuleCtx *ctx, const char *id, char *ip, char *master_id, int *port, int *flags) {
     UNUSED(ctx);
 
-    clusterNode *node = clusterLookupNode(id, strlen(id));
+    clusterNode *node = clusterLookupNode(id, CLUSTER_NAMELEN);
     if (node == NULL || clusterNodePending(node))
     {
         return REDISMODULE_ERR;


### PR DESCRIPTION
`RedisModule_GetClusterNodeInfo` is [documented](https://redis.io/docs/latest/develop/reference/modules/modules-api-ref/#redismodule_getclusternodeslist) to be used with `RedisModule_GetClusterNodesList`, which states (and does) that the returned strings are not null-terminated.

Therefore, it is unsafe to call `strlen` on the `const char *id` input of `RedisModule_GetClusterNodeInfo`, and the API should assume the string is of the correct length