### PR TITLE
Fix delayed config broadcast after ASM operations

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6622,7 +6622,7 @@ int clusterAsmOnEvent(const char *task_id, int event, void *arg) {
             /* Bump config epoch and broadcast the new config to the other nodes. */
             clusterBumpConfigEpochWithoutConsensus();
             clusterSaveConfigOrDie(1);
-            clusterDoBeforeSleep(CLUSTER_BROADCAST_ALL);
+            clusterDoBeforeSleep(CLUSTER_TODO_BROADCAST_PONG);
             clusterAsmProcess(task_id, ASM_EVENT_DONE, NULL, NULL);
             break;
         case ASM_EVENT_IMPORT_COMPLETED:


### PR DESCRIPTION
An incorrect constant value prevented the configuration from being broadcast immediately. As a result, the config was only broadcast later as part of periodic ping messages, causing other nodes to learn about the configuration change with a delay.

Introduced by https://github.com/redis/redis/pull/14504.