### PR TITLE
Fix flags of DELEX command

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -10786,7 +10786,7 @@ struct COMMAND_ARG DECRBY_Args[] = {
 #ifndef SKIP_CMD_KEY_SPECS_TABLE
 /* DELEX key specs */
 keySpec DELEX_Keyspecs[1] = {
-{NULL,CMD_KEY_RM|CMD_KEY_DELETE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+{NULL,CMD_KEY_RW|CMD_KEY_DELETE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
 };
 #endif
 

--- a/src/commands/delex.json
+++ b/src/commands/delex.json
@@ -16,7 +16,7 @@
         "key_specs": [
             {
                 "flags": [
-                    "RM",
+                    "RW",
                     "DELETE"
                 ],
                 "begin_search": {

--- a/src/server.h
+++ b/src/server.h
@@ -292,11 +292,12 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
  * distinctly deletion, overwrite or read-only would be marked as RW. */
 #define CMD_KEY_RO (1ULL<<0)     /* Read-Only - Reads the value of the key, but
                                   * doesn't necessarily returns it. */
-#define CMD_KEY_RW (1ULL<<1)     /* Read-Write - Modifies the data stored in the
-                                  * value of the key or its metadata. */
+#define CMD_KEY_RW (1ULL<<1)     /* Read-Write - Reads and modifies/deletes
+                                  * the data stored in the value of the key or
+                                  * its metadata. */
 #define CMD_KEY_OW (1ULL<<2)     /* Overwrite - Overwrites the data stored in
                                   * the value of the key. */
-#define CMD_KEY_RM (1ULL<<3)     /* Deletes the key. */
+#define CMD_KEY_RM (1ULL<<3)     /* Deletes the key without reading it's value. */
 /* The following refer to user data inside the value of the key, not the metadata
  * like LRU, type, cardinality. It refers to the logical operation on the user's
  * data (actual input strings / TTL), being used / returned / copied / changed,


### PR DESCRIPTION
In #14435 the `RM` flag  was incorrect for the DELEX command as the Redis command code accesses and uses the value of the key, it needs to be RW (just like `GETDEL` command).