### PR TITLE
Allow replicas without masterauth even when master has a password in cluster mode

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -543,6 +543,11 @@ dir ./
 # starting the replication synchronization process, otherwise the master will
 # refuse the replica request.
 #
+# NOTE: In cluster mode, if all nodes are running version 8.6 or later, you no
+# longer need to configure this password manually. Replicas will automatically
+# authenticate using an internally negotiated secret exchanged over the cluster
+# bus.
+#
 # masterauth <master-password>
 #
 # However this is not enough if you are using Redis ACLs (for Redis version

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -126,6 +126,7 @@ struct asmManager *asmManager = NULL;
 /* replication.c */
 char *sendCommand(connection *conn, ...);
 char *sendCommandArgv(connection *conn, int argc, char **argv, size_t *argv_lens);
+char *sendInternalAuth(connection *conn);
 char *receiveSynchronousResponse(connection *conn);
 ConnectionType *connTypeOfReplication(void);
 int startBgsaveForReplication(int mincapa, int req);
@@ -1227,19 +1228,6 @@ void asmCallbackOnFreeClient(client *c) {
     }
 }
 
-/* Sends an AUTH command to the source node using the internal secret.
- * Returns an error string if the command fails, or NULL on success. */
-char *asmSendInternalAuth(connection *conn) {
-    size_t len = 0;
-    const char *internal_secret = clusterGetSecret(&len);
-    serverAssert(internal_secret != NULL);
-
-    sds secret = sdsnewlen(internal_secret, len);
-    char *err = sendCommand(conn, "AUTH", "internal connection", secret, NULL);
-    sdsfree(secret);
-    return err;
-}
-
 /* Handles the RDB channel sync with the source node.
  * This function is called when the RDB channel is established
  * and ready to sync with the source node. */
