### PR TITLE
Fix daily CI after macOS-13 runners have been retired

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -953,7 +953,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: test
-      uses: cross-platform-actions/action@v0.22.0
+      uses: cross-platform-actions/action@v0.30.0
       with:
         operating_system: freebsd
         environment_variables: MAKE

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -907,7 +907,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-13, macos-15]
+        os: [macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
@@ -934,7 +934,7 @@ jobs:
       run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
 
   test-freebsd:
-    runs-on: macos-13
+    runs-on: macos-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'freebsd')

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -934,7 +934,7 @@ jobs:
       run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
 
   test-freebsd:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'freebsd')


### PR DESCRIPTION
Daily CI broke because macOS-13 runners have been retired.
Switch test-freebsd to ubuntu-latest host OS since macOS hosts are deprecated by cross-platform-actions/action and will be removed.