### PR TITLE
Disable io-threads for `Pending command pool expansion and shrinking` test

### DIFF
--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -377,7 +377,7 @@ start_server {tags {"timeout external:skip"}} {
 }
 
 test {Pending command pool expansion and shrinking} {
-    start_server {overrides {loglevel debug} tags {external:skip}} {
+    start_server {overrides {loglevel debug io-threads 1} tags {external:skip}} {
         set rd1 [redis_deferring_client]
         set rd2 [redis_deferring_client]
         


### PR DESCRIPTION
Introduced by https://github.com/redis/redis/pull/14440
We only enable the pending command pool when disabling iothreads, so make this test only runs without iothreads.