### PR TITLE
Allow comments in ACL files

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2265,15 +2265,15 @@ int ACLLoadConfiguredUsers(void) {
 }
 
 /* This function loads the ACL from the specified filename: every line
- * is validated and should be either empty or in the format used to specify
- * users in the redis.conf configuration or in the ACL file, that is:
+ * is validated and should be either empty, a comment, or in the format
+ * used to specify users in the redis.conf configuration or in the ACL file,
+ * that is:
  *
  *  user <username> ... rules ...
  *
- * Note that this function considers comments starting with '#' as errors
- * because the ACL file is meant to be rewritten, and comments would be
- * lost after the rewrite. Yet empty lines are allowed to avoid being too
- * strict.
+ * Lines starting with '#' are treated as comments and ignored. Note that
+ * comments will be lost after ACL SAVE rewrites the file. Empty lines are
+ * also allowed.
  *
  * One important part of implementing ACL LOAD, that uses this function, is
  * to avoid ending with broken rules if the ACL file is invalid for some
@@ -2325,8 +2325,8 @@ sds ACLLoadFromFile(const char *filename) {
 
         lines[i] = sdstrim(lines[i]," \t\r\n");
 
-        /* Skip blank lines */
-        if (lines[i][0] == '\0') continue;
+        /* Skip blank lines and comments */
+        if (lines[i][0] == '\0' || lines[i][0] == '#') continue;
 
         /* Split into arguments */
         argv = sdssplitlen(lines[i],sdslen(lines[i])," ",1,&argc);

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1298,6 +1298,26 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
         catch {exec src/redis-server --user default --user default} err
         assert_match {*Duplicate user*} $err
     } {} {external:skip}
+
+    test {Test loading an ACL file with comments} {
+        exec cp -f tests/assets/user.acl $server_path
+
+        # Add comments to the ACL file
+        set acl_content "# This is a comment at the beginning\nuser alice on allcommands allkeys &* >alice\n# Comment between users\nuser bob on -@all +@set +acl ~set* &* >bob\n\n# Comment with blank line above\nuser doug on resetchannels &test +@all ~* >doug\nuser default on nopass ~* &* +@all\n# Comment at the end"
+        set fd [open $server_path/user.acl w]
+        puts $fd $acl_content
+        close $fd
+
+        # Load the ACL file with comments
+        assert_match {OK} [r ACL LOAD]
+
+        # Verify all users loaded correctly
+        assert {[r ACL GETUSER alice] != ""}
+        assert_equal [dict get [r ACL GETUSER alice] commands] "+@all"
+        assert {[r ACL GETUSER bob] != ""}
+        assert {[r ACL GETUSER doug] != ""}
+        assert {[r ACL GETUSER default] != ""}
+    }
 }
 
 start_server {overrides {user "default on nopass ~* +@all -flushdb"} tags {acl external:skip}} {


### PR DESCRIPTION
## Summary

This PR allows ACL files to include comment lines starting with `#`, addressing issue #14403.

## Changes

- Modified ACL file parser in `src/acl.c` to skip lines starting with `#`
- Updated documentation to reflect comment support and note that comments are lost on ACL SAVE
- Added test case in `tests/unit/acl.tcl` to verify comments work correctly

## Implementation Details

The implementation follows the existing pattern used in Redis config files (`config.c`) and AOF manifest files (`aof.c`), where comments starting with `#` are silently skipped during file loading.

Comments are allowed but will be lost when `ACL SAVE` rewrites the file, which is documented in the code comments.

## Testing

All existing ACL tests pass, plus new test case:
- `Test loading an ACL file with comments` - Verifies ACL files with comments load correctly and all users are accessible

Fixes #14403