### PR TITLE
Clean up lookahead-related code

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1236,7 +1236,7 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
 
         for (j = 0; j < result.numkeys; j++) {
             /* The command has keys and was checked for cross-slot between its keys in preprocessCommand() */
-            if (pcmd->slot == CLUSTER_CROSSSLOT) {
+            if (pcmd->read_error == CLIENT_READ_CROSS_SLOT) {
                 /* Error: multiple keys from different slots. */
                 if (error_code)
                     *error_code = CLUSTER_REDIR_CROSS_SLOT;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1096,15 +1096,13 @@ void clusterCommand(client *c) {
 }
 
 /* Extract slot number from keys in a keys_result structure and return to caller.
- * Returns INVALID_CLUSTER_SLOT if keys belong to different slots (cross-slot error),
- * or if there are no keys.
- */
+ * Returns:
+ *   - The slot number if all keys belong to the same slot
+ *   - INVALID_CLUSTER_SLOT if there are no keys or cluster is disabled
+ *   - CLUSTER_CROSSSLOT if keys belong to different slots (cross-slot error) */
 int extractSlotFromKeysResult(robj **argv, getKeysResult *keys_result) {
-    if (keys_result->numkeys == 0)
+    if (keys_result->numkeys == 0 || !server.cluster_enabled)
         return INVALID_CLUSTER_SLOT;
-
-    if (!server.cluster_enabled)
-        return 0;
 
     int first_slot = INVALID_CLUSTER_SLOT;
     for (int j = 0; j < keys_result->numkeys; j++) {
@@ -1114,7 +1112,7 @@ int extractSlotFromKeysResult(robj **argv, getKeysResult *keys_result) {
         if (first_slot == INVALID_CLUSTER_SLOT)
             first_slot = this_slot;
         else if (first_slot != this_slot) {
-            return INVALID_CLUSTER_SLOT;
+            return CLUSTER_CROSSSLOT;
         }
     }
     return first_slot;
@@ -1238,7 +1236,7 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
 
         for (j = 0; j < result.numkeys; j++) {
             /* The command has keys and was checked for cross-slot between its keys in preprocessCommand() */
-            if (pcmd->read_error == CLIENT_READ_CROSS_SLOT) {
+            if (pcmd->slot == CLUSTER_CROSSSLOT) {
                 /* Error: multiple keys from different slots. */
                 if (error_code)
                     *error_code = CLUSTER_REDIR_CROSS_SLOT;

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -23,7 +23,7 @@
 #define CLUSTER_SLOTS (1<<CLUSTER_SLOT_MASK_BITS) /* Total number of slots in cluster mode, which is 16384. */
 #define CLUSTER_SLOT_MASK ((unsigned long long)(CLUSTER_SLOTS - 1)) /* Bit mask for slot id stored in LSB. */
 #define INVALID_CLUSTER_SLOT (-1) /* Invalid slot number. */
-#define GETSLOT_CROSSSLOT  (-2)
+#define CLUSTER_CROSSSLOT  (-2)
 #define CLUSTER_OK 0            /* Everything looks ok */
 #define CLUSTER_FAIL 1          /* The cluster can't work */
 #define CLUSTER_NAMELEN 40      /* sha1 hex length */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -23,6 +23,7 @@
 #define CLUSTER_SLOTS (1<<CLUSTER_SLOT_MASK_BITS) /* Total number of slots in cluster mode, which is 16384. */
 #define CLUSTER_SLOT_MASK ((unsigned long long)(CLUSTER_SLOTS - 1)) /* Bit mask for slot id stored in LSB. */
 #define INVALID_CLUSTER_SLOT (-1) /* Invalid slot number. */
+#define GETSLOT_CROSSSLOT  (-2)
 #define CLUSTER_OK 0            /* Everything looks ok */
 #define CLUSTER_FAIL 1          /* The cluster can't work */
 #define CLUSTER_NAMELEN 40      /* sha1 hex length */

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -762,7 +762,7 @@ void asmFeedMigrationClient(robj **argv, int argc) {
      *
      * NOTICE: if some keyless commands should be propagated to the destination,
      * we should identify them here and send. */
-    if (slot == GETSLOT_NOKEYS) return;
+    if (slot == INVALID_CLUSTER_SLOT) return;
 
     /* Generally we reject cross-slot commands before executing, but module may
      * replicate this kind of command, so we check again. To guarantee data
@@ -3461,7 +3461,7 @@ int asmModulePropagateBeforeSlotSnapshot(struct redisCommand *cmd, robj **argv, 
 
     /* Allow no-keys commands or if keys are in the slot range. */
     slotRange sr = {slot, slot};
-    if (slot != GETSLOT_NOKEYS && !slotRangeArrayOverlaps(task->slots, &sr)) {
+    if (slot != INVALID_CLUSTER_SLOT && !slotRangeArrayOverlaps(task->slots, &sr)) {
         errno = ERANGE;
         return C_ERR;
     }

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -767,7 +767,7 @@ void asmFeedMigrationClient(robj **argv, int argc) {
     /* Generally we reject cross-slot commands before executing, but module may
      * replicate this kind of command, so we check again. To guarantee data
      * consistency, we cancel the task if we encounter a cross-slot command. */
-    if (slot == GETSLOT_CROSSSLOT) {
+    if (slot == CLUSTER_CROSSSLOT) {
         /* We cannot cancel the task directly here, since it may lead to a recursive
          * call: asmTaskCancel() --> moduleFireServerEvent() --> moduleFreeContext()
          * --> postExecutionUnitOperations() --> propagateNow(). Even worse, this
@@ -3454,7 +3454,7 @@ int asmModulePropagateBeforeSlotSnapshot(struct redisCommand *cmd, robj **argv, 
 
     /* Crossslot commands are not allowed */
     int slot = getSlotFromCommand(cmd, argv, argc);
-    if (slot == GETSLOT_CROSSSLOT) {
+    if (slot == CLUSTER_CROSSSLOT) {
         errno = ENOTSUP;
         return C_ERR;
     }

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -137,7 +137,7 @@ static void addReplySortedSlotStats(client *c, slotStatForSort slot_stats[], lon
 }
 
 static int canAddNetworkBytesOut(client *c) {
-    return clusterSlotStatsEnabled() && c->slot >= 0;
+    return clusterSlotStatsEnabled() && c->slot != INVALID_CLUSTER_SLOT;
 }
 
 /* Accumulates egress bytes upon sending RESP responses back to user clients. */
@@ -223,7 +223,7 @@ void clusterSlotStatResetAll(void) {
 static int canAddCpuDuration(client *c) {
     return server.cluster_slot_stats_enabled &&  /* Config should be enabled. */
            server.cluster_enabled &&             /* Cluster mode should be enabled. */
-           c->slot >= 0 &&                       /* Command should be slot specific. */
+           c->slot != INVALID_CLUSTER_SLOT &&    /* Command should be slot specific. */
            (!server.execution_nesting ||         /* Either command should not be nested, */
             (c->realcmd->flags & CMD_BLOCKING)); /* or it must be due to unblocking. */
 }
@@ -249,7 +249,7 @@ static int canAddNetworkBytesIn(client *c) {
      * Third, blocked client is not aggregated, to avoid duplicate aggregation upon unblocking.
      * Fourth, the server is not under a MULTI/EXEC transaction, to avoid duplicate aggregation of
      * EXEC's 14 bytes RESP upon nested call()'s afterCommand(). */
-    return clusterSlotStatsEnabled() && c->slot >= 0 &&
+    return clusterSlotStatsEnabled() && c->slot != INVALID_CLUSTER_SLOT &&
         !(c->flags & CLIENT_BLOCKED) && !server.in_exec;
 }
 

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -137,7 +137,7 @@ static void addReplySortedSlotStats(client *c, slotStatForSort slot_stats[], lon
 }
 
 static int canAddNetworkBytesOut(client *c) {
-    return clusterSlotStatsEnabled() && c->slot != -1;
+    return clusterSlotStatsEnabled() && c->slot >= 0;
 }
 
 /* Accumulates egress bytes upon sending RESP responses back to user clients. */
@@ -223,7 +223,7 @@ void clusterSlotStatResetAll(void) {
 static int canAddCpuDuration(client *c) {
     return server.cluster_slot_stats_enabled &&  /* Config should be enabled. */
            server.cluster_enabled &&             /* Cluster mode should be enabled. */
-           c->slot != -1 &&                      /* Command should be slot specific. */
+           c->slot >= 0 &&                       /* Command should be slot specific. */
            (!server.execution_nesting ||         /* Either command should not be nested, */
             (c->realcmd->flags & CMD_BLOCKING)); /* or it must be due to unblocking. */
 }
@@ -249,7 +249,7 @@ static int canAddNetworkBytesIn(client *c) {
      * Third, blocked client is not aggregated, to avoid duplicate aggregation upon unblocking.
      * Fourth, the server is not under a MULTI/EXEC transaction, to avoid duplicate aggregation of
      * EXEC's 14 bytes RESP upon nested call()'s afterCommand(). */
-    return clusterSlotStatsEnabled() && c->slot != -1 &&
+    return clusterSlotStatsEnabled() && c->slot >= 0 &&
         !(c->flags & CLIENT_BLOCKED) && !server.in_exec;
 }
 

--- a/src/db.c
+++ b/src/db.c
@@ -426,7 +426,7 @@ int getKeySlot(sds key) {
 }
 
 /* Return the slot of the key in the command.
- * INVALID_CLUSTER_SLOT if no keys, GETSLOT_CROSSSLOT if cross slot, otherwise the slot number. */
+ * INVALID_CLUSTER_SLOT if no keys, CLUSTER_CROSSSLOT if cross slot, otherwise the slot number. */
 int getSlotFromCommand(struct redisCommand *cmd, robj **argv, int argc) {
     if (!cmd || !server.cluster_enabled) return INVALID_CLUSTER_SLOT;
 
@@ -440,7 +440,7 @@ int getSlotFromCommand(struct redisCommand *cmd, robj **argv, int argc) {
      * We check if there are keys to determine if it's a cross-slot case. */
     int slot = extractSlotFromKeysResult(argv, &result);
     if (slot == INVALID_CLUSTER_SLOT && result.numkeys > 0) {
-        slot = GETSLOT_CROSSSLOT;
+        slot = CLUSTER_CROSSSLOT;
     }
     getKeysFreeResult(&result);
     return slot;

--- a/src/db.c
+++ b/src/db.c
@@ -426,26 +426,21 @@ int getKeySlot(sds key) {
 }
 
 /* Return the slot of the key in the command.
- * GETSLOT_NOKEYS if no keys, GETSLOT_CROSSSLOT if cross slot, otherwise the slot number. */
+ * INVALID_CLUSTER_SLOT if no keys, GETSLOT_CROSSSLOT if cross slot, otherwise the slot number. */
 int getSlotFromCommand(struct redisCommand *cmd, robj **argv, int argc) {
-    int slot = GETSLOT_NOKEYS;
-    if (!cmd || !server.cluster_enabled) return slot;
+    if (!cmd || !server.cluster_enabled) return INVALID_CLUSTER_SLOT;
 
     /* Get the keys from the command */
     getKeysResult result = GETKEYS_RESULT_INIT;
-    int numkeys = getKeysFromCommand(cmd, argv, argc, &result);
-    keyReference *keyindex = result.keys;
+    getKeysFromCommand(cmd, argv, argc, &result);
 
-    /* Get slot of each key and check if they are all the same */
-    for (int j = 0; j < numkeys; j++) {
-        robj *thiskey = argv[keyindex[j].pos];
-        int thisslot = keyHashSlot((char*)thiskey->ptr, sdslen(thiskey->ptr));
-        if (slot == GETSLOT_NOKEYS) {
-            slot = thisslot;
-        } else if (slot != thisslot) {
-            slot = GETSLOT_CROSSSLOT; /* Mark as cross slot */
-            break;
-        }
+    /* Extract slot from the keys result.
+     * Note: extractSlotFromKeysResult returns INVALID_CLUSTER_SLOT for both
+     * "no keys" and "cross-slot" cases, but we need to distinguish them.
+     * We check if there are keys to determine if it's a cross-slot case. */
+    int slot = extractSlotFromKeysResult(argv, &result);
+    if (slot == INVALID_CLUSTER_SLOT && result.numkeys > 0) {
+        slot = GETSLOT_CROSSSLOT;
     }
     getKeysFreeResult(&result);
     return slot;

--- a/src/db.c
+++ b/src/db.c
@@ -434,14 +434,8 @@ int getSlotFromCommand(struct redisCommand *cmd, robj **argv, int argc) {
     getKeysResult result = GETKEYS_RESULT_INIT;
     getKeysFromCommand(cmd, argv, argc, &result);
 
-    /* Extract slot from the keys result.
-     * Note: extractSlotFromKeysResult returns INVALID_CLUSTER_SLOT for both
-     * "no keys" and "cross-slot" cases, but we need to distinguish them.
-     * We check if there are keys to determine if it's a cross-slot case. */
+    /* Extract slot from the keys result. */
     int slot = extractSlotFromKeysResult(argv, &result);
-    if (slot == INVALID_CLUSTER_SLOT && result.numkeys > 0) {
-        slot = CLUSTER_CROSSSLOT;
-    }
     getKeysFreeResult(&result);
     return slot;
 }
@@ -3204,10 +3198,7 @@ int extractKeysAndSlot(struct redisCommand *cmd, robj **argv, int argc,
         }
     }
 
-    *slot = INVALID_CLUSTER_SLOT;
-    if (num_keys >= 0)
-        *slot = extractSlotFromKeysResult(argv, result);
-
+    *slot = extractSlotFromKeysResult(argv, result);
     return num_keys;
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -5096,7 +5096,7 @@ void freePendingCommand(client *c, pendingCommand *pcmd) {
     if (pcmd->argv) {
         for (int j = 0; j < pcmd->argc; j++) {
             robj *o = pcmd->argv[j];
-            if (!o) continue; /* TODO */
+            if (!o) continue; /* argv[j] may be NULL when called from reclaimPendingCommand */
             decrRefCount(o);
         }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -2983,7 +2983,8 @@ void handleClientReadError(client *c) {
 int isClientReadErrorFatal(client *c) {
     return c->read_error != 0 &&
            c->read_error != CLIENT_READ_COMMAND_NOT_FOUND &&
-           c->read_error != CLIENT_READ_BAD_ARITY;
+           c->read_error != CLIENT_READ_BAD_ARITY &&
+           c->read_error != CLIENT_READ_CROSS_SLOT;
 }
 
 /* This function is called every time, in the client structure 'c', there is

--- a/src/networking.c
+++ b/src/networking.c
@@ -2983,8 +2983,7 @@ void handleClientReadError(client *c) {
 int isClientReadErrorFatal(client *c) {
     return c->read_error != 0 &&
            c->read_error != CLIENT_READ_COMMAND_NOT_FOUND &&
-           c->read_error != CLIENT_READ_BAD_ARITY &&
-           c->read_error != CLIENT_READ_CROSS_SLOT;
+           c->read_error != CLIENT_READ_BAD_ARITY;
 }
 
 /* This function is called every time, in the client structure 'c', there is

--- a/src/server.c
+++ b/src/server.c
@@ -4138,6 +4138,12 @@ void preprocessCommand(client *c, pendingCommand *pcmd) {
     if (num_keys < 0) {
         /* We skip the checks below since We expect the command to be rejected in this case */
         return;
+    } else if (num_keys > 0) {
+        /* Handle cross-slot keys: mark error and reset slot. */
+        if (pcmd->slot == CLUSTER_CROSSSLOT) {
+            pcmd->read_error = CLIENT_READ_CROSS_SLOT;
+            pcmd->slot = INVALID_CLUSTER_SLOT;
+        }
     }
     pcmd->flags |= PENDING_CMD_KEYS_RESULT_VALID;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -4138,11 +4138,6 @@ void preprocessCommand(client *c, pendingCommand *pcmd) {
     if (num_keys < 0) {
         /* We skip the checks below since We expect the command to be rejected in this case */
         return;
-    } else if (num_keys > 0) {
-        /* If the command has keys but the slot is invalid, it means
-         * there is a cross-slot case. */
-        if (pcmd->slot == INVALID_CLUSTER_SLOT)
-            pcmd->read_error = CLIENT_READ_CROSS_SLOT;
     }
     pcmd->flags |= PENDING_CMD_KEYS_RESULT_VALID;
 }

--- a/src/server.h
+++ b/src/server.h
@@ -469,7 +469,6 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_READ_REACHED_MAX_QUERYBUF 13
 #define CLIENT_READ_COMMAND_NOT_FOUND 14
 #define CLIENT_READ_BAD_ARITY 15
-#define CLIENT_READ_CROSS_SLOT 16
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/src/server.h
+++ b/src/server.h
@@ -469,6 +469,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_READ_REACHED_MAX_QUERYBUF 13
 #define CLIENT_READ_COMMAND_NOT_FOUND 14
 #define CLIENT_READ_BAD_ARITY 15
+#define CLIENT_READ_CROSS_SLOT 16
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/src/server.h
+++ b/src/server.h
@@ -2409,7 +2409,7 @@ typedef struct {
 enum {
     PENDING_CMD_FLAG_INCOMPLETE = 1 << 0,     /* Command parsing is incomplete, still waiting for more data */
     PENDING_CMD_FLAG_PREPROCESSED = 1 << 1,   /* This command has passed pre-processing */
-    PENDING_CMD_KEYS_RESULT_VALID = 1 << 2,     /* Command's keys_result is valid and cached */
+    PENDING_CMD_KEYS_RESULT_VALID = 1 << 2,   /* Command's keys_result is valid and cached */
 };
 
 /* Parser state and parse result of a command from a client's input buffer. */
@@ -3872,8 +3872,6 @@ int getKeysFromCommandWithSpecs(struct redisCommand *cmd, robj **argv, int argc,
 keyReference *getKeysPrepareResult(getKeysResult *result, int numkeys);
 int getKeysFromCommand(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 
-#define GETSLOT_NOKEYS     (-1)
-#define GETSLOT_CROSSSLOT  (-2)
 int getSlotFromCommand(struct redisCommand *cmd, robj **argv, int argc);
 int doesCommandHaveKeys(struct redisCommand *cmd);
 int getChannelsFromCommand(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);

--- a/src/server.h
+++ b/src/server.h
@@ -3871,7 +3871,6 @@ void freeReplicationBacklogRefMemAsync(list *blocks, rax *index);
 int getKeysFromCommandWithSpecs(struct redisCommand *cmd, robj **argv, int argc, int search_flags, getKeysResult *result);
 keyReference *getKeysPrepareResult(getKeysResult *result, int numkeys);
 int getKeysFromCommand(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
-
 int getSlotFromCommand(struct redisCommand *cmd, robj **argv, int argc);
 int doesCommandHaveKeys(struct redisCommand *cmd);
 int getChannelsFromCommand(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);


### PR DESCRIPTION
## Summary

Clean up lookahead-related(https://github.com/redis/redis/issues/14440) code by consolidating slot extraction logic.

## Changes

* Replace `GETSLOT_NOKEYS` with `INVALID_CLUSTER_SLOT`
* Refactor `getSlotFromCommand()` to reuse `extractSlotFromKeysResult()`
* Let extractSlotFromKeysResult () behavior more unified and more readable
* Fix comment alignment