### PR TITLE
pubsub: optimize subscriber heavy scenarios by using prebuild RESP replies

### DIFF
--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -85,6 +85,61 @@ pubsubtype pubSubShardType = {
  * Pubsub client replies API
  *----------------------------------------------------------------------------*/
 
+/* Build the RESP protocol for a pubsub message.
+ * This pre-formats the entire message to avoid formatting overhead.
+ *
+ * resp: 2 for RESP2, 3 for RESP3
+ * Returns an sds string containing the complete RESP protocol message.
+ * The caller is responsible for freeing the returned sds. */
+sds _pubsubBuildMessageReply(robj *message_bulk, robj *channel, robj *msg, int resp) {
+    sds proto = sdsempty();
+
+    /* Pre-allocate space for the entire protocol message */
+    size_t channel_len = sdslen(channel->ptr);
+    size_t msg_len = sdslen(msg->ptr);
+    size_t message_bulk_len = sdslen(message_bulk->ptr);
+
+    /* Calculate exact size needed:
+     * - Array/Push header: 4 bytes (*3\r\n or >3\r\n)
+     * - Message bulk: already formatted (e.g., $7\r\nmessage\r\n)
+     * - Channel bulk: $<len>\r\n<data>\r\n (max 20 bytes for length encoding + data + delimiters)
+     * - Message bulk: $<len>\r\n<data>\r\n (max 20 bytes for length encoding + data + delimiters)
+     */
+    size_t overhead = 4 + 20 + 20; /* Array header + max length encodings */
+    proto = sdsMakeRoomFor(proto, overhead + message_bulk_len + channel_len + msg_len);
+
+    /* Array/Push header */
+    if (resp == 2) {
+        /* RESP2 array header: *3\r\n */
+        proto = sdscatlen(proto, "*3\r\n", 4);
+    } else {
+        /* RESP3 push header: >3\r\n */
+        proto = sdscatlen(proto, ">3\r\n", 4);
+    }
+
+    /* Message type (e.g., "$7\r\nmessage\r\n") - already formatted */
+    proto = sdscatlen(proto, message_bulk->ptr, message_bulk_len);
+
+    /* Channel as bulk string: $<len>\r\n<data>\r\n */
+    char buf[32];
+    size_t len = ll2string(buf, sizeof(buf), channel_len);
+    proto = sdscatlen(proto, "$", 1);
+    proto = sdscatlen(proto, buf, len);
+    proto = sdscatlen(proto, "\r\n", 2);
+    proto = sdscatlen(proto, channel->ptr, channel_len);
+    proto = sdscatlen(proto, "\r\n", 2);
+
+    /* Message as bulk string: $<len>\r\n<data>\r\n */
+    len = ll2string(buf, sizeof(buf), msg_len);
+    proto = sdscatlen(proto, "$", 1);
+    proto = sdscatlen(proto, buf, len);
+    proto = sdscatlen(proto, "\r\n", 2);
+    proto = sdscatlen(proto, msg->ptr, msg_len);
+    proto = sdscatlen(proto, "\r\n", 2);
+
+    return proto;
+}
+
 /* Send a pubsub message of type "message" to the client.
  * Normally 'msg' is a Redis object containing the string to send as
  * message. However if the caller sets 'msg' as NULL, it will be able
@@ -100,6 +155,16 @@ void addReplyPubsubMessage(client *c, robj *channel, robj *msg, robj *message_bu
     addReply(c,message_bulk);
     addReplyBulk(c,channel);
     if (msg) addReplyBulk(c,msg);
+    if (!(old_flags & CLIENT_PUSHING)) c->flags &= ~CLIENT_PUSHING;
+}
+
+/* Send a pubsub message using pre-built RESP protocol.
+ * This is an optimized path for broadcasting to multiple clients.
+ * The proto string should be built using pubsubBuildBroadcastReply(). */
+void addReplyPubsubMessageProto(client *c, const char *proto, size_t len) {
+    uint64_t old_flags = c->flags;
+    c->flags |= CLIENT_PUSHING;
+    addReplyProto(c, proto, len);
     if (!(old_flags & CLIENT_PUSHING)) c->flags &= ~CLIENT_PUSHING;
 }
 
@@ -480,15 +545,37 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
         dictIterator iter;
 
         dictInitIterator(&iter, clients);
+
+        /* Pre-build the protocol for RESP2 and RESP3 clients.
+         * We lazily build each version when we encounter the first client of that type. */
+        sds proto_resp2 = NULL;
+        sds proto_resp3 = NULL;
+
         while ((entry = dictNext(&iter)) != NULL) {
             client *c = dictGetKey(entry);
-            addReplyPubsubMessage(c,channel,message,*type.messageBulk);
+
+            /* Lazily build pre-formatted protocol for each RESP version */
+            if (c->resp == 2) {
+                if (!proto_resp2) {
+                    proto_resp2 = _pubsubBuildMessageReply(*type.messageBulk, channel, message, 2);
+                }
+                addReplyPubsubMessageProto(c, proto_resp2, sdslen(proto_resp2));
+            } else {
+                if (!proto_resp3) {
+                    proto_resp3 = _pubsubBuildMessageReply(*type.messageBulk, channel, message, 3);
+                }
+                addReplyPubsubMessageProto(c, proto_resp3, sdslen(proto_resp3));
+            }
+
             if (clusterSlotStatsEnabled())
                 clusterSlotStatsAddNetworkBytesOutForShardedPubSubInternalPropagation(c, slot);
             updateClientMemUsageAndBucket(c);
             receivers++;
         }
         dictResetIterator(&iter);
+
+        if (proto_resp2) sdsfree(proto_resp2);
+        if (proto_resp3) sdsfree(proto_resp3);
     }
 
     if (type.shard) {


### PR DESCRIPTION
This PR optimizes Redis Pub/Sub broadcast performance by eliminating per-subscriber RESP formatting overhead during message fanout on subscriber heavy scenarios.

Today, each publish formats the Pub/Sub reply independently for every subscriber, repeatedly constructing array/push headers, bulk length headers, and payloads. This becomes a dominant CPU cost for medium-to-large fanout workloads and increases tail latency, as seen on perf profile of a subscriber heavy workload:

```
Hot path from perf report:

addReplyPubsubMessage
 ├─ addReplyBulk(channel)   → 19.0%
 ├─ addReplyBulk(message)   → 23.3%
 ├─ addReply(mbulkhdr)      → 13.5%
 └─ flag manipulation / glue
```

This patch introduces a **pre-built RESP protocol path**, formatting each Pub/Sub message **once per publish** (per RESP version) and reusing it across all subscribers, similar to what @antirez did for client side caching on the [trackingBuildBroadCastReply](https://github.com/redis/redis/blob/unstable/src/tracking.c#L559)

### Performance summary  
Improves Pub/Sub throughput by **30–50%** for fanout sizes ≥100 subscribers and reduces **P50 latency by ~25–30%** at high fanout, with no meaningful impact for single-subscriber workloads.

This was assessed with `pubsub-sub-bench` tool in `ssubscribe` mode, followed by a publisher running `SPUBLISH` via `memtier_benchmark`.  
Both publisher and subscribers run concurrently with a **100-byte payload**.  
Subscriber counts tested: **1, 100, 1000, 3500, 5000**.

#### Subscriber delivery throughput (msg/s)

| Subscribers | Baseline | Patched | Δ (%) |
|------------:|---------:|--------:|------:|
| 100 | 4.11M | 6.08M | +48% |
| 1000 | 4.35M | 6.51M | +50% |
| 3500 | 3.94M | 5.46M | +38% |
| 5000 | 3.42M | 4.71M | +38% |


#### Publisher throughput (ops/s)

| Subscribers | Baseline | Patched | Δ (%) |
|------------:|---------:|--------:|------:|
| 100 | 42,421 | 60,826 | +43% |
| 1000 | 4,490 | 6,508 | +45% |
| 3500 | 1,123 | 1,580 | +41% |
| 5000 | 701 | 970 | +38% |


#### P50 latency (publisher)

| Subscribers | Baseline | Patched | Δ (%) |
|------------:|---------:|--------:|------:|
| 100 | 4.70 ms | 3.26 ms | -31% |
| 1000 | 44.3 ms | 30.3 ms | -31% |
| 3500 | 175 ms | 127 ms | -27% |
| 5000 | 285 ms | 208 ms | -27% |

---

## Functional validation

tclsh tests/test_helper.tcl --dump-logs --single unit/pubsub
