### PR TITLE
Fix panic when cluster node is uninitialized

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1170,12 +1170,21 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
             existing_keys = 0;
     int pubsubshard_included = 0; /* Flag to indicate if a pubsub shard cmd is included. */
 
+    /* Base case: default to no redirection when serving locally. */
+    if (error_code) *error_code = CLUSTER_REDIR_NONE;
+
+    /* If cluster state isn't initialized, report cluster-down immediately. */
+    if (!myself) {
+        if (error_code) *error_code = CLUSTER_REDIR_DOWN_STATE;
+        serverLog(LL_DEBUG,
+                  "getNodeByQuery: cluster not initialized (myself=NULL); client=%llu cmd=%s -> CLUSTER_REDIR_DOWN_STATE",
+                  (unsigned long long)c->id,
+                  c->cmd ? c->cmd->fullname : "(nil)");
+        return myself; /* NULL */
+    }
     /* Allow any key to be set if a module disabled cluster redirections. */
     if (server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_REDIRECTION)
         return myself;
-
-    /* Set error code optimistically for the base case. */
-    if (error_code) *error_code = CLUSTER_REDIR_NONE;
 
     /* Modules can turn off Redis Cluster redirection: this is useful
      * when writing a module that implements a completely different

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1173,13 +1173,10 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
     /* Base case: default to no redirection when serving locally. */
     if (error_code) *error_code = CLUSTER_REDIR_NONE;
 
-    /* If cluster state isn't initialized, report cluster-down immediately. */
+    /* If local node isn't initialized, report cluster-down immediately. */
     if (!myself) {
         if (error_code) *error_code = CLUSTER_REDIR_DOWN_STATE;
-        serverLog(LL_DEBUG,
-                  "getNodeByQuery: cluster not initialized (myself=NULL); client=%llu cmd=%s -> CLUSTER_REDIR_DOWN_STATE",
-                  (unsigned long long)c->id,
-                  c->cmd ? c->cmd->fullname : "(nil)");
+        serverLog(LL_DEBUG, "Cluster local node not initialized, returning CLUSTERDOWN");
         return myself; /* NULL */
     }
     /* Allow any key to be set if a module disabled cluster redirections. */


### PR DESCRIPTION
**bug :**
When Redis cluster is enabled but the local node (myself) is not yet initialized, getNodeByQuery() returns n == NULL while leaving error_code == CLUSTER_REDIR_NONE. processCommand() then calls clusterRedirectClient(c, NULL, slot, CLUSTER_REDIR_NONE), which falls through to serverPanic("getNodeByQuery() unknown error."), causing a crash (reproducible with the Pixie cluster plugin after restart).
The root cause is that getNodeByQuery() doesn't handle the myself == NULL case.

**solution :**
In getNodeByQuery(), set the base case to CLUSTER_REDIR_NONE, and add an early myself == NULL check that logs a debug message, sets error_code = CLUSTER_REDIR_DOWN_STATE, and returns NULL. This keeps the normal initialized-cluster behavior unchanged, but in the uninitialized window it now produces a clean -CLUSTERDOWN reply instead of triggering the getNodeByQuery() unknown error panic.