### PR TITLE
Add kvstore type and decouple kvstore from its metadata

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2135,7 +2135,6 @@ void resetClusterStats(void) {
 /* This function is called at server startup in order to initialize cluster data
  * structures that are shared between the different cluster implementations. */
 void clusterCommonInit(void) {
-    server.cluster_slot_stats = zmalloc(CLUSTER_SLOTS*sizeof(clusterSlotStat));
     resetClusterStats();
     asmInit();
 }

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -40,13 +40,6 @@
 typedef struct _clusterNode clusterNode;
 struct clusterState;
 
-/* Struct used for storing slot statistics. */
-typedef struct clusterSlotStat {
-    uint64_t cpu_usec;          /* CPU time (in microseconds) spent on given slot */
-    uint64_t network_bytes_in;  /* Network ingress (in bytes) received for given slot */
-    uint64_t network_bytes_out; /* Network egress (in bytes) sent for given slot */
-} clusterSlotStat;
-
 /* Flags that a module can set in order to prevent certain Redis Cluster
  * features to be enabled. Useful when implementing a different distributed
  * system on top of Redis Cluster message bus, using modules. */

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -2884,10 +2884,10 @@ void asmTriggerBackgroundTrim(slotRangeArray *slots) {
 
     /* Create temp kvstores and estore, move relevant slot dicts/ebuckets into them,
      * and delete them in BIO thread asynchronously. */
-    kvstore *keys = kvstoreCreate(&dbDictType,
+    kvstore *keys = kvstoreCreate(&kvstoreBaseType, &dbDictType,
                                   CLUSTER_SLOT_MASK_BITS,
                                   KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
-    kvstore *expires = kvstoreCreate(&dbExpiresDictType,
+    kvstore *expires = kvstoreCreate(&kvstoreBaseType, &dbExpiresDictType,
                                      CLUSTER_SLOT_MASK_BITS,
                                      KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
     estore *subexpires = estoreCreate(&subexpiresBucketsType, CLUSTER_SLOT_MASK_BITS);

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -47,7 +47,7 @@ static int markSlotsAssignedToMyShard(unsigned char *assigned_slots, int start_s
 }
 
 static uint64_t getSlotStat(int slot, slotStatType stat_type) {
-    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreGetDictMetadata(server.db->keys, slot);
+    kvstoreDictMetadata *meta = getSlotMeta(slot, 0);
     switch (stat_type) {
     case KEY_COUNT: return countKeysInSlot(slot);
     case CPU_USEC: return meta ? meta->cpu_usec : 0;
@@ -103,7 +103,7 @@ static void addReplySlotStat(client *c, int slot) {
 
     /* Any additional metrics aside from key-count come with a performance trade-off,
      * and are aggregated and returned based on its server config. */
-    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreGetDictMetadata(server.db->keys, slot);
+    kvstoreDictMetadata *meta = getSlotMeta(slot, 0);
     if (server.memory_tracking_per_slot) {
         addReplyBulkCString(c, "memory-bytes");
         addReplyLongLong(c, meta ? meta->alloc_size : 0);
@@ -147,7 +147,7 @@ void clusterSlotStatsAddNetworkBytesOutForUserClient(client *c) {
     if (!canAddNetworkBytesOut(c)) return;
 
     serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
-    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreEnsureDictMetadata(server.db->keys, c->slot);
+    kvstoreDictMetadata *meta = getSlotMeta(c->slot, 1);
     meta->network_bytes_out += c->net_output_bytes_curr_cmd;
 }
 
@@ -160,10 +160,10 @@ static void clusterSlotStatsUpdateNetworkBytesOutForReplication(long long len) {
     len *= (long long)listLength(server.slaves);
     serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
     serverAssert(clusterNodeIsMaster(getMyClusterNode()));
-    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreEnsureDictMetadata(server.db->keys, c->slot);
+    kvstoreDictMetadata *meta = getSlotMeta(c->slot, 1);
     /* We sometimes want to adjust the counter downwards (for example when we want to undo accounting for
      * SELECT commands that don't belong to any slot) so let's make sure we don't underflow the counter. */
-    serverAssert(len >= 0 || meta->network_bytes_out >= (uint64_t)-len);
+    debugServerAssert(len >= 0 || meta->network_bytes_out >= (uint64_t)-len);
     meta->network_bytes_out += len;
 }
 
@@ -192,7 +192,7 @@ void clusterSlotStatsAddNetworkBytesOutForShardedPubSubInternalPropagation(clien
     c->slot = slot;
     if (canAddNetworkBytesOut(c)) {
         serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
-        kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreEnsureDictMetadata(server.db->keys, c->slot);
+        kvstoreDictMetadata *meta = getSlotMeta(c->slot, 1);
         meta->network_bytes_out += c->net_output_bytes_curr_cmd;
     }
     /* For sharded pubsub, the client's network bytes metrics must be reset here,
@@ -211,7 +211,7 @@ static void addReplyOrderBy(client *c, slotStatType order_by, long limit, int de
 
 /* Resets applicable slot statistics. */
 void clusterSlotStatReset(int slot) {
-    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreGetDictMetadata(server.db->keys, slot);
+    kvstoreDictMetadata *meta = getSlotMeta(slot, 0);
     if (!meta) return;
     meta->cpu_usec = 0;
     meta->network_bytes_in = 0;
@@ -242,7 +242,7 @@ void clusterSlotStatsAddCpuDuration(client *c, ustime_t duration) {
     if (!canAddCpuDuration(c)) return;
 
     serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
-    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreEnsureDictMetadata(server.db->keys, c->slot);
+    kvstoreDictMetadata *meta = getSlotMeta(c->slot, 1);
     meta->cpu_usec += duration;
 }
 
@@ -278,7 +278,7 @@ void clusterSlotStatsAddNetworkBytesInForUserClient(client *c) {
         c->net_input_bytes_curr_cmd += 15;
     }
 
-    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreEnsureDictMetadata(c->db->keys, c->slot);
+    kvstoreDictMetadata *meta = getSlotMeta(c->slot, 1);
     meta->network_bytes_in += c->net_input_bytes_curr_cmd;
 }
 

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -46,6 +46,10 @@ static int markSlotsAssignedToMyShard(unsigned char *assigned_slots, int start_s
     return assigned_slots_count;
 }
 
+static inline kvstoreDictMetadata *getSlotMeta(int slot, int createIfNeeded) {
+    return kvstoreGetDictMeta(server.db->keys, slot, createIfNeeded);
+}
+
 static uint64_t getSlotStat(int slot, slotStatType stat_type) {
     kvstoreDictMetadata *meta = getSlotMeta(slot, 0);
     switch (stat_type) {

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -216,6 +216,7 @@ void clusterSlotStatReset(int slot) {
     meta->cpu_usec = 0;
     meta->network_bytes_in = 0;
     meta->network_bytes_out = 0;
+    kvstoreFreeDictIfNeeded(server.db->keys, slot);
 }
 
 void clusterSlotStatResetAll(void) {

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -50,7 +50,7 @@ static uint64_t getSlotStat(int slot, slotStatType stat_type) {
     switch (stat_type) {
     case KEY_COUNT: return countKeysInSlot(slot);
     case CPU_USEC: return server.cluster_slot_stats[slot].cpu_usec;
-    case MEMORY_BYTES: return kvstoreDictAllocSize(server.db->keys, slot);
+    case MEMORY_BYTES: return dbSlotAllocSize(server.db, slot);
     case NETWORK_BYTES_IN: return server.cluster_slot_stats[slot].network_bytes_in;
     case NETWORK_BYTES_OUT: return server.cluster_slot_stats[slot].network_bytes_out;
     default: serverPanic("Invalid slot stat type %d was found.", stat_type);
@@ -104,7 +104,7 @@ static void addReplySlotStat(client *c, int slot) {
      * and are aggregated and returned based on its server config. */
     if (server.memory_tracking_per_slot) {
         addReplyBulkCString(c, "memory-bytes");
-        addReplyLongLong(c, kvstoreDictAllocSize(server.db->keys, slot));
+        addReplyLongLong(c, dbSlotAllocSize(server.db, slot));
     }
     if (server.cluster_slot_stats_enabled) {
         addReplyBulkCString(c, "cpu-usec");

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -47,12 +47,13 @@ static int markSlotsAssignedToMyShard(unsigned char *assigned_slots, int start_s
 }
 
 static uint64_t getSlotStat(int slot, slotStatType stat_type) {
+    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreGetDictMetadata(server.db->keys, slot);
     switch (stat_type) {
     case KEY_COUNT: return countKeysInSlot(slot);
-    case CPU_USEC: return server.cluster_slot_stats[slot].cpu_usec;
-    case MEMORY_BYTES: return dbSlotAllocSize(server.db, slot);
-    case NETWORK_BYTES_IN: return server.cluster_slot_stats[slot].network_bytes_in;
-    case NETWORK_BYTES_OUT: return server.cluster_slot_stats[slot].network_bytes_out;
+    case CPU_USEC: return meta ? meta->cpu_usec : 0;
+    case MEMORY_BYTES: return meta ? meta->alloc_size : 0;
+    case NETWORK_BYTES_IN: return meta ? meta->network_bytes_in : 0;
+    case NETWORK_BYTES_OUT: return meta ? meta->network_bytes_out : 0;
     default: serverPanic("Invalid slot stat type %d was found.", stat_type);
     }
 }
@@ -102,17 +103,18 @@ static void addReplySlotStat(client *c, int slot) {
 
     /* Any additional metrics aside from key-count come with a performance trade-off,
      * and are aggregated and returned based on its server config. */
+    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreGetDictMetadata(server.db->keys, slot);
     if (server.memory_tracking_per_slot) {
         addReplyBulkCString(c, "memory-bytes");
-        addReplyLongLong(c, dbSlotAllocSize(server.db, slot));
+        addReplyLongLong(c, meta ? meta->alloc_size : 0);
     }
     if (server.cluster_slot_stats_enabled) {
         addReplyBulkCString(c, "cpu-usec");
-        addReplyLongLong(c, server.cluster_slot_stats[slot].cpu_usec);
+        addReplyLongLong(c, meta ? meta->cpu_usec : 0);
         addReplyBulkCString(c, "network-bytes-in");
-        addReplyLongLong(c, server.cluster_slot_stats[slot].network_bytes_in);
+        addReplyLongLong(c, meta ? meta->network_bytes_in : 0);
         addReplyBulkCString(c, "network-bytes-out");
-        addReplyLongLong(c, server.cluster_slot_stats[slot].network_bytes_out);
+        addReplyLongLong(c, meta ? meta->network_bytes_out : 0);
     }
 }
 
@@ -145,7 +147,8 @@ void clusterSlotStatsAddNetworkBytesOutForUserClient(client *c) {
     if (!canAddNetworkBytesOut(c)) return;
 
     serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
-    server.cluster_slot_stats[c->slot].network_bytes_out += c->net_output_bytes_curr_cmd;
+    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreEnsureDictMetadata(server.db->keys, c->slot);
+    meta->network_bytes_out += c->net_output_bytes_curr_cmd;
 }
 
 /* Accumulates egress bytes upon sending replication stream. This only applies for primary nodes. */
@@ -157,10 +160,11 @@ static void clusterSlotStatsUpdateNetworkBytesOutForReplication(long long len) {
     len *= (long long)listLength(server.slaves);
     serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
     serverAssert(clusterNodeIsMaster(getMyClusterNode()));
+    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreEnsureDictMetadata(server.db->keys, c->slot);
     /* We sometimes want to adjust the counter downwards (for example when we want to undo accounting for
      * SELECT commands that don't belong to any slot) so let's make sure we don't underflow the counter. */
-    serverAssert(len >= 0 || server.cluster_slot_stats[c->slot].network_bytes_out >= (uint64_t)-len);
-    server.cluster_slot_stats[c->slot].network_bytes_out += len;
+    serverAssert(len >= 0 || meta->network_bytes_out >= (uint64_t)-len);
+    meta->network_bytes_out += len;
 }
 
 /* Increment network bytes out for replication stream. This method will increment `len` value times the active replica
@@ -188,7 +192,8 @@ void clusterSlotStatsAddNetworkBytesOutForShardedPubSubInternalPropagation(clien
     c->slot = slot;
     if (canAddNetworkBytesOut(c)) {
         serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
-        server.cluster_slot_stats[c->slot].network_bytes_out += c->net_output_bytes_curr_cmd;
+        kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreEnsureDictMetadata(server.db->keys, c->slot);
+        meta->network_bytes_out += c->net_output_bytes_curr_cmd;
     }
     /* For sharded pubsub, the client's network bytes metrics must be reset here,
      * as resetClient() is not called until subscription ends. */
@@ -206,12 +211,16 @@ static void addReplyOrderBy(client *c, slotStatType order_by, long limit, int de
 
 /* Resets applicable slot statistics. */
 void clusterSlotStatReset(int slot) {
-    /* key-count is exempt, as it is queried separately through `countKeysInSlot()`. */
-    memset(&server.cluster_slot_stats[slot], 0, sizeof(clusterSlotStat));
+    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreGetDictMetadata(server.db->keys, slot);
+    if (!meta) return;
+    meta->cpu_usec = 0;
+    meta->network_bytes_in = 0;
+    meta->network_bytes_out = 0;
 }
 
 void clusterSlotStatResetAll(void) {
-    memset(server.cluster_slot_stats, 0, CLUSTER_SLOTS * sizeof(clusterSlotStat));
+    for (int slot = 0; slot < CLUSTER_SLOTS; slot++)
+        clusterSlotStatReset(slot);
 }
 
 /* For cpu-usec accumulation, nested commands within EXEC, EVAL, FCALL are skipped.
@@ -232,7 +241,8 @@ void clusterSlotStatsAddCpuDuration(client *c, ustime_t duration) {
     if (!canAddCpuDuration(c)) return;
 
     serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
-    server.cluster_slot_stats[c->slot].cpu_usec += duration;
+    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreEnsureDictMetadata(server.db->keys, c->slot);
+    meta->cpu_usec += duration;
 }
 
 /* For cross-slot scripting, its caller client's slot must be invalidated,
@@ -267,7 +277,8 @@ void clusterSlotStatsAddNetworkBytesInForUserClient(client *c) {
         c->net_input_bytes_curr_cmd += 15;
     }
 
-    server.cluster_slot_stats[c->slot].network_bytes_in += c->net_input_bytes_curr_cmd;
+    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreEnsureDictMetadata(c->db->keys, c->slot);
+    meta->network_bytes_in += c->net_input_bytes_curr_cmd;
 }
 
 void clusterSlotStatsCommand(client *c) {

--- a/src/db.c
+++ b/src/db.c
@@ -155,7 +155,8 @@ void dbgAssertKeysizesHist(redisDb *db) {
     }
     kvstoreIteratorReset(&kvs_it);
     for (int type = 0; type < OBJ_TYPE_BASIC_MAX; type++) {
-        volatile int64_t *keysizesHist = kvstoreGetMetadata(db->keys)->keysizes_hist[type];
+        kvstoreMetadata *kvstoreMeta = (kvstoreMetadata *)kvstoreGetMetadata(db->keys);
+        volatile int64_t *keysizesHist = kvstoreMeta->keysizes_hist[type];
         for (int i = 0; i < MAX_KEYSIZES_BINS; i++) {
             if (scanHist[type][i] == keysizesHist[i])
                 continue;
@@ -977,9 +978,10 @@ redisDb *initTempDb(void) {
     redisDb *tempDb = zcalloc(sizeof(redisDb)*server.dbnum);
     for (int i=0; i<server.dbnum; i++) {
         tempDb[i].id = i;
-        tempDb[i].keys = kvstoreCreate(&dbDictType, slot_count_bits,
-                                       flags | KVSTORE_ALLOC_META_KEYS_HIST);
-        tempDb[i].expires = kvstoreCreate(&dbExpiresDictType, slot_count_bits, flags);
+        tempDb[i].keys = kvstoreCreate(&kvstoreExType, &dbDictType, slot_count_bits,
+                                       flags);
+        tempDb[i].expires = kvstoreCreate(&kvstoreBaseType, &dbExpiresDictType,
+                                          slot_count_bits, flags);
         tempDb[i].subexpires = estoreCreate(&subexpiresBucketsType, slot_count_bits);
     }
 

--- a/src/db.c
+++ b/src/db.c
@@ -77,7 +77,7 @@ void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, in
     if(unlikely(type >= OBJ_TYPE_BASIC_MAX))
         return;
 
-    kvstoreDictMetadata *dictMeta = kvstoreGetDictMetadata(db->keys, didx);
+    kvstoreDictMetadata *dictMeta = kvstoreGetDictMeta(db->keys, didx, 0);
     kvstoreMetadata *kvstoreMeta = kvstoreGetMetadata(db->keys);
 
     if (oldLen > 0) {
@@ -127,11 +127,9 @@ void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, in
 
 void updateSlotAllocSize(redisDb *db, int didx, size_t oldsize, size_t newsize) {
     debugServerAssert(server.memory_tracking_per_slot);
-    kvstoreDictMetadata *dictMeta = kvstoreGetDictMetadata(db->keys, didx);
+    kvstoreDictMetadata *dictMeta = kvstoreGetDictMeta(db->keys, didx, 0);
     if (!dictMeta) return;
-#ifdef REDIS_TEST
-    serverAssert(oldsize <= dictMeta->alloc_size);
-#endif
+    debugServerAssert(oldsize <= dictMeta->alloc_size);
     dictMeta->alloc_size -= oldsize;
     dictMeta->alloc_size += newsize;
 }
@@ -155,8 +153,8 @@ void dbgAssertKeysizesHist(redisDb *db) {
     }
     kvstoreIteratorReset(&kvs_it);
     for (int type = 0; type < OBJ_TYPE_BASIC_MAX; type++) {
-        kvstoreMetadata *kvstoreMeta = (kvstoreMetadata *)kvstoreGetMetadata(db->keys);
-        volatile int64_t *keysizesHist = kvstoreMeta->keysizes_hist[type];
+        kvstoreMetadata *meta = kvstoreGetMetadata(db->keys);
+        volatile int64_t *keysizesHist = meta->keysizes_hist[type];
         for (int i = 0; i < MAX_KEYSIZES_BINS; i++) {
             if (scanHist[type][i] == keysizesHist[i])
                 continue;
@@ -197,7 +195,7 @@ void dbgAssertAllocSizePerSlot(redisDb *db) {
 
     int num_slots = kvstoreNumDicts(db->keys);
     for (int slot = 0; slot < num_slots; slot++) {
-        kvstoreDictMetadata *dictMeta = kvstoreGetDictMetadata(db->keys, slot);
+        kvstoreDictMetadata *dictMeta = kvstoreGetDictMeta(db->keys, slot, 0);
         size_t want = slot_sizes[slot];
         size_t have = dictMeta ? dictMeta->alloc_size : 0;
         if (have == want) continue;

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -182,7 +182,7 @@ static void kvstoreDictBucketChanged(dict *d, long long delta) {
 }
 
 /* Returns the size of the DB dict extended metadata in bytes. */
-static size_t kvstoreDictBaseMetadataSize(dict *d) {
+static size_t kvstoreDictBaseMetaSize(dict *d) {
     UNUSED(d);
     return sizeof(kvstoreDictMetaBase);
 }
@@ -219,7 +219,7 @@ kvstore *kvstoreCreate(kvstoreType *type, dictType *dtype, int num_dicts_bits, i
     assert(!dtype->rehashingCompleted);
     kvs->dtype.userdata = kvs;
     kvs->dtype.dictMetadataBytes = type->dictMetadataBytes ?
-        type->dictMetadataBytes : kvstoreDictBaseMetadataSize;
+        type->dictMetadataBytes : kvstoreDictBaseMetaSize;
     kvs->dtype.rehashingStarted = kvstoreDictRehashingStarted;
     kvs->dtype.rehashingCompleted = kvstoreDictRehashingCompleted;
     kvs->dtype.bucketChanged = kvstoreDictBucketChanged;
@@ -931,14 +931,12 @@ int kvstoreDictDelete(kvstore *kvs, int didx, const void *key) {
     return ret;
 }
 
-void *kvstoreEnsureDictMetadata(kvstore *kvs, int didx) {
-    dict *d = createDictIfNeeded(kvs, didx);
-    return dictMetadata(d);
-}
-
-void *kvstoreGetDictMetadata(kvstore *kvs, int didx) {
+void *kvstoreGetDictMeta(kvstore *kvs, int didx, int createIfNeeded) {
     dict *d = kvstoreGetDict(kvs, didx);
-    if (!d) return NULL;
+    if (!d) {
+        if (!createIfNeeded) return NULL;
+        d = createDictIfNeeded(kvs, didx);
+    }
     return dictMetadata(d);
 }
 

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -251,11 +251,11 @@ void kvstoreEmpty(kvstore *kvs, void(callback)(dict*)) {
         if (metadata->rehashing_node)
             metadata->rehashing_node = NULL;
         dictEmpty(d, callback);
-        if (kvs->type->onDictEmpty) kvs->type->onDictEmpty(kvs, didx, 0);
+        if (kvs->type->onDictEmpty) kvs->type->onDictEmpty(kvs, didx);
         freeDictIfNeeded(kvs, didx);
     }
 
-    if (kvs->type->onKvstoreEmpty) kvs->type->onKvstoreEmpty(kvs, 0);
+    if (kvs->type->onKvstoreEmpty) kvs->type->onKvstoreEmpty(kvs);
 
     listEmpty(kvs->rehashing);
 
@@ -276,7 +276,7 @@ void kvstoreRelease(kvstore *kvs) {
         kvstoreDictMetaBase *metadata = (kvstoreDictMetaBase *)dictMetadata(d);
         if (metadata->rehashing_node)
             metadata->rehashing_node = NULL;
-        if (kvs->type->onDictEmpty) kvs->type->onDictEmpty(kvs, didx, 1);
+        if (kvs->type->onDictEmpty) kvs->type->onDictEmpty(kvs, didx);
         dictRelease(d);
     }
     zfree(kvs->dicts);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -123,7 +123,7 @@ static void freeDictIfNeeded(kvstore *kvs, int didx) {
         return;
 
     /* Use callback if provided to check if dict can be freed */
-    if (kvs->type->canFreeDictIfNeeded && !kvs->type->canFreeDictIfNeeded(kvs, didx))
+    if (kvs->type->canFreeDict && !kvs->type->canFreeDict(kvs, didx))
         return;
 
     dictRelease(kvs->dicts[didx]);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -927,6 +927,11 @@ int kvstoreDictDelete(kvstore *kvs, int didx, const void *key) {
     return ret;
 }
 
+void *kvstoreEnsureDictMetadata(kvstore *kvs, int didx) {
+    dict *d = createDictIfNeeded(kvs, didx);
+    return dictMetadata(d);
+}
+
 void *kvstoreGetDictMetadata(kvstore *kvs, int didx) {
     dict *d = kvstoreGetDict(kvs, didx);
     if (!d) return NULL;

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -131,6 +131,10 @@ static void freeDictIfNeeded(kvstore *kvs, int didx) {
     kvs->allocated_dicts--;
 }
 
+void kvstoreFreeDictIfNeeded(kvstore *kvs, int didx) {
+    freeDictIfNeeded(kvs, didx);
+}
+
 /**********************************/
 /*** dict callbacks ***************/
 /**********************************/

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -22,13 +22,12 @@
 #include "fwtree.h"
 #include "redisassert.h"
 #include "monotonic.h"
-#include "server.h"
-
 
 #define UNUSED(V) ((void) V)
 
 struct _kvstore {
     int flags;
+    kvstoreType *type;
     dictType dtype;
     dict **dicts;
     long long num_dicts;
@@ -43,18 +42,6 @@ struct _kvstore {
     size_t overhead_hashtable_rehashing;   /* The overhead of dictionaries rehashing. */
     void *metadata[];                      /* conditionally allocated based on "flags" */
 };
-
-/* Basic metadata allocated per dict */
-typedef struct {
-    listNode *rehashing_node;   /* list node in rehashing list */
-} kvstoreDictMetaBase;
-
-/* Conditionally metadata allocated per dict (specifically for keysizes histogram) */
-typedef struct {
-    kvstoreDictMetaBase base; /* must be first in struct ! */
-    /* External metadata */
-    kvstoreDictMetadata meta;
-} kvstoreDictMetaEx;
 
 /**********************************/
 /*** Helpers **********************/
@@ -134,12 +121,11 @@ static void freeDictIfNeeded(kvstore *kvs, int didx) {
         kvstoreDictSize(kvs, didx) != 0 ||
         kvstoreDictIsRehashingPaused(kvs, didx))
         return;
-#ifdef REDIS_TEST
-    if (kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST) {
-        kvstoreDictMetaEx *metadata = (kvstoreDictMetaEx *)dictMetadata(kvs->dicts[didx]);
-        serverAssert(metadata->meta.alloc_size == 0);
-    }
-#endif
+
+    /* Use callback if provided to check if dict can be freed */
+    if (kvs->type->canFreeDictIfNeeded && !kvs->type->canFreeDictIfNeeded(kvs, didx))
+        return;
+
     dictRelease(kvs->dicts[didx]);
     kvs->dicts[didx] = NULL;
     kvs->allocated_dicts--;
@@ -191,28 +177,10 @@ static void kvstoreDictBucketChanged(dict *d, long long delta) {
     kvs->bucket_count += delta;
 }
 
-/* Returns the size of the DB dict base metadata in bytes. */
-static size_t kvstoreDictMetaBaseSize(dict *d) {
+/* Returns the size of the DB dict extended metadata in bytes. */
+static size_t kvstoreDictBaseMetadataSize(dict *d) {
     UNUSED(d);
     return sizeof(kvstoreDictMetaBase);
-}
-/* Returns the size of the DB dict extended metadata in bytes. */
-static size_t kvstoreDictMetadataExtendSize(dict *d) {
-    UNUSED(d);
-    return sizeof(kvstoreDictMetaEx);
-}
-
-void kvstoreTrackDeallocation(dict *d, void *kv) {
-    if (!server.memory_tracking_per_slot) return;
-    kvstore *kvs = d->type->userdata;
-    if (kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST) {
-        kvstoreDictMetaEx *metadata = (kvstoreDictMetaEx *)dictMetadata(d);
-        size_t alloc_size = kvobjAllocSize(kv);
-#ifdef REDIS_TEST
-        serverAssert(alloc_size <= metadata->meta.alloc_size);
-#endif
-        metadata->meta.alloc_size -= alloc_size;
-    }
 }
 
 /**********************************/
@@ -222,32 +190,32 @@ void kvstoreTrackDeallocation(dict *d, void *kv) {
 /* Create an array of dictionaries
  * num_dicts_bits is the log2 of the amount of dictionaries needed (e.g. 0 for 1 dict,
  * 3 for 8 dicts, etc.) */
-kvstore *kvstoreCreate(dictType *type, int num_dicts_bits, int flags) {
+kvstore *kvstoreCreate(kvstoreType *type, dictType *dtype, int num_dicts_bits, int flags) {
     /* We can't support more than 2^16 dicts because we want to save 48 bits
      * for the dict cursor, see kvstoreScan */
     assert(num_dicts_bits <= 16);
+    assert(!type->dictMetadataBytes || type->dictMetadataBytes(NULL) >= sizeof(kvstoreDictMetaBase));
 
     /* Calc kvstore size */   
     size_t kvsize = sizeof(kvstore);
     /* Conditionally calc also histogram size */
-    if (flags & KVSTORE_ALLOC_META_KEYS_HIST) 
-        kvsize += sizeof(kvstoreMetadata);
+    if (type->kvstoreMetadataBytes)
+        kvsize += type->kvstoreMetadataBytes(NULL);
     
     kvstore *kvs = zcalloc(kvsize);
-    memcpy(&kvs->dtype, type, sizeof(kvs->dtype));
+    memcpy(&kvs->dtype, dtype, sizeof(kvs->dtype));
     kvs->flags = flags;
+    kvs->type = type;
 
     /* kvstore must be the one to set these callbacks, so we make sure the
      * caller didn't do it */
-    assert(!type->userdata);
-    assert(!type->dictMetadataBytes);
-    assert(!type->rehashingStarted);
-    assert(!type->rehashingCompleted);
+    assert(!dtype->userdata);
+    assert(!dtype->dictMetadataBytes);
+    assert(!dtype->rehashingStarted);
+    assert(!dtype->rehashingCompleted);
     kvs->dtype.userdata = kvs;
-    if (flags & KVSTORE_ALLOC_META_KEYS_HIST)
-        kvs->dtype.dictMetadataBytes = kvstoreDictMetadataExtendSize;
-    else
-        kvs->dtype.dictMetadataBytes = kvstoreDictMetaBaseSize;
+    kvs->dtype.dictMetadataBytes = type->dictMetadataBytes ?
+        type->dictMetadataBytes : kvstoreDictBaseMetadataSize;
     kvs->dtype.rehashingStarted = kvstoreDictRehashingStarted;
     kvs->dtype.rehashingCompleted = kvstoreDictRehashingCompleted;
     kvs->dtype.bucketChanged = kvstoreDictBucketChanged;
@@ -278,16 +246,12 @@ void kvstoreEmpty(kvstore *kvs, void(callback)(dict*)) {
         kvstoreDictMetaBase *metadata = (kvstoreDictMetaBase *)dictMetadata(d);
         if (metadata->rehashing_node)
             metadata->rehashing_node = NULL;
-        if (kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST) {
-            kvstoreDictMetaEx *metaExt = (kvstoreDictMetaEx *) metadata;
-            memset(&metaExt->meta.keysizes_hist, 0, sizeof(metaExt->meta.keysizes_hist));
-        }
         dictEmpty(d, callback);
+        if (kvs->type->onDictEmpty) kvs->type->onDictEmpty(kvs, didx, 0);
         freeDictIfNeeded(kvs, didx);
     }
 
-    if (kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST)
-        memset(kvstoreGetMetadata(kvs), 0, sizeof(kvstoreMetadata));
+    if (kvs->type->onKvstoreEmpty) kvs->type->onKvstoreEmpty(kvs, 0);
 
     listEmpty(kvs->rehashing);
 
@@ -308,13 +272,7 @@ void kvstoreRelease(kvstore *kvs) {
         kvstoreDictMetaBase *metadata = (kvstoreDictMetaBase *)dictMetadata(d);
         if (metadata->rehashing_node)
             metadata->rehashing_node = NULL;
-#ifdef REDIS_TEST
-        dictEmpty(d, NULL);
-        if (kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST) {
-            kvstoreDictMetaEx *metaEx = (kvstoreDictMetaEx *)metadata;
-            serverAssert(metaEx->meta.alloc_size == 0);
-        }
-#endif
+        if (kvs->type->onDictEmpty) kvs->type->onDictEmpty(kvs, didx, 1);
         dictRelease(d);
     }
     zfree(kvs->dicts);
@@ -342,11 +300,7 @@ unsigned long kvstoreBuckets(kvstore *kvs) {
 
 size_t kvstoreMemUsage(kvstore *kvs) {
     size_t mem = sizeof(*kvs);
-    size_t metaSize = sizeof(kvstoreDictMetaBase);
-
-    if (kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST)
-        metaSize = sizeof(kvstoreDictMetaEx);
-    
+    size_t metaSize = kvs->dtype.dictMetadataBytes(NULL);
     unsigned long long keys_count = kvstoreSize(kvs);
     mem += keys_count * dictEntryMemUsage(kvs->dtype.no_value) +
            kvstoreBuckets(kvs) * sizeof(dictEntry*) +
@@ -594,9 +548,9 @@ int kvstoreNumDicts(kvstore *kvs) {
 
 /* Move dict from one kvstore to another. */
 void kvstoreMoveDict(kvstore *kvs, kvstore *dst, int didx) {
-    serverAssert(kvs->num_dicts > didx);
-    serverAssert(kvs->num_dicts == dst->num_dicts);
-    serverAssert(dst->dicts[didx] == NULL);
+    assert(kvs->num_dicts > didx);
+    assert(kvs->num_dicts == dst->num_dicts);
+    assert(dst->dicts[didx] == NULL);
 
     dict *d = kvs->dicts[didx];
     if (d == NULL) return;
@@ -748,13 +702,6 @@ unsigned long kvstoreDictSize(kvstore *kvs, int didx)
     if (!d)
         return 0;
     return dictSize(d);
-}
-
-size_t kvstoreDictAllocSize(kvstore *kvs, int didx)
-{
-    kvstoreDictMetadata *dictMeta = kvstoreGetDictMetadata(kvs, didx);
-    if (!dictMeta) return 0;
-    return dictMeta->alloc_size;
 }
 
 void kvstoreInitDictIterator(kvstoreDictIterator *kvs_di, kvstore *kvs, int didx)
@@ -980,17 +927,14 @@ int kvstoreDictDelete(kvstore *kvs, int didx, const void *key) {
     return ret;
 }
 
-kvstoreDictMetadata *kvstoreGetDictMetadata(kvstore *kvs, int didx) {
+void *kvstoreGetDictMetadata(kvstore *kvs, int didx) {
     dict *d = kvstoreGetDict(kvs, didx);
-    if ((!d) || (!(kvs->flags & KVSTORE_ALLOC_META_KEYS_HIST)))
-        return NULL;
-    
-    kvstoreDictMetaEx *metadata = (kvstoreDictMetaEx *)dictMetadata(d);
-    return &(metadata->meta);
+    if (!d) return NULL;
+    return dictMetadata(d);
 }
 
-kvstoreMetadata *kvstoreGetMetadata(kvstore *kvs) {
-    return (kvstoreMetadata *) &kvs->metadata;
+void *kvstoreGetMetadata(kvstore *kvs) {
+    return &kvs->metadata;
 }
 
 #ifdef REDIS_TEST
@@ -1037,6 +981,14 @@ dictType KvstoreDictTestType = {
     NULL
 };
 
+kvstoreType KvstoreTestType = {
+    NULL, /* kvstore metadata size */
+    NULL, /* dict metadata size */
+    NULL, /* can free dict */
+    NULL, /* on kvstore empty */
+    NULL, /* on dict empty */
+};
+
 char *stringFromInt(int value) {
     char buf[32];
     int len;
@@ -1067,8 +1019,8 @@ int kvstoreTest(int argc, char **argv, int flags) {
 
     int didx = 0;
     int curr_slot = 0;
-    kvstore *kvs1 = kvstoreCreate(&KvstoreDictTestType, 0, KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
-    kvstore *kvs2 = kvstoreCreate(&KvstoreDictNovalTestType, 0, KVSTORE_ALLOCATE_DICTS_ON_DEMAND | KVSTORE_FREE_EMPTY_DICTS);
+    kvstore *kvs1 = kvstoreCreate(&KvstoreTestType, &KvstoreDictTestType, 0, KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
+    kvstore *kvs2 = kvstoreCreate(&KvstoreTestType, &KvstoreDictNovalTestType, 0, KVSTORE_ALLOCATE_DICTS_ON_DEMAND | KVSTORE_FREE_EMPTY_DICTS);
 
     TEST("Add 16 keys") {
         for (i = 0; i < 16; i++) {
@@ -1159,7 +1111,7 @@ int kvstoreTest(int argc, char **argv, int flags) {
 
     TEST("Verify that a rehashing dict's node in the rehashing list is correctly updated after defragmentation") {
         unsigned long cursor = 0;
-        kvstore *kvs = kvstoreCreate(&KvstoreDictTestType, 0, KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
+        kvstore *kvs = kvstoreCreate(&KvstoreTestType, &KvstoreDictTestType, 0, KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
         for (i = 0; i < 256; i++) {
             de = kvstoreDictAddRaw(kvs, 0, stringFromInt(i), NULL);
             if (listLength(kvs->rehashing)) break;
@@ -1171,8 +1123,8 @@ int kvstoreTest(int argc, char **argv, int flags) {
     }
 
     TEST("Verify non-empty dict count is correctly updated") {
-        kvstore *kvs = kvstoreCreate(&KvstoreDictTestType, 2, 
-                            KVSTORE_ALLOCATE_DICTS_ON_DEMAND | KVSTORE_ALLOC_META_KEYS_HIST);
+        kvstore *kvs = kvstoreCreate(&KvstoreTestType, &KvstoreDictTestType, 2, 
+                            KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
         for (int idx = 0; idx < 4; idx++) {
             for (i = 0; i < 16; i++) {
                 de = kvstoreDictAddRaw(kvs, idx, stringFromInt(i), NULL);

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -143,8 +143,7 @@ void kvstoreDictTwoPhaseUnlinkFree(kvstore *kvs, int didx, dictEntryLink plink, 
 int kvstoreDictDelete(kvstore *kvs, int didx, const void *key);
 dict *kvstoreGetDict(kvstore *kvs, int didx);
 void kvstoreFreeDictIfNeeded(kvstore *kvs, int didx);
-void *kvstoreEnsureDictMetadata(kvstore *kvs, int didx);
-void *kvstoreGetDictMetadata(kvstore *kvs, int didx);
+void *kvstoreGetDictMeta(kvstore *kvs, int didx, int createIfNeeded);
 void *kvstoreGetMetadata(kvstore *kvs);
 
 dictEntryLink kvstoreDictFindLink(kvstore *kvs, int didx, void *key, dictEntryLink *bucket);

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -29,22 +29,6 @@
 #include "dict.h"
 #include "adlist.h"
 
-/* maximum number of bins of keysizes histogram */
-#define MAX_KEYSIZES_BINS 60
-#define MAX_KEYSIZES_TYPES 5 /* static_assert at db.c verifies == OBJ_TYPE_BASIC_MAX */
-
-/* When creating kvstore with flag `KVSTORE_ALLOC_META_KEYS_HIST`, then kvstore 
- * alloc and memset struct kvstoreMetadata on init, yet, managed outside kvstore */
-typedef struct {
-    int64_t keysizes_hist[MAX_KEYSIZES_TYPES][MAX_KEYSIZES_BINS];
-} kvstoreMetadata;
-
-/* Like kvstoreMetadata, this one per dict */
-typedef struct {
-    size_t alloc_size; /* total memory used (in bytes) by this dict */
-    int64_t keysizes_hist[MAX_KEYSIZES_TYPES][MAX_KEYSIZES_BINS];
-} kvstoreDictMetadata;
-
 typedef struct _kvstore kvstore;
 
 /* Structure for kvstore iterator that allows iterating across multiple dicts. */
@@ -66,10 +50,42 @@ typedef int (kvstoreScanShouldSkipDict)(dict *d, int didx);
 typedef int (kvstoreExpandShouldSkipDictIndex)(int didx);
 typedef int (kvstoreRandomShouldSkipDictIndex)(int didx);
 
+/* kvstoreType: Callback structure for kvstore-specific operations.
+ * Similar to dictType for dict, this allows kvstore to be a generic data structure
+ * without hardcoding dependencies on specific subsystems. */
+typedef struct kvstoreType {
+    /* Allow kvstore to carry extra caller-defined metadata. The
+     * extra memory is initialized to 0 when a kvstore is allocated. */
+    size_t (*kvstoreMetadataBytes)(kvstore *kvs);
+
+    /* Allow a per slot dicts to carry extra caller-defined metadata. The
+     * extra memory is initialized to 0 when each dict is allocated. */
+    size_t (*dictMetadataBytes)(dict *d);
+
+    /* Check if a dict at given index can be freed. Used by kvstore when
+     * KVSTORE_FREE_EMPTY_DICTS is set. Return 1 if can free, 0 otherwise.
+     * Parameters: kvstore pointer, dict index */
+    int (*canFreeDictIfNeeded)(kvstore *kvs, int didx);
+
+    /* Called when kvstore becomes empty. Parameters: kvstore pointer,
+     * is_release (1 if kvstore is being released) */
+    void (*onKvstoreEmpty)(kvstore *kvs, int is_release);
+
+    /* Called when per slot dict becomes empty. Parameters: kvstore pointer,
+     * dict index, is_release (1 if dict is being released) */
+    void (*onDictEmpty)(kvstore *kvs, int didx, int is_release);
+} kvstoreType;
+
+/* Basic metadata allocated per dict.
+ * If additional metadata needed, embed this structure as the first member
+ * in a new, larger structure. */
+typedef struct {
+    listNode *rehashing_node;   /* list node in rehashing list */
+} kvstoreDictMetaBase;
+
 #define KVSTORE_ALLOCATE_DICTS_ON_DEMAND (1<<0)
 #define KVSTORE_FREE_EMPTY_DICTS (1<<1)
-#define KVSTORE_ALLOC_META_KEYS_HIST (1<<2) /* Alloc keysizes histogram */
-kvstore *kvstoreCreate(dictType *type, int num_dicts_bits, int flags);
+kvstore *kvstoreCreate(kvstoreType *type, dictType *dtype, int num_dicts_bits, int flags);
 void kvstoreEmpty(kvstore *kvs, void(callback)(dict*));
 void kvstoreRelease(kvstore *kvs);
 unsigned long long kvstoreSize(kvstore *kvs);
@@ -108,7 +124,6 @@ unsigned long kvstoreDictRehashingCount(kvstore *kvs);
 
 /* Specific dict access by dict-index */
 unsigned long kvstoreDictSize(kvstore *kvs, int didx);
-size_t kvstoreDictAllocSize(kvstore *kvs, int didx);
 void kvstoreInitDictIterator(kvstoreDictIterator *kvs_di, kvstore *kvs, int didx);
 void kvstoreInitDictSafeIterator(kvstoreDictIterator *kvs_di, kvstore *kvs, int didx);
 void kvstoreResetDictIterator(kvstoreDictIterator *kvs_di);
@@ -127,12 +142,11 @@ dictEntryLink kvstoreDictTwoPhaseUnlinkFind(kvstore *kvs, int didx, const void *
 void kvstoreDictTwoPhaseUnlinkFree(kvstore *kvs, int didx, dictEntryLink plink, int table_index);
 int kvstoreDictDelete(kvstore *kvs, int didx, const void *key);
 dict *kvstoreGetDict(kvstore *kvs, int didx);
-kvstoreDictMetadata *kvstoreGetDictMetadata(kvstore *kvs, int didx);
-kvstoreMetadata *kvstoreGetMetadata(kvstore *kvs);
+void *kvstoreGetDictMetadata(kvstore *kvs, int didx);
+void *kvstoreGetMetadata(kvstore *kvs);
 
 dictEntryLink kvstoreDictFindLink(kvstore *kvs, int didx, void *key, dictEntryLink *bucket);
 void kvstoreDictSetAtLink(kvstore *kvs, int didx, void *kv, dictEntryLink *link, int newItem);
-void kvstoreTrackDeallocation(dict *d, void *kv);
 
 /* dict with distinct key & value (no_value=1) currently is used only by pubsub. */
 void kvstoreDictSetKey(kvstore *kvs, int didx, dictEntry* de, void *key);

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -65,7 +65,7 @@ typedef struct kvstoreType {
     /* Check if a dict at given index can be freed. Used by kvstore when
      * KVSTORE_FREE_EMPTY_DICTS is set. Return 1 if can free, 0 otherwise.
      * Parameters: kvstore pointer, dict index */
-    int (*canFreeDictIfNeeded)(kvstore *kvs, int didx);
+    int (*canFreeDict)(kvstore *kvs, int didx);
 
     /* Called when kvstore becomes empty. */
     void (*onKvstoreEmpty)(kvstore *kvs);

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -142,6 +142,7 @@ dictEntryLink kvstoreDictTwoPhaseUnlinkFind(kvstore *kvs, int didx, const void *
 void kvstoreDictTwoPhaseUnlinkFree(kvstore *kvs, int didx, dictEntryLink plink, int table_index);
 int kvstoreDictDelete(kvstore *kvs, int didx, const void *key);
 dict *kvstoreGetDict(kvstore *kvs, int didx);
+void kvstoreFreeDictIfNeeded(kvstore *kvs, int didx);
 void *kvstoreEnsureDictMetadata(kvstore *kvs, int didx);
 void *kvstoreGetDictMetadata(kvstore *kvs, int didx);
 void *kvstoreGetMetadata(kvstore *kvs);

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -67,13 +67,12 @@ typedef struct kvstoreType {
      * Parameters: kvstore pointer, dict index */
     int (*canFreeDictIfNeeded)(kvstore *kvs, int didx);
 
-    /* Called when kvstore becomes empty. Parameters: kvstore pointer,
-     * is_release (1 if kvstore is being released) */
-    void (*onKvstoreEmpty)(kvstore *kvs, int is_release);
+    /* Called when kvstore becomes empty. */
+    void (*onKvstoreEmpty)(kvstore *kvs);
 
     /* Called when per slot dict becomes empty. Parameters: kvstore pointer,
-     * dict index, is_release (1 if dict is being released) */
-    void (*onDictEmpty)(kvstore *kvs, int didx, int is_release);
+     * dict index. */
+    void (*onDictEmpty)(kvstore *kvs, int didx);
 } kvstoreType;
 
 /* Basic metadata allocated per dict.

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -142,6 +142,7 @@ dictEntryLink kvstoreDictTwoPhaseUnlinkFind(kvstore *kvs, int didx, const void *
 void kvstoreDictTwoPhaseUnlinkFree(kvstore *kvs, int didx, dictEntryLink plink, int table_index);
 int kvstoreDictDelete(kvstore *kvs, int didx, const void *key);
 dict *kvstoreGetDict(kvstore *kvs, int didx);
+void *kvstoreEnsureDictMetadata(kvstore *kvs, int didx);
 void *kvstoreGetDictMetadata(kvstore *kvs, int didx);
 void *kvstoreGetMetadata(kvstore *kvs);
 

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -207,8 +207,8 @@ void emptyDbAsync(redisDb *db) {
     }
     kvstore *oldkeys = db->keys, *oldexpires = db->expires;
     estore *oldsubexpires = db->subexpires;
-    db->keys = kvstoreCreate(&dbDictType, slot_count_bits, flags | KVSTORE_ALLOC_META_KEYS_HIST);
-    db->expires = kvstoreCreate(&dbExpiresDictType, slot_count_bits, flags);
+    db->keys = kvstoreCreate(&kvstoreExType, &dbDictType, slot_count_bits, flags);
+    db->expires = kvstoreCreate(&kvstoreBaseType, &dbExpiresDictType, slot_count_bits, flags);
     db->subexpires = estoreCreate(&subexpiresBucketsType, slot_count_bits);
     emptyDbDataAsync(oldkeys, oldexpires, oldsubexpires);
 }

--- a/src/object.c
+++ b/src/object.c
@@ -533,9 +533,9 @@ void freeListObject(robj *o) {
 void freeSetObject(robj *o) {
     switch (o->encoding) {
     case OBJ_ENCODING_HT:
-#ifdef REDIS_TEST
+#ifdef DEBUG_ASSERTIONS
         dictEmpty(o->ptr, NULL);
-        serverAssert(*htGetMetadataSize(o->ptr) == 0);
+        debugServerAssert(*htGetMetadataSize(o->ptr) == 0);
 #endif
         dictRelease((dict*) o->ptr);
         break;

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -226,9 +226,7 @@ void quicklistRelease(quicklist *quicklist) {
         current = next;
     }
     quicklistBookmarksClear(quicklist);
-#ifdef REDIS_TEST
-    assert(quicklist->alloc_size == zmalloc_usable_size(quicklist));
-#endif
+    debugAssert(quicklist->alloc_size == zmalloc_usable_size(quicklist));
     zfree(quicklist);
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -549,20 +549,18 @@ static int kvstoreCanFreeDict(kvstore *kvs, int didx) {
     return 1;
 }
 
-static void kvstoreOnEmpty(kvstore *kvs, int is_release) {
+static void kvstoreOnEmpty(kvstore *kvs) {
     kvstoreMetadata *meta = kvstoreGetMetadata(kvs);
-    if (!is_release)
-        memset(&meta->keysizes_hist, 0, sizeof(meta->keysizes_hist));
+    memset(&meta->keysizes_hist, 0, sizeof(meta->keysizes_hist));
 }
 
-static void kvstoreOnDictEmpty(kvstore *kvs, int didx, int is_release) {
+static void kvstoreOnDictEmpty(kvstore *kvs, int didx) {
     kvstoreDictMetadata *meta = kvstoreGetDictMeta(kvs, didx, 0);
 #ifdef DEBUG_ASSERTIONS
-    if (is_release) dictEmpty(kvstoreGetDict(kvs, didx), NULL);
-    debugServerAssert(meta->alloc_size == 0);
+    dictEmpty(kvstoreGetDict(kvs, didx), NULL);
 #endif
-    if (!is_release)
-        memset(&meta->keysizes_hist, 0, sizeof(meta->keysizes_hist));
+    debugServerAssert(meta->alloc_size == 0);
+    memset(&meta->keysizes_hist, 0, sizeof(meta->keysizes_hist));
 }
 
 /* Return 1 if currently we allow dict to expand. Dict may allocate huge

--- a/src/server.c
+++ b/src/server.c
@@ -349,10 +349,20 @@ int dictSdsCompareKV(dictCmpCache *cache, const void *sdsLookup, const void *kv)
     return memcmp(sdsLookup, key2, l1) == 0;
 }
 
+static void trackDeallocationKV(dict *d, kvobj *kv) {
+    if (!server.memory_tracking_per_slot) return;
+    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)dictMetadata(d);
+    size_t alloc_size = kvobjAllocSize(kv);
+#ifdef REDIS_TEST
+    serverAssert(alloc_size <= meta->alloc_size);
+#endif
+    meta->alloc_size -= alloc_size;
+}
+
 static void dictDestructorKV(dict *d, void *kv) {
     UNUSED(d);
     if (kv == NULL) return;
-    kvstoreTrackDeallocation(d, kv);
+    trackDeallocationKV(d, kv);
     decrRefCount(kv);
 }
 
@@ -514,6 +524,52 @@ uint64_t dictEncObjHash(const void *key) {
     } else {
         serverPanic("Unknown string encoding");
     }
+}
+
+static size_t kvstoreMetadataBytes(kvstore *kvs) {
+    UNUSED(kvs);
+    return sizeof(kvstoreMetadata);
+}
+
+static size_t kvstoreDictMetadataBytes(dict *d) {
+    UNUSED(d);
+    return sizeof(kvstoreDictMetadata);
+}
+
+static int kvstoreCanFreeDictIfNeeded(kvstore *kvs, int didx) {
+    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreGetDictMetadata(kvs, didx);
+#ifdef REDIS_TEST
+    serverAssert(meta->alloc_size == 0);
+#endif
+    /* Free if not in cluster */
+    if (!server.cluster_enabled) return 1;
+
+    if (server.cluster_slot_stats_enabled &&
+        (meta->cpu_usec || meta->network_bytes_in || meta->network_bytes_out) &&
+        clusterIsMySlot(didx))
+    {
+        /* Don't free if we have stats for this slot */
+        return 0;
+    }
+
+    /* Otherwise, we can free */
+    return 1;
+}
+
+static void kvstoreOnEmpty(kvstore *kvs, int is_release) {
+    kvstoreMetadata *meta = (kvstoreMetadata *)kvstoreGetMetadata(kvs);
+    if (!is_release)
+        memset(&meta->keysizes_hist, 0, sizeof(meta->keysizes_hist));
+}
+
+static void kvstoreOnDictEmpty(kvstore *kvs, int didx, int is_release) {
+    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreGetDictMetadata(kvs, didx);
+#ifdef REDIS_TEST
+    if (is_release) dictEmpty(kvstoreGetDict(kvs, didx), NULL);
+    serverAssert(meta->alloc_size == 0);
+#endif
+    if (!is_release)
+        memset(&meta->keysizes_hist, 0, sizeof(meta->keysizes_hist));
 }
 
 /* Return 1 if currently we allow dict to expand. Dict may allocate huge
@@ -738,6 +794,22 @@ dictType clientDictType = {
     dictClientKeyCompare,       /* key compare */
     .no_value = 1,              /* no values in this dict */
     .keys_are_odd = 0           /* a client pointer is not an odd pointer */            
+};
+
+kvstoreType kvstoreBaseType = {
+    NULL, /* kvstore metadata size */
+    NULL, /* dict metadata size */
+    NULL, /* can free dict */
+    NULL, /* on kvstore empty */
+    NULL, /* on dict empty */
+};
+
+kvstoreType kvstoreExType = {
+    kvstoreMetadataBytes,       /* kvstore metadata size */
+    kvstoreDictMetadataBytes,   /* dict metadata size */
+    kvstoreCanFreeDictIfNeeded, /* can free dict */
+    kvstoreOnEmpty,             /* on kvstore empty */
+    kvstoreOnDictEmpty,         /* on dict empty */
 };
 
 /* This function is called once a background process of some kind terminates,
@@ -2887,8 +2959,8 @@ void initServer(void) {
         flags |= KVSTORE_FREE_EMPTY_DICTS;
     }
     for (j = 0; j < server.dbnum; j++) {
-        server.db[j].keys = kvstoreCreate(&dbDictType, slot_count_bits, flags | KVSTORE_ALLOC_META_KEYS_HIST);
-        server.db[j].expires = kvstoreCreate(&dbExpiresDictType, slot_count_bits, flags);
+        server.db[j].keys = kvstoreCreate(&kvstoreExType, &dbDictType, slot_count_bits, flags);
+        server.db[j].expires = kvstoreCreate(&kvstoreBaseType, &dbExpiresDictType, slot_count_bits, flags);
         server.db[j].subexpires = estoreCreate(&subexpiresBucketsType, slot_count_bits);
         server.db[j].expires_cursor = 0;
         server.db[j].blocking_keys = dictCreate(&keylistDictType);
@@ -2903,9 +2975,9 @@ void initServer(void) {
     /* Note that server.pubsub_channels was chosen to be a kvstore (with only one dict, which
      * seems odd) just to make the code cleaner by making it be the same type as server.pubsubshard_channels
      * (which has to be kvstore), see pubsubtype.serverPubSubChannels */
-    server.pubsub_channels = kvstoreCreate(&objToDictDictType, 0, KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
+    server.pubsub_channels = kvstoreCreate(&kvstoreBaseType, &objToDictDictType, 0, KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
     server.pubsub_patterns = dictCreate(&objToDictDictType);
-    server.pubsubshard_channels = kvstoreCreate(&objToDictDictType, slot_count_bits, KVSTORE_ALLOCATE_DICTS_ON_DEMAND | KVSTORE_FREE_EMPTY_DICTS);
+    server.pubsubshard_channels = kvstoreCreate(&kvstoreBaseType, &objToDictDictType, slot_count_bits, KVSTORE_ALLOCATE_DICTS_ON_DEMAND | KVSTORE_FREE_EMPTY_DICTS);
     server.pubsub_clients = 0;
     server.watching_clients = 0;
     server.cronloops = 0;
@@ -6632,7 +6704,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                 continue;
             
             for (int type = 0; type < OBJ_TYPE_BASIC_MAX; type++) {
-                int64_t *kvstoreHist = kvstoreGetMetadata(server.db[dbnum].keys)->keysizes_hist[type];
+                kvstoreMetadata *kvstoreMeta = (kvstoreMetadata *)kvstoreGetMetadata(server.db[dbnum].keys);
+                int64_t *kvstoreHist = kvstoreMeta->keysizes_hist[type];
                 char buf[10000];
                 int cnt = 0, buflen = 0;
 

--- a/src/server.c
+++ b/src/server.c
@@ -349,20 +349,15 @@ int dictSdsCompareKV(dictCmpCache *cache, const void *sdsLookup, const void *kv)
     return memcmp(sdsLookup, key2, l1) == 0;
 }
 
-static void trackDeallocationKV(dict *d, kvobj *kv) {
-    if (!server.memory_tracking_per_slot) return;
-    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)dictMetadata(d);
-    size_t alloc_size = kvobjAllocSize(kv);
-#ifdef REDIS_TEST
-    serverAssert(alloc_size <= meta->alloc_size);
-#endif
-    meta->alloc_size -= alloc_size;
-}
-
 static void dictDestructorKV(dict *d, void *kv) {
     UNUSED(d);
     if (kv == NULL) return;
-    trackDeallocationKV(d, kv);
+    if (server.memory_tracking_per_slot) {
+        kvstoreDictMetadata *meta = (kvstoreDictMetadata *)dictMetadata(d);
+        size_t alloc_size = kvobjAllocSize(kv);
+        debugServerAssert(alloc_size <= meta->alloc_size);
+        meta->alloc_size -= alloc_size;
+    }
     decrRefCount(kv);
 }
 
@@ -531,16 +526,14 @@ static size_t kvstoreMetadataBytes(kvstore *kvs) {
     return sizeof(kvstoreMetadata);
 }
 
-static size_t kvstoreDictMetadataBytes(dict *d) {
+static size_t kvstoreDictMetaBytes(dict *d) {
     UNUSED(d);
     return sizeof(kvstoreDictMetadata);
 }
 
-static int kvstoreCanFreeDictIfNeeded(kvstore *kvs, int didx) {
-    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreGetDictMetadata(kvs, didx);
-#ifdef REDIS_TEST
-    serverAssert(meta->alloc_size == 0);
-#endif
+static int kvstoreCanFreeDict(kvstore *kvs, int didx) {
+    kvstoreDictMetadata *meta = kvstoreGetDictMeta(kvs, didx, 0);
+    debugServerAssert(meta->alloc_size == 0);
     /* Free if not in cluster */
     if (!server.cluster_enabled) return 1;
 
@@ -557,16 +550,16 @@ static int kvstoreCanFreeDictIfNeeded(kvstore *kvs, int didx) {
 }
 
 static void kvstoreOnEmpty(kvstore *kvs, int is_release) {
-    kvstoreMetadata *meta = (kvstoreMetadata *)kvstoreGetMetadata(kvs);
+    kvstoreMetadata *meta = kvstoreGetMetadata(kvs);
     if (!is_release)
         memset(&meta->keysizes_hist, 0, sizeof(meta->keysizes_hist));
 }
 
 static void kvstoreOnDictEmpty(kvstore *kvs, int didx, int is_release) {
-    kvstoreDictMetadata *meta = (kvstoreDictMetadata *)kvstoreGetDictMetadata(kvs, didx);
-#ifdef REDIS_TEST
+    kvstoreDictMetadata *meta = kvstoreGetDictMeta(kvs, didx, 0);
+#ifdef DEBUG_ASSERTIONS
     if (is_release) dictEmpty(kvstoreGetDict(kvs, didx), NULL);
-    serverAssert(meta->alloc_size == 0);
+    debugServerAssert(meta->alloc_size == 0);
 #endif
     if (!is_release)
         memset(&meta->keysizes_hist, 0, sizeof(meta->keysizes_hist));
@@ -805,11 +798,11 @@ kvstoreType kvstoreBaseType = {
 };
 
 kvstoreType kvstoreExType = {
-    kvstoreMetadataBytes,       /* kvstore metadata size */
-    kvstoreDictMetadataBytes,   /* dict metadata size */
-    kvstoreCanFreeDictIfNeeded, /* can free dict */
-    kvstoreOnEmpty,             /* on kvstore empty */
-    kvstoreOnDictEmpty,         /* on dict empty */
+    kvstoreMetadataBytes, /* kvstore metadata size */
+    kvstoreDictMetaBytes, /* dict metadata size */
+    kvstoreCanFreeDict,   /* can free dict */
+    kvstoreOnEmpty,       /* on kvstore empty */
+    kvstoreOnDictEmpty,   /* on dict empty */
 };
 
 /* This function is called once a background process of some kind terminates,
@@ -2975,9 +2968,13 @@ void initServer(void) {
     /* Note that server.pubsub_channels was chosen to be a kvstore (with only one dict, which
      * seems odd) just to make the code cleaner by making it be the same type as server.pubsubshard_channels
      * (which has to be kvstore), see pubsubtype.serverPubSubChannels */
-    server.pubsub_channels = kvstoreCreate(&kvstoreBaseType, &objToDictDictType, 0, KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
+    server.pubsub_channels = kvstoreCreate(
+        &kvstoreBaseType, &objToDictDictType,
+        0, KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
     server.pubsub_patterns = dictCreate(&objToDictDictType);
-    server.pubsubshard_channels = kvstoreCreate(&kvstoreBaseType, &objToDictDictType, slot_count_bits, KVSTORE_ALLOCATE_DICTS_ON_DEMAND | KVSTORE_FREE_EMPTY_DICTS);
+    server.pubsubshard_channels = kvstoreCreate(
+        &kvstoreBaseType, &objToDictDictType,
+        slot_count_bits, KVSTORE_ALLOCATE_DICTS_ON_DEMAND | KVSTORE_FREE_EMPTY_DICTS);
     server.pubsub_clients = 0;
     server.watching_clients = 0;
     server.cronloops = 0;
@@ -6704,8 +6701,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                 continue;
             
             for (int type = 0; type < OBJ_TYPE_BASIC_MAX; type++) {
-                kvstoreMetadata *kvstoreMeta = (kvstoreMetadata *)kvstoreGetMetadata(server.db[dbnum].keys);
-                int64_t *kvstoreHist = kvstoreMeta->keysizes_hist[type];
+                kvstoreMetadata *meta = kvstoreGetMetadata(server.db[dbnum].keys);
+                int64_t *kvstoreHist = meta->keysizes_hist[type];
                 char buf[10000];
                 int cnt = 0, buflen = 0;
 

--- a/src/server.h
+++ b/src/server.h
@@ -1140,6 +1140,25 @@ typedef struct redisDb {
     unsigned long expires_cursor; /* Cursor of the active expire cycle. */
 } redisDb;
 
+/* maximum number of bins of keysizes histogram */
+#define MAX_KEYSIZES_BINS 60
+#define MAX_KEYSIZES_TYPES 5 /* static_assert at db.c verifies == OBJ_TYPE_BASIC_MAX */
+
+/* Metadata structure used for kvstores with type `kvstoreExType`, managed outside kvstore */
+typedef struct {
+    int64_t keysizes_hist[MAX_KEYSIZES_TYPES][MAX_KEYSIZES_BINS];
+} kvstoreMetadata;
+
+/* Like kvstoreMetadata, this one per dict */
+typedef struct {
+    kvstoreDictMetaBase base;   /* must be first in struct ! */
+    size_t alloc_size;          /* Total memory used (in bytes) by this slot */
+    uint64_t cpu_usec;          /* CPU time (in microseconds) spent on given slot */
+    uint64_t network_bytes_in;  /* Network ingress (in bytes) received for given slot */
+    uint64_t network_bytes_out; /* Network egress (in bytes) sent for given slot */
+    int64_t keysizes_hist[MAX_KEYSIZES_TYPES][MAX_KEYSIZES_BINS];
+} kvstoreDictMetadata;
+
 /* forward declaration for functions ctx */
 typedef struct functionsLibCtx functionsLibCtx;
 
@@ -2823,6 +2842,8 @@ extern dictType dbExpiresDictType;
 extern dictType modulesDictType;
 extern dictType sdsReplyDictType;
 extern dictType keylistDictType;
+extern kvstoreType kvstoreBaseType;
+extern kvstoreType kvstoreExType;
 extern dict *modules;
 
 extern EbucketsType subexpiresBucketsType;  /* global expires */

--- a/src/server.h
+++ b/src/server.h
@@ -3569,9 +3569,6 @@ kvobj *dbFindByLink(redisDb *db, sds key, dictEntryLink *link);
 kvobj *dbFindExpires(redisDb *db, sds key);
 unsigned long long dbSize(redisDb *db);
 unsigned long long dbScan(redisDb *db, unsigned long long cursor, dictScanFunction *scan_cb, void *privdata);
-static inline kvstoreDictMetadata *getSlotMeta(int slot, int createIfNeeded) {
-    return kvstoreGetDictMeta(server.db->keys, slot, createIfNeeded);
-}
 
 /* Set data type */
 robj *setTypeCreate(sds value, size_t size_hint);

--- a/src/server.h
+++ b/src/server.h
@@ -852,7 +852,6 @@ struct moduleLoadQueueEntry;
 struct RedisModuleKeyOptCtx;
 struct RedisModuleCommand;
 struct clusterState;
-struct clusterSlotStat;
 struct slotRangeArray;
 
 /* Each module type implementation should export a set of methods in order
@@ -2320,7 +2319,6 @@ struct redisServer {
     long long asm_sync_buffer_drain_timeout; /* Timeout in milliseconds for sync buffer to drain during ASM. */
     int asm_max_archived_tasks; /* Maximum number of archived ASM tasks to keep in memory. */
     struct clusterState *cluster;  /* State of the cluster */
-    struct clusterSlotStat *cluster_slot_stats; /* Struct used for storing slot statistics, for all slots owned by the current shard. */
     int cluster_migration_barrier; /* Cluster replicas migration barrier. */
     int cluster_allow_replica_migration; /* Automatic replica migrations to orphaned masters and from empty masters */
     int cluster_slave_validity_factor; /* Slave max data age for failover. */

--- a/src/server.h
+++ b/src/server.h
@@ -1142,10 +1142,11 @@ typedef struct redisDb {
 /* maximum number of bins of keysizes histogram */
 #define MAX_KEYSIZES_BINS 60
 #define MAX_KEYSIZES_TYPES 5 /* static_assert at db.c verifies == OBJ_TYPE_BASIC_MAX */
+typedef int64_t keysizesHist[MAX_KEYSIZES_TYPES][MAX_KEYSIZES_BINS];
 
 /* Metadata structure used for kvstores with type `kvstoreExType`, managed outside kvstore */
 typedef struct {
-    int64_t keysizes_hist[MAX_KEYSIZES_TYPES][MAX_KEYSIZES_BINS];
+    keysizesHist keysizes_hist;
 } kvstoreMetadata;
 
 /* Like kvstoreMetadata, this one per dict */
@@ -1155,7 +1156,7 @@ typedef struct {
     uint64_t cpu_usec;          /* CPU time (in microseconds) spent on given slot */
     uint64_t network_bytes_in;  /* Network ingress (in bytes) received for given slot */
     uint64_t network_bytes_out; /* Network egress (in bytes) sent for given slot */
-    int64_t keysizes_hist[MAX_KEYSIZES_TYPES][MAX_KEYSIZES_BINS];
+    keysizesHist keysizes_hist;
 } kvstoreDictMetadata;
 
 /* forward declaration for functions ctx */

--- a/src/server.h
+++ b/src/server.h
@@ -3569,6 +3569,9 @@ kvobj *dbFindByLink(redisDb *db, sds key, dictEntryLink *link);
 kvobj *dbFindExpires(redisDb *db, sds key);
 unsigned long long dbSize(redisDb *db);
 unsigned long long dbScan(redisDb *db, unsigned long long cursor, dictScanFunction *scan_cb, void *privdata);
+static inline kvstoreDictMetadata *getSlotMeta(int slot, int createIfNeeded) {
+    return kvstoreGetDictMeta(server.db->keys, slot, createIfNeeded);
+}
 
 /* Set data type */
 robj *setTypeCreate(sds value, size_t size_hint);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2035,9 +2035,9 @@ void hashTypeFree(robj *o) {
                 htMetadataEx *m = htGetMetadataEx((dict*)o->ptr);
                 serverAssert(m->expireMeta.trash == 1);
             }
-#ifdef REDIS_TEST
+#ifdef DEBUG_ASSERTIONS
             dictEmpty(o->ptr, NULL);
-            serverAssert(*htGetMetadataSize(o->ptr) == 0);
+            debugServerAssert(*htGetMetadataSize(o->ptr) == 0);
 #endif
             dictRelease((dict*) o->ptr);
             break;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -83,9 +83,7 @@ void freeStream(stream *s) {
         raxFreeWithCbAndContext(s->cgroups, streamFreeCGGeneric, s);
     if (s->cgroups_ref)
         raxFreeWithCallback(s->cgroups_ref, listReleaseGeneric);
-#ifdef REDIS_TEST
-    serverAssert(s->alloc_size == zmalloc_usable_size(s));
-#endif
+    debugServerAssert(s->alloc_size == zmalloc_usable_size(s));
     zfree(s);
 }
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -113,9 +113,7 @@ void zslFree(zskiplist *zsl) {
         zslFreeNode(zsl, node);
         node = next;
     }
-#ifdef REDIS_TEST
-    serverAssert(zsl->alloc_size == zmalloc_usable_size(zsl));
-#endif
+    debugServerAssert(zsl->alloc_size == zmalloc_usable_size(zsl));
     zfree(zsl);
 }
 

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -263,7 +263,7 @@ run_solo {defrag} {
                 puts "frag [s allocator_frag_ratio]"
                 puts "frag_bytes [s allocator_frag_bytes]"
             }
-            assert_morethan [s allocator_frag_ratio] 1.4
+            assert_morethan [s allocator_frag_ratio] 1.3
 
             catch {r config set activedefrag yes} e
             if {[r config get activedefrag] eq "activedefrag yes"} {
@@ -486,7 +486,7 @@ run_solo {defrag} {
                 puts "frag [s allocator_frag_ratio]"
                 puts "frag_bytes [s allocator_frag_bytes]"
             }
-            assert_morethan [s allocator_frag_ratio] 1.35
+            assert_morethan [s allocator_frag_ratio] 1.2
 
             catch {r config set activedefrag yes} e
             if {[r config get activedefrag] eq "activedefrag yes"} {
@@ -705,7 +705,7 @@ run_solo {defrag} {
                 puts "frag [s allocator_frag_ratio]"
                 puts "frag_bytes [s allocator_frag_bytes]"
             }
-            assert_morethan [s allocator_frag_ratio] 1.35
+            assert_morethan [s allocator_frag_ratio] 1.3
 
             catch {r config set activedefrag yes} e
             if {[r config get activedefrag] eq "activedefrag yes"} {

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -255,6 +255,10 @@ run_solo {defrag} {
             # Delete all the keys to create fragmentation
             for {set j 0} {$j < $n} {incr j} { $rd del k$j }
             for {set j 0} {$j < $n} {incr j} { $rd read } ; # Discard del replies
+            if {$type eq "cluster"} {
+                $rd config resetstat
+                $rd read ; # Discard config resetstat reply
+            }
             $rd close
             after 120 ;# serverCron only updates the info once in 100ms
             if {$::verbose} {
@@ -263,7 +267,7 @@ run_solo {defrag} {
                 puts "frag [s allocator_frag_ratio]"
                 puts "frag_bytes [s allocator_frag_bytes]"
             }
-            assert_morethan [s allocator_frag_ratio] 1.3
+            assert_morethan [s allocator_frag_ratio] 1.4
 
             catch {r config set activedefrag yes} e
             if {[r config get activedefrag] eq "activedefrag yes"} {
@@ -478,6 +482,10 @@ run_solo {defrag} {
             # Delete all the keys to create fragmentation
             for {set j 0} {$j < $n} {incr j} { $rd del k$j }
             for {set j 0} {$j < $n} {incr j} { $rd read } ; # Discard del replies
+            if {$type eq "cluster"} {
+                $rd config resetstat
+                $rd read ; # Discard config resetstat reply
+            }
             $rd close
             after 120 ;# serverCron only updates the info once in 100ms
             if {$::verbose} {
@@ -486,7 +494,7 @@ run_solo {defrag} {
                 puts "frag [s allocator_frag_ratio]"
                 puts "frag_bytes [s allocator_frag_bytes]"
             }
-            assert_morethan [s allocator_frag_ratio] 1.2
+            assert_morethan [s allocator_frag_ratio] 1.35
 
             catch {r config set activedefrag yes} e
             if {[r config get activedefrag] eq "activedefrag yes"} {
@@ -697,6 +705,9 @@ run_solo {defrag} {
             for {set i 0} {$i < [llength $clients]} {incr i} {
                 [lindex $clients $i] close
             }
+            if {$type eq "cluster"} {
+                r config resetstat
+            }
 
             after 120 ;# serverCron only updates the info once in 100ms
             if {$::verbose} {
@@ -705,7 +716,7 @@ run_solo {defrag} {
                 puts "frag [s allocator_frag_ratio]"
                 puts "frag_bytes [s allocator_frag_bytes]"
             }
-            assert_morethan [s allocator_frag_ratio] 1.3
+            assert_morethan [s allocator_frag_ratio] 1.35
 
             catch {r config set activedefrag yes} e
             if {[r config get activedefrag] eq "activedefrag yes"} {


### PR DESCRIPTION
Decouple kvstore from its metadata by introducing `kvstoreType` structure of
callbacks. This resolves the abstraction layer violation of having kvstore
include `server.h` directly.

Move (again) cluster slot statistics to per slot dicts' metadata. The callback
`canFreeDict` is used to prevent freeing empty per slot dicts from losing per
slot statistics.

Co-authored-by: Ran Tidhar <ran.tidhar@redis.com>