### PR TITLE
Fix flaky ASM tests

### DIFF
--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -534,7 +534,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             # Start the slot 0 write load on the R 0
             set port [get_port 0]
             set key [slot_key 0 mykey]
-            set load_handle0 [start_write_load "127.0.0.1" $port 100 $key]
+            set load_handle0 [start_write_load "127.0.0.1" $port 100 $key 0 5]
         }
 
         # Start write traffic on node-1
@@ -543,7 +543,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             # Start the slot 6000 write load on the R 1
             set port [get_port 1]
             set key [slot_key 6000 mykey]
-            set load_handle1 [start_write_load "127.0.0.1" $port 100 $key]
+            set load_handle1 [start_write_load "127.0.0.1" $port 100 $key 0 5]
         }
 
         # Migrate keys
@@ -2301,6 +2301,9 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
         } else {
             fail "migrate failed"
         }
+
+        # Wait for config propagation before checking the slot ownership on replica
+        wait_for_cluster_propagation
 
         # Verify slots that are being trimmed are not local
         assert_equal 0 [R 0 asm.cluster_can_access_keys_in_slot 0]


### PR DESCRIPTION
1. Fix "Simple slot migration with write load" by introducing artificial delay to traffic generator to slow down it for tsan builds. Failed test: https://github.com/redis/redis/actions/runs/19720942981/job/56503213650

2. Fix "Test RM_ClusterCanAccessKeysInSlot returns false for unowned slots" by waiting config propagation before checking it on a replica. Failed test: https://github.com/redis/redis/actions/runs/19841852142/job/56851802772