### PR TITLE
Hide PII from ACL log

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -802,7 +802,7 @@ sds ACLDescribeSelectorCommandRules(aclSelector *selector) {
     {
         serverLog(LL_WARNING,
             "CRITICAL ERROR: User ACLs don't match final bitmap: '%s'",
-            rules);
+            logRedactCstr(rules));
         serverPanic("No bitmap match in ACLDescribeSelectorCommandRules()");
     }
     ACLFreeSelector(fake_selector);
@@ -1181,7 +1181,7 @@ int ACLSetSelector(aclSelector *selector, const char* op, size_t oplen) {
                 /* Add the first-arg to the list of valid ones. */
                 serverLog(LL_WARNING, "Deprecation warning: Allowing a first arg of an otherwise "
                                       "blocked command is a misuse of ACL and may get disabled "
-                                      "in the future (offender: +%s)", op+1);
+                                      "in the future (offender: +%s)", logRedactCstr(op+1));
                 ACLAddAllowedFirstArg(selector,cmd->id,sub);
             }
             ACLUpdateCommandRules(selector,op+1,1);
@@ -2247,7 +2247,7 @@ int ACLLoadConfiguredUsers(void) {
                 const char *errmsg = ACLSetUserStringError();
                 serverLog(LL_WARNING,"Error loading ACL rule '%s' for "
                                      "the user named '%s': %s",
-                          aclrules[j],aclrules[0],errmsg);
+                          logRedactCstr(aclrules[j]),logRedactCstr(aclrules[0]),errmsg);
                 return C_ERR;
             }
         }
@@ -2258,7 +2258,7 @@ int ACLLoadConfiguredUsers(void) {
             serverLog(LL_NOTICE, "The user '%s' is disabled (there is no "
                                  "'on' modifier in the user description). Make "
                                  "sure this is not a configuration error.",
-                      aclrules[0]);
+                      logRedactCstr(aclrules[0]));
         }
     }
     return C_OK;

--- a/src/acl.c
+++ b/src/acl.c
@@ -802,7 +802,7 @@ sds ACLDescribeSelectorCommandRules(aclSelector *selector) {
     {
         serverLog(LL_WARNING,
             "CRITICAL ERROR: User ACLs don't match final bitmap: '%s'",
-            logRedactCstr(rules));
+            redactLogCstr(rules));
         serverPanic("No bitmap match in ACLDescribeSelectorCommandRules()");
     }
     ACLFreeSelector(fake_selector);
@@ -1181,7 +1181,7 @@ int ACLSetSelector(aclSelector *selector, const char* op, size_t oplen) {
                 /* Add the first-arg to the list of valid ones. */
                 serverLog(LL_WARNING, "Deprecation warning: Allowing a first arg of an otherwise "
                                       "blocked command is a misuse of ACL and may get disabled "
-                                      "in the future (offender: +%s)", logRedactCstr(op+1));
+                                      "in the future (offender: +%s)", redactLogCstr(op+1));
                 ACLAddAllowedFirstArg(selector,cmd->id,sub);
             }
             ACLUpdateCommandRules(selector,op+1,1);
@@ -2247,7 +2247,7 @@ int ACLLoadConfiguredUsers(void) {
                 const char *errmsg = ACLSetUserStringError();
                 serverLog(LL_WARNING,"Error loading ACL rule '%s' for "
                                      "the user named '%s': %s",
-                          logRedactCstr(aclrules[j]),logRedactCstr(aclrules[0]),errmsg);
+                                     redactLogCstr(aclrules[j]),redactLogCstr(aclrules[0]),errmsg);
                 return C_ERR;
             }
         }
@@ -2258,7 +2258,7 @@ int ACLLoadConfiguredUsers(void) {
             serverLog(LL_NOTICE, "The user '%s' is disabled (there is no "
                                  "'on' modifier in the user description). Make "
                                  "sure this is not a configuration error.",
-                      logRedactCstr(aclrules[0]));
+                                 redactLogCstr(aclrules[0]));
         }
     }
     return C_OK;

