### PR TITLE
Fix some comment spelling typos

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1752,7 +1752,7 @@ static int uintCompare(const void *a, const void *b) {
     return (*(unsigned int *) a - *(unsigned int *) b);
 }
 
-/* Helper method to store a string into from val or lval into dest */
+/* Helper method to store a string from val or lval into dest */
 static inline void lpSaveValue(unsigned char *val, unsigned int len, int64_t lval, listpackEntry *dest) {
     dest->sval = val;
     dest->slen = len;

--- a/src/sds.c
+++ b/src/sds.c
@@ -351,7 +351,7 @@ sds sdsRemoveFreeSpace(sds s, int would_regrow) {
 /* Resize the allocation, this can make the allocation bigger or smaller,
  * if the size is smaller than currently used len, the data will be truncated.
  *
- * The when the would_regrow argument is set to 1, it prevents the use of
+ * When the would_regrow argument is set to 1, it prevents the use of
  * SDS_TYPE_5, which is desired when the sds is likely to be changed again.
  *
  * The sdsAlloc size will be set to the requested size regardless of the actual

--- a/src/siphash.c
+++ b/src/siphash.c
@@ -25,7 +25,7 @@
       as Murmurhash2 that we used previously, while the 2-4 variant slowed
       down Redis by a 4% figure more or less.
    2. Hard-code rounds in the hope the compiler can optimize it more
-      in this raw from. Anyway we always want the standard 2-4 variant.
+      in this raw form. Anyway we always want the standard 2-4 variant.
    3. Modify the prototype and implementation so that the function directly
       returns an uint64_t value, the hash itself, instead of receiving an
       output buffer. This also means that the output size is set to 8 bytes

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1583,7 +1583,7 @@ int uintCompare(const void *a, const void *b) {
     return (*(unsigned int *) a - *(unsigned int *) b);
 }
 
-/* Helper method to store a string into from val or lval into dest */
+/* Helper method to store a string from val or lval into dest */
 static inline void ziplistSaveValue(unsigned char *val, unsigned int len, long long lval, ziplistEntry *dest) {
     dest->sval = val;
     dest->slen = len;


### PR DESCRIPTION
### Description
Fix 4 single-word comment spelling typos. Minimal changes only, no functional impact.

### Detailed Changes
- siphash.c line 28: Correct 'from' to 'form'
- sds.c line 354: Correct 'The when' to 'When'
- listpack.c line 1755: Correct 'string into from' to 'string from'
- ziplist.c line 1586: Correct 'string into from' to 'string from'