### PR TITLE
Enable hardware clock by default on ARM AArch64.

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,12 +890,6 @@ To build with support for the processor's internal instruction clock on other ar
 make CFLAGS="-DUSE_PROCESSOR_CLOCK"
 ```
 
-To explicitly disable use of the hardware clock (including on ARM aarch64 systems), build with:
-
-```sh
-make CFLAGS="-DDISABLE_PROCESSOR_CLOCK"
-```
-
 ### Verbose build
 
 Redis will build with a user-friendly colorized output by default.

--- a/README.md
+++ b/README.md
@@ -882,10 +882,18 @@ make MALLOC=jemalloc
 
 By default, Redis will build using the POSIX clock_gettime function as the monotonic clock source. On most modern systems, the internal processor clock can be used to improve performance. Cautions can be found here: http://oliveryang.net/2015/09/pitfalls-of-TSC-usage/
 
-To build with support for the processor's internal instruction clock, use:
+On ARM aarch64 systems, the hardware clock is enabled by default because the ARM Generic Timer is architecturally guaranteed to be available and monotonic on all ARMv8-A processors (see the *“The Generic Timer in AArch64 state”* section of the *Arm Architecture Reference Manual for Armv8-A*).
+
+To build with support for the processor's internal instruction clock on other architectures, use:
 
 ```sh
 make CFLAGS="-DUSE_PROCESSOR_CLOCK"
