### PR TITLE
Bump Redisearch module version to v8.4.1

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.4.0
+MODULE_VERSION = v8.4.1
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
Fix FT.CREATE failure with LeanVec parameters on non-Intel architectures(https://github.com/RediSearch/RediSearch/commit/4b9dceb2356758a1fa156edf392c970165f43181)