### PR TITLE
Fix CI flaky tests

### DIFF
--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -177,6 +177,7 @@ start_cluster 2 2 [list tags {external:skip cluster modules} config_lines $modul
         $master2 set count_dels_{4oi} 1
         $master2 del count_dels_{4oi}
         assert_equal 1 [$master2 keyspace.get_dels]
+        wait_for_ofs_sync $master2 $replica2
         assert_equal 1 [$replica2 keyspace.get_dels]
         $master2 set count_dels_{4oi} 1
 


### PR DESCRIPTION
- https://github.com/redis/redis/actions/runs/19200504999/job/54887625884
   avoid calling `start_write_load` before pausing the destination node

- https://github.com/redis/redis/actions/runs/18958533020/job/54140746904
   maybe the replica did not sync with master, then the replica did not update the counter