### PR TITLE
Upgrade GitHub Actions macOS runner

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -934,7 +934,7 @@ jobs:
       run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
 
   test-freebsd:
-    runs-on: macos-13
+    runs-on: macos-15
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'freebsd')

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -907,7 +907,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-15, macos-26]
+        os: [macos-14, macos-26]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -907,7 +907,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [ macos-15, macos-26 ]
+        os: [macos-15, macos-26]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -907,7 +907,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-13, macos-15]
+        os: [ macos-15, macos-26 ]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -934,7 +934,7 @@ jobs:
       run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
 
   test-freebsd:
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'freebsd')
@@ -953,7 +953,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: test
-      uses: cross-platform-actions/action@v0.22.0
+      uses: cross-platform-actions/action@v0.30.0
       with:
         operating_system: freebsd
         environment_variables: MAKE


### PR DESCRIPTION
1. GitHub has deprecated older macOS runners, and macos-13 is no longer supported. Updating to macos-26 ensures that CI workflows continue to run without interruption.
2. Previously, cross-platform-actions/action@v0.22.0 used runs-on: macos-13. I checked the latest version of cross-platform-actions, and the official examples now use runs-on: ubuntu. I think we can switch from macOS to Ubuntu.

This daily action did not run because of macOS 13: https://github.com/redis/redis/actions/runs/20047126465
This is the action execution result after the PR changes: https://github.com/vitahlin/redis/actions/runs/20049999199