### PR TITLE
Call makeObjectShared to normalize a shared object into a true shared object

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2030,167 +2030,174 @@ void afterSleep(struct aeEventLoop *eventLoop) {
 
 /* =========================== Server initialization ======================== */
 
+static inline robj *createSharedString(const char *string) {
+    return makeObjectShared(createStringObject(string, strlen(string)));
+}
+
+static inline robj *createSharedStringFromSds(sds s) {
+    return makeObjectShared(createObject(OBJ_STRING, s));
+}
+
 void createSharedObjects(void) {
     int j;
 
     /* Shared command responses */
-    shared.ok = createObject(OBJ_STRING,sdsnew("+OK\r\n"));
-    shared.emptybulk = createObject(OBJ_STRING,sdsnew("$0\r\n\r\n"));
-    shared.czero = createObject(OBJ_STRING,sdsnew(":0\r\n"));
-    shared.cone = createObject(OBJ_STRING,sdsnew(":1\r\n"));
-    shared.emptyarray = createObject(OBJ_STRING,sdsnew("*0\r\n"));
-    shared.pong = createObject(OBJ_STRING,sdsnew("+PONG\r\n"));
-    shared.queued = createObject(OBJ_STRING,sdsnew("+QUEUED\r\n"));
-    shared.emptyscan = createObject(OBJ_STRING,sdsnew("*2\r\n$1\r\n0\r\n*0\r\n"));
-    shared.space = createObject(OBJ_STRING,sdsnew(" "));
-    shared.plus = createObject(OBJ_STRING,sdsnew("+"));
+    shared.ok = createSharedString("+OK\r\n");
+    shared.emptybulk = createSharedString("$0\r\n\r\n");
+    shared.czero = createSharedString(":0\r\n");
+    shared.cone = createSharedString(":1\r\n");
+    shared.emptyarray = createSharedString("*0\r\n");
+    shared.pong = createSharedString("+PONG\r\n");
+    shared.queued = createSharedString("+QUEUED\r\n");
+    shared.emptyscan = createSharedString("*2\r\n$1\r\n0\r\n*0\r\n");
+    shared.space = createSharedString(" ");
+    shared.plus = createSharedString("+");
 
     /* Shared command error responses */
-    shared.wrongtypeerr = createObject(OBJ_STRING,sdsnew(
-        "-WRONGTYPE Operation against a key holding the wrong kind of value\r\n"));
-    shared.err = createObject(OBJ_STRING,sdsnew("-ERR\r\n"));
-    shared.nokeyerr = createObject(OBJ_STRING,sdsnew(
-        "-ERR no such key\r\n"));
-    shared.syntaxerr = createObject(OBJ_STRING,sdsnew(
-        "-ERR syntax error\r\n"));
-    shared.sameobjecterr = createObject(OBJ_STRING,sdsnew(
-        "-ERR source and destination objects are the same\r\n"));
-    shared.outofrangeerr = createObject(OBJ_STRING,sdsnew(
-        "-ERR index out of range\r\n"));
-    shared.noscripterr = createObject(OBJ_STRING,sdsnew(
-        "-NOSCRIPT No matching script. Please use EVAL.\r\n"));
-    shared.loadingerr = createObject(OBJ_STRING,sdsnew(
-        "-LOADING Redis is loading the dataset in memory\r\n"));
-    shared.slowevalerr = createObject(OBJ_STRING,sdsnew(
-        "-BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE.\r\n"));
-    shared.slowscripterr = createObject(OBJ_STRING,sdsnew(
-        "-BUSY Redis is busy running a script. You can only call FUNCTION KILL or SHUTDOWN NOSAVE.\r\n"));
-    shared.slowmoduleerr = createObject(OBJ_STRING,sdsnew(
-        "-BUSY Redis is busy running a module command.\r\n"));
-    shared.masterdownerr = createObject(OBJ_STRING,sdsnew(
-        "-MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'.\r\n"));
-    shared.bgsaveerr = createObject(OBJ_STRING,sdsnew(
-        "-MISCONF Redis is configured to save RDB snapshots, but it's currently unable to persist to disk. Commands that may modify the data set are disabled, because this instance is configured to report errors during writes if RDB snapshotting fails (stop-writes-on-bgsave-error option). Please check the Redis logs for details about the RDB error.\r\n"));
-    shared.roslaveerr = createObject(OBJ_STRING,sdsnew(
-        "-READONLY You can't write against a read only replica.\r\n"));
-    shared.noautherr = createObject(OBJ_STRING,sdsnew(
-        "-NOAUTH Authentication required.\r\n"));
-    shared.oomerr = createObject(OBJ_STRING,sdsnew(
-        "-OOM command not allowed when used memory > 'maxmemory'.\r\n"));
-    shared.execaborterr = createObject(OBJ_STRING,sdsnew(
-        "-EXECABORT Transaction discarded because of previous errors.\r\n"));
-    shared.noreplicaserr = createObject(OBJ_STRING,sdsnew(
-        "-NOREPLICAS Not enough good replicas to write.\r\n"));
-    shared.busykeyerr = createObject(OBJ_STRING,sdsnew(
-        "-BUSYKEY Target key name already exists.\r\n"));
+    shared.wrongtypeerr = createSharedString(
+        "-WRONGTYPE Operation against a key holding the wrong kind of value\r\n");
+    shared.err = createSharedString("-ERR\r\n");
+    shared.nokeyerr = createSharedString(
+        "-ERR no such key\r\n");
+    shared.syntaxerr = createSharedString(
+        "-ERR syntax error\r\n");
+    shared.sameobjecterr = createSharedString(
+        "-ERR source and destination objects are the same\r\n");
+    shared.outofrangeerr = createSharedString(
+        "-ERR index out of range\r\n");
+    shared.noscripterr = createSharedString(
+        "-NOSCRIPT No matching script. Please use EVAL.\r\n");
+    shared.loadingerr = createSharedString(
+        "-LOADING Redis is loading the dataset in memory\r\n");
+    shared.slowevalerr = createSharedString(
+        "-BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE.\r\n");
+    shared.slowscripterr = createSharedString(
+        "-BUSY Redis is busy running a script. You can only call FUNCTION KILL or SHUTDOWN NOSAVE.\r\n");
+    shared.slowmoduleerr = createSharedString(
+        "-BUSY Redis is busy running a module command.\r\n");
+    shared.masterdownerr = createSharedString(
+        "-MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'.\r\n");
+    shared.bgsaveerr = createSharedString(
+        "-MISCONF Redis is configured to save RDB snapshots, but it's currently unable to persist to disk. Commands that may modify the data set are disabled, because this instance is configured to report errors during writes if RDB snapshotting fails (stop-writes-on-bgsave-error option). Please check the Redis logs for details about the RDB error.\r\n");
+    shared.roslaveerr = createSharedString(
+        "-READONLY You can't write against a read only replica.\r\n");
+    shared.noautherr = createSharedString(
+        "-NOAUTH Authentication required.\r\n");
+    shared.oomerr = createSharedString(
+        "-OOM command not allowed when used memory > 'maxmemory'.\r\n");
+    shared.execaborterr = createSharedString(
+        "-EXECABORT Transaction discarded because of previous errors.\r\n");
+    shared.noreplicaserr = createSharedString(
+        "-NOREPLICAS Not enough good replicas to write.\r\n");
+    shared.busykeyerr = createSharedString(
+        "-BUSYKEY Target key name already exists.\r\n");
 
     /* The shared NULL depends on the protocol version. */
     shared.null[0] = NULL;
     shared.null[1] = NULL;
-    shared.null[2] = createObject(OBJ_STRING,sdsnew("$-1\r\n"));
-    shared.null[3] = createObject(OBJ_STRING,sdsnew("_\r\n"));
+    shared.null[2] = createSharedString("$-1\r\n");
+    shared.null[3] = createSharedString("_\r\n");
 
     shared.nullarray[0] = NULL;
     shared.nullarray[1] = NULL;
-    shared.nullarray[2] = createObject(OBJ_STRING,sdsnew("*-1\r\n"));
-    shared.nullarray[3] = createObject(OBJ_STRING,sdsnew("_\r\n"));
+    shared.nullarray[2] = createSharedString("*-1\r\n");
+    shared.nullarray[3] = createSharedString("_\r\n");
 
     shared.emptymap[0] = NULL;
     shared.emptymap[1] = NULL;
-    shared.emptymap[2] = createObject(OBJ_STRING,sdsnew("*0\r\n"));
-    shared.emptymap[3] = createObject(OBJ_STRING,sdsnew("%0\r\n"));
+    shared.emptymap[2] = createSharedString("*0\r\n");
+    shared.emptymap[3] = createSharedString("%0\r\n");
 
     shared.emptyset[0] = NULL;
     shared.emptyset[1] = NULL;
-    shared.emptyset[2] = createObject(OBJ_STRING,sdsnew("*0\r\n"));
-    shared.emptyset[3] = createObject(OBJ_STRING,sdsnew("~0\r\n"));
+    shared.emptyset[2] = createSharedString("*0\r\n");
+    shared.emptyset[3] = createSharedString("~0\r\n");
 
     for (j = 0; j < PROTO_SHARED_SELECT_CMDS; j++) {
         char dictid_str[64];
         int dictid_len;
 
         dictid_len = ll2string(dictid_str,sizeof(dictid_str),j);
-        shared.select[j] = createObject(OBJ_STRING,
+        shared.select[j] = createSharedStringFromSds(
             sdscatprintf(sdsempty(),
                 "*2\r\n$6\r\nSELECT\r\n$%d\r\n%s\r\n",
                 dictid_len, dictid_str));
     }
-    shared.messagebulk = createStringObject("$7\r\nmessage\r\n",13);
-    shared.pmessagebulk = createStringObject("$8\r\npmessage\r\n",14);
-    shared.subscribebulk = createStringObject("$9\r\nsubscribe\r\n",15);
-    shared.unsubscribebulk = createStringObject("$11\r\nunsubscribe\r\n",18);
-    shared.ssubscribebulk = createStringObject("$10\r\nssubscribe\r\n", 17);
-    shared.sunsubscribebulk = createStringObject("$12\r\nsunsubscribe\r\n", 19);
-    shared.smessagebulk = createStringObject("$8\r\nsmessage\r\n", 14);
-    shared.psubscribebulk = createStringObject("$10\r\npsubscribe\r\n",17);
-    shared.punsubscribebulk = createStringObject("$12\r\npunsubscribe\r\n",19);
+    shared.messagebulk = createSharedString("$7\r\nmessage\r\n");
+    shared.pmessagebulk = createSharedString("$8\r\npmessage\r\n");
+    shared.subscribebulk = createSharedString("$9\r\nsubscribe\r\n");
+    shared.unsubscribebulk = createSharedString("$11\r\nunsubscribe\r\n");
+    shared.ssubscribebulk = createSharedString("$10\r\nssubscribe\r\n");
+    shared.sunsubscribebulk = createSharedString("$12\r\nsunsubscribe\r\n");
+    shared.smessagebulk = createSharedString("$8\r\nsmessage\r\n");
+    shared.psubscribebulk = createSharedString("$10\r\npsubscribe\r\n");
+    shared.punsubscribebulk = createSharedString("$12\r\npunsubscribe\r\n");
 
     /* Shared command names */
-    shared.del = createStringObject("DEL",3);
-    shared.unlink = createStringObject("UNLINK",6);
-    shared.rpop = createStringObject("RPOP",4);
-    shared.lpop = createStringObject("LPOP",4);
-    shared.lpush = createStringObject("LPUSH",5);
-    shared.rpoplpush = createStringObject("RPOPLPUSH",9);
-    shared.lmove = createStringObject("LMOVE",5);
-    shared.blmove = createStringObject("BLMOVE",6);
-    shared.zpopmin = createStringObject("ZPOPMIN",7);
-    shared.zpopmax = createStringObject("ZPOPMAX",7);
-    shared.multi = createStringObject("MULTI",5);
-    shared.exec = createStringObject("EXEC",4);
-    shared.hset = createStringObject("HSET",4);
-    shared.srem = createStringObject("SREM",4);
-    shared.xgroup = createStringObject("XGROUP",6);
-    shared.xclaim = createStringObject("XCLAIM",6);
-    shared.script = createStringObject("SCRIPT",6);
-    shared.replconf = createStringObject("REPLCONF",8);
-    shared.pexpireat = createStringObject("PEXPIREAT",9);
-    shared.pexpire = createStringObject("PEXPIRE",7);
-    shared.persist = createStringObject("PERSIST",7);
-    shared.set = createStringObject("SET",3);
-    shared.eval = createStringObject("EVAL",4);
-    shared.hpexpireat = createStringObject("HPEXPIREAT",10);
-    shared.hpersist = createStringObject("HPERSIST",8);
-    shared.hdel = createStringObject("HDEL",4);
-    shared.hsetex = createStringObject("HSETEX",6);
+    shared.del = createSharedString("DEL");
+    shared.unlink = createSharedString("UNLINK");
+    shared.rpop = createSharedString("RPOP");
+    shared.lpop = createSharedString("LPOP");
+    shared.lpush = createSharedString("LPUSH");
+    shared.rpoplpush = createSharedString("RPOPLPUSH");
+    shared.lmove = createSharedString("LMOVE");
+    shared.blmove = createSharedString("BLMOVE");
+    shared.zpopmin = createSharedString("ZPOPMIN");
+    shared.zpopmax = createSharedString("ZPOPMAX");
+    shared.multi = createSharedString("MULTI");
+    shared.exec = createSharedString("EXEC");
+    shared.hset = createSharedString("HSET");
+    shared.srem = createSharedString("SREM");
+    shared.xgroup = createSharedString("XGROUP");
+    shared.xclaim = createSharedString("XCLAIM");
+    shared.script = createSharedString("SCRIPT");
+    shared.replconf = createSharedString("REPLCONF");
+    shared.pexpireat = createSharedString("PEXPIREAT");
+    shared.pexpire = createSharedString("PEXPIRE");
+    shared.persist = createSharedString("PERSIST");
+    shared.set = createSharedString("SET");
+    shared.eval = createSharedString("EVAL");
+    shared.hpexpireat = createSharedString("HPEXPIREAT");
+    shared.hpersist = createSharedString("HPERSIST");
+    shared.hdel = createSharedString("HDEL");
+    shared.hsetex = createSharedString("HSETEX");
 
     /* Shared command argument */
-    shared.left = createStringObject("left",4);
-    shared.right = createStringObject("right",5);
-    shared.pxat = createStringObject("PXAT", 4);
-    shared.time = createStringObject("TIME",4);
-    shared.retrycount = createStringObject("RETRYCOUNT",10);
-    shared.force = createStringObject("FORCE",5);
-    shared.justid = createStringObject("JUSTID",6);
-    shared.entriesread = createStringObject("ENTRIESREAD",11);
-    shared.lastid = createStringObject("LASTID",6);
-    shared.default_username = createStringObject("default",7);
-    shared.ping = createStringObject("ping",4);
-    shared.setid = createStringObject("SETID",5);
-    shared.keepttl = createStringObject("KEEPTTL",7);
-    shared.absttl = createStringObject("ABSTTL",6);
-    shared.load = createStringObject("LOAD",4);
-    shared.createconsumer = createStringObject("CREATECONSUMER",14);
-    shared.getack = createStringObject("GETACK",6);
-    shared.special_asterick = createStringObject("*",1);
-    shared.special_equals = createStringObject("=",1);
-    shared.redacted = makeObjectShared(createStringObject("(redacted)",10));
-    shared.fields = createStringObject("FIELDS",6);
+    shared.left = createSharedString("left");
+    shared.right = createSharedString("right");
+    shared.pxat = createSharedString("PXAT");
+    shared.time = createSharedString("TIME");
+    shared.retrycount = createSharedString("RETRYCOUNT");
+    shared.force = createSharedString("FORCE");
+    shared.justid = createSharedString("JUSTID");
+    shared.entriesread = createSharedString("ENTRIESREAD");
+    shared.lastid = createSharedString("LASTID");
+    shared.default_username = createSharedString("default");
+    shared.ping = createSharedString("ping");
+    shared.setid = createSharedString("SETID");
+    shared.keepttl = createSharedString("KEEPTTL");
+    shared.absttl = createSharedString("ABSTTL");
+    shared.load = createSharedString("LOAD");
+    shared.createconsumer = createSharedString("CREATECONSUMER");
+    shared.getack = createSharedString("GETACK");
+    shared.special_asterick = createSharedString("*");
+    shared.special_equals = createSharedString("=");
+    shared.redacted = createSharedString("(redacted)");
+    shared.fields = createSharedString("FIELDS");
 
     for (j = 0; j < OBJ_SHARED_INTEGERS; j++) {
         shared.integers[j] =
             makeObjectShared(createObject(OBJ_STRING,(void*)(long)j));
-        initObjectLRUOrLFU(shared.integers[j]);
         shared.integers[j]->encoding = OBJ_ENCODING_INT;
     }
     for (j = 0; j < OBJ_SHARED_BULKHDR_LEN; j++) {
-        shared.mbulkhdr[j] = createObject(OBJ_STRING,
+        shared.mbulkhdr[j] = createSharedStringFromSds(
             sdscatprintf(sdsempty(),"*%d\r\n",j));
-        shared.bulkhdr[j] = createObject(OBJ_STRING,
+        shared.bulkhdr[j] = createSharedStringFromSds(
             sdscatprintf(sdsempty(),"$%d\r\n",j));
-        shared.maphdr[j] = createObject(OBJ_STRING,
+        shared.maphdr[j] = createSharedStringFromSds(
             sdscatprintf(sdsempty(),"%%%d\r\n",j));
-        shared.sethdr[j] = createObject(OBJ_STRING,
+        shared.sethdr[j] = createSharedStringFromSds(
             sdscatprintf(sdsempty(),"~%d\r\n",j));
     }
     /* The following two shared objects, minstring and maxstring, are not


### PR DESCRIPTION
This PR is based on https://github.com/valkey-io/valkey/pull/1566

Currently, only int and shared.redacted call makeObjectShared for shared objects.

Although this breaks the blame log, there are a few points i would like to mention:
1. For cleanup, all shared objects's refcount should be the same.
2. For CoW, probably can reduce CoW although it is very minor.

Signed-off-by: Binbin <binloveplay1314@qq.com>
Co-authored-by: Viktor Söderqvist <viktor.soderqvist@est.tech>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core server shared-object initialization and changes refcount semantics (and in some cases string encoding) for many globally reused reply objects, which could expose subtle memory-management assumptions. The change is largely mechanical and should be behavior-preserving if all call sites already treat these objects as immutable singletons.
> 
> **Overview**
> **Normalizes shared reply/command objects to be true shared objects.** `createSharedObjects()` now builds nearly all `shared.*` strings via new `createSharedString()` / `createSharedStringFromSds()` helpers that wrap allocation with `makeObjectShared`, instead of leaving most objects with a normal refcount.
> 
> This also standardizes creation of RESP headers/`SELECT` commands and replaces the special-case `shared.redacted` sharing with the same helper, removing an effectively no-op `initObjectLRUOrLFU()` call for shared integers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6310375e4670c9f93fe09bdd0346ac5783a5a36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->