### PR TITLE
Fix rare server hang at shutdown

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4819,6 +4819,7 @@ int finishShutdown(void) {
          * The temp rdb file fd may won't be closed when redis exits quickly,
          * but OS will close this fd when process exits. */
         rdbRemoveTempFile(server.child_pid, 0);
+        resetChildState();
     }
 
     /* Kill module child if there is one. */


### PR DESCRIPTION
In case we have to kill an rdb child at shutdown, we wait for the child process to exit, and then resume with the shutodwn, and we did not clear the child_pid variable, since we're going to terminate anyway. but if the shutdown is then aborted due to another issue further down that function, we will try to kill that child again, and the waitpid will never get released.

Reproduced in the test "SHUTDOWN can proceed if shutdown command was with nosave"