### PR TITLE
Reply Copy Avoidance

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3177,6 +3177,7 @@ standardConfig static_configs[] = {
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */
     createIntConfig("io-threads", NULL, DEBUG_CONFIG | IMMUTABLE_CONFIG, 1, 128, server.io_threads_num, 1, INTEGER_CONFIG, NULL, NULL), /* Single threaded by default */
+    createIntConfig("min-string-size-avoid-copy-reply", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.min_string_size_copy_avoid, 4096, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("prefetch-batch-max-size", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, 128, server.prefetch_batch_max_size, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_slave_validity_factor, 10, INTEGER_CONFIG, NULL, NULL), /* Slave max data age factor. */

--- a/src/config.c
+++ b/src/config.c
@@ -3177,6 +3177,7 @@ standardConfig static_configs[] = {
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */
     createIntConfig("io-threads", NULL, DEBUG_CONFIG | IMMUTABLE_CONFIG, 1, 128, server.io_threads_num, 1, INTEGER_CONFIG, NULL, NULL), /* Single threaded by default */
+    createIntConfig("min-io-threads-avoid-copy-reply", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.min_io_threads_copy_avoid, 4, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("min-string-size-avoid-copy-reply", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.min_string_size_copy_avoid, 4096, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("prefetch-batch-max-size", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, 128, server.prefetch_batch_max_size, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, INTEGER_CONFIG, NULL, NULL),

--- a/src/db.c
+++ b/src/db.c
@@ -598,7 +598,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
     if (server.memory_tracking_per_slot)
         updateSlotAllocSize(db, slot, oldsize, kvobjAllocSize(kvNew));
 
-    if (server.io_threads_num > 1 && old->encoding == OBJ_ENCODING_RAW) {
+    if (server.io_threads_num > 1 && old->refcount == 1 && old->encoding == OBJ_ENCODING_RAW) {
         /* In multi-threaded mode, the OBJ_ENCODING_RAW string object usually is
          * allocated in the IO thread, so we defer the free to the IO thread.
          * Besides, we never free a string object in BIO threads, so, even with

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -447,6 +447,9 @@ int processClientsFromIOThread(IOThread *t) {
         /* Let main thread to run it, set running thread id first. */
         c->running_tid = IOTHREAD_MAIN_THREAD_ID;
 
+        /* Process any deferred reply blocks that were accumulated in IO thread */
+        processDeferredReplyBlocks(c);
+
         /* If a read error occurs, handle it in the main thread first, since we
          * want to print logs about client information before freeing. */
         if (isClientReadErrorFatal(c)) handleClientReadError(c);

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -258,7 +258,7 @@ void emptyDbAsync(redisDb *db) {
     db->keys = kvstoreCreate(&dbDictType, slot_count_bits, flags | KVSTORE_ALLOC_META_KEYS_HIST);
     db->expires = kvstoreCreate(&dbExpiresDictType, slot_count_bits, flags);
     db->subexpires = estoreCreate(&subexpiresBucketsType, slot_count_bits);
-    protectClientReplyObjects(); /* Protect client reply objects before async free. */
+    // protectClientReplyObjects(); /* Protect client reply objects before async free. */
     emptyDbDataAsync(oldkeys, oldexpires, oldsubexpires);
 }
 

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -223,14 +223,14 @@ static void protectClientReplyObjects(void) {
             while ((reply_ln = listNext(&reply_li))) {
                 clientReplyBlock *block = listNodeValue(reply_ln);
 
-                /* If this is an ROBJ block, duplicate the string object to avoid race condition */
-                if (block && block->type == CLIENT_REPLY_BLOCK_ROBJ) {
-                    clientReplyBlockRobj *robj_block = (clientReplyBlockRobj*)block;
+                /* If this is an referenced robj block, duplicate the string object to avoid race condition */
+                if (block && block->type == CLIENT_REPLY_BLOCK_REF) {
+                    clientReplyBlockRef *ref_block = (clientReplyBlockRef*)block;
 
                     /* Duplicate the string object */
-                    robj *new_obj = dupStringObject(robj_block->obj);
-                    decrRefCount(robj_block->obj);
-                    robj_block->obj = new_obj;
+                    robj *new_obj = dupStringObject(ref_block->obj);
+                    decrRefCount(ref_block->obj);
+                    ref_block->obj = new_obj;
                 }
             }
         }

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -201,7 +201,6 @@ void freeObjAsync(robj *key, robj *obj, int dbid) {
  * Since incrRefCount/decrRefCount are not thread-safe, and bio thread may
  * free database objects while main thread sends client replies, we need to
  * create independent copies of the string objects to avoid concurrent access. */
-#if 0
 static void protectClientReplyObjects(void) {
     int allpaused = 0;
     if (server.io_threads_num > 1) {
@@ -243,7 +242,6 @@ static void protectClientReplyObjects(void) {
 
     if (allpaused) resumeAllIOThreads();
 }
-#endif
 
 /* Empty a Redis DB asynchronously. What the function does actually is to
  * create a new empty set of hash tables and scheduling the old ones for
@@ -260,7 +258,7 @@ void emptyDbAsync(redisDb *db) {
     db->keys = kvstoreCreate(&dbDictType, slot_count_bits, flags | KVSTORE_ALLOC_META_KEYS_HIST);
     db->expires = kvstoreCreate(&dbExpiresDictType, slot_count_bits, flags);
     db->subexpires = estoreCreate(&subexpiresBucketsType, slot_count_bits);
-    // protectClientReplyObjects(); /* Protect client reply objects before async free. */
+    protectClientReplyObjects(); /* Protect client reply objects before async free. */
     emptyDbDataAsync(oldkeys, oldexpires, oldsubexpires);
 }
 

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -211,33 +211,32 @@ static void protectClientReplyObjects(void) {
 
     listNode *ln;
     listIter li;
-    listRewind(server.clients, &li);
+    listRewind(server.clients_with_pending_ref_reply, &li);
     while ((ln = listNext(&li)) != NULL) {
         client *c = listNodeValue(ln);
 
-        /* Process deferred reply blocks */
-        processDeferredReplyBlocks(c);
+        if (c->reply && listLength(c->reply)) {
+            /* Iterate through client's reply list */
+            listIter reply_li;
+            listNode *reply_ln;
+            listRewind(c->reply, &reply_li);
+            while ((reply_ln = listNext(&reply_li))) {
+                clientReplyBlock *block = listNodeValue(reply_ln);
 
-        /* Skip cs without reply list */
-        if (!c->reply || listLength(c->reply) == 0) continue;
+                /* If this is an ROBJ block, duplicate the string object to avoid race condition */
+                if (block && block->type == CLIENT_REPLY_BLOCK_ROBJ) {
+                    clientReplyBlockRobj *robj_block = (clientReplyBlockRobj*)block;
 
-        /* Iterate through client's reply list */
-        listIter reply_li;
-        listNode *reply_ln;
-        listRewind(c->reply, &reply_li);
-        while ((reply_ln = listNext(&reply_li))) {
-            clientReplyBlock *block = listNodeValue(reply_ln);
-
-            /* If this is an ROBJ block, duplicate the string object to avoid race condition */
-            if (block && block->type == CLIENT_REPLY_BLOCK_ROBJ) {
-                clientReplyBlockRobj *robj_block = (clientReplyBlockRobj*)block;
-
-                /* Duplicate the string object */
-                robj *new_obj = dupStringObject(robj_block->obj);
-                decrRefCount(robj_block->obj);
-                robj_block->obj = new_obj;
+                    /* Duplicate the string object */
+                    robj *new_obj = dupStringObject(robj_block->obj);
+                    decrRefCount(robj_block->obj);
+                    robj_block->obj = new_obj;
+                }
             }
         }
+
+        /* Process deferred reply blocks */
+        processDeferredReplyBlocks(c);
     }
 
     if (allpaused) resumeAllIOThreads();

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -195,6 +195,57 @@ void freeObjAsync(robj *key, robj *obj, int dbid) {
     }
 }
 
+/* Duplicate client reply objects to avoid race conditions with bio threads
+ * during async flushdb.
+ *
+ * Since incrRefCount/decrRefCount are not thread-safe, and bio thread may
+ * free database objects while main thread sends client replies, we need to
+ * create independent copies of the string objects to avoid concurrent access. */
+static void protectClientReplyObjects(void) {
+    int allpaused = 0;
+    if (server.io_threads_num > 1 &&
+        pthread_equal(server.main_thread_id, pthread_self()))
+    {
+        allpaused = 1;
+        pauseAllIOThreads();
+    }
+
+    listNode *ln;
+    listIter li;
+    client *client;
+
+    listRewind(server.clients, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        client = listNodeValue(ln);
+
+        /* Process deferred reply blocks */
+        processDeferredReplyBlocks(client);
+
+        /* Skip clients without reply list */
+        if (!client->reply || listLength(client->reply) == 0) continue;
+
+        /* Iterate through client's reply list */
+        listIter reply_iter;
+        listNode *reply_node;
+        listRewind(client->reply, &reply_iter);
+        while ((reply_node = listNext(&reply_iter)) != NULL) {
+            clientReplyBlock *block = listNodeValue(reply_node);
+
+            /* If this is an ROBJ block, duplicate the string object to avoid race condition */
+            if (block && block->type == CLIENT_REPLY_BLOCK_ROBJ) {
+                clientReplyBlockRobj *robj_block = (clientReplyBlockRobj*)block;
+
+                /* Duplicate the string object */
+                robj *new_obj = dupStringObject(robj_block->obj);
+                decrRefCount(robj_block->obj);
+                robj_block->obj = new_obj;
+            }
+        }
+    }
+
+    if (allpaused) resumeAllIOThreads();
+}
+
 /* Empty a Redis DB asynchronously. What the function does actually is to
  * create a new empty set of hash tables and scheduling the old ones for
  * lazy freeing. */
@@ -210,6 +261,7 @@ void emptyDbAsync(redisDb *db) {
     db->keys = kvstoreCreate(&dbDictType, slot_count_bits, flags | KVSTORE_ALLOC_META_KEYS_HIST);
     db->expires = kvstoreCreate(&dbExpiresDictType, slot_count_bits, flags);
     db->subexpires = estoreCreate(&subexpiresBucketsType, slot_count_bits);
+    protectClientReplyObjects(); /* Protect client reply objects before async free. */
     emptyDbDataAsync(oldkeys, oldexpires, oldsubexpires);
 }
 

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -203,33 +203,30 @@ void freeObjAsync(robj *key, robj *obj, int dbid) {
  * create independent copies of the string objects to avoid concurrent access. */
 static void protectClientReplyObjects(void) {
     int allpaused = 0;
-    if (server.io_threads_num > 1 &&
-        pthread_equal(server.main_thread_id, pthread_self()))
-    {
+    if (server.io_threads_num > 1) {
+        serverAssert(pthread_equal(server.main_thread_id, pthread_self()));
         allpaused = 1;
         pauseAllIOThreads();
     }
 
     listNode *ln;
     listIter li;
-    client *client;
-
     listRewind(server.clients, &li);
     while ((ln = listNext(&li)) != NULL) {
-        client = listNodeValue(ln);
+        client *c = listNodeValue(ln);
 
         /* Process deferred reply blocks */
-        processDeferredReplyBlocks(client);
+        processDeferredReplyBlocks(c);
 
-        /* Skip clients without reply list */
-        if (!client->reply || listLength(client->reply) == 0) continue;
+        /* Skip cs without reply list */
+        if (!c->reply || listLength(c->reply) == 0) continue;
 
         /* Iterate through client's reply list */
-        listIter reply_iter;
-        listNode *reply_node;
-        listRewind(client->reply, &reply_iter);
-        while ((reply_node = listNext(&reply_iter)) != NULL) {
-            clientReplyBlock *block = listNodeValue(reply_node);
+        listIter reply_li;
+        listNode *reply_ln;
+        listRewind(c->reply, &reply_li);
+        while ((reply_ln = listNext(&reply_li))) {
+            clientReplyBlock *block = listNodeValue(reply_ln);
 
             /* If this is an ROBJ block, duplicate the string object to avoid race condition */
             if (block && block->type == CLIENT_REPLY_BLOCK_ROBJ) {

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -201,6 +201,7 @@ void freeObjAsync(robj *key, robj *obj, int dbid) {
  * Since incrRefCount/decrRefCount are not thread-safe, and bio thread may
  * free database objects while main thread sends client replies, we need to
  * create independent copies of the string objects to avoid concurrent access. */
+#if 0
 static void protectClientReplyObjects(void) {
     int allpaused = 0;
     if (server.io_threads_num > 1) {
@@ -242,6 +243,7 @@ static void protectClientReplyObjects(void) {
 
     if (allpaused) resumeAllIOThreads();
 }
+#endif
 
 /* Empty a Redis DB asynchronously. What the function does actually is to
  * create a new empty set of hash tables and scheduling the old ones for

--- a/src/logreqres.c
+++ b/src/logreqres.c
@@ -148,7 +148,14 @@ void reqresSaveClientReplyOffset(client *c) {
     c->reqres.offset.bufpos = c->bufpos;
     if (listLength(c->reply) && listNodeValue(listLast(c->reply))) {
         c->reqres.offset.last_node.index = listLength(c->reply) - 1;
-        c->reqres.offset.last_node.used = ((clientReplyBlock *)listNodeValue(listLast(c->reply)))->used;
+        clientReplyBlock *block = listNodeValue(listLast(c->reply));
+        if (block->type == CLIENT_REPLY_BLOCK_PLAIN) {
+            c->reqres.offset.last_node.used = ((clientReplyBlockPlain *)block)->used;
+        } else {
+            /* For ROBJ blocks, we track the total size (prefix + data + crlf) */
+            clientReplyBlockRobj *robj_block = (clientReplyBlockRobj *)block;
+            c->reqres.offset.last_node.used = robj_block->prefix_cnt + sdslen(robj_block->obj->ptr) + 2;
+        }
     } else {
         c->reqres.offset.last_node.index = 0;
         c->reqres.offset.last_node.used = 0;
@@ -219,7 +226,14 @@ size_t reqresAppendResponse(client *c) {
     size_t curr_used = 0;
     if (listLength(c->reply)) {
         curr_index = listLength(c->reply) - 1;
-        curr_used = ((clientReplyBlock *)listNodeValue(listLast(c->reply)))->used;
+        clientReplyBlock *block = listNodeValue(listLast(c->reply));
+        if (block->type == CLIENT_REPLY_BLOCK_PLAIN) {
+            curr_used = ((clientReplyBlockPlain *)block)->used;
+        } else {
+            /* For ROBJ blocks, we track the total size (prefix + data + crlf) */
+            clientReplyBlockRobj *robj_block = (clientReplyBlockRobj *)block;
+            curr_used = robj_block->prefix_cnt + sdslen(robj_block->obj->ptr) + 2;
+        }
     }
 
     /* Now, append reply bytes from the reply list */
@@ -232,7 +246,7 @@ size_t reqresAppendResponse(client *c) {
         clientReplyBlock *o;
         listRewind(c->reply, &iter);
         while ((curr = listNext(&iter)) != NULL) {
-            size_t written;
+            size_t written = 0;
 
             /* Skip nodes we had already processed */
             if (i < c->reqres.offset.last_node.index) {
@@ -240,19 +254,46 @@ size_t reqresAppendResponse(client *c) {
                 continue;
             }
             o = listNodeValue(curr);
-            if (o->used == 0) {
-                i++;
-                continue;
-            }
-            if (i == c->reqres.offset.last_node.index) {
-                /* Write the potentially incomplete node, which had data from
-                 * before the current command started */
-                written = reqresAppendBuffer(c,
-                                             o->buf + c->reqres.offset.last_node.used,
-                                             o->used - c->reqres.offset.last_node.used);
+
+            if (o->type == CLIENT_REPLY_BLOCK_PLAIN) {
+                clientReplyBlockPlain *plain = (clientReplyBlockPlain *)o;
+                if (plain->used == 0) {
+                    i++;
+                    continue;
+                }
+                if (i == c->reqres.offset.last_node.index) {
+                    /* Write the potentially incomplete node, which had data from
+                     * before the current command started */
+                    written = reqresAppendBuffer(c,
+                                                 plain->buf + c->reqres.offset.last_node.used,
+                                                 plain->used - c->reqres.offset.last_node.used);
+                } else {
+                    /* New node */
+                    written = reqresAppendBuffer(c, plain->buf, plain->used);
+                }
             } else {
-                /* New node */
-                written = reqresAppendBuffer(c, o->buf, o->used);
+                /* Handle ROBJ blocks */
+                clientReplyBlockRobj *robj_block = (clientReplyBlockRobj *)o;
+
+                /* ROBJ blocks store a single complete bulk string (prefix + data + crlf).
+                 * Unlike PLAIN blocks which can be partially logged, ROBJ blocks are
+                 * either fully logged or not logged at all. */
+                if (i == c->reqres.offset.last_node.index &&
+                    c->reqres.offset.last_node.used != 0)
+                {
+                    i++;
+                    continue;
+                }
+
+                /* Write prefix */
+                written += reqresAppendBuffer(c, robj_block->prefix, robj_block->prefix_cnt);
+
+                /* Write data */
+                size_t data_len = sdslen(robj_block->obj->ptr);
+                written += reqresAppendBuffer(c, (char *)robj_block->obj->ptr, data_len);
+
+                /* Write CRLF */
+                written += reqresAppendBuffer(c, robj_block->crlf, 2);
             }
             ret += written;
             i++;

--- a/src/logreqres.c
+++ b/src/logreqres.c
@@ -152,9 +152,9 @@ void reqresSaveClientReplyOffset(client *c) {
         if (block->type == CLIENT_REPLY_BLOCK_PLAIN) {
             c->reqres.offset.last_node.used = ((clientReplyBlockPlain *)block)->used;
         } else {
-            /* For ROBJ blocks, we track the total size (prefix + data + crlf) */
-            clientReplyBlockRobj *robj_block = (clientReplyBlockRobj *)block;
-            c->reqres.offset.last_node.used = robj_block->prefix_cnt + sdslen(robj_block->obj->ptr) + 2;
+            /* For referenced robj block, we track the total size (prefix + data + crlf) */
+            clientReplyBlockRef *ref_block = (clientReplyBlockRef *)block;
+            c->reqres.offset.last_node.used = ref_block->prefix_cnt + sdslen(ref_block->obj->ptr) + 2;
         }
     } else {
         c->reqres.offset.last_node.index = 0;
@@ -230,9 +230,9 @@ size_t reqresAppendResponse(client *c) {
         if (block->type == CLIENT_REPLY_BLOCK_PLAIN) {
             curr_used = ((clientReplyBlockPlain *)block)->used;
         } else {
-            /* For ROBJ blocks, we track the total size (prefix + data + crlf) */
-            clientReplyBlockRobj *robj_block = (clientReplyBlockRobj *)block;
-            curr_used = robj_block->prefix_cnt + sdslen(robj_block->obj->ptr) + 2;
+            /* For referenced robj block, we track the total size (prefix + data + crlf) */
+            clientReplyBlockRef *ref_block = (clientReplyBlockRef *)block;
+            curr_used = ref_block->prefix_cnt + sdslen(ref_block->obj->ptr) + 2;
         }
     }
 
@@ -272,11 +272,11 @@ size_t reqresAppendResponse(client *c) {
                     written = reqresAppendBuffer(c, plain->buf, plain->used);
                 }
             } else {
-                /* Handle ROBJ blocks */
-                clientReplyBlockRobj *robj_block = (clientReplyBlockRobj *)o;
+                /* Handle referenced robj block. */
+                clientReplyBlockRef *ref_block = (clientReplyBlockRef *)o;
 
-                /* ROBJ blocks store a single complete bulk string (prefix + data + crlf).
-                 * Unlike PLAIN blocks which can be partially logged, ROBJ blocks are
+                /* Referenced block store a single complete bulk string (prefix + data + crlf).
+                 * Unlike PLAIN blocks which can be partially logged, referenced blocks are
                  * either fully logged or not logged at all. */
                 if (i == c->reqres.offset.last_node.index &&
                     c->reqres.offset.last_node.used != 0)
@@ -286,14 +286,14 @@ size_t reqresAppendResponse(client *c) {
                 }
 
                 /* Write prefix */
-                written += reqresAppendBuffer(c, robj_block->prefix, robj_block->prefix_cnt);
+                written += reqresAppendBuffer(c, ref_block->prefix, ref_block->prefix_cnt);
 
                 /* Write data */
-                size_t data_len = sdslen(robj_block->obj->ptr);
-                written += reqresAppendBuffer(c, (char *)robj_block->obj->ptr, data_len);
+                size_t data_len = sdslen(ref_block->obj->ptr);
+                written += reqresAppendBuffer(c, (char *)ref_block->obj->ptr, data_len);
 
                 /* Write CRLF */
-                written += reqresAppendBuffer(c, robj_block->crlf, 2);
+                written += reqresAppendBuffer(c, ref_block->crlf, 2);
             }
             ret += written;
             i++;

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -209,6 +209,10 @@ static void prefetchEntry(KeyPrefetchInfo *info) {
         prefetchAndMoveToNextKey(info->current_entry);
         info->current_kv = NULL;
         info->state = PREFETCH_KVOBJ;
+    } else if (server.io_threads_num >= server.min_io_threads_copy_avoid) {
+        /* Copy avoidance should be more efficient without value prefetch
+         * starting certain number of I/O threads */
+        markKeyAsdone(info);
     } else {
         /* No entry found in the bucket - try the bucket in the next table */
         info->state = PREFETCH_BUCKET;

--- a/src/module.c
+++ b/src/module.c
@@ -858,7 +858,8 @@ static CallReply *moduleParseReply(client *c, RedisModuleCtx *ctx) {
     sds proto = sdsnewlen(c->buf,c->bufpos);
     c->bufpos = 0;
     while(listLength(c->reply)) {
-        clientReplyBlock *o = listNodeValue(listFirst(c->reply));
+        clientReplyBlockPlain *o = listNodeValue(listFirst(c->reply));
+        serverAssert(o->type == CLIENT_REPLY_BLOCK_PLAIN);
 
         proto = sdscatlen(proto,o->buf,o->used);
         listDelNode(c->reply,listFirst(c->reply));

--- a/src/networking.c
+++ b/src/networking.c
@@ -1643,7 +1643,7 @@ void processDeferredReplyBlocks(client *c) {
     /* Clear the deferred reply blocks list */
     listEmpty(c->deferred_reply_blocks);
 
-    serverAssert(c->pending_ref_reply_client_list_node == NULL);
+    serverAssert(c->pending_ref_reply_client_list_node);
     listDelNode(server.clients_with_pending_ref_reply, c->pending_ref_reply_client_list_node);
     c->pending_ref_reply_client_list_node = NULL;
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -242,6 +242,7 @@ client *createClient(connection *conn) {
     c->client_list_node = NULL;
     c->io_thread_client_list_node = NULL;
     c->postponed_list_node = NULL;
+    c->pending_ref_reply_client_list_node = NULL;
     c->client_tracking_redirection = 0;
     c->client_tracking_prefixes = NULL;
     c->last_cron_check_time = 0;
@@ -397,6 +398,12 @@ static void _addReplyObjectToList(client *c, robj *obj) {
 
     listAddNodeTail(c->reply, block);
     c->reply_bytes += len + block->prefix_cnt + 2; /* data + prefix + crlf */
+
+    /* Add client to the robj blocks list if not already there */
+    if (c->pending_ref_reply_client_list_node == NULL) {
+        listAddNodeTail(server.clients_with_pending_ref_reply, c);
+        c->pending_ref_reply_client_list_node = listLast(server.clients_with_pending_ref_reply);
+    }
 
     closeClientOnOutputBufferLimitReached(c, 1);
 }
@@ -1635,6 +1642,10 @@ void processDeferredReplyBlocks(client *c) {
 
     /* Clear the deferred reply blocks list */
     listEmpty(c->deferred_reply_blocks);
+
+    serverAssert(c->pending_ref_reply_client_list_node == NULL);
+    listDelNode(server.clients_with_pending_ref_reply, c->pending_ref_reply_client_list_node);
+    c->pending_ref_reply_client_list_node = NULL;
 }
 
 void freeClientOriginalArgv(client *c) {
@@ -1775,6 +1786,12 @@ void unlinkClient(client *c) {
         serverAssert(ln != NULL);
         listDelNode(server.unblocked_clients,ln);
         c->flags &= ~CLIENT_UNBLOCKED;
+    }
+
+    /* Remove from the list of clients with robj blocks if needed. */
+    if (c->pending_ref_reply_client_list_node) {
+        listDelNode(server.clients_with_pending_ref_reply, c->pending_ref_reply_client_list_node);
+        c->pending_ref_reply_client_list_node = NULL;
     }
 
     freeClientPendingCommands(c, -1);
@@ -2427,6 +2444,15 @@ int writeToClient(client *c, int handler_installed) {
         if (handler_installed) {
             /* IO Thread also can do that now. */
             connSetWriteHandler(c->conn, NULL);
+        }
+
+        /* Remove from the list of clients with pending ref reply. */
+        if (c->running_tid == IOTHREAD_MAIN_THREAD_ID &&
+            c->pending_ref_reply_client_list_node)
+        {
+            serverAssert(listLength(c->deferred_reply_blocks) == 0);
+            listDelNode(server.clients_with_pending_ref_reply, c->pending_ref_reply_client_list_node);
+            c->pending_ref_reply_client_list_node = NULL;
         }
 
         /* Close connection after entire reply has been sent. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -90,9 +90,9 @@ void *dupClientReplyValue(void *o) {
         buf->type = type;
         memcpy(buf, o, sizeof(clientReplyBlockPlain) + old->size);
         return buf;
-    } else if (type == CLIENT_REPLY_BLOCK_ROBJ) {
-        clientReplyBlockRobj *old = o;
-        clientReplyBlockRobj *new = zmalloc(sizeof(clientReplyBlockRobj));
+    } else if (type == CLIENT_REPLY_BLOCK_REF) {
+        clientReplyBlockRef *old = o;
+        clientReplyBlockRef *new = zmalloc(sizeof(clientReplyBlockRef));
         new->type = type;
         new->obj = old->obj;
         incrRefCount(old->obj);
@@ -105,8 +105,8 @@ void *dupClientReplyValue(void *o) {
 void freeClientReplyValue(void *o) {
     if (!o) return;
     clientReplyBlock *block = o;
-    if (block->type == CLIENT_REPLY_BLOCK_ROBJ)
-        decrRefCount(((clientReplyBlockRobj*)block)->obj);
+    if (block->type == CLIENT_REPLY_BLOCK_REF)
+        decrRefCount(((clientReplyBlockRef*)block)->obj);
     zfree(block);
 }
 
@@ -381,8 +381,8 @@ static void _addReplyObjectToList(client *c, robj *obj) {
     if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return;
 
     /* Create a new block that references the robj */
-    clientReplyBlockRobj *block = zmalloc(sizeof(clientReplyBlockRobj));
-    block->type = CLIENT_REPLY_BLOCK_ROBJ;
+    clientReplyBlockRef *block = zmalloc(sizeof(clientReplyBlockRef));
+    block->type = CLIENT_REPLY_BLOCK_REF;
     block->obj = obj;
     incrRefCount(obj);
 
@@ -399,7 +399,7 @@ static void _addReplyObjectToList(client *c, robj *obj) {
     listAddNodeTail(c->reply, block);
     c->reply_bytes += len + block->prefix_cnt + 2; /* data + prefix + crlf */
 
-    /* Add client to the robj blocks list if not already there */
+    /* Add client to the referenced reply client list if not already there */
     if (c->pending_ref_reply_client_list_node == NULL) {
         listAddNodeTail(server.clients_with_pending_ref_reply, c);
         c->pending_ref_reply_client_list_node = listLast(server.clients_with_pending_ref_reply);
@@ -1788,7 +1788,7 @@ void unlinkClient(client *c) {
         c->flags &= ~CLIENT_UNBLOCKED;
     }
 
-    /* Remove from the list of clients with robj blocks if needed. */
+    /* Remove from the list of clients with referenced reply blocks if needed. */
     if (c->pending_ref_reply_client_list_node) {
         listDelNode(server.clients_with_pending_ref_reply, c->pending_ref_reply_client_list_node);
         c->pending_ref_reply_client_list_node = NULL;
@@ -2198,23 +2198,23 @@ static int _writevToClient(client *c, ssize_t *nwritten) {
     while ((next = listNext(&iter)) && iovcnt < iovmax && iov_bytes_len < NET_MAX_WRITES_PER_EVENT) {
         o = listNodeValue(next);
 
-        if (unlikely(o->type == CLIENT_REPLY_BLOCK_ROBJ)) {
-            clientReplyBlockRobj *obj_block = (clientReplyBlockRobj*)o;
-            size_t data_len = sdslen(obj_block->obj->ptr);
+        if (unlikely(o->type == CLIENT_REPLY_BLOCK_REF)) {
+            clientReplyBlockRef *ref_block = (clientReplyBlockRef*)o;
+            size_t data_len = sdslen(ref_block->obj->ptr);
 
             /* Add prefix */
-            if (offset < obj_block->prefix_cnt) {
-                iov[iovcnt].iov_base = obj_block->prefix + offset;
-                iov[iovcnt].iov_len = obj_block->prefix_cnt - offset;
+            if (offset < ref_block->prefix_cnt) {
+                iov[iovcnt].iov_base = ref_block->prefix + offset;
+                iov[iovcnt].iov_len = ref_block->prefix_cnt - offset;
                 iov_bytes_len += iov[iovcnt++].iov_len;
                 offset = 0;
             } else {
-                offset -= obj_block->prefix_cnt;
+                offset -= ref_block->prefix_cnt;
             }
 
             /* Add data */
             if (offset < data_len) {
-                iov[iovcnt].iov_base = (char*)obj_block->obj->ptr + offset;
+                iov[iovcnt].iov_base = (char*)ref_block->obj->ptr + offset;
                 iov[iovcnt].iov_len = data_len - offset;
                 iov_bytes_len += iov[iovcnt++].iov_len;
                 offset = 0;
@@ -2224,7 +2224,7 @@ static int _writevToClient(client *c, ssize_t *nwritten) {
 
             /* Add CRLF */
             if (offset < 2) {
-                iov[iovcnt].iov_base = obj_block->crlf + offset;
+                iov[iovcnt].iov_base = ref_block->crlf + offset;
                 iov[iovcnt].iov_len = 2 - offset;
                 iov_bytes_len += iov[iovcnt++].iov_len;
             }
@@ -2269,9 +2269,9 @@ static int _writevToClient(client *c, ssize_t *nwritten) {
         next = listNext(&iter);
         o = listNodeValue(next);
 
-        if (unlikely(o->type == CLIENT_REPLY_BLOCK_ROBJ)) {
-            clientReplyBlockRobj *robj_block = (clientReplyBlockRobj*)o;
-            size_t len = sdslen(robj_block->obj->ptr) + robj_block->prefix_cnt + 2;
+        if (unlikely(o->type == CLIENT_REPLY_BLOCK_REF)) {
+            clientReplyBlockRef *ref_block = (clientReplyBlockRef*)o;
+            size_t len = sdslen(ref_block->obj->ptr) + ref_block->prefix_cnt + 2;
             if (remaining < (ssize_t)(len - c->sentlen)) {
                 c->sentlen += remaining;
                 break;

--- a/src/networking.c
+++ b/src/networking.c
@@ -412,7 +412,7 @@ static void _addReplyObjectToList(client *c, robj *obj) {
  * Note: some edits to this function need to be relayed to AddReplyFromClient. */
 void _addReplyProtoToList(client *c, list *reply_list, const char *s, size_t len) {
     listNode *ln = listLast(reply_list);
-    clientReplyBlock *block = ln? listNodeValue(ln): NULL;
+    clientReplyBlock *block = ln ? listNodeValue(ln) : NULL;
     /* Check if the tail node is a plain block that we can append to */
     clientReplyBlockPlain *tail = (block && block->type == CLIENT_REPLY_BLOCK_PLAIN) ?
         (clientReplyBlockPlain*)block: NULL;
@@ -792,7 +792,7 @@ void addReplyStatusFormat(client *c, const char *fmt, ...) {
  * at the end of the last reply node which we won't use anymore. */
 void trimReplyUnusedTailSpace(client *c) {
     listNode *ln = listLast(c->reply);
-    clientReplyBlock *block = ln? listNodeValue(ln): NULL;
+    clientReplyBlock *block = ln ? listNodeValue(ln) : NULL;
     clientReplyBlockPlain *tail = (block && block->type == CLIENT_REPLY_BLOCK_PLAIN) ?
         (clientReplyBlockPlain*)block: NULL;
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1185,6 +1185,9 @@ static int isCopyAvoidPreferred(client *c, robj *obj) {
     if (type != CLIENT_TYPE_NORMAL && type != CLIENT_TYPE_PUBSUB) return 0;
     if (obj->encoding != OBJ_ENCODING_RAW || obj->refcount == OBJ_STATIC_REFCOUNT) return 0;
 
+    /* Copy avoidance is preferred for any string size starting certain number of I/O threads  */
+    if (server.min_io_threads_copy_avoid && server.io_threads_num < server.min_io_threads_copy_avoid) return 0;
+
     /* Copy avoidance is preferred starting certain string size */
     return server.min_string_size_copy_avoid && sdslen(obj->ptr) >= (size_t)server.min_string_size_copy_avoid;
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -1180,10 +1180,10 @@ void addReplyBulkLen(client *c, robj *obj) {
  * that use _writeToClient handler to write replies to client connection */
 static int isCopyAvoidPreferred(client *c, robj *obj) {
     if (!c->conn || !obj) return 0;
+    if (obj->encoding != OBJ_ENCODING_RAW || obj->refcount == OBJ_STATIC_REFCOUNT) return 0;
 
     int type = getClientType(c);
     if (type != CLIENT_TYPE_NORMAL && type != CLIENT_TYPE_PUBSUB) return 0;
-    if (obj->encoding != OBJ_ENCODING_RAW || obj->refcount == OBJ_STATIC_REFCOUNT) return 0;
 
     /* Copy avoidance is preferred for any string size starting certain number of I/O threads  */
     if (server.min_io_threads_copy_avoid && server.io_threads_num < server.min_io_threads_copy_avoid) return 0;
@@ -1203,10 +1203,9 @@ static int tryAvoidBulkStrCopyToReply(client *c, robj *obj) {
 /* Add a Redis Object as a bulk reply */
 void addReplyBulk(client *c, robj *obj) {
     if (_prepareClientToWrite(c) != C_OK) return;
+    if (unlikely(tryAvoidBulkStrCopyToReply(c, obj) == C_OK)) return; 
 
     if (sdsEncodedObject(obj)) {
-        if (tryAvoidBulkStrCopyToReply(c, obj) == C_OK) return; 
-
         const size_t len = sdslen(obj->ptr);
         _addReplyLongLongBulk(c, len);
         _addReplyToBufferOrList(c,obj->ptr,len);

--- a/src/networking.c
+++ b/src/networking.c
@@ -82,14 +82,32 @@ size_t getStringObjectLen(robj *o) {
 
 /* Client.reply list dup and free methods. */
 void *dupClientReplyValue(void *o) {
-    clientReplyBlock *old = o;
-    clientReplyBlock *buf = zmalloc(sizeof(clientReplyBlock) + old->size);
-    memcpy(buf, o, sizeof(clientReplyBlock) + old->size);
-    return buf;
+    int type = ((clientReplyBlock*)o)->type;
+
+    if (type == CLIENT_REPLY_BLOCK_PLAIN) {
+        clientReplyBlockPlain *old = o;
+        clientReplyBlockPlain *buf = zmalloc(sizeof(clientReplyBlockPlain) + old->size);
+        buf->type = type;
+        memcpy(buf, o, sizeof(clientReplyBlockPlain) + old->size);
+        return buf;
+    } else if (type == CLIENT_REPLY_BLOCK_ROBJ) {
+        clientReplyBlockRobj *old = o;
+        clientReplyBlockRobj *new = zmalloc(sizeof(clientReplyBlockRobj));
+        new->type = type;
+        new->obj = old->obj;
+        incrRefCount(old->obj);
+        return new;
+    } else {
+        serverPanic("Unknown client reply block type");
+    }
 }
 
 void freeClientReplyValue(void *o) {
-    zfree(o);
+    if (!o) return;
+    clientReplyBlock *block = o;
+    if (block->type == CLIENT_REPLY_BLOCK_ROBJ)
+        decrRefCount(((clientReplyBlockRobj*)block)->obj);
+    zfree(block);
 }
 
 /* This function links the client to the global linked list of clients.
@@ -207,6 +225,8 @@ client *createClient(connection *conn) {
     c->main_ch_client_id = 0;
     c->reply = listCreate();
     c->deferred_reply_errors = NULL;
+    c->deferred_reply_blocks = listCreate();
+    listSetFreeMethod(c->deferred_reply_blocks,freeClientReplyValue);
     c->reply_bytes = 0;
     c->obuf_soft_limit_reached_time = 0;
     listSetFreeMethod(c->reply,freeClientReplyValue);
@@ -355,11 +375,40 @@ int prepareClientToWrite(client *c) {
  * Low level functions to add more data to output buffers.
  * -------------------------------------------------------------------------- */
 
+ /* Add a robj reference to the reply linked list. */
+static void _addReplyObjectToList(client *c, robj *obj) {
+    if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return;
+
+    /* Create a new block that references the robj */
+    clientReplyBlockRobj *block = zmalloc(sizeof(clientReplyBlockRobj));
+    block->type = CLIENT_REPLY_BLOCK_ROBJ;
+    block->obj = obj;
+    incrRefCount(obj);
+
+    /* Fill prefix with bulk string length: "$<len>\r\n" and crlf: "\r\n" */
+    const size_t len = sdslen(obj->ptr);
+    block->prefix[0] = '$';
+    size_t num_len = ll2string(block->prefix + 1, sizeof(block->prefix) - 3, len);
+    block->prefix[num_len + 1] = '\r';
+    block->prefix[num_len + 2] = '\n';
+    block->prefix_cnt = num_len + 3;
+    block->crlf[0] = '\r';
+    block->crlf[1] = '\n';
+
+    listAddNodeTail(c->reply, block);
+    c->reply_bytes += len + block->prefix_cnt + 2; /* data + prefix + crlf */
+
+    closeClientOnOutputBufferLimitReached(c, 1);
+}
+
 /* Adds the reply to the reply linked list.
  * Note: some edits to this function need to be relayed to AddReplyFromClient. */
 void _addReplyProtoToList(client *c, list *reply_list, const char *s, size_t len) {
     listNode *ln = listLast(reply_list);
-    clientReplyBlock *tail = ln? listNodeValue(ln): NULL;
+    clientReplyBlock *block = ln? listNodeValue(ln): NULL;
+    /* Check if the tail node is a plain block that we can append to */
+    clientReplyBlockPlain *tail = (block && block->type == CLIENT_REPLY_BLOCK_PLAIN) ?
+        (clientReplyBlockPlain*)block: NULL;
 
     /* Note that 'tail' may be NULL even if we have a tail node, because when
      * addReplyDeferredLen() is used, it sets a dummy node to NULL just
@@ -381,9 +430,10 @@ void _addReplyProtoToList(client *c, list *reply_list, const char *s, size_t len
          * least PROTO_REPLY_CHUNK_BYTES */
         size_t usable_size;
         size_t size = len < PROTO_REPLY_CHUNK_BYTES? PROTO_REPLY_CHUNK_BYTES: len;
-        tail = zmalloc_usable(size + sizeof(clientReplyBlock), &usable_size);
+        tail = zmalloc_usable(size + sizeof(clientReplyBlockPlain), &usable_size);
         /* take over the allocation's internal fragmentation */
-        tail->size = usable_size - sizeof(clientReplyBlock);
+        tail->type = CLIENT_REPLY_BLOCK_PLAIN;
+        tail->size = usable_size - sizeof(clientReplyBlockPlain);
         tail->used = len;
         memcpy(tail->buf, s, len);
         listAddNodeTail(reply_list, tail);
@@ -735,7 +785,9 @@ void addReplyStatusFormat(client *c, const char *fmt, ...) {
  * at the end of the last reply node which we won't use anymore. */
 void trimReplyUnusedTailSpace(client *c) {
     listNode *ln = listLast(c->reply);
-    clientReplyBlock *tail = ln? listNodeValue(ln): NULL;
+    clientReplyBlock *block = ln? listNodeValue(ln): NULL;
+    clientReplyBlockPlain *tail = (block && block->type == CLIENT_REPLY_BLOCK_PLAIN) ?
+        (clientReplyBlockPlain*)block: NULL;
 
     /* Note that 'tail' may be NULL even if we have a tail node, because when
      * addReplyDeferredLen() is used */
@@ -750,10 +802,10 @@ void trimReplyUnusedTailSpace(client *c) {
     {
         size_t usable_size;
         size_t old_size = tail->size;
-        tail = zrealloc_usable(tail, tail->used + sizeof(clientReplyBlock), &usable_size, NULL);
+        tail = zrealloc_usable(tail, tail->used + sizeof(clientReplyBlockPlain), &usable_size, NULL);
         /* take over the allocation's internal fragmentation (at least for
          * memory usage tracking) */
-        tail->size = usable_size - sizeof(clientReplyBlock);
+        tail->size = usable_size - sizeof(clientReplyBlockPlain);
         c->reply_bytes = c->reply_bytes + tail->size - old_size;
         listNodeValue(ln) = tail;
     }
@@ -789,7 +841,8 @@ void *addReplyDeferredLen(client *c) {
 
 void setDeferredReply(client *c, void *node, const char *s, size_t length) {
     listNode *ln = (listNode*)node;
-    clientReplyBlock *next, *prev;
+    clientReplyBlock *block;
+    clientReplyBlockPlain *next = NULL, *prev = NULL;
 
     /* Abort when *node is NULL: when the client should not accept writes
      * we return NULL in addReplyDeferredLen() */
@@ -807,9 +860,12 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
      * - The next node is non-NULL,
      * - It has enough room already allocated
      * - And not too large (avoid large memmove) */
-    if (ln->prev != NULL && (prev = listNodeValue(ln->prev)) &&
-        prev->size - prev->used > 0)
+    if (ln->prev != NULL && (block = listNodeValue(ln->prev)) &&
+        block->type == CLIENT_REPLY_BLOCK_PLAIN)
     {
+        prev = (clientReplyBlockPlain*)block;
+    }
+    if (prev && prev->size > prev->used) {
         size_t len_to_copy = prev->size - prev->used;
         if (len_to_copy > length)
             len_to_copy = length;
@@ -824,8 +880,12 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
         s += len_to_copy;
     }
 
-    if (ln->next != NULL && (next = listNodeValue(ln->next)) &&
-        next->size - next->used >= length &&
+    if (ln->next != NULL && (block = listNodeValue(ln->next)) &&
+        block->type == CLIENT_REPLY_BLOCK_PLAIN)
+    {
+        next = (clientReplyBlockPlain*)block;
+    }
+    if (next && next->size - next->used >= length &&
         next->used < PROTO_REPLY_CHUNK_BYTES * 4)
     {
         memmove(next->buf + length, next->buf, next->used);
@@ -836,9 +896,10 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
     } else {
         /* Create a new node */
         size_t usable_size;
-        clientReplyBlock *buf = zmalloc_usable(length + sizeof(clientReplyBlock), &usable_size);
+        clientReplyBlockPlain *buf = zmalloc_usable(length + sizeof(clientReplyBlockPlain), &usable_size);
+        buf->type = CLIENT_REPLY_BLOCK_PLAIN;
         /* Take over the allocation's internal fragmentation */
-        buf->size = usable_size - sizeof(clientReplyBlock);
+        buf->size = usable_size - sizeof(clientReplyBlockPlain);
         buf->used = length;
         memcpy(buf->buf, s, length);
         c->net_output_bytes_curr_cmd += length;
@@ -1113,11 +1174,36 @@ void addReplyBulkLen(client *c, robj *obj) {
     _addReplyLongLongBulk(c, len);
 }
 
+/* Decides if copy avoidance is preferred according to client type, number of I/O threads, object size
+ * Maybe called with NULL obj for evaluation with no regard to object size
+ * Copy avoidance can be allowed only for regular Valkey clients
+ * that use _writeToClient handler to write replies to client connection */
+static int isCopyAvoidPreferred(client *c, robj *obj) {
+    if (!c->conn || !obj) return 0;
+
+    int type = getClientType(c);
+    if (type != CLIENT_TYPE_NORMAL && type != CLIENT_TYPE_PUBSUB) return 0;
+    if (obj->encoding != OBJ_ENCODING_RAW || obj->refcount == OBJ_STATIC_REFCOUNT) return 0;
+
+    /* Copy avoidance is preferred starting certain string size */
+    return server.min_string_size_copy_avoid && sdslen(obj->ptr) >= (size_t)server.min_string_size_copy_avoid;
+}
+
+/* Try to avoid whole bulk string copy to a reply buffer
+ * If copy avoidance allowed then only pointer to object and string will be copied to the buffer */
+static int tryAvoidBulkStrCopyToReply(client *c, robj *obj) {
+    if (!isCopyAvoidPreferred(c, obj)) return C_ERR;
+    _addReplyObjectToList(c, obj);
+    return C_OK;
+}
+
 /* Add a Redis Object as a bulk reply */
 void addReplyBulk(client *c, robj *obj) {
     if (_prepareClientToWrite(c) != C_OK) return;
 
     if (sdsEncodedObject(obj)) {
+        if (tryAvoidBulkStrCopyToReply(c, obj) == C_OK) return; 
+
         const size_t len = sdslen(obj->ptr);
         _addReplyLongLongBulk(c, len);
         _addReplyToBufferOrList(c,obj->ptr,len);
@@ -1537,6 +1623,18 @@ void freeClientDeferredObjects(client *c, int free_array) {
     }
 }
 
+/* Process deferred reply blocks by transferring them to the main thread's
+ * deferred objects mechanism for proper cleanup. This is called when a client
+ * is being processed in the main thread and has accumulated reply blocks
+ * that need to be freed. */
+void processDeferredReplyBlocks(client *c) {
+    if (!c->deferred_reply_blocks || listLength(c->deferred_reply_blocks) == 0)
+        return;
+
+    /* Clear the deferred reply blocks list */
+    listEmpty(c->deferred_reply_blocks);
+}
+
 void freeClientOriginalArgv(client *c) {
     /* We didn't rewrite this client */
     if (!c->original_argv) return;
@@ -1864,6 +1962,7 @@ void freeClient(client *c) {
 
     /* Free data structures. */
     listRelease(c->reply);
+    listRelease(c->deferred_reply_blocks);
     zfree(c->buf);
     freeReplicaReferencedReplBuffer(c);
     freeClientOriginalArgv(c);
@@ -2079,15 +2178,52 @@ static int _writevToClient(client *c, ssize_t *nwritten) {
     listRewind(c->reply, &iter);
     while ((next = listNext(&iter)) && iovcnt < iovmax && iov_bytes_len < NET_MAX_WRITES_PER_EVENT) {
         o = listNodeValue(next);
-        if (o->used == 0) { /* empty node, just release it and skip. */
-            c->reply_bytes -= o->size;
+
+        if (unlikely(o->type == CLIENT_REPLY_BLOCK_ROBJ)) {
+            clientReplyBlockRobj *obj_block = (clientReplyBlockRobj*)o;
+            size_t data_len = sdslen(obj_block->obj->ptr);
+
+            /* Add prefix */
+            if (offset < obj_block->prefix_cnt) {
+                iov[iovcnt].iov_base = obj_block->prefix + offset;
+                iov[iovcnt].iov_len = obj_block->prefix_cnt - offset;
+                iov_bytes_len += iov[iovcnt++].iov_len;
+                offset = 0;
+            } else {
+                offset -= obj_block->prefix_cnt;
+            }
+
+            /* Add data */
+            if (offset < data_len) {
+                iov[iovcnt].iov_base = (char*)obj_block->obj->ptr + offset;
+                iov[iovcnt].iov_len = data_len - offset;
+                iov_bytes_len += iov[iovcnt++].iov_len;
+                offset = 0;
+            } else if (offset >= data_len) {
+                offset -= data_len;
+            }
+
+            /* Add CRLF */
+            if (offset < 2) {
+                iov[iovcnt].iov_base = obj_block->crlf + offset;
+                iov[iovcnt].iov_len = 2 - offset;
+                iov_bytes_len += iov[iovcnt++].iov_len;
+            }
+
+            offset = 0;
+            continue;
+        }
+
+        clientReplyBlockPlain *plain_block = (clientReplyBlockPlain*)o;
+        if (plain_block->used == 0) { /* empty node, just release it and skip. */
+            c->reply_bytes -= plain_block->size;
             listDelNode(c->reply, next);
             offset = 0;
             continue;
         }
 
-        iov[iovcnt].iov_base = o->buf + offset;
-        iov[iovcnt].iov_len = o->used - offset;
+        iov[iovcnt].iov_base = plain_block->buf + offset;
+        iov[iovcnt].iov_len = plain_block->used - offset;
         iov_bytes_len += iov[iovcnt++].iov_len;
         offset = 0;
     }
@@ -2113,12 +2249,33 @@ static int _writevToClient(client *c, ssize_t *nwritten) {
     while (remaining > 0) {
         next = listNext(&iter);
         o = listNodeValue(next);
-        if (remaining < (ssize_t)(o->used - c->sentlen)) {
+
+        if (unlikely(o->type == CLIENT_REPLY_BLOCK_ROBJ)) {
+            clientReplyBlockRobj *robj_block = (clientReplyBlockRobj*)o;
+            size_t len = sdslen(robj_block->obj->ptr) + robj_block->prefix_cnt + 2;
+            if (remaining < (ssize_t)(len - c->sentlen)) {
+                c->sentlen += remaining;
+                break;
+            }
+            remaining -= (ssize_t)(len - c->sentlen);
+            c->reply_bytes -= len;
+            if (c->running_tid != IOTHREAD_MAIN_THREAD_ID) {
+                listUnlinkNode(c->reply, next);
+                listLinkNodeTail(c->deferred_reply_blocks, next);
+            } else {
+                listDelNode(c->reply, next);
+            }
+            c->sentlen = 0;
+            continue;
+        }
+
+        clientReplyBlockPlain *plain_block = (clientReplyBlockPlain*)o;
+        if (remaining < (ssize_t)(plain_block->used - c->sentlen)) {
             c->sentlen += remaining;
             break;
         }
-        remaining -= (ssize_t)(o->used - c->sentlen);
-        c->reply_bytes -= o->size;
+        remaining -= (ssize_t)(plain_block->used - c->sentlen);
+        c->reply_bytes -= plain_block->size;
         listDelNode(c->reply, next);
         c->sentlen = 0;
     }
@@ -4494,8 +4651,9 @@ size_t getClientOutputBufferMemoryUsage(client *c) {
             repl_node_num = last->id - cur->id + 1;
         }
         return repl_buf_size + (repl_node_size*repl_node_num);
-    } else { 
-        size_t list_item_size = sizeof(listNode) + sizeof(clientReplyBlock);
+    } else {
+        /* Large replies are rare, so we always use clientReplyBlockPlain for estimation */
+        size_t list_item_size = sizeof(listNode) + sizeof(clientReplyBlockPlain);
         return c->reply_bytes + (list_item_size*listLength(c->reply));
     }
 }
@@ -4505,7 +4663,13 @@ size_t getNormalClientPendingReplyBytes(client *c) {
     if (listLength(c->reply) == 0) return c->bufpos;
 
     clientReplyBlock *block = listNodeValue(listLast(c->reply));
-    return (c->reply_bytes - block->size + block->used) + c->bufpos;
+    size_t size = 0, used = 0;
+    if (block->type == CLIENT_REPLY_BLOCK_PLAIN) {
+        clientReplyBlockPlain *plain = (clientReplyBlockPlain *)block;
+        size = plain->size;
+        used = plain->used;
+    }
+    return (c->reply_bytes - size + used) + c->bufpos;
 }
 
 /* Returns the total client's memory usage.

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -950,7 +950,8 @@ static int luaRedisGenericCommand(lua_State *lua, int raise_error) {
         reply = sdsnewlen(c->buf,c->bufpos);
         c->bufpos = 0;
         while(listLength(c->reply)) {
-            clientReplyBlock *o = listNodeValue(listFirst(c->reply));
+            clientReplyBlockPlain *o = listNodeValue(listFirst(c->reply));
+            serverAssert(o->type == CLIENT_REPLY_BLOCK_PLAIN);
 
             reply = sdscatlen(reply,o->buf,o->used);
             listDelNode(c->reply,listFirst(c->reply));

--- a/src/server.c
+++ b/src/server.c
@@ -2825,6 +2825,7 @@ void initServer(void) {
     server.monitors = listCreate();
     server.clients_pending_write = listCreate();
     server.clients_pending_read = listCreate();
+    server.clients_with_pending_ref_reply = listCreate();
     server.clients_timeout_table = raxNew();
     server.replication_allowed = 1;
     server.slaveseldb = -1; /* Force to emit the first SELECT command. */

--- a/src/server.c
+++ b/src/server.c
@@ -7111,7 +7111,8 @@ void dismissClientMemory(client *c) {
             clientReplyBlock *bulk = listNodeValue(ln);
             /* Default bulk size is 16k, actually it has extra data, maybe it
              * occupies 20k according to jemalloc bin size if using jemalloc. */
-            if (bulk) dismissMemory(bulk, bulk->size);
+            if (bulk && bulk->type == CLIENT_REPLY_BLOCK_PLAIN)
+                dismissMemory(bulk, ((clientReplyBlockPlain*)bulk)->size);
         }
     }
 }

--- a/src/server.h
+++ b/src/server.h
@@ -1087,11 +1087,33 @@ char *getObjectTypeName(robj*);
 
 struct evictionPoolEntry; /* Defined in evict.c */
 
+/* Type of clientReplyBlock */
+#define CLIENT_REPLY_BLOCK_PLAIN  1  /* Plain, data stored in buf[] */
+#define CLIENT_REPLY_BLOCK_ROBJ   2  /* Shared robj, data referenced via robj pointer */
+
+/* Bulk string prefix max size (long + $ + \r\n) */
+#define BULK_STR_LEN_PREFIX_MAX_SIZE (LONG_STR_SIZE + 3)
+
+/* Plain buffer block */
+typedef struct clientReplyBlockPlain {
+    int type;  /* Always CLIENT_REPLY_BLOCK_PLAIN */
+    size_t size, used;
+    char buf[];
+} clientReplyBlockPlain;
+
+/* Robj reference block */
+typedef struct clientReplyBlockRobj {
+    int type;  /* Always CLIENT_REPLY_BLOCK_ROBJ */
+    robj *obj;           /* robj pointer */
+    unsigned int prefix_cnt;
+    char prefix[BULK_STR_LEN_PREFIX_MAX_SIZE];
+    char crlf[2]; /* \r\n */
+} clientReplyBlockRobj;
+
 /* This structure is used in order to represent the output buffer of a client,
  * which is actually a linked list of blocks like that, that is: client->reply. */
 typedef struct clientReplyBlock {
-    size_t size, used;
-    char buf[];
+    int type;  /* CLIENT_REPLY_BLOCK_PLAIN or CLIENT_REPLY_BLOCK_ROBJ */
 } clientReplyBlock;
 
 /* Replication buffer blocks is the list of replBufBlock.
@@ -1401,6 +1423,7 @@ typedef struct client {
     list *reply;            /* List of reply objects to send to the client. */
     unsigned long long reply_bytes; /* Tot bytes of objects in reply list. */
     list *deferred_reply_errors;    /* Used for module thread safe contexts. */
+    list *deferred_reply_blocks;    /* List of reply blocks to be freed in main thread. */
     size_t sentlen;         /* Amount of bytes already sent in the current
                                buffer or object being sent. */
     time_t ctime;           /* Client creation time. */
@@ -1913,6 +1936,9 @@ struct redisServer {
     int enable_protected_configs;    /* Enable the modification of protected configs, see PROTECTED_ACTION_ALLOWED_* */
     int enable_debug_cmd;            /* Enable DEBUG commands, see PROTECTED_ACTION_ALLOWED_* */
     int enable_module_cmd;           /* Enable MODULE commands, see PROTECTED_ACTION_ALLOWED_* */
+
+    /* Reply construction copy avoidance */
+    int min_string_size_copy_avoid;          /* Minimum bulk string size for copy avoidance in reply construction when IO threads disabled */
 
     /* RDB / AOF loading information */
     volatile sig_atomic_t loading; /* We are loading data from disk if true */
@@ -2932,6 +2958,7 @@ void freeClientArgv(client *c);
 void freeClientPendingCommands(client *c, int num_pcmds_to_free);
 void tryDeferFreeClientObject(client *c, int type, void *ptr);
 void freeClientDeferredObjects(client *c, int free_array);
+void processDeferredReplyBlocks(client *c);
 void sendReplyToClient(connection *conn);
 void *addReplyDeferredLen(client *c);
 void setDeferredArrayLen(client *c, void *node, long length);

--- a/src/server.h
+++ b/src/server.h
@@ -1089,7 +1089,7 @@ struct evictionPoolEntry; /* Defined in evict.c */
 
 /* Type of clientReplyBlock */
 #define CLIENT_REPLY_BLOCK_PLAIN  1  /* Plain, data stored in buf[] */
-#define CLIENT_REPLY_BLOCK_ROBJ   2  /* Shared robj, data referenced via robj pointer */
+#define CLIENT_REPLY_BLOCK_REF    2  /* Reference to robj, data referenced via robj pointer */
 
 /* Plain buffer block */
 typedef struct clientReplyBlockPlain {
@@ -1099,18 +1099,18 @@ typedef struct clientReplyBlockPlain {
 } clientReplyBlockPlain;
 
 /* Robj reference block */
-typedef struct clientReplyBlockRobj {
-    int type;  /* Always CLIENT_REPLY_BLOCK_ROBJ */
+typedef struct clientReplyBlockRef {
+    int type;  /* Always CLIENT_REPLY_BLOCK_REF */
     robj *obj;
     unsigned int prefix_cnt;
     char prefix[LONG_STR_SIZE + 3]; /* $<len>\r\n */
     char crlf[2]; /* \r\n */
-} clientReplyBlockRobj;
+} clientReplyBlockRef;
 
 /* This structure is used in order to represent the output buffer of a client,
  * which is actually a linked list of blocks like that, that is: client->reply. */
 typedef struct clientReplyBlock {
-    int type;  /* CLIENT_REPLY_BLOCK_PLAIN or CLIENT_REPLY_BLOCK_ROBJ */
+    int type;  /* CLIENT_REPLY_BLOCK_PLAIN or CLIENT_REPLY_BLOCK_REF */
 } clientReplyBlock;
 
 /* Replication buffer blocks is the list of replBufBlock.

--- a/src/server.h
+++ b/src/server.h
@@ -1935,7 +1935,8 @@ struct redisServer {
     int enable_module_cmd;           /* Enable MODULE commands, see PROTECTED_ACTION_ALLOWED_* */
 
     /* Reply construction copy avoidance */
-    int min_string_size_copy_avoid;          /* Minimum bulk string size for copy avoidance in reply construction when IO threads disabled */
+    int min_io_threads_copy_avoid;  /* Minimum number of IO threads for copy avoidance in reply construction */
+    int min_string_size_copy_avoid; /* Minimum bulk string size for copy avoidance in reply construction when IO threads disabled */
 
     /* RDB / AOF loading information */
     volatile sig_atomic_t loading; /* We are loading data from disk if true */

--- a/src/server.h
+++ b/src/server.h
@@ -1471,6 +1471,7 @@ typedef struct client {
     listNode *client_list_node; /* list node in client list */
     listNode *io_thread_client_list_node; /* list node in io thread client list */
     listNode *postponed_list_node; /* list node within the postponed list */
+    listNode *pending_ref_reply_client_list_node; /* list node in clients_with_pending_ref_reply list */
     void *module_blocked_client; /* Pointer to the RedisModuleBlockedClient associated with this
                                   * client. This is set in case of module authentication before the
                                   * unblocked client is reprocessed to handle reply callbacks. */
@@ -1898,6 +1899,7 @@ struct redisServer {
     list *clients_to_close;     /* Clients to close asynchronously */
     list *clients_pending_write; /* There is to write or install handler. */
     list *clients_pending_read;  /* Client has pending read socket buffers. */
+    list *clients_with_pending_ref_reply; /* Clients that have pending referenced replies. */
     list *slaves, *monitors;    /* List of slaves and MONITORs */
     client *current_client;     /* The client that triggered the command execution (External or AOF). */
     client *executing_client;   /* The client executing the current command (possibly script or module). */

--- a/src/server.h
+++ b/src/server.h
@@ -1104,7 +1104,7 @@ typedef struct clientReplyBlockPlain {
 /* Robj reference block */
 typedef struct clientReplyBlockRobj {
     int type;  /* Always CLIENT_REPLY_BLOCK_ROBJ */
-    robj *obj;           /* robj pointer */
+    robj *obj;
     unsigned int prefix_cnt;
     char prefix[BULK_STR_LEN_PREFIX_MAX_SIZE];
     char crlf[2]; /* \r\n */

--- a/src/server.h
+++ b/src/server.h
@@ -1091,9 +1091,6 @@ struct evictionPoolEntry; /* Defined in evict.c */
 #define CLIENT_REPLY_BLOCK_PLAIN  1  /* Plain, data stored in buf[] */
 #define CLIENT_REPLY_BLOCK_ROBJ   2  /* Shared robj, data referenced via robj pointer */
 
-/* Bulk string prefix max size (long + $ + \r\n) */
-#define BULK_STR_LEN_PREFIX_MAX_SIZE (LONG_STR_SIZE + 3)
-
 /* Plain buffer block */
 typedef struct clientReplyBlockPlain {
     int type;  /* Always CLIENT_REPLY_BLOCK_PLAIN */
@@ -1106,7 +1103,7 @@ typedef struct clientReplyBlockRobj {
     int type;  /* Always CLIENT_REPLY_BLOCK_ROBJ */
     robj *obj;
     unsigned int prefix_cnt;
-    char prefix[BULK_STR_LEN_PREFIX_MAX_SIZE];
+    char prefix[LONG_STR_SIZE + 3]; /* $<len>\r\n */
     char crlf[2]; /* \r\n */
 } clientReplyBlockRobj;
 

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -149,7 +149,7 @@ start_server {} {
         assert_equal [s rdb_bgsave_in_progress] 1
         r flushall
         # wait a second max (bgsave should take 5)
-        wait_for_condition 10 100 {
+        wait_for_condition 10 500 {
             [s rdb_bgsave_in_progress] == 0
         } else {
             fail "bgsave not aborted"

--- a/tests/unit/replybufsize.tcl
+++ b/tests/unit/replybufsize.tcl
@@ -13,6 +13,7 @@ start_server {tags {"replybufsize"}} {
     test {verify reply buffer limits} {
         # In order to reduce test time we can set the peak reset time very low
         r debug replybuffer peak-reset-time 100
+        r config set min-string-size-avoid-copy-reply 0
         
         # Create a simple idle test client
         variable tc [redis_client]


### PR DESCRIPTION
This PR introduces a copy avoidance optimization for bulk string replies in Redis, significantly reducing memory allocations and improving performance for large string responses.

### New Reply Block Type
Introduced two types of reply blocks:
* CLIENT_REPLY_BLOCK_PLAIN: Traditional buffer-based blocks (existing behavior)
* CLIENT_REPLY_BLOCK_ROBJ: New reference-based blocks that avoid copying large strings

### New config
New config option: `min-string-size-avoid-copy-reply` allows tuning the threshold.

### Command changes
When using `FLUSHDB ASYNC`, we need to put the robj into the bio.
This can lead to race conditions with the IO threads or the main thread, since the robj might still be referenced elsewhere. To handle this, I changed the code to iterate over all clients before putting db to bio, make a copy of the robj for the reply to all clients, and then perform the asynchronous flush.

