### PR TITLE
Use fixed position keys parameter for MSETEX command

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -11141,20 +11141,14 @@ const char *MSETEX_Tips[] = {
 #ifndef SKIP_CMD_KEY_SPECS_TABLE
 /* MSETEX key specs */
 keySpec MSETEX_Keyspecs[1] = {
-{NULL,CMD_KEY_OW|CMD_KEY_UPDATE,KSPEC_BS_KEYWORD,.bs.keyword={"KEYS",1},KSPEC_FK_KEYNUM,.fk.keynum={0,1,2}}
+{NULL,CMD_KEY_OW|CMD_KEY_UPDATE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_KEYNUM,.fk.keynum={0,1,2}}
 };
 #endif
 
-/* MSETEX keys data argument table */
-struct COMMAND_ARG MSETEX_keys_data_Subargs[] = {
+/* MSETEX data argument table */
+struct COMMAND_ARG MSETEX_data_Subargs[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("value",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-};
-
-/* MSETEX keys argument table */
-struct COMMAND_ARG MSETEX_keys_Subargs[] = {
-{MAKE_ARG("numkeys",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=MSETEX_keys_data_Subargs},
 };
 
 /* MSETEX condition argument table */
@@ -11174,7 +11168,8 @@ struct COMMAND_ARG MSETEX_expiration_Subargs[] = {
 
 /* MSETEX argument table */
 struct COMMAND_ARG MSETEX_Args[] = {
-{MAKE_ARG("keys",ARG_TYPE_BLOCK,-1,"KEYS",NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=MSETEX_keys_Subargs},
+{MAKE_ARG("numkeys",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=MSETEX_data_Subargs},
 {MAKE_ARG("condition",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=MSETEX_condition_Subargs},
 {MAKE_ARG("expiration",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,5,NULL),.subargs=MSETEX_expiration_Subargs},
 };
@@ -11771,7 +11766,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("lcs","Finds the longest common substring.","O(N*M) where N and M are the lengths of s1 and s2, respectively","7.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,LCS_History,0,LCS_Tips,0,lcsCommand,-3,CMD_READONLY,ACL_CATEGORY_STRING,LCS_Keyspecs,1,NULL,6),.args=LCS_Args},
 {MAKE_CMD("mget","Atomically returns the string values of one or more keys.","O(N) where N is the number of keys to retrieve.","1.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,MGET_History,0,MGET_Tips,1,mgetCommand,-2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_STRING,MGET_Keyspecs,1,NULL,1),.args=MGET_Args},
 {MAKE_CMD("mset","Atomically creates or modifies the string values of one or more keys.","O(N) where N is the number of keys to set.","1.0.1",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,MSET_History,0,MSET_Tips,2,msetCommand,-3,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_STRING,MSET_Keyspecs,1,NULL,1),.args=MSET_Args},
-{MAKE_CMD("msetex","Atomically sets multiple string keys with a shared expiration in a single operation. Supports flexible argument parsing where condition and expiration flags can appear in any order.","O(N) where N is the number of keys to set.","8.4.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,MSETEX_History,0,MSETEX_Tips,2,msetexCommand,-5,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_STRING,MSETEX_Keyspecs,1,NULL,3),.args=MSETEX_Args},
+{MAKE_CMD("msetex","Atomically sets multiple string keys with a shared expiration in a single operation. Supports flexible argument parsing where condition and expiration flags can appear in any order.","O(N) where N is the number of keys to set.","8.4.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,MSETEX_History,0,MSETEX_Tips,2,msetexCommand,-4,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_STRING,MSETEX_Keyspecs,1,NULL,4),.args=MSETEX_Args},
 {MAKE_CMD("msetnx","Atomically modifies the string values of one or more keys only when all keys don't exist.","O(N) where N is the number of keys to set.","1.0.1",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,MSETNX_History,0,MSETNX_Tips,0,msetnxCommand,-3,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_STRING,MSETNX_Keyspecs,1,NULL,1),.args=MSETNX_Args},
 {MAKE_CMD("psetex","Sets both string value and expiration time in milliseconds of a key. The key is created if it doesn't exist.","O(1)","2.6.0",CMD_DOC_DEPRECATED,"`SET` with the `PX` argument","2.6.12","string",COMMAND_GROUP_STRING,PSETEX_History,0,PSETEX_Tips,0,psetexCommand,4,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_STRING,PSETEX_Keyspecs,1,NULL,3),.args=PSETEX_Args},
 {MAKE_CMD("set","Sets the string value of a key, ignoring its type. The key is created if it doesn't exist.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,SET_History,5,SET_Tips,0,setCommand,-3,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_STRING,SET_Keyspecs,1,setGetKeys,5),.args=SET_Args},

--- a/src/commands/msetex.json
+++ b/src/commands/msetex.json
@@ -4,7 +4,7 @@
         "complexity": "O(N) where N is the number of keys to set.",
         "group": "string",
         "since": "8.4.0",
-        "arity": -5,
+        "arity": -4,
         "function": "msetexCommand",
         "command_flags": [
             "WRITE",
@@ -24,9 +24,8 @@
                     "UPDATE"
                 ],
                 "begin_search": {
-                    "keyword": {
-                        "keyword": "KEYS",
-                        "startfrom": 1
+                    "index": {
+                        "pos": 1
                     }
                 },
                 "find_keys": {
@@ -52,29 +51,22 @@
         },
         "arguments": [
             {
-                "name": "keys",
-                "token": "KEYS",
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "data",
                 "type": "block",
+                "multiple": true,
                 "arguments": [
                     {
-                        "name": "numkeys",
-                        "type": "integer"
+                        "name": "key",
+                        "type": "key",
+                        "key_spec_index": 0
                     },
                     {
-                        "name": "data",
-                        "type": "block",
-                        "multiple": true,
-                        "arguments": [
-                            {
-                                "name": "key",
-                                "type": "key",
-                                "key_spec_index": 0
-                            },
-                            {
-                                "name": "value",
-                                "type": "string"
-                            }
-                        ]
+                        "name": "value",
+                        "type": "string"
                     }
                 ]
             },

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -715,9 +715,10 @@ void msetexCommand(client *c) {
         return;
     }
 
-    long long kv_count = count;
-    /* Validate we have enough arguments: command + numkeys + (key-value pairs) * 2 */
-    if (kv_count * 2 + 2 > c->argc) {
+    long kv_count = count;
+    /* Validate we have enough arguments: command + numkeys + (key-value pairs) * 2
+     * Be careful to avoid overflow when calculating kv_count * 2 */
+    if ((long long)kv_count * 2 + 2 > c->argc) {
         addReplyError(c, "wrong number of key-value pairs");
         return;
     }

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -751,7 +751,7 @@ void msetexCommand(client *c) {
     /* Set all key-value pairs */
     for (int j = 0; j < kv_count; j++) {
         int key_idx = (j * 2) + 2;
-        int val_idx = (j * 2) + 3;
+        int val_idx = key_idx + 1;
 
         c->argv[val_idx] = tryObjectEncoding(c->argv[val_idx]);
 

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -708,14 +708,13 @@ void msetnxCommand(client *c) {
 
 void msetexCommand(client *c) {
     /* Parse numkeys parameter */
-    long count;
+    long kv_count;
     if (getRangeLongFromObjectOrReply(c, c->argv[1], 1, INT_MAX,
-        &count, "invalid numkeys value") != C_OK)
+        &kv_count, "invalid numkeys value") != C_OK)
     {
         return;
     }
 
-    long kv_count = count;
     /* Validate we have enough arguments: command + numkeys + (key-value pairs) * 2
      * Be careful to avoid overflow when calculating kv_count * 2 */
     if ((long long)kv_count * 2 + 2 > c->argc) {

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -242,8 +242,6 @@ typedef struct {
     int expire_pos;  /* Position of EX/PX flag for replication rewriting */
     robj *expire;
     robj *match_value; /* For IFEQ/IFNE/IFDEQ/IFDNE conditions */
-    int kv_count;    /* Only used by MSETEX */
-    int kv_start;    /* Only used by MSETEX */
 } extendedStringArgs;
 
 /*
@@ -266,7 +264,6 @@ typedef struct {
 int parseExtendedStringArgumentsOrReply(client *c, int start_pos, extendedStringArgs *args, int command_type) {
     /* Initialize arguments to defaults */
     memset(args, 0, sizeof(*args));
-    args->kv_start = -1;
     args->expire_pos = -1;
     args->unit = UNIT_SECONDS;
 
@@ -302,24 +299,6 @@ int parseExtendedStringArgumentsOrReply(client *c, int start_pos, extendedString
                    (command_type == COMMAND_SET))
         {
             args->flags |= OBJ_SET_GET;
-        } else if (!strcasecmp(opt, "KEYS") && command_type == COMMAND_MSETEX && j+1 < c->argc) {
-            /* Handle KEYS block skipping and populate KEYS parameters */
-            long kv_count_long;
-            if (getRangeLongFromObjectOrReply(c, c->argv[j+1], 1, INT_MAX,
-                &kv_count_long, "invalid numkeys value") != C_OK)
-            {
-                return C_ERR;
-            }
-            if (j + 2 + (long long)kv_count_long * 2 > c->argc) {
-                addReplyError(c, "wrong number of key-value pairs");
-                return C_ERR;
-            }
-
-            /* Populate KEYS parameters for MSETEX */
-            args->kv_count = (int)kv_count_long;
-            args->kv_start = j + 2;
-
-            j = j + 1 + (kv_count_long * 2);  /* Skip "KEYS", numkeys, and all key-value pairs */
         } else if (!strcasecmp(opt, "KEEPTTL") && !(args->flags & OBJ_PERSIST) &&
             !(args->flags & OBJ_EX) && !(args->flags & OBJ_EXAT) &&
             !(args->flags & OBJ_PX) && !(args->flags & OBJ_PXAT) &&
@@ -728,19 +707,28 @@ void msetnxCommand(client *c) {
 }
 
 void msetexCommand(client *c) {
+    /* Parse numkeys parameter */
+    long count;
+    if (getRangeLongFromObjectOrReply(c, c->argv[1], 1, INT_MAX,
+        &count, "invalid numkeys value") != C_OK)
+    {
+        return;
+    }
+
+    long long kv_count = count;
+    /* Validate we have enough arguments: command + numkeys + (key-value pairs) * 2 */
+    if (kv_count * 2 + 2 > c->argc) {
+        addReplyError(c, "wrong number of key-value pairs");
+        return;
+    }
+
     extendedStringArgs args;
-    if (parseExtendedStringArgumentsOrReply(c, 1, &args, COMMAND_MSETEX) != C_OK) {
+    if (parseExtendedStringArgumentsOrReply(c, kv_count * 2 + 2, &args, COMMAND_MSETEX) != C_OK) {
         return;
     }
 
     if ((args.flags & OBJ_SET_NX) && (args.flags & OBJ_SET_XX)) {
         addReplyErrorObject(c, shared.syntaxerr);
-        return;
-    }
-
-    /* Validate KEYS block was found */
-    if (args.kv_count == 0) {
-        addReplyError(c, "syntax error - KEYS keyword is required");
         return;
     }
 
@@ -752,8 +740,8 @@ void msetexCommand(client *c) {
 
     if (args.flags & (OBJ_SET_NX | OBJ_SET_XX)) {
         /* Check NX/XX conditions for each key - pattern from setGenericCommand */
-        for (int j = 0; j < args.kv_count; j++) {
-            int key_idx = args.kv_start + (j * 2);
+        for (int j = 0; j < kv_count; j++) {
+            int key_idx = (j * 2) + 2;
             robj *found = lookupKeyWrite(c->db, c->argv[key_idx]);
 
             if ((args.flags & OBJ_SET_NX && found) ||
@@ -766,9 +754,9 @@ void msetexCommand(client *c) {
     }
 
     /* Set all key-value pairs */
-    for (int j = 0; j < args.kv_count; j++) {
-        int key_idx = args.kv_start + (j * 2);
-        int val_idx = args.kv_start + (j * 2) + 1;
+    for (int j = 0; j < kv_count; j++) {
+        int key_idx = (j * 2) + 2;
+        int val_idx = (j * 2) + 3;
 
         c->argv[val_idx] = tryObjectEncoding(c->argv[val_idx]);
 
@@ -798,7 +786,7 @@ void msetexCommand(client *c) {
         decrRefCount(milliseconds_obj);
     }
 
-    server.dirty += args.kv_count;
+    server.dirty += kv_count;
     addReply(c, shared.cone);
 }
 

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -727,11 +727,6 @@ void msetexCommand(client *c) {
         return;
     }
 
-    if ((args.flags & OBJ_SET_NX) && (args.flags & OBJ_SET_XX)) {
-        addReplyErrorObject(c, shared.syntaxerr);
-        return;
-    }
-
     /* Validate the expiration time value first */
     long long milliseconds = 0;
     if (args.expire && getExpireMillisecondsOrReply(c, args.expire, args.flags, args.unit, &milliseconds) != C_OK) {


### PR DESCRIPTION
In PR https://github.com/redis/redis/pull/14434, we made the keys parameter flexible, meaning it could appear anywhere among the command arguments. However, this also made key parsing more complex, since we could no longer determine the fixed position of key arguments. Therefore, in this PR, we reverted it back to using fixed positions for the keys.

And also fix this [comment](https://github.com/redis/redis/pull/14434#discussion_r2459282563).