### PR TITLE
incrRefCount off-by-one error

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -587,6 +587,8 @@ void incrRefCount(robj *o) {
             /* Nothing to do: this refcount is immutable. */
         } else if (o->refcount == OBJ_STATIC_REFCOUNT) {
             serverPanic("You tried to retain an object allocated in the stack");
+        } else {
+            serverPanic("You tried to retain an object with maximum refcount");
         }
     }
 }

--- a/src/object.c
+++ b/src/object.c
@@ -580,7 +580,7 @@ void freeStreamObject(robj *o) {
 }
 
 void incrRefCount(robj *o) {
-    if (o->refcount < OBJ_FIRST_SPECIAL_REFCOUNT) {
+    if (o->refcount < OBJ_FIRST_SPECIAL_REFCOUNT - 1) {
         o->refcount++;
     } else {
         if (o->refcount == OBJ_SHARED_REFCOUNT) {


### PR DESCRIPTION
The condition for blocking `o->refcount++` in `incrRefCount` is `if (o->refcount < OBJ_FIRST_SPECIAL_REFCOUNT)`, meaning refcount can accidentally reach the first special refcount (`OBJ_STATIC_REFCOUNT` currently).
Fixed the condition to be `if (o->refcount < OBJ_FIRST_SPECIAL_REFCOUNT - 1)`