### PR TITLE
Fix UBSan error in stream trim when processing last entry

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -886,12 +886,12 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
 
                 if (can_delete) {
                     /* Mark the entry as deleted. */
-                    intptr_t delta = p - lp;
+                    intptr_t delta = p ? (p - lp) : 0; /* p may be NULL if this was the last entry */
                     flags |= STREAM_ITEM_FLAG_DELETED;
                     lp = lpReplaceInteger(lp, &pcopy, flags);
                     deleted_from_lp++;
                     s->length--;
-                    p = lp + delta;
+                    if (p) p = lp + delta;
                 }
             }
         }


### PR DESCRIPTION
## Summary

This bus was introduced by https://github.com/redis/redis/pull/14623

Before PR #14623, when a stream node was going to be fully removed, we would just delete the whole node directly instead of iterating through and deleting each entry.

Now, with the XTRIM / XADD flags, we have to iterate and delete entries one by one. However, the implementation in issue #8169 didn’t consider the case where all entries are removed, so p can end up being NULL.

Fixes an UndefinedBehaviorSanitizer error in `streamTrim()` when marking the last entry in a listpack as deleted. The issue occurs when performing pointer arithmetic on a NULL pointer after `lpNext()` reaches the end of the listpack.

## Solution
If p is NULL, we skip the delta calculation and skip the calculation of new `p`.

Failed CI: https://github.com/redis/redis/actions/runs/20766104241/job/59632440335