### PR TITLE
Fix race condition for lookupCommand

### DIFF
--- a/src/dict.h
+++ b/src/dict.h
@@ -128,11 +128,11 @@ struct dict {
     long rehashidx; /* rehashing not in progress if rehashidx == -1 */
 
     /* Keep small vars at end for optimal (minimal) struct padding */
-    unsigned pauserehash : 15; /* If >0 rehashing is paused */
+    unsigned pauserehash; /* If >0 rehashing is paused */
 
-    unsigned useStoredKeyApi : 1; /* See comment of storedHashFunction above */
     signed char ht_size_exp[2]; /* exponent of size. (size = 1<<exp) */
-    int16_t pauseAutoResize;  /* If >0 automatic resizing is disallowed (<0 indicates coding error) */
+    signed pauseAutoResize: 15;  /* If >0 automatic resizing is disallowed (<0 indicates coding error) */
+    unsigned useStoredKeyApi : 1; /* See comment of storedHashFunction above */
     void *metadata[];
 };
 

--- a/src/dict.h
+++ b/src/dict.h
@@ -127,9 +127,11 @@ struct dict {
 
     long rehashidx; /* rehashing not in progress if rehashidx == -1 */
 
-    /* Keep small vars at end for optimal (minimal) struct padding */
+    /* Note: pauserehash is a full unsigned so iterator increments
+     * don't perform RMW on the same storage unit as other bitfields. */
     unsigned pauserehash; /* If >0 rehashing is paused */
 
+    /* Keep small vars at end for optimal (minimal) struct padding */
     signed char ht_size_exp[2]; /* exponent of size. (size = 1<<exp) */
     signed pauseAutoResize: 15;  /* If >0 automatic resizing is disallowed (<0 indicates coding error) */
     unsigned useStoredKeyApi: 1; /* See comment of storedHashFunction above */

--- a/src/dict.h
+++ b/src/dict.h
@@ -132,7 +132,7 @@ struct dict {
 
     signed char ht_size_exp[2]; /* exponent of size. (size = 1<<exp) */
     signed pauseAutoResize: 15;  /* If >0 automatic resizing is disallowed (<0 indicates coding error) */
-    unsigned useStoredKeyApi : 1; /* See comment of storedHashFunction above */
+    unsigned useStoredKeyApi: 1; /* See comment of storedHashFunction above */
     void *metadata[];
 };
 


### PR DESCRIPTION
Fixes data race where main thread modifies pauserehash in dictNext while IO thread reads `useStoredKeyApi()` in `lookupCommand()->dictFind()` path.
ASAN detected overlapping memory access at same byte offset
causing race condition. When bit fields are adjacent in a struct, modifying one bit field requires a read-modify-write operation on the entire memory unit, which can cause race conditions with concurrent access to other bit fields in the same unit.
This was introduced by https://github.com/redis/redis/pull/13696, although it was changed by https://github.com/redis/redis/pull/14440, but this issue still exist.

The fix moves `useStoredKeyApi` to share a memory word with `pauseAutoResize` instead. Since `pauseAutoResize` is never modified for `server.commands`, this eliminates the race condition while maintaining memory efficiency through bit field packing.

Reproduce step:
```
make SANITIZER=thread
./runtest --tsan --config io-threads 4 --accurate --verbose --dump-logs --single unit/obuf-limits --loop --stop
```

failed CI: https://github.com/redis/redis/actions/runs/18803219305/job/53653572710