### PR TITLE
Retry an ASM import step when the source node is temporarily not ready

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1501,7 +1501,6 @@ void asmSyncWithSource(connection *conn) {
              * trigger unnecessary cleanup in the cluster implementation.
              * Instead, we'll retry sending SYNCSLOTS later in asmCron(). */
             sdsfree(err);
-            err = NULL;
             task->state = ASM_SEND_SYNCSLOTS;
             serverLog(LL_NOTICE,
                 "Source node replied to SYNCSLOTS SYNC with -NOTREADY, will retry later...");

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1496,10 +1496,10 @@ void asmSyncWithSource(connection *conn) {
                 "Source node replied to SYNCSLOTS SYNC, syncslots can continue...");
         } else if (!strncmp(err, "-NOTREADY", strlen("-NOTREADY"))) {
             /* The source-side cluster is temporarily not ready to start a
-             * migration and replied -NOTREADY. Instead of failing the task,
-             * we'll retry sending SYNCSLOTS later in asmCron(). This avoids
-             * failing the task due to a transient condition and prevents
-             * unnecessary cleanup in the cluster implementation. */
+             * migration and replied -NOTREADY. We could fail this attempt and
+             * let the import task start another attempt later but that could
+             * trigger unnecessary cleanup in the cluster implementation.
+             * Instead, we'll retry sending SYNCSLOTS later in asmCron(). */
             sdsfree(err);
             err = NULL;
             task->state = ASM_SEND_SYNCSLOTS;
@@ -2553,7 +2553,7 @@ void asmCron(void) {
         } else if (task->state == ASM_SEND_SYNCSLOTS) {
             /* Rare case: the source node replied to SYNCSLOTS with -NOTREADY
              * because it wasn't ready to start a migration. We'll retry
-             * SYNCSLOTS every second instead of failing the task which could
+             * SYNCSLOTS every second instead of failing the attempt which could
              * trigger unnecessary cleanup in the cluster implementation. */
             if (asm_cron_runs % 10 == 0)
                 asmSyncWithSource(task->main_channel_conn);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -64,8 +64,8 @@ struct asmManager {
     asmTask *master_task;               /* The task that is currently active on the master */
 
     /* Fail point injection for debugging */
-    int debug_failed_channel;     /* Channel where the task failed */
-    int debug_failed_state;       /* State where the task failed */
+    int debug_fail_channel;       /* Channel where the task will fail */
+    int debug_fail_state;         /* State where the task will fail */
     int debug_trim_method;        /* Method to trim the buffer */
     int debug_active_trim_delay;  /* Sleep before trimming each key */
 
@@ -152,8 +152,8 @@ void asmInit(void) {
     asmManager->pending_trim_jobs = listCreate();
     asmManager->sync_buffer_peak = 0;
     asmManager->master_task = NULL;
-    asmManager->debug_failed_channel = 0;
-    asmManager->debug_failed_state = 0;
+    asmManager->debug_fail_channel = -1;
+    asmManager->debug_fail_state = -1;
     asmManager->debug_trim_method = ASM_DEBUG_TRIM_DEFAULT;
     asmManager->debug_active_trim_delay = 0;
     asmManager->active_trim_jobs = listCreate();
@@ -213,13 +213,13 @@ const char *asmChannelToString(int channel) {
     }
 }
 
-int asmDebugSetFailPoint(char * channel, char *state) {
+int asmDebugSetFailPoint(char *channel, char *state) {
     if (!asmManager) {
         serverLog(LL_WARNING, "ASM manager is not initialized");
         return C_ERR;
     }
-    asmManager->debug_failed_channel = 0;
-    asmManager->debug_failed_state = 0;
+    asmManager->debug_fail_channel = -1;
+    asmManager->debug_fail_state = -1;
     if (!channel && !state) return C_ERR;
     if (sdslen(channel) == 0 && sdslen(state) == 0) {
         serverLog(LL_WARNING, "ASM fail point is cleared");
@@ -228,19 +228,19 @@ int asmDebugSetFailPoint(char * channel, char *state) {
 
     for (int i = ASM_IMPORT_MAIN_CHANNEL; i <= ASM_MIGRATE_RDB_CHANNEL; i++) {
         if (!strcasecmp(channel, asmChannelToString(i))) {
-            asmManager->debug_failed_channel = i;
+            asmManager->debug_fail_channel = i;
             break;
         }
     }
-    if (asmManager->debug_failed_channel == 0) return C_ERR;
+    if (asmManager->debug_fail_channel == -1) return C_ERR;
 
     for (int i = ASM_NONE; i <= ASM_RDBCHANNEL_TRANSFER; i++) {
         if (!strcasecmp(state, asmTaskStateToString(i))) {
-            asmManager->debug_failed_state = i;
+            asmManager->debug_fail_state = i;
             break;
         }
     }
-    if (asmManager->debug_failed_state == 0) return C_ERR;
+    if (asmManager->debug_fail_state == -1) return C_ERR;
 
     serverLog(LL_NOTICE, "ASM fail point set: channel=%s, state=%s", channel, state);
     return C_OK;
@@ -272,7 +272,7 @@ int asmDebugSetTrimMethod(const char *method, int active_trim_delay) {
 
 int asmDebugIsFailPointActive(int channel, int state) {
     if (!asmManager) return 0; /* ASM manager not initialized */
-    if (asmManager->debug_failed_channel == channel && asmManager->debug_failed_state == state) {
+    if (asmManager->debug_fail_channel == channel && asmManager->debug_fail_state == state) {
         serverLog(LL_NOTICE, "ASM fail point active: channel=%s, state=%s",
                   asmChannelToString(channel), asmTaskStateToString(state));
         return 1;
@@ -1493,7 +1493,19 @@ void asmSyncWithSource(connection *conn) {
             err = NULL;
             task->state = ASM_INIT_RDBCHANNEL;
             serverLog(LL_NOTICE,
-                "Source node replied to RDBCHANNELSYNCSLOTS, syncslots can continue...");
+                "Source node replied to SYNCSLOTS SYNC, syncslots can continue...");
+        } else if (!strncmp(err, "-NOTREADY", strlen("-NOTREADY"))) {
+            /* The source-side cluster is temporarily not ready to start a
+             * migration and replied -NOTREADY. Instead of failing the task,
+             * we'll retry sending SYNCSLOTS later in asmCron(). This avoids
+             * failing the task due to a transient condition and prevents
+             * unnecessary cleanup in the cluster implementation. */
+            sdsfree(err);
+            err = NULL;
+            task->state = ASM_SEND_SYNCSLOTS;
+            serverLog(LL_NOTICE,
+                "Source node replied to SYNCSLOTS SYNC with -NOTREADY, will retry later...");
+            return;
         } else {
             task_error_msg = sdscatprintf(sdsempty(),
                 "Error reply to CLUSTER SYNCSLOTS SYNC from the source: %s", err);
@@ -1823,8 +1835,10 @@ void clusterSyncSlotsCommand(client *c) {
 
         sds task_id = c->argv[3]->ptr;
         /* Notify the cluster implementation to prepare for the migrate task. */
-        if (clusterAsmOnEvent(task_id, ASM_EVENT_MIGRATE_PREP, slots) != C_OK) {
-            addReplyError(c, "Cluster is not ready right now, please retry later");
+        int debug_fail = asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, ASM_NONE);
+        if (clusterAsmOnEvent(task_id, ASM_EVENT_MIGRATE_PREP, slots) != C_OK || debug_fail)
+        {
+            addReplyError(c, "-NOTREADY Cluster is not ready to migrate slots");
             slotRangeArrayFree(slots);
             return;
         }
@@ -2536,6 +2550,13 @@ void asmCron(void) {
             serverAssert(c->task == task);
             if (server.unixtime - c->lastinteraction > server.repl_timeout)
                 asmTaskSetFailed(task, "RDB channel - Connection timeout");
+        } else if (task->state == ASM_SEND_SYNCSLOTS) {
+            /* Rare case: the source node replied to SYNCSLOTS with -NOTREADY
+             * because it wasn't ready to start a migration. We'll retry
+             * SYNCSLOTS every second instead of failing the task which could
+             * trigger unnecessary cleanup in the cluster implementation. */
+            if (asm_cron_runs % 10 == 0)
+                asmSyncWithSource(task->main_channel_conn);
         }
     } else if (task->operation == ASM_MIGRATE) {
         if (task->state == ASM_SEND_STREAM) {

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1835,8 +1835,8 @@ void clusterSyncSlotsCommand(client *c) {
 
         sds task_id = c->argv[3]->ptr;
         /* Notify the cluster implementation to prepare for the migrate task. */
-        int debug_fail = asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, ASM_NONE);
-        if (clusterAsmOnEvent(task_id, ASM_EVENT_MIGRATE_PREP, slots) != C_OK || debug_fail)
+        if (clusterAsmOnEvent(task_id, ASM_EVENT_MIGRATE_PREP, slots) != C_OK ||
+            asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, ASM_NONE))
         {
             addReplyError(c, "-NOTREADY Cluster is not ready to migrate slots");
             slotRangeArrayFree(slots);

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1454,6 +1454,28 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 cluster migration cancel id $task_id
         R 1 cluster migration cancel id $task_id
     }
+
+    test "Cluster implementation cannot start migrate task temporarily" {
+        # Inject a fail point to make the source node not ready
+        R 0 debug asm-failpoint "migrate-main-channel" "none"
+
+        # start migration from node 0 to 1
+        set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
+
+        # verify source node replies SYNCSLOTS with -NOTREADY
+        set loglines [count_log_lines -1]
+        wait_for_log_messages -1 {"*Source node replied to SYNCSLOTS SYNC with -NOTREADY, will retry later*"} $loglines 100 100
+
+        # clear the fail point and verify the task is completed
+        R 0 debug asm-failpoint "" ""
+        wait_for_asm_done
+        assert_equal "completed" [migration_status 0 $task_id state]
+        assert_equal "completed" [migration_status 1 $task_id state]
+
+        # cleanup
+        R 0 CLUSTER MIGRATION IMPORT 0 100
+        wait_for_asm_done
+    }
 }
 
 start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 60000 cluster-allow-replica-migration no}} {


### PR DESCRIPTION
The cluster implementation may be temporarily unavailable and return an error to the `ASM_EVENT_MIGRATE_PREP` event to prevent starting a new migration. Although this is most likely a transient condition, the source node has no way to distinguish it from a real error, so it must fail the import attempt and start a new one.

In Redis, failing an attempt is cheap, but in other cluster implementations it may require cleaning up resources and can cause unnecessary disruption.

This PR introduces a new `-NOTREADY` error reply for the `CLUSTER SYNCSLOTS SYNC` command. When the source replies with `-NOTREADY`, the destination can recognize the condition as transient and retry sending `CLUSTER SYNCSLOTS SYNC` step periodically instead of failing the attempt.