### PR TITLE
Fix FreeBSD daily runs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -960,7 +960,7 @@ jobs:
         version: 13.2
         shell: bash
         run: |
-          sudo pkg install -y bash gmake lang/tcl86 lang/tclx gcc
+          sudo pkg install -y bash gmake lang/tcl86 lang/tclX gcc
           gmake
           ./runtest --single unit/keyspace --single unit/auth --single unit/networking --single unit/protocol
 

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -30,6 +30,7 @@
 #include <arm_neon.h>
 #endif
 
+#undef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 /* The Redis HyperLogLog implementation is based on the following ideas:


### PR DESCRIPTION
Daily CI runs on FreeBSD started failing due to package rename tclx -> tclX.
Also fix macro redefinition warning on FreeBSD while here.