### PR TITLE
Prevent building with modules on 32-bit systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 SUBDIRS = src
 ifeq ($(BUILD_WITH_MODULES), yes)
+	ifeq ($(MAKECMDGOALS),32bit)
+    	$(error BUILD_WITH_MODULES=yes is not supported on 32 bit systems)
+	endif
 	SUBDIRS += modules
 endif
 


### PR DESCRIPTION
Redis modules do not support 32-bit architectures. The build now fails early when modules are enabled on such systems.