### PR TITLE
Add `--name` flag to redis-cli for setting client name

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -265,6 +265,7 @@ static struct config {
     char *server_version;
     char *test_hint;
     char *test_hint_file;
+    char *client_name;
     int prefer_ipv4; /* Prefer IPv4 over IPv6 on DNS lookup. */
     int prefer_ipv6; /* Prefer IPv6 over IPv4 on DNS lookup. */
 } config;
@@ -1635,7 +1636,12 @@ static int cliSwitchProto(void) {
     redisReply *reply;
     if (!config.resp3 || config.resp2) return REDIS_OK;
 
-    reply = redisCommand(context,"HELLO 3");
+    if (config.client_name) {
+        reply = redisCommand(context, "HELLO 3 SETNAME %s", config.client_name);
+    } else {
+        reply = redisCommand(context,"HELLO 3");
+    }
+
     if (reply == NULL) {
         fprintf(stderr, "\nI/O error\n");
         return REDIS_ERR;
@@ -2901,6 +2907,8 @@ static int parseOptions(int argc, char **argv) {
             config.cluster_manager_command.from_pass = argv[++i];
         } else if (!strcmp(argv[i], "--cluster-from-askpass")) {
             config.cluster_manager_command.from_askpass = 1;
+        } else if (!strcmp(argv[i], "--name") && !lastarg) {
+            config.client_name = argv[++i];
         } else if (!strcmp(argv[i],"--cluster-weight") && !lastarg) {
             if (config.cluster_manager_command.weight != NULL) {
                 fprintf(stderr, "WARNING: you cannot use --cluster-weight "

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1636,11 +1636,7 @@ static int cliSwitchProto(void) {
     redisReply *reply;
     if (!config.resp3 || config.resp2) return REDIS_OK;
 
-    if (config.client_name) {
-        reply = redisCommand(context, "HELLO 3 SETNAME %s", config.client_name);
-    } else {
-        reply = redisCommand(context,"HELLO 3");
-    }
+    reply = redisCommand(context,"HELLO 3");
 
     if (reply == NULL) {
         fprintf(stderr, "\nI/O error\n");
@@ -1676,7 +1672,6 @@ static int cliSwitchProto(void) {
  * if we are in RESP2 mode. */
 static int cliSetName(void) {
     if (config.client_name == NULL) return REDIS_OK;
-    if (config.current_resp3) return REDIS_OK; // Already handled by HELLO
 
     redisReply *reply = redisCommand(context,"CLIENT SETNAME %s", config.client_name);
     if (reply == NULL) {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1637,7 +1637,6 @@ static int cliSwitchProto(void) {
     if (!config.resp3 || config.resp2) return REDIS_OK;
 
     reply = redisCommand(context,"HELLO 3");
-
     if (reply == NULL) {
         fprintf(stderr, "\nI/O error\n");
         return REDIS_ERR;
@@ -3155,6 +3154,7 @@ static void usage(int err) {
 "                     This interval is also used in --scan and --stat per cycle.\n"
 "                     and in --bigkeys, --memkeys, --keystats, and --hotkeys per 100 cycles.\n"
 "  -n <db>            Database number.\n"
+"  --name <name>      Set the client name\n"
 "  -2                 Start session in RESP2 protocol mode.\n"
 "  -3                 Start session in RESP3 protocol mode.\n"
 "  -x                 Read last argument from STDIN (see example below).\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1666,9 +1666,7 @@ static int cliSwitchProto(void) {
     return result;
 }
 
-/* Set the client name if configured.
- * In RESP3 this is handled by HELLO, so we only need to do this
- * if we are in RESP2 mode. */
+/* Set the client name if configured. */
 static int cliSetName(void) {
     if (config.client_name == NULL) return REDIS_OK;
 
@@ -3154,7 +3152,7 @@ static void usage(int err) {
 "                     This interval is also used in --scan and --stat per cycle.\n"
 "                     and in --bigkeys, --memkeys, --keystats, and --hotkeys per 100 cycles.\n"
 "  -n <db>            Database number.\n"
-"  --name <name>      Set the client name\n"
+"  --name <name>      Set the client name.\n"
 "  -2                 Start session in RESP2 protocol mode.\n"
 "  -3                 Start session in RESP3 protocol mode.\n"
 "  -x                 Read last argument from STDIN (see example below).\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1671,6 +1671,27 @@ static int cliSwitchProto(void) {
     return result;
 }
 
+/* Set the client name if configured.
+ * In RESP3 this is handled by HELLO, so we only need to do this
+ * if we are in RESP2 mode. */
+static int cliSetName(void) {
+    if (config.client_name == NULL) return REDIS_OK;
+    if (config.current_resp3) return REDIS_OK; // Already handled by HELLO
+
+    redisReply *reply = redisCommand(context,"CLIENT SETNAME %s", config.client_name);
+    if (reply == NULL) {
+        fprintf(stderr, "\nI/O error\n");
+        return REDIS_ERR;
+    }
+    int result = REDIS_OK;
+    if (reply->type == REDIS_REPLY_ERROR) {
+        fprintf(stderr,"CLIENT SETNAME failed: %s\n", reply->str);
+        result = REDIS_ERR;
+    }
+    freeReplyObject(reply);
+    return result;
+}
+
 /* Connect to the server. It is possible to pass certain flags to the function:
  *      CC_FORCE: The connection is performed even if there is already
  *                a connected socket.
@@ -1738,6 +1759,8 @@ static int cliConnect(int flags) {
         if (cliSelect() != REDIS_OK)
             return REDIS_ERR;
         if (cliSwitchProto() != REDIS_OK)
+            return REDIS_ERR;
+        if (cliSetName() != REDIS_OK)
             return REDIS_ERR;
     }
 

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2907,8 +2907,6 @@ static int parseOptions(int argc, char **argv) {
             config.cluster_manager_command.from_pass = argv[++i];
         } else if (!strcmp(argv[i], "--cluster-from-askpass")) {
             config.cluster_manager_command.from_askpass = 1;
-        } else if (!strcmp(argv[i], "--name") && !lastarg) {
-            config.client_name = argv[++i];
         } else if (!strcmp(argv[i],"--cluster-weight") && !lastarg) {
             if (config.cluster_manager_command.weight != NULL) {
                 fprintf(stderr, "WARNING: you cannot use --cluster-weight "
@@ -2967,6 +2965,8 @@ static int parseOptions(int argc, char **argv) {
             config.test_hint = argv[++i];
         } else if (!strcmp(argv[i],"--test_hint_file") && !lastarg) {
             config.test_hint_file = argv[++i];
+        } else if (!strcmp(argv[i], "--name") && !lastarg) {
+            config.client_name = argv[++i];
 #ifdef USE_OPENSSL
         } else if (!strcmp(argv[i],"--tls")) {
             config.tls = 1;


### PR DESCRIPTION
​This PR introduces a new flag `--name <client-name>` to `redis-cli`.
This allows users to specify a persistent client name that remains associated with the connection. 

​Implementation Details:
- ​Configuration: Added `client_name` field to the global config struct.
- ​Argument Parsing: Updated `parseOptions` to handle the `--name` flag.
- ​Unified Logic (`cliSetName`): Introduced a helper function cliSetName that sends `CLIENT SETNAME <name>` immediately after the connection is established. This ensures the name is set consistently for both RESP2 and RESP3 modes.
- ​Documentation: Updated `redis-cli --help` output to include the new flag.

This PR can close #14585 