### PR TITLE
update bloom v8.4.1

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.4.0
+MODULE_VERSION = v8.4.1
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 


### PR DESCRIPTION
**Bug fixes**
- Bloom filter: crash when loading an invalid RDB file (MOD-11590, VDP-2707)
- Cuckoo filter: crash when loading an invalid RDB file (MOD-11593, VDP-2708)
- Bloom filter: memory leak when restoring an invalid RDB file (MOD-12225)
