### PR TITLE
Fix ASM failpoint tests for fast state transitions

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -2082,6 +2082,13 @@ void clusterSyncSlotsCommand(client *c) {
             if (task->state == ASM_SEND_BULK_AND_STREAM || task->state == ASM_SEND_STREAM) {
                 /* Pause writes on the main channel if the lag is less than the threshold. */
                 if (task->dest_offset + server.asm_handoff_max_lag_bytes >= task->source_offset) {
+                    /* Check failpoint for send-stream state. When there's no data,
+                     * the task may skip SEND_STREAM and go directly to HANDOFF_PREP. */
+                    if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, ASM_SEND_STREAM))) {
+                        asmTaskSetFailed(task, "Main channel - send-stream failpoint");
+                        return;
+                    }
+
                     if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, ASM_HANDOFF_PREP)))
                         return; /* Do not enter handoff prep state for testing buffer drain timeout. */
 
@@ -2434,6 +2441,14 @@ static int asmSyncBufferStreamShouldContinue(void *ctx) {
 
 /* Stream the sync buffer to the database. */
 void asmSyncBufferStreamToDb(asmTask *task) {
+    /* Check failpoint for streaming-buffer state before changing state. This
+     * handles the case where the buffer is empty and streaming completes
+     * instantly without triggering the failpoint in the streaming loop. */
+    if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, ASM_STREAMING_BUF))) {
+        asmTaskSetFailed(task, "Main channel - streaming-buffer failpoint");
+        return;
+    }
+
     task->state = ASM_STREAMING_BUF;
     serverLog(LL_NOTICE, "Starting to stream accumulated buffer for the import task (%zu bytes)",
                          task->sync_buffer.used);
@@ -2796,6 +2811,12 @@ int clusterAsmHandoff(const char *task_id, sds *err) {
     if (!task || task->state != ASM_HANDOFF_PREP) {
         *err = sdscatprintf(sdsempty(), "No suitable ASM task found for id: %s, task_state: %s",
                             task_id, task ? asmTaskStateToString(task->state) : "null");
+        return C_ERR;
+    }
+
+    /* Check failpoint for handoff state before changing state. */
+    if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, ASM_HANDOFF))) {
+        asmTaskSetFailed(task, "Main channel - handoff failpoint");
         return C_ERR;
     }
 


### PR DESCRIPTION
Disclaimer: **This PR was written using AI**

Running the test with my Dell Latitude 7420, a slow machine compared to today's MacBooks or our CI systems, had a test failing due to timing issues. The Redis build system advertises to run the test after compiling the server. Having it failing on older systems is not great. The failing test was about ASM, that has built-in features in order to simulate failure points to provide "synthetic testing", but those stuff are highly time dependent. Now, you know what sucks? Investigating other folks broken tests (no offense, it is in the nature of such tests) failing for timing issues. So I tried to do this with a coding agent, and the result seems good.

I'll leave you with the words of the LLM in person. I read the patch for sanity, and tested that now the test works, but would be great if somebody that knows such code paths could double check it.

## LLM report

The ASM error-handling tests were failing intermittently because failpoints weren't triggering when migrations completed too quickly due to little or no data being migrated.

Changes:

1. Add failpoint check in ACK handling (clusterSyncSlotsCommand) for send-stream state before transitioning to HANDOFF_PREP - handles the case when source skips directly to handoff with no data.

2. Add failpoint check in clusterAsmHandoff for handoff state.

3. Add failpoint check in asmSyncBufferStreamToDb for streaming-buffer state before changing state - handles empty buffer case on destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)