### PR TITLE
Add TLS certificate-based automatic client authentication

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -260,7 +260,7 @@ tcp-keepalive 300
 # Supported values: CN, off. Default: off.
 #
 # Matches certificate CN to Redis username (exact match only).
-# Example: Cert CN=myapp → authenticates as user "myapp"
+# Example: Cert CN=myapp -> authenticates as user "myapp"
 #
 # tls-auth-clients-user CN
 

--- a/redis.conf
+++ b/redis.conf
@@ -247,6 +247,20 @@ tcp-keepalive 300
 # tls-auth-clients no
 # tls-auth-clients optional
 
+# Automatically authenticate TLS clients as Redis users based on their
+# certificates.
+#
+# If set to a field like "CN", the server will extract the corresponding field
+# from the client's TLS certificate and attempt to find a Redis user with the
+# same name. If a matching user is found, the client is automatically
+# authenticated as that user during the TLS handshake. If no matching user is
+# found, the client is connected as the unauthenticated default user. Set to
+# "off" to disable automatic user authentication via certificate fields.
+#
+# Supported values: CN, off. Default: off.
+#
+# tls-auth-clients-user CN
+
 # By default, a Redis replica does not attempt to establish a TLS connection
 # with its master.
 #

--- a/redis.conf
+++ b/redis.conf
@@ -259,6 +259,9 @@ tcp-keepalive 300
 #
 # Supported values: CN, off. Default: off.
 #
+# Matches certificate CN to Redis username (exact match only).
+# Example: Cert CN=myapp → authenticates as user "myapp"
+#
 # tls-auth-clients-user CN
 
 # By default, a Redis replica does not attempt to establish a TLS connection

--- a/src/acl.c
+++ b/src/acl.c
@@ -2647,6 +2647,8 @@ void ACLUpdateInfoMetrics(int reason){
         server.acl_info.invalid_key_accesses++;
     } else if (reason == ACL_DENIED_CHANNEL) {
         server.acl_info.invalid_channel_accesses++;
+    } else if (reason == ACL_INVALID_TLS_CERT_AUTH) {
+        server.acl_info.acl_access_denied_tls_cert++;
     } else {
         serverPanic("Unknown ACL_DENIED encoding");
     }
@@ -3091,6 +3093,7 @@ void aclCommand(client *c) {
             case ACL_DENIED_KEY: reasonstr="key"; break;
             case ACL_DENIED_CHANNEL: reasonstr="channel"; break;
             case ACL_DENIED_AUTH: reasonstr="auth"; break;
+            case ACL_INVALID_TLS_CERT_AUTH: reasonstr = "tls-cert"; break;
             default: reasonstr="unknown";
             }
             addReplyBulkCString(c,reasonstr);

--- a/src/acl.c
+++ b/src/acl.c
@@ -2,6 +2,9 @@
  * Copyright (c) 2018-Present, Redis Ltd.
  * All rights reserved.
  *
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
+ *
  * Licensed under your choice of (a) the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).

--- a/src/config.c
+++ b/src/config.c
@@ -108,6 +108,12 @@ configEnum tls_auth_clients_enum[] = {
     {NULL, 0}
 };
 
