### PR TITLE
Remove dead code leftover

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -571,11 +571,8 @@ void *rdbGenericLoadStringObjectUsable(rio *rdb, int flags, size_t *lenptr, size
     if (len && rioRead(rdb,buf,len) == 0) {
         if (plainFlag)
             zfree(buf);
-        else if (sdsFlag) {
+        else
             sdsfree(buf);
-        } else { /* hfldFlag */
-            entryFree(buf, NULL);
-        }
         return NULL;
     }
     return buf;


### PR DESCRIPTION
**Why the hfldFlag branch was dead code:**
Due to PR #14595, which removed the mstr structure and replaced it with the new Entry struct, the hash field handling changed.

**The logic flow:**

Lines 517-519 define three mutually exclusive flags:

- plainFlag = flags & RDB_LOAD_PLAIN
- sdsFlag = flags & RDB_LOAD_SDS
- robjFlag = !(plainFlag || sdsFlag)
If robjFlag is true, the function returns early. Otherwise, we're in the "plain/sds" path:

- Either plainFlag is true → allocate with ztrymalloc_usable()
- OR sdsFlag is true → allocate with sdstrynewlen() 

therefore at the error handling only two cases are possible:
- plainFlag is true → use zfree(buf)
- plainFlag is false → sdsFlag MUST be true → use sdsfree(buf)

The hfldFlag branch assumed a third case that no longer exists after PR #14595 removed the hash field-specific allocation path. The entryFree(buf, NULL) call was unreachable.