### PR TITLE
Propagate migrate task info to replicas

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -3032,9 +3032,11 @@ void asmTrimJobProcessPending(void) {
         return;
     }
 
-    /* If this node is a replica, it should not initiate slot trimming actively. */
+    /* If this node is a replica, it should not initiate slot trimming actively.
+     * Cancel the trim job and unblock the master if it is blocked. */
     if (clusterNodeIsSlave(getMyClusterNode())) {
         asmCancelPendingTrimJobs();
+        asmUnblockMasterAfterTrim();
         return;
     }
 
@@ -3104,7 +3106,8 @@ void asmTrimSlotsIfNotOwned(slotRangeArray *slots) {
     slotRangeArrayFree(trim_slots);
 }
 
-/* Handle the master task when it is no longer used, trim unowned slots if necessary. */
+/* Handle the master task when it is no longer used, trim unowned slots if necessary.
+ * This function is called when the replica is just promoted to master. */
 void asmFinalizeMasterTask(void) {
     if (!server.cluster_enabled) return;
 
@@ -3128,10 +3131,11 @@ void asmFinalizeMasterTask(void) {
             asmTrimSlotsIfNotOwned(task->slots);
         }
     } else if (task->operation == ASM_MIGRATE) {
-        /* For migrate tasks, attempt to trim slots if necessary. The previous master
-         * may not have initiated slot trimming before the failover occurred.
-         * And the ownership of the slots is not changed if migration is failed, so
-         * we don't need to trim the slots if it is failed. */
+        /* For migrate tasks, attempt to trim slots if necessary. After ASM completed,
+         * the previous master may not have initiated slot trimming before the failover
+         * occurred. In that case, we need to initiate slot trimming here.
+         * However, if ASM failed, slot ownership did not change, so no slot trimming
+         * is needed. */
         if (clusterNodeIsMaster(getMyClusterNode()) && task->state != ASM_FAILED) {
             asmTrimSlotsIfNotOwned(task->slots);
         }
@@ -3216,7 +3220,7 @@ int asmReplicaHandleMasterTask(sds task_info) {
 /* Cancel all pending trim jobs. */
 void asmCancelPendingTrimJobs(void) {
     if (!asmManager) return;
-    /* Cancel pending trim jobs */
+
     listIter li;
     listNode *ln;
     listRewind(asmManager->pending_trim_jobs, &li);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -139,6 +139,7 @@ static void asmSyncBufferReadFromConn(connection *conn);
 static void propagateTrimSlots(slotRangeArray *slots);
 void asmTrimJobSchedule(slotRangeArray *slots);
 void asmTrimJobProcessPending(void);
+void asmCancelPendingTrimJobs(void);
 void asmTriggerActiveTrim(slotRangeArray *slots);
 void asmActiveTrimEnd(void);
 int asmIsAnyTrimJobOverlaps(slotRangeArray *slots);
@@ -473,9 +474,6 @@ err:
 void asmNotifyReplicasStateChange(struct asmTask *task) {
     if (!server.cluster_enabled || !clusterNodeIsMaster(getMyClusterNode())) return;
 
-    /* Do not propagate migrate task to replicas, as replicas never migrate data. */
-    if (task->operation == ASM_MIGRATE) return;
-
     /* Create command arguments for CLUSTER SYNCSLOTS CONF ASM-TASK */
     robj *argv[5];
     argv[0] = createStringObject("CLUSTER", 7);
@@ -509,7 +507,6 @@ sds asmDumpActiveImportTask(void) {
     /* For master, dump the first active task. */
     if (!asmManager || listLength(asmManager->tasks) == 0) return NULL;
     asmTask *task = listNodeValue(listFirst(asmManager->tasks));
-    if (task->operation == ASM_MIGRATE) return NULL;
     if (task->state == ASM_NONE || task->state == ASM_FAILED ||
         task->state == ASM_COMPLETED) return NULL;
 
@@ -3021,17 +3018,9 @@ void asmTrimSlots(slotRangeArray *slots) {
 
 /* Schedule a trim job for the specified slot ranges. The job will be
  * deferred and handled later in asmBeforeSleep(). We delay the trim jobs to
- * asmBeforeSleep() to ensure it only runs when there is no write pause.
- * Attempting to process it during a write pause could trigger an assertion
- * in propagateNow(), as propagation is not allowed during a write pause. */
+ * asmBeforeSleep() to ensure it only runs when there is no write pause. */
 void asmTrimJobSchedule(slotRangeArray *slots) {
     listAddNodeTail(asmManager->pending_trim_jobs, slotRangeArrayDup(slots));
-
-    /* If we call this function from beforeSleep, or cluster gossip message
-     * handlers instead of normal command handlers, we can try to process the
-     * trim job immediately. */
-    if (server.execution_nesting == 0)
-        asmTrimJobProcessPending();
 }
 
 /* Process any pending trim jobs. */
@@ -3040,6 +3029,12 @@ void asmTrimJobProcessPending(void) {
     if (listLength(asmManager->pending_trim_jobs) == 0 ||
         asmManager->debug_trim_method == ASM_DEBUG_TRIM_NONE)
     {
+        return;
+    }
+
+    /* If this node is a replica, it should not initiate slot trimming actively. */
+    if (clusterNodeIsSlave(getMyClusterNode())) {
+        asmCancelPendingTrimJobs();
         return;
     }
 
@@ -3109,32 +3104,40 @@ void asmTrimSlotsIfNotOwned(slotRangeArray *slots) {
     slotRangeArrayFree(trim_slots);
 }
 
-/* Handle the master task when it is no longer used. And trim unowned
- * slots when the task is failed and this node is master. */
+/* Handle the master task when it is no longer used, trim unowned slots if necessary. */
 void asmFinalizeMasterTask(void) {
     if (!server.cluster_enabled) return;
 
     asmTask *task = asmManager->master_task;
     if (task == NULL) return;
-    serverAssert(task->operation == ASM_IMPORT);
 
-    sds slots_str = slotRangeArrayToString(task->slots);
-    serverLog(LL_WARNING, "Import task %s from old master failed: slots=%s",
-                           task->id, slots_str);
-    sdsfree(slots_str);
+    if (task->operation == ASM_IMPORT) {
+        /* Check if there is an ASM task that master did not finish. */
+        if (task->state != ASM_COMPLETED && task->state != ASM_FAILED) {
+            sds slots_str = slotRangeArrayToString(task->slots);
+            serverLog(LL_WARNING, "Import task %s from old master failed: slots=%s",
+                                task->id, slots_str);
+            sdsfree(slots_str);
+            /* Mark the task as failed and notify the replicas. */
+            task->state = ASM_FAILED;
+            asmNotifyStateChange(task, ASM_EVENT_IMPORT_FAILED);
+        }
 
-    /* Check if there is an ASM task that master did not finish. */
-    if (task->state != ASM_COMPLETED && task->state != ASM_FAILED) {
-        /* Mark the task as failed and notify the replicas. */
-        task->state = ASM_FAILED;
-        asmNotifyStateChange(task, ASM_EVENT_IMPORT_FAILED);
+        /* Trim the slots if the import task is failed. */
+        if (clusterNodeIsMaster(getMyClusterNode()) && task->state == ASM_FAILED) {
+            asmTrimSlotsIfNotOwned(task->slots);
+        }
+    } else if (task->operation == ASM_MIGRATE) {
+        /* For migrate tasks, attempt to trim slots if necessary. The previous master
+         * may not have initiated slot trimming before the failover occurred.
+         * And the ownership of the slots is not changed if migration is failed, so
+         * we don't need to trim the slots if it is failed. */
+        if (clusterNodeIsMaster(getMyClusterNode()) && task->state != ASM_FAILED) {
+            asmTrimSlotsIfNotOwned(task->slots);
+        }
     }
 
-    /* Trim the slots if the import task is failed. */
-    if (clusterNodeIsMaster(getMyClusterNode()) && task->state == ASM_FAILED)
-        asmTrimSlotsIfNotOwned(task->slots);
-
-    /* Clear the master task since it is not the master anymore. */
+    /* Clear the master task since it is not a replica anymore. */
     asmTaskFree(asmManager->master_task);
     asmManager->master_task = NULL;
 }
@@ -3142,6 +3145,13 @@ void asmFinalizeMasterTask(void) {
 /* The replicas handle the master import ASM task information. */
 int asmReplicaHandleMasterTask(sds task_info) {
     if (!server.cluster_enabled || !clusterNodeIsSlave(getMyClusterNode())) return C_ERR;
+
+    /* If the master task is migrating, just clear it when receiving a new task info,
+     * even the task info is empty since it means the master finished the task. */
+    if (asmManager->master_task && asmManager->master_task->operation == ASM_MIGRATE) {
+        asmTaskFree(asmManager->master_task);
+        asmManager->master_task = NULL;
+    }
 
     /* If the master task is empty, it means the master finished the task, the
      * replica should check the slot ownership to decide to raise completed or
@@ -3174,9 +3184,12 @@ int asmReplicaHandleMasterTask(sds task_info) {
 
     asmTask *task = asmTaskDeserialize(task_info);
     if (!task) return C_ERR;
-    if (task->operation != ASM_IMPORT) {
-        asmTaskFree(task);
-        return C_ERR;
+
+    /* For migrate task, replica just keeps the task info, doesn't notify any event. */
+    if (task->operation == ASM_MIGRATE) {
+        if (asmManager->master_task) asmTaskFree(asmManager->master_task);
+        asmManager->master_task = task;
+        return C_OK;
     }
 
     int notify_event = 0;
@@ -3200,6 +3213,23 @@ int asmReplicaHandleMasterTask(sds task_info) {
     return C_OK;
 }
 
+/* Cancel all pending trim jobs. */
+void asmCancelPendingTrimJobs(void) {
+    if (!asmManager) return;
+    /* Cancel pending trim jobs */
+    listIter li;
+    listNode *ln;
+    listRewind(asmManager->pending_trim_jobs, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        slotRangeArray *slots = listNodeValue(ln);
+        listDelNode(asmManager->pending_trim_jobs, ln);
+        sds str = slotRangeArrayToString(slots);
+        serverLog(LL_NOTICE, "Cancelling the pending trim job for slots: %s", str);
+        sdsfree(str);
+        slotRangeArrayFree(slots);
+    }
+}
+
 /* Cancel all pending and active trim jobs. */
 void asmCancelTrimJobs(void) {
     if (!asmManager) return;
@@ -3208,14 +3238,7 @@ void asmCancelTrimJobs(void) {
     asmUnblockMasterAfterTrim();
 
     /* Cancel pending trim jobs */
-    listIter li;
-    listNode *ln;
-    listRewind(asmManager->pending_trim_jobs, &li);
-    while ((ln = listNext(&li)) != NULL) {
-        slotRangeArray *slots = listNodeValue(ln);
-        listDelNode(asmManager->pending_trim_jobs, ln);
-        slotRangeArrayFree(slots);
-    }
+    asmCancelPendingTrimJobs();
 
     /* Cancel active trim jobs */
     if (listLength(asmManager->active_trim_jobs) == 0)

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -2568,7 +2568,8 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
             }
 
             # Verify the trim events on destination (partially imported keys are trimmed)
-            # NOTE: only slot 0 has data, so only slot 0 is trimmed
+            # NOTE: after failover, the new master will initiate the slot trimming,
+            # and only slot 0 has data, so only slot 0 is trimmed
             if {$trim_method eq "active"} {
                 set trim_event_log [list \
                     "sub: cluster-slot-migration-trim-started, slots:0-0" \

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -2600,7 +2600,7 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
         }
         }
     }
-    
+
     foreach with_rdb {"with" "without"} {
         test "Test cluster module notifications when replica restart $with_rdb RDB during importing" {
             clear_module_event_log
@@ -2780,8 +2780,7 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
             fail "Trim did not complete"
         }
 
-        # Verify the trim events on destination (partially imported keys are trimmed)
-        # NOTE: only slot 0 has data, so only slot 0 is trimmed
+        # verify the trim events, use active trim since module is subscribed to trimmed event
         set trim_event_log [list \
             "sub: cluster-slot-migration-trim-started, slots:0-0" \
             "keyspace: key_trimmed, key: $slot0_key" \

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -2571,13 +2571,13 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
             # NOTE: only slot 0 has data, so only slot 0 is trimmed
             if {$trim_method eq "active"} {
                 set trim_event_log [list \
-                    "sub: cluster-slot-migration-trim-started, slots:0-100" \
+                    "sub: cluster-slot-migration-trim-started, slots:0-0" \
                     "keyspace: key_trimmed, key: $key" \
-                    "sub: cluster-slot-migration-trim-completed, slots:0-100" \
+                    "sub: cluster-slot-migration-trim-completed, slots:0-0" \
                 ]
             } else {
                 set trim_event_log [list \
-                    "sub: cluster-slot-migration-trim-background, slots:0-100" \
+                    "sub: cluster-slot-migration-trim-background, slots:0-0" \
                 ]
             }
             wait_for_condition 500 20 {
@@ -2732,6 +2732,72 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
         assert_equal {} [R 4 asm.get_cluster_trim_event_log]
 
         R 0 CLUSTER MIGRATION IMPORT 0 100
+        wait_for_asm_done
+        clear_module_event_log
+        reset_default_trim_method
+        R 0 flushall
+        R 1 flushall
+    }
+
+    test "Test new master can trim slots when migration is completed and failover occurs on source side" {
+        R 0 asm.disable_trim ;# can not start slot trimming on source side
+        set slot0_key [slot_key 0 mykey]
+        R 0 set $slot0_key "value"
+
+        # migrate slot 0 from #0 to #1, and wait it completed, but not allow to trim slots
+        # on source node
+        set task_id [R 1 CLUSTER MIGRATION IMPORT 0 0]
+        wait_for_condition 1000 10 {
+            [string match {*completed*} [migration_status 0 $task_id state]] &&
+            [string match {*completed*} [migration_status 1 $task_id state]]
+        } else {
+            fail "ASM task did not complete"
+        }
+        # verify trim is not allowed on source node, and replica node doesn't have trim job either
+        wait_for_ofs_sync [Rn 0] [Rn 3]
+        assert_equal 1 [R 0 asm.trim_in_progress]
+        assert_equal "value" [R 0 asm.read_pending_trim_key $slot0_key]
+        assert_equal 0 [R 3 asm.trim_in_progress]
+        assert_equal "value" [R 3 asm.read_pending_trim_key $slot0_key]
+
+        set loglines [count_log_lines 0]
+
+        # failover happens on source node, instance #3 become slave, #0 become master
+        failover_and_wait_for_done 3
+        R 0 asm.enable_trim ;# enable trim on old master
+
+        # old master should cancel the pending trim job
+        wait_for_log_messages 0 {"*Cancelling the pending trim job*"} $loglines 1000 10
+
+        wait_for_ofs_sync [Rn 3] [Rn 0]
+        # verify trim is allowed on new master, and the key is trimmed
+        wait_for_condition 1000 10 {
+            [R 3 asm.trim_in_progress] == 0 &&
+            [R 3 asm.read_pending_trim_key $slot0_key] eq "" &&
+            [R 0 asm.trim_in_progress] == 0 &&
+            [R 0 asm.read_pending_trim_key $slot0_key] eq ""
+        } else {
+            fail "Trim did not complete"
+        }
+
+        # Verify the trim events on destination (partially imported keys are trimmed)
+        # NOTE: only slot 0 has data, so only slot 0 is trimmed
+        set trim_event_log [list \
+            "sub: cluster-slot-migration-trim-started, slots:0-0" \
+            "keyspace: key_trimmed, key: $slot0_key" \
+            "sub: cluster-slot-migration-trim-completed, slots:0-0" \
+        ]
+        wait_for_condition 500 20 {
+            [R 0 asm.get_cluster_trim_event_log] eq $trim_event_log &&
+            [R 3 asm.get_cluster_trim_event_log] eq $trim_event_log &&
+            [R 6 asm.get_cluster_trim_event_log] eq $trim_event_log
+        } else {
+            fail "ASM destination trim event not received"
+        }
+
+        # cleanup
+        failover_and_wait_for_done 0
+        R 0 CLUSTER MIGRATION IMPORT 0 0
         wait_for_asm_done
         clear_module_event_log
         reset_default_trim_method


### PR DESCRIPTION
- Allow replicas to track master's migrate task state
  Previously, we only propagate import task info to replicas, but now we also support propagating migrate task info, so the new master can initiate slots trimming again if needed after failover, this can avoid data redundancy.

- Prevent replicas from initiating slot trimming actively
   Lack of data cleaning mechanism on source side, so we allow replicas to continue pending slot trimming, but it is not good idea to let replicas trim actively. As we introduce above feature, we can delete this logic