### PR TITLE
Fix ACL key-pattern bypass in MSETEX command

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3014,7 +3014,7 @@ int getKeysUsingKeySpecs(struct redisCommand *cmd, robj **argv, int argc, int se
             }
 
             first += spec->fk.keynum.firstkey;
-            last = first + (long)numkeys-1;
+            last = first + ((long)numkeys - 1) * step;
         } else {
             /* unknown spec */
             goto invalid_spec;

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -161,6 +161,14 @@ start_server {tags {"introspection"}} {
         assert_error "ERR Invalid arguments*" {r command getkeysandflags ZINTERSTORE zz 1443677133621497600 asdf}
     }
 
+    test {COMMAND GETKEYSANDFLAGS MSETEX} {
+        assert_equal {{k1 {OW update}}} [r command getkeysandflags msetex 1 k1 v1 ex 10]
+        assert_equal {{k1 {OW update}} {k2 {OW update}}} [r command getkeysandflags msetex 2 k1 v1 k2 v2 ex 10]
+        assert_equal {{k1 {OW update}} {k2 {OW update}} {k3 {OW update}}} [r command getkeysandflags msetex 3 k1 v1 k2 v2 k3 v3 ex 10]
+        assert_equal {{k1 {OW update}} {k2 {OW update}}} [r command getkeysandflags msetex 2 k1 v1 k2 v2 keepttl]
+        assert_equal {{k1 {OW update}} {k2 {OW update}}} [r command getkeysandflags msetex 2 k1 v1 k2 v2 ex 10 nx]
+    }
+
     test {COMMAND GETKEYS MEMORY USAGE} {
         assert_equal {key} [r command getkeys memory usage key]
     }

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -311,7 +311,7 @@ start_server {tags {"string"}} {
     test {MSETEX - error cases} {
         assert_error {*wrong number of arguments*} {r msetex}
         assert_error {*invalid numkeys value*} {r msetex key1 val1 ex 10}
-        assert_error {*wrong number of key-value pairs*} {r msetex 2 key1 val1 key2}
+        assert_error {*wrong number of key-value pairs*} {r msetex 2 key1{t} val1 key2{t}}
         assert_error {*syntax error*} {r msetex 1 key1 val1 invalid_flag}
     }
 


### PR DESCRIPTION
MSETEX doesn't properly check ACL key permissions for all keys - only the first key is validated.

MSETEX arguments look like: MSETEX <numkeys> key1 val1 key2 val2 ... EX seconds

Keys are at every 2nd position (step=2). When Redis extracts keys for ACL checking, it calculates where the last key is:

last = first + numkeys - 1;        => calculation ignores step
last = first + (numkeys-1) * step; 
With 2 keys starting at position 2:

Bug: last = 2 + 2 - 1 = 3 → only checks position 2
Fix: last = 2 + (2-1)*2 = 4 → checks positions 2 and 4

Fixes #14657
