### PR TITLE
Detect accept4() on specific versions of various platforms

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -87,11 +87,10 @@
 #endif
 
 /* Test for accept4() */
-#if defined(__linux__) || \
+#if defined(__linux__) || defined(OpenBSD5_7) || \
     defined(__FreeBSD__) || \
-    defined(OpenBSD5_7) || \
-    (defined(__DragonFly__) && __DragonFly_version >= 400305) || \
-    (defined(__NetBSD__) && (defined(NetBSD8_0) || __NetBSD_Version__ >= 800000000))
+    (defined(__NetBSD__) && (defined(NetBSD8_0) || __NetBSD_Version__ >= 800000000)) || \
+    (defined(__DragonFly__) && __DragonFly_version >= 400305)
 #define HAVE_ACCEPT4 1
 #endif
 

--- a/src/config.h
+++ b/src/config.h
@@ -87,7 +87,7 @@
 #endif
 
 /* Test for accept4() */
-#if defined(__linux__) || defined(OpenBSD5_7) || \
+#if defined(__linux__) || (defined(OpenBSD) && OpenBSD >= 201505) || \
     defined(__FreeBSD__) || \
     (defined(__NetBSD_Version__) && __NetBSD_Version__ >= 800000000) || \
     (defined(__DragonFly__) && __DragonFly_version >= 400305)

--- a/src/config.h
+++ b/src/config.h
@@ -10,6 +10,8 @@
 #ifndef __CONFIG_H
 #define __CONFIG_H
 
+#include <sys/param.h>
+
 #ifdef __APPLE__
 #include <fcntl.h> // for fcntl(fd, F_FULLFSYNC)
 #include <AvailabilityMacros.h>
@@ -85,9 +87,11 @@
 #endif
 
 /* Test for accept4() */
-#if defined(__linux__) || defined(OpenBSD5_7) || \
-    (__FreeBSD__ >= 10 || __FreeBSD_version >= 1000000) || \
-    (defined(NetBSD8_0) || __NetBSD_Version__ >= 800000000)
+#if defined(__linux__) || \
+    defined(__FreeBSD__) || \
+    defined(OpenBSD5_7) || \
+    (defined(__DragonFly__) && __DragonFly_version >= 400305) || \
+    (defined(__NetBSD__) && (defined(NetBSD8_0) || __NetBSD_Version__ >= 800000000))
 #define HAVE_ACCEPT4 1
 #endif
 
@@ -330,7 +334,7 @@ void setcpuaffinity(const char *cpulist);
 #endif
 
 /* Test for posix_fadvise() */
-#if defined(__linux__) || __FreeBSD__ >= 10
+#if defined(__linux__) || defined(__FreeBSD__)
 #define HAVE_FADVISE
 #endif
 

--- a/src/config.h
+++ b/src/config.h
@@ -89,7 +89,7 @@
 /* Test for accept4() */
 #if defined(__linux__) || defined(OpenBSD5_7) || \
     defined(__FreeBSD__) || \
-    (defined(__NetBSD__) && (defined(NetBSD8_0) || __NetBSD_Version__ >= 800000000)) || \
+    (defined(__NetBSD_Version__) && __NetBSD_Version__ >= 800000000) || \
     (defined(__DragonFly__) && __DragonFly_version >= 400305)
 #define HAVE_ACCEPT4 1
 #endif


### PR DESCRIPTION
This PR has mainly done three things:
1. Enable `accept4()` on DragonFlyBSD 4.3+
2. Fix the failures of determining the presence of `accept4()` due to the missing <sys/param.h> on two OSs: NetBSD, OpenBSD
3. Drop the support of FreeBSD <10.0 for `redis`, FreeBSD 10 is past EOL, as are the two major versions following it, so defined(__FreeBSD__) is sufficient.

- [param.h in DragonFlyBSD](https://github.com/DragonFlyBSD/DragonFlyBSD/blob/7485684fa5c3fadb6c7a1da0d8bb6ea5da4e0f2f/sys/sys/param.h#L129-L257)
- [param.h in FreeBSD](https://github.com/freebsd/freebsd-src/blob/main/sys/sys/param.h#L46-L76)
- [param.h in NetBSD](https://github.com/NetBSD/src/blob/b5f8d2f930b7ef226d4dc1b4f7017e998c0e5cde/sys/sys/param.h#L53-L70)
- [param.h in OpenBSD](https://github.com/openbsd/src/blob/d9c286e032a7cee9baaecdd54eb0d43f658ae696/sys/sys/param.h#L40-L45)

---------