### PR TITLE
Fixes an issue where EXEC checks ACL during AOF loading.

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -179,6 +179,9 @@ void execCommand(client *c) {
 
     c->all_argv_len_sum = c->mstate.argv_len_sums;
 
+    /* Skip ACL check for the AOF client while server loading. */
+    int skip_acl_check = server.loading && c->id == CLIENT_ID_AOF;
+
     addReplyArrayLen(c,c->mstate.count);
     for (j = 0; j < c->mstate.count; j++) {
         c->argc = c->mstate.commands[j]->argc;
@@ -190,8 +193,6 @@ void execCommand(client *c) {
          * they were changed after the commands were queued. */
         int acl_errpos;
         int acl_retval = ACL_OK;
-        /* Skip ACL check for the AOF client while server loading. */
-        int skip_acl_check = server.loading && c->id == CLIENT_ID_AOF;
         if (!skip_acl_check) {
             acl_retval = ACLCheckAllPerm(c,&acl_errpos);
         }

--- a/src/multi.c
+++ b/src/multi.c
@@ -189,7 +189,12 @@ void execCommand(client *c) {
         /* ACL permissions are also checked at the time of execution in case
          * they were changed after the commands were queued. */
         int acl_errpos;
-        int acl_retval = ACLCheckAllPerm(c,&acl_errpos);
+        int acl_retval = ACL_OK;
+        /* Skip ACL check for the AOF client while server loading. */
+        int skip_acl_check = server.loading && c->id == CLIENT_ID_AOF;
+        if (!skip_acl_check) {
+            acl_retval = ACLCheckAllPerm(c,&acl_errpos);
+        }
         if (acl_retval != ACL_OK) {
             char *reason;
             switch (acl_retval) {

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -375,7 +375,7 @@ tags {"aof external:skip"} {
     }
 
     test {skip EXEC ACL check during AOF load} {
-        set user_acl "default on nopass ~* &* +@all -set"
+        set user_acl "default on nopass ~* &* +@read -@write +multi +exec +select +ping"
 
         create_aof_manifest $aof_dirpath $aof_manifest_file {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i\n"

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -374,6 +374,35 @@ tags {"aof external:skip"} {
         }
     }
 
+    test {skip EXEC ACL check during AOF load} {
+        set user_acl "default on nopass ~* &* +@all -set"
+
+        create_aof_manifest $aof_dirpath $aof_manifest_file {
+            append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i\n"
+        }
+
+        create_aof $aof_dirpath $aof_file {
+            append_to_aof [formatCommand set beforetx beforetx]
+            append_to_aof [formatCommand multi]
+            append_to_aof [formatCommand set tx1 tx1]
+            append_to_aof [formatCommand set tx2 tx2]
+            append_to_aof [formatCommand exec]
+            append_to_aof [formatCommand set aftertx aftertx]
+        }
+
+        start_server_aof [list dir $server_path user $user_acl] {
+            set c [redis [srv host] [srv port] 0 $::tls]
+            wait_done_loading $c
+            assert_equal {beforetx} [$c get beforetx]
+            assert_equal {aftertx}  [$c get aftertx]
+            assert_equal {tx1} [$c get tx1]
+            assert_equal {tx2} [$c get tx2]
+
+            catch {$c set newkey value} e
+            assert_match {*NOPERM*set*} $e
+        }
+    }
+
     # redis could load AOF which has timestamp annotations inside
     create_aof $aof_dirpath $aof_file {
         append_to_aof "#TS:1628217470\r\n"


### PR DESCRIPTION
This PR fixes an issue(#14541) where EXEC’s ACL recheck was still being performed during AOF loading, that may cause AOF loading failed, if ACL rules are changed and don't allow some commands in MULTI-EXEC.