### PR TITLE
Fix: Use dictSetKeyAtLink in activeDefragHfieldDictCallback

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -245,20 +245,25 @@ sds activeDefragSds(sds sdsptr) {
  * when it returns a non-null value, the old pointer was already released
  * and should NOT be accessed. */
 Entry *activeDefragEntry(Entry *entry) {
-    /* Defrag the value if it's not embedded */
-    sds *valuePtr = entryGetValuePtrRef(entry);
-    if (valuePtr) {
-        sds new_value = activeDefragSds(*valuePtr);
-        if (new_value) *valuePtr = new_value;
-    }
+    Entry *ret = NULL;
+
+    /* First, defrag the entry allocation itself */
     void *ptr = entryGetAllocPtr(entry);
     void *newptr = activeDefragAlloc(ptr);
     if (newptr) {
         size_t offset = (char*)entry - (char*)ptr;
         entry = (Entry *)((char*)newptr + offset);
-        return entry;
+        ret = entry;
     }
-    return NULL;
+
+    /* Then defrag the value if it's not embedded (using the potentially new entry) */
+    sds *valuePtr = entryGetValuePtrRef(entry);
+    if (valuePtr) {
+        sds new_value = activeDefragSds(*valuePtr);
+        if (new_value) *valuePtr = new_value;
+    }
+
+    return ret;
 }
 
 /* Defrag helper for hfield strings and update the reference in the dict.

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -484,8 +484,10 @@ void activeDefragHfieldDictCallback(void *privdata, const dictEntry *de, dictEnt
      * Fields with TTL are skipped here and will be defragmented later
      * during the hash expiry ebuckets defragmentation phase. */
     if (entryGetExpiry(entry) == EB_EXPIRE_TIME_INVALID) {
-        if ((newEntry = activeDefragEntry(entry)))
+        if ((newEntry = activeDefragEntry(entry))) {
+            /* Hash dicts use no_value=1, so we must use dictSetKeyAtLink */ 
             dictSetKeyAtLink(d, newEntry, &plink, 0);
+        }
     }
 }
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -485,7 +485,7 @@ void activeDefragHfieldDictCallback(void *privdata, const dictEntry *de, dictEnt
      * during the hash expiry ebuckets defragmentation phase. */
     if (entryGetExpiry(entry) == EB_EXPIRE_TIME_INVALID) {
         if ((newEntry = activeDefragEntry(entry)))
-            dictSetKey(d, (dictEntry *)de, newEntry);
+            dictSetKeyAtLink(d, newEntry, &plink, 0);
     }
 }
 


### PR DESCRIPTION
Problem:
The activeDefragHfieldDictCallback was wrongly using dictSetKey() which set key and value. However, hash field dictionaries use no_value=1 (since PR #14595), causing assertion `assert(!d->type->no_value)` to fail 

Solution:
* Replace `dictSetKey(d, (dictEntry *)de, newEntry)` with `dictSetKeyAtLink(d, newEntry, &plink, 0)` which properly handles both regular dictEntry and the optimized `no_value=1` case where keys are stored directly in the hash table. The callback already receives the plink parameter pointing to the exact location that needs updating.
* Following PR #14595 value can be now optionally embedded in `entry`. As a result, `activeDefragEntry()` refines and defragments an entry’s value only when `entryGetValuePtrRef(entry) != NULL`.
