### PR TITLE
Fix re-entrant deadlock in bugReportStart() when called from signal handlers

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -685,13 +685,13 @@ NULL
             addReplyErrorObject(c,shared.nokeyerr);
             return;
         }
-
+        
         val = kv;
         key = kvobjGetKey(kv);
         if (kv->type != OBJ_STRING || !sdsEncodedObject(val)) {
             addReplyError(c,"Not an sds encoded string.");
         } else {
-            /* The key's allocation size reflects the entire robj allocation.
+            /* The key's allocation size reflects the entire robj allocation.  
              * For embedded values, report an allocation size of 0. */
             size_t obj_alloc = zmalloc_usable_size(val);
             size_t val_alloc = val->encoding == OBJ_ENCODING_RAW ? sdsAllocSize(val->ptr) : 0;
@@ -755,7 +755,7 @@ NULL
             return;
         }
         long valsize = 0;
-        if ( c->argc == 5 && getPositiveLongFromObjectOrReply(c, c->argv[4], &valsize, NULL) != C_OK )
+        if ( c->argc == 5 && getPositiveLongFromObjectOrReply(c, c->argv[4], &valsize, NULL) != C_OK ) 
             return;
 
         for (j = 0; j < keys; j++) {
@@ -2728,7 +2728,7 @@ static int is_thread_ready_to_signal(const char *proc_pid_task_path, const char 
                 break;
             }
 
-            /* The bit position in a signal mask aligns with the signal number. Since signal numbers start from 1
+            /* The bit position in a signal mask aligns with the signal number. Since signal numbers start from 1 
             we need to adjust the signal number by subtracting 1 to align it correctly with the zero-based indexing used */
             if (sig_mask & (1L << (sig_num - 1))) { /* if the signal is blocked/ignored return 0 */
                 ret = 0;
@@ -2748,7 +2748,7 @@ static int is_thread_ready_to_signal(const char *proc_pid_task_path, const char 
     return ret;
 }
 
-/** We are using syscall(SYS_getdents64) to read directories, which unlike opendir(), is considered
+/** We are using syscall(SYS_getdents64) to read directories, which unlike opendir(), is considered 
  * async-signal-safe. This function wrapper getdents64() in glibc is supported as of glibc 2.30.
  * To support earlier versions of glibc, we use syscall(SYS_getdents64), which requires defining
  * linux_dirent64 ourselves. This structure is very old and stable: It will not change unless the kernel
@@ -2807,7 +2807,7 @@ static size_t get_ready_to_signal_threads_tids(int sig_num, pid_t tids[TIDS_MAX_
 
             /* save the thread id */
             tids[tids_count++] = tid;
-
+            
             /* Stop if we reached the maximum threads number. */
             if(tids_count == TIDS_MAX_SIZE) {
                 serverLogRawFromHandler(LL_WARNING, "get_ready_to_signal_threads_tids(): Reached the limit of the tids buffer.");

--- a/src/debug.c
+++ b/src/debug.c
@@ -53,7 +53,9 @@ typedef ucontext_t sigcontext_t;
 
 /* Globals */
 static int bug_report_start = 0; /* True if bug report header was already logged. */
-static pthread_mutex_t bug_report_start_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t bug_report_start_mutex;
+static pthread_mutexattr_t bug_report_start_attr;
+
 /* Mutex for a case when two threads crash at the same time. */
 static pthread_mutex_t signal_handler_lock;
 static pthread_mutexattr_t signal_handler_lock_attr;
@@ -683,13 +685,13 @@ NULL
             addReplyErrorObject(c,shared.nokeyerr);
             return;
         }
-        
+
         val = kv;
         key = kvobjGetKey(kv);
         if (kv->type != OBJ_STRING || !sdsEncodedObject(val)) {
             addReplyError(c,"Not an sds encoded string.");
         } else {
-            /* The key's allocation size reflects the entire robj allocation.  
+            /* The key's allocation size reflects the entire robj allocation.
              * For embedded values, report an allocation size of 0. */
             size_t obj_alloc = zmalloc_usable_size(val);
             size_t val_alloc = val->encoding == OBJ_ENCODING_RAW ? sdsAllocSize(val->ptr) : 0;
@@ -753,7 +755,7 @@ NULL
             return;
         }
         long valsize = 0;
-        if ( c->argc == 5 && getPositiveLongFromObjectOrReply(c, c->argv[4], &valsize, NULL) != C_OK ) 
+        if ( c->argc == 5 && getPositiveLongFromObjectOrReply(c, c->argv[4], &valsize, NULL) != C_OK )
             return;
 
         for (j = 0; j < keys; j++) {
@@ -1315,9 +1317,9 @@ void _serverPanic(const char *file, int line, const char *msg, ...) {
 int bugReportStart(void) {
     pthread_mutex_lock(&bug_report_start_mutex);
     if (bug_report_start == 0) {
+        bug_report_start = 1;
         serverLogRaw(LL_WARNING|LL_RAW,
         "\n\n=== REDIS BUG REPORT START: Cut & paste starting from here ===\n");
-        bug_report_start = 1;
         pthread_mutex_unlock(&bug_report_start_mutex);
         return 1;
     }
@@ -2498,6 +2500,12 @@ void setupSigSegvHandler(void) {
         pthread_mutexattr_init(&signal_handler_lock_attr);
         pthread_mutexattr_settype(&signal_handler_lock_attr, PTHREAD_MUTEX_ERRORCHECK);
         pthread_mutex_init(&signal_handler_lock, &signal_handler_lock_attr);
+
+        pthread_mutexattr_init(&bug_report_start_attr);
+        /* Use recursive to avoid deadlock when a signal is raised during bugReportStart(). */
+        pthread_mutexattr_settype(&bug_report_start_attr, PTHREAD_MUTEX_RECURSIVE);
+        pthread_mutex_init(&bug_report_start_mutex, &bug_report_start_attr);
+
         signal_handler_lock_initialized = 1;
     }
 
@@ -2720,7 +2728,7 @@ static int is_thread_ready_to_signal(const char *proc_pid_task_path, const char 
                 break;
             }
 
-            /* The bit position in a signal mask aligns with the signal number. Since signal numbers start from 1 
+            /* The bit position in a signal mask aligns with the signal number. Since signal numbers start from 1
             we need to adjust the signal number by subtracting 1 to align it correctly with the zero-based indexing used */
             if (sig_mask & (1L << (sig_num - 1))) { /* if the signal is blocked/ignored return 0 */
                 ret = 0;
@@ -2740,7 +2748,7 @@ static int is_thread_ready_to_signal(const char *proc_pid_task_path, const char 
     return ret;
 }
 
-/** We are using syscall(SYS_getdents64) to read directories, which unlike opendir(), is considered 
+/** We are using syscall(SYS_getdents64) to read directories, which unlike opendir(), is considered
  * async-signal-safe. This function wrapper getdents64() in glibc is supported as of glibc 2.30.
  * To support earlier versions of glibc, we use syscall(SYS_getdents64), which requires defining
  * linux_dirent64 ourselves. This structure is very old and stable: It will not change unless the kernel
@@ -2799,7 +2807,7 @@ static size_t get_ready_to_signal_threads_tids(int sig_num, pid_t tids[TIDS_MAX_
 
             /* save the thread id */
             tids[tids_count++] = tid;
-            
+
             /* Stop if we reached the maximum threads number. */
             if(tids_count == TIDS_MAX_SIZE) {
                 serverLogRawFromHandler(LL_WARNING, "get_ready_to_signal_threads_tids(): Reached the limit of the tids buffer.");


### PR DESCRIPTION
When a crash occurs during `bugReportStart()` execution, the signal handler re-enters the function on the same thread.  The signal handler calls `bugReportStart()` again on the same thread, causing a **mutex deadlock**.

## Solution
This PR implements a two-part fix:

1. **Use PTHREAD_MUTEX_RECURSIVE**: Changed `bug_report_start_mutex` to use `PTHREAD_MUTEX_RECURSIVE` type, which allows the same thread to re-acquire the lock multiple times. This prevents deadlock when a signal handler interrupts code that's already holding the lock.

2. **Set flag before printing**: Moved the `bug_report_start = 1` assignment **before** calling `serverLogRaw()`  to prevent infinite recursion if a crash occurs during printing.
