### PR TITLE
Fix flaky stream LRM test due to timing precision

### DIFF
--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -648,7 +648,11 @@ start_server {tags {"maxmemory" "external:skip"}} {
         r xgroup create mystream mygroup 0
         after 2000
         r xreadgroup GROUP mygroup consumer1 STREAMS mystream >
-        assert_lessthan [r object idletime mystream] 1
+
+        # OBJECT IDLETIME = estimateObjectIdleTime(kv) / 1000 (converts ms to seconds)
+        # If 1000-1999ms elapsed between LRM update and this check, it returns 1 second.
+        # Using <= allows for this timing variance while still verifying LRM was updated.
+        assert_lessthan_equal [r object idletime mystream] 1
     } {} {slow}
 
     test {LRM: Keys with only read operations should be removed first} {

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -649,9 +649,7 @@ start_server {tags {"maxmemory" "external:skip"}} {
         after 2000
         r xreadgroup GROUP mygroup consumer1 STREAMS mystream >
 
-        # OBJECT IDLETIME = estimateObjectIdleTime(kv) / 1000 (converts ms to seconds)
-        # If 1000-1999ms elapsed between LRM update and this check, it returns 1 second.
-        # Using <= allows for this timing variance while still verifying LRM was updated.
+        # LRM should be updated (idletime should be smaller)
         assert_lessthan_equal [r object idletime mystream] 1
     } {} {slow}
 


### PR DESCRIPTION
## Problem

The test `LRM: XREADGROUP updates stream LRM` occasionally fails in CI environments with the error: 
> *** [err]: LRM: XREADGROUP updates stream LRM in tests/unit/maxmemory.tcl
Expected '1' to be less than '1' (context: type eval line 7 cmd {assert_lessthan [r object idletime mystream] 1} proc ::test)

Failed Action Example:  https://github.com/redis/redis/actions/runs/20800757934/job/59744936583
<img width="2674" height="722" alt="CleanShot 2026-01-08 at 19 23 48@2x" src="https://github.com/user-attachments/assets/94201151-f9f0-45b2-9f69-69a504f8a16d" />



## Root Cause

`ROBJECT IDLETIME`  returns seconds (via `estimateObjectIdleTime(kv) / 1000`). 
If more than 1000ms elapses between the `XREADGROUP` command (which resets the LRM) and the assert check, the command returns 1 instead of 0. In slow CI environments, this 1-second delay is common. 

Failure Logic Timeline

```
test {LRM: XREADGROUP updates stream LRM} {
        r flushdb
        r xadd mystream * field value
        r xgroup create mystream mygroup 0
        after 2000
        r xreadgroup GROUP mygroup consumer1 STREAMS mystream >
        assert_lessthan [r object idletime mystream] 1
    } {} {slow}
```

```
T0:         XADD mystream (LRM = T0)
T0+2000ms:  after 2000 completes (Idle time is now 2s)
T0+2500ms:  XREADGROUP updates LRM = T0+2500ms (Reset happens)

            # System Latency: In slow CI or high-load environments, 
            # there is a delay between command execution and the next check.
            
T0+3500ms:  OBJECT IDLETIME = (3500-2500)/1000 = 1 second
            ASSERT [1 < 1] fails.
```

## Solution

Use assert_lessthan_equal instead of assert_lessthan to allow for timing variance while still validating LRM was updated (not 2+ seconds).