+```
+
+To explicitly disable use of the hardware clock (including on ARM aarch64 systems), build with:
+
+```sh
+make CFLAGS="-DDISABLE_PROCESSOR_CLOCK"
 ```
 
 ### Verbose build

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -92,18 +92,55 @@ static void monotonicInit_x86linux(void) {
 }
 #endif
 
+/* Enable hardware clock by default on ARM AArch64.
+ *
+ * This is safe because:
+ *
+ * 1. Architectural guarantee:
+ *    Per the Arm Architecture Reference Manual for Armv8-A,
+ *    the ARM Generic Timer is mandatory for all implementations
+ *    that support the AArch64 execution state. This includes the
+ *    system counter and the CNTVCT_EL0 and CNTFRQ_EL0 registers
+ *    (see "The Generic Timer in AArch64 state").
+ *
+ * 2. Runtime validation:
+ *    If cntfrq_hz() returns 0, a warning is printed and hardware
+ *    clock initialization is skipped (see monotonicInit_aarch64).
+ *
+ * 3. Automatic fallback:
+ *    If hardware clock initialization fails, monotonicInit()
+ *    falls back to POSIX clock_gettime() (see line 224).
+ *
+ * Using the hardware counter instead of gettimeofday() for command
+ * latency measurement provides a significant performance improvement
+ * on ARM AArch64 systems.
+ *
+ * To disable the hardware clock on ARM and force use of the POSIX clock,
+ * build with:
+ *   CFLAGS="-DDISABLE_PROCESSOR_CLOCK"
+ */
+#if defined(__aarch64__) && !defined(DISABLE_PROCESSOR_CLOCK)
+#define USE_AARCH64_PROCESSOR_CLOCK 1
+#else
+#define USE_AARCH64_PROCESSOR_CLOCK 0
+#endif
 
-#if defined(USE_PROCESSOR_CLOCK) && defined(__aarch64__)
+#if USE_AARCH64_PROCESSOR_CLOCK
 static long mono_ticksPerMicrosecond = 0;
 
-/* Read the clock value.  */
+/* Read the clock value.
+ * CNTVCT_EL0 is a system counter register, that provides the monotonic
+ * timestamp as a 64-bit count value. */
 static inline uint64_t __cntvct(void) {
     uint64_t virtual_timer_value;
     __asm__ volatile("mrs %0, cntvct_el0" : "=r"(virtual_timer_value));
     return virtual_timer_value;
 }
 
-/* Read the Count-timer Frequency.  */
+/* Read the Count-timer Frequency.
+ * CNTFRQ_EL0 is a system counter register that provides the frequency (in Hz)
+ * needed to convert ticks to microseconds. Together with CNTVCT_EL0, this enables
+ * high-performance monotonic time measurement without system calls. */
 static inline uint32_t cntfrq_hz(void) {
     uint64_t virtual_freq_value;
     __asm__ volatile("mrs %0, cntfrq_el0" : "=r"(virtual_freq_value));
@@ -213,7 +250,7 @@ const char * monotonicInit(void) {
     if (getMonotonicUs == NULL) monotonicInit_x86linux();
     #endif
 
-    #if defined(USE_PROCESSOR_CLOCK) && defined(__aarch64__)
+    #if USE_AARCH64_PROCESSOR_CLOCK
     if (getMonotonicUs == NULL) monotonicInit_aarch64();
     #endif
 

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -18,7 +18,13 @@ static char monotonic_info_string[32];
  * generally safe on modern systems, this link provides additional information
  * about use of the x86 TSC: http://oliveryang.net/2015/09/pitfalls-of-TSC-usage
  *
- * To use the processor clock, either uncomment this line, or build with
+ * On ARM aarch64 systems, the hardware clock is enabled by default because the
+ * ARM Generic Timer is architecturally guaranteed to be available and monotonic
+ * on all ARMv8-A processors (see the “The Generic Timer in AArch64 state”
+ * section of the Arm Architecture Reference Manual for Armv8-A).
+ *
+ * To use the processor clock on other architectures, either uncomment this line,
+ * or build with
  *   CFLAGS="-DUSE_PROCESSOR_CLOCK"
 #define USE_PROCESSOR_CLOCK
  */
@@ -92,40 +98,7 @@ static void monotonicInit_x86linux(void) {
 }
 #endif
 
-/* Enable hardware clock by default on ARM AArch64.
- *
- * This is safe because:
- *
- * 1. Architectural guarantee:
- *    Per the Arm Architecture Reference Manual for Armv8-A,
- *    the ARM Generic Timer is mandatory for all implementations
- *    that support the AArch64 execution state. This includes the
- *    system counter and the CNTVCT_EL0 and CNTFRQ_EL0 registers
- *    (see "The Generic Timer in AArch64 state").
- *
- * 2. Runtime validation:
- *    If cntfrq_hz() returns 0, a warning is printed and hardware
- *    clock initialization is skipped (see monotonicInit_aarch64).
- *
- * 3. Automatic fallback:
- *    If hardware clock initialization fails, monotonicInit()
- *    falls back to POSIX clock_gettime() (see line 224).
- *
- * Using the hardware counter instead of gettimeofday() for command
- * latency measurement provides a significant performance improvement
- * on ARM AArch64 systems.
- *
- * To disable the hardware clock on ARM and force use of the POSIX clock,
- * build with:
- *   CFLAGS="-DDISABLE_PROCESSOR_CLOCK"
- */
-#if defined(__aarch64__) && !defined(DISABLE_PROCESSOR_CLOCK)
-#define USE_AARCH64_PROCESSOR_CLOCK 1
-#else
-#define USE_AARCH64_PROCESSOR_CLOCK 0
-#endif
-
-#if USE_AARCH64_PROCESSOR_CLOCK
+#if defined(__aarch64__)
 static long mono_ticksPerMicrosecond = 0;
 
 /* Read the clock value.
@@ -250,7 +223,7 @@ const char * monotonicInit(void) {
     if (getMonotonicUs == NULL) monotonicInit_x86linux();
     #endif
 
-    #if USE_AARCH64_PROCESSOR_CLOCK
+    #if defined(__aarch64__)
     if (getMonotonicUs == NULL) monotonicInit_aarch64();
     #endif
 


### PR DESCRIPTION
Redis can already use a processor-provided hardware counter as a high-performance monotonic clock. On some architectures this must be enabled carefully, but on ARM AArch64 the situation is different:

- The ARM Generic Timer is architecturally mandatory for all processors that implement the AArch64 execution state.
- The system counter (`CNTVCT_EL0`) and its frequency (`CNTFRQ_EL0`) are guaranteed to exist and provide a monotonic time source (per the *“The Generic Timer in AArch64 state”* section of the *Arm® Architecture Reference Manual for Armv8-A* — https://developer.arm.com/documentation/ddi0487/latest).

Because of this architectural guarantee, it is safe to enable the hardware clock by default on ARM AArch64.
Like detailed bellow, this gives us around 5% boost on io-thread deployments for a simple strings benchmark.


### Performance results (ARM AArch64)

In the following measurements, all performance numbers were obtained on an **AWS m8g.metal** (ARM AArch64) server.  
The database was pre-populated with **1 million keys**, each holding a **1024-byte value**.  
Benchmarks were executed using a **memtier workload with an 90/10 GET/SET ratio**, pipeline 10. Full benchmark spec in [link](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-setget200c-1KiB-pipeline-10.yml). 

|        Environment         |Baseline /redis unstable (median obs. +- std.dev)|Comparison filipecosta90/redis c830780bc78ef3e488b26e2bc07660d8c08d3b3f (median obs. +- std.dev)|% change (higher-better)|   Note    |
|----------------------------|-------------------------------------------------|------------------------------------------------------------------------------------------------|------------------------|-----------|
|oss-standalone              | 803413 +- 0.2% (7 datapoints)                   |                                                                                          806765|0.4%                    |No Change  |
|oss-standalone-02-io-threads| 982698 +- 0.6% (7 datapoints)                   | 975580 +- 1.0% (2 datapoints)                                                                  |-0.7%                   |No Change  |
|oss-standalone-04-io-threads| 2573244 +- 0.6% (7 datapoints)                  | 2677330 +- 0.8% (2 datapoints)                                                                 |4.0%                    |IMPROVEMENT|
|oss-standalone-08-io-threads| 2348787 +- 0.4% (7 datapoints)                  | 2467005 +- 1.7% (2 datapoints)                                                                 |5.0%                    |IMPROVEMENT|
