### PR TITLE
CI: add riscv64 QEMU build+smoke test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,47 @@ jobs:
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
         make CC=gcc REDIS_CFLAGS='-Werror'
+
+  build-riscv64-qemu:
+    name: build-riscv64-qemu (ubuntu container via QEMU)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU (riscv64)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: riscv64
+
+      - name: Build + smoke test (riscv64 Ubuntu container)
+        run: |
+          set -euo pipefail
+          docker run --rm -t --platform=linux/riscv64 \
+            -v "${{ github.workspace }}:/work" \
+            -w /work \
+            -e DEBIAN_FRONTEND=noninteractive \
+            ubuntu:24.04 bash -lc '
+              set -euo pipefail
+              echo "Arch inside container: $(uname -m)"
+
+              apt-get update
+              apt-get install -y --no-install-recommends \
+                build-essential pkg-config \
+                ca-certificates \
+                tcl tclx \
+                libssl-dev \
+                libjemalloc-dev
+
+              # Treat warnings as errors + TLS build coverage
+              make -j2 REDIS_CFLAGS="-Werror" BUILD_TLS=yes
+              ./src/redis-server --version
+
+              # Quick runtime smoke test
+              ./src/redis-server --save "" --appendonly no --port 6379 --daemonize yes
+              sleep 1
+              ./src/redis-cli ping | grep -q PONG
+              ./src/redis-cli set hello riscv
+              ./src/redis-cli get hello | grep -q riscv
+              ./src/redis-cli shutdown
+            '


### PR DESCRIPTION
- Adds a new GitHub Actions job that builds Redis for riscv64 under QEMU user-mode and performs a basic runtime smoke test (PING, SET/GET, shutdown).
- Keeps the job lightweight (does not run the full test suite under QEMU).
- Validated locally on x86_64 using Docker --platform=linux/riscv64 with QEMU/binfmt.

Attached log:
[build-riscv64-qemu.log](https://github.com/user-attachments/files/24432192/build-riscv64-qemu.log)
