### PR TITLE
Expand hash dicts using original length when rdb loading

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2178,7 +2178,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             zsetConvert(o, OBJ_ENCODING_LISTPACK);
         }
     } else if (rdbtype == RDB_TYPE_HASH) {
-        uint64_t len;
+        uint64_t len, original_len;
         int ret;
         sds value;
         hfield field;
@@ -2186,6 +2186,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
 
         len = rdbLoadLen(rdb, NULL);
         if (len == RDB_LENERR) return NULL;
+        original_len = len;
         if (len == 0) goto emptykey;
 
         o = createHashObject();
@@ -2268,9 +2269,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             dupSearchDict = NULL;
         }
 
-        if (o->encoding == OBJ_ENCODING_HT && len > DICT_HT_INITIAL_SIZE) {
-            if (dictTryExpand(o->ptr, len) != DICT_OK) {
-                rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)len);
+        if (o->encoding == OBJ_ENCODING_HT && original_len > DICT_HT_INITIAL_SIZE) {
+            if (dictTryExpand(o->ptr, original_len) != DICT_OK) {
+                rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)original_len);
                 decrRefCount(o);
                 return NULL;
             }
@@ -2312,6 +2313,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
         sds value;
         hfield field;
         uint64_t ttl, expireAt, minExpire = EB_EXPIRE_TIME_INVALID;
+        uint64_t original_len;
         dict *dupSearchDict = NULL;
 
         /* If hash with TTLs, load next/min expiration time
@@ -2333,6 +2335,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
 
         len = rdbLoadLen(rdb, NULL);
         if (len == RDB_LENERR) return NULL;
+        original_len = len;
         if (len == 0) goto emptykey;
         /* TODO: create listpackEx or HT directly*/
         o = createHashObject();
@@ -2430,9 +2433,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     /* convert to hash */
                     hashTypeConvert(NULL, o, OBJ_ENCODING_HT);
 
-                    if (len > DICT_HT_INITIAL_SIZE) { /* TODO: this is NOT the original len, but this is also the case for simple hash, is this a bug? */
-                        if (dictTryExpand(o->ptr, len) != DICT_OK) {
-                            rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)len);
+                    if (original_len > DICT_HT_INITIAL_SIZE) {
+                        if (dictTryExpand(o->ptr, original_len) != DICT_OK) {
+                            rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)original_len);
                             decrRefCount(o);
                             if (dupSearchDict != NULL) dictRelease(dupSearchDict);
                             sdsfree(value);


### PR DESCRIPTION
## Background

During hash RDB loading (`rdbLoadObject`), the element count `len` is consumed as entries are read.
In the listpack -> hashtable (HT) spillover path, we later used the *remaining* `len` for `dictTryExpand`.
By that point `len` may no longer represent the original cardinality (and can be 0), which can skip/undersize the pre-sizing and lead to extra rehash/expansion work while loading large hashes.

The same issue existed in the hash-with-metadata (field expire) load path.

## What changed

- `src/rdb.c`:
  - Capture `original_len` immediately after `rdbLoadLen()`.
  - Use `original_len` for `dictTryExpand()` after converting/spilling to `OBJ_ENCODING_HT` in:
    - `RDB_TYPE_HASH`
    - `RDB_TYPE_HASH_METADATA`

## Why this is better

- Pre-sizes the dict using the real hash cardinality rather than a consumed counter.
- Avoids undersized hash tables and reduces rehash churn during load.
- No change to RDB format or functional behavior.

## Tests

- ./runtest --single unit/type/hash --single unit/type/hash-field-expire
- ./runtest --single integration/convert-ziplist-hash-on-load --single integration/convert-zipmap-hash-on-load
