### PR TITLE
Refactor: Simplify empty string handling in SDS

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -31,6 +31,7 @@ const char *SDS_NOINIT = "SDS_NOINIT";
  * would be truncated, creating a mismatch between `alloc` and the actual buffer size.
  */
 char sdsReqType(size_t string_size) {
+    if (string_size == 0) return SDS_TYPE_8;
     if (string_size < 1 << 5) return SDS_TYPE_5;
     if (string_size <= (1 << 8) - sizeof(struct sdshdr8) - 1) return SDS_TYPE_8;
     if (string_size <= (1 << 16) - sizeof(struct sdshdr16) - 1) return SDS_TYPE_16;
@@ -101,7 +102,6 @@ sds _sdsnewlen(const void *init, size_t initlen, int trymalloc) {
     char type = sdsReqType(initlen);
     /* Empty strings are usually created in order to append. Use type 8
      * since type 5 is not good at this. */
-    if (type == SDS_TYPE_5 && initlen == 0) type = SDS_TYPE_8;
     int hdrlen = sdsHdrSize(type);
     size_t bufsize;
 


### PR DESCRIPTION
The logic for handling empty strings during SDS creation is moved from _sdsnewlen to sdsReqType. Previously, _sdsnewlen had a special case to upgrade an SDS_TYPE_5 to SDS_TYPE_8 for empty strings. This change moves this logic into sdsReqType so that it returns SDS_TYPE_8 directly when the requested string size is 0. This refactoring simplifies _sdsnewlen and centralizes the type selection logic in sdsReqType.