### PR TITLE
Introduce flushdb option for repl-diskless-load

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -662,6 +662,9 @@ repl-diskless-sync-max-replicas 0
 #                 replication history.
 #                 Note that this requires sufficient memory, if you don't have it,
 #                 you risk an OOM kill.
+# "flushdb"     - Always flush the entire dataset before diskless load.
+#                 Note that if the diskless load fails, the replica will lose all
+#                 existing data.
 # "on-empty-db" - Use diskless load only when current dataset is empty. This is 
 #                 safer and avoid having old and new dataset loaded side by side
 #                 during replication.

--- a/src/config.c
+++ b/src/config.c
@@ -97,6 +97,7 @@ configEnum repl_diskless_load_enum[] = {
     {"disabled", REPL_DISKLESS_LOAD_DISABLED},
     {"on-empty-db", REPL_DISKLESS_LOAD_WHEN_DB_EMPTY},
     {"swapdb", REPL_DISKLESS_LOAD_SWAPDB},
+    {"flushdb", REPL_DISKLESS_LOAD_ALWAYS},
     {NULL, 0}
 };
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -2047,12 +2047,12 @@ void replicationCreateMasterClient(connection *conn, int dbid) {
 
 static int useDisklessLoad(void) {
     /* compute boolean decision to use diskless load */
-    int enabled = server.repl_diskless_load == REPL_DISKLESS_LOAD_SWAPDB ||
+    int enabled = server.repl_diskless_load == REPL_DISKLESS_LOAD_ALWAYS || server.repl_diskless_load == REPL_DISKLESS_LOAD_SWAPDB ||
            (server.repl_diskless_load == REPL_DISKLESS_LOAD_WHEN_DB_EMPTY && dbTotalServerKeyCount()==0);
 
     if (enabled) {
         /* Check all modules handle read errors, otherwise it's not safe to use diskless load. */
-        if (!moduleAllDatatypesHandleErrors()) {
+        if (server.repl_diskless_load != REPL_DISKLESS_LOAD_ALWAYS && !moduleAllDatatypesHandleErrors()) {
             serverLog(LL_NOTICE,
                 "Skipping diskless-load because there are modules that don't handle read errors.");
             enabled = 0;

--- a/src/server.h
+++ b/src/server.h
@@ -633,6 +633,7 @@ typedef enum {
 #define REPL_DISKLESS_LOAD_DISABLED 0
 #define REPL_DISKLESS_LOAD_WHEN_DB_EMPTY 1
 #define REPL_DISKLESS_LOAD_SWAPDB 2
+#define REPL_DISKLESS_LOAD_ALWAYS 3
 
 /* TLS Client Authentication */
 #define TLS_CLIENT_AUTH_NO 0

--- a/tests/integration/replication-psync.tcl
+++ b/tests/integration/replication-psync.tcl
@@ -135,7 +135,7 @@ proc test_psync {descr duration backlog_size backlog_ttl delay cond mdl sdl reco
 
 tags {"external:skip"} {
 foreach mdl {no yes} {
-    foreach sdl {disabled swapdb} {
+    foreach sdl {disabled swapdb flushdb} {
         foreach rdbchannel {yes no} {
             if {$rdbchannel == "yes" && $mdl == "no"} {
                 # rdbchannel replication requires repl-diskless-sync enabled

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -321,7 +321,7 @@ start_server {tags {"repl external:skip"}} {
 }
 
 foreach mdl {no yes} rdbchannel {no yes} {
-    foreach sdl {disabled swapdb} {
+    foreach sdl {disabled swapdb flushdb} {
         start_server {tags {"repl external:skip debug_defrag:skip"} overrides {save {}}} {
             set master [srv 0 client]
             $master config set repl-diskless-sync $mdl


### PR DESCRIPTION
`repl-diskless-load` feature can effectively reduce the time of full synchronization, but maybe it is not widely used.
`swapdb` option needs double `maxmemory`, and `on-empty-db` only works on the first full sync (the replica must have no data).

This PR introduce a new option: `flushdb` - Always flush the entire dataset before diskless load. If the diskless load fails, the replica will lose all existing data.

Of course, it brings the risk of data loss, but it provides a choice if you want to reduce full sync time and accept this risk.