### PR TITLE
Cleanup redundant declaration of getSlotOrReply()

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -166,7 +166,6 @@ int clusterRedirectBlockedClientIfNeeded(client *c);
 void clusterRedirectClient(client *c, clusterNode *n, int hashslot, int error_code);
 void migrateCloseTimedoutSockets(void);
 int patternHashSlot(char *pattern, int length);
-int getSlotOrReply(client *c, robj *o);
 int isValidAuxString(char *s, unsigned int length);
 void migrateCommand(client *c);
 void clusterCommand(client *c);


### PR DESCRIPTION
Remove redundant declaration of getSlotOrReply, declared at both lines 156 and 169:


https://github.com/redis/redis/blob/82fbf213eb47d2a623decf5c31b29d35459fcd71/src/cluster.h#L156

https://github.com/redis/redis/blob/82fbf213eb47d2a623decf5c31b29d35459fcd71/src/cluster.h#L169