### PR TITLE
Unify slot migration logs across cluster implementations

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1215,7 +1215,7 @@ void asmImportTakeover(asmTask *task) {
 
     task->state = ASM_TAKEOVER;
     asmLogTaskEvent(task, ASM_EVENT_TAKEOVER);
-    clusterAsmOnEvent(task->id, ASM_EVENT_TAKEOVER, NULL);
+    clusterAsmOnEvent(task->id, ASM_EVENT_TAKEOVER, task->slots);
 }
 
 void asmCallbackOnFreeClient(client *c) {
@@ -1793,9 +1793,6 @@ static void asmStartImportTask(asmTask *task) {
         serverLog(LL_NOTICE, "Import task %s source node changed: slots=%s, "
                              "new_source=%.40s", task->id, slots_str, clusterNodeGetName(source));
     }
-
-    serverLog(LL_NOTICE, "Import task %s starting: src=%.40s, dest=%.40s, slots=%s",
-                         task->id, task->source, task->dest, slots_str);
     sdsfree(slots_str);
 
     task->state = ASM_CONNECTING;

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1006,6 +1006,42 @@ void clusterMigrationCommand(client *c) {
     }
 }
 
+/* Log a human-readable message for ASM task lifecycle events. */
+void asmLogTaskEvent(asmTask *task, int event) {
+    sds str = slotRangeArrayToString(task->slots);
+
+    switch (event) {
+        case ASM_EVENT_IMPORT_STARTED:
+            serverLog(LL_NOTICE, "Import task %s started for slots: %s", task->id, str);
+            break;
+        case ASM_EVENT_IMPORT_FAILED:
+            serverLog(LL_NOTICE, "Import task %s failed for slots: %s", task->id, str);
+            break;
+        case ASM_EVENT_TAKEOVER:
+            serverLog(LL_NOTICE, "Import task %s is ready to takeover slots: %s", task->id, str);
+            break;
+        case ASM_EVENT_IMPORT_COMPLETED:
+            serverLog(LL_NOTICE, "Import task %s completed for slots: %s", task->id, str);
+            break;
+        case ASM_EVENT_MIGRATE_STARTED:
+            serverLog(LL_NOTICE, "Migrate task %s started for slots: %s", task->id, str);
+            break;
+        case ASM_EVENT_MIGRATE_FAILED:
+            serverLog(LL_NOTICE, "Migrate task %s failed for slots: %s", task->id, str);
+            break;
+        case ASM_EVENT_HANDOFF_PREP:
+            serverLog(LL_NOTICE, "Migrate task %s preparing to handoff for slots: %s", task->id, str);
+            break;
+        case ASM_EVENT_MIGRATE_COMPLETED:
+            serverLog(LL_NOTICE, "Migrate task %s completed for slots: %s", task->id, str);
+            break;
+        default:
+            break;
+    }
+
+    sdsfree(str);
+}
+
 /* Notify the state change to the module and the cluster implementation. */
 void asmNotifyStateChange(asmTask *task, int event) {
     RedisModuleClusterSlotMigrationInfo info = {
@@ -1031,8 +1067,10 @@ void asmNotifyStateChange(asmTask *task, int event) {
 
     if (clusterNodeIsMaster(getMyClusterNode())) {
         /* Notify the cluster impl only if it is a real active import task. */
-        if (task != asmManager->master_task)
+        if (task != asmManager->master_task) {
+            asmLogTaskEvent(task, event);
             clusterAsmOnEvent(task->id, event, task->slots);
+        }
         asmNotifyReplicasStateChange(task); /* Propagate state change to replicas */
     }
 }
@@ -1176,6 +1214,7 @@ void asmImportTakeover(asmTask *task) {
     task->main_channel_conn = NULL;
 
     task->state = ASM_TAKEOVER;
+    asmLogTaskEvent(task, ASM_EVENT_TAKEOVER);
     clusterAsmOnEvent(task->id, ASM_EVENT_TAKEOVER, NULL);
 }
 
@@ -2036,6 +2075,7 @@ void clusterSyncSlotsCommand(client *c) {
                                          task->source_offset - task->dest_offset,
                                          server.asm_handoff_max_lag_bytes);
                     task->state = ASM_HANDOFF_PREP;
+                    asmLogTaskEvent(task, ASM_EVENT_HANDOFF_PREP);
                     clusterAsmOnEvent(task->id, ASM_EVENT_HANDOFF_PREP, task->slots);
                 }
             }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6542,16 +6542,11 @@ int clusterAsmOnEvent(const char *task_id, int event, void *arg) {
     slotRangeArray *slots = asmTaskGetSlotRanges(task_id);
     if (slots) str = slotRangeArrayToString(slots);
 
-    switch (event) {
-        case ASM_EVENT_IMPORT_STARTED:
-            serverLog(LL_NOTICE, "Import task %s started for slots: %s", task_id, str);
-            break;
-        case ASM_EVENT_IMPORT_FAILED:
-            serverLog(LL_NOTICE, "Import task %s failed for slots: %s", task_id, str);
-            break;
-        case ASM_EVENT_TAKEOVER:
-            serverLog(LL_NOTICE, "Import task %s is ready to takeover slots: %s", task_id, str);
+    serverLog(LL_VERBOSE, "Slot migration task %s received event %d for slots: %s",
+                          task_id, event, str);
 
+    switch (event) {
+        case ASM_EVENT_TAKEOVER:
             for (int i = 0; i < slots->num_ranges; i++) {
                 slotRange *sr = &slots->ranges[i];
                 for (int j = sr->start; j <= sr->end; j++) {
@@ -6565,25 +6560,16 @@ int clusterAsmOnEvent(const char *task_id, int event, void *arg) {
             clusterDoBeforeSleep(CLUSTER_TODO_BROADCAST_PONG);
             clusterAsmProcess(task_id, ASM_EVENT_DONE, NULL, NULL);
             break;
-        case ASM_EVENT_IMPORT_COMPLETED:
-            serverLog(LL_NOTICE, "Import task %s completed for slots: %s", task_id, str);
-            break;
-        case ASM_EVENT_MIGRATE_STARTED:
-            serverLog(LL_NOTICE, "Migrate task %s started for slots: %s", task_id, str);
-            break;
         case ASM_EVENT_MIGRATE_FAILED:
-            serverLog(LL_NOTICE, "Migrate task %s failed for slots: %s", task_id, str);
             unpauseActions(PAUSE_DURING_SLOT_HANDOFF);
             break;
         case ASM_EVENT_HANDOFF_PREP:
-            serverLog(LL_NOTICE, "Migrate task %s preparing to handoff for slots: %s", task_id, str);
             pauseActions(PAUSE_DURING_SLOT_HANDOFF,
                          LLONG_MAX,
                          PAUSE_ACTIONS_CLIENT_WRITE_SET);
             clusterAsmProcess(task_id, ASM_EVENT_HANDOFF, NULL, NULL);
             break;
         case ASM_EVENT_MIGRATE_COMPLETED:
-            serverLog(LL_NOTICE, "Migrate task %s completed for slots: %s", task_id, str);
             unpauseActions(PAUSE_DURING_SLOT_HANDOFF);
             break;
         default:

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6536,14 +6536,14 @@ void clusterPromoteSelfToMaster(void) {
 }
 
 int clusterAsmOnEvent(const char *task_id, int event, void *arg) {
-    UNUSED(arg);
     sds str = NULL;
 
     slotRangeArray *slots = asmTaskGetSlotRanges(task_id);
     if (slots) str = slotRangeArrayToString(slots);
+    else if (arg) str = slotRangeArrayToString(arg);
 
     serverLog(LL_VERBOSE, "Slot migration task %s received event %d for slots: %s",
-                          task_id, event, str);
+                          task_id, event, str ? str : "unknown");
 
     switch (event) {
         case ASM_EVENT_TAKEOVER:


### PR DESCRIPTION
Using a different cluster implementation instead of the legacy one may result in inconsistent slot migration logs, which can cause confusion. Therefore, we should centralize these logs within the slot migration process itself rather than relying on the specific cluster implementation.