### PR TITLE
Fix incorrect stream ID comparison in streamReplyWithRangeFromConsumerPEL()

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2182,7 +2182,7 @@ size_t streamReplyWithRangeFromConsumerPEL(client *c, stream *s, streamID *start
     raxStart(&ri,consumer->pel);
     raxSeek(&ri,">=",startkey,sizeof(startkey));
     while(raxNext(&ri) && (!count || arraylen < count)) {
-        if (end && memcmp(ri.key,end,ri.key_len) > 0) break;
+        if (end && memcmp(ri.key,endkey,ri.key_len) > 0) break;
         streamID thisid;
         streamDecodeID(ri.key,&thisid);
         if (streamReplyWithRange(c,s,&thisid,&thisid,1,0,-1,NULL,NULL,


### PR DESCRIPTION
Since all commands that invoke streamReplyWithRange with a group argument always pass end as NULL, therefore will not trigger incorrect stream ID comparisons. In other words, even if this bug remains unfixed, no incident would occur.