### PR TITLE
Add CLUSTER MIGRATION subcommand in CLUSTER HELP

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6506,6 +6506,9 @@ const char **clusterCommandExtendedHelp(void) {
         "LINKS",
         "    Return information about all network links between this node and its peers.",
         "    Output format is an array where each array element is a map containing attributes of a link",
+        "MIGRATION IMPORT <start-slot end-slot [start-slot end-slot ...]> |",
+        "          STATUS [ID <task-id> | ALL] | CANCEL [ID <task-id> | ALL]",
+        "    Start, monitor and cancel slot migration.",
         NULL
     };
 


### PR DESCRIPTION
I tried to use `cluster help` to learn how to migrate a slot, but I found that we missed adding the `cluster migration` subcommand to `cluster help`.

```
54) SAVECONFIG
55)     Force saving cluster configuration on disk.
56) LINKS
57)     Return information about all network links between this node and its peers.
58)     Output format is an array where each array element is a map containing attributes of a link
59) MIGRATION IMPORT <start-slot end-slot [start-slot end-slot ...]> |
60)           STATUS [ID <task-id> | ALL] | CANCEL [ID <task-id> | ALL]
61)     Start, monitor and cancel slot migration.
62) HELP
63)     Print this help.
```