### PR TITLE
Fix min_cgroup_last_id cache not updated when destroying consumer group

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3143,7 +3143,7 @@ void streamDestroyCG(stream *s, streamCG *cg) {
     /* If we're destroying the group with the minimum last_id, the cached
      * minimum is no longer valid and needs to be recalculated from the
      * remaining groups. */
-    if (streamCompareID(&s->min_cgroup_last_id, &cg->last_id) == 0)
+    if (s->min_cgroup_last_id_valid && streamCompareID(&s->min_cgroup_last_id, &cg->last_id) == 0)
         s->min_cgroup_last_id_valid = 0;
 
     streamFreeCG(s, cg);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3130,6 +3130,7 @@ static void streamFreeCG(stream *s, streamCG *cg) {
 
 /* Destroy a consumer group and clean up all associated references. */
 void streamDestroyCG(stream *s, streamCG *cg) {
+    /* Remove all references from the cgroups_ref. */
     raxIterator it;
     raxStart(&it, cg->pel);
     raxSeek(&it, "^", NULL, 0);
@@ -3138,6 +3139,12 @@ void streamDestroyCG(stream *s, streamCG *cg) {
         streamUnlinkEntryFromCGroupRef(s, nack, it.key);
     }
     raxStop(&it);
+
+    /* If we're destroying the group with the minimum last_id, the cached
+     * minimum is no longer valid and needs to be recalculated from the
+     * remaining groups. */
+    if (streamCompareID(&s->min_cgroup_last_id, &cg->last_id) == 0)
+        s->min_cgroup_last_id_valid = 0;
 
     streamFreeCG(s, cg);
 }


### PR DESCRIPTION
This issue was introduced by #14130 and found by @guybe7.

## Problem

When destroying a consumer group with `XGROUP DESTROY`, the cached `min_cgroup_last_id` was not being invalidated. This caused incorrect behavior when using `XDELEX` with the `ACKED` option, as the cache still referenced the destroyed group's `last_id`.

## Solution

Invalidate the `min_cgroup_last_id` cache when the destroyed group's `last_id` equals the cached minimum. The cache will be recalculated on the next call to `streamEntryIsReferenced()`.
