### PR TITLE
Fix ASan Daily

### DIFF
--- a/tests/unit/moduleapi/moduleauth.tcl
+++ b/tests/unit/moduleapi/moduleauth.tcl
@@ -393,6 +393,15 @@ start_server {tags {"modules external:skip"}} {
         # of the testacl module. Module based auth should succeed.
         assert_equal {OK} [r AUTH foo allow]
 
+        # The above `r AUTH foo allow` may have called the blocking auth function.
+        # Since it starts a thread which sleeps for half a second (see auth.c)
+        # the call to `r module unload testacl` will cause the testacl module
+        # to be unloaded and after the sleep inside the started thread the
+        # runtime will try to execute non-existing code.
+        # This `after 1000` makes sure the thread spawned by the blocking auth cb
+        # has finished.
+        after 1000
+
         # Validate that the testacl module can be unloaded since blocking module auth is done.
         r module unload testacl
 

--- a/tests/unit/moduleapi/moduleauth.tcl
+++ b/tests/unit/moduleapi/moduleauth.tcl
@@ -393,15 +393,6 @@ start_server {tags {"modules external:skip"}} {
         # of the testacl module. Module based auth should succeed.
         assert_equal {OK} [r AUTH foo allow]
 
-        # The above `r AUTH foo allow` may have called the blocking auth function.
-        # Since it starts a thread which sleeps for half a second (see auth.c)
-        # the call to `r module unload testacl` will cause the testacl module
-        # to be unloaded and after the sleep inside the started thread the
-        # runtime will try to execute non-existing code.
-        # This `after 1000` makes sure the thread spawned by the blocking auth cb
-        # has finished.
-        after 1000
-
         # Validate that the testacl module can be unloaded since blocking module auth is done.
         r module unload testacl
 


### PR DESCRIPTION
After https://github.com/redis/redis/pull/14226 module tests started running with ASan enabled.

`auth.c` blocks the user on auth and spawns a thread that sleeps for 0.5s before unblocking the client and returning.

A tcl tests unloads the module which may happen just after the spawned thread unblocks the client. In that case if the unloading finishes fast enough the spawned thread may try to execute code from the module's dynamic library that is already unloaded resulting in sefault.

Fix: just wait on the thread during module's OnUnload method.