### PR TITLE
CVE-2025-62507 and Critical bugs into unstable

### DIFF
--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -408,7 +408,7 @@ static int simd_enabled = 1;
  * It was modified for Redis in order to provide the same result in
  * big and little endian archs (endian neutral). */
 REDIS_NO_SANITIZE("alignment")
-uint64_t MurmurHash64A (const void * key, int len, unsigned int seed) {
+uint64_t MurmurHash64A (const void * key, size_t len, unsigned int seed) {
     const uint64_t m = 0xc6a4a7935bd1e995;
     const int r = 47;
     uint64_t h = seed ^ (len * m);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2780,6 +2780,12 @@ void hgetexCommand(client *c) {
         num_fields_pos += 1;
     }
 
+    /* Check if we have enough arguments */
+    if (num_fields_pos >= c->argc) {
+        addReplyErrorArity(c);
+        return;
+    }
+
     if (strcasecmp(c->argv[num_fields_pos - 1]->ptr, "FIELDS") != 0) {
         addReplyError(c, "Mandatory argument FIELDS is missing or not at the right position");
         return;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3537,6 +3537,8 @@ void xackdelCommand(client *c) {
      * executed in a "all or nothing" fashion. */
     streamID static_ids[STREAMID_STATIC_VECTOR_LEN];
     streamID *ids = static_ids;
+    if (args.numids > STREAMID_STATIC_VECTOR_LEN)
+        ids = zmalloc(sizeof(streamID)*args.numids);
     for (int j = 0; j < args.numids; j++) {
         if (streamParseStrictIDOrReply(c,c->argv[j+args.startidx],&ids[j],0,NULL) != C_OK)
             goto cleanup;

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -1093,7 +1093,7 @@ proc get_nonloopback_client {} {
 }
 
 # The following functions and variables are used only when running large-memory
-# tests. We avoid defining them when not running large-memory tests because the 
+# tests. We avoid defining them when not running large-memory tests because the
 # global variables takes up lots of memory.
 proc init_large_mem_vars {} {
     if {![info exists ::str500]} {

--- a/tests/unit/hyperloglog.tcl
+++ b/tests/unit/hyperloglog.tcl
@@ -363,4 +363,12 @@ start_server {tags {"hll"}} {
         r pfadd hll 1 2 3
         assert {[r getrange hll 15 15] eq "\x80"}
     }
+
+    test {PFADD with 2GB entry should not crash server due to overflow in MurmurHash64A} {
+        r config set proto-max-bulk-len 3221225472
+        r config set client-query-buffer-limit 3221225472
+        r write "*3\r\n\$5\r\nPFADD\r\n\$3\r\nhll\r\n"
+        write_big_bulk 2147483648;
+        r ping
+    } {PONG} {large-memory}
 }

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -887,9 +887,9 @@ start_server {tags {"external:skip needs:debug"}} {
             assert_error "*wrong number of arguments*" {r HGETEX h1 FIELDS}
             assert_error "*wrong number of arguments*" {r HGETEX h1 FIELDS 0}
             assert_error "*wrong number of arguments*" {r HGETEX h1 FIELDS 1}
-            assert_error "*argument FIELDS is missing*" {r HGETEX h1 XFIELDX 1 a}
-            assert_error "*argument FIELDS is missing*" {r HGETEX h1 PXAT 1 1}
-            assert_error "*argument FIELDS is missing*" {r HGETEX h1 PERSIST 1 FIELDS 1 a}
+            assert_error "*wrong number of arguments*" {r HGETEX h1 PXAT 1 1}
+            assert_error "*Mandatory argument FIELDS*" {r HGETEX h1 XFIELDX 1 a}
+            assert_error "*Mandatory argument FIELDS*" {r HGETEX h1 PERSIST 1 FIELDS 1 a}
             assert_error "*must match the number of arguments*" {r HGETEX h1 FIELDS 2 a}
             assert_error "*Number of fields must be a positive integer*" {r HGETEX h1 FIELDS 0 a}
             assert_error "*Number of fields must be a positive integer*" {r HGETEX h1 FIELDS -1 a}
@@ -908,6 +908,8 @@ start_server {tags {"external:skip needs:debug"}} {
             assert_error "*invalid expire time*" {r HGETEX h1 EXAT [expr (1<<46) + 100 ] FIELDS 1 a}
             assert_error "*invalid expire time*" {r HGETEX h1 PX [expr (1<<46) - [clock milliseconds] + 100 ] FIELDS 1 a}
             assert_error "*invalid expire time*" {r HGETEX h1 PXAT [expr (1<<46) + 100 ] FIELDS 1 a}
+            assert_error "*wrong number of arguments*" {r HGETEX missingkey EX 100 FIELDS}
+            assert_error "*wrong number of arguments*" {r EVAL "return redis.call('HGETEX', 'missingkey', 'EX', '100', 'FIELDS')" 0}
         }
 
         test "HGETEX - get without setting ttl ($type)" {


### PR DESCRIPTION
- Fix XACKDEL stack overflow when IDs exceed STREAMID_STATIC_VECTOR_LEN (CVE-2025-62507)
- Fix HGETEX out-of-bounds read when FIELDS option missing numfields argument
- Fix MurmurHash64A overflow in HyperLogLog with 2GB+ entries
