### PR TITLE
Add per slot memory accounting

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -795,7 +795,11 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
     } else {
         o = dbUnshareStringValue(c->db,c->argv[1],o);
         *strOldSize  = sdslen(o->ptr);
+        size_t oldAllocSize = stringObjectAllocSize(o);
         o->ptr = sdsgrowzero(o->ptr,byte+1);
+        size_t allocSize = stringObjectAllocSize(o);
+        if (oldAllocSize != allocSize)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldAllocSize, allocSize);
         *strGrowSize = sdslen(o->ptr) - *strOldSize;
     }
     return o;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -800,7 +800,7 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
             oldAllocSize = stringObjectAllocSize(o);
         o->ptr = sdsgrowzero(o->ptr,byte+1);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldAllocSize, stringObjectAllocSize(o));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldAllocSize, stringObjectAllocSize(o));
         *strGrowSize = sdslen(o->ptr) - *strOldSize;
     }
     return o;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -796,10 +796,10 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
     } else {
         o = dbUnshareStringValue(c->db,c->argv[1],o);
         *strOldSize  = sdslen(o->ptr);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldAllocSize = stringObjectAllocSize(o);
         o->ptr = sdsgrowzero(o->ptr,byte+1);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldAllocSize, stringObjectAllocSize(o));
         *strGrowSize = sdslen(o->ptr) - *strOldSize;
     }

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -784,6 +784,7 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
 {
     dictEntryLink link;
     size_t byte = maxbit >> 3;
+    size_t oldAllocSize = 0;
     kvobj *o = lookupKeyWriteWithLink(c->db,c->argv[1],&link);
     if (checkType(c,o,OBJ_STRING)) return NULL;
 
@@ -795,11 +796,11 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
     } else {
         o = dbUnshareStringValue(c->db,c->argv[1],o);
         *strOldSize  = sdslen(o->ptr);
-        size_t oldAllocSize = stringObjectAllocSize(o);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldAllocSize = stringObjectAllocSize(o);
         o->ptr = sdsgrowzero(o->ptr,byte+1);
-        size_t allocSize = stringObjectAllocSize(o);
-        if (oldAllocSize != allocSize)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldAllocSize, allocSize);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldAllocSize, stringObjectAllocSize(o));
         *strGrowSize = sdslen(o->ptr) - *strOldSize;
     }
     return o;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -796,10 +796,10 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
     } else {
         o = dbUnshareStringValue(c->db,c->argv[1],o);
         *strOldSize  = sdslen(o->ptr);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldAllocSize = stringObjectAllocSize(o);
         o->ptr = sdsgrowzero(o->ptr,byte+1);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldAllocSize, stringObjectAllocSize(o));
         *strGrowSize = sdslen(o->ptr) - *strOldSize;
     }

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -18,6 +18,7 @@
 typedef enum {
     KEY_COUNT,
     CPU_USEC,
+    MEMORY_BYTES,
     NETWORK_BYTES_IN,
     NETWORK_BYTES_OUT,
     SLOT_STAT_COUNT,
@@ -49,6 +50,7 @@ static uint64_t getSlotStat(int slot, slotStatType stat_type) {
     switch (stat_type) {
     case KEY_COUNT: return countKeysInSlot(slot);
     case CPU_USEC: return server.cluster_slot_stats[slot].cpu_usec;
+    case MEMORY_BYTES: return kvstoreDictAllocSize(server.db->keys, slot);
     case NETWORK_BYTES_IN: return server.cluster_slot_stats[slot].network_bytes_in;
     case NETWORK_BYTES_OUT: return server.cluster_slot_stats[slot].network_bytes_out;
     default: serverPanic("Invalid slot stat type %d was found.", stat_type);
@@ -92,9 +94,11 @@ static void addReplySlotStat(client *c, int slot) {
                              * and 1st index represents (map) usage statistics. */
     addReplyLongLong(c, slot);
     addReplyMapLen(c, (server.cluster_slot_stats_enabled) ? SLOT_STAT_COUNT
-                                                          : 1); /* Nested map representing slot usage statistics. */
+                                                          : 2); /* Nested map representing slot usage statistics. */
     addReplyBulkCString(c, "key-count");
     addReplyLongLong(c, countKeysInSlot(slot));
+    addReplyBulkCString(c, "memory-bytes");
+    addReplyLongLong(c, kvstoreDictAllocSize(server.db->keys, slot));
 
     /* Any additional metrics aside from key-count come with a performance trade-off,
      * and are aggregated and returned based on its server config. */
@@ -293,6 +297,8 @@ void clusterSlotStatsCommand(client *c) {
             order_by = KEY_COUNT;
         } else if (!strcasecmp(c->argv[3]->ptr, "cpu-usec") && server.cluster_slot_stats_enabled) {
             order_by = CPU_USEC;
+        } else if (!strcasecmp(c->argv[3]->ptr, "memory-bytes") && server.cluster_slot_stats_enabled) {
+            order_by = MEMORY_BYTES;
         } else if (!strcasecmp(c->argv[3]->ptr, "network-bytes-in") && server.cluster_slot_stats_enabled) {
             order_by = NETWORK_BYTES_IN;
         } else if (!strcasecmp(c->argv[3]->ptr, "network-bytes-out") && server.cluster_slot_stats_enabled) {

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -93,16 +93,19 @@ static void addReplySlotStat(client *c, int slot) {
     addReplyArrayLen(c, 2); /* Array of size 2, where 0th index represents (int) slot,
                              * and 1st index represents (map) usage statistics. */
     addReplyLongLong(c, slot);
-    addReplyMapLen(c, (server.cluster_slot_stats_enabled) ? SLOT_STAT_COUNT
-                                                          : 1); /* Nested map representing slot usage statistics. */
+    addReplyMapLen(c, server.cluster_slot_stats_enabled
+        ? (server.memory_tracking_per_slot ? SLOT_STAT_COUNT : SLOT_STAT_COUNT-1)
+        : 1); /* Nested map representing slot usage statistics. */
     addReplyBulkCString(c, "key-count");
     addReplyLongLong(c, countKeysInSlot(slot));
 
     /* Any additional metrics aside from key-count come with a performance trade-off,
      * and are aggregated and returned based on its server config. */
     if (server.cluster_slot_stats_enabled) {
-        addReplyBulkCString(c, "memory-bytes");
-        addReplyLongLong(c, kvstoreDictAllocSize(server.db->keys, slot));
+        if (server.memory_tracking_per_slot) {
+            addReplyBulkCString(c, "memory-bytes");
+            addReplyLongLong(c, kvstoreDictAllocSize(server.db->keys, slot));
+        }
         addReplyBulkCString(c, "cpu-usec");
         addReplyLongLong(c, server.cluster_slot_stats[slot].cpu_usec);
         addReplyBulkCString(c, "network-bytes-in");
@@ -297,7 +300,7 @@ void clusterSlotStatsCommand(client *c) {
             order_by = KEY_COUNT;
         } else if (!strcasecmp(c->argv[3]->ptr, "cpu-usec") && server.cluster_slot_stats_enabled) {
             order_by = CPU_USEC;
-        } else if (!strcasecmp(c->argv[3]->ptr, "memory-bytes") && server.cluster_slot_stats_enabled) {
+        } else if (!strcasecmp(c->argv[3]->ptr, "memory-bytes") && server.cluster_slot_stats_enabled && server.memory_tracking_per_slot) {
             order_by = MEMORY_BYTES;
         } else if (!strcasecmp(c->argv[3]->ptr, "network-bytes-in") && server.cluster_slot_stats_enabled) {
             order_by = NETWORK_BYTES_IN;

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -133,7 +133,7 @@ static void addReplySortedSlotStats(client *c, slotStatForSort slot_stats[], lon
 }
 
 static int canAddNetworkBytesOut(client *c) {
-    return server.cluster_slot_stats_enabled && server.cluster_enabled && c->slot != -1;
+    return clusterSlotStatsEnabled() && c->slot != -1;
 }
 
 /* Accumulates egress bytes upon sending RESP responses back to user clients. */
@@ -245,8 +245,8 @@ static int canAddNetworkBytesIn(client *c) {
      * Third, blocked client is not aggregated, to avoid duplicate aggregation upon unblocking.
      * Fourth, the server is not under a MULTI/EXEC transaction, to avoid duplicate aggregation of
      * EXEC's 14 bytes RESP upon nested call()'s afterCommand(). */
-    return server.cluster_enabled && server.cluster_slot_stats_enabled &&
-        c->slot != -1 && !(c->flags & CLIENT_BLOCKED) && !server.in_exec;
+    return clusterSlotStatsEnabled() && c->slot != -1 &&
+        !(c->flags & CLIENT_BLOCKED) && !server.in_exec;
 }
 
 /* Adds network ingress bytes of the current command in execution,

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -94,15 +94,15 @@ static void addReplySlotStat(client *c, int slot) {
                              * and 1st index represents (map) usage statistics. */
     addReplyLongLong(c, slot);
     addReplyMapLen(c, (server.cluster_slot_stats_enabled) ? SLOT_STAT_COUNT
-                                                          : 2); /* Nested map representing slot usage statistics. */
+                                                          : 1); /* Nested map representing slot usage statistics. */
     addReplyBulkCString(c, "key-count");
     addReplyLongLong(c, countKeysInSlot(slot));
-    addReplyBulkCString(c, "memory-bytes");
-    addReplyLongLong(c, kvstoreDictAllocSize(server.db->keys, slot));
 
     /* Any additional metrics aside from key-count come with a performance trade-off,
      * and are aggregated and returned based on its server config. */
     if (server.cluster_slot_stats_enabled) {
+        addReplyBulkCString(c, "memory-bytes");
+        addReplyLongLong(c, kvstoreDictAllocSize(server.db->keys, slot));
         addReplyBulkCString(c, "cpu-usec");
         addReplyLongLong(c, server.cluster_slot_stats[slot].cpu_usec);
         addReplyBulkCString(c, "network-bytes-in");

--- a/src/commands/cluster-slot-stats.json
+++ b/src/commands/cluster-slot-stats.json
@@ -36,6 +36,9 @@
                             "key-count": {
                                 "type": "integer"
                             },
+                            "memory-bytes": {
+                                "type": "integer"
+                            },
                             "cpu-usec": {
                                 "type": "integer"
                             },

--- a/src/config.c
+++ b/src/config.c
@@ -3125,7 +3125,7 @@ standardConfig static_configs[] = {
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 0, NULL, NULL),
     createBoolConfig("lazyexpire-nested-arbitrary-keys", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.lazyexpire_nested_arbitrary_keys, 1, NULL, NULL),
-    createBoolConfig("cluster-slot-stats-enabled", NULL, MODIFIABLE_CONFIG, server.cluster_slot_stats_enabled, 0, NULL, NULL),
+    createBoolConfig("cluster-slot-stats-enabled", NULL, IMMUTABLE_CONFIG, server.cluster_slot_stats_enabled, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3125,7 +3125,7 @@ standardConfig static_configs[] = {
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 0, NULL, NULL),
     createBoolConfig("lazyexpire-nested-arbitrary-keys", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.lazyexpire_nested_arbitrary_keys, 1, NULL, NULL),
-    createBoolConfig("cluster-slot-stats-enabled", NULL, IMMUTABLE_CONFIG, server.cluster_slot_stats_enabled, 0, NULL, NULL),
+    createBoolConfig("cluster-slot-stats-enabled", NULL, MODIFIABLE_CONFIG, server.cluster_slot_stats_enabled, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/db.c
+++ b/src/db.c
@@ -125,6 +125,16 @@ void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, in
     }
 }
 
+void updateAllocSizes(redisDb *db, int didx, size_t oldsize, size_t newsize) {
+    kvstoreDictMetadata *dictMeta = kvstoreGetDictMetadata(db->keys, didx);
+    if (!dictMeta) return;
+#ifdef REDIS_TEST
+    serverAssert(oldsize <= dictMeta->alloc_size);
+#endif
+    dictMeta->alloc_size -= oldsize;
+    dictMeta->alloc_size += newsize;
+}
+
 /* Assert keysizes histogram (For debugging only)
  *
  * Triggered by DEBUG KEYSIZES-HIST-ASSERT 1 and tested after each command.
@@ -345,6 +355,7 @@ kvobj *dbAddInternal(redisDb *db, robj *key, robj **valref, dictEntryLink *link,
     signalKeyAsReady(db, key, kv->type);
     notifyKeyspaceEvent(NOTIFY_NEW,"new",key,db->id);
     updateKeysizesHist(db, slot, kv->type, -1, getObjectLength(kv)); /* add hist */
+    updateAllocSizes(db, slot, 0, kvobjAllocSize(kv));
     *valref = kv;
     return kv;
 }
@@ -453,6 +464,7 @@ kvobj *dbAddRDBLoad(redisDb *db, sds key, robj **valref, long long expire) {
         kv = setExpireByLink(NULL, db, key, expire, bucket);
 
     updateKeysizesHist(db, slot, kv->type, -1, (int64_t) getObjectLength(kv));
+    updateAllocSizes(db, slot, 0, kvobjAllocSize(kv));
     return *valref = kv;
 }
 
@@ -507,6 +519,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
         /* Because of RM_StringDMA, old may be changed, so we need get old again */
         old = dictGetKV(*link);
     }
+    size_t oldsize = kvobjAllocSize(old);
 
     if ((old->refcount == 1 && old->encoding != OBJ_ENCODING_EMBSTR) &&
         (val->refcount == 1 && val->encoding != OBJ_ENCODING_EMBSTR)) {
@@ -560,6 +573,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
             updateKeysizesHist(db, slot, kvNew->type, -1, newlen);
         }
     }
+    updateAllocSizes(db, slot, oldsize, kvobjAllocSize(kvNew));
 
     if (server.io_threads_num > 1 && old->encoding == OBJ_ENCODING_RAW) {
         /* In multi-threaded mode, the OBJ_ENCODING_RAW string object usually is
@@ -742,6 +756,7 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
             kvstoreDictDelete(db->expires, slot, key->ptr);
 
         if (async) {
+            updateAllocSizes(db, slot, kvobjAllocSize(kv), 0);
             freeObjAsync(key, kv, db->id);
             /* Set the key to NULL in the main dictionary. */
             kvstoreDictSetAtLink(db->keys, slot, NULL, &link, 0);
@@ -2476,6 +2491,7 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
         /* Val already had an expire field, so it was not reallocated. */
         serverAssert(kv == kvnew);
     } else { /* No old expire */
+        size_t oldsize = kvobjAllocSize(kv);
         uint64_t subexpiry = EB_EXPIRE_TIME_INVALID;
         /* If hash with HFEs, take care to remove from global HFE DS before attempting
          * to manipulate and maybe free kv object */
@@ -2486,6 +2502,7 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
         /* if kvobj was reallocated, update dict */
         if (kv != kvnew) {
             kvstoreDictSetAtLink(db->keys, slot, kvnew, &keyLink, 0);
+            updateAllocSizes(db, slot, oldsize, kvobjAllocSize(kvnew));
             kv = kvnew;
         }
         /* Now add to expires */

--- a/src/db.c
+++ b/src/db.c
@@ -126,6 +126,7 @@ void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, in
 }
 
 void updateAllocSizes(redisDb *db, int didx, size_t oldsize, size_t newsize) {
+    debugServerAssert(server.cluster_enabled && server.cluster_slot_stats_enabled);
     kvstoreDictMetadata *dictMeta = kvstoreGetDictMetadata(db->keys, didx);
     if (!dictMeta) return;
 #ifdef REDIS_TEST
@@ -180,6 +181,7 @@ void dbgAssertKeysizesHist(redisDb *db) {
  * Triggered by DEBUG ALLOCSIZE-SLOTS-ASSERT 1 and tested after each command.
  */
 void dbgAssertAllocSizePerSlot(redisDb *db) {
+    if (!(server.cluster_enabled && server.cluster_slot_stats_enabled)) return;
     size_t slot_sizes[CLUSTER_SLOTS] = {0};
     dictEntry *de;
     kvstoreIterator *kvs_it = kvstoreIteratorInit(db->keys);
@@ -381,7 +383,8 @@ kvobj *dbAddInternal(redisDb *db, robj *key, robj **valref, dictEntryLink *link,
     signalKeyAsReady(db, key, kv->type);
     notifyKeyspaceEvent(NOTIFY_NEW,"new",key,db->id);
     updateKeysizesHist(db, slot, kv->type, -1, getObjectLength(kv)); /* add hist */
-    updateAllocSizes(db, slot, 0, kvobjAllocSize(kv));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(db, slot, 0, kvobjAllocSize(kv));
     *valref = kv;
     return kv;
 }
@@ -490,7 +493,8 @@ kvobj *dbAddRDBLoad(redisDb *db, sds key, robj **valref, long long expire) {
         kv = setExpireByLink(NULL, db, key, expire, bucket);
 
     updateKeysizesHist(db, slot, kv->type, -1, (int64_t) getObjectLength(kv));
-    updateAllocSizes(db, slot, 0, kvobjAllocSize(kv));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(db, slot, 0, kvobjAllocSize(kv));
     return *valref = kv;
 }
 
@@ -516,6 +520,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
                        int overwrite, int updateKeySizes, int keepTTL) {
     robj *val = *valref;
     int slot = getKeySlot(key->ptr);
+    size_t oldsize = 0;
     if (!link) {
         link = kvstoreDictFindLink(db->keys, slot, key->ptr, NULL);
         serverAssertWithInfo(NULL, key, link != NULL); /* expected to exist */
@@ -545,7 +550,8 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
         /* Because of RM_StringDMA, old may be changed, so we need get old again */
         old = dictGetKV(*link);
     }
-    size_t oldsize = kvobjAllocSize(old);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = kvobjAllocSize(old);
 
     if ((old->refcount == 1 && old->encoding != OBJ_ENCODING_EMBSTR) &&
         (val->refcount == 1 && val->encoding != OBJ_ENCODING_EMBSTR)) {
@@ -599,7 +605,9 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
             updateKeysizesHist(db, slot, kvNew->type, -1, newlen);
         }
     }
-    updateAllocSizes(db, slot, oldsize, kvobjAllocSize(kvNew));
+
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(db, slot, oldsize, kvobjAllocSize(kvNew));
 
     if (server.io_threads_num > 1 && old->encoding == OBJ_ENCODING_RAW) {
         /* In multi-threaded mode, the OBJ_ENCODING_RAW string object usually is
@@ -782,7 +790,8 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
             kvstoreDictDelete(db->expires, slot, key->ptr);
 
         if (async) {
-            updateAllocSizes(db, slot, kvobjAllocSize(kv), 0);
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(db, slot, kvobjAllocSize(kv), 0);
             freeObjAsync(key, kv, db->id);
             /* Set the key to NULL in the main dictionary. */
             kvstoreDictSetAtLink(db->keys, slot, NULL, &link, 0);
@@ -2505,6 +2514,7 @@ kvobj *setExpire(client *c, redisDb *db, robj *key, long long when) {
 kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntryLink keyLink) {
     /* Reuse the sds from the main dict in the expire dict */
     int slot = getKeySlot(key);
+    size_t oldsize = 0;
     if (!keyLink) {
         keyLink = kvstoreDictFindLink(db->keys, slot, key, NULL);
         serverAssert(keyLink != NULL);
@@ -2517,7 +2527,8 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
         /* Val already had an expire field, so it was not reallocated. */
         serverAssert(kv == kvnew);
     } else { /* No old expire */
-        size_t oldsize = kvobjAllocSize(kv);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = kvobjAllocSize(kv);
         uint64_t subexpiry = EB_EXPIRE_TIME_INVALID;
         /* If hash with HFEs, take care to remove from global HFE DS before attempting
          * to manipulate and maybe free kv object */
@@ -2528,7 +2539,8 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
         /* if kvobj was reallocated, update dict */
         if (kv != kvnew) {
             kvstoreDictSetAtLink(db->keys, slot, kvnew, &keyLink, 0);
-            updateAllocSizes(db, slot, oldsize, kvobjAllocSize(kvnew));
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(db, slot, oldsize, kvobjAllocSize(kvnew));
             kv = kvnew;
         }
         /* Now add to expires */

--- a/src/db.c
+++ b/src/db.c
@@ -126,7 +126,7 @@ void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, in
 }
 
 void updateSlotAllocSize(redisDb *db, int didx, size_t oldsize, size_t newsize) {
-    debugServerAssert(clusterSlotStatsEnabled());
+    debugServerAssert(server.memory_tracking_per_slot);
     kvstoreDictMetadata *dictMeta = kvstoreGetDictMetadata(db->keys, didx);
     if (!dictMeta) return;
 #ifdef REDIS_TEST
@@ -181,7 +181,7 @@ void dbgAssertKeysizesHist(redisDb *db) {
  * Triggered by DEBUG ALLOCSIZE-SLOTS-ASSERT 1 and tested after each command.
  */
 void dbgAssertAllocSizePerSlot(redisDb *db) {
-    if (!clusterSlotStatsEnabled()) return;
+    if (!server.memory_tracking_per_slot) return;
     size_t slot_sizes[CLUSTER_SLOTS] = {0};
     dictEntry *de;
     kvstoreIterator *kvs_it = kvstoreIteratorInit(db->keys);
@@ -383,7 +383,7 @@ kvobj *dbAddInternal(redisDb *db, robj *key, robj **valref, dictEntryLink *link,
     signalKeyAsReady(db, key, kv->type);
     notifyKeyspaceEvent(NOTIFY_NEW,"new",key,db->id);
     updateKeysizesHist(db, slot, kv->type, -1, getObjectLength(kv)); /* add hist */
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(db, slot, 0, kvobjAllocSize(kv));
     *valref = kv;
     return kv;
@@ -493,7 +493,7 @@ kvobj *dbAddRDBLoad(redisDb *db, sds key, robj **valref, long long expire) {
         kv = setExpireByLink(NULL, db, key, expire, bucket);
 
     updateKeysizesHist(db, slot, kv->type, -1, (int64_t) getObjectLength(kv));
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(db, slot, 0, kvobjAllocSize(kv));
     return *valref = kv;
 }
@@ -550,7 +550,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
         /* Because of RM_StringDMA, old may be changed, so we need get old again */
         old = dictGetKV(*link);
     }
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = kvobjAllocSize(old);
 
     if ((old->refcount == 1 && old->encoding != OBJ_ENCODING_EMBSTR) &&
@@ -606,7 +606,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
         }
     }
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(kvNew));
 
     if (server.io_threads_num > 1 && old->encoding == OBJ_ENCODING_RAW) {
@@ -790,7 +790,7 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
             kvstoreDictDelete(db->expires, slot, key->ptr);
 
         if (async) {
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(db, slot, kvobjAllocSize(kv), 0);
             freeObjAsync(key, kv, db->id);
             /* Set the key to NULL in the main dictionary. */
@@ -2527,7 +2527,7 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
         /* Val already had an expire field, so it was not reallocated. */
         serverAssert(kv == kvnew);
     } else { /* No old expire */
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = kvobjAllocSize(kv);
         uint64_t subexpiry = EB_EXPIRE_TIME_INVALID;
         /* If hash with HFEs, take care to remove from global HFE DS before attempting
@@ -2539,7 +2539,7 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
         /* if kvobj was reallocated, update dict */
         if (kv != kvnew) {
             kvstoreDictSetAtLink(db->keys, slot, kvnew, &keyLink, 0);
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(kvnew));
             kv = kvnew;
         }

--- a/src/db.c
+++ b/src/db.c
@@ -186,8 +186,7 @@ void dbgAssertAllocSizePerSlot(redisDb *db) {
     while ((de = kvstoreIteratorNext(kvs_it)) != NULL) {
         int slot = kvstoreIteratorGetCurrentDictIndex(kvs_it);
         kvobj *kv = dictGetKV(de);
-        if (kv->type < OBJ_TYPE_BASIC_MAX)
-            slot_sizes[slot] += kvobjAllocSize(kv);
+        slot_sizes[slot] += kvobjAllocSize(kv);
     }
     kvstoreIteratorRelease(kvs_it);
 

--- a/src/db.c
+++ b/src/db.c
@@ -125,7 +125,7 @@ void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, in
     }
 }
 
-void updateAllocSizes(redisDb *db, int didx, size_t oldsize, size_t newsize) {
+void updateSlotAllocSize(redisDb *db, int didx, size_t oldsize, size_t newsize) {
     debugServerAssert(server.cluster_enabled && server.cluster_slot_stats_enabled);
     kvstoreDictMetadata *dictMeta = kvstoreGetDictMetadata(db->keys, didx);
     if (!dictMeta) return;
@@ -384,7 +384,7 @@ kvobj *dbAddInternal(redisDb *db, robj *key, robj **valref, dictEntryLink *link,
     notifyKeyspaceEvent(NOTIFY_NEW,"new",key,db->id);
     updateKeysizesHist(db, slot, kv->type, -1, getObjectLength(kv)); /* add hist */
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(db, slot, 0, kvobjAllocSize(kv));
+        updateSlotAllocSize(db, slot, 0, kvobjAllocSize(kv));
     *valref = kv;
     return kv;
 }
@@ -494,7 +494,7 @@ kvobj *dbAddRDBLoad(redisDb *db, sds key, robj **valref, long long expire) {
 
     updateKeysizesHist(db, slot, kv->type, -1, (int64_t) getObjectLength(kv));
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(db, slot, 0, kvobjAllocSize(kv));
+        updateSlotAllocSize(db, slot, 0, kvobjAllocSize(kv));
     return *valref = kv;
 }
 
@@ -607,7 +607,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
     }
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(db, slot, oldsize, kvobjAllocSize(kvNew));
+        updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(kvNew));
 
     if (server.io_threads_num > 1 && old->encoding == OBJ_ENCODING_RAW) {
         /* In multi-threaded mode, the OBJ_ENCODING_RAW string object usually is
@@ -791,7 +791,7 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
 
         if (async) {
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(db, slot, kvobjAllocSize(kv), 0);
+                updateSlotAllocSize(db, slot, kvobjAllocSize(kv), 0);
             freeObjAsync(key, kv, db->id);
             /* Set the key to NULL in the main dictionary. */
             kvstoreDictSetAtLink(db->keys, slot, NULL, &link, 0);
@@ -2540,7 +2540,7 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
         if (kv != kvnew) {
             kvstoreDictSetAtLink(db->keys, slot, kvnew, &keyLink, 0);
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(db, slot, oldsize, kvobjAllocSize(kvnew));
+                updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(kvnew));
             kv = kvnew;
         }
         /* Now add to expires */

--- a/src/db.c
+++ b/src/db.c
@@ -126,7 +126,7 @@ void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, in
 }
 
 void updateSlotAllocSize(redisDb *db, int didx, size_t oldsize, size_t newsize) {
-    debugServerAssert(server.cluster_enabled && server.cluster_slot_stats_enabled);
+    debugServerAssert(clusterSlotStatsEnabled());
     kvstoreDictMetadata *dictMeta = kvstoreGetDictMetadata(db->keys, didx);
     if (!dictMeta) return;
 #ifdef REDIS_TEST
@@ -181,7 +181,7 @@ void dbgAssertKeysizesHist(redisDb *db) {
  * Triggered by DEBUG ALLOCSIZE-SLOTS-ASSERT 1 and tested after each command.
  */
 void dbgAssertAllocSizePerSlot(redisDb *db) {
-    if (!(server.cluster_enabled && server.cluster_slot_stats_enabled)) return;
+    if (!clusterSlotStatsEnabled()) return;
     size_t slot_sizes[CLUSTER_SLOTS] = {0};
     dictEntry *de;
     kvstoreIterator *kvs_it = kvstoreIteratorInit(db->keys);
@@ -383,7 +383,7 @@ kvobj *dbAddInternal(redisDb *db, robj *key, robj **valref, dictEntryLink *link,
     signalKeyAsReady(db, key, kv->type);
     notifyKeyspaceEvent(NOTIFY_NEW,"new",key,db->id);
     updateKeysizesHist(db, slot, kv->type, -1, getObjectLength(kv)); /* add hist */
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(db, slot, 0, kvobjAllocSize(kv));
     *valref = kv;
     return kv;
@@ -493,7 +493,7 @@ kvobj *dbAddRDBLoad(redisDb *db, sds key, robj **valref, long long expire) {
         kv = setExpireByLink(NULL, db, key, expire, bucket);
 
     updateKeysizesHist(db, slot, kv->type, -1, (int64_t) getObjectLength(kv));
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(db, slot, 0, kvobjAllocSize(kv));
     return *valref = kv;
 }
@@ -550,7 +550,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
         /* Because of RM_StringDMA, old may be changed, so we need get old again */
         old = dictGetKV(*link);
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = kvobjAllocSize(old);
 
     if ((old->refcount == 1 && old->encoding != OBJ_ENCODING_EMBSTR) &&
@@ -606,7 +606,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
         }
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(kvNew));
 
     if (server.io_threads_num > 1 && old->encoding == OBJ_ENCODING_RAW) {
@@ -790,7 +790,7 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
             kvstoreDictDelete(db->expires, slot, key->ptr);
 
         if (async) {
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(db, slot, kvobjAllocSize(kv), 0);
             freeObjAsync(key, kv, db->id);
             /* Set the key to NULL in the main dictionary. */
@@ -2527,7 +2527,7 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
         /* Val already had an expire field, so it was not reallocated. */
         serverAssert(kv == kvnew);
     } else { /* No old expire */
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = kvobjAllocSize(kv);
         uint64_t subexpiry = EB_EXPIRE_TIME_INVALID;
         /* If hash with HFEs, take care to remove from global HFE DS before attempting
@@ -2539,7 +2539,7 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
         /* if kvobj was reallocated, update dict */
         if (kv != kvnew) {
             kvstoreDictSetAtLink(db->keys, slot, kvnew, &keyLink, 0);
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(kvnew));
             kv = kvnew;
         }

--- a/src/db.c
+++ b/src/db.c
@@ -175,6 +175,33 @@ void dbgAssertKeysizesHist(redisDb *db) {
     }
 }
 
+/* Assert per-slot alloc_size (For debugging only)
+ *
+ * Triggered by DEBUG ALLOCSIZE-SLOTS-ASSERT 1 and tested after each command.
+ */
+void dbgAssertAllocSizePerSlot(redisDb *db) {
+    size_t slot_sizes[CLUSTER_SLOTS] = {0};
+    dictEntry *de;
+    kvstoreIterator *kvs_it = kvstoreIteratorInit(db->keys);
+    while ((de = kvstoreIteratorNext(kvs_it)) != NULL) {
+        int slot = kvstoreIteratorGetCurrentDictIndex(kvs_it);
+        kvobj *kv = dictGetKV(de);
+        if (kv->type < OBJ_TYPE_BASIC_MAX)
+            slot_sizes[slot] += kvobjAllocSize(kv);
+    }
+    kvstoreIteratorRelease(kvs_it);
+
+    int num_slots = kvstoreNumDicts(db->keys);
+    for (int slot = 0; slot < num_slots; slot++) {
+        kvstoreDictMetadata *dictMeta = kvstoreGetDictMetadata(db->keys, slot);
+        size_t want = slot_sizes[slot];
+        size_t have = dictMeta ? dictMeta->alloc_size : 0;
+        if (have == want) continue;
+        serverPanic("dbgAssertAllocSizePerSlot: slot=%d expected=%zu actual=%zu",
+                    slot, want, have);
+    }
+}
+
 /* Lookup a kvobj for read or write operations, or return NULL if the it is not
  * found in the specified DB. This function implements the functionality of
  * lookupKeyRead(), lookupKeyWrite() and their ...WithFlags() variants.

--- a/src/debug.c
+++ b/src/debug.c
@@ -547,6 +547,12 @@ NULL
             return;
         server.dbg_assert_keysizes = (flag != 0);
         addReply(c, shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr,"ALLOCSIZE-SLOTS-ASSERT") && c->argc == 3) {
+        long long flag;
+        if (getLongLongFromObjectOrReply(c, c->argv[2], &flag, NULL) != C_OK)
+            return;
+        server.dbg_assert_alloc_per_slot = (flag != 0);
+        addReply(c, shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"log") && c->argc == 3) {
         serverLog(LL_WARNING, "DEBUG LOG: %s", (char*)c->argv[2]->ptr);
         addReply(c,shared.ok);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1008,6 +1008,7 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
         ob = kvnew;
     }
 
+    size_t oldsize = kvobjAllocSize(ob);
     if (ob->type == OBJ_STRING) {
         /* Already handled in activeDefragStringOb. */
     } else if (ob->type == OBJ_LIST) {
@@ -1062,6 +1063,7 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
     } else {
         serverPanic("Unknown object type");
     }
+    updateAllocSizes(db, slot, oldsize, kvobjAllocSize(ob));
 }
 
 /* Defrag scan callback for the main db dictionary. */

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -982,11 +982,14 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
     UNUSED(link);
     dictEntryLink exlink = NULL;
     kvobj *kvnew = NULL, *ob = dictGetKV(de);
-    size_t oldsize = kvobjAllocSize(ob);
+    size_t oldsize = 0;
     redisDb *db = &server.db[ctx->dbid];
     int slot = ctx->kvstate.slot;
     unsigned char *newzl;
-    
+
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = kvobjAllocSize(ob);
+
     long long expire = kvobjGetExpire(ob);
     /* We can't search in db->expires for that KV after we've released
      * the pointer it holds, since it won't be able to do the string
@@ -1063,7 +1066,8 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
     } else {
         serverPanic("Unknown object type");
     }
-    updateAllocSizes(db, slot, oldsize, kvobjAllocSize(ob));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(db, slot, oldsize, kvobjAllocSize(ob));
 }
 
 /* Defrag scan callback for the main db dictionary. */
@@ -1193,6 +1197,7 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
     defragKeysCtx *defrag_keys_ctx = ctx;
     redisDb *db = &server.db[defrag_keys_ctx->dbid];
     int slot = defrag_keys_ctx->kvstate.slot;
+    size_t oldsize = 0;
 
     unsigned int iterations = 0;
     unsigned long long prev_defragged = server.stat_active_defrag_hits;
@@ -1203,11 +1208,13 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
         sds key = head->value;
         dictEntry *de = kvstoreDictFind(defrag_keys_ctx->kvstate.kvs, defrag_keys_ctx->kvstate.slot, key);
         kvobj *kv = de ? dictGetKV(de) : NULL;
-        size_t oldsize = kv ? kvobjAllocSize(kv) : 0;
 
         long long key_defragged = server.stat_active_defrag_hits;
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled && kv)
+            oldsize = kvobjAllocSize(kv);
         int timeout = (defragLaterItem(kv, &defrag_keys_ctx->defrag_later_cursor, endtime, defrag_keys_ctx->dbid) == 1);
-        if (kv) updateAllocSizes(db, slot, oldsize, kvobjAllocSize(kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled && kv)
+            updateAllocSizes(db, slot, oldsize, kvobjAllocSize(kv));
         if (key_defragged != server.stat_active_defrag_hits) {
             server.stat_active_defrag_key_hits++;
         } else {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -987,7 +987,7 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
     int slot = ctx->kvstate.slot;
     unsigned char *newzl;
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = kvobjAllocSize(ob);
 
     long long expire = kvobjGetExpire(ob);
@@ -1066,7 +1066,7 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
     } else {
         serverPanic("Unknown object type");
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(ob));
 }
 
@@ -1210,10 +1210,10 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
         kvobj *kv = de ? dictGetKV(de) : NULL;
 
         long long key_defragged = server.stat_active_defrag_hits;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled && kv)
+        if (clusterSlotStatsEnabled() && kv)
             oldsize = kvobjAllocSize(kv);
         int timeout = (defragLaterItem(kv, &defrag_keys_ctx->defrag_later_cursor, endtime, defrag_keys_ctx->dbid) == 1);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled && kv)
+        if (clusterSlotStatsEnabled() && kv)
             updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(kv));
         if (key_defragged != server.stat_active_defrag_hits) {
             server.stat_active_defrag_key_hits++;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1067,7 +1067,7 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
         serverPanic("Unknown object type");
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(db, slot, oldsize, kvobjAllocSize(ob));
+        updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(ob));
 }
 
 /* Defrag scan callback for the main db dictionary. */
@@ -1214,7 +1214,7 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
             oldsize = kvobjAllocSize(kv);
         int timeout = (defragLaterItem(kv, &defrag_keys_ctx->defrag_later_cursor, endtime, defrag_keys_ctx->dbid) == 1);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled && kv)
-            updateAllocSizes(db, slot, oldsize, kvobjAllocSize(kv));
+            updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(kv));
         if (key_defragged != server.stat_active_defrag_hits) {
             server.stat_active_defrag_key_hits++;
         } else {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -987,7 +987,7 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
     int slot = ctx->kvstate.slot;
     unsigned char *newzl;
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = kvobjAllocSize(ob);
 
     long long expire = kvobjGetExpire(ob);
@@ -1066,7 +1066,7 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
     } else {
         serverPanic("Unknown object type");
     }
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(ob));
 }
 
@@ -1210,10 +1210,10 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
         kvobj *kv = de ? dictGetKV(de) : NULL;
 
         long long key_defragged = server.stat_active_defrag_hits;
-        if (clusterSlotStatsEnabled() && kv)
+        if (server.memory_tracking_per_slot && kv)
             oldsize = kvobjAllocSize(kv);
         int timeout = (defragLaterItem(kv, &defrag_keys_ctx->defrag_later_cursor, endtime, defrag_keys_ctx->dbid) == 1);
-        if (clusterSlotStatsEnabled() && kv)
+        if (server.memory_tracking_per_slot && kv)
             updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(kv));
         if (key_defragged != server.stat_active_defrag_hits) {
             server.stat_active_defrag_key_hits++;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -982,6 +982,7 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
     UNUSED(link);
     dictEntryLink exlink = NULL;
     kvobj *kvnew = NULL, *ob = dictGetKV(de);
+    size_t oldsize = kvobjAllocSize(ob);
     redisDb *db = &server.db[ctx->dbid];
     int slot = ctx->kvstate.slot;
     unsigned char *newzl;
@@ -1008,7 +1009,6 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
         ob = kvnew;
     }
 
-    size_t oldsize = kvobjAllocSize(ob);
     if (ob->type == OBJ_STRING) {
         /* Already handled in activeDefragStringOb. */
     } else if (ob->type == OBJ_LIST) {
@@ -1191,6 +1191,8 @@ static int defragIsRunning(void) {
 /* A kvstoreHelperPreContinueFn */
 static doneStatus defragLaterStep(void *ctx, monotime endtime) {
     defragKeysCtx *defrag_keys_ctx = ctx;
+    redisDb *db = &server.db[defrag_keys_ctx->dbid];
+    int slot = defrag_keys_ctx->kvstate.slot;
 
     unsigned int iterations = 0;
     unsigned long long prev_defragged = server.stat_active_defrag_hits;
@@ -1201,9 +1203,11 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
         sds key = head->value;
         dictEntry *de = kvstoreDictFind(defrag_keys_ctx->kvstate.kvs, defrag_keys_ctx->kvstate.slot, key);
         kvobj *kv = de ? dictGetKV(de) : NULL;
+        size_t oldsize = kv ? kvobjAllocSize(kv) : 0;
 
         long long key_defragged = server.stat_active_defrag_hits;
         int timeout = (defragLaterItem(kv, &defrag_keys_ctx->defrag_later_cursor, endtime, defrag_keys_ctx->dbid) == 1);
+        if (kv) updateAllocSizes(db, slot, oldsize, kvobjAllocSize(kv));
         if (key_defragged != server.stat_active_defrag_hits) {
             server.stat_active_defrag_key_hits++;
         } else {

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1628,6 +1628,7 @@ void pfaddCommand(client *c) {
         kv = dbUnshareStringValue(c->db,c->argv[1],kv);
     }
     oldlen = stringObjectLen(kv);
+    size_t oldsize = stringObjectAllocSize(kv);
 
     /* Perform the low level ADD operation for every element. */
     for (j = 2; j < c->argc; j++) {
@@ -1639,12 +1640,14 @@ void pfaddCommand(client *c) {
             break;
         case -1:
             addReplyError(c,invalid_hll_err);
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
             return;
         }
     }
 
     hdr = kv->ptr;
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, oldlen, stringObjectLen(kv));
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
     if (updated) {
         HLL_INVALIDATE_CACHE(hdr);
         signalModifiedKey(c,c->db,c->argv[1]);
@@ -1796,6 +1799,7 @@ void pfmergeCommand(client *c) {
     }
 
     uint64_t oldLen = stringObjectLen(kv);
+    size_t oldsize = stringObjectAllocSize(kv);
 
     /* Convert the destination object to dense representation if at least
      * one of the inputs was dense. */
@@ -1823,6 +1827,7 @@ void pfmergeCommand(client *c) {
                      last hllSparseSet() call. */
     HLL_INVALIDATE_CACHE(hdr);
 
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
     signalModifiedKey(c,c->db,c->argv[1]);
     /* We generate a PFADD event for PFMERGE for semantical simplicity
      * since in theory this is a mass-add of elements. */
@@ -1984,6 +1989,7 @@ void pfdebugCommand(client *c) {
     if (isHLLObjectOrReply(c,o) != C_OK) return;
     o = dbUnshareStringValue(c->db,c->argv[2],o);
     hdr = o->ptr;
+    size_t oldsize = stringObjectAllocSize(o);
 
     /* PFDEBUG GETREG <key> */
     if (!strcasecmp(cmd,"getreg")) {
@@ -1996,6 +2002,7 @@ void pfdebugCommand(client *c) {
                 return;
             }
             updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, oldlen, stringObjectLen(o));
+            updateAllocSizes(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
             server.dirty++; /* Force propagation on encoding change. */
         }
 
@@ -2063,6 +2070,7 @@ void pfdebugCommand(client *c) {
                 return;
             }
             updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, oldlen, stringObjectLen(o));
+            updateAllocSizes(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
             conv = 1;
             server.dirty++; /* Force propagation on encoding change. */
         }

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1629,7 +1629,7 @@ void pfaddCommand(client *c) {
         kv = dbUnshareStringValue(c->db,c->argv[1],kv);
     }
     oldlen = stringObjectLen(kv);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = stringObjectAllocSize(kv);
 
     /* Perform the low level ADD operation for every element. */
@@ -1642,7 +1642,7 @@ void pfaddCommand(client *c) {
             break;
         case -1:
             addReplyError(c,invalid_hll_err);
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
             return;
         }
@@ -1650,7 +1650,7 @@ void pfaddCommand(client *c) {
 
     hdr = kv->ptr;
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, oldlen, stringObjectLen(kv));
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
     if (updated) {
         HLL_INVALIDATE_CACHE(hdr);
@@ -1804,7 +1804,7 @@ void pfmergeCommand(client *c) {
     }
 
     uint64_t oldLen = stringObjectLen(kv);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = stringObjectAllocSize(kv);
 
     /* Convert the destination object to dense representation if at least
@@ -1833,7 +1833,7 @@ void pfmergeCommand(client *c) {
                      last hllSparseSet() call. */
     HLL_INVALIDATE_CACHE(hdr);
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
     signalModifiedKey(c,c->db,c->argv[1]);
     /* We generate a PFADD event for PFMERGE for semantical simplicity
@@ -1997,7 +1997,7 @@ void pfdebugCommand(client *c) {
     if (isHLLObjectOrReply(c,o) != C_OK) return;
     o = dbUnshareStringValue(c->db,c->argv[2],o);
     hdr = o->ptr;
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = stringObjectAllocSize(o);
 
     /* PFDEBUG GETREG <key> */
@@ -2011,7 +2011,7 @@ void pfdebugCommand(client *c) {
                 return;
             }
             updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, oldlen, stringObjectLen(o));
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
             server.dirty++; /* Force propagation on encoding change. */
         }
@@ -2080,7 +2080,7 @@ void pfdebugCommand(client *c) {
                 return;
             }
             updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, oldlen, stringObjectLen(o));
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
             conv = 1;
             server.dirty++; /* Force propagation on encoding change. */

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1629,7 +1629,7 @@ void pfaddCommand(client *c) {
         kv = dbUnshareStringValue(c->db,c->argv[1],kv);
     }
     oldlen = stringObjectLen(kv);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = stringObjectAllocSize(kv);
 
     /* Perform the low level ADD operation for every element. */
@@ -1642,7 +1642,7 @@ void pfaddCommand(client *c) {
             break;
         case -1:
             addReplyError(c,invalid_hll_err);
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
             return;
         }
@@ -1650,7 +1650,7 @@ void pfaddCommand(client *c) {
 
     hdr = kv->ptr;
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, oldlen, stringObjectLen(kv));
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
     if (updated) {
         HLL_INVALIDATE_CACHE(hdr);
@@ -1804,7 +1804,7 @@ void pfmergeCommand(client *c) {
     }
 
     uint64_t oldLen = stringObjectLen(kv);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = stringObjectAllocSize(kv);
 
     /* Convert the destination object to dense representation if at least
@@ -1833,7 +1833,7 @@ void pfmergeCommand(client *c) {
                      last hllSparseSet() call. */
     HLL_INVALIDATE_CACHE(hdr);
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
     signalModifiedKey(c,c->db,c->argv[1]);
     /* We generate a PFADD event for PFMERGE for semantical simplicity
@@ -1997,7 +1997,7 @@ void pfdebugCommand(client *c) {
     if (isHLLObjectOrReply(c,o) != C_OK) return;
     o = dbUnshareStringValue(c->db,c->argv[2],o);
     hdr = o->ptr;
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = stringObjectAllocSize(o);
 
     /* PFDEBUG GETREG <key> */
@@ -2011,7 +2011,7 @@ void pfdebugCommand(client *c) {
                 return;
             }
             updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, oldlen, stringObjectLen(o));
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
             server.dirty++; /* Force propagation on encoding change. */
         }
@@ -2080,7 +2080,7 @@ void pfdebugCommand(client *c) {
                 return;
             }
             updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, oldlen, stringObjectLen(o));
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
             conv = 1;
             server.dirty++; /* Force propagation on encoding change. */

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1643,7 +1643,7 @@ void pfaddCommand(client *c) {
         case -1:
             addReplyError(c,invalid_hll_err);
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
+                updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
             return;
         }
     }
@@ -1651,7 +1651,7 @@ void pfaddCommand(client *c) {
     hdr = kv->ptr;
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, oldlen, stringObjectLen(kv));
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
     if (updated) {
         HLL_INVALIDATE_CACHE(hdr);
         signalModifiedKey(c,c->db,c->argv[1]);
@@ -1834,7 +1834,7 @@ void pfmergeCommand(client *c) {
     HLL_INVALIDATE_CACHE(hdr);
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
     signalModifiedKey(c,c->db,c->argv[1]);
     /* We generate a PFADD event for PFMERGE for semantical simplicity
      * since in theory this is a mass-add of elements. */
@@ -2012,7 +2012,7 @@ void pfdebugCommand(client *c) {
             }
             updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, oldlen, stringObjectLen(o));
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
+                updateSlotAllocSize(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
             server.dirty++; /* Force propagation on encoding change. */
         }
 
@@ -2081,7 +2081,7 @@ void pfdebugCommand(client *c) {
             }
             updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, oldlen, stringObjectLen(o));
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
+                updateSlotAllocSize(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
             conv = 1;
             server.dirty++; /* Force propagation on encoding change. */
         }

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1611,6 +1611,7 @@ invalid:
 void pfaddCommand(client *c) {
     uint64_t oldlen;
     dictEntryLink link;
+    size_t oldsize = 0;
     kvobj *kv = lookupKeyWriteWithLink(c->db,c->argv[1], &link);
 
     struct hllhdr *hdr;
@@ -1628,7 +1629,8 @@ void pfaddCommand(client *c) {
         kv = dbUnshareStringValue(c->db,c->argv[1],kv);
     }
     oldlen = stringObjectLen(kv);
-    size_t oldsize = stringObjectAllocSize(kv);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = stringObjectAllocSize(kv);
 
     /* Perform the low level ADD operation for every element. */
     for (j = 2; j < c->argc; j++) {
@@ -1640,14 +1642,16 @@ void pfaddCommand(client *c) {
             break;
         case -1:
             addReplyError(c,invalid_hll_err);
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
             return;
         }
     }
 
     hdr = kv->ptr;
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, oldlen, stringObjectLen(kv));
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
     if (updated) {
         HLL_INVALIDATE_CACHE(hdr);
         signalModifiedKey(c,c->db,c->argv[1]);
@@ -1758,6 +1762,7 @@ void pfmergeCommand(client *c) {
     struct hllhdr *hdr;
     int j;
     int use_dense = 0; /* Use dense representation as target? */
+    size_t oldsize = 0;
 
     /* Compute an HLL with M[i] = MAX(M[i]_j).
      * We store the maximum into the max array of registers. We'll write
@@ -1799,7 +1804,8 @@ void pfmergeCommand(client *c) {
     }
 
     uint64_t oldLen = stringObjectLen(kv);
-    size_t oldsize = stringObjectAllocSize(kv);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = stringObjectAllocSize(kv);
 
     /* Convert the destination object to dense representation if at least
      * one of the inputs was dense. */
@@ -1827,7 +1833,8 @@ void pfmergeCommand(client *c) {
                      last hllSparseSet() call. */
     HLL_INVALIDATE_CACHE(hdr);
 
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
     signalModifiedKey(c,c->db,c->argv[1]);
     /* We generate a PFADD event for PFMERGE for semantical simplicity
      * since in theory this is a mass-add of elements. */
@@ -1960,6 +1967,7 @@ void pfdebugCommand(client *c) {
     struct hllhdr *hdr;
     kvobj *o;
     int j;
+    size_t oldsize = 0;
 
     if (!strcasecmp(cmd, "simd")) {
         if (c->argc != 3) goto arityerr;
@@ -1989,7 +1997,8 @@ void pfdebugCommand(client *c) {
     if (isHLLObjectOrReply(c,o) != C_OK) return;
     o = dbUnshareStringValue(c->db,c->argv[2],o);
     hdr = o->ptr;
-    size_t oldsize = stringObjectAllocSize(o);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = stringObjectAllocSize(o);
 
     /* PFDEBUG GETREG <key> */
     if (!strcasecmp(cmd,"getreg")) {
@@ -2002,7 +2011,8 @@ void pfdebugCommand(client *c) {
                 return;
             }
             updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, oldlen, stringObjectLen(o));
-            updateAllocSizes(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
             server.dirty++; /* Force propagation on encoding change. */
         }
 
@@ -2070,7 +2080,8 @@ void pfdebugCommand(client *c) {
                 return;
             }
             updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, oldlen, stringObjectLen(o));
-            updateAllocSizes(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(c->db, getKeySlot(c->argv[2]->ptr), oldsize, stringObjectAllocSize(o));
             conv = 1;
             server.dirty++; /* Force propagation on encoding change. */
         }

--- a/src/intset.c
+++ b/src/intset.c
@@ -102,6 +102,12 @@ intset *intsetNew(void) {
     return is;
 }
 
+size_t intsetAllocSize(intset *is) {
+    uint64_t size = (uint64_t)intrev32ifbe(is->length)*intrev32ifbe(is->encoding);
+    assert(size <= SIZE_MAX - sizeof(intset));
+    return sizeof(intset)+size;
+}
+
 /* Resize the intset */
 static intset *intsetResize(intset *is, uint32_t len) {
     uint64_t size = (uint64_t)len*intrev32ifbe(is->encoding);

--- a/src/intset.h
+++ b/src/intset.h
@@ -49,6 +49,7 @@ uint8_t intsetGet(intset *is, uint32_t pos, int64_t *value);
 uint32_t intsetLen(const intset *is);
 size_t intsetBlobLen(intset *is);
 int intsetValidateIntegrity(const unsigned char *is, size_t size, int deep);
+size_t intsetAllocSize(intset *is);
 
 #ifdef REDIS_TEST
 int intsetTest(int argc, char *argv[], int flags);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -149,6 +149,12 @@ static void freeDictIfNeeded(kvstore *kvs, int didx) {
         kvstoreDictSize(kvs, didx) != 0 ||
         kvstoreDictIsRehashingPaused(kvs, didx))
         return;
+#ifdef REDIS_TEST
+    if (kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST) {
+        kvstoreDictMetaEx *metadata = (kvstoreDictMetaEx *)dictMetadata(kvs->dicts[didx]);
+        serverAssert(metadata->meta.alloc_size == 0);
+    }
+#endif
     dictRelease(kvs->dicts[didx]);
     kvs->dicts[didx] = NULL;
     kvs->allocated_dicts--;
@@ -209,6 +215,18 @@ static size_t kvstoreDictMetaBaseSize(dict *d) {
 static size_t kvstoreDictMetadataExtendSize(dict *d) {
     UNUSED(d);
     return sizeof(kvstoreDictMetaEx);
+}
+
+void kvstoreTrackDeallocation(dict *d, void *kv) {
+    kvstore *kvs = d->type->userdata;
+    if (kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST) {
+        kvstoreDictMetaEx *metadata = (kvstoreDictMetaEx *)dictMetadata(d);
+        size_t alloc_size = kvobjAllocSize(kv);
+#ifdef REDIS_TEST
+        serverAssert(alloc_size <= metadata->meta.alloc_size);
+#endif
+        metadata->meta.alloc_size -= alloc_size;
+    }
 }
 
 /**********************************/
@@ -304,6 +322,13 @@ void kvstoreRelease(kvstore *kvs) {
         kvstoreDictMetaBase *metadata = (kvstoreDictMetaBase *)dictMetadata(d);
         if (metadata->rehashing_node)
             metadata->rehashing_node = NULL;
+#ifdef REDIS_TEST
+        dictEmpty(d, NULL);
+        if (kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST) {
+            kvstoreDictMetaEx *metaEx = (kvstoreDictMetaEx *)metadata;
+            serverAssert(metaEx->meta.alloc_size == 0);
+        }
+#endif
         dictRelease(d);
     }
     zfree(kvs->dicts);
@@ -739,6 +764,13 @@ unsigned long kvstoreDictSize(kvstore *kvs, int didx)
     if (!d)
         return 0;
     return dictSize(d);
+}
+
+size_t kvstoreDictAllocSize(kvstore *kvs, int didx)
+{
+    kvstoreDictMetadata *dictMeta = kvstoreGetDictMetadata(kvs, didx);
+    if (!dictMeta) return 0;
+    return dictMeta->alloc_size;
 }
 
 kvstoreDictIterator *kvstoreGetDictIterator(kvstore *kvs, int didx)

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -218,7 +218,7 @@ static size_t kvstoreDictMetadataExtendSize(dict *d) {
 }
 
 void kvstoreTrackDeallocation(dict *d, void *kv) {
-    if (!(server.cluster_enabled && server.cluster_slot_stats_enabled)) return;
+    if (!clusterSlotStatsEnabled()) return;
     kvstore *kvs = d->type->userdata;
     if (kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST) {
         kvstoreDictMetaEx *metadata = (kvstoreDictMetaEx *)dictMetadata(d);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -218,7 +218,7 @@ static size_t kvstoreDictMetadataExtendSize(dict *d) {
 }
 
 void kvstoreTrackDeallocation(dict *d, void *kv) {
-    if (!clusterSlotStatsEnabled()) return;
+    if (!server.memory_tracking_per_slot) return;
     kvstore *kvs = d->type->userdata;
     if (kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST) {
         kvstoreDictMetaEx *metadata = (kvstoreDictMetaEx *)dictMetadata(d);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -218,6 +218,7 @@ static size_t kvstoreDictMetadataExtendSize(dict *d) {
 }
 
 void kvstoreTrackDeallocation(dict *d, void *kv) {
+    if (!(server.cluster_enabled && server.cluster_slot_stats_enabled)) return;
     kvstore *kvs = d->type->userdata;
     if (kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST) {
         kvstoreDictMetaEx *metadata = (kvstoreDictMetaEx *)dictMetadata(d);

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -41,6 +41,7 @@ typedef struct {
 
 /* Like kvstoreMetadata, this one per dict */
 typedef struct {
+    size_t alloc_size; /* total memory used (in bytes) by this dict */
     int64_t keysizes_hist[MAX_KEYSIZES_TYPES][MAX_KEYSIZES_BINS];
 } kvstoreDictMetadata;
 
@@ -94,6 +95,7 @@ unsigned long kvstoreDictRehashingCount(kvstore *kvs);
 
 /* Specific dict access by dict-index */
 unsigned long kvstoreDictSize(kvstore *kvs, int didx);
+size_t kvstoreDictAllocSize(kvstore *kvs, int didx);
 kvstoreDictIterator *kvstoreGetDictIterator(kvstore *kvs, int didx);
 kvstoreDictIterator *kvstoreGetDictSafeIterator(kvstore *kvs, int didx);
 void kvstoreReleaseDictIterator(kvstoreDictIterator *kvs_id);
@@ -117,6 +119,7 @@ kvstoreMetadata *kvstoreGetMetadata(kvstore *kvs);
 
 dictEntryLink kvstoreDictFindLink(kvstore *kvs, int didx, void *key, dictEntryLink *bucket);
 void kvstoreDictSetAtLink(kvstore *kvs, int didx, void *kv, dictEntryLink *link, int newItem);
+void kvstoreTrackDeallocation(dict *d, void *kv);
 
 /* dict with distinct key & value (no_value=1) currently is used only by pubsub. */
 void kvstoreDictSetKey(kvstore *kvs, int didx, dictEntry* de, void *key);

--- a/src/module.c
+++ b/src/module.c
@@ -4581,11 +4581,13 @@ int RM_ListPush(RedisModuleKey *key, int where, RedisModuleString *ele) {
     if (key->kv && key->kv->type != OBJ_LIST) return REDISMODULE_ERR;
     if (key->iter) moduleFreeKeyIterator(key);
     if (key->kv == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_LIST);
+    size_t oldsize = listTypeAllocSize(key->kv);
     listTypeTryConversionAppend(key->kv, &ele, 0, 0, moduleFreeListIterator, key);
     listTypePush(key->kv, ele,
         (where == REDISMODULE_LIST_HEAD) ? LIST_HEAD : LIST_TAIL);
     int64_t l = listTypeLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l-1, l);
+    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
     return REDISMODULE_OK;
 }
 
@@ -4613,14 +4615,19 @@ RedisModuleString *RM_ListPop(RedisModuleKey *key, int where) {
         return NULL;
     }
     if (key->iter) moduleFreeKeyIterator(key);
+    size_t oldsize = listTypeAllocSize(key->kv);
     robj *ele = listTypePop(key->kv,
         (where == REDISMODULE_LIST_HEAD) ? LIST_HEAD : LIST_TAIL);
     robj *decoded = getDecodedObject(ele);
     decrRefCount(ele);
     int64_t l = (int64_t) listTypeLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l+1, l);
-    if (!moduleDelKeyIfEmpty(key))
+    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+    if (!moduleDelKeyIfEmpty(key)) {
+        oldsize = listTypeAllocSize(key->kv);
         listTypeTryConversion(key->kv, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+    }
     autoMemoryAdd(key->ctx,REDISMODULE_AM_STRING,decoded);
     return decoded;
 }
@@ -4678,14 +4685,17 @@ int RM_ListSet(RedisModuleKey *key, long index, RedisModuleString *value) {
         errno = ENOTSUP;
         return REDISMODULE_ERR;
     }
+    size_t oldsize = listTypeAllocSize(key->kv);
     listTypeTryConversionAppend(key->kv, &value, 0, 0, moduleFreeListIterator, key);
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         listTypeReplace(&key->u.list.entry, value);
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         /* A note in quicklist.c forbids use of iterator after insert, so
          * probably also after replace. */
         moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         return REDISMODULE_ERR;
     }
 }
@@ -4724,14 +4734,19 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
         /* Insert before the first element => push head. */
         return RM_ListPush(key, REDISMODULE_LIST_HEAD, value);
     }
+    size_t oldsize = listTypeAllocSize(key->kv);
     listTypeTryConversionAppend(key->kv, &value, 0, 0, moduleFreeListIterator, key);
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         int where = index < 0 ? LIST_TAIL : LIST_HEAD;
         listTypeInsert(&key->u.list.entry, value, where);
+        int64_t l = (int64_t) listTypeLength(key->kv);
+        updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l-1, l);
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         /* A note in quicklist.c forbids use of iterator after insert. */
         moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         return REDISMODULE_ERR;
     }
 }
@@ -4749,11 +4764,15 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
  */
 int RM_ListDelete(RedisModuleKey *key, long index) {
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
+        size_t oldsize = listTypeAllocSize(key->kv);
         listTypeDelete(key->iter, &key->u.list.entry);
         int64_t l = (int64_t) listTypeLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l+1, l);
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         if (moduleDelKeyIfEmpty(key)) return REDISMODULE_OK;
+        oldsize = listTypeAllocSize(key->kv);
         listTypeTryConversion(key->kv, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         if (!key->iter) return REDISMODULE_OK; /* Return ASAP if iterator has been freed */
         if (listTypeNext(key->iter, &key->u.list.entry)) {
             /* After delete entry at position 'index', we need to update
@@ -4841,15 +4860,18 @@ int RM_ZsetAdd(RedisModuleKey *key, double score, RedisModuleString *ele, int *f
     if (!(key->mode & REDISMODULE_WRITE)) return REDISMODULE_ERR;
     if (key->kv && key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
     if (key->kv == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_ZSET);
+    size_t oldsize = zsetAllocSize(key->kv);
     if (flagsptr) in_flags = moduleZsetAddFlagsToCoreFlags(*flagsptr);
     if (zsetAdd(key->kv,score,ele->ptr,in_flags,&out_flags,NULL) == 0) {
         if (flagsptr) *flagsptr = 0;
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
     if (flagsptr) *flagsptr = moduleZsetAddFlagsFromCoreFlags(out_flags);
     int64_t l = (int64_t) zsetLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l-1, l);
+    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     return REDISMODULE_OK;
 }
 
@@ -4871,13 +4893,16 @@ int RM_ZsetIncrby(RedisModuleKey *key, double score, RedisModuleString *ele, int
     if (!(key->mode & REDISMODULE_WRITE)) return REDISMODULE_ERR;
     if (key->kv && key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
     if (key->kv == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_ZSET);
+    size_t oldsize = zsetAllocSize(key->kv);
     if (flagsptr) in_flags = moduleZsetAddFlagsToCoreFlags(*flagsptr);
     in_flags |= ZADD_IN_INCR;
     if (zsetAdd(key->kv,score,ele->ptr,in_flags,&out_flags,newscore) == 0) {
         if (flagsptr) *flagsptr = 0;
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
+    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     if (out_flags & ZADD_OUT_ADDED) {
         int64_t l = (int64_t) zsetLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l-1, l);
@@ -4906,14 +4931,21 @@ int RM_ZsetIncrby(RedisModuleKey *key, double score, RedisModuleString *ele, int
  * Empty keys will be handled correctly by doing nothing. */
 int RM_ZsetRem(RedisModuleKey *key, RedisModuleString *ele, int *deleted) {
     if (!(key->mode & REDISMODULE_WRITE)) return REDISMODULE_ERR;
-    if (key->kv && key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
-    if (key->kv != NULL && zsetDel(key->kv,ele->ptr)) {
+    if (key->kv == NULL) {
+        if (deleted) *deleted = 0;
+        return REDISMODULE_OK;
+    }
+    if (key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
+    size_t oldsize = zsetAllocSize(key->kv);
+    if (zsetDel(key->kv,ele->ptr)) {
         if (deleted) *deleted = 1;
         int64_t l = (int64_t) zsetLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l+1, l);
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
     } else {
         if (deleted) *deleted = 0;
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     }
     return REDISMODULE_OK;
 }
@@ -5374,7 +5406,9 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
 
         /* Handle deletion if value is REDISMODULE_HASH_DELETE. */
         if (value == REDISMODULE_HASH_DELETE) {
+            size_t oldsize = hashTypeAllocSize(key->kv);
             count += hashTypeDelete(key->kv, field->ptr, 1);
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
             if (flags & REDISMODULE_HASH_CFIELDS) decrRefCount(field);
             continue;
         }
@@ -5387,8 +5421,10 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
             low_flags |= HASH_SET_TAKE_FIELD;
 
         robj *argv[2] = {field,value};
+        size_t oldsize = hashTypeAllocSize(key->kv);
         hashTypeTryConversion(key->db,key->kv,argv,0,1);
         int updated = hashTypeSet(key->db, key->kv, field->ptr, value->ptr, low_flags);
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
         count += (flags & REDISMODULE_HASH_COUNT_ALL) ? 1 : updated;
 
         /* If CFIELDS is active, SDS string ownership is now of hashTypeSet(),
@@ -5628,6 +5664,7 @@ int RM_StreamAdd(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisM
         use_id_ptr = &use_id;
     }
 
+    size_t oldsize = s->alloc_size;
     if (streamAppendItem(s,argv,numfields,&added_id,use_id_ptr,1) == C_ERR) {
         /* Either the ID not greater than all existing IDs in the stream, or
          * the elements are too large to be stored. either way, errno is already
@@ -5635,6 +5672,7 @@ int RM_StreamAdd(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisM
         if (created) moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
+    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     /* Postponed signalKeyAsReady(). Done implicitly by moduleCreateEmptyKey()
      * so not needed if the stream has just been created. */
     if (!created) key->u.stream.signalready = 1;
@@ -5678,8 +5716,10 @@ int RM_StreamDelete(RedisModuleKey *key, RedisModuleStreamID *id) {
         return REDISMODULE_ERR;
     }
     stream *s = key->kv->ptr;
+    size_t oldsize = s->alloc_size;
     streamID streamid = {id->ms, id->seq};
     if (streamDeleteItem(s, &streamid)) {
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
         return REDISMODULE_OK;
     } else {
         errno = ENOENT; /* no entry with this id */
@@ -5978,7 +6018,11 @@ long long RM_StreamTrimByLength(RedisModuleKey *key, int flags, long long length
         return -1;
     }
     int approx = flags & REDISMODULE_STREAM_TRIM_APPROX ? 1 : 0;
-    return streamTrimByLength((stream *)key->kv->ptr, length, approx);
+    stream *s = key->kv->ptr;
+    size_t oldsize = s->alloc_size;
+    long long retval = streamTrimByLength(s, length, approx);
+    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
+    return retval;
 }
 
 /* Trim a stream by ID, similar to XTRIM with MINID.
@@ -6009,7 +6053,11 @@ long long RM_StreamTrimByID(RedisModuleKey *key, int flags, RedisModuleStreamID 
     }
     int approx = flags & REDISMODULE_STREAM_TRIM_APPROX ? 1 : 0;
     streamID minid = (streamID){id->ms, id->seq};
-    return streamTrimByID((stream *)key->kv->ptr, minid, approx);
+    stream *s = key->kv->ptr;
+    size_t oldsize = s->alloc_size;
+    long long retval = streamTrimByID(s, minid, approx);
+    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
+    return retval;
 }
 
 /* --------------------------------------------------------------------------

--- a/src/module.c
+++ b/src/module.c
@@ -4582,14 +4582,14 @@ int RM_ListPush(RedisModuleKey *key, int where, RedisModuleString *ele) {
     if (key->kv && key->kv->type != OBJ_LIST) return REDISMODULE_ERR;
     if (key->iter) moduleFreeKeyIterator(key);
     if (key->kv == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_LIST);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = listTypeAllocSize(key->kv);
     listTypeTryConversionAppend(key->kv, &ele, 0, 0, moduleFreeListIterator, key);
     listTypePush(key->kv, ele,
         (where == REDISMODULE_LIST_HEAD) ? LIST_HEAD : LIST_TAIL);
     int64_t l = listTypeLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l-1, l);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
     return REDISMODULE_OK;
 }
@@ -4619,7 +4619,7 @@ RedisModuleString *RM_ListPop(RedisModuleKey *key, int where) {
         return NULL;
     }
     if (key->iter) moduleFreeKeyIterator(key);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = listTypeAllocSize(key->kv);
     robj *ele = listTypePop(key->kv,
         (where == REDISMODULE_LIST_HEAD) ? LIST_HEAD : LIST_TAIL);
@@ -4627,13 +4627,13 @@ RedisModuleString *RM_ListPop(RedisModuleKey *key, int where) {
     decrRefCount(ele);
     int64_t l = (int64_t) listTypeLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l+1, l);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
     if (!moduleDelKeyIfEmpty(key)) {
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = listTypeAllocSize(key->kv);
         listTypeTryConversion(key->kv, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
     }
     autoMemoryAdd(key->ctx,REDISMODULE_AM_STRING,decoded);
@@ -4694,19 +4694,19 @@ int RM_ListSet(RedisModuleKey *key, long index, RedisModuleString *value) {
         errno = ENOTSUP;
         return REDISMODULE_ERR;
     }
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = listTypeAllocSize(key->kv);
     listTypeTryConversionAppend(key->kv, &value, 0, 0, moduleFreeListIterator, key);
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         listTypeReplace(&key->u.list.entry, value);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         /* A note in quicklist.c forbids use of iterator after insert, so
          * probably also after replace. */
         moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         return REDISMODULE_ERR;
     }
@@ -4747,7 +4747,7 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
         /* Insert before the first element => push head. */
         return RM_ListPush(key, REDISMODULE_LIST_HEAD, value);
     }
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = listTypeAllocSize(key->kv);
     listTypeTryConversionAppend(key->kv, &value, 0, 0, moduleFreeListIterator, key);
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
@@ -4755,13 +4755,13 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
         listTypeInsert(&key->u.list.entry, value, where);
         int64_t l = (int64_t) listTypeLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l-1, l);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         /* A note in quicklist.c forbids use of iterator after insert. */
         moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         return REDISMODULE_ERR;
     }
@@ -4781,18 +4781,18 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
 int RM_ListDelete(RedisModuleKey *key, long index) {
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         size_t oldsize = 0;
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = listTypeAllocSize(key->kv);
         listTypeDelete(key->iter, &key->u.list.entry);
         int64_t l = (int64_t) listTypeLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l+1, l);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         if (moduleDelKeyIfEmpty(key)) return REDISMODULE_OK;
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = listTypeAllocSize(key->kv);
         listTypeTryConversion(key->kv, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         if (!key->iter) return REDISMODULE_OK; /* Return ASAP if iterator has been freed */
         if (listTypeNext(key->iter, &key->u.list.entry)) {
@@ -4882,12 +4882,12 @@ int RM_ZsetAdd(RedisModuleKey *key, double score, RedisModuleString *ele, int *f
     if (!(key->mode & REDISMODULE_WRITE)) return REDISMODULE_ERR;
     if (key->kv && key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
     if (key->kv == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_ZSET);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(key->kv);
     if (flagsptr) in_flags = moduleZsetAddFlagsToCoreFlags(*flagsptr);
     if (zsetAdd(key->kv,score,ele->ptr,in_flags,&out_flags,NULL) == 0) {
         if (flagsptr) *flagsptr = 0;
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
@@ -4895,7 +4895,7 @@ int RM_ZsetAdd(RedisModuleKey *key, double score, RedisModuleString *ele, int *f
     if (flagsptr) *flagsptr = moduleZsetAddFlagsFromCoreFlags(out_flags);
     int64_t l = (int64_t) zsetLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l-1, l);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     return REDISMODULE_OK;
 }
@@ -4919,18 +4919,18 @@ int RM_ZsetIncrby(RedisModuleKey *key, double score, RedisModuleString *ele, int
     if (!(key->mode & REDISMODULE_WRITE)) return REDISMODULE_ERR;
     if (key->kv && key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
     if (key->kv == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_ZSET);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(key->kv);
     if (flagsptr) in_flags = moduleZsetAddFlagsToCoreFlags(*flagsptr);
     in_flags |= ZADD_IN_INCR;
     if (zsetAdd(key->kv,score,ele->ptr,in_flags,&out_flags,newscore) == 0) {
         if (flagsptr) *flagsptr = 0;
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     if (out_flags & ZADD_OUT_ADDED) {
         int64_t l = (int64_t) zsetLength(key->kv);
@@ -4966,18 +4966,18 @@ int RM_ZsetRem(RedisModuleKey *key, RedisModuleString *ele, int *deleted) {
         return REDISMODULE_OK;
     }
     if (key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(key->kv);
     if (zsetDel(key->kv,ele->ptr)) {
         if (deleted) *deleted = 1;
         int64_t l = (int64_t) zsetLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l+1, l);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
     } else {
         if (deleted) *deleted = 0;
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     }
     return REDISMODULE_OK;
@@ -5440,10 +5440,10 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
 
         /* Handle deletion if value is REDISMODULE_HASH_DELETE. */
         if (value == REDISMODULE_HASH_DELETE) {
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 oldsize = hashTypeAllocSize(key->kv);
             count += hashTypeDelete(key->kv, field->ptr, 1);
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
             if (flags & REDISMODULE_HASH_CFIELDS) decrRefCount(field);
             continue;
@@ -5457,11 +5457,11 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
             low_flags |= HASH_SET_TAKE_FIELD;
 
         robj *argv[2] = {field,value};
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = hashTypeAllocSize(key->kv);
         hashTypeTryConversion(key->db,key->kv,argv,0,1);
         int updated = hashTypeSet(key->db, key->kv, field->ptr, value->ptr, low_flags);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
         count += (flags & REDISMODULE_HASH_COUNT_ALL) ? 1 : updated;
 
@@ -5710,7 +5710,7 @@ int RM_StreamAdd(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisM
         if (created) moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     /* Postponed signalKeyAsReady(). Done implicitly by moduleCreateEmptyKey()
      * so not needed if the stream has just been created. */
@@ -5758,7 +5758,7 @@ int RM_StreamDelete(RedisModuleKey *key, RedisModuleStreamID *id) {
     size_t oldsize = s->alloc_size;
     streamID streamid = {id->ms, id->seq};
     if (streamDeleteItem(s, &streamid)) {
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
         return REDISMODULE_OK;
     } else {
@@ -6061,7 +6061,7 @@ long long RM_StreamTrimByLength(RedisModuleKey *key, int flags, long long length
     stream *s = key->kv->ptr;
     size_t oldsize = s->alloc_size;
     long long retval = streamTrimByLength(s, length, approx);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     return retval;
 }
@@ -6097,7 +6097,7 @@ long long RM_StreamTrimByID(RedisModuleKey *key, int flags, RedisModuleStreamID 
     stream *s = key->kv->ptr;
     size_t oldsize = s->alloc_size;
     long long retval = streamTrimByID(s, minid, approx);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     return retval;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -4590,7 +4590,7 @@ int RM_ListPush(RedisModuleKey *key, int where, RedisModuleString *ele) {
     int64_t l = listTypeLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l-1, l);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+        updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
     return REDISMODULE_OK;
 }
 
@@ -4628,13 +4628,13 @@ RedisModuleString *RM_ListPop(RedisModuleKey *key, int where) {
     int64_t l = (int64_t) listTypeLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l+1, l);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+        updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
     if (!moduleDelKeyIfEmpty(key)) {
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
             oldsize = listTypeAllocSize(key->kv);
         listTypeTryConversion(key->kv, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
     }
     autoMemoryAdd(key->ctx,REDISMODULE_AM_STRING,decoded);
     return decoded;
@@ -4700,14 +4700,14 @@ int RM_ListSet(RedisModuleKey *key, long index, RedisModuleString *value) {
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         listTypeReplace(&key->u.list.entry, value);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         /* A note in quicklist.c forbids use of iterator after insert, so
          * probably also after replace. */
         moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         return REDISMODULE_ERR;
     }
 }
@@ -4756,13 +4756,13 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
         int64_t l = (int64_t) listTypeLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l-1, l);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         /* A note in quicklist.c forbids use of iterator after insert. */
         moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         return REDISMODULE_ERR;
     }
 }
@@ -4787,13 +4787,13 @@ int RM_ListDelete(RedisModuleKey *key, long index) {
         int64_t l = (int64_t) listTypeLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l+1, l);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         if (moduleDelKeyIfEmpty(key)) return REDISMODULE_OK;
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
             oldsize = listTypeAllocSize(key->kv);
         listTypeTryConversion(key->kv, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         if (!key->iter) return REDISMODULE_OK; /* Return ASAP if iterator has been freed */
         if (listTypeNext(key->iter, &key->u.list.entry)) {
             /* After delete entry at position 'index', we need to update
@@ -4888,7 +4888,7 @@ int RM_ZsetAdd(RedisModuleKey *key, double score, RedisModuleString *ele, int *f
     if (zsetAdd(key->kv,score,ele->ptr,in_flags,&out_flags,NULL) == 0) {
         if (flagsptr) *flagsptr = 0;
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
@@ -4896,7 +4896,7 @@ int RM_ZsetAdd(RedisModuleKey *key, double score, RedisModuleString *ele, int *f
     int64_t l = (int64_t) zsetLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l-1, l);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
+        updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     return REDISMODULE_OK;
 }
 
@@ -4926,12 +4926,12 @@ int RM_ZsetIncrby(RedisModuleKey *key, double score, RedisModuleString *ele, int
     if (zsetAdd(key->kv,score,ele->ptr,in_flags,&out_flags,newscore) == 0) {
         if (flagsptr) *flagsptr = 0;
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
+        updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     if (out_flags & ZADD_OUT_ADDED) {
         int64_t l = (int64_t) zsetLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l-1, l);
@@ -4973,12 +4973,12 @@ int RM_ZsetRem(RedisModuleKey *key, RedisModuleString *ele, int *deleted) {
         int64_t l = (int64_t) zsetLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l+1, l);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
     } else {
         if (deleted) *deleted = 0;
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     }
     return REDISMODULE_OK;
 }
@@ -5444,7 +5444,7 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
                 oldsize = hashTypeAllocSize(key->kv);
             count += hashTypeDelete(key->kv, field->ptr, 1);
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
+                updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
             if (flags & REDISMODULE_HASH_CFIELDS) decrRefCount(field);
             continue;
         }
@@ -5462,7 +5462,7 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
         hashTypeTryConversion(key->db,key->kv,argv,0,1);
         int updated = hashTypeSet(key->db, key->kv, field->ptr, value->ptr, low_flags);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
         count += (flags & REDISMODULE_HASH_COUNT_ALL) ? 1 : updated;
 
         /* If CFIELDS is active, SDS string ownership is now of hashTypeSet(),
@@ -5711,7 +5711,7 @@ int RM_StreamAdd(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisM
         return REDISMODULE_ERR;
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
+        updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     /* Postponed signalKeyAsReady(). Done implicitly by moduleCreateEmptyKey()
      * so not needed if the stream has just been created. */
     if (!created) key->u.stream.signalready = 1;
@@ -5759,7 +5759,7 @@ int RM_StreamDelete(RedisModuleKey *key, RedisModuleStreamID *id) {
     streamID streamid = {id->ms, id->seq};
     if (streamDeleteItem(s, &streamid)) {
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
+            updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
         return REDISMODULE_OK;
     } else {
         errno = ENOENT; /* no entry with this id */
@@ -6062,7 +6062,7 @@ long long RM_StreamTrimByLength(RedisModuleKey *key, int flags, long long length
     size_t oldsize = s->alloc_size;
     long long retval = streamTrimByLength(s, length, approx);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
+        updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     return retval;
 }
 
@@ -6098,7 +6098,7 @@ long long RM_StreamTrimByID(RedisModuleKey *key, int flags, RedisModuleStreamID 
     size_t oldsize = s->alloc_size;
     long long retval = streamTrimByID(s, minid, approx);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
+        updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     return retval;
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -4582,14 +4582,14 @@ int RM_ListPush(RedisModuleKey *key, int where, RedisModuleString *ele) {
     if (key->kv && key->kv->type != OBJ_LIST) return REDISMODULE_ERR;
     if (key->iter) moduleFreeKeyIterator(key);
     if (key->kv == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_LIST);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = listTypeAllocSize(key->kv);
     listTypeTryConversionAppend(key->kv, &ele, 0, 0, moduleFreeListIterator, key);
     listTypePush(key->kv, ele,
         (where == REDISMODULE_LIST_HEAD) ? LIST_HEAD : LIST_TAIL);
     int64_t l = listTypeLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l-1, l);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
     return REDISMODULE_OK;
 }
@@ -4619,7 +4619,7 @@ RedisModuleString *RM_ListPop(RedisModuleKey *key, int where) {
         return NULL;
     }
     if (key->iter) moduleFreeKeyIterator(key);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = listTypeAllocSize(key->kv);
     robj *ele = listTypePop(key->kv,
         (where == REDISMODULE_LIST_HEAD) ? LIST_HEAD : LIST_TAIL);
@@ -4627,13 +4627,13 @@ RedisModuleString *RM_ListPop(RedisModuleKey *key, int where) {
     decrRefCount(ele);
     int64_t l = (int64_t) listTypeLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l+1, l);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
     if (!moduleDelKeyIfEmpty(key)) {
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = listTypeAllocSize(key->kv);
         listTypeTryConversion(key->kv, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
     }
     autoMemoryAdd(key->ctx,REDISMODULE_AM_STRING,decoded);
@@ -4694,19 +4694,19 @@ int RM_ListSet(RedisModuleKey *key, long index, RedisModuleString *value) {
         errno = ENOTSUP;
         return REDISMODULE_ERR;
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = listTypeAllocSize(key->kv);
     listTypeTryConversionAppend(key->kv, &value, 0, 0, moduleFreeListIterator, key);
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         listTypeReplace(&key->u.list.entry, value);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         /* A note in quicklist.c forbids use of iterator after insert, so
          * probably also after replace. */
         moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         return REDISMODULE_ERR;
     }
@@ -4747,7 +4747,7 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
         /* Insert before the first element => push head. */
         return RM_ListPush(key, REDISMODULE_LIST_HEAD, value);
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = listTypeAllocSize(key->kv);
     listTypeTryConversionAppend(key->kv, &value, 0, 0, moduleFreeListIterator, key);
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
@@ -4755,13 +4755,13 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
         listTypeInsert(&key->u.list.entry, value, where);
         int64_t l = (int64_t) listTypeLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l-1, l);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         /* A note in quicklist.c forbids use of iterator after insert. */
         moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         return REDISMODULE_ERR;
     }
@@ -4781,18 +4781,18 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
 int RM_ListDelete(RedisModuleKey *key, long index) {
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         size_t oldsize = 0;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = listTypeAllocSize(key->kv);
         listTypeDelete(key->iter, &key->u.list.entry);
         int64_t l = (int64_t) listTypeLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l+1, l);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         if (moduleDelKeyIfEmpty(key)) return REDISMODULE_OK;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = listTypeAllocSize(key->kv);
         listTypeTryConversion(key->kv, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         if (!key->iter) return REDISMODULE_OK; /* Return ASAP if iterator has been freed */
         if (listTypeNext(key->iter, &key->u.list.entry)) {
@@ -4882,12 +4882,12 @@ int RM_ZsetAdd(RedisModuleKey *key, double score, RedisModuleString *ele, int *f
     if (!(key->mode & REDISMODULE_WRITE)) return REDISMODULE_ERR;
     if (key->kv && key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
     if (key->kv == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_ZSET);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(key->kv);
     if (flagsptr) in_flags = moduleZsetAddFlagsToCoreFlags(*flagsptr);
     if (zsetAdd(key->kv,score,ele->ptr,in_flags,&out_flags,NULL) == 0) {
         if (flagsptr) *flagsptr = 0;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
@@ -4895,7 +4895,7 @@ int RM_ZsetAdd(RedisModuleKey *key, double score, RedisModuleString *ele, int *f
     if (flagsptr) *flagsptr = moduleZsetAddFlagsFromCoreFlags(out_flags);
     int64_t l = (int64_t) zsetLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l-1, l);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     return REDISMODULE_OK;
 }
@@ -4919,18 +4919,18 @@ int RM_ZsetIncrby(RedisModuleKey *key, double score, RedisModuleString *ele, int
     if (!(key->mode & REDISMODULE_WRITE)) return REDISMODULE_ERR;
     if (key->kv && key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
     if (key->kv == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_ZSET);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(key->kv);
     if (flagsptr) in_flags = moduleZsetAddFlagsToCoreFlags(*flagsptr);
     in_flags |= ZADD_IN_INCR;
     if (zsetAdd(key->kv,score,ele->ptr,in_flags,&out_flags,newscore) == 0) {
         if (flagsptr) *flagsptr = 0;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     if (out_flags & ZADD_OUT_ADDED) {
         int64_t l = (int64_t) zsetLength(key->kv);
@@ -4966,18 +4966,18 @@ int RM_ZsetRem(RedisModuleKey *key, RedisModuleString *ele, int *deleted) {
         return REDISMODULE_OK;
     }
     if (key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(key->kv);
     if (zsetDel(key->kv,ele->ptr)) {
         if (deleted) *deleted = 1;
         int64_t l = (int64_t) zsetLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l+1, l);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
     } else {
         if (deleted) *deleted = 0;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     }
     return REDISMODULE_OK;
@@ -5440,10 +5440,10 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
 
         /* Handle deletion if value is REDISMODULE_HASH_DELETE. */
         if (value == REDISMODULE_HASH_DELETE) {
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 oldsize = hashTypeAllocSize(key->kv);
             count += hashTypeDelete(key->kv, field->ptr, 1);
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
             if (flags & REDISMODULE_HASH_CFIELDS) decrRefCount(field);
             continue;
@@ -5457,11 +5457,11 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
             low_flags |= HASH_SET_TAKE_FIELD;
 
         robj *argv[2] = {field,value};
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = hashTypeAllocSize(key->kv);
         hashTypeTryConversion(key->db,key->kv,argv,0,1);
         int updated = hashTypeSet(key->db, key->kv, field->ptr, value->ptr, low_flags);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
         count += (flags & REDISMODULE_HASH_COUNT_ALL) ? 1 : updated;
 
@@ -5710,7 +5710,7 @@ int RM_StreamAdd(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisM
         if (created) moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     /* Postponed signalKeyAsReady(). Done implicitly by moduleCreateEmptyKey()
      * so not needed if the stream has just been created. */
@@ -5758,7 +5758,7 @@ int RM_StreamDelete(RedisModuleKey *key, RedisModuleStreamID *id) {
     size_t oldsize = s->alloc_size;
     streamID streamid = {id->ms, id->seq};
     if (streamDeleteItem(s, &streamid)) {
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
         return REDISMODULE_OK;
     } else {
@@ -6061,7 +6061,7 @@ long long RM_StreamTrimByLength(RedisModuleKey *key, int flags, long long length
     stream *s = key->kv->ptr;
     size_t oldsize = s->alloc_size;
     long long retval = streamTrimByLength(s, length, approx);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     return retval;
 }
@@ -6097,7 +6097,7 @@ long long RM_StreamTrimByID(RedisModuleKey *key, int flags, RedisModuleStreamID 
     stream *s = key->kv->ptr;
     size_t oldsize = s->alloc_size;
     long long retval = streamTrimByID(s, minid, approx);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     return retval;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -4566,6 +4566,7 @@ int moduleListIteratorSeek(RedisModuleKey *key, long index, int mode) {
  *
  * Note: Before Redis 7.0, `errno` was not set by this function. */
 int RM_ListPush(RedisModuleKey *key, int where, RedisModuleString *ele) {
+    size_t oldsize = 0;
     if (!key || !ele) {
         errno = EINVAL;
         return REDISMODULE_ERR;
@@ -4581,13 +4582,15 @@ int RM_ListPush(RedisModuleKey *key, int where, RedisModuleString *ele) {
     if (key->kv && key->kv->type != OBJ_LIST) return REDISMODULE_ERR;
     if (key->iter) moduleFreeKeyIterator(key);
     if (key->kv == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_LIST);
-    size_t oldsize = listTypeAllocSize(key->kv);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = listTypeAllocSize(key->kv);
     listTypeTryConversionAppend(key->kv, &ele, 0, 0, moduleFreeListIterator, key);
     listTypePush(key->kv, ele,
         (where == REDISMODULE_LIST_HEAD) ? LIST_HEAD : LIST_TAIL);
     int64_t l = listTypeLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l-1, l);
-    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
     return REDISMODULE_OK;
 }
 
@@ -4604,6 +4607,7 @@ int RM_ListPush(RedisModuleKey *key, int where, RedisModuleString *ele) {
  *
  * Note: Before Redis 7.0, `errno` was not set by this function. */
 RedisModuleString *RM_ListPop(RedisModuleKey *key, int where) {
+    size_t oldsize = 0;
     if (!key) {
         errno = EINVAL;
         return NULL;
@@ -4615,18 +4619,22 @@ RedisModuleString *RM_ListPop(RedisModuleKey *key, int where) {
         return NULL;
     }
     if (key->iter) moduleFreeKeyIterator(key);
-    size_t oldsize = listTypeAllocSize(key->kv);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = listTypeAllocSize(key->kv);
     robj *ele = listTypePop(key->kv,
         (where == REDISMODULE_LIST_HEAD) ? LIST_HEAD : LIST_TAIL);
     robj *decoded = getDecodedObject(ele);
     decrRefCount(ele);
     int64_t l = (int64_t) listTypeLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l+1, l);
-    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
-    if (!moduleDelKeyIfEmpty(key)) {
-        oldsize = listTypeAllocSize(key->kv);
-        listTypeTryConversion(key->kv, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
         updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+    if (!moduleDelKeyIfEmpty(key)) {
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = listTypeAllocSize(key->kv);
+        listTypeTryConversion(key->kv, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
     }
     autoMemoryAdd(key->ctx,REDISMODULE_AM_STRING,decoded);
     return decoded;
@@ -4677,6 +4685,7 @@ RedisModuleString *RM_ListGet(RedisModuleKey *key, long index) {
  * - EDOM if the index is not a valid index in the list.
  */
 int RM_ListSet(RedisModuleKey *key, long index, RedisModuleString *value) {
+    size_t oldsize = 0;
     if (!value) {
         errno = EINVAL;
         return REDISMODULE_ERR;
@@ -4685,17 +4694,20 @@ int RM_ListSet(RedisModuleKey *key, long index, RedisModuleString *value) {
         errno = ENOTSUP;
         return REDISMODULE_ERR;
     }
-    size_t oldsize = listTypeAllocSize(key->kv);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = listTypeAllocSize(key->kv);
     listTypeTryConversionAppend(key->kv, &value, 0, 0, moduleFreeListIterator, key);
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         listTypeReplace(&key->u.list.entry, value);
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         /* A note in quicklist.c forbids use of iterator after insert, so
          * probably also after replace. */
         moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         return REDISMODULE_ERR;
     }
 }
@@ -4716,6 +4728,7 @@ int RM_ListSet(RedisModuleKey *key, long index, RedisModuleString *value) {
  * - EDOM if the index is not a valid index in the list.
  */
 int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
+    size_t oldsize = 0;
     if (!value) {
         errno = EINVAL;
         return REDISMODULE_ERR;
@@ -4734,19 +4747,22 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
         /* Insert before the first element => push head. */
         return RM_ListPush(key, REDISMODULE_LIST_HEAD, value);
     }
-    size_t oldsize = listTypeAllocSize(key->kv);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = listTypeAllocSize(key->kv);
     listTypeTryConversionAppend(key->kv, &value, 0, 0, moduleFreeListIterator, key);
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         int where = index < 0 ? LIST_TAIL : LIST_HEAD;
         listTypeInsert(&key->u.list.entry, value, where);
         int64_t l = (int64_t) listTypeLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l-1, l);
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         /* A note in quicklist.c forbids use of iterator after insert. */
         moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         return REDISMODULE_ERR;
     }
 }
@@ -4764,15 +4780,20 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
  */
 int RM_ListDelete(RedisModuleKey *key, long index) {
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
-        size_t oldsize = listTypeAllocSize(key->kv);
+        size_t oldsize = 0;
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = listTypeAllocSize(key->kv);
         listTypeDelete(key->iter, &key->u.list.entry);
         int64_t l = (int64_t) listTypeLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l+1, l);
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         if (moduleDelKeyIfEmpty(key)) return REDISMODULE_OK;
-        oldsize = listTypeAllocSize(key->kv);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = listTypeAllocSize(key->kv);
         listTypeTryConversion(key->kv, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, listTypeAllocSize(key->kv));
         if (!key->iter) return REDISMODULE_OK; /* Return ASAP if iterator has been freed */
         if (listTypeNext(key->iter, &key->u.list.entry)) {
             /* After delete entry at position 'index', we need to update
@@ -4857,21 +4878,25 @@ int moduleZsetAddFlagsFromCoreFlags(int flags) {
  */
 int RM_ZsetAdd(RedisModuleKey *key, double score, RedisModuleString *ele, int *flagsptr) {
     int in_flags = 0, out_flags = 0;
+    size_t oldsize = 0;
     if (!(key->mode & REDISMODULE_WRITE)) return REDISMODULE_ERR;
     if (key->kv && key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
     if (key->kv == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_ZSET);
-    size_t oldsize = zsetAllocSize(key->kv);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(key->kv);
     if (flagsptr) in_flags = moduleZsetAddFlagsToCoreFlags(*flagsptr);
     if (zsetAdd(key->kv,score,ele->ptr,in_flags,&out_flags,NULL) == 0) {
         if (flagsptr) *flagsptr = 0;
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
     if (flagsptr) *flagsptr = moduleZsetAddFlagsFromCoreFlags(out_flags);
     int64_t l = (int64_t) zsetLength(key->kv);
     updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l-1, l);
-    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     return REDISMODULE_OK;
 }
 
@@ -4890,19 +4915,23 @@ int RM_ZsetAdd(RedisModuleKey *key, double score, RedisModuleString *ele, int *f
  * is returned. */
 int RM_ZsetIncrby(RedisModuleKey *key, double score, RedisModuleString *ele, int *flagsptr, double *newscore) {
     int in_flags = 0, out_flags = 0;
+    size_t oldsize = 0;
     if (!(key->mode & REDISMODULE_WRITE)) return REDISMODULE_ERR;
     if (key->kv && key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
     if (key->kv == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_ZSET);
-    size_t oldsize = zsetAllocSize(key->kv);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(key->kv);
     if (flagsptr) in_flags = moduleZsetAddFlagsToCoreFlags(*flagsptr);
     in_flags |= ZADD_IN_INCR;
     if (zsetAdd(key->kv,score,ele->ptr,in_flags,&out_flags,newscore) == 0) {
         if (flagsptr) *flagsptr = 0;
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
-    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     if (out_flags & ZADD_OUT_ADDED) {
         int64_t l = (int64_t) zsetLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l-1, l);
@@ -4930,22 +4959,26 @@ int RM_ZsetIncrby(RedisModuleKey *key, double score, RedisModuleString *ele, int
  *
  * Empty keys will be handled correctly by doing nothing. */
 int RM_ZsetRem(RedisModuleKey *key, RedisModuleString *ele, int *deleted) {
+    size_t oldsize = 0;
     if (!(key->mode & REDISMODULE_WRITE)) return REDISMODULE_ERR;
     if (key->kv == NULL) {
         if (deleted) *deleted = 0;
         return REDISMODULE_OK;
     }
     if (key->kv->type != OBJ_ZSET) return REDISMODULE_ERR;
-    size_t oldsize = zsetAllocSize(key->kv);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(key->kv);
     if (zsetDel(key->kv,ele->ptr)) {
         if (deleted) *deleted = 1;
         int64_t l = (int64_t) zsetLength(key->kv);
         updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l+1, l);
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
         moduleDelKeyIfEmpty(key);
     } else {
         if (deleted) *deleted = 0;
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, zsetAllocSize(key->kv));
     }
     return REDISMODULE_OK;
 }
@@ -5347,6 +5380,7 @@ int RM_ZsetRangePrev(RedisModuleKey *key) {
  */
 int RM_HashSet(RedisModuleKey *key, int flags, ...) {
     va_list ap;
+    size_t oldsize = 0;
     if (!key || (flags & ~(REDISMODULE_HASH_NX |
                            REDISMODULE_HASH_XX |
                            REDISMODULE_HASH_CFIELDS |
@@ -5406,9 +5440,11 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
 
         /* Handle deletion if value is REDISMODULE_HASH_DELETE. */
         if (value == REDISMODULE_HASH_DELETE) {
-            size_t oldsize = hashTypeAllocSize(key->kv);
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                oldsize = hashTypeAllocSize(key->kv);
             count += hashTypeDelete(key->kv, field->ptr, 1);
-            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
             if (flags & REDISMODULE_HASH_CFIELDS) decrRefCount(field);
             continue;
         }
@@ -5421,10 +5457,12 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
             low_flags |= HASH_SET_TAKE_FIELD;
 
         robj *argv[2] = {field,value};
-        size_t oldsize = hashTypeAllocSize(key->kv);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = hashTypeAllocSize(key->kv);
         hashTypeTryConversion(key->db,key->kv,argv,0,1);
         int updated = hashTypeSet(key->db, key->kv, field->ptr, value->ptr, low_flags);
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, hashTypeAllocSize(key->kv));
         count += (flags & REDISMODULE_HASH_COUNT_ALL) ? 1 : updated;
 
         /* If CFIELDS is active, SDS string ownership is now of hashTypeSet(),
@@ -5672,7 +5710,8 @@ int RM_StreamAdd(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisM
         if (created) moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
-    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     /* Postponed signalKeyAsReady(). Done implicitly by moduleCreateEmptyKey()
      * so not needed if the stream has just been created. */
     if (!created) key->u.stream.signalready = 1;
@@ -5719,7 +5758,8 @@ int RM_StreamDelete(RedisModuleKey *key, RedisModuleStreamID *id) {
     size_t oldsize = s->alloc_size;
     streamID streamid = {id->ms, id->seq};
     if (streamDeleteItem(s, &streamid)) {
-        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
         return REDISMODULE_OK;
     } else {
         errno = ENOENT; /* no entry with this id */
@@ -6021,7 +6061,8 @@ long long RM_StreamTrimByLength(RedisModuleKey *key, int flags, long long length
     stream *s = key->kv->ptr;
     size_t oldsize = s->alloc_size;
     long long retval = streamTrimByLength(s, length, approx);
-    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     return retval;
 }
 
@@ -6056,7 +6097,8 @@ long long RM_StreamTrimByID(RedisModuleKey *key, int flags, RedisModuleStreamID 
     stream *s = key->kv->ptr;
     size_t oldsize = s->alloc_size;
     long long retval = streamTrimByID(s, minid, approx);
-    updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(key->db, getKeySlot(key->key->ptr), oldsize, s->alloc_size);
     return retval;
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -1017,6 +1017,21 @@ size_t stringObjectLen(robj *o) {
     }
 }
 
+size_t stringObjectAllocSize(const robj *o) {
+    debugServerAssertWithInfo(NULL,o,o->type == OBJ_STRING);
+    if(o->encoding == OBJ_ENCODING_INT) {
+        /* Value already counted (reuse the "ptr" in header to store int) */
+        return 0;
+    } else if(o->encoding == OBJ_ENCODING_RAW) {
+        return sdsAllocSize(o->ptr);
+    } else if(o->encoding == OBJ_ENCODING_EMBSTR) {
+        /* Value already counted (Value embedded in the object as well) */
+        return 0;
+    } else {
+        serverPanic("Unknown string encoding");
+    }
+}
+
 int getDoubleFromObject(const robj *o, double *target) {
     double value;
 
@@ -1189,72 +1204,39 @@ char *strEncoding(int encoding) {
  * are checked and averaged to estimate the total size. */
 #define OBJ_COMPUTE_SIZE_DEF_SAMPLES 5 /* Default sample size. */
 size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
-    dict *d;
-    
+    if (o->type == OBJ_STRING ||
+        o->type == OBJ_LIST ||
+        o->type == OBJ_SET ||
+        o->type == OBJ_ZSET ||
+        o->type == OBJ_HASH ||
+        o->type == OBJ_STREAM)
+    {
+        return kvobjAllocSize(o);
+    } else if (o->type == OBJ_MODULE) {
+        return zmalloc_size(o) + moduleGetMemUsage(key, o, sample_size, dbid);
+    }
+    serverPanic("Unknown object type");
+}
+
+size_t kvobjAllocSize(kvobj *o) {
     /* All kv-objects has at least kvobj header and embedded key */
     size_t asize = zmalloc_size((void *)o);
 
     if (o->type == OBJ_STRING) {
-        if(o->encoding == OBJ_ENCODING_INT) {
-            /* Value already counted (reuse the "ptr" in header to store int) */
-        } else if(o->encoding == OBJ_ENCODING_RAW) {
-            asize += sdsZmallocSize(o->ptr);
-        } else if(o->encoding == OBJ_ENCODING_EMBSTR) {
-            /* Value already counted (Value embedded in the object as well) */
-        } else {
-            serverPanic("Unknown string encoding");
-        }
+        asize += stringObjectAllocSize(o);
     } else if (o->type == OBJ_LIST) {
-        if (o->encoding == OBJ_ENCODING_QUICKLIST) {
-            asize += quicklistAllocSize(o->ptr);
-        } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
-            asize += zmalloc_size(o->ptr);
-        } else {
-            serverPanic("Unknown list encoding");
-        }
+        asize += listTypeAllocSize(o);
     } else if (o->type == OBJ_SET) {
-        if (o->encoding == OBJ_ENCODING_HT) {
-            d = o->ptr;
-            asize += sizeof(dict) + dictMemUsage(d) +
-                *htGetMetadataSize(d);
-        } else if (o->encoding == OBJ_ENCODING_INTSET) {
-            asize += zmalloc_size(o->ptr);
-        } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
-            asize += zmalloc_size(o->ptr);
-        } else {
-            serverPanic("Unknown set encoding");
-        }
+        asize += setTypeAllocSize(o);
     } else if (o->type == OBJ_ZSET) {
-        if (o->encoding == OBJ_ENCODING_LISTPACK) {
-            asize += zmalloc_size(o->ptr);
-        } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
-            d = ((zset*)o->ptr)->dict;
-            zskiplist *zsl = ((zset*)o->ptr)->zsl;
-            asize += sizeof(zset) + zslAllocSize(zsl) +
-                sizeof(dict) + dictMemUsage(d);
-        } else {
-            serverPanic("Unknown sorted set encoding");
-        }
+        asize += zsetAllocSize(o);
     } else if (o->type == OBJ_HASH) {
-        if (o->encoding == OBJ_ENCODING_LISTPACK) {
-            asize += zmalloc_size(o->ptr);
-        } else if (o->encoding == OBJ_ENCODING_LISTPACK_EX) {
-            listpackEx *lpt = o->ptr;
-            asize += zmalloc_size(lpt) + zmalloc_size(lpt->lp);
-        } else if (o->encoding == OBJ_ENCODING_HT) {
-            d = o->ptr;
-            asize += sizeof(dict) + dictMemUsage(d) +
-                *htGetMetadataSize(d);
-        } else {
-            serverPanic("Unknown hash encoding");
-        }
+        asize += hashTypeAllocSize(o);
     } else if (o->type == OBJ_STREAM) {
         stream *s = o->ptr;
         asize += s->alloc_size;
     } else if (o->type == OBJ_MODULE) {
-        asize += moduleGetMemUsage(key, o, sample_size, dbid);
-    } else {
-        serverPanic("Unknown object type");
+        // TODO: Provide moduleGetAllocSize() module API for O(1) allocation size retrieval
     }
     return asize;
 }

--- a/src/object.c
+++ b/src/object.c
@@ -1244,7 +1244,7 @@ size_t kvobjAllocSize(kvobj *o) {
         stream *s = o->ptr;
         asize += s->alloc_size;
     } else if (o->type == OBJ_MODULE) {
-        // TODO: Provide moduleGetAllocSize() module API for O(1) allocation size retrieval
+        /* TODO: Provide moduleGetAllocSize() module API for O(1) allocation size retrieval */
     }
     return asize;
 }

--- a/src/object.c
+++ b/src/object.c
@@ -1220,7 +1220,15 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
 
 size_t kvobjAllocSize(kvobj *o) {
     /* All kv-objects has at least kvobj header and embedded key */
-    size_t asize = zmalloc_size((void *)o);
+    serverAssert(o->iskvobj);
+    size_t asize = sizeof(kvobj);
+    if (o->expirable) asize += sizeof(long long);
+    /* Add embedded key size */
+    asize += 1; /* embedded key header size */
+    asize += sdsAllocSize(kvobjGetKey(o));
+    /* Add embedded string size */
+    if (o->encoding == OBJ_ENCODING_EMBSTR)
+        asize += sdsAllocSize(o->ptr);
 
     if (o->type == OBJ_STRING) {
         asize += stringObjectAllocSize(o);

--- a/src/object.c
+++ b/src/object.c
@@ -1018,7 +1018,7 @@ size_t stringObjectLen(robj *o) {
 }
 
 size_t stringObjectAllocSize(const robj *o) {
-    debugServerAssertWithInfo(NULL,o,o->type == OBJ_STRING);
+    serverAssertWithInfo(NULL,o,o->type == OBJ_STRING);
     if(o->encoding == OBJ_ENCODING_INT) {
         /* Value already counted (reuse the "ptr" in header to store int) */
         return 0;

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -482,7 +482,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
         while ((entry = dictNext(&iter)) != NULL) {
             client *c = dictGetKey(entry);
             addReplyPubsubMessage(c,channel,message,*type.messageBulk);
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 clusterSlotStatsAddNetworkBytesOutForShardedPubSubInternalPropagation(c, slot);
             updateClientMemUsageAndBucket(c);
             receivers++;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1445,7 +1445,9 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter, unsigned 
 
         initStaticStringObject(key,kvobjGetKey(kv));
         expire = kvobjGetExpire(kv);
+        size_t oldsize = kvobjAllocSize(kv);
         if ((res = rdbSaveKeyValuePair(rdb, &key, kv, expire, dbid)) < 0) goto werr;
+        updateAllocSizes(db, curr_slot, oldsize, kvobjAllocSize(kv));
         written += res;
 
         /* In fork child process, we can try to release memory back to the

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1446,10 +1446,10 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter, unsigned 
 
         initStaticStringObject(key,kvobjGetKey(kv));
         expire = kvobjGetExpire(kv);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = kvobjAllocSize(kv);
         res = rdbSaveKeyValuePair(rdb, &key, kv, expire, dbid);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(db, curr_slot, oldsize, kvobjAllocSize(kv));
         if (res < 0) goto werr;
         written += res;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1446,10 +1446,10 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter, unsigned 
 
         initStaticStringObject(key,kvobjGetKey(kv));
         expire = kvobjGetExpire(kv);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = kvobjAllocSize(kv);
         res = rdbSaveKeyValuePair(rdb, &key, kv, expire, dbid);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(db, curr_slot, oldsize, kvobjAllocSize(kv));
         if (res < 0) goto werr;
         written += res;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1392,6 +1392,7 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter, unsigned 
     dictEntry *de;
     ssize_t written = 0;
     ssize_t res;
+    size_t oldsize = 0;
     kvstoreIterator *kvs_it = NULL;
     static long long info_updated_time = 0;
     char *pname = (rdbflags & RDBFLAGS_AOF_PREAMBLE) ? "AOF rewrite" :  "RDB";
@@ -1445,9 +1446,11 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter, unsigned 
 
         initStaticStringObject(key,kvobjGetKey(kv));
         expire = kvobjGetExpire(kv);
-        size_t oldsize = kvobjAllocSize(kv);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = kvobjAllocSize(kv);
         res = rdbSaveKeyValuePair(rdb, &key, kv, expire, dbid);
-        updateAllocSizes(db, curr_slot, oldsize, kvobjAllocSize(kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(db, curr_slot, oldsize, kvobjAllocSize(kv));
         if (res < 0) goto werr;
         written += res;
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1450,7 +1450,7 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter, unsigned 
             oldsize = kvobjAllocSize(kv);
         res = rdbSaveKeyValuePair(rdb, &key, kv, expire, dbid);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(db, curr_slot, oldsize, kvobjAllocSize(kv));
+            updateSlotAllocSize(db, curr_slot, oldsize, kvobjAllocSize(kv));
         if (res < 0) goto werr;
         written += res;
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1446,8 +1446,9 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter, unsigned 
         initStaticStringObject(key,kvobjGetKey(kv));
         expire = kvobjGetExpire(kv);
         size_t oldsize = kvobjAllocSize(kv);
-        if ((res = rdbSaveKeyValuePair(rdb, &key, kv, expire, dbid)) < 0) goto werr;
+        res = rdbSaveKeyValuePair(rdb, &key, kv, expire, dbid);
         updateAllocSizes(db, curr_slot, oldsize, kvobjAllocSize(kv));
+        if (res < 0) goto werr;
         written += res;
 
         /* In fork child process, we can try to release memory back to the

--- a/src/sds.h
+++ b/src/sds.h
@@ -167,15 +167,15 @@ static inline void sdsinclen(sds s, size_t inc) {
 static inline size_t sdsAllocSize(sds s) {
     switch(sdsType(s)) {
         case SDS_TYPE_5:
-            return SDS_TYPE_5_LEN(s) + sizeof(struct sdshdr5);
+            return sizeof(struct sdshdr5) + SDS_TYPE_5_LEN(s) + 1;
         case SDS_TYPE_8:
-            return SDS_HDR(8,s)->alloc + sizeof(struct sdshdr8);
+            return sizeof(struct sdshdr8) + SDS_HDR(8,s)->alloc + 1;
         case SDS_TYPE_16:
-            return SDS_HDR(16,s)->alloc + sizeof(struct sdshdr16);
+            return sizeof(struct sdshdr16) + SDS_HDR(16,s)->alloc + 1;
         case SDS_TYPE_32:
-            return SDS_HDR(32,s)->alloc + sizeof(struct sdshdr32);
+            return sizeof(struct sdshdr32) + SDS_HDR(32,s)->alloc + 1;
         case SDS_TYPE_64:
-            return SDS_HDR(64,s)->alloc + sizeof(struct sdshdr64);
+            return sizeof(struct sdshdr64) + SDS_HDR(64,s)->alloc + 1;
     }
     return 0;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -352,6 +352,7 @@ int dictSdsCompareKV(dictCmpCache *cache, const void *sdsLookup, const void *kv)
 static void dictDestructorKV(dict *d, void *kv) {
     UNUSED(d);
     if (kv == NULL) return;
+    kvstoreTrackDeallocation(d, kv);
     decrRefCount(kv);
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -2846,6 +2846,7 @@ void initServer(void) {
     server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
     server.reply_buffer_resizing_enabled = 1;
     server.client_mem_usage_buckets = NULL;
+    server.memory_tracking_per_slot = clusterSlotStatsEnabled();
     resetReplicationBuffer();
 
     /* Make sure the locale is set on startup based on the config file. */

--- a/src/server.c
+++ b/src/server.c
@@ -2240,6 +2240,7 @@ void initServerConfig(void) {
     server.executable = NULL;
     server.arch_bits = (sizeof(long) == 8) ? 64 : 32;
     server.dbg_assert_keysizes = 0; /* Disabled by default */
+    server.dbg_assert_alloc_per_slot = 0; /* Disabled by default */
     server.bindaddr_count = CONFIG_DEFAULT_BINDADDR_COUNT;
     for (j = 0; j < CONFIG_DEFAULT_BINDADDR_COUNT; j++)
         server.bindaddr[j] = zstrdup(default_bindaddr[j]);
@@ -4030,6 +4031,10 @@ void afterCommand(client *c) {
     /* Assert keysizes histogram if enabled */
     if (unlikely(server.dbg_assert_keysizes))
         dbgAssertKeysizesHist(c->db);
+
+    /* Assert per-slot alloc_size if enabled */
+    if (unlikely(server.dbg_assert_alloc_per_slot))
+        dbgAssertAllocSizePerSlot(c->db);
 }
 
 /* Check if c->cmd exists, fills `err` with details in case it doesn't.

--- a/src/server.h
+++ b/src/server.h
@@ -91,6 +91,8 @@ typedef struct redisObject robj;
  */
 typedef struct redisObject kvobj;
 
+size_t kvobjAllocSize(kvobj *o);
+
 #include "redismodule.h"    /* Redis modules API defines. */
 
 /* Following includes allow test functions to be called from Redis main() */
@@ -3097,6 +3099,7 @@ int checkPrefixCollisionsOrReply(client *c, robj **prefix, size_t numprefix);
 void listTypePush(robj *subject, robj *value, int where);
 robj *listTypePop(robj *subject, int where);
 unsigned long listTypeLength(const robj *subject);
+size_t listTypeAllocSize(const robj *o);
 listTypeIterator *listTypeInitIterator(robj *subject, long index, unsigned char direction);
 void listTypeReleaseIterator(listTypeIterator *li);
 void listTypeSetIteratorDirection(listTypeIterator *li, listTypeEntry *entry, unsigned char direction);
@@ -3111,7 +3114,7 @@ void listTypeDelete(listTypeIterator *iter, listTypeEntry *entry);
 robj *listTypeDup(robj *o);
 void listTypeDelRange(robj *o, long start, long stop);
 void popGenericCommand(client *c, int where);
-void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, int signal, int *deleted);
+void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, size_t oldsize, int signal, int *deleted);
 typedef enum {
     LIST_CONV_AUTO,
     LIST_CONV_GROWING,
@@ -3158,6 +3161,7 @@ robj *tryObjectEncodingEx(robj *o, int try_trim);
 size_t getObjectLength(robj *o);
 robj *getDecodedObject(robj *o);
 size_t stringObjectLen(robj *o);
+size_t stringObjectAllocSize(const robj *o);
 robj *createStringObjectFromLongLong(long long value);
 robj *createStringObjectFromLongLongForValue(long long value);
 robj *createStringObjectFromLongLongWithSds(long long value);
@@ -3416,6 +3420,7 @@ void zzlPrev(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);
 unsigned char *zzlFirstInRange(unsigned char *zl, zrangespec *range);
 unsigned char *zzlLastInRange(unsigned char *zl, zrangespec *range);
 unsigned long zsetLength(const robj *zobj);
+size_t zsetAllocSize(const robj *o);
 void zsetConvert(robj *zobj, int encoding);
 void zsetConvertToListpackIfNeeded(robj *zobj, size_t maxelelen, size_t totelelen);
 int zsetScore(robj *zobj, sds member, double *score);
@@ -3555,6 +3560,7 @@ int setTypeNext(setTypeIterator *si, char **str, size_t *len, int64_t *llele);
 sds setTypeNextObject(setTypeIterator *si);
 int setTypeRandomElement(robj *setobj, char **str, size_t *len, int64_t *llele);
 unsigned long setTypeSize(const robj *subject);
+size_t setTypeAllocSize(const robj *o);
 void setTypeConvert(robj *subject, int enc);
 int setTypeConvertAndExpand(robj *setobj, int enc, unsigned long cap, int panic);
 robj *setTypeDup(robj *o);
@@ -3608,12 +3614,14 @@ static inline size_t *htGetMetadataSize(dict *d) {
                                              * may expire and only one signal is desired. */
 #define HFE_LAZY_ACCESS_EXPIRED      (1<<4) /* Avoid lazy expire and allow access to expired fields */
 #define HFE_LAZY_NO_UPDATE_KEYSIZES  (1<<5) /* If field lazy deleted, avoid updating keysizes histogram */
+#define HFE_LAZY_NO_UPDATE_ALLOCSIZES (1<<6) /* If field lazy deleted, avoid updating slot allocation sizes */
 
 void hashTypeConvert(redisDb *db, robj *o, int enc);
 void hashTypeTryConversion(redisDb *db, kvobj *kv, robj **argv, int start, int end);
 int hashTypeExists(redisDb *db, kvobj *kv, sds field, int hfeFlags, int *isHashDeleted);
 int hashTypeDelete(robj *o, void *key, int isSdsField);
 unsigned long hashTypeLength(const robj *o, int subtractExpiredFields);
+size_t hashTypeAllocSize(const robj *o);
 hashTypeIterator *hashTypeInitIterator(robj *subject);
 void hashTypeReleaseIterator(hashTypeIterator *hi);
 int hashTypeNext(hashTypeIterator *hi, int skipExpiredFields);
@@ -3763,6 +3771,7 @@ int moduleSetNumericConfig(client *c, sds name, long long val, const char **err)
 
 /* db.c -- Keyspace access API */
 void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, int64_t newLen);
+void updateAllocSizes(redisDb *db, int didx, size_t oldsize, size_t newsize);
 void dbgAssertKeysizesHist(redisDb *db);
 int removeExpire(redisDb *db, robj *key);
 void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj);

--- a/src/server.h
+++ b/src/server.h
@@ -3734,6 +3734,7 @@ sds getConfigDebugInfo(void);
 int allowProtectedAction(int config, client *c);
 void initServerClientMemUsageBuckets(void);
 void freeServerClientMemUsageBuckets(void);
+static inline bool clusterSlotStatsEnabled(void) { return server.cluster_enabled && server.cluster_slot_stats_enabled; }
 
 /* Module Configuration */
 typedef struct ModuleConfig ModuleConfig;

--- a/src/server.h
+++ b/src/server.h
@@ -2379,6 +2379,7 @@ struct redisServer {
     /* Local environment */
     char *locale_collate;
     int dbg_assert_keysizes;       /* Assert keysizes histogram after each command */
+    int dbg_assert_alloc_per_slot; /* Assert per-slot alloc_size after each command */
 };
 
 /* we use 6 so that all getKeyResult fits a cacheline */
@@ -3773,6 +3774,7 @@ int moduleSetNumericConfig(client *c, sds name, long long val, const char **err)
 void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, int64_t newLen);
 void updateAllocSizes(redisDb *db, int didx, size_t oldsize, size_t newsize);
 void dbgAssertKeysizesHist(redisDb *db);
+void dbgAssertAllocSizePerSlot(redisDb *db);
 int removeExpire(redisDb *db, robj *key);
 void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj);
 void deleteEvictedKeyAndPropagate(redisDb *db, robj *keyobj, long long *key_mem_freed);

--- a/src/server.h
+++ b/src/server.h
@@ -3734,7 +3734,7 @@ sds getConfigDebugInfo(void);
 int allowProtectedAction(int config, client *c);
 void initServerClientMemUsageBuckets(void);
 void freeServerClientMemUsageBuckets(void);
-static inline bool clusterSlotStatsEnabled(void) { return server.cluster_enabled && server.cluster_slot_stats_enabled; }
+static inline int clusterSlotStatsEnabled(void) { return server.cluster_enabled && server.cluster_slot_stats_enabled; }
 
 /* Module Configuration */
 typedef struct ModuleConfig ModuleConfig;

--- a/src/server.h
+++ b/src/server.h
@@ -2041,6 +2041,7 @@ struct redisServer {
     int latency_tracking_enabled;   /* 1 if extended latency tracking is enabled, 0 otherwise. */
     double *latency_tracking_info_percentiles; /* Extended latency tracking info output percentile list configuration. */
     int latency_tracking_info_percentiles_len;
+    int memory_tracking_per_slot;   /* Account used memory per slot */
     unsigned int max_new_tls_conns_per_cycle; /* The maximum number of tls connections that will be accepted during each invocation of the event loop. */
     unsigned int max_new_conns_per_cycle; /* The maximum number of tcp connections that will be accepted during each invocation of the event loop. */
     int cluster_compatibility_sample_ratio; /* Sampling ratio for cluster mode incompatible commands. */

--- a/src/server.h
+++ b/src/server.h
@@ -3771,7 +3771,7 @@ int moduleSetNumericConfig(client *c, sds name, long long val, const char **err)
 
 /* db.c -- Keyspace access API */
 void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, int64_t newLen);
-void updateAllocSizes(redisDb *db, int didx, size_t oldsize, size_t newsize);
+void updateSlotAllocSize(redisDb *db, int didx, size_t oldsize, size_t newsize);
 void dbgAssertKeysizesHist(redisDb *db);
 void dbgAssertAllocSizePerSlot(redisDb *db);
 int removeExpire(redisDb *db, robj *key);

--- a/src/server.h
+++ b/src/server.h
@@ -91,8 +91,6 @@ typedef struct redisObject robj;
  */
 typedef struct redisObject kvobj;
 
-size_t kvobjAllocSize(kvobj *o);
-
 #include "redismodule.h"    /* Redis modules API defines. */
 
 /* Following includes allow test functions to be called from Redis main() */
@@ -3201,6 +3199,7 @@ kvobj *kvobjSet(sds key, robj *val, int hasExpire);
 kvobj *kvobjSetExpire(kvobj *kv, long long expire);
 sds kvobjGetKey(const kvobj *kv);
 long long kvobjGetExpire(const kvobj *val);
+size_t kvobjAllocSize(kvobj *o);
 
 /* Synchronous I/O with timeout */
 ssize_t syncWrite(int fd, char *ptr, ssize_t size, long long timeout);

--- a/src/sort.c
+++ b/src/sort.c
@@ -338,8 +338,11 @@ void sortCommandGeneric(client *c, int readonly) {
     }
 
     /* Destructively convert encoded sorted sets for SORT. */
-    if (sortval->type == OBJ_ZSET)
+    if (sortval->type == OBJ_ZSET) {
+        size_t oldsize = zsetAllocSize(sortval);
         zsetConvert(sortval, OBJ_ENCODING_SKIPLIST);
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(sortval));
+    }
 
     /* Obtain the length of the object to sort. */
     switch(sortval->type) {

--- a/src/sort.c
+++ b/src/sort.c
@@ -340,10 +340,10 @@ void sortCommandGeneric(client *c, int readonly) {
     /* Destructively convert encoded sorted sets for SORT. */
     if (sortval->type == OBJ_ZSET) {
         size_t oldsize = 0;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = zsetAllocSize(sortval);
         zsetConvert(sortval, OBJ_ENCODING_SKIPLIST);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(sortval));
     }
 

--- a/src/sort.c
+++ b/src/sort.c
@@ -339,9 +339,12 @@ void sortCommandGeneric(client *c, int readonly) {
 
     /* Destructively convert encoded sorted sets for SORT. */
     if (sortval->type == OBJ_ZSET) {
-        size_t oldsize = zsetAllocSize(sortval);
+        size_t oldsize = 0;
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = zsetAllocSize(sortval);
         zsetConvert(sortval, OBJ_ENCODING_SKIPLIST);
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(sortval));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(sortval));
     }
 
     /* Obtain the length of the object to sort. */

--- a/src/sort.c
+++ b/src/sort.c
@@ -344,7 +344,7 @@ void sortCommandGeneric(client *c, int readonly) {
             oldsize = zsetAllocSize(sortval);
         zsetConvert(sortval, OBJ_ENCODING_SKIPLIST);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(sortval));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(sortval));
     }
 
     /* Obtain the length of the object to sort. */

--- a/src/sort.c
+++ b/src/sort.c
@@ -185,6 +185,7 @@ void sortCommandGeneric(client *c, int readonly) {
     int int_conversion_error = 0;
     int syntax_error = 0;
     robj *sortval, *sortby = NULL, *storekey = NULL;
+    size_t oldsize = 0;
     redisSortObject *vector; /* Resulting vector to sort */
     int user_has_full_key_access = 0; /* ACL - used in order to verify 'get' and 'by' options can be used */
     /* Create a list of operations to perform for every sorted element.
@@ -339,7 +340,6 @@ void sortCommandGeneric(client *c, int readonly) {
 
     /* Destructively convert encoded sorted sets for SORT. */
     if (sortval->type == OBJ_ZSET) {
-        size_t oldsize = 0;
         if (server.memory_tracking_per_slot)
             oldsize = zsetAllocSize(sortval);
         zsetConvert(sortval, OBJ_ENCODING_SKIPLIST);
@@ -423,6 +423,8 @@ void sortCommandGeneric(client *c, int readonly) {
         }
         listTypeReleaseIterator(li);
     } else if (sortval->type == OBJ_SET) {
+        if (server.memory_tracking_per_slot)
+            oldsize = setTypeAllocSize(sortval);
         setTypeIterator *si = setTypeInitIterator(sortval);
         sds sdsele;
         while((sdsele = setTypeNextObject(si)) != NULL) {
@@ -432,6 +434,8 @@ void sortCommandGeneric(client *c, int readonly) {
             j++;
         }
         setTypeReleaseIterator(si);
+        if (server.memory_tracking_per_slot)
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(sortval));
     } else if (sortval->type == OBJ_ZSET && dontsort) {
         /* Special handling for a sorted set, if 'dontsort' is true.
          * This makes sure we return elements in the sorted set original
@@ -477,6 +481,8 @@ void sortCommandGeneric(client *c, int readonly) {
         dictEntry *setele;
         sds sdsele;
 
+        if (server.memory_tracking_per_slot)
+            oldsize = zsetAllocSize(sortval);
         dictInitIterator(&di, set);
         while((setele = dictNext(&di)) != NULL) {
             sdsele =  dictGetKey(setele);
@@ -486,6 +492,8 @@ void sortCommandGeneric(client *c, int readonly) {
             j++;
         }
         dictResetIterator(&di);
+        if (server.memory_tracking_per_slot)
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(sortval));
     } else {
         serverPanic("Unknown type");
     }

--- a/src/sort.c
+++ b/src/sort.c
@@ -340,10 +340,10 @@ void sortCommandGeneric(client *c, int readonly) {
     /* Destructively convert encoded sorted sets for SORT. */
     if (sortval->type == OBJ_ZSET) {
         size_t oldsize = 0;
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = zsetAllocSize(sortval);
         zsetConvert(sortval, OBJ_ENCODING_SKIPLIST);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(sortval));
     }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -426,7 +426,9 @@ void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info) {
     }
 
     if (expired) {
+        size_t oldsize = lpBytes(lpt->lp);
         lpt->lp = lpDeleteRange(lpt->lp, 0, expired * 3);
+        updateAllocSizes(db, getKeySlot(key), oldsize, lpBytes(lpt->lp));
         
         /* update keysizes */
         unsigned long l = lpLength(lpt->lp) / 3;
@@ -731,7 +733,7 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
                                    unsigned int *vlen, long long *vll, 
                                    int hfeFlags, uint64_t *expiredAt)
 {
-    sds key;
+    sds key = kvobjGetKey(o);
     GetFieldRes res;
     uint64_t dummy;
     if (expiredAt == NULL) expiredAt = &dummy;
@@ -745,7 +747,12 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
 
     } else if (o->encoding == OBJ_ENCODING_HT) {
         sds value = NULL;
+        size_t oldsize = 0;
+        if (!(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+            oldsize = hashTypeAllocSize(o);
         res = hashTypeGetFromHashTable(o, field, &value, expiredAt);
+        if (!(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+            updateAllocSizes(db, getKeySlot(key), oldsize, hashTypeAllocSize(o));
 
         if (res == GETF_NOT_FOUND)
             return GETF_NOT_FOUND;
@@ -780,10 +787,13 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
         (isPausedActionsWithUpdate(PAUSE_ACTION_EXPIRE)))
         return GETF_EXPIRED;
 
-    key = kvobjGetKey(o);
-
     /* delete the field and propagate the deletion */
+    size_t oldsize = 0;
+    if (!(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+        oldsize = hashTypeAllocSize(o);
     serverAssert(hashTypeDelete(o, field, 1) == 1);
+    if (!(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+        updateAllocSizes(db, getKeySlot(key), oldsize, hashTypeAllocSize(o));
     propagateHashFieldDeletion(db, key, field, sdslen(field));
     server.stat_expired_subkeys++;
 
@@ -1326,6 +1336,23 @@ unsigned long hashTypeLength(const robj *o, int subtractExpiredFields) {
         serverPanic("Unknown hash encoding");
     }
     return length;
+}
+
+size_t hashTypeAllocSize(const robj *o) {
+    debugServerAssertWithInfo(NULL,o,o->type == OBJ_HASH);
+    size_t size = 0;
+    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+        size = lpBytes(o->ptr);
+    } else if (o->encoding == OBJ_ENCODING_LISTPACK_EX) {
+        listpackEx *lpt = o->ptr;
+        size = sizeof(listpackEx) + lpBytes(lpt->lp);
+    } else if (o->encoding == OBJ_ENCODING_HT) {
+        dict *d = o->ptr;
+        size += sizeof(dict) + dictMemUsage(d) + *htGetMetadataSize(d);
+    } else {
+        serverPanic("Unknown hash encoding");
+    }
+    return size;
 }
 
 hashTypeIterator *hashTypeInitIterator(robj *subject) {
@@ -2055,6 +2082,7 @@ void hsetnxCommand(client *c) {
         kv = dbAdd(c->db,c->argv[1],&o);
     }
 
+    size_t oldsize = hashTypeAllocSize(kv);
     hashTypeTryConversion(c->db, kv, c->argv, 2, 3);
     hashTypeSet(c->db, kv, c->argv[2]->ptr, c->argv[3]->ptr, HASH_SET_COPY);
     addReply(c, shared.cone);
@@ -2062,6 +2090,7 @@ void hsetnxCommand(client *c) {
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
     hlen = hashTypeLength(kv, 0);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, hlen - 1, hlen);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
     server.dirty++;
 }
 
@@ -2075,6 +2104,7 @@ void hsetCommand(client *c) {
     }
 
     if ((kv = hashTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
+    size_t oldsize = hashTypeAllocSize(kv);
     hashTypeTryConversion(c->db, kv, c->argv, 2, c->argc-1);
 
     for (i = 2; i < c->argc; i += 2)
@@ -2092,6 +2122,7 @@ void hsetCommand(client *c) {
     signalModifiedKey(c,c->db,c->argv[1]);
     unsigned long l = hashTypeLength(kv, 0);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, l - created, l);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
     server.dirty += (c->argc - 2)/2;
 }
@@ -2281,6 +2312,7 @@ void hsetexCommand(client *c) {
     int64_t oldlen, newlen;
     HashTypeSetEx setex;
     dictEntryLink link;
+    size_t oldsize = 0;
 
     if (hsetexParseArgs(c, &flags, &expire_time, &expire_time_pos,
                         &first_field_pos, &field_count) != C_OK)
@@ -2299,6 +2331,7 @@ void hsetexCommand(client *c) {
         dbAddByLink(c->db, c->argv[1], &o, &link);
     }
     oldlen = (int64_t) hashTypeLength(o, 0);
+    oldsize = hashTypeAllocSize(o);
 
     if (flags & (HFE_FXX | HFE_FNX)) {
         int found = 0;
@@ -2310,7 +2343,8 @@ void hsetexCommand(client *c) {
             const int opt = HFE_LAZY_NO_NOTIFICATION |
                             HFE_LAZY_NO_SIGNAL |
                             HFE_LAZY_AVOID_HASH_DEL |
-                            HFE_LAZY_NO_UPDATE_KEYSIZES;
+                            HFE_LAZY_NO_UPDATE_KEYSIZES |
+                            HFE_LAZY_NO_UPDATE_ALLOCSIZES;
 
             GetFieldRes res = hashTypeGetValue(c->db, o, field, &vstr, &vlen, &vll, opt, NULL);
             int exists = (res == GETF_OK);
@@ -2339,7 +2373,6 @@ void hsetexCommand(client *c) {
     set_expiry = flags & (HFE_EX | HFE_PX | HFE_EXAT | HFE_PXAT);
     if (set_expiry)
         hashTypeSetExInit(c->argv[1], o, c, c->db, 0, &setex);
-
 
     for (int i = 0; i < field_count; i++) {
         sds field = c->argv[first_field_pos + (i * 2)]->ptr;
@@ -2384,6 +2417,7 @@ void hsetexCommand(client *c) {
     addReplyLongLong(c, 1);
 
 out:
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     /* Emit keyspace notifications based on field expiry, mutation, or key deletion */
     if (fields_set || expired) {
         signalModifiedKey(c, c->db, c->argv[1]);
@@ -2448,7 +2482,9 @@ void hincrbyCommand(client *c) {
     }
     value += incr;
     new = sdsfromlonglong(value);
+    size_t oldsize = hashTypeAllocSize(o);
     hashTypeSet(c->db, o,c->argv[2]->ptr,new,HASH_SET_TAKE_VALUE | HASH_SET_KEEP_TTL);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     addReplyLongLong(c,value);
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH,"hincrby",c->argv[1],c->db->id);
@@ -2501,7 +2537,9 @@ void hincrbyfloatCommand(client *c) {
     char buf[MAX_LONG_DOUBLE_CHARS];
     int len = ld2string(buf,sizeof(buf),value,LD_STR_HUMAN);
     new = sdsnewlen(buf,len);
+    size_t oldsize = hashTypeAllocSize(o);
     hashTypeSet(c->db, o,c->argv[2]->ptr,new,HASH_SET_TAKE_VALUE | HASH_SET_KEEP_TTL);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     addReplyBulkCBuffer(c,buf,len);
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH,"hincrbyfloat",c->argv[1],c->db->id);
@@ -2589,6 +2627,7 @@ void hgetdelCommand(client *c) {
     int res = 0, hfe = 0, deleted = 0, expired = 0;
     int64_t oldlen = -1; /* not exists as long as it is not set */
     long num_fields = 0;
+    size_t oldsize = 0;
 
     kvobj *o = lookupKeyWrite(c->db, c->argv[1]);
     if (checkType(c, o, OBJ_HASH))
@@ -2619,6 +2658,7 @@ void hgetdelCommand(client *c) {
     if (o) {
         hfe = hashTypeIsFieldsWithExpire(o);
         oldlen = hashTypeLength(o, 0);
+        oldsize = hashTypeAllocSize(o);
     }
 
     addReplyArrayLen(c, num_fields);
@@ -2626,7 +2666,8 @@ void hgetdelCommand(client *c) {
         const int flags = HFE_LAZY_NO_NOTIFICATION |
                           HFE_LAZY_NO_SIGNAL |
                           HFE_LAZY_AVOID_HASH_DEL |
-                          HFE_LAZY_NO_UPDATE_KEYSIZES;
+                          HFE_LAZY_NO_UPDATE_KEYSIZES |
+                          HFE_LAZY_NO_UPDATE_ALLOCSIZES;
         res = addHashFieldToReply(c, o, c->argv[i]->ptr, flags);
         expired += (res == GETF_EXPIRED);
         /* Try to delete only if it's found and not expired lazily. */
@@ -2640,6 +2681,7 @@ void hgetdelCommand(client *c) {
     if (expired == 0 && deleted == 0)
         return;
 
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     signalModifiedKey(c, c->db, c->argv[1]);
 
     if (expired)
@@ -2663,8 +2705,10 @@ void hgetdelCommand(client *c) {
         /* Del key but don't update KEYSIZES. else it will decr wrong bin in histogram */
         dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
-    } else if (hfe && (hashTypeIsFieldsWithExpire(o) == 0)) { /*is it last HFE*/
-        estoreRemove(c->db->subexpires, getKeySlot(kvobjGetKey(o)), o);
+    } else {
+        if (hfe && (hashTypeIsFieldsWithExpire(o) == 0)) { /*is it last HFE*/
+            estoreRemove(c->db->subexpires, getKeySlot(kvobjGetKey(o)), o);
+        }
     }
 
     if (oldlen != newlen)
@@ -2741,6 +2785,7 @@ void hgetexCommand(client *c) {
         return;
     }
 
+    size_t oldsize = hashTypeAllocSize(o);
     oldlen = hashTypeLength(o, 0);
     if (cond)
         hashTypeSetExInit(c->argv[1], o, c, c->db, 0, &setex);
@@ -2750,7 +2795,8 @@ void hgetexCommand(client *c) {
         const int flags = HFE_LAZY_NO_NOTIFICATION |
                           HFE_LAZY_NO_SIGNAL |
                           HFE_LAZY_AVOID_HASH_DEL |
-                          HFE_LAZY_NO_UPDATE_KEYSIZES;
+                          HFE_LAZY_NO_UPDATE_KEYSIZES |
+                          HFE_LAZY_NO_UPDATE_ALLOCSIZES;
         sds field = c->argv[i]->ptr;
         int res = addHashFieldToReply(c, o, field, flags);
         expired += (res == GETF_EXPIRED);
@@ -2768,6 +2814,8 @@ void hgetexCommand(client *c) {
 
     if (cond)
         hashTypeSetExDone(&setex);
+
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 
     /* Exit early if no modification has been made. */
     if (expired == 0 && deleted == 0 && updated == 0)
@@ -2837,6 +2885,7 @@ void hdelCommand(client *c) {
         checkType(c,o,OBJ_HASH)) return;
 
     int64_t oldLen = (int64_t) hashTypeLength(o, 0);
+    size_t oldsize = hashTypeAllocSize(o);
     
     /* Hash field expiration is optimized to avoid frequent update global HFE DS for
      * each field deletion. Eventually active-expiration will run and update or remove
@@ -2850,6 +2899,7 @@ void hdelCommand(client *c) {
         if (hashTypeDelete(o,c->argv[j]->ptr,1)) {
             deleted++;
             if (hashTypeLength(o, 0) == 0) {
+                updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
                 /* del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
                 dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
                 keyremoved = 1;
@@ -2857,6 +2907,8 @@ void hdelCommand(client *c) {
             }
         }
     }
+    if (!keyremoved)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     if (deleted) {
         int64_t newLen = -1; /* The value -1 indicates that the key is deleted. */
         signalModifiedKey(c,c->db,c->argv[1]);
@@ -2950,6 +3002,7 @@ void genericHgetallCommand(client *c, int flags) {
         addReplyArrayLen(c, length);
     }
 
+    size_t oldsize = hashTypeAllocSize(o);
     hi = hashTypeInitIterator(o);
 
     while (hashTypeNext(hi, 1 /*skipExpiredFields*/) != C_ERR) {
@@ -2964,6 +3017,7 @@ void genericHgetallCommand(client *c, int flags) {
     }
 
     hashTypeReleaseIterator(hi);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 
     /* Make sure we returned the right number of elements. */
     if (flags & OBJ_HASH_KEY && flags & OBJ_HASH_VALUE) count /= 2;
@@ -2999,7 +3053,9 @@ void hscanCommand(client *c) {
     if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.emptyscan)) == NULL ||
         checkType(c,o,OBJ_HASH)) return;
 
+    size_t oldsize = hashTypeAllocSize(o);
     scanGenericCommand(c,o,cursor);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 }
 
 static void hrandfieldReplyWithListpack(client *c, unsigned int count, listpackEntry *keys, listpackEntry *vals) {
@@ -3059,6 +3115,8 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         return;
     }
 
+    size_t oldsize = hashTypeAllocSize(hash);
+
     /* CASE 1: The count was negative, so the extraction method is just:
      * "return N random elements" sampling the whole set every time.
      * This case is trivial and can be served without auxiliary data
@@ -3105,7 +3163,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
             zfree(keys);
             zfree(vals);
         }
-        return;
+        goto out;
     }
 
     /* Initiate reply count, RESP3 responds with nested array, RESP2 with flat one. */
@@ -3128,7 +3186,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
                 addHashIteratorCursorToReply(c, hi, OBJ_HASH_VALUE);
         }
         hashTypeReleaseIterator(hi);
-        return;
+        goto out;
     }
 
     /* CASE 2.5 listpack only. Sampling unique elements, in non-random order.
@@ -3152,7 +3210,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         hrandfieldReplyWithListpack(c, count, keys, vals);
         zfree(keys);
         zfree(vals);
-        return;
+        goto out;
     }
 
     /* CASE 3:
@@ -3243,6 +3301,8 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         /* Release memory */
         dictRelease(dictUnique);
     }
+out:
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
 }
 
 /*
@@ -3308,7 +3368,9 @@ void hrandfieldCommand(client *c) {
         return;
     }
 
+    size_t oldsize = hashTypeAllocSize(hash);
     hashTypeRandomElement(hash,hashTypeLength(hash, 0),&ele,NULL);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
 
     if (ele.sval)
         addReplyBulkCBuffer(c, ele.sval, ele.slen);
@@ -3429,6 +3491,7 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     OnFieldExpireCtx *expCtx = ctx;
     hfield hf = item;
     kvobj *kv = expCtx->hashObj;
+    size_t oldsize = hashTypeAllocSize(kv);
     sds key = kvobjGetKey(kv);
     propagateHashFieldDeletion(expCtx->db, key, hf, hfieldlen(hf));
 
@@ -3437,6 +3500,7 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     updateKeysizesHist(expCtx->db, getKeySlot(key), OBJ_HASH, l, l - 1);
     
     serverAssert(hashTypeDelete(expCtx->hashObj, hf, 0) == 1);
+    updateAllocSizes(expCtx->db, getKeySlot(key), oldsize, hashTypeAllocSize(kv));
     server.stat_expired_subkeys++;
     return ACT_REMOVE_EXP_ITEM;
 }
@@ -3549,6 +3613,7 @@ static void httlGenericCommand(client *c, const char *cmd, long long basetime, i
         return;
     } else if (hashObj->encoding == OBJ_ENCODING_HT) {
         dict *d = hashObj->ptr;
+        size_t oldsize = dictMemUsage(d);
 
         addReplyArrayLen(c, numFields);
         for (int i = 0 ; i < numFields ; i++) {
@@ -3576,6 +3641,7 @@ static void httlGenericCommand(client *c, const char *cmd, long long basetime, i
             else
                 addReplyLongLong(c, (expire - basetime));
         }
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
         return;
     } else {
         serverPanic("Unknown encoding: %d", hashObj->encoding);
@@ -3669,6 +3735,7 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
     }
 
     oldlen = hashTypeLength(hashObj, 0);
+    size_t oldsize = hashTypeAllocSize(hashObj);
 
     HashTypeSetEx exCtx;
     hashTypeSetExInit(keyArg, hashObj, c, c->db, expireSetCond, &exCtx);
@@ -3693,6 +3760,7 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
     }
 
     hashTypeSetExDone(&exCtx);
+    updateAllocSizes(c->db, getKeySlot(keyArg->ptr), oldsize, hashTypeAllocSize(hashObj));
 
     if (deleted + updated > 0) {
         server.dirty += deleted + updated;
@@ -3867,12 +3935,15 @@ void hpersistCommand(client *c) {
                 continue;
             }
 
+            size_t oldsize = hashTypeAllocSize(hashObj);
             listpackExUpdateExpiry(hashObj, field, fptr, vptr, HASH_LP_NO_TTL);
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hashObj));
             addReplyLongLong(c, HFE_PERSIST_OK);
             changed = 1;
         }
     } else if (hashObj->encoding == OBJ_ENCODING_HT) {
         dict *d = hashObj->ptr;
+        size_t oldsize = dictMemUsage(d);
 
         addReplyArrayLen(c, numFields);
         for (int i = 0 ; i < numFields ; i++) {
@@ -3900,6 +3971,7 @@ void hpersistCommand(client *c) {
             addReplyLongLong(c, HFE_PERSIST_OK);
             changed = 1;
         }
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
     } else {
         serverPanic("Unknown encoding: %d", hashObj->encoding);
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -431,7 +431,7 @@ void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info) {
             oldsize = lpBytes(lpt->lp);
         lpt->lp = lpDeleteRange(lpt->lp, 0, expired * 3);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(db, getKeySlot(key), oldsize, lpBytes(lpt->lp));
+            updateSlotAllocSize(db, getKeySlot(key), oldsize, lpBytes(lpt->lp));
         
         /* update keysizes */
         unsigned long l = lpLength(lpt->lp) / 3;
@@ -755,7 +755,7 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
             oldsize = hashTypeAllocSize(o);
         res = hashTypeGetFromHashTable(o, field, &value, expiredAt);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
-            updateAllocSizes(db, getKeySlot(key), oldsize, hashTypeAllocSize(o));
+            updateSlotAllocSize(db, getKeySlot(key), oldsize, hashTypeAllocSize(o));
 
         if (res == GETF_NOT_FOUND)
             return GETF_NOT_FOUND;
@@ -795,7 +795,7 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
         oldsize = hashTypeAllocSize(o);
     serverAssert(hashTypeDelete(o, field, 1) == 1);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
-        updateAllocSizes(db, getKeySlot(key), oldsize, hashTypeAllocSize(o));
+        updateSlotAllocSize(db, getKeySlot(key), oldsize, hashTypeAllocSize(o));
     propagateHashFieldDeletion(db, key, field, sdslen(field));
     server.stat_expired_subkeys++;
 
@@ -2095,7 +2095,7 @@ void hsetnxCommand(client *c) {
     hlen = hashTypeLength(kv, 0);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, hlen - 1, hlen);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
     server.dirty++;
 }
 
@@ -2131,7 +2131,7 @@ void hsetCommand(client *c) {
     unsigned long l = hashTypeLength(kv, 0);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, l - created, l);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
     server.dirty += (c->argc - 2)/2;
 }
@@ -2428,7 +2428,7 @@ void hsetexCommand(client *c) {
 
 out:
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     /* Emit keyspace notifications based on field expiry, mutation, or key deletion */
     if (fields_set || expired) {
         signalModifiedKey(c, c->db, c->argv[1]);
@@ -2498,7 +2498,7 @@ void hincrbyCommand(client *c) {
         oldsize = hashTypeAllocSize(o);
     hashTypeSet(c->db, o,c->argv[2]->ptr,new,HASH_SET_TAKE_VALUE | HASH_SET_KEEP_TTL);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     addReplyLongLong(c,value);
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH,"hincrby",c->argv[1],c->db->id);
@@ -2556,7 +2556,7 @@ void hincrbyfloatCommand(client *c) {
         oldsize = hashTypeAllocSize(o);
     hashTypeSet(c->db, o,c->argv[2]->ptr,new,HASH_SET_TAKE_VALUE | HASH_SET_KEEP_TTL);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     addReplyBulkCBuffer(c,buf,len);
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH,"hincrbyfloat",c->argv[1],c->db->id);
@@ -2700,7 +2700,7 @@ void hgetdelCommand(client *c) {
         return;
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     signalModifiedKey(c, c->db, c->argv[1]);
 
     if (expired)
@@ -2837,7 +2837,7 @@ void hgetexCommand(client *c) {
         hashTypeSetExDone(&setex);
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 
     /* Exit early if no modification has been made. */
     if (expired == 0 && deleted == 0 && updated == 0)
@@ -2924,7 +2924,7 @@ void hdelCommand(client *c) {
             deleted++;
             if (hashTypeLength(o, 0) == 0) {
                 if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+                    updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
                 /* del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
                 dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
                 keyremoved = 1;
@@ -2933,7 +2933,7 @@ void hdelCommand(client *c) {
         }
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && !keyremoved)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     if (deleted) {
         int64_t newLen = -1; /* The value -1 indicates that the key is deleted. */
         signalModifiedKey(c,c->db,c->argv[1]);
@@ -3045,7 +3045,7 @@ void genericHgetallCommand(client *c, int flags) {
 
     hashTypeReleaseIterator(hi);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 
     /* Make sure we returned the right number of elements. */
     if (flags & OBJ_HASH_KEY && flags & OBJ_HASH_VALUE) count /= 2;
@@ -3086,7 +3086,7 @@ void hscanCommand(client *c) {
         oldsize = hashTypeAllocSize(o);
     scanGenericCommand(c,o,cursor);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 }
 
 static void hrandfieldReplyWithListpack(client *c, unsigned int count, listpackEntry *keys, listpackEntry *vals) {
@@ -3336,7 +3336,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     }
 out:
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
 }
 
 /*
@@ -3407,7 +3407,7 @@ void hrandfieldCommand(client *c) {
         oldsize = hashTypeAllocSize(hash);
     hashTypeRandomElement(hash,hashTypeLength(hash, 0),&ele,NULL);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
 
     if (ele.sval)
         addReplyBulkCBuffer(c, ele.sval, ele.slen);
@@ -3541,7 +3541,7 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     
     serverAssert(hashTypeDelete(expCtx->hashObj, hf, 0) == 1);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(expCtx->db, getKeySlot(key), oldsize, hashTypeAllocSize(kv));
+        updateSlotAllocSize(expCtx->db, getKeySlot(key), oldsize, hashTypeAllocSize(kv));
     server.stat_expired_subkeys++;
     return ACT_REMOVE_EXP_ITEM;
 }
@@ -3683,7 +3683,7 @@ static void httlGenericCommand(client *c, const char *cmd, long long basetime, i
                 addReplyLongLong(c, (expire - basetime));
         }
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
         return;
     } else {
         serverPanic("Unknown encoding: %d", hashObj->encoding);
@@ -3805,7 +3805,7 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
 
     hashTypeSetExDone(&exCtx);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(keyArg->ptr), oldsize, hashTypeAllocSize(hashObj));
+        updateSlotAllocSize(c->db, getKeySlot(keyArg->ptr), oldsize, hashTypeAllocSize(hashObj));
 
     if (deleted + updated > 0) {
         server.dirty += deleted + updated;
@@ -3985,7 +3985,7 @@ void hpersistCommand(client *c) {
                 oldsize = hashTypeAllocSize(hashObj);
             listpackExUpdateExpiry(hashObj, field, fptr, vptr, HASH_LP_NO_TTL);
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hashObj));
+                updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hashObj));
             addReplyLongLong(c, HFE_PERSIST_OK);
             changed = 1;
         }
@@ -4020,7 +4020,7 @@ void hpersistCommand(client *c) {
             changed = 1;
         }
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
     } else {
         serverPanic("Unknown encoding: %d", hashObj->encoding);
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -427,10 +427,10 @@ void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info) {
 
     if (expired) {
         size_t oldsize = 0;
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = lpBytes(lpt->lp);
         lpt->lp = lpDeleteRange(lpt->lp, 0, expired * 3);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(db, getKeySlot(key), oldsize, lpBytes(lpt->lp));
         
         /* update keysizes */
@@ -751,10 +751,10 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
 
     } else if (o->encoding == OBJ_ENCODING_HT) {
         sds value = NULL;
-        if (clusterSlotStatsEnabled() && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+        if (server.memory_tracking_per_slot && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
             oldsize = hashTypeAllocSize(o);
         res = hashTypeGetFromHashTable(o, field, &value, expiredAt);
-        if (clusterSlotStatsEnabled() && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+        if (server.memory_tracking_per_slot && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
             updateSlotAllocSize(db, getKeySlot(key), oldsize, hashTypeAllocSize(o));
 
         if (res == GETF_NOT_FOUND)
@@ -791,10 +791,10 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
         return GETF_EXPIRED;
 
     /* delete the field and propagate the deletion */
-    if (clusterSlotStatsEnabled() && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+    if (server.memory_tracking_per_slot && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
         oldsize = hashTypeAllocSize(o);
     serverAssert(hashTypeDelete(o, field, 1) == 1);
-    if (clusterSlotStatsEnabled() && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+    if (server.memory_tracking_per_slot && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
         updateSlotAllocSize(db, getKeySlot(key), oldsize, hashTypeAllocSize(o));
     propagateHashFieldDeletion(db, key, field, sdslen(field));
     server.stat_expired_subkeys++;
@@ -2085,7 +2085,7 @@ void hsetnxCommand(client *c) {
         kv = dbAdd(c->db,c->argv[1],&o);
     }
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(kv);
     hashTypeTryConversion(c->db, kv, c->argv, 2, 3);
     hashTypeSet(c->db, kv, c->argv[2]->ptr, c->argv[3]->ptr, HASH_SET_COPY);
@@ -2094,7 +2094,7 @@ void hsetnxCommand(client *c) {
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
     hlen = hashTypeLength(kv, 0);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, hlen - 1, hlen);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
     server.dirty++;
 }
@@ -2111,7 +2111,7 @@ void hsetCommand(client *c) {
 
     if ((kv = hashTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(kv);
     hashTypeTryConversion(c->db, kv, c->argv, 2, c->argc-1);
 
@@ -2130,7 +2130,7 @@ void hsetCommand(client *c) {
     signalModifiedKey(c,c->db,c->argv[1]);
     unsigned long l = hashTypeLength(kv, 0);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, l - created, l);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
     server.dirty += (c->argc - 2)/2;
@@ -2340,7 +2340,7 @@ void hsetexCommand(client *c) {
         dbAddByLink(c->db, c->argv[1], &o, &link);
     }
     oldlen = (int64_t) hashTypeLength(o, 0);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(o);
 
     if (flags & (HFE_FXX | HFE_FNX)) {
@@ -2427,7 +2427,7 @@ void hsetexCommand(client *c) {
     addReplyLongLong(c, 1);
 
 out:
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     /* Emit keyspace notifications based on field expiry, mutation, or key deletion */
     if (fields_set || expired) {
@@ -2494,10 +2494,10 @@ void hincrbyCommand(client *c) {
     }
     value += incr;
     new = sdsfromlonglong(value);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(o);
     hashTypeSet(c->db, o,c->argv[2]->ptr,new,HASH_SET_TAKE_VALUE | HASH_SET_KEEP_TTL);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     addReplyLongLong(c,value);
     signalModifiedKey(c,c->db,c->argv[1]);
@@ -2552,10 +2552,10 @@ void hincrbyfloatCommand(client *c) {
     char buf[MAX_LONG_DOUBLE_CHARS];
     int len = ld2string(buf,sizeof(buf),value,LD_STR_HUMAN);
     new = sdsnewlen(buf,len);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(o);
     hashTypeSet(c->db, o,c->argv[2]->ptr,new,HASH_SET_TAKE_VALUE | HASH_SET_KEEP_TTL);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     addReplyBulkCBuffer(c,buf,len);
     signalModifiedKey(c,c->db,c->argv[1]);
@@ -2675,7 +2675,7 @@ void hgetdelCommand(client *c) {
     if (o) {
         hfe = hashTypeIsFieldsWithExpire(o);
         oldlen = hashTypeLength(o, 0);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = hashTypeAllocSize(o);
     }
 
@@ -2699,7 +2699,7 @@ void hgetdelCommand(client *c) {
     if (expired == 0 && deleted == 0)
         return;
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     signalModifiedKey(c, c->db, c->argv[1]);
 
@@ -2805,7 +2805,7 @@ void hgetexCommand(client *c) {
         return;
     }
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(o);
     oldlen = hashTypeLength(o, 0);
     if (cond)
@@ -2836,7 +2836,7 @@ void hgetexCommand(client *c) {
     if (cond)
         hashTypeSetExDone(&setex);
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 
     /* Exit early if no modification has been made. */
@@ -2908,7 +2908,7 @@ void hdelCommand(client *c) {
         checkType(c,o,OBJ_HASH)) return;
 
     int64_t oldLen = (int64_t) hashTypeLength(o, 0);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(o);
     
     /* Hash field expiration is optimized to avoid frequent update global HFE DS for
@@ -2923,7 +2923,7 @@ void hdelCommand(client *c) {
         if (hashTypeDelete(o,c->argv[j]->ptr,1)) {
             deleted++;
             if (hashTypeLength(o, 0) == 0) {
-                if (clusterSlotStatsEnabled())
+                if (server.memory_tracking_per_slot)
                     updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
                 /* del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
                 dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
@@ -2932,7 +2932,7 @@ void hdelCommand(client *c) {
             }
         }
     }
-    if (clusterSlotStatsEnabled() && !keyremoved)
+    if (server.memory_tracking_per_slot && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     if (deleted) {
         int64_t newLen = -1; /* The value -1 indicates that the key is deleted. */
@@ -3028,7 +3028,7 @@ void genericHgetallCommand(client *c, int flags) {
         addReplyArrayLen(c, length);
     }
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(o);
     hi = hashTypeInitIterator(o);
 
@@ -3044,7 +3044,7 @@ void genericHgetallCommand(client *c, int flags) {
     }
 
     hashTypeReleaseIterator(hi);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 
     /* Make sure we returned the right number of elements. */
@@ -3082,10 +3082,10 @@ void hscanCommand(client *c) {
     if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.emptyscan)) == NULL ||
         checkType(c,o,OBJ_HASH)) return;
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(o);
     scanGenericCommand(c,o,cursor);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 }
 
@@ -3147,7 +3147,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         return;
     }
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(hash);
 
     /* CASE 1: The count was negative, so the extraction method is just:
@@ -3335,7 +3335,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         dictRelease(dictUnique);
     }
 out:
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
 }
 
@@ -3403,10 +3403,10 @@ void hrandfieldCommand(client *c) {
         return;
     }
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(hash);
     hashTypeRandomElement(hash,hashTypeLength(hash, 0),&ele,NULL);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
 
     if (ele.sval)
@@ -3531,7 +3531,7 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     size_t oldsize = 0;
     sds key = kvobjGetKey(kv);
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(kv);
     propagateHashFieldDeletion(expCtx->db, key, hf, hfieldlen(hf));
 
@@ -3540,7 +3540,7 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     updateKeysizesHist(expCtx->db, getKeySlot(key), OBJ_HASH, l, l - 1);
     
     serverAssert(hashTypeDelete(expCtx->hashObj, hf, 0) == 1);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(expCtx->db, getKeySlot(key), oldsize, hashTypeAllocSize(kv));
     server.stat_expired_subkeys++;
     return ACT_REMOVE_EXP_ITEM;
@@ -3682,7 +3682,7 @@ static void httlGenericCommand(client *c, const char *cmd, long long basetime, i
             else
                 addReplyLongLong(c, (expire - basetime));
         }
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
         return;
     } else {
@@ -3778,7 +3778,7 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
     }
 
     oldlen = hashTypeLength(hashObj, 0);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = hashTypeAllocSize(hashObj);
 
     HashTypeSetEx exCtx;
@@ -3804,7 +3804,7 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
     }
 
     hashTypeSetExDone(&exCtx);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(keyArg->ptr), oldsize, hashTypeAllocSize(hashObj));
 
     if (deleted + updated > 0) {
@@ -3981,10 +3981,10 @@ void hpersistCommand(client *c) {
                 continue;
             }
 
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 oldsize = hashTypeAllocSize(hashObj);
             listpackExUpdateExpiry(hashObj, field, fptr, vptr, HASH_LP_NO_TTL);
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hashObj));
             addReplyLongLong(c, HFE_PERSIST_OK);
             changed = 1;
@@ -4019,7 +4019,7 @@ void hpersistCommand(client *c) {
             addReplyLongLong(c, HFE_PERSIST_OK);
             changed = 1;
         }
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
     } else {
         serverPanic("Unknown encoding: %d", hashObj->encoding);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -427,10 +427,10 @@ void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info) {
 
     if (expired) {
         size_t oldsize = 0;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = lpBytes(lpt->lp);
         lpt->lp = lpDeleteRange(lpt->lp, 0, expired * 3);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(db, getKeySlot(key), oldsize, lpBytes(lpt->lp));
         
         /* update keysizes */
@@ -751,10 +751,10 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
 
     } else if (o->encoding == OBJ_ENCODING_HT) {
         sds value = NULL;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+        if (clusterSlotStatsEnabled() && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
             oldsize = hashTypeAllocSize(o);
         res = hashTypeGetFromHashTable(o, field, &value, expiredAt);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+        if (clusterSlotStatsEnabled() && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
             updateSlotAllocSize(db, getKeySlot(key), oldsize, hashTypeAllocSize(o));
 
         if (res == GETF_NOT_FOUND)
@@ -791,10 +791,10 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
         return GETF_EXPIRED;
 
     /* delete the field and propagate the deletion */
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+    if (clusterSlotStatsEnabled() && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
         oldsize = hashTypeAllocSize(o);
     serverAssert(hashTypeDelete(o, field, 1) == 1);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+    if (clusterSlotStatsEnabled() && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
         updateSlotAllocSize(db, getKeySlot(key), oldsize, hashTypeAllocSize(o));
     propagateHashFieldDeletion(db, key, field, sdslen(field));
     server.stat_expired_subkeys++;
@@ -2085,7 +2085,7 @@ void hsetnxCommand(client *c) {
         kv = dbAdd(c->db,c->argv[1],&o);
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(kv);
     hashTypeTryConversion(c->db, kv, c->argv, 2, 3);
     hashTypeSet(c->db, kv, c->argv[2]->ptr, c->argv[3]->ptr, HASH_SET_COPY);
@@ -2094,7 +2094,7 @@ void hsetnxCommand(client *c) {
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
     hlen = hashTypeLength(kv, 0);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, hlen - 1, hlen);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
     server.dirty++;
 }
@@ -2111,7 +2111,7 @@ void hsetCommand(client *c) {
 
     if ((kv = hashTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(kv);
     hashTypeTryConversion(c->db, kv, c->argv, 2, c->argc-1);
 
@@ -2130,7 +2130,7 @@ void hsetCommand(client *c) {
     signalModifiedKey(c,c->db,c->argv[1]);
     unsigned long l = hashTypeLength(kv, 0);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, l - created, l);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
     server.dirty += (c->argc - 2)/2;
@@ -2340,7 +2340,7 @@ void hsetexCommand(client *c) {
         dbAddByLink(c->db, c->argv[1], &o, &link);
     }
     oldlen = (int64_t) hashTypeLength(o, 0);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(o);
 
     if (flags & (HFE_FXX | HFE_FNX)) {
@@ -2427,7 +2427,7 @@ void hsetexCommand(client *c) {
     addReplyLongLong(c, 1);
 
 out:
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     /* Emit keyspace notifications based on field expiry, mutation, or key deletion */
     if (fields_set || expired) {
@@ -2494,10 +2494,10 @@ void hincrbyCommand(client *c) {
     }
     value += incr;
     new = sdsfromlonglong(value);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(o);
     hashTypeSet(c->db, o,c->argv[2]->ptr,new,HASH_SET_TAKE_VALUE | HASH_SET_KEEP_TTL);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     addReplyLongLong(c,value);
     signalModifiedKey(c,c->db,c->argv[1]);
@@ -2552,10 +2552,10 @@ void hincrbyfloatCommand(client *c) {
     char buf[MAX_LONG_DOUBLE_CHARS];
     int len = ld2string(buf,sizeof(buf),value,LD_STR_HUMAN);
     new = sdsnewlen(buf,len);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(o);
     hashTypeSet(c->db, o,c->argv[2]->ptr,new,HASH_SET_TAKE_VALUE | HASH_SET_KEEP_TTL);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     addReplyBulkCBuffer(c,buf,len);
     signalModifiedKey(c,c->db,c->argv[1]);
@@ -2675,7 +2675,7 @@ void hgetdelCommand(client *c) {
     if (o) {
         hfe = hashTypeIsFieldsWithExpire(o);
         oldlen = hashTypeLength(o, 0);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = hashTypeAllocSize(o);
     }
 
@@ -2699,7 +2699,7 @@ void hgetdelCommand(client *c) {
     if (expired == 0 && deleted == 0)
         return;
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     signalModifiedKey(c, c->db, c->argv[1]);
 
@@ -2805,7 +2805,7 @@ void hgetexCommand(client *c) {
         return;
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(o);
     oldlen = hashTypeLength(o, 0);
     if (cond)
@@ -2836,7 +2836,7 @@ void hgetexCommand(client *c) {
     if (cond)
         hashTypeSetExDone(&setex);
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 
     /* Exit early if no modification has been made. */
@@ -2908,7 +2908,7 @@ void hdelCommand(client *c) {
         checkType(c,o,OBJ_HASH)) return;
 
     int64_t oldLen = (int64_t) hashTypeLength(o, 0);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(o);
     
     /* Hash field expiration is optimized to avoid frequent update global HFE DS for
@@ -2923,7 +2923,7 @@ void hdelCommand(client *c) {
         if (hashTypeDelete(o,c->argv[j]->ptr,1)) {
             deleted++;
             if (hashTypeLength(o, 0) == 0) {
-                if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                if (clusterSlotStatsEnabled())
                     updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
                 /* del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
                 dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
@@ -2932,7 +2932,7 @@ void hdelCommand(client *c) {
             }
         }
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && !keyremoved)
+    if (clusterSlotStatsEnabled() && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     if (deleted) {
         int64_t newLen = -1; /* The value -1 indicates that the key is deleted. */
@@ -3028,7 +3028,7 @@ void genericHgetallCommand(client *c, int flags) {
         addReplyArrayLen(c, length);
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(o);
     hi = hashTypeInitIterator(o);
 
@@ -3044,7 +3044,7 @@ void genericHgetallCommand(client *c, int flags) {
     }
 
     hashTypeReleaseIterator(hi);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 
     /* Make sure we returned the right number of elements. */
@@ -3082,10 +3082,10 @@ void hscanCommand(client *c) {
     if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.emptyscan)) == NULL ||
         checkType(c,o,OBJ_HASH)) return;
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(o);
     scanGenericCommand(c,o,cursor);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 }
 
@@ -3147,7 +3147,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         return;
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(hash);
 
     /* CASE 1: The count was negative, so the extraction method is just:
@@ -3335,7 +3335,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         dictRelease(dictUnique);
     }
 out:
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
 }
 
@@ -3403,10 +3403,10 @@ void hrandfieldCommand(client *c) {
         return;
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(hash);
     hashTypeRandomElement(hash,hashTypeLength(hash, 0),&ele,NULL);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
 
     if (ele.sval)
@@ -3531,7 +3531,7 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     size_t oldsize = 0;
     sds key = kvobjGetKey(kv);
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(kv);
     propagateHashFieldDeletion(expCtx->db, key, hf, hfieldlen(hf));
 
@@ -3540,7 +3540,7 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     updateKeysizesHist(expCtx->db, getKeySlot(key), OBJ_HASH, l, l - 1);
     
     serverAssert(hashTypeDelete(expCtx->hashObj, hf, 0) == 1);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(expCtx->db, getKeySlot(key), oldsize, hashTypeAllocSize(kv));
     server.stat_expired_subkeys++;
     return ACT_REMOVE_EXP_ITEM;
@@ -3682,7 +3682,7 @@ static void httlGenericCommand(client *c, const char *cmd, long long basetime, i
             else
                 addReplyLongLong(c, (expire - basetime));
         }
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
         return;
     } else {
@@ -3778,7 +3778,7 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
     }
 
     oldlen = hashTypeLength(hashObj, 0);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = hashTypeAllocSize(hashObj);
 
     HashTypeSetEx exCtx;
@@ -3804,7 +3804,7 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
     }
 
     hashTypeSetExDone(&exCtx);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(keyArg->ptr), oldsize, hashTypeAllocSize(hashObj));
 
     if (deleted + updated > 0) {
@@ -3981,10 +3981,10 @@ void hpersistCommand(client *c) {
                 continue;
             }
 
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 oldsize = hashTypeAllocSize(hashObj);
             listpackExUpdateExpiry(hashObj, field, fptr, vptr, HASH_LP_NO_TTL);
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hashObj));
             addReplyLongLong(c, HFE_PERSIST_OK);
             changed = 1;
@@ -4019,7 +4019,7 @@ void hpersistCommand(client *c) {
             addReplyLongLong(c, HFE_PERSIST_OK);
             changed = 1;
         }
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
     } else {
         serverPanic("Unknown encoding: %d", hashObj->encoding);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1341,7 +1341,7 @@ unsigned long hashTypeLength(const robj *o, int subtractExpiredFields) {
 }
 
 size_t hashTypeAllocSize(const robj *o) {
-    debugServerAssertWithInfo(NULL,o,o->type == OBJ_HASH);
+    serverAssertWithInfo(NULL,o,o->type == OBJ_HASH);
     size_t size = 0;
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
         size = lpBytes(o->ptr);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -426,9 +426,12 @@ void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info) {
     }
 
     if (expired) {
-        size_t oldsize = lpBytes(lpt->lp);
+        size_t oldsize = 0;
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = lpBytes(lpt->lp);
         lpt->lp = lpDeleteRange(lpt->lp, 0, expired * 3);
-        updateAllocSizes(db, getKeySlot(key), oldsize, lpBytes(lpt->lp));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(db, getKeySlot(key), oldsize, lpBytes(lpt->lp));
         
         /* update keysizes */
         unsigned long l = lpLength(lpt->lp) / 3;
@@ -736,6 +739,7 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
     sds key = kvobjGetKey(o);
     GetFieldRes res;
     uint64_t dummy;
+    size_t oldsize = 0;
     if (expiredAt == NULL) expiredAt = &dummy;
     if (o->encoding == OBJ_ENCODING_LISTPACK ||
         o->encoding == OBJ_ENCODING_LISTPACK_EX) {
@@ -747,11 +751,10 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
 
     } else if (o->encoding == OBJ_ENCODING_HT) {
         sds value = NULL;
-        size_t oldsize = 0;
-        if (!(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
             oldsize = hashTypeAllocSize(o);
         res = hashTypeGetFromHashTable(o, field, &value, expiredAt);
-        if (!(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
             updateAllocSizes(db, getKeySlot(key), oldsize, hashTypeAllocSize(o));
 
         if (res == GETF_NOT_FOUND)
@@ -788,11 +791,10 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
         return GETF_EXPIRED;
 
     /* delete the field and propagate the deletion */
-    size_t oldsize = 0;
-    if (!(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
         oldsize = hashTypeAllocSize(o);
     serverAssert(hashTypeDelete(o, field, 1) == 1);
-    if (!(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && !(hfeFlags & HFE_LAZY_NO_UPDATE_ALLOCSIZES))
         updateAllocSizes(db, getKeySlot(key), oldsize, hashTypeAllocSize(o));
     propagateHashFieldDeletion(db, key, field, sdslen(field));
     server.stat_expired_subkeys++;
@@ -2068,6 +2070,7 @@ ebuckets *hashTypeGetDictMetaHFE(dict *d) {
 void hsetnxCommand(client *c) {
     unsigned long hlen;
     int isHashDeleted;
+    size_t oldsize = 0;
     robj *kv = hashTypeLookupWriteOrCreate(c,c->argv[1]);
     if (kv == NULL) return;
 
@@ -2082,7 +2085,8 @@ void hsetnxCommand(client *c) {
         kv = dbAdd(c->db,c->argv[1],&o);
     }
 
-    size_t oldsize = hashTypeAllocSize(kv);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(kv);
     hashTypeTryConversion(c->db, kv, c->argv, 2, 3);
     hashTypeSet(c->db, kv, c->argv[2]->ptr, c->argv[3]->ptr, HASH_SET_COPY);
     addReply(c, shared.cone);
@@ -2090,12 +2094,14 @@ void hsetnxCommand(client *c) {
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
     hlen = hashTypeLength(kv, 0);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, hlen - 1, hlen);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
     server.dirty++;
 }
 
 void hsetCommand(client *c) {
     int i, created = 0;
+    size_t oldsize = 0;
     kvobj *kv;
 
     if ((c->argc % 2) == 1) {
@@ -2104,7 +2110,9 @@ void hsetCommand(client *c) {
     }
 
     if ((kv = hashTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
-    size_t oldsize = hashTypeAllocSize(kv);
+
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(kv);
     hashTypeTryConversion(c->db, kv, c->argv, 2, c->argc-1);
 
     for (i = 2; i < c->argc; i += 2)
@@ -2122,7 +2130,8 @@ void hsetCommand(client *c) {
     signalModifiedKey(c,c->db,c->argv[1]);
     unsigned long l = hashTypeLength(kv, 0);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, l - created, l);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(kv));
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
     server.dirty += (c->argc - 2)/2;
 }
@@ -2331,7 +2340,8 @@ void hsetexCommand(client *c) {
         dbAddByLink(c->db, c->argv[1], &o, &link);
     }
     oldlen = (int64_t) hashTypeLength(o, 0);
-    oldsize = hashTypeAllocSize(o);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(o);
 
     if (flags & (HFE_FXX | HFE_FNX)) {
         int found = 0;
@@ -2417,7 +2427,8 @@ void hsetexCommand(client *c) {
     addReplyLongLong(c, 1);
 
 out:
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     /* Emit keyspace notifications based on field expiry, mutation, or key deletion */
     if (fields_set || expired) {
         signalModifiedKey(c, c->db, c->argv[1]);
@@ -2449,6 +2460,7 @@ void hincrbyCommand(client *c) {
     sds new;
     unsigned char *vstr;
     unsigned int vlen;
+    size_t oldsize = 0;
 
     if (getLongLongFromObjectOrReply(c,c->argv[3],&incr,NULL) != C_OK) return;
     if ((o = hashTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
@@ -2482,9 +2494,11 @@ void hincrbyCommand(client *c) {
     }
     value += incr;
     new = sdsfromlonglong(value);
-    size_t oldsize = hashTypeAllocSize(o);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(o);
     hashTypeSet(c->db, o,c->argv[2]->ptr,new,HASH_SET_TAKE_VALUE | HASH_SET_KEEP_TTL);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     addReplyLongLong(c,value);
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH,"hincrby",c->argv[1],c->db->id);
@@ -2498,6 +2512,7 @@ void hincrbyfloatCommand(client *c) {
     sds new;
     unsigned char *vstr;
     unsigned int vlen;
+    size_t oldsize = 0;
 
     if (getLongDoubleFromObjectOrReply(c,c->argv[3],&incr,NULL) != C_OK) return;
     if (isnan(incr) || isinf(incr)) {
@@ -2537,9 +2552,11 @@ void hincrbyfloatCommand(client *c) {
     char buf[MAX_LONG_DOUBLE_CHARS];
     int len = ld2string(buf,sizeof(buf),value,LD_STR_HUMAN);
     new = sdsnewlen(buf,len);
-    size_t oldsize = hashTypeAllocSize(o);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(o);
     hashTypeSet(c->db, o,c->argv[2]->ptr,new,HASH_SET_TAKE_VALUE | HASH_SET_KEEP_TTL);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     addReplyBulkCBuffer(c,buf,len);
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH,"hincrbyfloat",c->argv[1],c->db->id);
@@ -2658,7 +2675,8 @@ void hgetdelCommand(client *c) {
     if (o) {
         hfe = hashTypeIsFieldsWithExpire(o);
         oldlen = hashTypeLength(o, 0);
-        oldsize = hashTypeAllocSize(o);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = hashTypeAllocSize(o);
     }
 
     addReplyArrayLen(c, num_fields);
@@ -2681,7 +2699,8 @@ void hgetdelCommand(client *c) {
     if (expired == 0 && deleted == 0)
         return;
 
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     signalModifiedKey(c, c->db, c->argv[1]);
 
     if (expired)
@@ -2732,6 +2751,7 @@ void hgetexCommand(client *c) {
     int64_t oldlen = 0, newlen = -1;
     long long expire_time = 0;
     HashTypeSetEx setex;
+    size_t oldsize = 0;
 
     kvobj *o = lookupKeyWrite(c->db, c->argv[1]);
     if (checkType(c, o, OBJ_HASH))
@@ -2785,7 +2805,8 @@ void hgetexCommand(client *c) {
         return;
     }
 
-    size_t oldsize = hashTypeAllocSize(o);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(o);
     oldlen = hashTypeLength(o, 0);
     if (cond)
         hashTypeSetExInit(c->argv[1], o, c, c->db, 0, &setex);
@@ -2815,7 +2836,8 @@ void hgetexCommand(client *c) {
     if (cond)
         hashTypeSetExDone(&setex);
 
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 
     /* Exit early if no modification has been made. */
     if (expired == 0 && deleted == 0 && updated == 0)
@@ -2880,12 +2902,14 @@ void hgetexCommand(client *c) {
 void hdelCommand(client *c) {
     kvobj *o;
     int j, deleted = 0, keyremoved = 0;
+    size_t oldsize = 0;
 
     if ((o = lookupKeyWriteOrReply(c,c->argv[1],shared.czero)) == NULL ||
         checkType(c,o,OBJ_HASH)) return;
 
     int64_t oldLen = (int64_t) hashTypeLength(o, 0);
-    size_t oldsize = hashTypeAllocSize(o);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(o);
     
     /* Hash field expiration is optimized to avoid frequent update global HFE DS for
      * each field deletion. Eventually active-expiration will run and update or remove
@@ -2899,7 +2923,8 @@ void hdelCommand(client *c) {
         if (hashTypeDelete(o,c->argv[j]->ptr,1)) {
             deleted++;
             if (hashTypeLength(o, 0) == 0) {
-                updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+                if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
                 /* del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
                 dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
                 keyremoved = 1;
@@ -2907,7 +2932,7 @@ void hdelCommand(client *c) {
             }
         }
     }
-    if (!keyremoved)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && !keyremoved)
         updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
     if (deleted) {
         int64_t newLen = -1; /* The value -1 indicates that the key is deleted. */
@@ -2983,6 +3008,7 @@ void genericHgetallCommand(client *c, int flags) {
     kvobj *o;
     hashTypeIterator *hi;
     int length, count = 0;
+    size_t oldsize = 0;
 
     robj *emptyResp = (flags & OBJ_HASH_KEY && flags & OBJ_HASH_VALUE) ?
         shared.emptymap[c->resp] : shared.emptyarray;
@@ -3002,7 +3028,8 @@ void genericHgetallCommand(client *c, int flags) {
         addReplyArrayLen(c, length);
     }
 
-    size_t oldsize = hashTypeAllocSize(o);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(o);
     hi = hashTypeInitIterator(o);
 
     while (hashTypeNext(hi, 1 /*skipExpiredFields*/) != C_ERR) {
@@ -3017,7 +3044,8 @@ void genericHgetallCommand(client *c, int flags) {
     }
 
     hashTypeReleaseIterator(hi);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 
     /* Make sure we returned the right number of elements. */
     if (flags & OBJ_HASH_KEY && flags & OBJ_HASH_VALUE) count /= 2;
@@ -3048,14 +3076,17 @@ void hexistsCommand(client *c) {
 void hscanCommand(client *c) {
     kvobj *o;
     unsigned long long cursor;
+    size_t oldsize = 0;
 
     if (parseScanCursorOrReply(c,c->argv[2],&cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.emptyscan)) == NULL ||
         checkType(c,o,OBJ_HASH)) return;
 
-    size_t oldsize = hashTypeAllocSize(o);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(o);
     scanGenericCommand(c,o,cursor);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(o));
 }
 
 static void hrandfieldReplyWithListpack(client *c, unsigned int count, listpackEntry *keys, listpackEntry *vals) {
@@ -3089,6 +3120,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     unsigned long count, size;
     int uniq = 1;
     kvobj *hash;
+    size_t oldsize = 0;
 
     if ((hash = lookupKeyReadOrReply(c,c->argv[1],shared.emptyarray))
         == NULL || checkType(c,hash,OBJ_HASH)) return;
@@ -3115,7 +3147,8 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         return;
     }
 
-    size_t oldsize = hashTypeAllocSize(hash);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(hash);
 
     /* CASE 1: The count was negative, so the extraction method is just:
      * "return N random elements" sampling the whole set every time.
@@ -3302,7 +3335,8 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         dictRelease(dictUnique);
     }
 out:
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
 }
 
 /*
@@ -3339,6 +3373,7 @@ void hrandfieldCommand(client *c) {
     int withvalues = 0;
     kvobj *hash;
     CommonEntry ele;
+    size_t oldsize = 0;
 
     if (c->argc >= 3) {
         if (getRangeLongFromObjectOrReply(c,c->argv[2],-LONG_MAX,LONG_MAX,&l,NULL) != C_OK) return;
@@ -3368,9 +3403,11 @@ void hrandfieldCommand(client *c) {
         return;
     }
 
-    size_t oldsize = hashTypeAllocSize(hash);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(hash);
     hashTypeRandomElement(hash,hashTypeLength(hash, 0),&ele,NULL);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hash));
 
     if (ele.sval)
         addReplyBulkCBuffer(c, ele.sval, ele.slen);
@@ -3491,8 +3528,11 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     OnFieldExpireCtx *expCtx = ctx;
     hfield hf = item;
     kvobj *kv = expCtx->hashObj;
-    size_t oldsize = hashTypeAllocSize(kv);
+    size_t oldsize = 0;
     sds key = kvobjGetKey(kv);
+
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(kv);
     propagateHashFieldDeletion(expCtx->db, key, hf, hfieldlen(hf));
 
     /* update keysizes */
@@ -3500,7 +3540,8 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     updateKeysizesHist(expCtx->db, getKeySlot(key), OBJ_HASH, l, l - 1);
     
     serverAssert(hashTypeDelete(expCtx->hashObj, hf, 0) == 1);
-    updateAllocSizes(expCtx->db, getKeySlot(key), oldsize, hashTypeAllocSize(kv));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(expCtx->db, getKeySlot(key), oldsize, hashTypeAllocSize(kv));
     server.stat_expired_subkeys++;
     return ACT_REMOVE_EXP_ITEM;
 }
@@ -3641,7 +3682,8 @@ static void httlGenericCommand(client *c, const char *cmd, long long basetime, i
             else
                 addReplyLongLong(c, (expire - basetime));
         }
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
         return;
     } else {
         serverPanic("Unknown encoding: %d", hashObj->encoding);
@@ -3686,6 +3728,7 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
     int fieldAt, fieldsNotSet = 0, expireSetCond = 0, updated = 0, deleted = 0;
     int64_t oldlen, newlen;
     robj *keyArg = c->argv[1], *expireArg = c->argv[2];
+    size_t oldsize = 0;
 
     /* Read the hash object */
     kvobj *hashObj = lookupKeyWrite(c->db, keyArg);
@@ -3735,7 +3778,8 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
     }
 
     oldlen = hashTypeLength(hashObj, 0);
-    size_t oldsize = hashTypeAllocSize(hashObj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = hashTypeAllocSize(hashObj);
 
     HashTypeSetEx exCtx;
     hashTypeSetExInit(keyArg, hashObj, c, c->db, expireSetCond, &exCtx);
@@ -3760,7 +3804,8 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
     }
 
     hashTypeSetExDone(&exCtx);
-    updateAllocSizes(c->db, getKeySlot(keyArg->ptr), oldsize, hashTypeAllocSize(hashObj));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(keyArg->ptr), oldsize, hashTypeAllocSize(hashObj));
 
     if (deleted + updated > 0) {
         server.dirty += deleted + updated;
@@ -3906,6 +3951,7 @@ void hpersistCommand(client *c) {
         long long prevExpire;
         unsigned char *fptr, *vptr, *tptr;
         listpackEx *lpt = hashObj->ptr;
+        size_t oldsize = 0;
 
         addReplyArrayLen(c, numFields);
         for (int i = 0 ; i < numFields ; i++) {
@@ -3935,9 +3981,11 @@ void hpersistCommand(client *c) {
                 continue;
             }
 
-            size_t oldsize = hashTypeAllocSize(hashObj);
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                oldsize = hashTypeAllocSize(hashObj);
             listpackExUpdateExpiry(hashObj, field, fptr, vptr, HASH_LP_NO_TTL);
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hashObj));
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, hashTypeAllocSize(hashObj));
             addReplyLongLong(c, HFE_PERSIST_OK);
             changed = 1;
         }
@@ -3971,7 +4019,8 @@ void hpersistCommand(client *c) {
             addReplyLongLong(c, HFE_PERSIST_OK);
             changed = 1;
         }
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, dictMemUsage(d));
     } else {
         serverPanic("Unknown encoding: %d", hashObj->encoding);
     }

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -212,6 +212,19 @@ unsigned long listTypeLength(const robj *subject) {
     }
 }
 
+size_t listTypeAllocSize(const robj *o) {
+    debugServerAssertWithInfo(NULL,o,o->type == OBJ_LIST);
+    size_t size = 0;
+    if (o->encoding == OBJ_ENCODING_QUICKLIST) {
+        size = quicklistAllocSize(o->ptr);
+    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+        size = lpBytes(o->ptr);
+    } else {
+        serverPanic("Unknown list encoding");
+    }
+    return size;
+}
+
 /* Initialize an iterator at the specified index. */
 listTypeIterator *listTypeInitIterator(robj *subject, long index,
                                        unsigned char direction) {
@@ -490,6 +503,7 @@ void pushGenericCommand(client *c, int where, int xx) {
         dbAddByLink(c->db, c->argv[1], &lobj, &link);
     }
 
+    size_t oldsize = listTypeAllocSize(lobj);
     listTypeTryConversionAppend(lobj,c->argv,2,c->argc-1,NULL,NULL);
     for (j = 2; j < c->argc; j++) {
         listTypePush(lobj,c->argv[j],where);
@@ -503,6 +517,7 @@ void pushGenericCommand(client *c, int where, int xx) {
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_LIST,event,c->argv[1],c->db->id);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_LIST, llen - (c->argc - 2), llen);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(lobj));
 }
 
 /* LPUSH <key> <element> [<element> ...] */
@@ -550,6 +565,7 @@ void linsertCommand(client *c) {
      * the list twice (once to see if the value can be inserted and once
      * to do the actual insert), so we assume this value can be inserted
      * and convert the listpack to a regular list if necessary. */
+    size_t oldsize = listTypeAllocSize(subject);
     listTypeTryConversionAppend(subject,c->argv,4,4,NULL,NULL);
 
     /* Seek pivot from head to tail */
@@ -565,6 +581,7 @@ void linsertCommand(client *c) {
         }
     }
     listTypeReleaseIterator(iter);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(subject));
 
     if (inserted) {
         signalModifiedKey(c,c->db,c->argv[1]);
@@ -628,6 +645,7 @@ void lsetCommand(client *c) {
     if ((getLongFromObjectOrReply(c, c->argv[2], &index, NULL) != C_OK))
         return;
 
+    size_t oldsize = listTypeAllocSize(o);
     listTypeTryConversionAppend(o,c->argv,3,3,NULL,NULL);
     if (listTypeReplaceAtIndex(o,index,value)) {
         /* We might replace a big item with a small one or vice versa, but we've
@@ -641,6 +659,9 @@ void lsetCommand(client *c) {
     } else {
         addReplyErrorObject(c,shared.outofrangeerr);
     }
+    /* Always update db allocation sizes since listTypeTryConversionAppend()
+     * might have changed object encoding. */
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(o));
 }
 
 /* A helper function like addListRangeReply, more details see below.
@@ -667,9 +688,10 @@ void listPopRangeAndReplyWithKey(client *c, robj *o, robj *key, int where, long 
     addListRangeReply(c, o, rangestart, rangeend, reverse);
 
     /* Pop these elements. */
+    size_t oldsize = listTypeAllocSize(o);
     listTypeDelRange(o, rangestart, rangelen);
     /* Maintain the notifications and dirty. */
-    listElementsRemoved(c, key, where, o, rangelen, signal, deleted);
+    listElementsRemoved(c, key, where, o, rangelen, oldsize, signal, deleted);
 }
 
 /* Extracted from `addListRangeReply()` to reply with a quicklist list.
@@ -751,7 +773,7 @@ void addListRangeReply(client *c, robj *o, long start, long end, int reverse) {
  *
  * 'deleted' is an optional output argument to get an indication
  * if the key got deleted by this function. */
-void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, int signal, int *deleted) {
+void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, size_t oldsize, int signal, int *deleted) {
     char *event = (where == LIST_HEAD) ? "lpop" : "rpop";
     unsigned long llen = listTypeLength(o);
     
@@ -760,10 +782,12 @@ void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, i
     if (llen == 0) {
         if (deleted) *deleted = 1;
 
+        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, listTypeAllocSize(o));
         dbDelete(c->db, key);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
     } else {
         listTypeTryConversion(o, LIST_CONV_SHRINKING, NULL, NULL);
+        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, listTypeAllocSize(o));
         if (deleted) *deleted = 0;
     }
     if (signal) signalModifiedKey(c, c->db, key);
@@ -798,6 +822,7 @@ void popGenericCommand(client *c, int where) {
         return;
     }
 
+    size_t oldsize = listTypeAllocSize(o);
     if (!count) {
         /* Pop a single element. This is POP's original behavior that replies
          * with a bulk string. */
@@ -805,7 +830,7 @@ void popGenericCommand(client *c, int where) {
         serverAssert(value != NULL);
         addReplyBulk(c,value);
         decrRefCount(value);
-        listElementsRemoved(c,c->argv[1],where,o,1,1,NULL);
+        listElementsRemoved(c,c->argv[1],where,o,1,oldsize,1,NULL);
     } else {
         /* Pop a range of elements. An addition to the original POP command,
          *  which replies with a multi-bulk. */
@@ -817,7 +842,7 @@ void popGenericCommand(client *c, int where) {
 
         addListRangeReply(c,o,rangestart,rangeend,reverse);
         listTypeDelRange(o,rangestart,rangelen);
-        listElementsRemoved(c,c->argv[1],where,o,rangelen,1,NULL);
+        listElementsRemoved(c,c->argv[1],where,o,rangelen,oldsize,1,NULL);
     }
 }
 
@@ -916,6 +941,7 @@ void ltrimCommand(client *c) {
     }
 
     /* Remove list elements to perform the trim */
+    size_t oldsize = listTypeAllocSize(o);
     if (o->encoding == OBJ_ENCODING_QUICKLIST) {
         quicklistDelRange(o->ptr,0,ltrim);
         quicklistDelRange(o->ptr,-rtrim,rtrim);
@@ -926,6 +952,7 @@ void ltrimCommand(client *c) {
         serverPanic("Unknown list encoding");
     }
 
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(o));
     notifyKeyspaceEvent(NOTIFY_LIST,"ltrim",c->argv[1],c->db->id);
     if ((llenNew = listTypeLength(o)) == 0) {
         dbDeleteSkipKeysizesUpdate(c->db,c->argv[1]);
@@ -1081,6 +1108,7 @@ void lremCommand(client *c) {
     const size_t object_len = sdslen(c->argv[3]->ptr);
     long long cached_longval = 0;
     int cached_valid = 0;
+    size_t oldsize = listTypeAllocSize(subject);
     while (listTypeNext(li,&entry)) {
         if (listTypeEqual(&entry,obj,object_len,&cached_longval,&cached_valid)) {
             listTypeDelete(li, &entry);
@@ -1093,6 +1121,7 @@ void lremCommand(client *c) {
 
     if (removed) {
         long ll = listTypeLength(subject);
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(subject));
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_LIST, ll + removed, ll);
         notifyKeyspaceEvent(NOTIFY_LIST,"lrem",c->argv[1],c->db->id);
         
@@ -1115,8 +1144,10 @@ void lmoveHandlePush(client *c, robj *dstkey, robj *dstobj, robj *value,
         dstobj = createListListpackObject();
         dbAdd(c->db, dstkey, &dstobj);
     }
+    size_t oldsize = listTypeAllocSize(dstobj);
     listTypeTryConversionAppend(dstobj,&value,0,0,NULL,NULL);
     listTypePush(dstobj,value,where);
+    updateAllocSizes(c->db, getKeySlot(dstkey->ptr), oldsize, listTypeAllocSize(dstobj));
     signalModifiedKey(c,c->db,dstkey);
 
     notifyKeyspaceEvent(NOTIFY_LIST,
@@ -1167,13 +1198,15 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
             newlen = oldlen + 1;
         }
 
+        size_t oldsize = listTypeAllocSize(kvsrc);
         robj *value = listTypePop(kvsrc, wherefrom);
         serverAssert(value); /* assertion for valgrind (avoid NPD) */
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(kvsrc));
         lmoveHandlePush(c, c->argv[2], kvdst, value, whereto);
         /* Update dst obj cardinality in KEYSIZES */
         updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_LIST, oldlen, newlen);
         /* Update src obj cardinality in KEYSIZES by listElementsRemoved() */
-        listElementsRemoved(c, skey, wherefrom, kvsrc, 1, 1, NULL);
+        listElementsRemoved(c, skey, wherefrom, kvsrc, 1, listTypeAllocSize(kvsrc), 1, NULL);
         /* listTypePop returns an object with its refcount incremented */
         decrRefCount(value);
 
@@ -1263,6 +1296,7 @@ void blockingPopGenericCommand(client *c, robj **keys, int numkeys, int where, i
         }
 
         /* Non empty list, this is like a normal [LR]POP. */
+        size_t oldsize = listTypeAllocSize(o);
         robj *value = listTypePop(o,where);
         serverAssert(value != NULL);
 
@@ -1270,7 +1304,7 @@ void blockingPopGenericCommand(client *c, robj **keys, int numkeys, int where, i
         addReplyBulk(c,key);
         addReplyBulk(c,value);
         decrRefCount(value);
-        listElementsRemoved(c,key,where,o,1,1,NULL);
+        listElementsRemoved(c,key,where,o,1,oldsize,1,NULL);
 
         /* Replicate it as an [LR]POP instead of B[LR]POP. */
         rewriteClientCommandVector(c,2,

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -520,7 +520,7 @@ void pushGenericCommand(client *c, int where, int xx) {
     notifyKeyspaceEvent(NOTIFY_LIST,event,c->argv[1],c->db->id);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_LIST, llen - (c->argc - 2), llen);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(lobj));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(lobj));
 }
 
 /* LPUSH <key> <element> [<element> ...] */
@@ -587,7 +587,7 @@ void linsertCommand(client *c) {
     }
     listTypeReleaseIterator(iter);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(subject));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(subject));
 
     if (inserted) {
         signalModifiedKey(c,c->db,c->argv[1]);
@@ -670,7 +670,7 @@ void lsetCommand(client *c) {
     /* Always update db allocation sizes since listTypeTryConversionAppend()
      * might have changed object encoding. */
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(o));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(o));
 }
 
 /* A helper function like addListRangeReply, more details see below.
@@ -794,13 +794,13 @@ void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, s
         if (deleted) *deleted = 1;
 
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, listTypeAllocSize(o));
+            updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, listTypeAllocSize(o));
         dbDelete(c->db, key);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
     } else {
         listTypeTryConversion(o, LIST_CONV_SHRINKING, NULL, NULL);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, listTypeAllocSize(o));
+            updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, listTypeAllocSize(o));
         if (deleted) *deleted = 0;
     }
     if (signal) signalModifiedKey(c, c->db, key);
@@ -970,7 +970,7 @@ void ltrimCommand(client *c) {
     }
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(o));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(o));
     notifyKeyspaceEvent(NOTIFY_LIST,"ltrim",c->argv[1],c->db->id);
     if ((llenNew = listTypeLength(o)) == 0) {
         dbDeleteSkipKeysizesUpdate(c->db,c->argv[1]);
@@ -1142,7 +1142,7 @@ void lremCommand(client *c) {
     if (removed) {
         long ll = listTypeLength(subject);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(subject));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(subject));
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_LIST, ll + removed, ll);
         notifyKeyspaceEvent(NOTIFY_LIST,"lrem",c->argv[1],c->db->id);
         
@@ -1171,7 +1171,7 @@ void lmoveHandlePush(client *c, robj *dstkey, robj *dstobj, robj *value,
     listTypeTryConversionAppend(dstobj,&value,0,0,NULL,NULL);
     listTypePush(dstobj,value,where);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(dstkey->ptr), oldsize, listTypeAllocSize(dstobj));
+        updateSlotAllocSize(c->db, getKeySlot(dstkey->ptr), oldsize, listTypeAllocSize(dstobj));
     signalModifiedKey(c,c->db,dstkey);
 
     notifyKeyspaceEvent(NOTIFY_LIST,
@@ -1228,7 +1228,7 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
         robj *value = listTypePop(kvsrc, wherefrom);
         serverAssert(value); /* assertion for valgrind (avoid NPD) */
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(kvsrc));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(kvsrc));
         lmoveHandlePush(c, c->argv[2], kvdst, value, whereto);
         /* Update dst obj cardinality in KEYSIZES */
         updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_LIST, oldlen, newlen);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -490,6 +490,7 @@ void pushGenericCommand(client *c, int where, int xx) {
     unsigned long llen;
     dictEntryLink link;
     int j;
+    size_t oldsize = 0;
 
     kvobj *lobj = lookupKeyWriteWithLink(c->db, c->argv[1], &link);
     if (checkType(c,lobj,OBJ_LIST)) return;
@@ -503,7 +504,8 @@ void pushGenericCommand(client *c, int where, int xx) {
         dbAddByLink(c->db, c->argv[1], &lobj, &link);
     }
 
-    size_t oldsize = listTypeAllocSize(lobj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = listTypeAllocSize(lobj);
     listTypeTryConversionAppend(lobj,c->argv,2,c->argc-1,NULL,NULL);
     for (j = 2; j < c->argc; j++) {
         listTypePush(lobj,c->argv[j],where);
@@ -517,7 +519,8 @@ void pushGenericCommand(client *c, int where, int xx) {
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_LIST,event,c->argv[1],c->db->id);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_LIST, llen - (c->argc - 2), llen);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(lobj));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(lobj));
 }
 
 /* LPUSH <key> <element> [<element> ...] */
@@ -547,6 +550,7 @@ void linsertCommand(client *c) {
     listTypeIterator *iter;
     listTypeEntry entry;
     int inserted = 0;
+    size_t oldsize = 0;
 
     if (strcasecmp(c->argv[2]->ptr,"after") == 0) {
         where = LIST_TAIL;
@@ -565,7 +569,8 @@ void linsertCommand(client *c) {
      * the list twice (once to see if the value can be inserted and once
      * to do the actual insert), so we assume this value can be inserted
      * and convert the listpack to a regular list if necessary. */
-    size_t oldsize = listTypeAllocSize(subject);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = listTypeAllocSize(subject);
     listTypeTryConversionAppend(subject,c->argv,4,4,NULL,NULL);
 
     /* Seek pivot from head to tail */
@@ -581,7 +586,8 @@ void linsertCommand(client *c) {
         }
     }
     listTypeReleaseIterator(iter);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(subject));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(subject));
 
     if (inserted) {
         signalModifiedKey(c,c->db,c->argv[1]);
@@ -641,11 +647,13 @@ void lsetCommand(client *c) {
     if (o == NULL || checkType(c,o,OBJ_LIST)) return;
     long index;
     robj *value = c->argv[3];
+    size_t oldsize = 0;
 
     if ((getLongFromObjectOrReply(c, c->argv[2], &index, NULL) != C_OK))
         return;
 
-    size_t oldsize = listTypeAllocSize(o);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = listTypeAllocSize(o);
     listTypeTryConversionAppend(o,c->argv,3,3,NULL,NULL);
     if (listTypeReplaceAtIndex(o,index,value)) {
         /* We might replace a big item with a small one or vice versa, but we've
@@ -661,7 +669,8 @@ void lsetCommand(client *c) {
     }
     /* Always update db allocation sizes since listTypeTryConversionAppend()
      * might have changed object encoding. */
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(o));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(o));
 }
 
 /* A helper function like addListRangeReply, more details see below.
@@ -688,7 +697,9 @@ void listPopRangeAndReplyWithKey(client *c, robj *o, robj *key, int where, long 
     addListRangeReply(c, o, rangestart, rangeend, reverse);
 
     /* Pop these elements. */
-    size_t oldsize = listTypeAllocSize(o);
+    size_t oldsize = 0;
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = listTypeAllocSize(o);
     listTypeDelRange(o, rangestart, rangelen);
     /* Maintain the notifications and dirty. */
     listElementsRemoved(c, key, where, o, rangelen, oldsize, signal, deleted);
@@ -782,12 +793,14 @@ void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, s
     if (llen == 0) {
         if (deleted) *deleted = 1;
 
-        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, listTypeAllocSize(o));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, listTypeAllocSize(o));
         dbDelete(c->db, key);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
     } else {
         listTypeTryConversion(o, LIST_CONV_SHRINKING, NULL, NULL);
-        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, listTypeAllocSize(o));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, listTypeAllocSize(o));
         if (deleted) *deleted = 0;
     }
     if (signal) signalModifiedKey(c, c->db, key);
@@ -822,7 +835,9 @@ void popGenericCommand(client *c, int where) {
         return;
     }
 
-    size_t oldsize = listTypeAllocSize(o);
+    size_t oldsize = 0;
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = listTypeAllocSize(o);
     if (!count) {
         /* Pop a single element. This is POP's original behavior that replies
          * with a bulk string. */
@@ -915,6 +930,7 @@ void lrangeCommand(client *c) {
 void ltrimCommand(client *c) {
     kvobj *o;
     long start, end, llen, ltrim, rtrim, llenNew;
+    size_t oldsize = 0;
 
     if ((getLongFromObjectOrReply(c, c->argv[2], &start, NULL) != C_OK) ||
         (getLongFromObjectOrReply(c, c->argv[3], &end, NULL) != C_OK)) return;
@@ -941,7 +957,8 @@ void ltrimCommand(client *c) {
     }
 
     /* Remove list elements to perform the trim */
-    size_t oldsize = listTypeAllocSize(o);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = listTypeAllocSize(o);
     if (o->encoding == OBJ_ENCODING_QUICKLIST) {
         quicklistDelRange(o->ptr,0,ltrim);
         quicklistDelRange(o->ptr,-rtrim,rtrim);
@@ -952,7 +969,8 @@ void ltrimCommand(client *c) {
         serverPanic("Unknown list encoding");
     }
 
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(o));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(o));
     notifyKeyspaceEvent(NOTIFY_LIST,"ltrim",c->argv[1],c->db->id);
     if ((llenNew = listTypeLength(o)) == 0) {
         dbDeleteSkipKeysizesUpdate(c->db,c->argv[1]);
@@ -1108,7 +1126,9 @@ void lremCommand(client *c) {
     const size_t object_len = sdslen(c->argv[3]->ptr);
     long long cached_longval = 0;
     int cached_valid = 0;
-    size_t oldsize = listTypeAllocSize(subject);
+    size_t oldsize = 0;
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = listTypeAllocSize(subject);
     while (listTypeNext(li,&entry)) {
         if (listTypeEqual(&entry,obj,object_len,&cached_longval,&cached_valid)) {
             listTypeDelete(li, &entry);
@@ -1121,7 +1141,8 @@ void lremCommand(client *c) {
 
     if (removed) {
         long ll = listTypeLength(subject);
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(subject));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(subject));
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_LIST, ll + removed, ll);
         notifyKeyspaceEvent(NOTIFY_LIST,"lrem",c->argv[1],c->db->id);
         
@@ -1139,15 +1160,18 @@ void lremCommand(client *c) {
 
 void lmoveHandlePush(client *c, robj *dstkey, robj *dstobj, robj *value,
                      int where) {
+    size_t oldsize = 0;
     /* Create the list if the key does not exist */
     if (!dstobj) {
         dstobj = createListListpackObject();
         dbAdd(c->db, dstkey, &dstobj);
     }
-    size_t oldsize = listTypeAllocSize(dstobj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = listTypeAllocSize(dstobj);
     listTypeTryConversionAppend(dstobj,&value,0,0,NULL,NULL);
     listTypePush(dstobj,value,where);
-    updateAllocSizes(c->db, getKeySlot(dstkey->ptr), oldsize, listTypeAllocSize(dstobj));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(dstkey->ptr), oldsize, listTypeAllocSize(dstobj));
     signalModifiedKey(c,c->db,dstkey);
 
     notifyKeyspaceEvent(NOTIFY_LIST,
@@ -1180,6 +1204,7 @@ robj *getStringObjectFromListPosition(int position) {
 }
 
 void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
+    size_t oldsize = 0;
     kvobj *kvsrc = lookupKeyWriteOrReply(c,c->argv[1],shared.null[c->resp]);
     if (kvsrc == NULL || checkType(c,kvsrc,OBJ_LIST)) return;
 
@@ -1198,10 +1223,12 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
             newlen = oldlen + 1;
         }
 
-        size_t oldsize = listTypeAllocSize(kvsrc);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = listTypeAllocSize(kvsrc);
         robj *value = listTypePop(kvsrc, wherefrom);
         serverAssert(value); /* assertion for valgrind (avoid NPD) */
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(kvsrc));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(kvsrc));
         lmoveHandlePush(c, c->argv[2], kvdst, value, whereto);
         /* Update dst obj cardinality in KEYSIZES */
         updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_LIST, oldlen, newlen);
@@ -1296,7 +1323,9 @@ void blockingPopGenericCommand(client *c, robj **keys, int numkeys, int where, i
         }
 
         /* Non empty list, this is like a normal [LR]POP. */
-        size_t oldsize = listTypeAllocSize(o);
+        size_t oldsize = 0;
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = listTypeAllocSize(o);
         robj *value = listTypePop(o,where);
         serverAssert(value != NULL);
 

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -213,7 +213,7 @@ unsigned long listTypeLength(const robj *subject) {
 }
 
 size_t listTypeAllocSize(const robj *o) {
-    debugServerAssertWithInfo(NULL,o,o->type == OBJ_LIST);
+    serverAssertWithInfo(NULL,o,o->type == OBJ_LIST);
     size_t size = 0;
     if (o->encoding == OBJ_ENCODING_QUICKLIST) {
         size = quicklistAllocSize(o->ptr);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -504,7 +504,7 @@ void pushGenericCommand(client *c, int where, int xx) {
         dbAddByLink(c->db, c->argv[1], &lobj, &link);
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = listTypeAllocSize(lobj);
     listTypeTryConversionAppend(lobj,c->argv,2,c->argc-1,NULL,NULL);
     for (j = 2; j < c->argc; j++) {
@@ -519,7 +519,7 @@ void pushGenericCommand(client *c, int where, int xx) {
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_LIST,event,c->argv[1],c->db->id);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_LIST, llen - (c->argc - 2), llen);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(lobj));
 }
 
@@ -569,7 +569,7 @@ void linsertCommand(client *c) {
      * the list twice (once to see if the value can be inserted and once
      * to do the actual insert), so we assume this value can be inserted
      * and convert the listpack to a regular list if necessary. */
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = listTypeAllocSize(subject);
     listTypeTryConversionAppend(subject,c->argv,4,4,NULL,NULL);
 
@@ -586,7 +586,7 @@ void linsertCommand(client *c) {
         }
     }
     listTypeReleaseIterator(iter);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(subject));
 
     if (inserted) {
@@ -652,7 +652,7 @@ void lsetCommand(client *c) {
     if ((getLongFromObjectOrReply(c, c->argv[2], &index, NULL) != C_OK))
         return;
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = listTypeAllocSize(o);
     listTypeTryConversionAppend(o,c->argv,3,3,NULL,NULL);
     if (listTypeReplaceAtIndex(o,index,value)) {
@@ -669,7 +669,7 @@ void lsetCommand(client *c) {
     }
     /* Always update db allocation sizes since listTypeTryConversionAppend()
      * might have changed object encoding. */
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(o));
 }
 
@@ -698,7 +698,7 @@ void listPopRangeAndReplyWithKey(client *c, robj *o, robj *key, int where, long 
 
     /* Pop these elements. */
     size_t oldsize = 0;
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = listTypeAllocSize(o);
     listTypeDelRange(o, rangestart, rangelen);
     /* Maintain the notifications and dirty. */
@@ -793,13 +793,13 @@ void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, s
     if (llen == 0) {
         if (deleted) *deleted = 1;
 
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, listTypeAllocSize(o));
         dbDelete(c->db, key);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
     } else {
         listTypeTryConversion(o, LIST_CONV_SHRINKING, NULL, NULL);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, listTypeAllocSize(o));
         if (deleted) *deleted = 0;
     }
@@ -836,7 +836,7 @@ void popGenericCommand(client *c, int where) {
     }
 
     size_t oldsize = 0;
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = listTypeAllocSize(o);
     if (!count) {
         /* Pop a single element. This is POP's original behavior that replies
@@ -957,7 +957,7 @@ void ltrimCommand(client *c) {
     }
 
     /* Remove list elements to perform the trim */
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = listTypeAllocSize(o);
     if (o->encoding == OBJ_ENCODING_QUICKLIST) {
         quicklistDelRange(o->ptr,0,ltrim);
@@ -969,7 +969,7 @@ void ltrimCommand(client *c) {
         serverPanic("Unknown list encoding");
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(o));
     notifyKeyspaceEvent(NOTIFY_LIST,"ltrim",c->argv[1],c->db->id);
     if ((llenNew = listTypeLength(o)) == 0) {
@@ -1127,7 +1127,7 @@ void lremCommand(client *c) {
     long long cached_longval = 0;
     int cached_valid = 0;
     size_t oldsize = 0;
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = listTypeAllocSize(subject);
     while (listTypeNext(li,&entry)) {
         if (listTypeEqual(&entry,obj,object_len,&cached_longval,&cached_valid)) {
@@ -1141,7 +1141,7 @@ void lremCommand(client *c) {
 
     if (removed) {
         long ll = listTypeLength(subject);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(subject));
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_LIST, ll + removed, ll);
         notifyKeyspaceEvent(NOTIFY_LIST,"lrem",c->argv[1],c->db->id);
@@ -1166,11 +1166,11 @@ void lmoveHandlePush(client *c, robj *dstkey, robj *dstobj, robj *value,
         dstobj = createListListpackObject();
         dbAdd(c->db, dstkey, &dstobj);
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = listTypeAllocSize(dstobj);
     listTypeTryConversionAppend(dstobj,&value,0,0,NULL,NULL);
     listTypePush(dstobj,value,where);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(dstkey->ptr), oldsize, listTypeAllocSize(dstobj));
     signalModifiedKey(c,c->db,dstkey);
 
@@ -1223,11 +1223,11 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
             newlen = oldlen + 1;
         }
 
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = listTypeAllocSize(kvsrc);
         robj *value = listTypePop(kvsrc, wherefrom);
         serverAssert(value); /* assertion for valgrind (avoid NPD) */
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, listTypeAllocSize(kvsrc));
         lmoveHandlePush(c, c->argv[2], kvdst, value, whereto);
         /* Update dst obj cardinality in KEYSIZES */
@@ -1324,7 +1324,7 @@ void blockingPopGenericCommand(client *c, robj **keys, int numkeys, int where, i
 
         /* Non empty list, this is like a normal [LR]POP. */
         size_t oldsize = 0;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = listTypeAllocSize(o);
         robj *value = listTypePop(o,where);
         serverAssert(value != NULL);

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -479,6 +479,22 @@ unsigned long setTypeSize(const robj *subject) {
     }
 }
 
+size_t setTypeAllocSize(const robj *o) {
+    debugServerAssertWithInfo(NULL,o,o->type == OBJ_SET);
+    size_t size = 0;
+    if (o->encoding == OBJ_ENCODING_HT) {
+        dict *d = o->ptr;
+        size += sizeof(dict) + dictMemUsage(d) + *htGetMetadataSize(d);
+    } else if (o->encoding == OBJ_ENCODING_INTSET) {
+        size = intsetAllocSize(o->ptr);
+    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+        size = lpBytes(o->ptr);
+    } else {
+        serverPanic("Unknown set encoding");
+    }
+    return size;
+}
+
 /* Convert the set to specified encoding. The resulting dict (when converting
  * to a hash table) is presized to hold the number of elements in the original
  * set. */
@@ -606,12 +622,16 @@ void saddCommand(client *c) {
         robj *o = setTypeCreate(c->argv[2]->ptr, c->argc - 2);
         set = dbAddByLink(c->db, c->argv[1], &o, &link);
     } else {
+        size_t oldsize = setTypeAllocSize(set);
         setTypeMaybeConvert(set, c->argc - 2);
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     }
 
+    size_t oldsize = setTypeAllocSize(set);
     for (j = 2; j < c->argc; j++) {
         if (setTypeAdd(set,c->argv[j]->ptr)) added++;
     }
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (added) {
         unsigned long size = setTypeSize(set);
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size - added, size);
@@ -630,17 +650,21 @@ void sremCommand(client *c) {
         return;
 
     unsigned long oldSize = setTypeSize(set);
+    size_t oldsize = setTypeAllocSize(set);
 
     for (j = 2; j < c->argc; j++) {
         if (setTypeRemove(set,c->argv[j]->ptr)) {
             deleted++;
             if (setTypeSize(set) == 0) {
+                updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
                 dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
                 keyremoved = 1;
                 break;
             }
         }
     }
+    if (!keyremoved)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (deleted) {
         int64_t newSize = oldSize - deleted;
 
@@ -681,8 +705,11 @@ void smoveCommand(client *c) {
         return;
     }
 
+    size_t oldSrcAllocSize = setTypeAllocSize(srcset);
+    int deleted = setTypeRemove(srcset,ele->ptr);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldSrcAllocSize, setTypeAllocSize(srcset));
     /* If the element cannot be removed from the src set, return 0. */
-    if (!setTypeRemove(srcset,ele->ptr)) {
+    if (!deleted) {
         addReply(c,shared.czero);
         return;
     }
@@ -708,6 +735,7 @@ void smoveCommand(client *c) {
     signalModifiedKey(c,c->db,c->argv[1]);
     server.dirty++;
 
+    size_t oldDstAllocSize = setTypeAllocSize(dstset);
     /* An extra key has changed when ele was successfully added to dstset */
     if (setTypeAdd(dstset,ele->ptr)) {
         unsigned long dstLen = setTypeSize(dstset);
@@ -716,6 +744,7 @@ void smoveCommand(client *c) {
         signalModifiedKey(c,c->db,c->argv[2]);
         notifyKeyspaceEvent(NOTIFY_SET,"sadd",c->argv[2],c->db->id);
     }
+    updateAllocSizes(c->db, getKeySlot(c->argv[2]->ptr), oldDstAllocSize, setTypeAllocSize(dstset));
     addReply(c,shared.cone);
 }
 
@@ -725,10 +754,12 @@ void sismemberCommand(client *c) {
     if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.czero)) == NULL ||
         checkType(c,set,OBJ_SET)) return;
 
+    size_t oldsize = setTypeAllocSize(set);
     if (setTypeIsMember(set,c->argv[2]->ptr))
         addReply(c,shared.cone);
     else
         addReply(c,shared.czero);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }
 
 void smismemberCommand(client *c) {
@@ -739,12 +770,16 @@ void smismemberCommand(client *c) {
 
     addReplyArrayLen(c,c->argc - 2);
 
+    size_t oldsize = 0;
+    if (set) setTypeAllocSize(set);
     for (int j = 2; j < c->argc; j++) {
         if (set && setTypeIsMember(set,c->argv[j]->ptr))
             addReply(c,shared.cone);
         else
             addReply(c,shared.czero);
     }
+    if (set)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }
 
 void scardCommand(client *c) {
@@ -838,6 +873,7 @@ void spopWithCountCommand(client *c) {
         set->encoding == OBJ_ENCODING_LISTPACK)
     {
         /* Specialized case for listpack. Traverse it only once. */
+        size_t oldsize = setTypeAllocSize(set);
         unsigned char *lp = set->ptr;
         unsigned char *p = lpFirst(lp);
         unsigned int index = 0;
@@ -872,7 +908,9 @@ void spopWithCountCommand(client *c) {
         zfree(ps);
         set->ptr = lp;
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - count);
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     } else if (remaining*SPOP_MOVE_STRATEGY_MUL > count) {
+        size_t oldsize = setTypeAllocSize(set);
         for (unsigned long i = 0; i < count; i++) {
             propargv[propindex] = setTypePopRandom(set);
             addReplyBulk(c, propargv[propindex]);
@@ -887,6 +925,7 @@ void spopWithCountCommand(client *c) {
             }
         }
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - count);
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     } else {
     /* CASE 3: The number of elements to return is very big, approaching
      * the size of the set itself. After some time extracting random elements
@@ -897,6 +936,7 @@ void spopWithCountCommand(client *c) {
      * set). Then we return the elements left in the original set and
      * release it. */
         robj *newset = NULL;
+        size_t oldsize = setTypeAllocSize(set);
 
         /* Create a new set with just the remaining elements. */
         if (set->encoding == OBJ_ENCODING_LISTPACK) {
@@ -956,6 +996,7 @@ void spopWithCountCommand(client *c) {
          * but here we're building the new set from the existing one. As a result, 
          * the size of the old set has already changed by the time we reach this point. */
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size-count);
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
         dbReplaceValue(c->db, c->argv[1], &newset, 0);
     }
 
@@ -997,8 +1038,12 @@ void spopCommand(client *c) {
     size = setTypeSize(kv);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size-1);
 
+    size_t oldsize = setTypeAllocSize(kv);
+
     /* Pop a random element from the kv */
     ele = setTypePopRandom(kv);
+
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(kv));
 
     notifyKeyspaceEvent(NOTIFY_SET,"spop",c->argv[1],c->db->id);
 
@@ -1256,7 +1301,9 @@ void srandmemberCommand(client *c) {
     if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp]))
         == NULL || checkType(c,set,OBJ_SET)) return;
 
+    size_t oldsize = setTypeAllocSize(set);
     setTypeRandomElement(set, &str, &len, &llele);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (str == NULL) {
         addReplyBulkLongLong(c,llele);
     } else {
@@ -1264,16 +1311,22 @@ void srandmemberCommand(client *c) {
     }
 }
 
+typedef struct setopsrc {
+    robj *set;
+    size_t oldsize;
+} setopsrc;
+
 int qsortCompareSetsByCardinality(const void *s1, const void *s2) {
-    if (setTypeSize(*(robj**)s1) > setTypeSize(*(robj**)s2)) return 1;
-    if (setTypeSize(*(robj**)s1) < setTypeSize(*(robj**)s2)) return -1;
+    robj *o1 = ((setopsrc*)s1)->set, *o2 = ((setopsrc*)s2)->set;
+    if (setTypeSize(o1) > setTypeSize(o2)) return 1;
+    if (setTypeSize(o1) < setTypeSize(o2)) return -1;
     return 0;
 }
 
 /* This is used by SDIFF and in this case we can receive NULL that should
  * be handled as empty sets. */
 int qsortCompareSetsByRevCardinality(const void *s1, const void *s2) {
-    robj *o1 = *(robj**)s1, *o2 = *(robj**)s2;
+    robj *o1 = ((setopsrc*)s1)->set, *o2 = ((setopsrc*)s2)->set;
     unsigned long first = o1 ? setTypeSize(o1) : 0;
     unsigned long second = o2 ? setTypeSize(o2) : 0;
 
@@ -1293,7 +1346,7 @@ int qsortCompareSetsByRevCardinality(const void *s1, const void *s2) {
 void sinterGenericCommand(client *c, robj **setkeys,
                           unsigned long setnum, robj *dstkey,
                           int cardinality_only, unsigned long limit) {
-    kvobj **sets = zmalloc(sizeof(robj*)*setnum);
+    setopsrc *sets = zmalloc(sizeof(setopsrc)*setnum);
     setTypeIterator *si;
     robj *dstset = NULL;
     char *str;
@@ -1308,14 +1361,16 @@ void sinterGenericCommand(client *c, robj **setkeys,
         if (!kv) {
             /* A NULL is considered an empty set */
             empty += 1;
-            sets[j] = NULL;
+            sets[j].set = NULL;
+            sets[j].oldsize = 0;
             continue;
         }
         if (checkType(c, kv, OBJ_SET)) {
             zfree(sets);
             return;
         }
-        sets[j] = kv;
+        sets[j].set = kv;
+        sets[j].oldsize = setTypeAllocSize(kv);
     }
 
     /* Set intersection with an empty set always results in an empty set.
@@ -1339,7 +1394,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
 
     /* Sort sets from the smallest to largest, this will improve our
      * algorithm's performance */
-    qsort(sets,setnum,sizeof(robj*),qsortCompareSetsByCardinality);
+    qsort(sets,setnum,sizeof(setopsrc),qsortCompareSetsByCardinality);
 
     /* The first thing we should output is the total number of elements...
      * since this is a multi-bulk write, but at this stage we don't know
@@ -1349,16 +1404,16 @@ void sinterGenericCommand(client *c, robj **setkeys,
     if (dstkey) {
         /* If we have a target key where to store the resulting set
          * create this key with an empty set inside */
-        if (sets[0]->encoding == OBJ_ENCODING_INTSET) {
+        if (sets[0].set->encoding == OBJ_ENCODING_INTSET) {
             /* The first set is an intset, so the result is an intset too. The
              * elements are inserted in ascending order which is efficient in an
              * intset. */
             dstset = createIntsetObject();
-        } else if (sets[0]->encoding == OBJ_ENCODING_LISTPACK) {
+        } else if (sets[0].set->encoding == OBJ_ENCODING_LISTPACK) {
             /* To avoid many reallocs, we estimate that the result is a listpack
              * of approximately the same size as the first set. Then we shrink
              * it or possibly convert it to intset in the end. */
-            unsigned char *lp = lpNew(lpBytes(sets[0]->ptr));
+            unsigned char *lp = lpNew(lpBytes(sets[0].set->ptr));
             dstset = createObject(OBJ_SET, lp);
             dstset->encoding = OBJ_ENCODING_LISTPACK;
         } else {
@@ -1375,11 +1430,11 @@ void sinterGenericCommand(client *c, robj **setkeys,
      * the element against all the other sets, if at least one set does
      * not include the element it is discarded */
     int only_integers = 1;
-    si = setTypeInitIterator(sets[0]);
+    si = setTypeInitIterator(sets[0].set);
     while((encoding = setTypeNext(si, &str, &len, &intobj)) != -1) {
         for (j = 1; j < setnum; j++) {
-            if (sets[j] == sets[0]) continue;
-            if (!setTypeIsMemberAux(sets[j], str, len, intobj,
+            if (sets[j].set == sets[0].set) continue;
+            if (!setTypeIsMemberAux(sets[j].set, str, len, intobj,
                                     encoding == OBJ_ENCODING_HT))
                 break;
         }
@@ -1420,6 +1475,11 @@ void sinterGenericCommand(client *c, robj **setkeys,
         }
     }
     setTypeReleaseIterator(si);
+    for (j = 0; j < setnum; j++) {
+        if (!sets[j].set) continue;
+        updateAllocSizes(c->db, getKeySlot(setkeys[j]->ptr),
+                         sets[j].oldsize, setTypeAllocSize(sets[j].set));
+    }
 
     if (cardinality_only) {
         addReplyLongLong(c,cardinality);
@@ -1474,6 +1534,7 @@ void smembersCommand(client *c) {
     /* Prepare the response. */
     unsigned long length = setTypeSize(setobj);
     addReplySetLen(c,length);
+    size_t oldsize = setTypeAllocSize(setobj);
     /* Iterate through the elements of the set. */
     si = setTypeInitIterator(setobj);
 
@@ -1485,6 +1546,7 @@ void smembersCommand(client *c) {
         length--;
     }
     setTypeReleaseIterator(si);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(setobj));
     serverAssert(length == 0); /* fail on corrupt data */
 }
 
@@ -1527,7 +1589,7 @@ void sinterstoreCommand(client *c) {
 
 void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
                               robj *dstkey, int op) {
-    robj **sets = zmalloc(sizeof(robj*)*setnum);
+    setopsrc *sets = zmalloc(sizeof(setopsrc)*setnum);
     setTypeIterator *si;
     robj *dstset = NULL;
     int dstset_encoding = OBJ_ENCODING_INTSET;
@@ -1542,7 +1604,8 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
     for (j = 0; j < setnum; j++) {
         kvobj *setobj = lookupKeyRead(c->db, setkeys[j]);
         if (!setobj) {
-            sets[j] = NULL;
+            sets[j].set = NULL;
+            sets[j].oldsize = 0;
             continue;
         }
         if (checkType(c,setobj,OBJ_SET)) {
@@ -1566,8 +1629,9 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             (setobj->encoding == OBJ_ENCODING_LISTPACK || setobj->encoding == OBJ_ENCODING_HT)) {
             dstset_encoding = OBJ_ENCODING_HT;
         }
-        sets[j] = setobj;
-        if (j > 0 && sets[0] == sets[j]) {
+        sets[j].set = setobj;
+        sets[j].oldsize = setTypeAllocSize(setobj);
+        if (j > 0 && sets[0].set == sets[j].set) {
             sameset = 1; 
         }
     }
@@ -1581,14 +1645,14 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
      * the sets.
      *
      * We compute what is the best bet with the current input here. */
-    if (op == SET_OP_DIFF && sets[0] && !sameset) {
+    if (op == SET_OP_DIFF && sets[0].set && !sameset) {
         long long algo_one_work = 0, algo_two_work = 0;
 
         for (j = 0; j < setnum; j++) {
-            if (sets[j] == NULL) continue;
+            if (sets[j].set == NULL) continue;
 
-            algo_one_work += setTypeSize(sets[0]);
-            algo_two_work += setTypeSize(sets[j]);
+            algo_one_work += setTypeSize(sets[0].set);
+            algo_two_work += setTypeSize(sets[j].set);
         }
 
         /* Algorithm 1 has better constant times and performs less operations
@@ -1600,7 +1664,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             /* With algorithm 1 it is better to order the sets to subtract
              * by decreasing size, so that we are more likely to find
              * duplicated elements ASAP. */
-            qsort(sets+1,setnum-1,sizeof(robj*),
+            qsort(sets+1,setnum-1,sizeof(setopsrc),
                 qsortCompareSetsByRevCardinality);
         }
     }
@@ -1618,9 +1682,9 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
         /* Union is trivial, just add every element of every set to the
          * temporary set. */
         for (j = 0; j < setnum; j++) {
-            if (!sets[j]) continue; /* non existing keys are like empty sets */
+            if (!sets[j].set) continue; /* non existing keys are like empty sets */
 
-            si = setTypeInitIterator(sets[j]);
+            si = setTypeInitIterator(sets[j].set);
             while ((encoding = setTypeNext(si, &str, &len, &llval)) != -1) {
                 cardinality += setTypeAddAux(dstset, str, len, llval, encoding == OBJ_ENCODING_HT);
             }
@@ -1628,7 +1692,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
         }
     } else if (op == SET_OP_DIFF && sameset) {
         /* At least one of the sets is the same one (same key) as the first one, result must be empty. */
-    } else if (op == SET_OP_DIFF && sets[0] && diff_algo == 1) {
+    } else if (op == SET_OP_DIFF && sets[0].set && diff_algo == 1) {
         /* DIFF Algorithm 1:
          *
          * We perform the diff by iterating all the elements of the first set,
@@ -1637,12 +1701,12 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
          *
          * This way we perform at max N*M operations, where N is the size of
          * the first set, and M the number of sets. */
-        si = setTypeInitIterator(sets[0]);
+        si = setTypeInitIterator(sets[0].set);
         while ((encoding = setTypeNext(si, &str, &len, &llval)) != -1) {
             for (j = 1; j < setnum; j++) {
-                if (!sets[j]) continue; /* no key is an empty set. */
-                if (sets[j] == sets[0]) break; /* same set! */
-                if (setTypeIsMemberAux(sets[j], str, len, llval,
+                if (!sets[j].set) continue; /* no key is an empty set. */
+                if (sets[j].set == sets[0].set) break; /* same set! */
+                if (setTypeIsMemberAux(sets[j].set, str, len, llval,
                                        encoding == OBJ_ENCODING_HT))
                     break;
             }
@@ -1652,7 +1716,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             }
         }
         setTypeReleaseIterator(si);
-    } else if (op == SET_OP_DIFF && sets[0] && diff_algo == 2) {
+    } else if (op == SET_OP_DIFF && sets[0].set && diff_algo == 2) {
         /* DIFF Algorithm 2:
          *
          * Add all the elements of the first set to the auxiliary set.
@@ -1661,9 +1725,9 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
          * This is O(N) where N is the sum of all the elements in every
          * set. */
         for (j = 0; j < setnum; j++) {
-            if (!sets[j]) continue; /* non existing keys are like empty sets */
+            if (!sets[j].set) continue; /* non existing keys are like empty sets */
 
-            si = setTypeInitIterator(sets[j]);
+            si = setTypeInitIterator(sets[j].set);
             while((encoding = setTypeNext(si, &str, &len, &llval)) != -1) {
                 if (j == 0) {
                     cardinality += setTypeAddAux(dstset, str, len, llval,
@@ -1679,6 +1743,11 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
              * of elements will have no effect. */
             if (cardinality == 0) break;
         }
+    }
+    for (j = 0; j < setnum; j++) {
+        if (!sets[j].set) continue;
+        updateAllocSizes(c->db, getKeySlot(setkeys[j]->ptr),
+                         sets[j].oldsize, setTypeAllocSize(sets[j].set));
     }
 
     /* Output the content of the resulting set, if not in STORE mode */
@@ -1744,5 +1813,7 @@ void sscanCommand(client *c) {
     if (parseScanCursorOrReply(c,c->argv[2],&cursor) == C_ERR) return;
     if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.emptyscan)) == NULL ||
         checkType(c,set,OBJ_SET)) return;
+    size_t oldsize = setTypeAllocSize(set);
     scanGenericCommand(c,set,cursor);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -480,7 +480,7 @@ unsigned long setTypeSize(const robj *subject) {
 }
 
 size_t setTypeAllocSize(const robj *o) {
-    debugServerAssertWithInfo(NULL,o,o->type == OBJ_SET);
+    serverAssertWithInfo(NULL,o,o->type == OBJ_SET);
     size_t size = 0;
     if (o->encoding == OBJ_ENCODING_HT) {
         dict *d = o->ptr;

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -623,19 +623,19 @@ void saddCommand(client *c) {
         robj *o = setTypeCreate(c->argv[2]->ptr, c->argc - 2);
         set = dbAddByLink(c->db, c->argv[1], &o, &link);
     } else {
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = setTypeAllocSize(set);
         setTypeMaybeConvert(set, c->argc - 2);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = setTypeAllocSize(set);
     for (j = 2; j < c->argc; j++) {
         if (setTypeAdd(set,c->argv[j]->ptr)) added++;
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (added) {
         unsigned long size = setTypeSize(set);
@@ -656,14 +656,14 @@ void sremCommand(client *c) {
         return;
 
     unsigned long oldSize = setTypeSize(set);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = setTypeAllocSize(set);
 
     for (j = 2; j < c->argc; j++) {
         if (setTypeRemove(set,c->argv[j]->ptr)) {
             deleted++;
             if (setTypeSize(set) == 0) {
-                if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                if (clusterSlotStatsEnabled())
                     updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
                 dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
                 keyremoved = 1;
@@ -671,7 +671,7 @@ void sremCommand(client *c) {
             }
         }
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && !keyremoved)
+    if (clusterSlotStatsEnabled() && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (deleted) {
         int64_t newSize = oldSize - deleted;
@@ -714,10 +714,10 @@ void smoveCommand(client *c) {
         return;
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldSrcAllocSize = setTypeAllocSize(srcset);
     int deleted = setTypeRemove(srcset,ele->ptr);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldSrcAllocSize, setTypeAllocSize(srcset));
     /* If the element cannot be removed from the src set, return 0. */
     if (!deleted) {
@@ -746,7 +746,7 @@ void smoveCommand(client *c) {
     signalModifiedKey(c,c->db,c->argv[1]);
     server.dirty++;
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldDstAllocSize = setTypeAllocSize(dstset);
     /* An extra key has changed when ele was successfully added to dstset */
     if (setTypeAdd(dstset,ele->ptr)) {
@@ -756,7 +756,7 @@ void smoveCommand(client *c) {
         signalModifiedKey(c,c->db,c->argv[2]);
         notifyKeyspaceEvent(NOTIFY_SET,"sadd",c->argv[2],c->db->id);
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[2]->ptr), oldDstAllocSize, setTypeAllocSize(dstset));
     addReply(c,shared.cone);
 }
@@ -768,13 +768,13 @@ void sismemberCommand(client *c) {
     if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.czero)) == NULL ||
         checkType(c,set,OBJ_SET)) return;
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = setTypeAllocSize(set);
     if (setTypeIsMember(set,c->argv[2]->ptr))
         addReply(c,shared.cone);
     else
         addReply(c,shared.czero);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }
 
@@ -787,7 +787,7 @@ void smismemberCommand(client *c) {
 
     addReplyArrayLen(c,c->argc - 2);
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && set)
+    if (clusterSlotStatsEnabled() && set)
         setTypeAllocSize(set);
     for (int j = 2; j < c->argc; j++) {
         if (set && setTypeIsMember(set,c->argv[j]->ptr))
@@ -795,7 +795,7 @@ void smismemberCommand(client *c) {
         else
             addReply(c,shared.czero);
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && set)
+    if (clusterSlotStatsEnabled() && set)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }
 
@@ -891,7 +891,7 @@ void spopWithCountCommand(client *c) {
         set->encoding == OBJ_ENCODING_LISTPACK)
     {
         /* Specialized case for listpack. Traverse it only once. */
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = setTypeAllocSize(set);
         unsigned char *lp = set->ptr;
         unsigned char *p = lpFirst(lp);
@@ -927,10 +927,10 @@ void spopWithCountCommand(client *c) {
         zfree(ps);
         set->ptr = lp;
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - count);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     } else if (remaining*SPOP_MOVE_STRATEGY_MUL > count) {
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = setTypeAllocSize(set);
         for (unsigned long i = 0; i < count; i++) {
             propargv[propindex] = setTypePopRandom(set);
@@ -946,7 +946,7 @@ void spopWithCountCommand(client *c) {
             }
         }
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - count);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     } else {
     /* CASE 3: The number of elements to return is very big, approaching
@@ -958,7 +958,7 @@ void spopWithCountCommand(client *c) {
      * set). Then we return the elements left in the original set and
      * release it. */
         robj *newset = NULL;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = setTypeAllocSize(set);
 
         /* Create a new set with just the remaining elements. */
@@ -1019,7 +1019,7 @@ void spopWithCountCommand(client *c) {
          * but here we're building the new set from the existing one. As a result, 
          * the size of the old set has already changed by the time we reach this point. */
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size-count);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
         dbReplaceValue(c->db, c->argv[1], &newset, 0);
     }
@@ -1063,13 +1063,13 @@ void spopCommand(client *c) {
     size = setTypeSize(kv);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size-1);
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = setTypeAllocSize(kv);
 
     /* Pop a random element from the kv */
     ele = setTypePopRandom(kv);
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(kv));
 
     notifyKeyspaceEvent(NOTIFY_SET,"spop",c->argv[1],c->db->id);
@@ -1329,10 +1329,10 @@ void srandmemberCommand(client *c) {
     if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp]))
         == NULL || checkType(c,set,OBJ_SET)) return;
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = setTypeAllocSize(set);
     setTypeRandomElement(set, &str, &len, &llele);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (str == NULL) {
         addReplyBulkLongLong(c,llele);
@@ -1400,7 +1400,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
             return;
         }
         sets[j].set = kv;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             sets[j].oldsize = setTypeAllocSize(kv);
     }
 
@@ -1507,7 +1507,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
     }
     setTypeReleaseIterator(si);
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled) {
+    if (clusterSlotStatsEnabled()) {
         for (j = 0; j < setnum; j++) {
             if (!sets[j].set) continue;
             updateSlotAllocSize(c->db, getKeySlot(setkeys[j]->ptr),
@@ -1569,7 +1569,7 @@ void smembersCommand(client *c) {
     /* Prepare the response. */
     unsigned long length = setTypeSize(setobj);
     addReplySetLen(c,length);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = setTypeAllocSize(setobj);
     /* Iterate through the elements of the set. */
     si = setTypeInitIterator(setobj);
@@ -1582,7 +1582,7 @@ void smembersCommand(client *c) {
         length--;
     }
     setTypeReleaseIterator(si);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(setobj));
     serverAssert(length == 0); /* fail on corrupt data */
 }
@@ -1667,7 +1667,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             dstset_encoding = OBJ_ENCODING_HT;
         }
         sets[j].set = setobj;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             sets[j].oldsize = setTypeAllocSize(setobj);
         if (j > 0 && sets[0].set == sets[j].set) {
             sameset = 1; 
@@ -1782,7 +1782,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             if (cardinality == 0) break;
         }
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled) {
+    if (clusterSlotStatsEnabled()) {
         for (j = 0; j < setnum; j++) {
             if (!sets[j].set) continue;
             updateSlotAllocSize(c->db, getKeySlot(setkeys[j]->ptr),
@@ -1854,9 +1854,9 @@ void sscanCommand(client *c) {
     if (parseScanCursorOrReply(c,c->argv[2],&cursor) == C_ERR) return;
     if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.emptyscan)) == NULL ||
         checkType(c,set,OBJ_SET)) return;
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = setTypeAllocSize(set);
     scanGenericCommand(c,set,cursor);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -614,6 +614,7 @@ void saddCommand(client *c) {
     kvobj *set;
     int j, added = 0;
     dictEntryLink link;
+    size_t oldsize = 0;
 
     set = lookupKeyWriteWithLink(c->db,c->argv[1], &link);
     if (checkType(c,set,OBJ_SET)) return;
@@ -622,16 +623,20 @@ void saddCommand(client *c) {
         robj *o = setTypeCreate(c->argv[2]->ptr, c->argc - 2);
         set = dbAddByLink(c->db, c->argv[1], &o, &link);
     } else {
-        size_t oldsize = setTypeAllocSize(set);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = setTypeAllocSize(set);
         setTypeMaybeConvert(set, c->argc - 2);
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     }
 
-    size_t oldsize = setTypeAllocSize(set);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = setTypeAllocSize(set);
     for (j = 2; j < c->argc; j++) {
         if (setTypeAdd(set,c->argv[j]->ptr)) added++;
     }
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (added) {
         unsigned long size = setTypeSize(set);
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size - added, size);
@@ -644,26 +649,29 @@ void saddCommand(client *c) {
 
 void sremCommand(client *c) {
     int j, deleted = 0, keyremoved = 0;
+    size_t oldsize = 0;
 
     kvobj *set = lookupKeyWriteOrReply(c, c->argv[1], shared.czero);
     if (set == NULL || checkType(c, set, OBJ_SET))
         return;
 
     unsigned long oldSize = setTypeSize(set);
-    size_t oldsize = setTypeAllocSize(set);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = setTypeAllocSize(set);
 
     for (j = 2; j < c->argc; j++) {
         if (setTypeRemove(set,c->argv[j]->ptr)) {
             deleted++;
             if (setTypeSize(set) == 0) {
-                updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+                if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
                 dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
                 keyremoved = 1;
                 break;
             }
         }
     }
-    if (!keyremoved)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && !keyremoved)
         updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (deleted) {
         int64_t newSize = oldSize - deleted;
@@ -683,6 +691,7 @@ void sremCommand(client *c) {
 
 void smoveCommand(client *c) {
     robj *srcset, *dstset, *ele;
+    size_t oldSrcAllocSize = 0, oldDstAllocSize = 0;
     srcset = lookupKeyWrite(c->db,c->argv[1]);
     dstset = lookupKeyWrite(c->db,c->argv[2]);
     ele = c->argv[3];
@@ -705,9 +714,11 @@ void smoveCommand(client *c) {
         return;
     }
 
-    size_t oldSrcAllocSize = setTypeAllocSize(srcset);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldSrcAllocSize = setTypeAllocSize(srcset);
     int deleted = setTypeRemove(srcset,ele->ptr);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldSrcAllocSize, setTypeAllocSize(srcset));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldSrcAllocSize, setTypeAllocSize(srcset));
     /* If the element cannot be removed from the src set, return 0. */
     if (!deleted) {
         addReply(c,shared.czero);
@@ -735,7 +746,8 @@ void smoveCommand(client *c) {
     signalModifiedKey(c,c->db,c->argv[1]);
     server.dirty++;
 
-    size_t oldDstAllocSize = setTypeAllocSize(dstset);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldDstAllocSize = setTypeAllocSize(dstset);
     /* An extra key has changed when ele was successfully added to dstset */
     if (setTypeAdd(dstset,ele->ptr)) {
         unsigned long dstLen = setTypeSize(dstset);
@@ -744,41 +756,46 @@ void smoveCommand(client *c) {
         signalModifiedKey(c,c->db,c->argv[2]);
         notifyKeyspaceEvent(NOTIFY_SET,"sadd",c->argv[2],c->db->id);
     }
-    updateAllocSizes(c->db, getKeySlot(c->argv[2]->ptr), oldDstAllocSize, setTypeAllocSize(dstset));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[2]->ptr), oldDstAllocSize, setTypeAllocSize(dstset));
     addReply(c,shared.cone);
 }
 
 void sismemberCommand(client *c) {
     kvobj *set;
+    size_t oldsize = 0;
 
     if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.czero)) == NULL ||
         checkType(c,set,OBJ_SET)) return;
 
-    size_t oldsize = setTypeAllocSize(set);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = setTypeAllocSize(set);
     if (setTypeIsMember(set,c->argv[2]->ptr))
         addReply(c,shared.cone);
     else
         addReply(c,shared.czero);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }
 
 void smismemberCommand(client *c) {
     /* Don't abort when the key cannot be found. Non-existing keys are empty
      * sets, where SMISMEMBER should respond with a series of zeros. */
+    size_t oldsize = 0;
     kvobj *set = lookupKeyRead(c->db, c->argv[1]);
     if (set && checkType(c,set,OBJ_SET)) return;
 
     addReplyArrayLen(c,c->argc - 2);
 
-    size_t oldsize = 0;
-    if (set) setTypeAllocSize(set);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && set)
+        setTypeAllocSize(set);
     for (int j = 2; j < c->argc; j++) {
         if (set && setTypeIsMember(set,c->argv[j]->ptr))
             addReply(c,shared.cone);
         else
             addReply(c,shared.czero);
     }
-    if (set)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && set)
         updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }
 
@@ -802,6 +819,7 @@ void scardCommand(client *c) {
 void spopWithCountCommand(client *c) {
     long l;
     unsigned long count, size, toRemove;
+    size_t oldsize = 0;
 
     /* Get the count argument */
     if (getPositiveLongFromObjectOrReply(c,c->argv[2],&l,NULL) != C_OK) return;
@@ -873,7 +891,8 @@ void spopWithCountCommand(client *c) {
         set->encoding == OBJ_ENCODING_LISTPACK)
     {
         /* Specialized case for listpack. Traverse it only once. */
-        size_t oldsize = setTypeAllocSize(set);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = setTypeAllocSize(set);
         unsigned char *lp = set->ptr;
         unsigned char *p = lpFirst(lp);
         unsigned int index = 0;
@@ -908,9 +927,11 @@ void spopWithCountCommand(client *c) {
         zfree(ps);
         set->ptr = lp;
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - count);
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     } else if (remaining*SPOP_MOVE_STRATEGY_MUL > count) {
-        size_t oldsize = setTypeAllocSize(set);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = setTypeAllocSize(set);
         for (unsigned long i = 0; i < count; i++) {
             propargv[propindex] = setTypePopRandom(set);
             addReplyBulk(c, propargv[propindex]);
@@ -925,7 +946,8 @@ void spopWithCountCommand(client *c) {
             }
         }
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - count);
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     } else {
     /* CASE 3: The number of elements to return is very big, approaching
      * the size of the set itself. After some time extracting random elements
@@ -936,7 +958,8 @@ void spopWithCountCommand(client *c) {
      * set). Then we return the elements left in the original set and
      * release it. */
         robj *newset = NULL;
-        size_t oldsize = setTypeAllocSize(set);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = setTypeAllocSize(set);
 
         /* Create a new set with just the remaining elements. */
         if (set->encoding == OBJ_ENCODING_LISTPACK) {
@@ -996,7 +1019,8 @@ void spopWithCountCommand(client *c) {
          * but here we're building the new set from the existing one. As a result, 
          * the size of the old set has already changed by the time we reach this point. */
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size-count);
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
         dbReplaceValue(c->db, c->argv[1], &newset, 0);
     }
 
@@ -1021,6 +1045,7 @@ void spopWithCountCommand(client *c) {
 void spopCommand(client *c) {
     unsigned long size;
     robj *ele;
+    size_t oldsize = 0;
 
     if (c->argc == 3) {
         spopWithCountCommand(c);
@@ -1038,12 +1063,14 @@ void spopCommand(client *c) {
     size = setTypeSize(kv);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size-1);
 
-    size_t oldsize = setTypeAllocSize(kv);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = setTypeAllocSize(kv);
 
     /* Pop a random element from the kv */
     ele = setTypePopRandom(kv);
 
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(kv));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(kv));
 
     notifyKeyspaceEvent(NOTIFY_SET,"spop",c->argv[1],c->db->id);
 
@@ -1288,6 +1315,7 @@ void srandmemberCommand(client *c) {
     char *str;
     size_t len = 0;
     int64_t llele = 0;
+    size_t oldsize = 0;
 
     if (c->argc == 3) {
         srandmemberWithCountCommand(c);
@@ -1301,9 +1329,11 @@ void srandmemberCommand(client *c) {
     if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp]))
         == NULL || checkType(c,set,OBJ_SET)) return;
 
-    size_t oldsize = setTypeAllocSize(set);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = setTypeAllocSize(set);
     setTypeRandomElement(set, &str, &len, &llele);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (str == NULL) {
         addReplyBulkLongLong(c,llele);
     } else {
@@ -1370,7 +1400,8 @@ void sinterGenericCommand(client *c, robj **setkeys,
             return;
         }
         sets[j].set = kv;
-        sets[j].oldsize = setTypeAllocSize(kv);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            sets[j].oldsize = setTypeAllocSize(kv);
     }
 
     /* Set intersection with an empty set always results in an empty set.
@@ -1475,10 +1506,13 @@ void sinterGenericCommand(client *c, robj **setkeys,
         }
     }
     setTypeReleaseIterator(si);
-    for (j = 0; j < setnum; j++) {
-        if (!sets[j].set) continue;
-        updateAllocSizes(c->db, getKeySlot(setkeys[j]->ptr),
-                         sets[j].oldsize, setTypeAllocSize(sets[j].set));
+
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled) {
+        for (j = 0; j < setnum; j++) {
+            if (!sets[j].set) continue;
+            updateAllocSizes(c->db, getKeySlot(setkeys[j]->ptr),
+                            sets[j].oldsize, setTypeAllocSize(sets[j].set));
+        }
     }
 
     if (cardinality_only) {
@@ -1524,6 +1558,7 @@ void smembersCommand(client *c) {
     char *str;
     size_t len = 0;
     int64_t intobj = 0;
+    size_t oldsize = 0;
     kvobj *setobj = lookupKeyRead(c->db, c->argv[1]);
     if (checkType(c,setobj,OBJ_SET)) return;
     if (!setobj) {
@@ -1534,7 +1569,8 @@ void smembersCommand(client *c) {
     /* Prepare the response. */
     unsigned long length = setTypeSize(setobj);
     addReplySetLen(c,length);
-    size_t oldsize = setTypeAllocSize(setobj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = setTypeAllocSize(setobj);
     /* Iterate through the elements of the set. */
     si = setTypeInitIterator(setobj);
 
@@ -1546,7 +1582,8 @@ void smembersCommand(client *c) {
         length--;
     }
     setTypeReleaseIterator(si);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(setobj));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(setobj));
     serverAssert(length == 0); /* fail on corrupt data */
 }
 
@@ -1630,7 +1667,8 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             dstset_encoding = OBJ_ENCODING_HT;
         }
         sets[j].set = setobj;
-        sets[j].oldsize = setTypeAllocSize(setobj);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            sets[j].oldsize = setTypeAllocSize(setobj);
         if (j > 0 && sets[0].set == sets[j].set) {
             sameset = 1; 
         }
@@ -1744,10 +1782,12 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             if (cardinality == 0) break;
         }
     }
-    for (j = 0; j < setnum; j++) {
-        if (!sets[j].set) continue;
-        updateAllocSizes(c->db, getKeySlot(setkeys[j]->ptr),
-                         sets[j].oldsize, setTypeAllocSize(sets[j].set));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled) {
+        for (j = 0; j < setnum; j++) {
+            if (!sets[j].set) continue;
+            updateAllocSizes(c->db, getKeySlot(setkeys[j]->ptr),
+                            sets[j].oldsize, setTypeAllocSize(sets[j].set));
+        }
     }
 
     /* Output the content of the resulting set, if not in STORE mode */
@@ -1809,11 +1849,14 @@ void sdiffstoreCommand(client *c) {
 void sscanCommand(client *c) {
     kvobj *set;
     unsigned long long cursor;
+    size_t oldsize = 0;
 
     if (parseScanCursorOrReply(c,c->argv[2],&cursor) == C_ERR) return;
     if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.emptyscan)) == NULL ||
         checkType(c,set,OBJ_SET)) return;
-    size_t oldsize = setTypeAllocSize(set);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = setTypeAllocSize(set);
     scanGenericCommand(c,set,cursor);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -623,19 +623,19 @@ void saddCommand(client *c) {
         robj *o = setTypeCreate(c->argv[2]->ptr, c->argc - 2);
         set = dbAddByLink(c->db, c->argv[1], &o, &link);
     } else {
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = setTypeAllocSize(set);
         setTypeMaybeConvert(set, c->argc - 2);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     }
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = setTypeAllocSize(set);
     for (j = 2; j < c->argc; j++) {
         if (setTypeAdd(set,c->argv[j]->ptr)) added++;
     }
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (added) {
         unsigned long size = setTypeSize(set);
@@ -656,14 +656,14 @@ void sremCommand(client *c) {
         return;
 
     unsigned long oldSize = setTypeSize(set);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = setTypeAllocSize(set);
 
     for (j = 2; j < c->argc; j++) {
         if (setTypeRemove(set,c->argv[j]->ptr)) {
             deleted++;
             if (setTypeSize(set) == 0) {
-                if (clusterSlotStatsEnabled())
+                if (server.memory_tracking_per_slot)
                     updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
                 dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
                 keyremoved = 1;
@@ -671,7 +671,7 @@ void sremCommand(client *c) {
             }
         }
     }
-    if (clusterSlotStatsEnabled() && !keyremoved)
+    if (server.memory_tracking_per_slot && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (deleted) {
         int64_t newSize = oldSize - deleted;
@@ -714,10 +714,10 @@ void smoveCommand(client *c) {
         return;
     }
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldSrcAllocSize = setTypeAllocSize(srcset);
     int deleted = setTypeRemove(srcset,ele->ptr);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldSrcAllocSize, setTypeAllocSize(srcset));
     /* If the element cannot be removed from the src set, return 0. */
     if (!deleted) {
@@ -746,7 +746,7 @@ void smoveCommand(client *c) {
     signalModifiedKey(c,c->db,c->argv[1]);
     server.dirty++;
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldDstAllocSize = setTypeAllocSize(dstset);
     /* An extra key has changed when ele was successfully added to dstset */
     if (setTypeAdd(dstset,ele->ptr)) {
@@ -756,7 +756,7 @@ void smoveCommand(client *c) {
         signalModifiedKey(c,c->db,c->argv[2]);
         notifyKeyspaceEvent(NOTIFY_SET,"sadd",c->argv[2],c->db->id);
     }
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[2]->ptr), oldDstAllocSize, setTypeAllocSize(dstset));
     addReply(c,shared.cone);
 }
@@ -768,13 +768,13 @@ void sismemberCommand(client *c) {
     if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.czero)) == NULL ||
         checkType(c,set,OBJ_SET)) return;
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = setTypeAllocSize(set);
     if (setTypeIsMember(set,c->argv[2]->ptr))
         addReply(c,shared.cone);
     else
         addReply(c,shared.czero);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }
 
@@ -787,7 +787,7 @@ void smismemberCommand(client *c) {
 
     addReplyArrayLen(c,c->argc - 2);
 
-    if (clusterSlotStatsEnabled() && set)
+    if (server.memory_tracking_per_slot && set)
         setTypeAllocSize(set);
     for (int j = 2; j < c->argc; j++) {
         if (set && setTypeIsMember(set,c->argv[j]->ptr))
@@ -795,7 +795,7 @@ void smismemberCommand(client *c) {
         else
             addReply(c,shared.czero);
     }
-    if (clusterSlotStatsEnabled() && set)
+    if (server.memory_tracking_per_slot && set)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }
 
@@ -891,7 +891,7 @@ void spopWithCountCommand(client *c) {
         set->encoding == OBJ_ENCODING_LISTPACK)
     {
         /* Specialized case for listpack. Traverse it only once. */
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = setTypeAllocSize(set);
         unsigned char *lp = set->ptr;
         unsigned char *p = lpFirst(lp);
@@ -927,10 +927,10 @@ void spopWithCountCommand(client *c) {
         zfree(ps);
         set->ptr = lp;
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - count);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     } else if (remaining*SPOP_MOVE_STRATEGY_MUL > count) {
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = setTypeAllocSize(set);
         for (unsigned long i = 0; i < count; i++) {
             propargv[propindex] = setTypePopRandom(set);
@@ -946,7 +946,7 @@ void spopWithCountCommand(client *c) {
             }
         }
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - count);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     } else {
     /* CASE 3: The number of elements to return is very big, approaching
@@ -958,7 +958,7 @@ void spopWithCountCommand(client *c) {
      * set). Then we return the elements left in the original set and
      * release it. */
         robj *newset = NULL;
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = setTypeAllocSize(set);
 
         /* Create a new set with just the remaining elements. */
@@ -1019,7 +1019,7 @@ void spopWithCountCommand(client *c) {
          * but here we're building the new set from the existing one. As a result, 
          * the size of the old set has already changed by the time we reach this point. */
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size-count);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
         dbReplaceValue(c->db, c->argv[1], &newset, 0);
     }
@@ -1063,13 +1063,13 @@ void spopCommand(client *c) {
     size = setTypeSize(kv);
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size-1);
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = setTypeAllocSize(kv);
 
     /* Pop a random element from the kv */
     ele = setTypePopRandom(kv);
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(kv));
 
     notifyKeyspaceEvent(NOTIFY_SET,"spop",c->argv[1],c->db->id);
@@ -1329,10 +1329,10 @@ void srandmemberCommand(client *c) {
     if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp]))
         == NULL || checkType(c,set,OBJ_SET)) return;
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = setTypeAllocSize(set);
     setTypeRandomElement(set, &str, &len, &llele);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (str == NULL) {
         addReplyBulkLongLong(c,llele);
@@ -1400,7 +1400,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
             return;
         }
         sets[j].set = kv;
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             sets[j].oldsize = setTypeAllocSize(kv);
     }
 
@@ -1507,7 +1507,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
     }
     setTypeReleaseIterator(si);
 
-    if (clusterSlotStatsEnabled()) {
+    if (server.memory_tracking_per_slot) {
         for (j = 0; j < setnum; j++) {
             if (!sets[j].set) continue;
             updateSlotAllocSize(c->db, getKeySlot(setkeys[j]->ptr),
@@ -1569,7 +1569,7 @@ void smembersCommand(client *c) {
     /* Prepare the response. */
     unsigned long length = setTypeSize(setobj);
     addReplySetLen(c,length);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = setTypeAllocSize(setobj);
     /* Iterate through the elements of the set. */
     si = setTypeInitIterator(setobj);
@@ -1582,7 +1582,7 @@ void smembersCommand(client *c) {
         length--;
     }
     setTypeReleaseIterator(si);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(setobj));
     serverAssert(length == 0); /* fail on corrupt data */
 }
@@ -1667,7 +1667,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             dstset_encoding = OBJ_ENCODING_HT;
         }
         sets[j].set = setobj;
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             sets[j].oldsize = setTypeAllocSize(setobj);
         if (j > 0 && sets[0].set == sets[j].set) {
             sameset = 1; 
@@ -1782,7 +1782,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             if (cardinality == 0) break;
         }
     }
-    if (clusterSlotStatsEnabled()) {
+    if (server.memory_tracking_per_slot) {
         for (j = 0; j < setnum; j++) {
             if (!sets[j].set) continue;
             updateSlotAllocSize(c->db, getKeySlot(setkeys[j]->ptr),
@@ -1854,9 +1854,9 @@ void sscanCommand(client *c) {
     if (parseScanCursorOrReply(c,c->argv[2],&cursor) == C_ERR) return;
     if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.emptyscan)) == NULL ||
         checkType(c,set,OBJ_SET)) return;
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = setTypeAllocSize(set);
     scanGenericCommand(c,set,cursor);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -627,7 +627,7 @@ void saddCommand(client *c) {
             oldsize = setTypeAllocSize(set);
         setTypeMaybeConvert(set, c->argc - 2);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     }
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
@@ -636,7 +636,7 @@ void saddCommand(client *c) {
         if (setTypeAdd(set,c->argv[j]->ptr)) added++;
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (added) {
         unsigned long size = setTypeSize(set);
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size - added, size);
@@ -664,7 +664,7 @@ void sremCommand(client *c) {
             deleted++;
             if (setTypeSize(set) == 0) {
                 if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+                    updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
                 dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
                 keyremoved = 1;
                 break;
@@ -672,7 +672,7 @@ void sremCommand(client *c) {
         }
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && !keyremoved)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (deleted) {
         int64_t newSize = oldSize - deleted;
 
@@ -718,7 +718,7 @@ void smoveCommand(client *c) {
         oldSrcAllocSize = setTypeAllocSize(srcset);
     int deleted = setTypeRemove(srcset,ele->ptr);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldSrcAllocSize, setTypeAllocSize(srcset));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldSrcAllocSize, setTypeAllocSize(srcset));
     /* If the element cannot be removed from the src set, return 0. */
     if (!deleted) {
         addReply(c,shared.czero);
@@ -757,7 +757,7 @@ void smoveCommand(client *c) {
         notifyKeyspaceEvent(NOTIFY_SET,"sadd",c->argv[2],c->db->id);
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[2]->ptr), oldDstAllocSize, setTypeAllocSize(dstset));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[2]->ptr), oldDstAllocSize, setTypeAllocSize(dstset));
     addReply(c,shared.cone);
 }
 
@@ -775,7 +775,7 @@ void sismemberCommand(client *c) {
     else
         addReply(c,shared.czero);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }
 
 void smismemberCommand(client *c) {
@@ -796,7 +796,7 @@ void smismemberCommand(client *c) {
             addReply(c,shared.czero);
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && set)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }
 
 void scardCommand(client *c) {
@@ -928,7 +928,7 @@ void spopWithCountCommand(client *c) {
         set->ptr = lp;
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - count);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     } else if (remaining*SPOP_MOVE_STRATEGY_MUL > count) {
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
             oldsize = setTypeAllocSize(set);
@@ -947,7 +947,7 @@ void spopWithCountCommand(client *c) {
         }
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - count);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     } else {
     /* CASE 3: The number of elements to return is very big, approaching
      * the size of the set itself. After some time extracting random elements
@@ -1020,7 +1020,7 @@ void spopWithCountCommand(client *c) {
          * the size of the old set has already changed by the time we reach this point. */
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size-count);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
         dbReplaceValue(c->db, c->argv[1], &newset, 0);
     }
 
@@ -1070,7 +1070,7 @@ void spopCommand(client *c) {
     ele = setTypePopRandom(kv);
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(kv));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(kv));
 
     notifyKeyspaceEvent(NOTIFY_SET,"spop",c->argv[1],c->db->id);
 
@@ -1333,7 +1333,7 @@ void srandmemberCommand(client *c) {
         oldsize = setTypeAllocSize(set);
     setTypeRandomElement(set, &str, &len, &llele);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
     if (str == NULL) {
         addReplyBulkLongLong(c,llele);
     } else {
@@ -1510,7 +1510,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
     if (server.cluster_enabled && server.cluster_slot_stats_enabled) {
         for (j = 0; j < setnum; j++) {
             if (!sets[j].set) continue;
-            updateAllocSizes(c->db, getKeySlot(setkeys[j]->ptr),
+            updateSlotAllocSize(c->db, getKeySlot(setkeys[j]->ptr),
                             sets[j].oldsize, setTypeAllocSize(sets[j].set));
         }
     }
@@ -1583,7 +1583,7 @@ void smembersCommand(client *c) {
     }
     setTypeReleaseIterator(si);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(setobj));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(setobj));
     serverAssert(length == 0); /* fail on corrupt data */
 }
 
@@ -1785,7 +1785,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
     if (server.cluster_enabled && server.cluster_slot_stats_enabled) {
         for (j = 0; j < setnum; j++) {
             if (!sets[j].set) continue;
-            updateAllocSizes(c->db, getKeySlot(setkeys[j]->ptr),
+            updateSlotAllocSize(c->db, getKeySlot(setkeys[j]->ptr),
                             sets[j].oldsize, setTypeAllocSize(sets[j].set));
         }
     }
@@ -1858,5 +1858,5 @@ void sscanCommand(client *c) {
         oldsize = setTypeAllocSize(set);
     scanGenericCommand(c,set,cursor);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, setTypeAllocSize(set));
 }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2343,6 +2343,7 @@ void xaddCommand(client *c) {
     stream *s;
     if ((kv = streamTypeLookupWriteOrCreate(c,c->argv[1],parsed_args.no_mkstream)) == NULL) return;
     s = kv->ptr;
+    size_t old_alloc = s->alloc_size;
 
     /* Return ASAP if the stream has reached the last possible ID */
     if (s->last_id.ms == UINT64_MAX && s->last_id.seq == UINT64_MAX) {
@@ -2368,12 +2369,16 @@ void xaddCommand(client *c) {
     sds replyid = createStreamIDString(&id);
     addReplyBulkCBuffer(c, replyid, sdslen(replyid));
 
+    if (old_alloc != s->alloc_size)
+        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     notifyKeyspaceEvent(NOTIFY_STREAM,"xadd",c->argv[1],c->db->id);
     server.dirty++;
 
     /* Trim if needed. */
     if (parsed_args.trim_strategy != TRIM_STRATEGY_NONE) {
+        old_alloc = s->alloc_size;
         if (streamTrim(s, &parsed_args)) {
+            updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
             notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
         }
         if (parsed_args.approx_trim) {
@@ -2460,7 +2465,10 @@ void xrangeGenericCommand(client *c, int rev) {
         addReplyNullArray(c);
     } else {
         if (count == -1) count = 0;
+        size_t old_alloc = s->alloc_size;
         streamReplyWithRange(c,s,&startid,&endid,count,rev,-1,NULL,NULL,0,NULL,NULL);
+        if (old_alloc != s->alloc_size)
+            updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     }
 }
 
@@ -2732,9 +2740,11 @@ void xreadCommand(client *c) {
             }
             consumer = streamLookupConsumer(groups[i],consumername->ptr);
             if (consumer == NULL) {
+                size_t old_alloc = s->alloc_size;
                 consumer = streamCreateConsumer(s,groups[i],consumername->ptr,
                                                 c->argv[streams_arg+i],
                                                 c->db->id,SCC_DEFAULT);
+                updateAllocSizes(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
                 if (noack)
                     streamPropagateConsumerCreation(c,spi.keyname,
                                                     spi.groupname,
@@ -2780,9 +2790,12 @@ void xreadCommand(client *c) {
             unsigned long propCount = 0;
             if (noack) flags |= STREAM_RWR_NOACK;
             if (serve_history) flags |= STREAM_RWR_HISTORY;
+            size_t old_alloc = s->alloc_size;
             streamReplyWithRange(c,s,&start,NULL,count,0, min_idle_time,
                                  groups ? groups[i] : NULL,
                                  consumer, flags, &spi, &propCount);
+            if (old_alloc != s->alloc_size)
+                updateAllocSizes(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
             if (propCount) server.dirty++;
         }
     }
@@ -3273,8 +3286,10 @@ NULL
             entries_read = s->entries_added;
         }
 
+        size_t old_alloc = s->alloc_size;
         streamCG *cg = streamCreateCG(s,grpname,sdslen(grpname),&id,entries_read);
         if (cg) {
+            updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             addReply(c,shared.ok);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-create",
@@ -3301,8 +3316,10 @@ NULL
         notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-setid",c->argv[2],c->db->id);
     } else if (!strcasecmp(opt,"DESTROY") && c->argc == 4) {
         if (cg) {
+            size_t old_alloc = s->alloc_size;
             raxRemove(s->cgroups,(unsigned char*)grpname,sdslen(grpname),NULL);
             streamDestroyCG(s, cg);
+            updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             addReply(c,shared.cone);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-destroy",
@@ -3313,8 +3330,10 @@ NULL
             addReply(c,shared.czero);
         }
     } else if (!strcasecmp(opt,"CREATECONSUMER") && c->argc == 5) {
+        size_t old_alloc = s->alloc_size;
         streamConsumer *created = streamCreateConsumer(s,cg,c->argv[4]->ptr,c->argv[2],
                                                        c->db->id,SCC_DEFAULT);
+        updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
         addReplyLongLong(c,created ? 1 : 0);
     } else if (!strcasecmp(opt,"DELCONSUMER") && c->argc == 5) {
         long long pending = 0;
@@ -3322,8 +3341,10 @@ NULL
         if (consumer) {
             /* Delete the consumer and returns the number of pending messages
              * that were yet associated with such a consumer. */
+            size_t old_alloc = s->alloc_size;
             pending = raxSize(consumer->pel);
             streamDelConsumer(s,cg,consumer);
+            updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-delconsumer",
                                 c->argv[2],c->db->id);
@@ -3445,6 +3466,8 @@ void xackCommand(client *c) {
     }
 
     int acknowledged = 0;
+    stream *s = kv->ptr;
+    size_t old_alloc = s->alloc_size;
     for (int j = 3; j < c->argc; j++) {
         unsigned char buf[sizeof(streamID)];
         streamEncodeID(buf,&ids[j-3]);
@@ -3463,6 +3486,8 @@ void xackCommand(client *c) {
             server.dirty++;
         }
     }
+    if (old_alloc != s->alloc_size)
+        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     addReplyLongLong(c,acknowledged);
 cleanup:
     if (ids != static_ids) zfree(ids);
@@ -3510,6 +3535,7 @@ void xackdelCommand(client *c) {
     }
 
     s = kv->ptr;
+    size_t old_alloc = s->alloc_size;
     int first_entry = 0;
     int deleted = 0;
     addReplyArrayLen(c, args.numids);
@@ -3559,6 +3585,9 @@ void xackdelCommand(client *c) {
         }
         addReplyLongLong(c, res);
     }
+
+    if (old_alloc != s->alloc_size)
+        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     /* Update the stream's first ID. */
     if (deleted) {
@@ -3930,13 +3959,14 @@ void xclaimCommand(client *c) {
     }
 
     /* Do the actual claiming. */
+    stream *s = o->ptr;
+    size_t old_alloc = s->alloc_size;
     streamConsumer *consumer = streamLookupConsumer(group,c->argv[3]->ptr);
     if (consumer == NULL) {
         consumer = streamCreateConsumer(o->ptr,group,c->argv[3]->ptr,c->argv[1],c->db->id,SCC_DEFAULT);
     }
     consumer->seen_time = commandTimeSnapshot();
 
-    stream *s = o->ptr;
     void *arraylenptr = addReplyDeferredLen(c);
     size_t arraylen = 0;
     for (int j = 5; j <= last_id_arg; j++) {
@@ -4032,6 +4062,8 @@ void xclaimCommand(client *c) {
             server.dirty++;
         }
     }
+    if (old_alloc != s->alloc_size)
+        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     if (propagate_last_id) {
         streamPropagateGroupID(c,c->argv[1],group,c->argv[2]);
         server.dirty++;
@@ -4121,6 +4153,8 @@ void xautoclaimCommand(client *c) {
     }
 
     /* Do the actual claiming. */
+    stream *s = o->ptr;
+    size_t old_alloc = s->alloc_size;
     streamConsumer *consumer = streamLookupConsumer(group,c->argv[3]->ptr);
     if (consumer == NULL) {
         consumer = streamCreateConsumer(o->ptr,group,c->argv[3]->ptr,c->argv[1],c->db->id,SCC_DEFAULT);
@@ -4133,7 +4167,6 @@ void xautoclaimCommand(client *c) {
     void *endidptr = addReplyDeferredLen(c); /* reply[0] */
     void *arraylenptr = addReplyDeferredLen(c); /* reply[1] */
 
-    stream *s = o->ptr;
     unsigned char startkey[sizeof(streamID)];
     streamEncodeID(startkey,&startid);
     raxIterator ri;
@@ -4218,6 +4251,9 @@ void xautoclaimCommand(client *c) {
     /* We need to return the next entry as a cursor for the next XAUTOCLAIM call */
     raxNext(&ri);
 
+    if (old_alloc != s->alloc_size)
+        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+
     streamID endid;
     if (raxEOF(&ri)) {
         endid.ms = endid.seq = 0;
@@ -4247,6 +4283,7 @@ void xdelCommand(client *c) {
     kvobj *kv = lookupKeyWriteOrReply(c, c->argv[1], shared.czero); 
     if (kv == NULL || checkType(c, kv, OBJ_STREAM)) return;
     stream *s = kv->ptr;
+    size_t old_alloc = s->alloc_size;
 
     /* We need to sanity check the IDs passed to start. Even if not
      * a big issue, it is not great that the command is only partially
@@ -4278,6 +4315,9 @@ void xdelCommand(client *c) {
             deleted++;
         };
     }
+
+    if (old_alloc != s->alloc_size)
+        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     /* Update the stream's first ID. */
     if (deleted) {
@@ -4341,6 +4381,7 @@ void xdelexCommand(client *c) {
     }
 
     stream *s = kv->ptr;
+    size_t old_alloc = s->alloc_size;
     int first_entry = 0;
     int deleted = 0;
     addReplyArrayLen(c, args.numids);
@@ -4384,6 +4425,7 @@ void xdelexCommand(client *c) {
 
     /* Update the stream's first ID. */
     if (deleted) {
+        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
         if (s->length == 0) {
             s->first_id.ms = 0;
             s->first_id.seq = 0;
@@ -4441,10 +4483,12 @@ void xtrimCommand(client *c) {
     kvobj *kv = lookupKeyWriteOrReply(c, c->argv[1], shared.czero); 
     if (kv == NULL || checkType(c, kv, OBJ_STREAM)) return;
     stream *s = kv->ptr;
+    size_t old_alloc = s->alloc_size;
 
     /* Perform the trimming. */
     int64_t deleted = streamTrim(s, &parsed_args);
     if (deleted) {
+        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
         notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
         if (parsed_args.approx_trim) {
             /* In case our trimming was limited (by LIMIT or by ~) we must
@@ -4515,6 +4559,7 @@ void xinfoReplyWithStreamInfo(client *c, stream *s) {
     addReplyBulkCString(c,"recorded-first-entry-id");
     addReplyStreamID(c,&s->first_id);
 
+    size_t old_alloc = s->alloc_size;
     if (!full) {
         /* XINFO STREAM <key> */
 
@@ -4668,6 +4713,8 @@ void xinfoReplyWithStreamInfo(client *c, stream *s) {
             raxStop(&ri_cgroups);
         }
     }
+    if (old_alloc != s->alloc_size)
+        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 }
 
 /* XINFO CONSUMERS <key> <group>

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2364,23 +2364,20 @@ void xaddCommand(client *c) {
                             "the target stream top item");
         else
             addReplyError(c,"Elements are too large to be stored");
+        if (old_alloc != s->alloc_size)
+            updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
         return;
     }
     sds replyid = createStreamIDString(&id);
     addReplyBulkCBuffer(c, replyid, sdslen(replyid));
 
-    if (old_alloc != s->alloc_size)
-        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     notifyKeyspaceEvent(NOTIFY_STREAM,"xadd",c->argv[1],c->db->id);
     server.dirty++;
 
     /* Trim if needed. */
     if (parsed_args.trim_strategy != TRIM_STRATEGY_NONE) {
-        old_alloc = s->alloc_size;
-        if (streamTrim(s, &parsed_args)) {
-            updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+        if (streamTrim(s, &parsed_args))
             notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
-        }
         if (parsed_args.approx_trim) {
             /* In case our trimming was limited (by LIMIT or by ~) we must
              * re-write the relevant trim argument to make sure there will be
@@ -2391,6 +2388,9 @@ void xaddCommand(client *c) {
             streamRewriteTrimArgument(c,s,parsed_args.trim_strategy,parsed_args.trim_strategy_arg_idx);
         }
     }
+
+    if (old_alloc != s->alloc_size)
+        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     signalModifiedKey(c,c->db,c->argv[1]);
 
@@ -4483,12 +4483,12 @@ void xtrimCommand(client *c) {
     kvobj *kv = lookupKeyWriteOrReply(c, c->argv[1], shared.czero); 
     if (kv == NULL || checkType(c, kv, OBJ_STREAM)) return;
     stream *s = kv->ptr;
-    size_t old_alloc = s->alloc_size;
 
     /* Perform the trimming. */
+    size_t old_alloc = s->alloc_size;
     int64_t deleted = streamTrim(s, &parsed_args);
+    updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     if (deleted) {
-        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
         notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
         if (parsed_args.approx_trim) {
             /* In case our trimming was limited (by LIMIT or by ~) we must

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2364,7 +2364,7 @@ void xaddCommand(client *c) {
                             "the target stream top item");
         else
             addReplyError(c,"Elements are too large to be stored");
-        if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
+        if (server.memory_tracking_per_slot && old_alloc != s->alloc_size)
             updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
         return;
     }
@@ -2389,7 +2389,7 @@ void xaddCommand(client *c) {
         }
     }
 
-    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
+    if (server.memory_tracking_per_slot && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     signalModifiedKey(c,c->db,c->argv[1]);
@@ -2468,7 +2468,7 @@ void xrangeGenericCommand(client *c, int rev) {
         if (count == -1) count = 0;
         old_alloc = s->alloc_size;
         streamReplyWithRange(c,s,&startid,&endid,count,rev,-1,NULL,NULL,0,NULL,NULL);
-        if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
+        if (server.memory_tracking_per_slot && old_alloc != s->alloc_size)
             updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     }
 }
@@ -2746,7 +2746,7 @@ void xreadCommand(client *c) {
                 consumer = streamCreateConsumer(s,groups[i],consumername->ptr,
                                                 c->argv[streams_arg+i],
                                                 c->db->id,SCC_DEFAULT);
-                if (clusterSlotStatsEnabled())
+                if (server.memory_tracking_per_slot)
                     updateSlotAllocSize(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
                 if (noack)
                     streamPropagateConsumerCreation(c,spi.keyname,
@@ -2797,7 +2797,7 @@ void xreadCommand(client *c) {
             streamReplyWithRange(c,s,&start,NULL,count,0, min_idle_time,
                                  groups ? groups[i] : NULL,
                                  consumer, flags, &spi, &propCount);
-            if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
+            if (server.memory_tracking_per_slot && old_alloc != s->alloc_size)
                 updateSlotAllocSize(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
             if (propCount) server.dirty++;
         }
@@ -3293,7 +3293,7 @@ NULL
         old_alloc = s->alloc_size;
         streamCG *cg = streamCreateCG(s,grpname,sdslen(grpname),&id,entries_read);
         if (cg) {
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             addReply(c,shared.ok);
             server.dirty++;
@@ -3324,7 +3324,7 @@ NULL
             old_alloc = s->alloc_size;
             raxRemove(s->cgroups,(unsigned char*)grpname,sdslen(grpname),NULL);
             streamDestroyCG(s, cg);
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             addReply(c,shared.cone);
             server.dirty++;
@@ -3339,7 +3339,7 @@ NULL
         old_alloc = s->alloc_size;
         streamConsumer *created = streamCreateConsumer(s,cg,c->argv[4]->ptr,c->argv[2],
                                                        c->db->id,SCC_DEFAULT);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
         addReplyLongLong(c,created ? 1 : 0);
     } else if (!strcasecmp(opt,"DELCONSUMER") && c->argc == 5) {
@@ -3351,7 +3351,7 @@ NULL
             old_alloc = s->alloc_size;
             pending = raxSize(consumer->pel);
             streamDelConsumer(s,cg,consumer);
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-delconsumer",
@@ -3494,7 +3494,7 @@ void xackCommand(client *c) {
             server.dirty++;
         }
     }
-    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
+    if (server.memory_tracking_per_slot && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     addReplyLongLong(c,acknowledged);
 cleanup:
@@ -3594,7 +3594,7 @@ void xackdelCommand(client *c) {
         addReplyLongLong(c, res);
     }
 
-    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
+    if (server.memory_tracking_per_slot && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     /* Update the stream's first ID. */
@@ -4070,7 +4070,7 @@ void xclaimCommand(client *c) {
             server.dirty++;
         }
     }
-    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
+    if (server.memory_tracking_per_slot && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     if (propagate_last_id) {
         streamPropagateGroupID(c,c->argv[1],group,c->argv[2]);
@@ -4259,7 +4259,7 @@ void xautoclaimCommand(client *c) {
     /* We need to return the next entry as a cursor for the next XAUTOCLAIM call */
     raxNext(&ri);
 
-    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
+    if (server.memory_tracking_per_slot && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     streamID endid;
@@ -4324,7 +4324,7 @@ void xdelCommand(client *c) {
         };
     }
 
-    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
+    if (server.memory_tracking_per_slot && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     /* Update the stream's first ID. */
@@ -4433,7 +4433,7 @@ void xdelexCommand(client *c) {
 
     /* Update the stream's first ID. */
     if (deleted) {
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
         if (s->length == 0) {
             s->first_id.ms = 0;
@@ -4496,7 +4496,7 @@ void xtrimCommand(client *c) {
     /* Perform the trimming. */
     size_t old_alloc = s->alloc_size;
     int64_t deleted = streamTrim(s, &parsed_args);
-    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
+    if (server.memory_tracking_per_slot && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     if (deleted) {
         notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
@@ -4723,7 +4723,7 @@ void xinfoReplyWithStreamInfo(client *c, stream *s) {
             raxStop(&ri_cgroups);
         }
     }
-    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
+    if (server.memory_tracking_per_slot && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2364,7 +2364,7 @@ void xaddCommand(client *c) {
                             "the target stream top item");
         else
             addReplyError(c,"Elements are too large to be stored");
-        if (old_alloc != s->alloc_size)
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
             updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
         return;
     }
@@ -2389,7 +2389,7 @@ void xaddCommand(client *c) {
         }
     }
 
-    if (old_alloc != s->alloc_size)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
         updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     signalModifiedKey(c,c->db,c->argv[1]);
@@ -2424,6 +2424,7 @@ void xrangeGenericCommand(client *c, int rev) {
     robj *startarg = rev ? c->argv[3] : c->argv[2];
     robj *endarg = rev ? c->argv[2] : c->argv[3];
     int startex = 0, endex = 0;
+    size_t old_alloc;
     
     /* Parse start and end IDs. */
     if (streamParseIntervalIDOrReply(c,startarg,&startid,&startex,0) != C_OK)
@@ -2465,9 +2466,9 @@ void xrangeGenericCommand(client *c, int rev) {
         addReplyNullArray(c);
     } else {
         if (count == -1) count = 0;
-        size_t old_alloc = s->alloc_size;
+        old_alloc = s->alloc_size;
         streamReplyWithRange(c,s,&startid,&endid,count,rev,-1,NULL,NULL,0,NULL,NULL);
-        if (old_alloc != s->alloc_size)
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
             updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     }
 }
@@ -2512,6 +2513,7 @@ void xreadCommand(client *c) {
     int xreadgroup = sdslen(c->argv[0]->ptr) == 10; /* XREAD or XREADGROUP? */
     robj *groupname = NULL;
     robj *consumername = NULL;
+    size_t old_alloc;
 
     /* Parse arguments. */
     for (int i = 1; i < c->argc; i++) {
@@ -2740,11 +2742,12 @@ void xreadCommand(client *c) {
             }
             consumer = streamLookupConsumer(groups[i],consumername->ptr);
             if (consumer == NULL) {
-                size_t old_alloc = s->alloc_size;
+                old_alloc = s->alloc_size;
                 consumer = streamCreateConsumer(s,groups[i],consumername->ptr,
                                                 c->argv[streams_arg+i],
                                                 c->db->id,SCC_DEFAULT);
-                updateAllocSizes(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
+                if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                    updateAllocSizes(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
                 if (noack)
                     streamPropagateConsumerCreation(c,spi.keyname,
                                                     spi.groupname,
@@ -2790,11 +2793,11 @@ void xreadCommand(client *c) {
             unsigned long propCount = 0;
             if (noack) flags |= STREAM_RWR_NOACK;
             if (serve_history) flags |= STREAM_RWR_HISTORY;
-            size_t old_alloc = s->alloc_size;
+            old_alloc = s->alloc_size;
             streamReplyWithRange(c,s,&start,NULL,count,0, min_idle_time,
                                  groups ? groups[i] : NULL,
                                  consumer, flags, &spi, &propCount);
-            if (old_alloc != s->alloc_size)
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
                 updateAllocSizes(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
             if (propCount) server.dirty++;
         }
@@ -3183,6 +3186,7 @@ void xgroupCommand(client *c) {
     int mkstream = 0;
     long long entries_read = SCG_INVALID_ENTRIES_READ;
     robj *o;
+    size_t old_alloc;
 
     /* Everything but the "HELP" option requires a key and group name. */
     if (c->argc >= 4) {
@@ -3286,10 +3290,11 @@ NULL
             entries_read = s->entries_added;
         }
 
-        size_t old_alloc = s->alloc_size;
+        old_alloc = s->alloc_size;
         streamCG *cg = streamCreateCG(s,grpname,sdslen(grpname),&id,entries_read);
         if (cg) {
-            updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             addReply(c,shared.ok);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-create",
@@ -3316,10 +3321,11 @@ NULL
         notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-setid",c->argv[2],c->db->id);
     } else if (!strcasecmp(opt,"DESTROY") && c->argc == 4) {
         if (cg) {
-            size_t old_alloc = s->alloc_size;
+            old_alloc = s->alloc_size;
             raxRemove(s->cgroups,(unsigned char*)grpname,sdslen(grpname),NULL);
             streamDestroyCG(s, cg);
-            updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             addReply(c,shared.cone);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-destroy",
@@ -3330,10 +3336,11 @@ NULL
             addReply(c,shared.czero);
         }
     } else if (!strcasecmp(opt,"CREATECONSUMER") && c->argc == 5) {
-        size_t old_alloc = s->alloc_size;
+        old_alloc = s->alloc_size;
         streamConsumer *created = streamCreateConsumer(s,cg,c->argv[4]->ptr,c->argv[2],
                                                        c->db->id,SCC_DEFAULT);
-        updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
         addReplyLongLong(c,created ? 1 : 0);
     } else if (!strcasecmp(opt,"DELCONSUMER") && c->argc == 5) {
         long long pending = 0;
@@ -3341,10 +3348,11 @@ NULL
         if (consumer) {
             /* Delete the consumer and returns the number of pending messages
              * that were yet associated with such a consumer. */
-            size_t old_alloc = s->alloc_size;
+            old_alloc = s->alloc_size;
             pending = raxSize(consumer->pel);
             streamDelConsumer(s,cg,consumer);
-            updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-delconsumer",
                                 c->argv[2],c->db->id);
@@ -3486,7 +3494,7 @@ void xackCommand(client *c) {
             server.dirty++;
         }
     }
-    if (old_alloc != s->alloc_size)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
         updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     addReplyLongLong(c,acknowledged);
 cleanup:
@@ -3586,7 +3594,7 @@ void xackdelCommand(client *c) {
         addReplyLongLong(c, res);
     }
 
-    if (old_alloc != s->alloc_size)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
         updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     /* Update the stream's first ID. */
@@ -4062,7 +4070,7 @@ void xclaimCommand(client *c) {
             server.dirty++;
         }
     }
-    if (old_alloc != s->alloc_size)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
         updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     if (propagate_last_id) {
         streamPropagateGroupID(c,c->argv[1],group,c->argv[2]);
@@ -4251,7 +4259,7 @@ void xautoclaimCommand(client *c) {
     /* We need to return the next entry as a cursor for the next XAUTOCLAIM call */
     raxNext(&ri);
 
-    if (old_alloc != s->alloc_size)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
         updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     streamID endid;
@@ -4316,7 +4324,7 @@ void xdelCommand(client *c) {
         };
     }
 
-    if (old_alloc != s->alloc_size)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
         updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     /* Update the stream's first ID. */
@@ -4425,7 +4433,8 @@ void xdelexCommand(client *c) {
 
     /* Update the stream's first ID. */
     if (deleted) {
-        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
         if (s->length == 0) {
             s->first_id.ms = 0;
             s->first_id.seq = 0;
@@ -4487,7 +4496,8 @@ void xtrimCommand(client *c) {
     /* Perform the trimming. */
     size_t old_alloc = s->alloc_size;
     int64_t deleted = streamTrim(s, &parsed_args);
-    updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
+        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     if (deleted) {
         notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
         if (parsed_args.approx_trim) {
@@ -4713,7 +4723,7 @@ void xinfoReplyWithStreamInfo(client *c, stream *s) {
             raxStop(&ri_cgroups);
         }
     }
-    if (old_alloc != s->alloc_size)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
         updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2364,7 +2364,7 @@ void xaddCommand(client *c) {
                             "the target stream top item");
         else
             addReplyError(c,"Elements are too large to be stored");
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
+        if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
             updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
         return;
     }
@@ -2389,7 +2389,7 @@ void xaddCommand(client *c) {
         }
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
+    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     signalModifiedKey(c,c->db,c->argv[1]);
@@ -2468,7 +2468,7 @@ void xrangeGenericCommand(client *c, int rev) {
         if (count == -1) count = 0;
         old_alloc = s->alloc_size;
         streamReplyWithRange(c,s,&startid,&endid,count,rev,-1,NULL,NULL,0,NULL,NULL);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
+        if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
             updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     }
 }
@@ -2746,7 +2746,7 @@ void xreadCommand(client *c) {
                 consumer = streamCreateConsumer(s,groups[i],consumername->ptr,
                                                 c->argv[streams_arg+i],
                                                 c->db->id,SCC_DEFAULT);
-                if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                if (clusterSlotStatsEnabled())
                     updateSlotAllocSize(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
                 if (noack)
                     streamPropagateConsumerCreation(c,spi.keyname,
@@ -2797,7 +2797,7 @@ void xreadCommand(client *c) {
             streamReplyWithRange(c,s,&start,NULL,count,0, min_idle_time,
                                  groups ? groups[i] : NULL,
                                  consumer, flags, &spi, &propCount);
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
+            if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
                 updateSlotAllocSize(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
             if (propCount) server.dirty++;
         }
@@ -3293,7 +3293,7 @@ NULL
         old_alloc = s->alloc_size;
         streamCG *cg = streamCreateCG(s,grpname,sdslen(grpname),&id,entries_read);
         if (cg) {
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             addReply(c,shared.ok);
             server.dirty++;
@@ -3324,7 +3324,7 @@ NULL
             old_alloc = s->alloc_size;
             raxRemove(s->cgroups,(unsigned char*)grpname,sdslen(grpname),NULL);
             streamDestroyCG(s, cg);
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             addReply(c,shared.cone);
             server.dirty++;
@@ -3339,7 +3339,7 @@ NULL
         old_alloc = s->alloc_size;
         streamConsumer *created = streamCreateConsumer(s,cg,c->argv[4]->ptr,c->argv[2],
                                                        c->db->id,SCC_DEFAULT);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
         addReplyLongLong(c,created ? 1 : 0);
     } else if (!strcasecmp(opt,"DELCONSUMER") && c->argc == 5) {
@@ -3351,7 +3351,7 @@ NULL
             old_alloc = s->alloc_size;
             pending = raxSize(consumer->pel);
             streamDelConsumer(s,cg,consumer);
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-delconsumer",
@@ -3494,7 +3494,7 @@ void xackCommand(client *c) {
             server.dirty++;
         }
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
+    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     addReplyLongLong(c,acknowledged);
 cleanup:
@@ -3594,7 +3594,7 @@ void xackdelCommand(client *c) {
         addReplyLongLong(c, res);
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
+    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     /* Update the stream's first ID. */
@@ -4070,7 +4070,7 @@ void xclaimCommand(client *c) {
             server.dirty++;
         }
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
+    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     if (propagate_last_id) {
         streamPropagateGroupID(c,c->argv[1],group,c->argv[2]);
@@ -4259,7 +4259,7 @@ void xautoclaimCommand(client *c) {
     /* We need to return the next entry as a cursor for the next XAUTOCLAIM call */
     raxNext(&ri);
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
+    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     streamID endid;
@@ -4324,7 +4324,7 @@ void xdelCommand(client *c) {
         };
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
+    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     /* Update the stream's first ID. */
@@ -4433,7 +4433,7 @@ void xdelexCommand(client *c) {
 
     /* Update the stream's first ID. */
     if (deleted) {
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
         if (s->length == 0) {
             s->first_id.ms = 0;
@@ -4496,7 +4496,7 @@ void xtrimCommand(client *c) {
     /* Perform the trimming. */
     size_t old_alloc = s->alloc_size;
     int64_t deleted = streamTrim(s, &parsed_args);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
+    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     if (deleted) {
         notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
@@ -4723,7 +4723,7 @@ void xinfoReplyWithStreamInfo(client *c, stream *s) {
             raxStop(&ri_cgroups);
         }
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
+    if (clusterSlotStatsEnabled() && old_alloc != s->alloc_size)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2365,7 +2365,7 @@ void xaddCommand(client *c) {
         else
             addReplyError(c,"Elements are too large to be stored");
         if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
-            updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+            updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
         return;
     }
     sds replyid = createStreamIDString(&id);
@@ -2390,7 +2390,7 @@ void xaddCommand(client *c) {
     }
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
-        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+        updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     signalModifiedKey(c,c->db,c->argv[1]);
 
@@ -2469,7 +2469,7 @@ void xrangeGenericCommand(client *c, int rev) {
         old_alloc = s->alloc_size;
         streamReplyWithRange(c,s,&startid,&endid,count,rev,-1,NULL,NULL,0,NULL,NULL);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
-            updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+            updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     }
 }
 
@@ -2747,7 +2747,7 @@ void xreadCommand(client *c) {
                                                 c->argv[streams_arg+i],
                                                 c->db->id,SCC_DEFAULT);
                 if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                    updateAllocSizes(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
+                    updateSlotAllocSize(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
                 if (noack)
                     streamPropagateConsumerCreation(c,spi.keyname,
                                                     spi.groupname,
@@ -2798,7 +2798,7 @@ void xreadCommand(client *c) {
                                  groups ? groups[i] : NULL,
                                  consumer, flags, &spi, &propCount);
             if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
-                updateAllocSizes(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
+                updateSlotAllocSize(c->db,getKeySlot(c->argv[streams_arg+i]->ptr),old_alloc,s->alloc_size);
             if (propCount) server.dirty++;
         }
     }
@@ -3294,7 +3294,7 @@ NULL
         streamCG *cg = streamCreateCG(s,grpname,sdslen(grpname),&id,entries_read);
         if (cg) {
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
+                updateSlotAllocSize(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             addReply(c,shared.ok);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-create",
@@ -3325,7 +3325,7 @@ NULL
             raxRemove(s->cgroups,(unsigned char*)grpname,sdslen(grpname),NULL);
             streamDestroyCG(s, cg);
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
+                updateSlotAllocSize(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             addReply(c,shared.cone);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-destroy",
@@ -3340,7 +3340,7 @@ NULL
         streamConsumer *created = streamCreateConsumer(s,cg,c->argv[4]->ptr,c->argv[2],
                                                        c->db->id,SCC_DEFAULT);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
+            updateSlotAllocSize(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
         addReplyLongLong(c,created ? 1 : 0);
     } else if (!strcasecmp(opt,"DELCONSUMER") && c->argc == 5) {
         long long pending = 0;
@@ -3352,7 +3352,7 @@ NULL
             pending = raxSize(consumer->pel);
             streamDelConsumer(s,cg,consumer);
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
+                updateSlotAllocSize(c->db,getKeySlot(c->argv[2]->ptr),old_alloc,s->alloc_size);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM,"xgroup-delconsumer",
                                 c->argv[2],c->db->id);
@@ -3495,7 +3495,7 @@ void xackCommand(client *c) {
         }
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
-        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+        updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     addReplyLongLong(c,acknowledged);
 cleanup:
     if (ids != static_ids) zfree(ids);
@@ -3595,7 +3595,7 @@ void xackdelCommand(client *c) {
     }
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
-        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+        updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     /* Update the stream's first ID. */
     if (deleted) {
@@ -4071,7 +4071,7 @@ void xclaimCommand(client *c) {
         }
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
-        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+        updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     if (propagate_last_id) {
         streamPropagateGroupID(c,c->argv[1],group,c->argv[2]);
         server.dirty++;
@@ -4260,7 +4260,7 @@ void xautoclaimCommand(client *c) {
     raxNext(&ri);
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
-        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+        updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     streamID endid;
     if (raxEOF(&ri)) {
@@ -4325,7 +4325,7 @@ void xdelCommand(client *c) {
     }
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
-        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+        updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 
     /* Update the stream's first ID. */
     if (deleted) {
@@ -4434,7 +4434,7 @@ void xdelexCommand(client *c) {
     /* Update the stream's first ID. */
     if (deleted) {
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+            updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
         if (s->length == 0) {
             s->first_id.ms = 0;
             s->first_id.seq = 0;
@@ -4497,7 +4497,7 @@ void xtrimCommand(client *c) {
     size_t old_alloc = s->alloc_size;
     int64_t deleted = streamTrim(s, &parsed_args);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
-        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+        updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
     if (deleted) {
         notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
         if (parsed_args.approx_trim) {
@@ -4724,7 +4724,7 @@ void xinfoReplyWithStreamInfo(client *c, stream *s) {
         }
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && old_alloc != s->alloc_size)
-        updateAllocSizes(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
+        updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),old_alloc,s->alloc_size);
 }
 
 /* XINFO CONSUMERS <key> <group>

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -582,7 +582,9 @@ void setrangeCommand(client *c) {
     }
 
     if (value_len > 0) {
+        size_t oldsize = stringObjectAllocSize(kv);
         kv->ptr = sdsgrowzero(kv->ptr,offset+value_len);
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
         memcpy((char*)kv->ptr+offset,value,value_len);
         signalModifiedKey(c,c->db,c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_STRING,
@@ -817,7 +819,9 @@ void appendCommand(client *c) {
 
         /* Append the value */
         o = dbUnshareStringValueByLink(c->db,c->argv[1],o,link);
+        size_t oldsize = stringObjectAllocSize(o);
         o->ptr = sdscatlen(o->ptr,append->ptr,append_len);
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(o));
         totlen = sdslen(o->ptr);
         int64_t oldlen = totlen - append_len;
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, oldlen, totlen);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -583,10 +583,10 @@ void setrangeCommand(client *c) {
 
     if (value_len > 0) {
         size_t oldsize = 0;
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = stringObjectAllocSize(kv);
         kv->ptr = sdsgrowzero(kv->ptr,offset+value_len);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
         memcpy((char*)kv->ptr+offset,value,value_len);
         signalModifiedKey(c,c->db,c->argv[1]);
@@ -823,10 +823,10 @@ void appendCommand(client *c) {
 
         /* Append the value */
         o = dbUnshareStringValueByLink(c->db,c->argv[1],o,link);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = stringObjectAllocSize(o);
         o->ptr = sdscatlen(o->ptr,append->ptr,append_len);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(o));
         totlen = sdslen(o->ptr);
         int64_t oldlen = totlen - append_len;

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -583,10 +583,10 @@ void setrangeCommand(client *c) {
 
     if (value_len > 0) {
         size_t oldsize = 0;
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = stringObjectAllocSize(kv);
         kv->ptr = sdsgrowzero(kv->ptr,offset+value_len);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
         memcpy((char*)kv->ptr+offset,value,value_len);
         signalModifiedKey(c,c->db,c->argv[1]);
@@ -823,10 +823,10 @@ void appendCommand(client *c) {
 
         /* Append the value */
         o = dbUnshareStringValueByLink(c->db,c->argv[1],o,link);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = stringObjectAllocSize(o);
         o->ptr = sdscatlen(o->ptr,append->ptr,append_len);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(o));
         totlen = sdslen(o->ptr);
         int64_t oldlen = totlen - append_len;

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -582,9 +582,12 @@ void setrangeCommand(client *c) {
     }
 
     if (value_len > 0) {
-        size_t oldsize = stringObjectAllocSize(kv);
+        size_t oldsize = 0;
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = stringObjectAllocSize(kv);
         kv->ptr = sdsgrowzero(kv->ptr,offset+value_len);
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
         memcpy((char*)kv->ptr+offset,value,value_len);
         signalModifiedKey(c,c->db,c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_STRING,
@@ -797,6 +800,7 @@ void appendCommand(client *c) {
     size_t totlen;
     robj *append;
     kvobj *o;
+    size_t oldsize = 0;
 
     dictEntryLink link;
     o = lookupKeyWriteWithLink(c->db,c->argv[1],&link);
@@ -819,9 +823,11 @@ void appendCommand(client *c) {
 
         /* Append the value */
         o = dbUnshareStringValueByLink(c->db,c->argv[1],o,link);
-        size_t oldsize = stringObjectAllocSize(o);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = stringObjectAllocSize(o);
         o->ptr = sdscatlen(o->ptr,append->ptr,append_len);
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(o));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(o));
         totlen = sdslen(o->ptr);
         int64_t oldlen = totlen - append_len;
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, oldlen, totlen);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -587,7 +587,7 @@ void setrangeCommand(client *c) {
             oldsize = stringObjectAllocSize(kv);
         kv->ptr = sdsgrowzero(kv->ptr,offset+value_len);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(kv));
         memcpy((char*)kv->ptr+offset,value,value_len);
         signalModifiedKey(c,c->db,c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_STRING,
@@ -827,7 +827,7 @@ void appendCommand(client *c) {
             oldsize = stringObjectAllocSize(o);
         o->ptr = sdscatlen(o->ptr,append->ptr,append_len);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(o));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, stringObjectAllocSize(o));
         totlen = sdslen(o->ptr);
         int64_t oldlen = totlen - append_len;
         updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, oldlen, totlen);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1799,6 +1799,7 @@ void zaddGenericCommand(client *c, int flags) {
     robj *key = c->argv[1];
     robj *zobj;
     sds ele;
+    size_t oldsize = 0;
     double score = 0, *scores = NULL;
     int j, elements, ch = 0;
     int scoreidx = 0;
@@ -1878,12 +1879,15 @@ void zaddGenericCommand(client *c, int flags) {
         robj *o = zsetTypeCreate(elements, sdslen(c->argv[scoreidx + 1]->ptr));
         zobj = dbAdd(c->db,key,&o);
     } else {
-        size_t oldsize = zsetAllocSize(zobj);
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            oldsize = zsetAllocSize(zobj);
         zsetTypeMaybeConvert(zobj, elements);
-        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     }
 
-    size_t oldsize = zsetAllocSize(zobj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(zobj);
     unsigned long llen = zsetLength(zobj);
     for (j = 0; j < elements; j++) {
         double newscore;
@@ -1894,7 +1898,8 @@ void zaddGenericCommand(client *c, int flags) {
         int retval = zsetAdd(zobj, score, ele, flags, &retflags, &newscore);
         if (retval == 0) {
             addReplyError(c,nanerr);
-            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             goto cleanup;
         }
         if (retflags & ZADD_OUT_ADDED) added++;
@@ -1903,7 +1908,8 @@ void zaddGenericCommand(client *c, int flags) {
         score = newscore;
     }
     server.dirty += (added+updated);
-    updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, llen, llen+added);
 
 reply_to_client:
@@ -1936,16 +1942,19 @@ void zincrbyCommand(client *c) {
 void zremCommand(client *c) {
     robj *key = c->argv[1];
     int deleted = 0, keyremoved = 0, j;
+    size_t oldsize = 0;
 
     kvobj *zobj = lookupKeyWriteOrReply(c, key, shared.czero); 
     if (zobj == NULL || checkType(c,zobj,OBJ_ZSET)) return;
 
     int64_t oldlen = (int64_t) zsetLength(zobj);
-    size_t oldsize = zsetAllocSize(zobj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(zobj);
     for (j = 2; j < c->argc; j++) {
         if (zsetDel(zobj, c->argv[j]->ptr)) deleted++;
         if (zsetLength(zobj) == 0) {
-            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             /* Del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
@@ -1953,7 +1962,7 @@ void zremCommand(client *c) {
         }
     }
 
-    if (!keyremoved)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && !keyremoved)
         updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (deleted) {
         int64_t newlen = oldlen - deleted;
@@ -1986,6 +1995,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     zlexrangespec lexrange;
     long start, end, llen;
     char *notify_type = NULL;
+    size_t oldsize = 0;
 
     /* Step 1: Parse the range. */
     if (rangetype == ZRANGE_RANK) {
@@ -2030,7 +2040,8 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     }
 
     /* Step 3: Perform the range deletion operation. */
-    size_t oldsize = zsetAllocSize(zobj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(zobj);
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         switch(rangetype) {
         case ZRANGE_AUTO:
@@ -2045,7 +2056,8 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
             break;
         }
         if (zzlLength(zobj->ptr) == 0) {
-            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
         }
@@ -2066,7 +2078,8 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
         }
         dictResumeAutoResize(zs->dict);
         if (dictSize(zs->dict) == 0) {
-            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
         } else {
@@ -2077,7 +2090,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     }
 
     /* Step 4: Notifications and reply. */
-    if (!keyremoved)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && !keyremoved)
         updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (deleted) {
         int64_t  oldlen, newlen;
@@ -2740,7 +2753,8 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
             src[i].subject = obj;
             src[i].type = obj->type;
             src[i].encoding = obj->encoding;
-            src[i].oldsize = zuiAllocSize(&src[i]);
+            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+                src[i].oldsize = zuiAllocSize(&src[i]);
         } else {
             src[i].subject = NULL;
         }
@@ -2935,11 +2949,13 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
     } else {
         serverPanic("Unknown operator");
     }
-    for (i = 0; i < setnum; i++) {
-        robj *obj = src[i].subject;
-        if (obj == NULL) continue;
-        updateAllocSizes(c->db, getKeySlot(kvobjGetKey(obj)),
-                         src[i].oldsize, zuiAllocSize(&src[i]));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled) {
+        for (i = 0; i < setnum; i++) {
+            robj *obj = src[i].subject;
+            if (obj == NULL) continue;
+            updateAllocSizes(c->db, getKeySlot(kvobjGetKey(obj)),
+                            src[i].oldsize, zuiAllocSize(&src[i]));
+        }
     }
 
     if (dstkey) {
@@ -3737,6 +3753,7 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
     zlexrangespec lexrange;
     int minidx = argc_start + 1;
     int maxidx = argc_start + 2;
+    size_t oldsize = 0;
 
     /* Options common to all */
     long opt_start = 0;
@@ -3848,7 +3865,8 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
     if (checkType(c,zobj,OBJ_ZSET)) goto cleanup;
 
     /* Step 4: Pass this to the command-specific handler. */
-    size_t oldsize = zsetAllocSize(zobj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(zobj);
     switch (rangetype) {
     case ZRANGE_AUTO:
     case ZRANGE_RANK:
@@ -3866,7 +3884,8 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
             opt_offset, opt_limit, direction == ZRANGE_DIRECTION_REVERSE);
         break;
     }
-    updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 
     /* Instead of returning here, we'll just fall-through the clean-up. */
 
@@ -3891,17 +3910,20 @@ void zscoreCommand(client *c) {
     robj *key = c->argv[1];
     kvobj *zobj;
     double score;
+    size_t oldsize = 0;
 
     if ((zobj = lookupKeyReadOrReply(c,key,shared.null[c->resp])) == NULL ||
         checkType(c,zobj,OBJ_ZSET)) return;
 
-    size_t oldsize = zsetAllocSize(zobj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(zobj);
     if (zsetScore(zobj,c->argv[2]->ptr,&score) == C_ERR) {
         addReplyNull(c);
     } else {
         addReplyDouble(c,score);
     }
-    updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 }
 
 void zmscoreCommand(client *c) {
@@ -3911,7 +3933,8 @@ void zmscoreCommand(client *c) {
     kvobj *zobj = lookupKeyRead(c->db, key);
     if (checkType(c,zobj,OBJ_ZSET)) return;
 
-    if (zobj != NULL) oldsize = zsetAllocSize(zobj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && zobj != NULL)
+        oldsize = zsetAllocSize(zobj);
     addReplyArrayLen(c,c->argc - 2);
     for (int j = 2; j < c->argc; j++) {
         /* Treat a missing set the same way as an empty set */
@@ -3921,7 +3944,7 @@ void zmscoreCommand(client *c) {
             addReplyDouble(c,score);
         }
     }
-    if (zobj != NULL)
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled && zobj != NULL)
         updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 }
 
@@ -3933,6 +3956,7 @@ void zrankGenericCommand(client *c, int reverse) {
     long rank;
     int opt_withscore = 0;
     double score;
+    size_t oldsize = 0;
 
     if (c->argc > 4) {
         addReplyErrorArity(c);
@@ -3950,10 +3974,12 @@ void zrankGenericCommand(client *c, int reverse) {
     if ((zobj = lookupKeyReadOrReply(c, key, reply)) == NULL || checkType(c, zobj, OBJ_ZSET)) {
         return;
     }
-    size_t oldsize = zsetAllocSize(zobj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(zobj);
     serverAssertWithInfo(c, ele, sdsEncodedObject(ele));
     rank = zsetRank(zobj, ele->ptr, reverse, opt_withscore ? &score : NULL);
-    updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (rank >= 0) {
         if (opt_withscore) {
             addReplyArrayLen(c, 2);
@@ -3982,13 +4008,16 @@ void zrevrankCommand(client *c) {
 void zscanCommand(client *c) {
     kvobj *o;
     unsigned long long cursor;
+    size_t oldsize = 0;
 
     if (parseScanCursorOrReply(c,c->argv[2],&cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.emptyscan)) == NULL ||
         checkType(c,o,OBJ_ZSET)) return;
-    size_t oldsize = zsetAllocSize(o);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(o);
     scanGenericCommand(c,o,cursor);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(o));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(o));
 }
 
 /* This command implements the generic zpop operation, used by:
@@ -4019,6 +4048,7 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
     robj *zobj = NULL;
     sds ele;
     double score;
+    size_t oldsize = 0;
 
     if (deleted) *deleted = 0;
 
@@ -4053,7 +4083,8 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
     /* When count is -1, we need to correct it to 1 for plain single pop. */
     if (count == -1) count = 1;
 
-    size_t oldsize = zsetAllocSize(zobj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(zobj);
     long llen = zsetLength(zobj);
     long rangelen = (count > llen) ? llen : count;
 
@@ -4130,7 +4161,8 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
         ++result_count;
     } while(--rangelen);
 
-    updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     
     int64_t oldlen = llen, newlen = llen - result_count;
 
@@ -4291,6 +4323,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     unsigned long count, size;
     int uniq = 1;
     kvobj *zsetobj;
+    size_t oldsize = 0;
 
     if ((zsetobj = lookupKeyReadOrReply(c, c->argv[1], shared.emptyarray))
         == NULL || checkType(c, zsetobj, OBJ_ZSET)) return;
@@ -4309,7 +4342,8 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         return;
     }
 
-    size_t oldsize = zsetAllocSize(zsetobj);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(zsetobj);
 
     /* CASE 1: The count was negative, so the extraction method is just:
      * "return N random elements" sampling the whole set every time.
@@ -4493,7 +4527,8 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     }
     zuiClearIterator(&src);
 out:
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zsetobj));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zsetobj));
 }
 
 /* ZRANDMEMBER key [<count> [WITHSCORES]] */
@@ -4502,6 +4537,7 @@ void zrandmemberCommand(client *c) {
     int withscores = 0;
     kvobj *zset;
     listpackEntry ele;
+    size_t oldsize = 0;
 
     if (c->argc >= 3) {
         if (getRangeLongFromObjectOrReply(c,c->argv[2],-LONG_MAX,LONG_MAX,&l,NULL) != C_OK) return;
@@ -4525,10 +4561,12 @@ void zrandmemberCommand(client *c) {
         return;
     }
 
-    size_t oldsize = zsetAllocSize(zset);
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        oldsize = zsetAllocSize(zset);
     zsetTypeRandomElement(zset, zsetLength(zset), &ele,NULL);
     zsetReplyFromListpackEntry(c,&ele);
-    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zset));
+    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zset));
 }
 
 /* ZMPOP/BZMPOP

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1879,14 +1879,14 @@ void zaddGenericCommand(client *c, int flags) {
         robj *o = zsetTypeCreate(elements, sdslen(c->argv[scoreidx + 1]->ptr));
         zobj = dbAdd(c->db,key,&o);
     } else {
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             oldsize = zsetAllocSize(zobj);
         zsetTypeMaybeConvert(zobj, elements);
-        if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+        if (clusterSlotStatsEnabled())
             updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(zobj);
     unsigned long llen = zsetLength(zobj);
     for (j = 0; j < elements; j++) {
@@ -1898,7 +1898,7 @@ void zaddGenericCommand(client *c, int flags) {
         int retval = zsetAdd(zobj, score, ele, flags, &retflags, &newscore);
         if (retval == 0) {
             addReplyError(c,nanerr);
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             goto cleanup;
         }
@@ -1908,7 +1908,7 @@ void zaddGenericCommand(client *c, int flags) {
         score = newscore;
     }
     server.dirty += (added+updated);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, llen, llen+added);
 
@@ -1948,12 +1948,12 @@ void zremCommand(client *c) {
     if (zobj == NULL || checkType(c,zobj,OBJ_ZSET)) return;
 
     int64_t oldlen = (int64_t) zsetLength(zobj);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(zobj);
     for (j = 2; j < c->argc; j++) {
         if (zsetDel(zobj, c->argv[j]->ptr)) deleted++;
         if (zsetLength(zobj) == 0) {
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             /* Del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
             dbDeleteSkipKeysizesUpdate(c->db, key);
@@ -1962,7 +1962,7 @@ void zremCommand(client *c) {
         }
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && !keyremoved)
+    if (clusterSlotStatsEnabled() && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (deleted) {
         int64_t newlen = oldlen - deleted;
@@ -2040,7 +2040,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     }
 
     /* Step 3: Perform the range deletion operation. */
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(zobj);
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         switch(rangetype) {
@@ -2056,7 +2056,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
             break;
         }
         if (zzlLength(zobj->ptr) == 0) {
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
@@ -2078,7 +2078,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
         }
         dictResumeAutoResize(zs->dict);
         if (dictSize(zs->dict) == 0) {
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
@@ -2090,7 +2090,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     }
 
     /* Step 4: Notifications and reply. */
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && !keyremoved)
+    if (clusterSlotStatsEnabled() && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (deleted) {
         int64_t  oldlen, newlen;
@@ -2753,7 +2753,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
             src[i].subject = obj;
             src[i].type = obj->type;
             src[i].encoding = obj->encoding;
-            if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+            if (clusterSlotStatsEnabled())
                 src[i].oldsize = zuiAllocSize(&src[i]);
         } else {
             src[i].subject = NULL;
@@ -2949,7 +2949,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
     } else {
         serverPanic("Unknown operator");
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled) {
+    if (clusterSlotStatsEnabled()) {
         for (i = 0; i < setnum; i++) {
             robj *obj = src[i].subject;
             if (obj == NULL) continue;
@@ -3865,7 +3865,7 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
     if (checkType(c,zobj,OBJ_ZSET)) goto cleanup;
 
     /* Step 4: Pass this to the command-specific handler. */
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(zobj);
     switch (rangetype) {
     case ZRANGE_AUTO:
@@ -3884,7 +3884,7 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
             opt_offset, opt_limit, direction == ZRANGE_DIRECTION_REVERSE);
         break;
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 
     /* Instead of returning here, we'll just fall-through the clean-up. */
@@ -3915,14 +3915,14 @@ void zscoreCommand(client *c) {
     if ((zobj = lookupKeyReadOrReply(c,key,shared.null[c->resp])) == NULL ||
         checkType(c,zobj,OBJ_ZSET)) return;
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(zobj);
     if (zsetScore(zobj,c->argv[2]->ptr,&score) == C_ERR) {
         addReplyNull(c);
     } else {
         addReplyDouble(c,score);
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 }
 
@@ -3933,7 +3933,7 @@ void zmscoreCommand(client *c) {
     kvobj *zobj = lookupKeyRead(c->db, key);
     if (checkType(c,zobj,OBJ_ZSET)) return;
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && zobj != NULL)
+    if (clusterSlotStatsEnabled() && zobj != NULL)
         oldsize = zsetAllocSize(zobj);
     addReplyArrayLen(c,c->argc - 2);
     for (int j = 2; j < c->argc; j++) {
@@ -3944,7 +3944,7 @@ void zmscoreCommand(client *c) {
             addReplyDouble(c,score);
         }
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled && zobj != NULL)
+    if (clusterSlotStatsEnabled() && zobj != NULL)
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 }
 
@@ -3974,11 +3974,11 @@ void zrankGenericCommand(client *c, int reverse) {
     if ((zobj = lookupKeyReadOrReply(c, key, reply)) == NULL || checkType(c, zobj, OBJ_ZSET)) {
         return;
     }
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(zobj);
     serverAssertWithInfo(c, ele, sdsEncodedObject(ele));
     rank = zsetRank(zobj, ele->ptr, reverse, opt_withscore ? &score : NULL);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (rank >= 0) {
         if (opt_withscore) {
@@ -4013,10 +4013,10 @@ void zscanCommand(client *c) {
     if (parseScanCursorOrReply(c,c->argv[2],&cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.emptyscan)) == NULL ||
         checkType(c,o,OBJ_ZSET)) return;
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(o);
     scanGenericCommand(c,o,cursor);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(o));
 }
 
@@ -4083,7 +4083,7 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
     /* When count is -1, we need to correct it to 1 for plain single pop. */
     if (count == -1) count = 1;
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(zobj);
     long llen = zsetLength(zobj);
     long rangelen = (count > llen) ? llen : count;
@@ -4161,7 +4161,7 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
         ++result_count;
     } while(--rangelen);
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     
     int64_t oldlen = llen, newlen = llen - result_count;
@@ -4342,7 +4342,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         return;
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(zsetobj);
 
     /* CASE 1: The count was negative, so the extraction method is just:
@@ -4527,7 +4527,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     }
     zuiClearIterator(&src);
 out:
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zsetobj));
 }
 
@@ -4561,11 +4561,11 @@ void zrandmemberCommand(client *c) {
         return;
     }
 
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         oldsize = zsetAllocSize(zset);
     zsetTypeRandomElement(zset, zsetLength(zset), &ele,NULL);
     zsetReplyFromListpackEntry(c,&ele);
-    if (server.cluster_enabled && server.cluster_slot_stats_enabled)
+    if (clusterSlotStatsEnabled())
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zset));
 }
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1233,7 +1233,7 @@ unsigned long zsetLength(const robj *zobj) {
 }
 
 size_t zsetAllocSize(const robj *o) {
-    debugServerAssertWithInfo(NULL,o,o->type == OBJ_ZSET);
+    serverAssertWithInfo(NULL,o,o->type == OBJ_ZSET);
     size_t size = 0;
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
         size = lpBytes(o->ptr);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1879,14 +1879,14 @@ void zaddGenericCommand(client *c, int flags) {
         robj *o = zsetTypeCreate(elements, sdslen(c->argv[scoreidx + 1]->ptr));
         zobj = dbAdd(c->db,key,&o);
     } else {
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             oldsize = zsetAllocSize(zobj);
         zsetTypeMaybeConvert(zobj, elements);
-        if (clusterSlotStatsEnabled())
+        if (server.memory_tracking_per_slot)
             updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     }
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(zobj);
     unsigned long llen = zsetLength(zobj);
     for (j = 0; j < elements; j++) {
@@ -1898,7 +1898,7 @@ void zaddGenericCommand(client *c, int flags) {
         int retval = zsetAdd(zobj, score, ele, flags, &retflags, &newscore);
         if (retval == 0) {
             addReplyError(c,nanerr);
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             goto cleanup;
         }
@@ -1908,7 +1908,7 @@ void zaddGenericCommand(client *c, int flags) {
         score = newscore;
     }
     server.dirty += (added+updated);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, llen, llen+added);
 
@@ -1948,12 +1948,12 @@ void zremCommand(client *c) {
     if (zobj == NULL || checkType(c,zobj,OBJ_ZSET)) return;
 
     int64_t oldlen = (int64_t) zsetLength(zobj);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(zobj);
     for (j = 2; j < c->argc; j++) {
         if (zsetDel(zobj, c->argv[j]->ptr)) deleted++;
         if (zsetLength(zobj) == 0) {
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             /* Del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
             dbDeleteSkipKeysizesUpdate(c->db, key);
@@ -1962,7 +1962,7 @@ void zremCommand(client *c) {
         }
     }
 
-    if (clusterSlotStatsEnabled() && !keyremoved)
+    if (server.memory_tracking_per_slot && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (deleted) {
         int64_t newlen = oldlen - deleted;
@@ -2040,7 +2040,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     }
 
     /* Step 3: Perform the range deletion operation. */
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(zobj);
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         switch(rangetype) {
@@ -2056,7 +2056,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
             break;
         }
         if (zzlLength(zobj->ptr) == 0) {
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
@@ -2078,7 +2078,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
         }
         dictResumeAutoResize(zs->dict);
         if (dictSize(zs->dict) == 0) {
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
@@ -2090,7 +2090,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     }
 
     /* Step 4: Notifications and reply. */
-    if (clusterSlotStatsEnabled() && !keyremoved)
+    if (server.memory_tracking_per_slot && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (deleted) {
         int64_t  oldlen, newlen;
@@ -2753,7 +2753,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
             src[i].subject = obj;
             src[i].type = obj->type;
             src[i].encoding = obj->encoding;
-            if (clusterSlotStatsEnabled())
+            if (server.memory_tracking_per_slot)
                 src[i].oldsize = zuiAllocSize(&src[i]);
         } else {
             src[i].subject = NULL;
@@ -2949,7 +2949,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
     } else {
         serverPanic("Unknown operator");
     }
-    if (clusterSlotStatsEnabled()) {
+    if (server.memory_tracking_per_slot) {
         for (i = 0; i < setnum; i++) {
             robj *obj = src[i].subject;
             if (obj == NULL) continue;
@@ -3865,7 +3865,7 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
     if (checkType(c,zobj,OBJ_ZSET)) goto cleanup;
 
     /* Step 4: Pass this to the command-specific handler. */
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(zobj);
     switch (rangetype) {
     case ZRANGE_AUTO:
@@ -3884,7 +3884,7 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
             opt_offset, opt_limit, direction == ZRANGE_DIRECTION_REVERSE);
         break;
     }
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 
     /* Instead of returning here, we'll just fall-through the clean-up. */
@@ -3915,14 +3915,14 @@ void zscoreCommand(client *c) {
     if ((zobj = lookupKeyReadOrReply(c,key,shared.null[c->resp])) == NULL ||
         checkType(c,zobj,OBJ_ZSET)) return;
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(zobj);
     if (zsetScore(zobj,c->argv[2]->ptr,&score) == C_ERR) {
         addReplyNull(c);
     } else {
         addReplyDouble(c,score);
     }
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 }
 
@@ -3933,7 +3933,7 @@ void zmscoreCommand(client *c) {
     kvobj *zobj = lookupKeyRead(c->db, key);
     if (checkType(c,zobj,OBJ_ZSET)) return;
 
-    if (clusterSlotStatsEnabled() && zobj != NULL)
+    if (server.memory_tracking_per_slot && zobj != NULL)
         oldsize = zsetAllocSize(zobj);
     addReplyArrayLen(c,c->argc - 2);
     for (int j = 2; j < c->argc; j++) {
@@ -3944,7 +3944,7 @@ void zmscoreCommand(client *c) {
             addReplyDouble(c,score);
         }
     }
-    if (clusterSlotStatsEnabled() && zobj != NULL)
+    if (server.memory_tracking_per_slot && zobj != NULL)
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 }
 
@@ -3974,11 +3974,11 @@ void zrankGenericCommand(client *c, int reverse) {
     if ((zobj = lookupKeyReadOrReply(c, key, reply)) == NULL || checkType(c, zobj, OBJ_ZSET)) {
         return;
     }
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(zobj);
     serverAssertWithInfo(c, ele, sdsEncodedObject(ele));
     rank = zsetRank(zobj, ele->ptr, reverse, opt_withscore ? &score : NULL);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (rank >= 0) {
         if (opt_withscore) {
@@ -4013,10 +4013,10 @@ void zscanCommand(client *c) {
     if (parseScanCursorOrReply(c,c->argv[2],&cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.emptyscan)) == NULL ||
         checkType(c,o,OBJ_ZSET)) return;
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(o);
     scanGenericCommand(c,o,cursor);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(o));
 }
 
@@ -4083,7 +4083,7 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
     /* When count is -1, we need to correct it to 1 for plain single pop. */
     if (count == -1) count = 1;
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(zobj);
     long llen = zsetLength(zobj);
     long rangelen = (count > llen) ? llen : count;
@@ -4161,7 +4161,7 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
         ++result_count;
     } while(--rangelen);
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     
     int64_t oldlen = llen, newlen = llen - result_count;
@@ -4342,7 +4342,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         return;
     }
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(zsetobj);
 
     /* CASE 1: The count was negative, so the extraction method is just:
@@ -4527,7 +4527,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     }
     zuiClearIterator(&src);
 out:
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zsetobj));
 }
 
@@ -4561,11 +4561,11 @@ void zrandmemberCommand(client *c) {
         return;
     }
 
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         oldsize = zsetAllocSize(zset);
     zsetTypeRandomElement(zset, zsetLength(zset), &ele,NULL);
     zsetReplyFromListpackEntry(c,&ele);
-    if (clusterSlotStatsEnabled())
+    if (server.memory_tracking_per_slot)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zset));
 }
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1883,7 +1883,7 @@ void zaddGenericCommand(client *c, int flags) {
             oldsize = zsetAllocSize(zobj);
         zsetTypeMaybeConvert(zobj, elements);
         if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+            updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     }
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
@@ -1899,7 +1899,7 @@ void zaddGenericCommand(client *c, int flags) {
         if (retval == 0) {
             addReplyError(c,nanerr);
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+                updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             goto cleanup;
         }
         if (retflags & ZADD_OUT_ADDED) added++;
@@ -1909,7 +1909,7 @@ void zaddGenericCommand(client *c, int flags) {
     }
     server.dirty += (added+updated);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+        updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, llen, llen+added);
 
 reply_to_client:
@@ -1954,7 +1954,7 @@ void zremCommand(client *c) {
         if (zsetDel(zobj, c->argv[j]->ptr)) deleted++;
         if (zsetLength(zobj) == 0) {
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+                updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             /* Del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
@@ -1963,7 +1963,7 @@ void zremCommand(client *c) {
     }
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && !keyremoved)
-        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+        updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (deleted) {
         int64_t newlen = oldlen - deleted;
         notifyKeyspaceEvent(NOTIFY_ZSET,"zrem",key,c->db->id);
@@ -2057,7 +2057,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
         }
         if (zzlLength(zobj->ptr) == 0) {
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+                updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
         }
@@ -2079,7 +2079,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
         dictResumeAutoResize(zs->dict);
         if (dictSize(zs->dict) == 0) {
             if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-                updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+                updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
         } else {
@@ -2091,7 +2091,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
 
     /* Step 4: Notifications and reply. */
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && !keyremoved)
-        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+        updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (deleted) {
         int64_t  oldlen, newlen;
         signalModifiedKey(c,c->db,key);
@@ -2953,7 +2953,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
         for (i = 0; i < setnum; i++) {
             robj *obj = src[i].subject;
             if (obj == NULL) continue;
-            updateAllocSizes(c->db, getKeySlot(kvobjGetKey(obj)),
+            updateSlotAllocSize(c->db, getKeySlot(kvobjGetKey(obj)),
                             src[i].oldsize, zuiAllocSize(&src[i]));
         }
     }
@@ -3885,7 +3885,7 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
         break;
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+        updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 
     /* Instead of returning here, we'll just fall-through the clean-up. */
 
@@ -3923,7 +3923,7 @@ void zscoreCommand(client *c) {
         addReplyDouble(c,score);
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+        updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 }
 
 void zmscoreCommand(client *c) {
@@ -3945,7 +3945,7 @@ void zmscoreCommand(client *c) {
         }
     }
     if (server.cluster_enabled && server.cluster_slot_stats_enabled && zobj != NULL)
-        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+        updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 }
 
 void zrankGenericCommand(client *c, int reverse) {
@@ -3979,7 +3979,7 @@ void zrankGenericCommand(client *c, int reverse) {
     serverAssertWithInfo(c, ele, sdsEncodedObject(ele));
     rank = zsetRank(zobj, ele->ptr, reverse, opt_withscore ? &score : NULL);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+        updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (rank >= 0) {
         if (opt_withscore) {
             addReplyArrayLen(c, 2);
@@ -4017,7 +4017,7 @@ void zscanCommand(client *c) {
         oldsize = zsetAllocSize(o);
     scanGenericCommand(c,o,cursor);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(o));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(o));
 }
 
 /* This command implements the generic zpop operation, used by:
@@ -4162,7 +4162,7 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
     } while(--rangelen);
 
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
+        updateSlotAllocSize(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     
     int64_t oldlen = llen, newlen = llen - result_count;
 
@@ -4528,7 +4528,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     zuiClearIterator(&src);
 out:
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zsetobj));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zsetobj));
 }
 
 /* ZRANDMEMBER key [<count> [WITHSCORES]] */
@@ -4566,7 +4566,7 @@ void zrandmemberCommand(client *c) {
     zsetTypeRandomElement(zset, zsetLength(zset), &ele,NULL);
     zsetReplyFromListpackEntry(c,&ele);
     if (server.cluster_enabled && server.cluster_slot_stats_enabled)
-        updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zset));
+        updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zset));
 }
 
 /* ZMPOP/BZMPOP

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1232,6 +1232,22 @@ unsigned long zsetLength(const robj *zobj) {
     return length;
 }
 
+size_t zsetAllocSize(const robj *o) {
+    debugServerAssertWithInfo(NULL,o,o->type == OBJ_ZSET);
+    size_t size = 0;
+    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+        size = lpBytes(o->ptr);
+    } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
+        dict *d = ((zset*)o->ptr)->dict;
+        zskiplist *zsl = ((zset*)o->ptr)->zsl;
+        size = sizeof(zset) + zslAllocSize(zsl) +
+            sizeof(dict) + dictMemUsage(d);
+    } else {
+        serverPanic("Unknown sorted set encoding");
+    }
+    return size;
+}
+
 /* Factory method to return a zset.
  *
  * The size hint indicates approximately how many items will be added,
@@ -1862,9 +1878,12 @@ void zaddGenericCommand(client *c, int flags) {
         robj *o = zsetTypeCreate(elements, sdslen(c->argv[scoreidx + 1]->ptr));
         zobj = dbAdd(c->db,key,&o);
     } else {
+        size_t oldsize = zsetAllocSize(zobj);
         zsetTypeMaybeConvert(zobj, elements);
+        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     }
 
+    size_t oldsize = zsetAllocSize(zobj);
     unsigned long llen = zsetLength(zobj);
     for (j = 0; j < elements; j++) {
         double newscore;
@@ -1875,6 +1894,7 @@ void zaddGenericCommand(client *c, int flags) {
         int retval = zsetAdd(zobj, score, ele, flags, &retflags, &newscore);
         if (retval == 0) {
             addReplyError(c,nanerr);
+            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             goto cleanup;
         }
         if (retflags & ZADD_OUT_ADDED) added++;
@@ -1883,6 +1903,7 @@ void zaddGenericCommand(client *c, int flags) {
         score = newscore;
     }
     server.dirty += (added+updated);
+    updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, llen, llen+added);
 
 reply_to_client:
@@ -1920,9 +1941,11 @@ void zremCommand(client *c) {
     if (zobj == NULL || checkType(c,zobj,OBJ_ZSET)) return;
 
     int64_t oldlen = (int64_t) zsetLength(zobj);
+    size_t oldsize = zsetAllocSize(zobj);
     for (j = 2; j < c->argc; j++) {
         if (zsetDel(zobj, c->argv[j]->ptr)) deleted++;
         if (zsetLength(zobj) == 0) {
+            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             /* Del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
@@ -1930,6 +1953,8 @@ void zremCommand(client *c) {
         }
     }
 
+    if (!keyremoved)
+        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (deleted) {
         int64_t newlen = oldlen - deleted;
         notifyKeyspaceEvent(NOTIFY_ZSET,"zrem",key,c->db->id);
@@ -1937,7 +1962,7 @@ void zremCommand(client *c) {
             notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
             newlen = -1; /* means key got deleted */
         }
-        
+
         updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, oldlen, newlen);
         signalModifiedKey(c,c->db,key);
         server.dirty += deleted;
@@ -2005,6 +2030,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     }
 
     /* Step 3: Perform the range deletion operation. */
+    size_t oldsize = zsetAllocSize(zobj);
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         switch(rangetype) {
         case ZRANGE_AUTO:
@@ -2019,6 +2045,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
             break;
         }
         if (zzlLength(zobj->ptr) == 0) {
+            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
         }
@@ -2039,6 +2066,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
         }
         dictResumeAutoResize(zs->dict);
         if (dictSize(zs->dict) == 0) {
+            updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
             dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
         } else {
@@ -2049,6 +2077,8 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     }
 
     /* Step 4: Notifications and reply. */
+    if (!keyremoved)
+        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (deleted) {
         int64_t  oldlen, newlen;
         signalModifiedKey(c,c->db,key);
@@ -2087,6 +2117,7 @@ typedef struct {
     int type; /* Set, sorted set */
     int encoding;
     double weight;
+    size_t oldsize;
 
     union {
         /* Set iterators. */
@@ -2239,6 +2270,19 @@ unsigned long zuiLength(zsetopsrc *op) {
         } else {
             serverPanic("Unknown sorted set encoding");
         }
+    } else {
+        serverPanic("Unsupported type");
+    }
+}
+
+unsigned long zuiAllocSize(zsetopsrc *op) {
+    if (op->subject == NULL)
+        return 0;
+
+    if (op->type == OBJ_SET) {
+        return setTypeAllocSize(op->subject);
+    } else if (op->type == OBJ_ZSET) {
+        return zsetAllocSize(op->subject);
     } else {
         serverPanic("Unsupported type");
     }
@@ -2696,6 +2740,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
             src[i].subject = obj;
             src[i].type = obj->type;
             src[i].encoding = obj->encoding;
+            src[i].oldsize = zuiAllocSize(&src[i]);
         } else {
             src[i].subject = NULL;
         }
@@ -2889,6 +2934,12 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
         zdiff(src, setnum, dstzset, &maxelelen, &totelelen);
     } else {
         serverPanic("Unknown operator");
+    }
+    for (i = 0; i < setnum; i++) {
+        robj *obj = src[i].subject;
+        if (obj == NULL) continue;
+        updateAllocSizes(c->db, getKeySlot(kvobjGetKey(obj)),
+                         src[i].oldsize, zuiAllocSize(&src[i]));
     }
 
     if (dstkey) {
@@ -3797,6 +3848,7 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
     if (checkType(c,zobj,OBJ_ZSET)) goto cleanup;
 
     /* Step 4: Pass this to the command-specific handler. */
+    size_t oldsize = zsetAllocSize(zobj);
     switch (rangetype) {
     case ZRANGE_AUTO:
     case ZRANGE_RANK:
@@ -3814,6 +3866,7 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
             opt_offset, opt_limit, direction == ZRANGE_DIRECTION_REVERSE);
         break;
     }
+    updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 
     /* Instead of returning here, we'll just fall-through the clean-up. */
 
@@ -3842,19 +3895,23 @@ void zscoreCommand(client *c) {
     if ((zobj = lookupKeyReadOrReply(c,key,shared.null[c->resp])) == NULL ||
         checkType(c,zobj,OBJ_ZSET)) return;
 
+    size_t oldsize = zsetAllocSize(zobj);
     if (zsetScore(zobj,c->argv[2]->ptr,&score) == C_ERR) {
         addReplyNull(c);
     } else {
         addReplyDouble(c,score);
     }
+    updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 }
 
 void zmscoreCommand(client *c) {
     robj *key = c->argv[1];
     double score;
+    size_t oldsize = 0;
     kvobj *zobj = lookupKeyRead(c->db, key);
     if (checkType(c,zobj,OBJ_ZSET)) return;
 
+    if (zobj != NULL) oldsize = zsetAllocSize(zobj);
     addReplyArrayLen(c,c->argc - 2);
     for (int j = 2; j < c->argc; j++) {
         /* Treat a missing set the same way as an empty set */
@@ -3864,6 +3921,8 @@ void zmscoreCommand(client *c) {
             addReplyDouble(c,score);
         }
     }
+    if (zobj != NULL)
+        updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
 }
 
 void zrankGenericCommand(client *c, int reverse) {
@@ -3891,8 +3950,10 @@ void zrankGenericCommand(client *c, int reverse) {
     if ((zobj = lookupKeyReadOrReply(c, key, reply)) == NULL || checkType(c, zobj, OBJ_ZSET)) {
         return;
     }
+    size_t oldsize = zsetAllocSize(zobj);
     serverAssertWithInfo(c, ele, sdsEncodedObject(ele));
     rank = zsetRank(zobj, ele->ptr, reverse, opt_withscore ? &score : NULL);
+    updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     if (rank >= 0) {
         if (opt_withscore) {
             addReplyArrayLen(c, 2);
@@ -3925,7 +3986,9 @@ void zscanCommand(client *c) {
     if (parseScanCursorOrReply(c,c->argv[2],&cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.emptyscan)) == NULL ||
         checkType(c,o,OBJ_ZSET)) return;
+    size_t oldsize = zsetAllocSize(o);
     scanGenericCommand(c,o,cursor);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(o));
 }
 
 /* This command implements the generic zpop operation, used by:
@@ -3990,6 +4053,7 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
     /* When count is -1, we need to correct it to 1 for plain single pop. */
     if (count == -1) count = 1;
 
+    size_t oldsize = zsetAllocSize(zobj);
     long llen = zsetLength(zobj);
     long rangelen = (count > llen) ? llen : count;
 
@@ -4065,6 +4129,8 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
         sdsfree(ele);
         ++result_count;
     } while(--rangelen);
+
+    updateAllocSizes(c->db, getKeySlot(key->ptr), oldsize, zsetAllocSize(zobj));
     
     int64_t oldlen = llen, newlen = llen - result_count;
 
@@ -4243,6 +4309,8 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         return;
     }
 
+    size_t oldsize = zsetAllocSize(zsetobj);
+
     /* CASE 1: The count was negative, so the extraction method is just:
      * "return N random elements" sampling the whole set every time.
      * This case is trivial and can be served without auxiliary data
@@ -4284,7 +4352,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
             zfree(keys);
             zfree(vals);
         }
-        return;
+        goto out;
     }
 
     zsetopsrc src;
@@ -4314,7 +4382,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
                 addReplyDouble(c, zval.score);
         }
         zuiClearIterator(&src);
-        return;
+        goto out;
     }
 
     /* CASE 2.5 listpack only. Sampling unique elements, in non-random order.
@@ -4335,7 +4403,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         zfree(keys);
         zfree(vals);
         zuiClearIterator(&src);
-        return;
+        goto out;
     }
 
     /* CASE 3:
@@ -4424,6 +4492,8 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         dictRelease(d);
     }
     zuiClearIterator(&src);
+out:
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zsetobj));
 }
 
 /* ZRANDMEMBER key [<count> [WITHSCORES]] */
@@ -4455,8 +4525,10 @@ void zrandmemberCommand(client *c) {
         return;
     }
 
+    size_t oldsize = zsetAllocSize(zset);
     zsetTypeRandomElement(zset, zsetLength(zset), &ele,NULL);
     zsetReplyFromListpackEntry(c,&ele);
+    updateAllocSizes(c->db, getKeySlot(c->argv[1]->ptr), oldsize, zsetAllocSize(zset));
 }
 
 /* ZMPOP/BZMPOP

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -786,7 +786,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
 
 start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
 
-    set metrics [list "key-count" "cpu-usec" "network-bytes-in" "network-bytes-out"]
+    set metrics [list "key-count" "memory-bytes" "cpu-usec" "network-bytes-in" "network-bytes-out"]
 
     # SET keys for target hashslots, to encourage ordering.
     set hash_tags [list 0 1 2 3 4]

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -518,12 +518,13 @@ start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-en
 # Test cases for CLUSTER SLOT-STATS network-bytes-out correctness.
 # -----------------------------------------------------------------------------
 
-start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+start_cluster 1 0 {tags {external:skip cluster}} {
     # Define shared variables.
     set key "FOO"
     set key_slot [R 0 cluster keyslot $key]
     set expected_slots_to_key_count [dict create $key_slot 1]
     set metrics_to_assert [list network-bytes-out]
+    R 0 CONFIG SET cluster-slot-stats-enabled yes
 
     test "CLUSTER SLOT-STATS network-bytes-out, for non-slot specific commands." {
         R 0 INFO
@@ -575,12 +576,13 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
     R 0 FLUSHALL
 }
 
-start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+start_cluster 1 1 {tags {external:skip cluster}} {
 
     # Define shared variables.
     set key "FOO"
     set key_slot [R 0 CLUSTER KEYSLOT $key]
     set metrics_to_assert [list network-bytes-out]
+    R 0 CONFIG SET cluster-slot-stats-enabled yes
 
     # Setup replication.
     assert {[s -1 role] eq {slave}}
@@ -605,7 +607,7 @@ start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-en
     }
 }
 
-start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+start_cluster 1 1 {tags {external:skip cluster}} {
 
     # Define shared variables.
     set channel "channel"
@@ -613,6 +615,7 @@ start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-en
     set channel_secondary "channel2"
     set key_slot_secondary [R 0 cluster keyslot $channel_secondary]
     set metrics_to_assert [list network-bytes-out]
+    R 0 CONFIG SET cluster-slot-stats-enabled yes
 
     test "CLUSTER SLOT-STATS network-bytes-out, sharded pub/sub, single channel." {
         set slot [R 0 cluster keyslot $channel]
@@ -858,18 +861,7 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         }
     }
 
-    test "CLUSTER SLOT-STATS ORDERBY arg sanity check (slot stats enabled)." {
-        # Non-existent argument.
-        assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY key-count non-existent-arg}
-        # Negative LIMIT.
-        assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY key-count DESC LIMIT -1}
-        # Non-existent ORDERBY metric.
-        assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY non-existent-metric}
-    }
-}
-
-start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled no}} {
-    test "CLUSTER SLOT-STATS ORDERBY arg sanity check (slot stats disabled)." {
+    test "CLUSTER SLOT-STATS ORDERBY arg sanity check." {
         # Non-existent argument.
         assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY key-count non-existent-arg}
         # Negative LIMIT.
@@ -877,6 +869,7 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         # Non-existent ORDERBY metric.
         assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY non-existent-metric}
         # When cluster-slot-stats-enabled config is disabled, you cannot sort using advanced metrics.
+        R 0 CONFIG SET cluster-slot-stats-enabled no
         set orderby "cpu-usec"
         assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY $orderby}
         set orderby "network-bytes-in"
@@ -884,6 +877,7 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         set orderby "network-bytes-out"
         assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY $orderby}
     }
+
 }
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -518,13 +518,12 @@ start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-en
 # Test cases for CLUSTER SLOT-STATS network-bytes-out correctness.
 # -----------------------------------------------------------------------------
 
-start_cluster 1 0 {tags {external:skip cluster}} {
+start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
     # Define shared variables.
     set key "FOO"
     set key_slot [R 0 cluster keyslot $key]
     set expected_slots_to_key_count [dict create $key_slot 1]
     set metrics_to_assert [list network-bytes-out]
-    R 0 CONFIG SET cluster-slot-stats-enabled yes
 
     test "CLUSTER SLOT-STATS network-bytes-out, for non-slot specific commands." {
         R 0 INFO
@@ -576,13 +575,12 @@ start_cluster 1 0 {tags {external:skip cluster}} {
     R 0 FLUSHALL
 }
 
-start_cluster 1 1 {tags {external:skip cluster}} {
+start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
 
     # Define shared variables.
     set key "FOO"
     set key_slot [R 0 CLUSTER KEYSLOT $key]
     set metrics_to_assert [list network-bytes-out]
-    R 0 CONFIG SET cluster-slot-stats-enabled yes
 
     # Setup replication.
     assert {[s -1 role] eq {slave}}
@@ -607,7 +605,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
     }
 }
 
-start_cluster 1 1 {tags {external:skip cluster}} {
+start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
 
     # Define shared variables.
     set channel "channel"
@@ -615,7 +613,6 @@ start_cluster 1 1 {tags {external:skip cluster}} {
     set channel_secondary "channel2"
     set key_slot_secondary [R 0 cluster keyslot $channel_secondary]
     set metrics_to_assert [list network-bytes-out]
-    R 0 CONFIG SET cluster-slot-stats-enabled yes
 
     test "CLUSTER SLOT-STATS network-bytes-out, sharded pub/sub, single channel." {
         set slot [R 0 cluster keyslot $channel]
@@ -861,7 +858,18 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         }
     }
 
-    test "CLUSTER SLOT-STATS ORDERBY arg sanity check." {
+    test "CLUSTER SLOT-STATS ORDERBY arg sanity check (slot stats enabled)." {
+        # Non-existent argument.
+        assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY key-count non-existent-arg}
+        # Negative LIMIT.
+        assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY key-count DESC LIMIT -1}
+        # Non-existent ORDERBY metric.
+        assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY non-existent-metric}
+    }
+}
+
+start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled no}} {
+    test "CLUSTER SLOT-STATS ORDERBY arg sanity check (slot stats disabled)." {
         # Non-existent argument.
         assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY key-count non-existent-arg}
         # Negative LIMIT.
@@ -869,7 +877,6 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         # Non-existent ORDERBY metric.
         assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY non-existent-metric}
         # When cluster-slot-stats-enabled config is disabled, you cannot sort using advanced metrics.
-        R 0 CONFIG SET cluster-slot-stats-enabled no
         set orderby "cpu-usec"
         assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY $orderby}
         set orderby "network-bytes-in"
@@ -877,7 +884,6 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         set orderby "network-bytes-out"
         assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY $orderby}
     }
-
 }
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/info-keysizes.tcl
+++ b/tests/unit/info-keysizes.tcl
@@ -484,6 +484,14 @@ proc test_all_keysizes { {replMode 0} } {
             createComplexDataset r 100 {useexpire usehexpire}
         }
     }
+    start_server {tags {"external:skip" "needs:debug"}} {
+        test "SLOT-ALLOCSIZE - Test DEBUG ALLOCSIZE-SLOTS-ASSERT command" {
+            r DEBUG ALLOCSIZE-SLOTS-ASSERT 1
+            r FLUSHALL
+            createComplexDataset r 100
+            createComplexDataset r 100 {useexpire usehexpire}
+        }
+    }
     
     foreach type {listpackex hashtable} {
         # Test different implementations of hash tables and listpacks

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -564,6 +564,7 @@ start_server {tags {"introspection"}} {
             always-show-logo
             syslog-enabled
             cluster-enabled
+            cluster-slot-stats-enabled
             disable-thp
             aclfile
             unixsocket

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -564,7 +564,6 @@ start_server {tags {"introspection"}} {
             always-show-logo
             syslog-enabled
             cluster-enabled
-            cluster-slot-stats-enabled
             disable-thp
             aclfile
             unixsocket


### PR DESCRIPTION
Add per slot memory accounting.

See issue #10472 and the discussion in #14119 for background and motivation.
 
We leverage per key memory accounting introduced in #14363 and extend it to
per slot level.

The per slot metrics are available through the `CLUSTER SLOT-STATS` command,
introduced in #14039, and is reported in the `memory-bytes` map field.

To enable per slot memory tracking `cluster_slot_stats_enabled` config must be set
on redis startup. The reason for this is that starting redis without per slot accounting
and enabling it later would imply iterating over all slots and robjs in order to catch up
and we want to avoid this.

Note that hash, set and zset types of robjs we need to account for changes in the
objects' allocation size both for read and write commands since the underlying dicts
may be continuously rehashing even during dict lookups and iteration.