--- a/src/networking.c
+++ b/src/networking.c
@@ -2538,22 +2538,22 @@ static void setProtocolError(const char *errstr, client *c) {
 
         /* Sample some protocol to given an idea about what was inside. */
         char buf[256];
-        if (server.hide_user_data_from_log) {  
+        if (server.hide_user_data_from_log) {
             snprintf(buf,sizeof(buf),"Query buffer during protocol error: '*redacted*'");  
-        } else if (sdslen(c->querybuf)-c->qb_pos < PROTO_DUMP_LEN) {  
+        } else if (sdslen(c->querybuf)-c->qb_pos < PROTO_DUMP_LEN) {
             snprintf(buf,sizeof(buf),"Query buffer during protocol error: '%s'", c->querybuf+c->qb_pos);  
-        } else {  
+        } else {
             snprintf(buf,sizeof(buf),"Query buffer during protocol error: '%.*s' (... more %zu bytes ...) '%.*s'", PROTO_DUMP_LEN/2, c->querybuf+c->qb_pos, sdslen(c->querybuf)-c->qb_pos-PROTO_DUMP_LEN, PROTO_DUMP_LEN/2, c->querybuf+sdslen(c->querybuf)-PROTO_DUMP_LEN/2);  
-        }  
+        }
 
         /* Remove non printable chars. */  
-        if (!server.hide_user_data_from_log) {  
-            char *p = buf;  
-            while (*p != '\0') {  
-                if (!isprint(*p)) *p = '.';  
-                p++;  
-            }  
-        }  
+        if (!server.hide_user_data_from_log) {
+            char *p = buf;
+            while (*p != '\0') {
+                if (!isprint(*p)) *p = '.';
+                p++;
+            }
+        }
 
         /* Log all the client and protocol info. */
         int loglevel = (c->flags & CLIENT_MASTER) ? LL_WARNING :

--- a/src/networking.c
+++ b/src/networking.c
@@ -2538,22 +2538,22 @@ static void setProtocolError(const char *errstr, client *c) {
 
         /* Sample some protocol to given an idea about what was inside. */
         char buf[256];
-        if (server.hide_user_data_from_log) {
-            snprintf(buf,sizeof(buf),"Query buffer during protocol error: '*redacted*'");
-        } else {
-            if (sdslen(c->querybuf)-c->qb_pos < PROTO_DUMP_LEN) {
-                snprintf(buf,sizeof(buf),"Query buffer during protocol error: '%s'", c->querybuf+c->qb_pos);
-            } else {
-                snprintf(buf,sizeof(buf),"Query buffer during protocol error: '%.*s' (... more %zu bytes ...) '%.*s'", PROTO_DUMP_LEN/2, c->querybuf+c->qb_pos, sdslen(c->querybuf)-c->qb_pos-PROTO_DUMP_LEN, PROTO_DUMP_LEN/2, c->querybuf+sdslen(c->querybuf)-PROTO_DUMP_LEN/2);
-            }
+        if (server.hide_user_data_from_log) {  
+            snprintf(buf,sizeof(buf),"Query buffer during protocol error: '*redacted*'");  
+        } else if (sdslen(c->querybuf)-c->qb_pos < PROTO_DUMP_LEN) {  
+            snprintf(buf,sizeof(buf),"Query buffer during protocol error: '%s'", c->querybuf+c->qb_pos);  
+        } else {  
+            snprintf(buf,sizeof(buf),"Query buffer during protocol error: '%.*s' (... more %zu bytes ...) '%.*s'", PROTO_DUMP_LEN/2, c->querybuf+c->qb_pos, sdslen(c->querybuf)-c->qb_pos-PROTO_DUMP_LEN, PROTO_DUMP_LEN/2, c->querybuf+sdslen(c->querybuf)-PROTO_DUMP_LEN/2);  
+        }  
 
-            /* Remove non printable chars. */
-            char *p = buf;
-            while (*p != '\0') {
-                if (!isprint(*p)) *p = '.';
-                p++;
-            }
-        }
+        /* Remove non printable chars. */  
+        if (!server.hide_user_data_from_log) {  
+            char *p = buf;  
+            while (*p != '\0') {  
+                if (!isprint(*p)) *p = '.';  
+                p++;  
+            }  
+        }  
 
         /* Log all the client and protocol info. */
         int loglevel = (c->flags & CLIENT_MASTER) ? LL_WARNING :

--- a/src/networking.c
+++ b/src/networking.c
@@ -2538,17 +2538,21 @@ static void setProtocolError(const char *errstr, client *c) {
 
         /* Sample some protocol to given an idea about what was inside. */
         char buf[256];
-        if (sdslen(c->querybuf)-c->qb_pos < PROTO_DUMP_LEN) {
-            snprintf(buf,sizeof(buf),"Query buffer during protocol error: '%s'", c->querybuf+c->qb_pos);
+        if (server.hide_user_data_from_log) {
+            snprintf(buf,sizeof(buf),"Query buffer during protocol error: '*redacted*'");
         } else {
-            snprintf(buf,sizeof(buf),"Query buffer during protocol error: '%.*s' (... more %zu bytes ...) '%.*s'", PROTO_DUMP_LEN/2, c->querybuf+c->qb_pos, sdslen(c->querybuf)-c->qb_pos-PROTO_DUMP_LEN, PROTO_DUMP_LEN/2, c->querybuf+sdslen(c->querybuf)-PROTO_DUMP_LEN/2);
-        }
+            if (sdslen(c->querybuf)-c->qb_pos < PROTO_DUMP_LEN) {
+                snprintf(buf,sizeof(buf),"Query buffer during protocol error: '%s'", c->querybuf+c->qb_pos);
+            } else {
+                snprintf(buf,sizeof(buf),"Query buffer during protocol error: '%.*s' (... more %zu bytes ...) '%.*s'", PROTO_DUMP_LEN/2, c->querybuf+c->qb_pos, sdslen(c->querybuf)-c->qb_pos-PROTO_DUMP_LEN, PROTO_DUMP_LEN/2, c->querybuf+sdslen(c->querybuf)-PROTO_DUMP_LEN/2);
+            }
 
-        /* Remove non printable chars. */
-        char *p = buf;
-        while (*p != '\0') {
-            if (!isprint(*p)) *p = '.';
-            p++;
+            /* Remove non printable chars. */
+            char *p = buf;
+            while (*p != '\0') {
+                if (!isprint(*p)) *p = '.';
+                p++;
+            }
         }
 
         /* Log all the client and protocol info. */

--- a/src/server.h
+++ b/src/server.h
@@ -4355,6 +4355,9 @@ void swapMainDbWithTempDb(redisDb *tempDb);
 sds getVersion(void);
 void debugPauseProcess(void);
 
+/* Log redaction helpers: return "*redacted*" when hide-user-data-from-log is on. */
+static inline const char *logRedactCstr(const char *s) {return server.hide_user_data_from_log ? "*redacted*" : (s ? s : "(null)");}
+
 /* Use macro for checking log level to avoid evaluating arguments in cases log
  * should be ignored due to low level. */
 #define serverLog(level, ...) do {\

--- a/src/server.h
+++ b/src/server.h
@@ -4356,7 +4356,7 @@ sds getVersion(void);
 void debugPauseProcess(void);
 
 /* Log redaction helpers: return "*redacted*" when hide-user-data-from-log is on. */
-static inline const char *logRedactCstr(const char *s) {return server.hide_user_data_from_log ? "*redacted*" : (s ? s : "(null)");}
+static inline const char *redactLogCstr(const char *s) {return server.hide_user_data_from_log ? "*redacted*" : (s ? s : "(null)");}
 
 /* Use macro for checking log level to avoid evaluating arguments in cases log
  * should be ignored due to low level. */

--- a/src/server.h
+++ b/src/server.h
@@ -4356,7 +4356,9 @@ sds getVersion(void);
 void debugPauseProcess(void);
 
 /* Log redaction helpers: return "*redacted*" when hide-user-data-from-log is on. */
-static inline const char *redactLogCstr(const char *s) {return server.hide_user_data_from_log ? "*redacted*" : (s ? s : "(null)");}
+static inline const char *redactLogCstr(const char *s) {
+    return server.hide_user_data_from_log ? "*redacted*" : (s ? s : "(null)");
+}
 
 /* Use macro for checking log level to avoid evaluating arguments in cases log
  * should be ignored due to low level. */


### PR DESCRIPTION
This PR continues the work from [#13400](https://github.com/redis/redis/pull/13400), following the discussion in [#11747](https://github.com/redis/redis/pull/11747#discussion_r1094418111), to further ensure sensitive user data is not exposed in logs when hide_user_data_from_log is enabled.

- Introduce redactLogCstr() helper for safe, centralized log redaction.
- Update ACL and networking log messages to use redacted values where appropriate.
- Prevent leaking raw query buffer contents.