### PR TITLE
Validate existence of backup directory for cluster backup in redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -8209,9 +8209,9 @@ static int clusterManagerCommandBackup(int argc, char **argv) {
         } else {
             clusterManagerLogErr("Cannot stat backup directory %s: %s\n",
                                  backup_dir, strerror(errno));
-            success = 0;
-            goto cleanup;
         }
+        success = 0;
+        goto cleanup;
     } else if (!S_ISDIR(st.st_mode)) {
         clusterManagerLogErr("[ERR] The specified backup path '%s' exists but is not a directory.\n", backup_dir);
         success = 0;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -8207,7 +8207,7 @@ static int clusterManagerCommandBackup(int argc, char **argv) {
         if (errno == ENOENT) {
             clusterManagerLogErr("[ERR] The specified backup directory '%s' does not exist.\n", backup_dir);
         } else {
-            clusterManagerLogErr("Cannot stat backup directory %s: %s\n",
+            clusterManagerLogErr("[ERR] Cannot stat backup directory %s: %s\n",
                                  backup_dir, strerror(errno));
         }
         success = 0;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -8205,13 +8205,7 @@ static int clusterManagerCommandBackup(int argc, char **argv) {
 
     if (stat(backup_dir, &st) == -1) {
         if (errno == ENOENT) {
-            clusterManagerLogInfo(">>> Creating backup directory %s\n", backup_dir);
-            if (mkdir(backup_dir, 0755) == -1) {
-                clusterManagerLogErr("Could not create backup directory %s: %s\n",
-                                     backup_dir, strerror(errno));
-                success = 0;
-                goto cleanup;
-            }
+            clusterManagerLogErr("[ERR] The specified backup directory '%s' does not exist.\n", backup_dir);
         } else {
             clusterManagerLogErr("Cannot stat backup directory %s: %s\n",
                                  backup_dir, strerror(errno));

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -8196,7 +8196,31 @@ static int clusterManagerCommandBackup(int argc, char **argv) {
     int cluster_errors_count = (no_issues ? 0 :
                                 listLength(cluster_manager.errors));
     config.cluster_manager_command.backup_dir = argv[1];
-    /* TODO: check if backup_dir is a valid directory. */
+
+    struct stat st = {0};
+    char *backup_dir = config.cluster_manager_command.backup_dir;
+
+    if (stat(backup_dir, &st) == -1) {
+        if (errno == ENOENT) {
+            clusterManagerLogInfo(">>> Creating backup directory %s\n", backup_dir);
+            if (mkdir(backup_dir, 0755) == -1) {
+                clusterManagerLogErr("Could not create backup directory %s: %s\n",
+                                     backup_dir, strerror(errno));
+                success = 0;
+                goto cleanup;
+            }
+        } else {
+            clusterManagerLogErr("Cannot stat backup directory %s: %s\n",
+                                 backup_dir, strerror(errno));
+            success = 0;
+            goto cleanup;
+        }
+    } else if (!S_ISDIR(st.st_mode)) {
+        clusterManagerLogErr("[ERR] The specified backup path '%s' exists but is not a directory.\n", backup_dir);
+        success = 0;
+        goto cleanup;
+    }
+
     sds json = sdsnew("[\n");
     int first_node = 0;
     listIter li;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -8189,6 +8189,9 @@ static int clusterManagerCommandBackup(int argc, char **argv) {
     UNUSED(argc);
     int success = 1, port = 0;
     char *ip = NULL;
+    sds json = NULL;
+    sds jsonpath = NULL;
+
     if (!getClusterHostFromCmdArgs(1, argv, &ip, &port)) goto invalid_args;
     clusterManagerNode *refnode = clusterManagerNewNode(ip, port, 0);
     if (!clusterManagerLoadInfoFromNode(refnode)) return 0;
@@ -8221,7 +8224,7 @@ static int clusterManagerCommandBackup(int argc, char **argv) {
         goto cleanup;
     }
 
-    sds json = sdsnew("[\n");
+    json = sdsnew("[\n");
     int first_node = 0;
     listIter li;
     listNode *ln;
@@ -8241,7 +8244,7 @@ static int clusterManagerCommandBackup(int argc, char **argv) {
         getRDB(node);
     }
     json = sdscat(json, "\n]");
-    sds jsonpath = sdsnew(config.cluster_manager_command.backup_dir);
+    jsonpath = sdsnew(config.cluster_manager_command.backup_dir);
     if (jsonpath[sdslen(jsonpath) - 1] != '/')
         jsonpath = sdscat(jsonpath, "/");
     jsonpath = sdscat(jsonpath, "nodes.json");


### PR DESCRIPTION
Currently, there is a `TODO` regarding adding a check if the backup directory exists in `redis-cli`.

This PR adds a check to improve usability:

  - If the backup directory does not exist, the user is informed with an error message.
  - If the specified path exists but is not a directory, an error is now properly reported.