@@ -1271,7 +1259,7 @@ void asmRdbChannelSyncWithSource(connection *conn) {
         connSetWriteHandler(conn, NULL);
 
         /* Send AUTH command to source node using internal auth */
-        err = asmSendInternalAuth(conn);
+        err = sendInternalAuth(conn);
         if (err) goto write_error;
         task->rdb_channel_state = ASM_AUTH_REPLY;
         return;
@@ -1421,7 +1409,7 @@ void asmSyncWithSource(connection *conn) {
         connSetReadHandler(conn, asmSyncWithSource);
         connSetWriteHandler(conn, NULL);
         /* Send AUTH command to source node using internal auth */
-        err = asmSendInternalAuth(conn);
+        err = sendInternalAuth(conn);
         if (err) goto write_error;
         task->state = ASM_AUTH_REPLY;
         return;

--- a/src/replication.c
+++ b/src/replication.c
@@ -2658,6 +2658,19 @@ char *sendCommandArgv(connection *conn, int argc, char **argv, size_t *argv_lens
     return NULL;
 }
 
+/* Sends an AUTH command on the connection using the internal cluster secret.
+ * Returns an error string if the command fails, or NULL on success. */
+char *sendInternalAuth(connection *conn) {
+    size_t len = 0;
+    const char *internal_secret = clusterGetSecret(&len);
+    serverAssert(internal_secret != NULL);
+
+    sds secret = sdsnewlen(internal_secret, len);
+    char *err = sendCommand(conn, "AUTH", "internal connection", secret, NULL);
+    sdsfree(secret);
+    return err;
+}
+
 /* Try a partial resynchronization with the master if we are about to reconnect.
  * If there is no cached master structure, at least try to issue a
  * "PSYNC ? -1" command in order to trigger a full resync using the PSYNC
@@ -2984,6 +2997,11 @@ void syncWithMaster(connection *conn) {
             argc++;
             err = sendCommandArgv(conn, argc, args, lens);
             if (err) goto write_error;
+        } else if (server.cluster_enabled) {
+            /* Authenticate with the internal secret if cluster is enabled and
+             * no master username/password is configured. */
+            err = sendInternalAuth(conn);
+            if (err) goto write_error;
         }
 
         /* Set the slave port, so that Master's INFO command can list the
@@ -3022,8 +3040,12 @@ void syncWithMaster(connection *conn) {
         return;
     }
 
-    if (server.repl_state == REPL_STATE_RECEIVE_AUTH_REPLY && !server.masterauth)
+    if (server.repl_state == REPL_STATE_RECEIVE_AUTH_REPLY &&
+        !server.masterauth &&
+        !server.cluster_enabled)
+    {
         server.repl_state = REPL_STATE_RECEIVE_PORT_REPLY;
+    }
 
     /* Receive AUTH reply. */
     if (server.repl_state == REPL_STATE_RECEIVE_AUTH_REPLY) {
@@ -3586,6 +3608,14 @@ static int rdbChannelSendHandshake(connection *conn, sds *err) {
             serverLog(LL_WARNING, "Error sending AUTH to master in rdb channel replication handshake: %s", *err);
             return C_ERR;
         }
+    } else if (server.cluster_enabled) {
+        /* Authenticate with the internal secret if cluster is enabled and
+         * no master username/password is configured. */
+        *err = sendInternalAuth(conn);
+        if (*err) {
+            serverLog(LL_WARNING, "Error sending AUTH to master in rdb channel replication handshake: %s", *err);
+            return C_ERR;
+        }
     }
 
     char buf[LONG_STR_SIZE];
@@ -3734,7 +3764,7 @@ static void rdbChannelFullSyncWithMaster(connection *conn) {
                 server.repl_rdb_ch_state = REPL_RDB_CH_RECEIVE_AUTH_REPLY;
             break;
         case REPL_RDB_CH_RECEIVE_AUTH_REPLY:
-            if (server.masterauth) {
+            if (server.masterauth || server.cluster_enabled) {
                 ret = rdbChannelHandleAuthReply(conn, &err);
                 if (ret == C_OK)
                     server.repl_rdb_ch_state = REPL_RDB_CH_RECEIVE_REPLCONF_REPLY;

--- a/src/replication.c
+++ b/src/replication.c
@@ -2921,6 +2921,8 @@ void syncWithMaster(connection *conn) {
     char tmpfile[256], *err = NULL;
     int dfd = -1, maxtries = 5;
     int psync_result;
+    int need_auth = 0;
+    static int sent_internal_auth = 0;
 
     /* If this event fired after the user turned the instance into a master
      * with SLAVEOF NO ONE we must just return ASAP. */
@@ -2973,6 +2975,7 @@ void syncWithMaster(connection *conn) {
             sdsfree(err);
             goto error;
         } else {
+            if (err[0] == '-') need_auth = 1;
             serverLog(LL_NOTICE,
                 "Master replied to PING, replication can continue...");
         }
@@ -2982,6 +2985,7 @@ void syncWithMaster(connection *conn) {
     }
 
     if (server.repl_state == REPL_STATE_SEND_HANDSHAKE) {
+        sent_internal_auth = 0;
         /* AUTH with the master if required. */
         if (server.masterauth) {
             char *args[3] = {"AUTH",NULL,NULL};
@@ -2997,10 +3001,12 @@ void syncWithMaster(connection *conn) {
             argc++;
             err = sendCommandArgv(conn, argc, args, lens);
             if (err) goto write_error;
-        } else if (server.cluster_enabled) {
+        } else if (server.cluster_enabled && need_auth) {
             /* Authenticate with the internal secret if cluster is enabled and
-             * no master username/password is configured. */
+             * no master username/password is configured and master requires
+             * authentication. */
             err = sendInternalAuth(conn);
+            sent_internal_auth = 1;
             if (err) goto write_error;
         }
 
@@ -3042,7 +3048,7 @@ void syncWithMaster(connection *conn) {
 
     if (server.repl_state == REPL_STATE_RECEIVE_AUTH_REPLY &&
         !server.masterauth &&
-        !server.cluster_enabled)
+        !sent_internal_auth)
     {
         server.repl_state = REPL_STATE_RECEIVE_PORT_REPLY;
     }


### PR DESCRIPTION
In #13762,  users want to hide the plaintext passwords in config file, for `requirepass`, we can use ACL instead of plaintext, but for `masterauth`, we must use plaintext since the replica is a client from POV of master.

In #13763 we introduced internal secret in cluster mode, we can use this internal secret to auth when replicas ask sync with master, instead of using `masterauth`,  so we don't need to write plaintext `masterauth` in config file.