### PR TITLE
Fix incorrect comment about LRU clock resolution in initObjectLRUOrLFU

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -100,7 +100,7 @@ robj *createObject(int type, void *ptr) {
 void initObjectLRUOrLFU(robj *o) {
     if (o->refcount == OBJ_SHARED_REFCOUNT)
         return;
-    /* Set the LRU to the current lruclock (minutes resolution), or
+    /* Set the LRU to the current lruclock (seconds resolution), or
      * alternatively the LFU counter. */
     if (server.maxmemory_policy & MAXMEMORY_FLAG_LFU) {
         o->lru = (LFUGetTimeInMinutes() << 8) | LFU_INIT_VAL;


### PR DESCRIPTION
Because the LRU_CLOCK_RESOLUTION macro is 1000 and its comment is  LRU clock resolution in ms