### PR TITLE
Optimize `lpDecodeBacklen()` fast paths by removing loop-based decoding

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -388,18 +388,49 @@ static inline unsigned long lpEncodeBacklenBytes(uint64_t l) {
 }
 
 /* Decode the backlen and returns it. If the encoding looks invalid (more than
- * 5 bytes are used), UINT64_MAX is returned to report the problem. */
+ * 5 bytes are used), UINT64_MAX is returned to report the problem.
+ *
+ * Optimized for the common case: most backlen values fit in one or two bytes
+ * due to listpack size limits. This version avoids a loop and pointer
+ * mutation, reducing overhead in hot paths while keeping the same encoding
+ * semantics.
+ *
+ * Note: the caller guarantees that up to 5 bytes preceding 'p' are readable,
+ * as ensured by listpack invariants. */
 static inline uint64_t lpDecodeBacklen(unsigned char *p) {
-    uint64_t val = 0;
-    uint64_t shift = 0;
-    do {
-        val |= (uint64_t)(p[0] & 127) << shift;
-        if (!(p[0] & 128)) break;
-        shift += 7;
-        p--;
-        if (shift > 28) return UINT64_MAX;
-    } while(1);
-    return val;
+    uint64_t val;
+
+    /* Fast path: single byte (most common for small entries <= 127 bytes) */
+    if (likely(!(p[0] & 128))) {
+        return p[0] & 127;
+    }
+
+    /* Two bytes */
+    val = (uint64_t)(p[0] & 127);
+    if (!(p[-1] & 128)) {
+        return val | ((uint64_t)(p[-1] & 127) << 7);
+    }
+
+    /* Three bytes */
+    val |= (uint64_t)(p[-1] & 127) << 7;
+    if (!(p[-2] & 128)) {
+        return val | ((uint64_t)(p[-2] & 127) << 14);
+    }
+
+    /* Four bytes */
+    val |= (uint64_t)(p[-2] & 127) << 14;
+    if (!(p[-3] & 128)) {
+        return val | ((uint64_t)(p[-3] & 127) << 21);
+    }
+
+    /* Five bytes */
+    val |= (uint64_t)(p[-3] & 127) << 21;
+    if (!(p[-4] & 128)) {
+        return val | ((uint64_t)(p[-4] & 127) << 28);
+    }
+
+    /* Invalid: more than 5 bytes */
+    return UINT64_MAX;
 }
 
 /* Encode the string element pointed by 's' of size 'len' in the target


### PR DESCRIPTION
## Optimization details

The current `lpDecodeBacklen()` implementation decodes the backlen using a loop with backward pointer mutation and a branch-heavy termination condition:

```c
do {
    val |= (uint64_t)(p[0] & 127) << shift;
    if (!(p[0] & 128)) break;
    shift += 7;
    p--;
    if (shift > 28) return UINT64_MAX;
} while(1);
```

While correct, this structure introduces avoidable overhead in hot paths:

- repeated loop control
- unpredictable branch (if (!(p[0] & 128)) break)
- increased front-end pressure and bad speculation

Top-down and VTune analysis show this function to be front-end and speculation bound.
<img width="541" height="376" alt="image" src="https://github.com/user-attachments/assets/dcfda1ef-c685-447c-b3ca-a2c56aa993d5" />


### Optimization

This PR replaces the loop with a straight-line implementation optimized for the common case:

- explicit fast paths for 1–2 byte backlen encodings (dominant in practice)
- unrolled handling up to the maximum 5-byte encoding
- no pointer mutation, no loop, fewer branches
- identical encoding semantics and validation behavior

leading to a 5.3% boost on listpack iterator heavy benchmark on HASH datatype. 

### Microarchitectural analysis for lpDecodeBacklen

VTune diff (baseline → optimized) for `lpDecodeBacklen`:

| Metric | Baseline | Optimized | Δ |
|------|---------:|----------:|--:|
| CPU Time | 0.168s (~2%) | ~0s | -0.168s |
| Clockticks | 974.7M | 99.9M | **-89.8%** |
| Instructions Retired | 4.43B | 0.78B | **-82.5%** |
| CPI | 0.220 | 0.128 | **-41.8%** |

## Performance Results on Intel Xeon SPR (single shard)

|                                                                                                                                               Test Case                                                                                                                                               |Baseline /redis unstable (median obs. +- std.dev)|Comparison filipecosta90/redis 4cdd738327570a0bc7abac41dada0212894d7dfd (median obs. +- std.dev)|% change (higher-better)|   Note    |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------:|------------------------------------------------------------------------------------------------|------------------------|-----------|
|[memtier_benchmark-1Mkeys-hash-hkeys-50-fields-with-10B-values-with-expiration-pipeline-10](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hkeys-50-fields-with-10B-values-with-expiration-pipeline-10.yml)|                                           286264| 301459 +- 0.0% (2 datapoints)                                                                  |5.3%                    |IMPROVEMENT|


### Reproduce Benchmarks

```bash
pip3 install redis-benchmarks-specification
redis-benchmarks-spec-client-runner \
  --test memtier_benchmark-1Mkeys-hash-hkeys-50-fields-with-10B-values-with-expiration-pipeline-10.yml \
  --db_server_host <...> --db_server_port <...> --db_server_password <...> \
  --flushall_on_every_test_start
 ```