### PR TITLE
Enforce 16-char hex digest length and case-insensitive comparison for IFDEQ/IFDNE

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1332,10 +1332,8 @@ void delexCommand(client *c) {
 
         decrRefCount(valueobj);
     } else if (!strcasecmp("ifdeq", condition)) {
-        if (validateHexDigest(c->argv[3]->ptr) != C_OK) {
-            addReplyError(c, "must be exactly 16 hexadecimal characters");
+        if (validateHexDigest(c, c->argv[3]->ptr) != C_OK)
             return;
-        }
 
         sds current_digest = stringDigest(o);
         if (strcasecmp(current_digest, c->argv[3]->ptr) == 0)
@@ -1343,10 +1341,8 @@ void delexCommand(client *c) {
 
         sdsfree(current_digest);
     } else if (!strcasecmp("ifdne", condition)) {
-        if (validateHexDigest(c->argv[3]->ptr) != C_OK) {
-            addReplyError(c, "must be exactly 16 hexadecimal characters");
+        if (validateHexDigest(c, c->argv[3]->ptr) != C_OK)
             return;
-        }
 
         sds current_digest = stringDigest(o);
         if (strcasecmp(current_digest, c->argv[3]->ptr) != 0)

--- a/src/db.c
+++ b/src/db.c
@@ -1332,14 +1332,24 @@ void delexCommand(client *c) {
 
         decrRefCount(valueobj);
     } else if (!strcasecmp("ifdeq", condition)) {
+        if (validateHexDigest(c->argv[3]->ptr) != C_OK) {
+            addReplyError(c, "must be exactly 16 hexadecimal characters");
+            return;
+        }
+
         sds current_digest = stringDigest(o);
-        if (sdscmp(current_digest, c->argv[3]->ptr) == 0)
+        if (strcasecmp(current_digest, c->argv[3]->ptr) == 0)
             should_delete = 1;
 
         sdsfree(current_digest);
     } else if (!strcasecmp("ifdne", condition)) {
+        if (validateHexDigest(c->argv[3]->ptr) != C_OK) {
+            addReplyError(c, "must be exactly 16 hexadecimal characters");
+            return;
+        }
+
         sds current_digest = stringDigest(o);
-        if (sdscmp(current_digest, c->argv[3]->ptr) != 0)
+        if (strcasecmp(current_digest, c->argv[3]->ptr) != 0)
             should_delete = 1;
 
         sdsfree(current_digest);

--- a/src/server.h
+++ b/src/server.h
@@ -4023,6 +4023,7 @@ char *redisBuildIdString(void);
 
 /* XXH3 hash of a string as hex string */
 sds stringDigest(robj *o);
+int validateHexDigest(const sds digest);
 
 /* Commands prototypes */
 void authCommand(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -4023,7 +4023,7 @@ char *redisBuildIdString(void);
 
 /* XXH3 hash of a string as hex string */
 sds stringDigest(robj *o);
-int validateHexDigest(const sds digest);
+int validateHexDigest(client *c, const sds digest);
 
 /* Commands prototypes */
 void authCommand(client *c);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -1159,8 +1159,10 @@ cleanup:
     return;
 }
 
-/* Validate that a string is a valid DIGEST_HEX_LENGTH-character hex digest.
- * Returns C_OK if valid, C_ERR otherwise. */
+/* Validate that a digest string has the correct length (DIGEST_HEX_LENGTH characters).
+ * Note: This only validates length, not whether characters are valid hex digits.
+ * Invalid hex characters will simply fail to match during comparison.
+ * Returns C_OK if length is correct, C_ERR otherwise. */
 int validateHexDigest(const sds digest) {
     size_t len = sdslen(digest);
     if (len != DIGEST_HEX_LENGTH)

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -11,6 +11,9 @@
 #include "xxhash.h"
 #include <math.h> /* isnan(), isinf() */
 
+/* XXH3 64-bit hash produces 16 hex characters when formatted */
+#define DIGEST_HEX_LENGTH 16
+
 /* Forward declarations */
 int getGenericCommand(client *c);
 
@@ -127,10 +130,15 @@ void setGenericCommand(client *c, int flags, robj *key, robj **valref, robj *exp
                 return;
             }
         } else if (flags & OBJ_SET_IFDEQ || flags & OBJ_SET_IFDNE) {
+            if (validateHexDigest(match_value->ptr) != C_OK) {
+                addReplyError(c, "must be exactly 16 hexadecimal characters");
+                return;
+            }
+
             sds current_digest = stringDigest(current);
             int condition = flags & OBJ_SET_IFDEQ ?
-                            sdscmp(current_digest, match_value->ptr) == 0 :
-                            sdscmp(current_digest, match_value->ptr) != 0;
+                            strcasecmp(current_digest, match_value->ptr) == 0 :
+                            strcasecmp(current_digest, match_value->ptr) != 0;
             sdsfree(current_digest);
             if (!condition) {
                 if (!(flags & OBJ_SET_GET)) {
@@ -1151,6 +1159,15 @@ cleanup:
     return;
 }
 
+/* Validate that a string is a valid DIGEST_HEX_LENGTH-character hex digest.
+ * Returns C_OK if valid, C_ERR otherwise. */
+int validateHexDigest(const sds digest) {
+    size_t len = sdslen(digest);
+    if (len != DIGEST_HEX_LENGTH)
+        return C_ERR;
+    return C_OK;
+}
+
 /* Return the xxh3 hash of a string object as a hex string stored in an sds.
  * The user is responsible for freeing the sds. */
 sds stringDigest(robj *o) {
@@ -1168,7 +1185,7 @@ sds stringDigest(robj *o) {
     }
 
     sds hexhash = sdsempty();
-    hexhash = sdscatprintf(hexhash, "%" PRIx64, hash);
+    hexhash = sdscatprintf(hexhash, "%0" STRINGIFY(DIGEST_HEX_LENGTH) PRIx64, hash);
     return hexhash;
 }
 

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -130,10 +130,8 @@ void setGenericCommand(client *c, int flags, robj *key, robj **valref, robj *exp
                 return;
             }
         } else if (flags & OBJ_SET_IFDEQ || flags & OBJ_SET_IFDNE) {
-            if (validateHexDigest(match_value->ptr) != C_OK) {
-                addReplyError(c, "must be exactly 16 hexadecimal characters");
+            if (validateHexDigest(c, match_value->ptr) != C_OK)
                 return;
-            }
 
             sds current_digest = stringDigest(current);
             int condition = flags & OBJ_SET_IFDEQ ?
@@ -1163,10 +1161,12 @@ cleanup:
  * Note: This only validates length, not whether characters are valid hex digits.
  * Invalid hex characters will simply fail to match during comparison.
  * Returns C_OK if length is correct, C_ERR otherwise. */
-int validateHexDigest(const sds digest) {
+int validateHexDigest(client *c, const sds digest) {
     size_t len = sdslen(digest);
-    if (len != DIGEST_HEX_LENGTH)
+    if (len != DIGEST_HEX_LENGTH) {
+        addReplyErrorFormat(c, "must be exactly %d hexadecimal characters", DIGEST_HEX_LENGTH);
         return C_ERR;
+    }
     return C_OK;
 }
 

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -1493,4 +1493,57 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         assert_equal "OK" [r set mykey "world" IFDNE $wrong_digest]
         assert_equal "world" [r get mykey]
     }
+
+    test {IFDEQ/IFDNE reject digest with incorrect format} {
+        r set mykey "test"
+        set digest [r digest mykey]
+
+        # Test with too short digest (15 chars)
+        set short_digest [string range $digest 1 end]
+        assert_error "*must be exactly 16 hexadecimal characters*" {r set mykey "new" IFDEQ $short_digest}
+        assert_error "*must be exactly 16 hexadecimal characters*" {r set mykey "new" IFDNE $short_digest}
+        assert_error "*must be exactly 16 hexadecimal characters*" {r delex mykey IFDEQ $short_digest}
+        assert_error "*must be exactly 16 hexadecimal characters*" {r delex mykey IFDNE $short_digest}
+
+        # Test with too long digest (17 chars)
+        set long_digest "0${digest}"
+        assert_error "*must be exactly 16 hexadecimal characters*" {r set mykey "new" IFDEQ $long_digest}
+        assert_error "*must be exactly 16 hexadecimal characters*" {r set mykey "new" IFDNE $long_digest}
+        assert_error "*must be exactly 16 hexadecimal characters*" {r delex mykey IFDEQ $long_digest}
+        assert_error "*must be exactly 16 hexadecimal characters*" {r delex mykey IFDNE $long_digest}
+
+        # Test with empty digest
+        assert_error "*must be exactly 16 hexadecimal characters*" {r set mykey "new" IFDEQ ""}
+        assert_error "*must be exactly 16 hexadecimal characters*" {r set mykey "new" IFDNE ""}
+        assert_error "*must be exactly 16 hexadecimal characters*" {r delex mykey IFDEQ ""}
+        assert_error "*must be exactly 16 hexadecimal characters*" {r delex mykey IFDNE ""}
+    }
+
+    test {IFDEQ/IFDNE accepts uppercase hex digits (case-insensitive)} {
+        # Test SET IFDEQ with uppercase
+        r set mykey "hello"
+        set digest [r digest mykey]
+        set upper_digest [string toupper $digest]
+        assert_equal "OK" [r set mykey "world" IFDEQ $upper_digest]
+        assert_equal "world" [r get mykey]
+
+        # Test SET IFDEQ with uppercase
+        r set mykey "hello"
+        set digest [r digest mykey]
+        set upper_digest [string toupper $digest]
+        assert_equal "" [r set mykey "world" IFDNE $upper_digest]
+        assert_equal "hello" [r get mykey]
+
+        # Test DELEX IFDEQ with uppercase
+        r set mykey "hello"
+        set upper_digest [string toupper [r digest mykey]]
+        assert_equal 1 [r delex mykey IFDEQ $upper_digest]
+        assert_equal 0 [r exists mykey]
+
+        # Test DELEX IFDNE with uppercase
+        r set mykey "hello"
+        set upper_digest [string toupper [r digest mykey]]
+        assert_equal 0 [r delex mykey IFDNE $upper_digest]
+        assert_equal 1 [r exists mykey]
+    }
 }

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -1494,6 +1494,13 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         assert_equal "world" [r get mykey]
     }
 
+    test {DIGEST always returns exactly 16 hex characters with leading zeros} {
+        # Test with a value that produces a digest with leading zeros
+        r set foo "v8lf0c11xh8ymlqztfd3eeq16kfn4sspw7fqmnuuq3k3t75em5wdizgcdw7uc26nnf961u2jkfzkjytls2kwlj7626sd"
+        # Verify it matches the expected value with leading zeros
+        assert_equal "00006c38adf31777" [r digest foo]
+    }
+
     test {IFDEQ/IFDNE reject digest with incorrect format} {
         r set mykey "test"
         set digest [r digest mykey]


### PR DESCRIPTION
Fix https://github.com/redis/redis/issues/14496

This PR makes the following changes:
- DIGEST: Always return 16 hex characters with leading zeros
  Example: "00006c38adf31777" instead of "6c38adf31777"

- IFDEQ/IFDNE: Validate the digest must be exactly 16 characters

- IFDEQ/IFDNE: Use strcasecmp for case-insensitive hex comparison
  Both uppercase and lowercase hex digits now work identically