### PR TITLE
Fix flaky ASM write load test

### DIFF
--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -511,14 +511,14 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # 5. Stop write traffic, verify db's are identical.
 
         # This test runs slowly under the thread sanitizer.
-        #   1. Increase the lag threshold from the default 1 MB to 10 MB to let the destination catch up easily.
-        #   2. Increase the write pause timeout from the default 10s to 60s so the source can wait longer.
+        #  1. Increase the lag threshold from the default 1 MB to 10 MB to let the destination catch up easily.
+        #  2. Increase the write pause timeout from the default 10s to 60s so the source can wait longer.
         set prev_config_lag [lindex [R 0 config get cluster-slot-migration-handoff-max-lag-bytes] 1]
         R 0 config set cluster-slot-migration-handoff-max-lag-bytes 10mb
         R 1 config set cluster-slot-migration-handoff-max-lag-bytes 10mb
         set prev_config_timeout [lindex [R 0 config get cluster-slot-migration-write-pause-timeout] 1]
-        R 0 config set cluster-slot-migration-write-pause-timeout 60
-        R 1 config set cluster-slot-migration-write-pause-timeout 60
+        R 0 config set cluster-slot-migration-write-pause-timeout 60000
+        R 1 config set cluster-slot-migration-write-pause-timeout 60000
 
         R 0 flushall
         R 0 debug asm-trim-method none

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -510,9 +510,15 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # 4. Migrate slot 6000 from node-1 to node-0
         # 5. Stop write traffic, verify db's are identical.
 
-        set prev_config [lindex [R 0 config get cluster-slot-migration-handoff-max-lag-bytes] 1]
+        # This test runs slowly under the thread sanitizer.
+        #   1. Increase the lag threshold from the default 1 MB to 10 MB to let the destination catch up easily.
+        #   2. Increase the write pause timeout from the default 10s to 60s so the source can wait longer.
+        set prev_config_lag [lindex [R 0 config get cluster-slot-migration-handoff-max-lag-bytes] 1]
         R 0 config set cluster-slot-migration-handoff-max-lag-bytes 10mb
         R 1 config set cluster-slot-migration-handoff-max-lag-bytes 10mb
+        set prev_config_timeout [lindex [R 0 config get cluster-slot-migration-write-pause-timeout] 1]
+        R 0 config set cluster-slot-migration-write-pause-timeout 60
+        R 1 config set cluster-slot-migration-write-pause-timeout 60
 
         R 0 flushall
         R 0 debug asm-trim-method none
@@ -554,10 +560,12 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         assert_equal [R 0 debug digest] [R 1 debug digest]
 
         # cleanup
-        R 0 config set cluster-slot-migration-handoff-max-lag-bytes $prev_config
+        R 0 config set cluster-slot-migration-handoff-max-lag-bytes $prev_config_lag
+        R 0 config set cluster-slot-migration-write-pause-timeout $prev_config_timeout
         R 0 debug asm-trim-method default
         R 0 flushall
-        R 1 config set cluster-slot-migration-handoff-max-lag-bytes $prev_config
+        R 1 config set cluster-slot-migration-handoff-max-lag-bytes $prev_config_lag
+        R 1 config set cluster-slot-migration-write-pause-timeout $prev_config_timeout
         R 1 debug asm-trim-method default
         R 1 flushall
 


### PR DESCRIPTION
Extend write pause timeout to stabilize ASM write load test under TSAN.

Failing test for reference:
https://github.com/redis/redis/actions/runs/19520561209/job/55882882951