### PR TITLE
Document per slot memory tracking config behavior in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1824,8 +1824,8 @@ aof-timestamp-enabled no
 # By enabling the 'cluster-slot-stats-enabled' config, the cluster will begin to capture advanced statistics.
 # These statistics can be leveraged to assess general slot usage trends, identify hot / cold slots,
 # migrate slots for a balanced cluster workload, and / or re-write application logic to better utilize slots.
-# Note that per slot memory statistics are collected only if 'cluster-slot-stats-enabled' is enabled
-# on start up and future config changes don't affect it.
+# Note that per slot **memory** statistics are collected only if 'cluster-slot-stats-enabled' is enabled
+# at startup, and later config changes don't affect it.
 #
 # cluster-slot-stats-enabled no
 

--- a/redis.conf
+++ b/redis.conf
@@ -1824,6 +1824,8 @@ aof-timestamp-enabled no
 # By enabling the 'cluster-slot-stats-enabled' config, the cluster will begin to capture advanced statistics.
 # These statistics can be leveraged to assess general slot usage trends, identify hot / cold slots,
 # migrate slots for a balanced cluster workload, and / or re-write application logic to better utilize slots.
+# Note that per slot memory statistics are collected only if 'cluster-slot-stats-enabled' is enabled
+# on start up and future config changes don't affect it.
 #
 # cluster-slot-stats-enabled no
 


### PR DESCRIPTION
Per slot memory statistics are collected only if 'cluster-slot-stats-enabled' is enabled on strartup.
Document this behavior in 'redis.conf'.