### PR TITLE
Update RediSearch to 8.4 RC1 (v8.3.90)

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.2.1
+MODULE_VERSION = v8.3.90
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
(https://github.com/RediSearch/RediSearch/pull/7076, https://github.com/RediSearch/RediSearch/pull/6857) - Introducing `FT.HYBRID`, a new command that enables hybrid queries combining both text and vector search, with support for **RRF** and **LINEAR** result combination. This update enhances performance and reliability through a more efficient networking layer, smoother query execution, and improved overall stability.
(https://github.com/RediSearch/RediSearch/pull/7065) - Add `search-default-scorer` configuration to set the default text scorer across queries (by default it is BM25). 
https://github.com/RediSearch/RediSearch/pull/7022 - Handle Atomic Slot Migration events upon moving slots from one node to another in a cluster mode.
(https://github.com/RediSearch/RediSearch/pull/6769, https://github.com/RediSearch/RediSearch/pull/6828, https://github.com/RediSearch/RediSearch/pull/6877, https://github.com/RediSearch/RediSearch/pull/6921) - Introduce query time memory guardrails by adding a new `search-on-oom` configuration which defines the query engine behavior when OOM (Out Of Memory) is reached. OOM checks are applied to `FT.SEARCH`, `FT.AGGREGATE`, and `FT.HYBRID` commands. The behavior on OOM can be configured to one of three modes: `IGNORE`, `FAIL`, or `RETURN`.
`IGNORE` - The default behavior, run queries anyway (not recommended for heavy queries returning a large result set).
`FAIL` - Fail query execution immediately if any of the nodes are in OOM state when query execution starts.
`RETURN` - A best effort appraoch to return partial results when OOM is detected in only some of the nodes in a cluster mode. 