### PR TITLE
[8.2] [RED-170693] Limit efSearch parameter to avoid heap overflow (#14373)

### DIFF
--- a/modules/vector-sets/tests/vsim_limit_efsearch.py
+++ b/modules/vector-sets/tests/vsim_limit_efsearch.py
@@ -1,0 +1,32 @@
+from test import TestCase, generate_random_vector
+import struct
+
+class VSIMLimitEFSearch(TestCase):
+    def getname(self):
+        return "VSIM Limit EF Search"
+
+    def estimated_runtime(self):
+        return 0.2
+
+    def test(self):
+        dim = 32
+        vec = generate_random_vector(dim)
+        vec_bytes = struct.pack(f'{dim}f', *vec)
+
+        # Add test vector
+        self.redis.execute_command('VADD', self.test_key, 'FP32', vec_bytes, f'{self.test_key}:item:1')
+
+        query_vec = generate_random_vector(dim)
+
+        # Test EF upper bound (should accept 1000000)
+        result = self.redis.execute_command('VSIM', self.test_key, 'VALUES', dim,
+                                          *[str(x) for x in query_vec], 'EF', 1000000)
+        assert isinstance(result, list), "EF=1000000 should be accepted"
+
+        # Test EF over limit (should reject > 1000000)
+        try:
+            self.redis.execute_command('VSIM', self.test_key, 'VALUES', dim,
+                                     *[str(x) for x in query_vec], 'EF', 1000001)
+            assert False, "EF=1000001 should be rejected"
+        except Exception as e:
+            assert "invalid EF" in str(e), f"Expected EF validation error, got: {e}"


### PR DESCRIPTION
This PR aims to avoid the situation of a potential crash when efSearch is too large (and therefore the memory allocated could lead to a server crash or an integer overflow (where less memory is allocated than expected).

- Limit the accepted EF in the request o 100_000 as in VADD
- Limit the ef search to the number of nodes in the HNSW graph