### PR TITLE
Fix estoreEmpty not clearing buckets sizes

### DIFF
--- a/src/estore.c
+++ b/src/estore.c
@@ -50,7 +50,7 @@ estore *estoreCreate(EbucketsType *type, int num_buckets_bits) {
     /* Calculate number of buckets based on num_buckets_bits */
     es->num_buckets_bits = num_buckets_bits;
     es->num_buckets = 1 << num_buckets_bits;
-    es->buckets_sizes = num_buckets_bits > 1 ? fwTreeCreate(num_buckets_bits) : NULL;
+    es->buckets_sizes = es->num_buckets > 1 ? fwTreeCreate(num_buckets_bits) : NULL;
 
     /* Allocate the buckets array */
     es->ebArray = zcalloc(sizeof(ebuckets) * es->num_buckets);
@@ -73,6 +73,7 @@ void estoreEmpty(estore *es) {
         es->ebArray[i] = ebCreate();
     }
 
+    if (es->buckets_sizes) fwTreeClear(es->buckets_sizes);
     es->count = 0;
 }
 

--- a/src/fwtree.c
+++ b/src/fwtree.c
@@ -24,7 +24,6 @@ struct _fenwickTree {
 
 /* Create a new Fenwick tree with 2^sizeBits elements (all initialized to 0) */
 fenwickTree *fwTreeCreate(int sizeBits) {
-
     fenwickTree *ft = zmalloc(sizeof(fenwickTree));
     ft->size_bits = sizeBits;
     ft->size = 1 << sizeBits;


### PR DESCRIPTION
`TEST("Empty estore")` can not find this bug because we don't create buckets_sizes if `num_buckets_bits` == 1, two bugs make us not find issues.

```
    TEST("Empty estore") {
        estore *es = estoreCreate(&testEbucketsType, 1); /* 2 buckets */
        ...
        assert(estoreGetNextNonEmptyBucket(es, 0) == -1);
```
this bug may cause active expiration cycle for hash-fields wrongly searches bucket in cluster mode after we execute `flushall` or `empty db on replicas`.

introduced in #14294