+configEnum tls_client_auth_user_enum[] = {
+    {"CN", TLS_CLIENT_FIELD_CN},
+    {"off", TLS_CLIENT_FIELD_OFF},
+    {NULL, 0}
+};
+
 configEnum oom_score_adj_enum[] = {
     {"no", OOM_SCORE_ADJ_NO},
     {"yes", OOM_SCORE_RELATIVE},
@@ -3277,6 +3283,7 @@ standardConfig static_configs[] = {
     createBoolConfig("tls-cluster", NULL, MODIFIABLE_CONFIG, server.tls_cluster, 0, NULL, applyTlsCfg),
     createBoolConfig("tls-replication", NULL, MODIFIABLE_CONFIG, server.tls_replication, 0, NULL, applyTlsCfg),
     createEnumConfig("tls-auth-clients", NULL, MODIFIABLE_CONFIG, tls_auth_clients_enum, server.tls_auth_clients, TLS_CLIENT_AUTH_YES, NULL, NULL),
+    createEnumConfig("tls-auth-clients-user", NULL, MODIFIABLE_CONFIG, tls_client_auth_user_enum, server.tls_ctx_config.client_auth_user, TLS_CLIENT_FIELD_OFF, NULL, NULL),
     createBoolConfig("tls-prefer-server-ciphers", NULL, MODIFIABLE_CONFIG, server.tls_ctx_config.prefer_server_ciphers, 0, NULL, applyTlsCfg),
     createBoolConfig("tls-session-caching", NULL, MODIFIABLE_CONFIG, server.tls_ctx_config.session_caching, 1, NULL, applyTlsCfg),
     createStringConfig("tls-cert-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.cert_file, NULL, NULL, applyTlsCfg),

--- a/src/connection.h
+++ b/src/connection.h
@@ -92,6 +92,9 @@ typedef struct ConnectionType {
 
     /* TLS specified methods */
     sds (*get_peer_cert)(struct connection *conn);
+
+    /* Get peer username based on connection type */
+    sds (*get_peer_username)(connection *conn);
 } ConnectionType;
 
 struct connection {
@@ -382,6 +385,14 @@ static inline sds connGetPeerCert(connection *conn) {
         return conn->type->get_peer_cert(conn);
     }
 
+    return NULL;
+}
+
+/* Get Peer username based on connection type */
+static inline sds connGetPeerUsername(connection *conn) {
+    if (conn->type && conn->type->get_peer_username) {
+        return conn->type->get_peer_username(conn);
+    }
     return NULL;
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1413,9 +1413,10 @@ void clientAcceptHandler(connection *conn) {
     sds username = connGetPeerUsername(conn);
     if (username != NULL) {
         user *u = ACLGetUserByName(username, sdslen(username));
-        if (u) {
+        if (u && !(u->flags & USER_FLAG_DISABLED)) {
             c->user = u;
             c->authenticated = 1;
+            moduleNotifyUserChanged(c);
             serverLog(LL_VERBOSE, "TLS: Auto-authenticated client as %s",
                       server.hide_user_data_from_log ? "*redacted*" : u->name);
         } else {

--- a/src/networking.c
+++ b/src/networking.c
@@ -21,6 +21,7 @@
 #include "fmtargs.h"
 #include "cluster_asm.h"
 #include "memory_prefetch.h"
+#include "connection.h"
 #include <sys/socket.h>
 #include <sys/uio.h>
 #include <math.h>
@@ -1406,6 +1407,21 @@ void clientAcceptHandler(connection *conn) {
             freeClientAsync(c);
             return;
         }
+    }
+
+    /* Auto-authenticate from cert_user field if set */
+    sds username = connGetPeerUsername(conn);
+    if (username != NULL) {
+        user *u = ACLGetUserByName(username, sdslen(username));
+        if (u) {
+            c->user = u;
+            c->authenticated = 1;
+            serverLog(LL_VERBOSE, "TLS: Auto-authenticated client as %s",
+                      server.hide_user_data_from_log ? "*redacted*" : u->name);
+        } else {
+            addACLLogEntry(c, ACL_INVALID_TLS_CERT_AUTH, ACL_LOG_CTX_TOPLEVEL, 0, username, NULL);
+        }
+        sdsfree(username);
     }
 
     server.stat_numconnections++;

--- a/src/server.c
+++ b/src/server.c
@@ -3037,6 +3037,7 @@ void initServer(void) {
     server.acl_info.invalid_key_accesses  = 0;
     server.acl_info.user_auth_failures = 0;
     server.acl_info.invalid_channel_accesses = 0;
+    server.acl_info.acl_access_denied_tls_cert = 0;
 
     /* Initialize the shared pending command pool. */
     server.cmd_pool.size = 0;
@@ -5918,14 +5919,16 @@ sds genRedisInfoStringCommandStats(sds info, dict *commands) {
 /* Writes the ACL metrics to the info */
 sds genRedisInfoStringACLStats(sds info) {
     info = sdscatprintf(info,
-         "acl_access_denied_auth:%lld\r\n"
-         "acl_access_denied_cmd:%lld\r\n"
-         "acl_access_denied_key:%lld\r\n"
-         "acl_access_denied_channel:%lld\r\n",
-         server.acl_info.user_auth_failures,
-         server.acl_info.invalid_cmd_accesses,
-         server.acl_info.invalid_key_accesses,
-         server.acl_info.invalid_channel_accesses);
+	     "acl_access_denied_auth:%lld\r\n"
+	     "acl_access_denied_cmd:%lld\r\n"
+	     "acl_access_denied_key:%lld\r\n"
+	     "acl_access_denied_channel:%lld\r\n"
+	     "acl_access_denied_tls_cert:%lld\r\n",
+	     server.acl_info.user_auth_failures,
+	     server.acl_info.invalid_cmd_accesses,
+	     server.acl_info.invalid_key_accesses,
+	     server.acl_info.invalid_channel_accesses,
+	     server.acl_info.acl_access_denied_tls_cert);
     return info;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -642,6 +642,10 @@ typedef enum {
 #define TLS_CLIENT_AUTH_YES 1
 #define TLS_CLIENT_AUTH_OPTIONAL 2
 
+/* TLS Client Certfiicate Authentication */
+#define TLS_CLIENT_FIELD_OFF 0
+#define TLS_CLIENT_FIELD_CN 1
+
 /* Sanitize dump payload */
 #define SANITIZE_DUMP_NO 0
 #define SANITIZE_DUMP_YES 1
@@ -1565,6 +1569,7 @@ typedef struct aclInfo {
     long long invalid_cmd_accesses; /* Invalid command accesses that user doesn't have permission to */
     long long invalid_key_accesses; /* Invalid key accesses that user doesn't have permission to */
     long long invalid_channel_accesses; /* Invalid channel accesses that user doesn't have permission to */
+    long long acl_access_denied_tls_cert; /* TLS clients with cert not matching any existing user. */
 } aclInfo;
 
 struct saveparam {
@@ -1767,6 +1772,7 @@ typedef struct redisTLSContextConfig {
     char *client_cert_file;         /* Certificate to use as a client; if none, use cert_file */
     char *client_key_file;          /* Private key filename for client_cert_file */
     char *client_key_file_pass;     /* Optional password for client_key_file */
+    int client_auth_user;           /* Field to be used for automatic TLS authentication based on client TLS certificate */
     char *dh_params_file;
     char *ca_cert_file;
     char *ca_cert_dir;
@@ -3352,6 +3358,7 @@ void ACLInit(void);
 #define ACL_DENIED_KEY 2
 #define ACL_DENIED_AUTH 3 /* Only used for ACL LOG entries. */
 #define ACL_DENIED_CHANNEL 4 /* Only used for pub/sub commands */
+#define ACL_INVALID_TLS_CERT_AUTH 5 /* Only used for TLS Auto-authentication */
 
 /* Context values for addACLLogEntry(). */
 #define ACL_LOG_CTX_TOPLEVEL 0

--- a/src/tls.c
+++ b/src/tls.c
@@ -2,6 +2,9 @@
  * Copyright (c) 2019-Present, Redis Ltd.
  * All rights reserved.
  *
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
+ *
  * Licensed under your choice of (a) the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).

--- a/src/tls.c
+++ b/src/tls.c
@@ -17,6 +17,7 @@
 
 #include <openssl/conf.h>
 #include <openssl/ssl.h>
+#include <openssl/x509.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include <openssl/pem.h>
@@ -630,6 +631,57 @@ static void tlsPendingRemove(tls_connection *conn) {
     }
 }
 
+static int getCertFieldByName(X509 *cert, const char *field, char *out, size_t outlen) {
+    if (!cert || !field || !out) return 0;
+
+    int nid = -1;
+
+    if (!strcasecmp(field, "CN"))
+        nid = NID_commonName;
+    else if (!strcasecmp(field, "O"))
+        nid = NID_organizationName;
+    /* Add more mappings here as needed */
+
+    if (nid == -1) return 0;
+
+    X509_NAME *subject = X509_get_subject_name(cert);
+    if (!subject) return 0;
+
+    return X509_NAME_get_text_by_NID(subject, nid, out, outlen) > 0;
+}
+
+sds tlsGetPeerUsername(connection *conn_) {
+    tls_connection *conn = (tls_connection *)conn_;
+    if (!conn || !SSL_is_init_finished(conn->ssl)) return NULL;
+
+    /* Find the corresponding field name from the enum mapping */
+    const char *field = NULL;
+    switch (server.tls_ctx_config.client_auth_user) {
+    case TLS_CLIENT_FIELD_CN:
+        field = "CN";
+        break;
+    default:
+        return NULL;
+    }
+
+    if (!field) return NULL;
+
+    X509 *cert = SSL_get_peer_certificate(conn->ssl);
+    if (!cert) return NULL;
+
+    char field_value[256];
+    sds result = NULL;
+
+    if (getCertFieldByName(cert, field, field_value, sizeof(field_value))) {
+        result = sdsnew(field_value);
+    } else {
+        serverLog(LL_NOTICE, "TLS: Failed to extract field '%s' from certificate", field);
+    }
+
+    X509_free(cert);
+    return result;
+}
+
 static void tlsHandleEvent(tls_connection *conn, int mask) {
     int ret, conn_error;
 
@@ -1185,6 +1237,7 @@ static ConnectionType CT_TLS = {
 
     /* TLS specified methods */
     .get_peer_cert = connTLSGetPeerCert,
+    .get_peer_username = tlsGetPeerUsername,
 };
 
 int RedisRegisterConnectionTypeTLS(void) {

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -202,5 +202,39 @@ start_server {tags {"tls"}} {
 	        regexp {acl_access_denied_tls_cert:(\d+)} $info_after -> after
 	        assert {$after == $before + 1}
 	    }
+
+	    test {TLS: Disabled user cannot auto-authenticate via certificate} {
+	        r ACL SETUSER {Client-only} on >clientpass allcommands allkeys
+	        r ACL SETUSER {Client-only} off  ;# Disable the user
+
+	        # Reset ACL log so we only see entries from this test
+	        r ACL LOG RESET
+	        r CONFIG SET tls-auth-clients-user CN
+
+	        # Capture the current value of acl_access_denied_tls_cert from INFO stats
+	        set info_before [r INFO stats]
+	        regexp {acl_access_denied_tls_cert:(\d+)} $info_before -> before
+
+	        # Connect over TLS using the test client certificate (CN=Client-only)
+	        # Since the user exists but is disabled, auto-auth should fail and the
+	        # connection should remain authenticated as the default user
+	        set s [redis [srv 0 host] [srv 0 port] 0 1]
+	        assert_equal "default" [$s ACL WHOAMI]
+
+	        # The ACL LOG should contain a single entry with reason "tls-cert"
+	        # and username "Client-only" (same as non-existent user case)
+	        set log [r ACL LOG]
+	        assert_equal 1 [llength $log]
+	        set entry [lindex $log 0]
+	        assert_equal "tls-cert" [dict get $entry reason]
+	        assert_equal "Client-only" [dict get $entry username]
+
+	        # INFO stats should report that acl_access_denied_tls_cert increased by 1
+	        set info_after [r INFO stats]
+	        regexp {acl_access_denied_tls_cert:(\d+)} $info_after -> after
+	        assert {$after == $before + 1}
+
+	        r ACL DELUSER {Client-only}
+	    }
     }
 }

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -154,5 +154,53 @@ start_server {tags {"tls"}} {
             r config set tls-key-file-pass 1234
             r config set tls-key-file $keyfile_encrypted
         }
+
+	    test {TLS: Auto-authenticate using tls-auth-clients-user (CN)} {
+	        # Create a user matching the CN in the client certificate (CN=Client-only)
+	        r ACL SETUSER {Client-only} on >clientpass allcommands allkeys
+
+	        # Map the client certificate CN to the ACL user name.
+	        r CONFIG SET tls-auth-clients-user CN
+
+	        # Connect over TLS using the test client certificate (CN=Client-only)
+	        set s [redis [srv 0 host] [srv 0 port] 0 1]
+	        catch {$s PING} e
+	        assert_match {PONG} $e
+	        assert_equal "Client-only" [$s ACL WHOAMI]
+	    }
+
+	    test {TLS: Failed auto-auth (unknown CN) logs tls-cert and bumps acl_access_denied_tls_cert} {
+	        # Ensure the Client-only user does not exist so auto-auth will fail.
+	        catch {r ACL DELUSER {Client-only}}
+
+	        # Reset ACL log so we only see entries from this test.
+	        r ACL LOG RESET
+
+	        # Enable mapping from client certificate CN to ACL username.
+	        r CONFIG SET tls-auth-clients-user CN
+
+	        # Capture the current value of acl_access_denied_tls_cert from INFO stats.
+	        set info_before [r INFO stats]
+	        regexp {acl_access_denied_tls_cert:(\d+)} $info_before -> before
+
+	        # Connect over TLS using the test client certificate (CN=Client-only).
+	        # Since there is no matching ACL user, auto-auth should fail and the
+	        # connection should remain authenticated as the default user.
+	        set s [redis [srv 0 host] [srv 0 port] 0 1]
+	        assert_equal "default" [$s ACL WHOAMI]
+
+	        # The ACL LOG should contain a single entry with reason "tls-cert"
+	        # and username "Client-only".
+	        set log [r ACL LOG]
+	        assert_equal 1 [llength $log]
+	        set entry [lindex $log 0]
+	        assert_equal "tls-cert" [dict get $entry reason]
+	        assert_equal "Client-only" [dict get $entry username]
+
+	        # INFO stats should report that acl_access_denied_tls_cert increased by 1.
+	        set info_after [r INFO stats]
+	        regexp {acl_access_denied_tls_cert:(\d+)} $info_after -> after
+	        assert {$after == $before + 1}
+	    }
     }
 }

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -169,72 +169,51 @@ start_server {tags {"tls"}} {
 	        assert_equal "Client-only" [$s ACL WHOAMI]
 	    }
 
-	    test {TLS: Failed auto-auth (unknown CN) logs tls-cert and bumps acl_access_denied_tls_cert} {
-	        # Ensure the Client-only user does not exist so auto-auth will fail.
-	        catch {r ACL DELUSER {Client-only}}
+	    foreach user_type {"non-existent" "disabled"} {
+	        test "TLS: $user_type user cannot auto-authenticate via certificate" {
+	            if {$user_type eq "non-existent"} {
+	                # Ensure the Client-only user does not exist so auto-auth will fail
+	                catch {r ACL DELUSER {Client-only}}
+	            } else {
+	                r ACL SETUSER {Client-only} on >clientpass allcommands allkeys
+	                r ACL SETUSER {Client-only} off  ;# Disable the user
+	            }
+	            r ACL LOG RESET
+	            r CONFIG SET tls-auth-clients-user CN
 
-	        # Reset ACL log so we only see entries from this test.
-	        r ACL LOG RESET
+	            # Capture the current value of acl_access_denied_tls_cert from INFO stats
+	            set info_before [r INFO stats]
+	            regexp {acl_access_denied_tls_cert:(\d+)} $info_before -> before
 
-	        # Enable mapping from client certificate CN to ACL username.
-	        r CONFIG SET tls-auth-clients-user CN
+	            # Connect over TLS using the test client certificate (CN=Client-only)
+	            # Since there is no matching ACL user or user is disabled, auto-auth should fail
+	            # and the connection should remain authenticated as the default user
+	            set s [redis [srv 0 host] [srv 0 port] 0 1]
+	            assert_equal "default" [$s ACL WHOAMI]
 
-	        # Capture the current value of acl_access_denied_tls_cert from INFO stats.
-	        set info_before [r INFO stats]
-	        regexp {acl_access_denied_tls_cert:(\d+)} $info_before -> before
+	            # The ACL LOG should contain a single entry with reason "tls-cert"
+	            # and username "Client-only"
+	            set log [r ACL LOG]
+	            assert_equal 1 [llength $log]
+	            set entry [lindex $log 0]
+	            assert_equal "tls-cert" [dict get $entry reason]
+	            assert_equal "Client-only" [dict get $entry username]
 
-	        # Connect over TLS using the test client certificate (CN=Client-only).
-	        # Since there is no matching ACL user, auto-auth should fail and the
-	        # connection should remain authenticated as the default user.
-	        set s [redis [srv 0 host] [srv 0 port] 0 1]
-	        assert_equal "default" [$s ACL WHOAMI]
+	            # INFO stats should report that acl_access_denied_tls_cert increased by 1
+	            set info_after [r INFO stats]
+	            regexp {acl_access_denied_tls_cert:(\d+)} $info_after -> after
+	            assert {$after == $before + 1}
 
-	        # The ACL LOG should contain a single entry with reason "tls-cert"
-	        # and username "Client-only".
-	        set log [r ACL LOG]
-	        assert_equal 1 [llength $log]
-	        set entry [lindex $log 0]
-	        assert_equal "tls-cert" [dict get $entry reason]
-	        assert_equal "Client-only" [dict get $entry username]
+	            # Verify fallback to password auth works after cert auth fails
+	            r ACL SETUSER testuser on >testpass +@all ~*
+	            $s AUTH testuser testpass
+	            assert_equal "testuser" [$s ACL WHOAMI]
+	            assert_equal "PONG" [$s PING]
 
-	        # INFO stats should report that acl_access_denied_tls_cert increased by 1.
-	        set info_after [r INFO stats]
-	        regexp {acl_access_denied_tls_cert:(\d+)} $info_after -> after
-	        assert {$after == $before + 1}
-	    }
-
-	    test {TLS: Disabled user cannot auto-authenticate via certificate} {
-	        r ACL SETUSER {Client-only} on >clientpass allcommands allkeys
-	        r ACL SETUSER {Client-only} off  ;# Disable the user
-
-	        # Reset ACL log so we only see entries from this test
-	        r ACL LOG RESET
-	        r CONFIG SET tls-auth-clients-user CN
-
-	        # Capture the current value of acl_access_denied_tls_cert from INFO stats
-	        set info_before [r INFO stats]
-	        regexp {acl_access_denied_tls_cert:(\d+)} $info_before -> before
-
-	        # Connect over TLS using the test client certificate (CN=Client-only)
-	        # Since the user exists but is disabled, auto-auth should fail and the
-	        # connection should remain authenticated as the default user
-	        set s [redis [srv 0 host] [srv 0 port] 0 1]
-	        assert_equal "default" [$s ACL WHOAMI]
-
-	        # The ACL LOG should contain a single entry with reason "tls-cert"
-	        # and username "Client-only" (same as non-existent user case)
-	        set log [r ACL LOG]
-	        assert_equal 1 [llength $log]
-	        set entry [lindex $log 0]
-	        assert_equal "tls-cert" [dict get $entry reason]
-	        assert_equal "Client-only" [dict get $entry username]
-
-	        # INFO stats should report that acl_access_denied_tls_cert increased by 1
-	        set info_after [r INFO stats]
-	        regexp {acl_access_denied_tls_cert:(\d+)} $info_after -> after
-	        assert {$after == $before + 1}
-
-	        r ACL DELUSER {Client-only}
+	            # Clean up
+	            r ACL DELUSER testuser
+	            catch {r ACL DELUSER {Client-only}}
+	        }
 	    }
     }
 }


### PR DESCRIPTION
This PR implements support for automatic client authentication based on a field in the client's TLS certificate.
We adopt ValKey’s PR: https://github.com/valkey-io/valkey/pull/1920

API Changes:

Add New configuration tls-auth-clients-user  
  -  Allowed values: `off` (default), `CN`.
  - `off` – disable TLS certificate–based auto-authentication.
  - `CN` – derive the ACL username from the Common Name (CN) field of the client certificate.
 
New INFO stat
  - `acl_access_denied_tls_cert`
  - Counts failed TLS certificate–based authentication attempts, i.e. TLS connections where a client certificate was presented, a username was derived from it, but no matching ACL user was found.

New ACL LOG reason
  - Reason string: `"tls-cert"`
  - Emitted when a client certificate’s Common Name fails to match any existing ACL user.


Implementation Details:

- Added getCertFieldByName() utility to extract fields from peer certificates.

- Added autoAuthenticateClientFromCert() to handle automatic login logic post-handshake.

- Integrated automatic authentication into the TLSAccept function after handshake completion.

- Updated test suite (tests/integration/tls.tcl) to validate the feature.