### PR TITLE
ignore module sources and Rust toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,5 @@ Makefile.dep
 .ccls-cache/*
 compile_commands.json
 redis.code-workspace
-modules/rust*
+modules/rust*.tar.xz
 modules/*/src/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ Makefile.dep
 .ccls-cache/*
 compile_commands.json
 redis.code-workspace
+modules/rust*
+modules/*/src/


### PR DESCRIPTION
This prevents untracked build files from cluttering git status while keeping the module sources versioned.