### PR TITLE
feat: Add module api to retrieve cmd flags

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1366,6 +1366,23 @@ RedisModuleCommand *moduleCreateCommandProxy(struct RedisModule *module, sds dec
     return cp;
 }
 
+/* Retrieve the flags of a command.
+ *
+ * Returns REDISMODULE_OK on success, storing the command flags into the `flags` pointer.
+ * Returns REDISMODULE_ERR if the command is not exists.
+ *
+ * The flags value is a bitmask of CMD_* flags defined in server.h
+ */
+int RM_GetCommandFlags(const char *name, uint64_t *flags) {
+    struct redisCommand *cmd = lookupCommandByCString(name);
+
+    if (!cmd)
+        return REDISMODULE_ERR;
+
+    *flags = cmd->flags;
+    return REDISMODULE_OK;
+}
+
 /* Get an opaque structure, representing a module command, by command name.
  * This structure is used in some of the command-related APIs.
  *
@@ -14904,6 +14921,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(TryRealloc);
     REGISTER_API(Free);
     REGISTER_API(Strdup);
+    REGISTER_API(GetCommandFlags);
     REGISTER_API(CreateCommand);
     REGISTER_API(GetCommand);
     REGISTER_API(CreateSubcommand);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -137,6 +137,38 @@ typedef long long ustime_t;
 #define REDISMODULE_CONFIG_BITFLAGS (1ULL<<8) /* Indicates if this value can be set as a multiple enum values */
 #define REDISMODULE_CONFIG_UNPREFIXED (1ULL<<9) /* Provided configuration name won't be prefixed with the module name */
 
+/* Command flags. */
+#define CMD_WRITE (1ULL<<0)
+#define CMD_READONLY (1ULL<<1)
+#define CMD_DENYOOM (1ULL<<2)
+#define CMD_MODULE (1ULL<<3)           /* Command exported by module. */
+#define CMD_ADMIN (1ULL<<4)
+#define CMD_PUBSUB (1ULL<<5)
+#define CMD_NOSCRIPT (1ULL<<6)
+#define CMD_BLOCKING (1ULL<<8)       /* Has potential to block. */
+#define CMD_LOADING (1ULL<<9)
+#define CMD_STALE (1ULL<<10)
+#define CMD_SKIP_MONITOR (1ULL<<11)
+#define CMD_SKIP_SLOWLOG (1ULL<<12)
+#define CMD_ASKING (1ULL<<13)
+#define CMD_FAST (1ULL<<14)
+#define CMD_NO_AUTH (1ULL<<15)
+#define CMD_MAY_REPLICATE (1ULL<<16)
+#define CMD_SENTINEL (1ULL<<17)
+#define CMD_ONLY_SENTINEL (1ULL<<18)
+#define CMD_NO_MANDATORY_KEYS (1ULL<<19)
+#define CMD_PROTECTED (1ULL<<20)
+#define CMD_MODULE_GETKEYS (1ULL<<21)  /* Use the modules getkeys interface. */
+#define CMD_MODULE_NO_CLUSTER (1ULL<<22) /* Deny on Redis Cluster. */
+#define CMD_NO_ASYNC_LOADING (1ULL<<23)
+#define CMD_NO_MULTI (1ULL<<24)
+#define CMD_MOVABLE_KEYS (1ULL<<25) /* The legacy range spec doesn't cover all keys.
+                                     * Populated by populateCommandLegacyRangeSpec. */
+#define CMD_ALLOW_BUSY ((1ULL<<26))
+#define CMD_MODULE_GETCHANNELS (1ULL<<27)  /* Use the modules getchannels interface. */
+#define CMD_TOUCHES_ARBITRARY_KEYS (1ULL<<28)
+#define CMD_INTERNAL (1ULL<<29) /* Internal command. */
+
 /* StreamID type. */
 typedef struct RedisModuleStreamID {
     uint64_t ms;
@@ -1051,6 +1083,7 @@ REDISMODULE_API char * (*RedisModule_Strdup)(const char *str) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetApi)(const char *, void *) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CreateCommand)(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleCommand *(*RedisModule_GetCommand)(RedisModuleCtx *ctx, const char *name) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_GetCommandFlags)(const char *name, uint64_t *flags) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CreateSubcommand)(RedisModuleCommand *parent, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandInfo)(RedisModuleCommand *command, const RedisModuleCommandInfo *info) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandACLCategories)(RedisModuleCommand *command, const char *ctgrsflags) REDISMODULE_ATTR;
@@ -1445,6 +1478,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(TryRealloc);
     REDISMODULE_GET_API(Strdup);
     REDISMODULE_GET_API(CreateCommand);
+    REDISMODULE_GET_API(GetCommandFlags);
     REDISMODULE_GET_API(GetCommand);
     REDISMODULE_GET_API(CreateSubcommand);
     REDISMODULE_GET_API(SetCommandInfo);


### PR DESCRIPTION
Add a new module API RedisModule_GetCommandFlags that allows modules to retrieve the flags of any Redis command by name.

Previously, Redis modules had no way to introspect command flags (such as write, readonly, fast, admin, etc.) at runtime. This capability is useful for modules that need to:
  - Implement command routing or filtering based on command properties
  - Make decisions about command execution based on flags

Changes:
  - Added RedisModule_GetCommandFlags(const char *name, uint64_t *flags) API function
  - Returns REDISMODULE_OK on success, storing the command flags bitmask into the flags pointer
  - Returns REDISMODULE_ERR if the command does not exist
