### PR TITLE
Fix list commands per slot memory accounting condition

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2846,6 +2846,10 @@ void initServer(void) {
     server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
     server.reply_buffer_resizing_enabled = 1;
     server.client_mem_usage_buckets = NULL;
+    /* Enable per slot memory accounting only if cluster-slot-stats-enabled is
+     * enabled on startup and disregard future configuration changes.
+     * The reason behind this behavior is we want to avoid situation where we
+     * would need to catch up or iterate over all slots and kvobjs. */
     server.memory_tracking_per_slot = clusterSlotStatsEnabled();
     resetReplicationBuffer();
 


### PR DESCRIPTION
Fix list commands per slot memory accounting condition introduced in #14451.

While `cluster-slot-stats-enabled` config can be dynamically changed, currently
we decide on startup whether to collect per slot memory stats (based on its
initial value) and stick with this choice disregarding future config changes.

The reason behind this behavior is that we want to avoid situation where we
would need to catch up or iterate over slots.