### PR TITLE
Fix daily CI for atomic slot migration

### DIFF
--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -22,7 +22,7 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
     set start_time [clock seconds]
     set r [redis $host $port 1 $tls]
     $r client setname LOAD_HANDLER
-    $r select 9
+    catch {$r select 9} ;# select 9 will fail in cluster mode
 
     # fixed size value
     if {$size != 0} {

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1334,7 +1334,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
     test "Source node main channel timeout when sending incremental stream" {
         R 0 flushall
-        R 0 config set repl-timeout 3   ;# 3s for main channel timeout
+        R 0 config set repl-timeout 2   ;# 2s for main channel timeout
 
         set r1_pid [S 1 process_id]
         # in order to have time to pause the destination node
@@ -1347,7 +1347,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         populate_slot 200 -idx 0 -slot 0 -size 16384
 
         # Start the slot 0 write load on the R 0
-        set load_handle [start_write_load "127.0.0.1" [get_port 0] 100 [slot_key 0 mykey]]
+        set load_handle [start_write_load "127.0.0.1" [get_port 0] 100 [slot_key 0 mykey] 500]
 
         # wait for streaming buffer state, then pause the destination node
         wait_for_condition 1000 20 {

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -652,7 +652,8 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             }
 
             # Start the slot 0 write load on the R 1
-            set load_handle [start_write_load "127.0.0.1" [get_port 1] 500 "06S"]
+            set slot0_key [slot_key 0 mykey]
+            set load_handle [start_write_load "127.0.0.1" [get_port 1] 100 $slot0_key 500]
 
             # clear old fail points and set the new fail point
             assert_equal {OK} [R 0 debug asm-failpoint "" ""]
@@ -669,7 +670,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             set task_id [R 0 CLUSTER MIGRATION IMPORT 0 100]
 
             # The task should be failed due to the fail point
-            wait_for_condition 1000 50 {
+            wait_for_condition 2000 10 {
                 [string match -nocase "*$channel*${state}*" [migration_status 0 $task_id last_error]] ||
                 [string match -nocase "*$channel*${state}*" [migration_status 1 $task_id last_error]]
             } else {
@@ -785,7 +786,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         set loglines [count_log_lines 0]
 
         # Start the slot 0 write load on the R 0
-        set load_handle [start_write_load "127.0.0.1" [get_port 0] 1000 $slot0_key]
+        set load_handle [start_write_load "127.0.0.1" [get_port 0] 100 $slot0_key 1000]
 
         # wait for buffer to accumulate on source side (more than 1m)
         wait_for_condition 1000 10 {
@@ -1148,7 +1149,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # the importing task on #0 will be retried, and eventually succeed
         # since now #0 is back in the cluster
-        wait_for_condition 2000 50 {
+        wait_for_condition 3000 50 {
             [string match {*completed*} [migration_status 0 $task_id state]] &&
             [string match {*completed*} [migration_status 1 $task_id state]]
         } else {
@@ -1213,7 +1214,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # start the slot 0 write load on the node 0
         set slot0_key [slot_key 0 mykey]
-        set load_handle [start_write_load "127.0.0.1" [get_port 0] 1000 $slot0_key]
+        set load_handle [start_write_load "127.0.0.1" [get_port 0] 100 $slot0_key 500]
 
         # wait for entering streaming buffer state
         wait_for_condition 1000 10 {
@@ -1346,7 +1347,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         populate_slot 200 -idx 0 -slot 0 -size 16384
 
         # Start the slot 0 write load on the R 0
-        set load_handle [start_write_load "127.0.0.1" [get_port 0] 10000 [slot_key 0 mykey]]
+        set load_handle [start_write_load "127.0.0.1" [get_port 0] 100 [slot_key 0 mykey]]
 
         # wait for streaming buffer state, then pause the destination node
         wait_for_condition 1000 20 {
@@ -1385,7 +1386,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # start the slot 0 write load on the node 0
         set slot0_key [slot_key 0 mykey]
-        set load_handle [start_write_load "127.0.0.1" [get_port 0] 1000 $slot0_key]
+        set load_handle [start_write_load "127.0.0.1" [get_port 0] 100 $slot0_key]
 
         # node 0 will fail since server paused timeout
         wait_for_condition 2000 10 {
@@ -1417,7 +1418,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # start the slot 0 write load on the node 0
         set slot0_key [slot_key 0 mykey]
-        set load_handle [start_write_load "127.0.0.1" [get_port 0] 1000 $slot0_key]
+        set load_handle [start_write_load "127.0.0.1" [get_port 0] 100 $slot0_key]
 
         # wait for entering streaming buffer state
         wait_for_condition 1000 10 {

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -123,6 +123,8 @@ proc wait_for_asm_done {} {
         }
         fail "ASM tasks did not complete on all instances"
     }
+    # wait all nodes to reach the same cluster config after ASM
+    wait_for_cluster_propagation
 }
 
 proc failover_and_wait_for_done {node_id {failover_arg ""}} {


### PR DESCRIPTION
Mainly fix the usage of `start_write_load`.

Daily CI is much stable now
- Daily CI: https://github.com/ShooterIT/redis/actions/workflows/daily.yml
- Daily Arm64 CI: https://github.com/redis/redis-extra-ci/actions/workflows/daily-arm64.yml