### PR TITLE
Propagate migrate task info to replicas

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -907,7 +907,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-13, macos-15]
+        os: [macos-14, macos-26]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
@@ -934,7 +934,7 @@ jobs:
       run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
 
   test-freebsd:
-    runs-on: macos-13
+    runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'freebsd')
@@ -953,7 +953,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: test
-      uses: cross-platform-actions/action@v0.22.0
+      uses: cross-platform-actions/action@v0.30.0
       with:
         operating_system: freebsd
         environment_variables: MAKE

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -139,6 +139,7 @@ static void asmSyncBufferReadFromConn(connection *conn);
 static void propagateTrimSlots(slotRangeArray *slots);
 void asmTrimJobSchedule(slotRangeArray *slots);
 void asmTrimJobProcessPending(void);
+void asmCancelPendingTrimJobs(void);
 void asmTriggerActiveTrim(slotRangeArray *slots);
 void asmActiveTrimEnd(void);
 int asmIsAnyTrimJobOverlaps(slotRangeArray *slots);
@@ -473,9 +474,6 @@ err:
 void asmNotifyReplicasStateChange(struct asmTask *task) {
     if (!server.cluster_enabled || !clusterNodeIsMaster(getMyClusterNode())) return;
 
-    /* Do not propagate migrate task to replicas, as replicas never migrate data. */
-    if (task->operation == ASM_MIGRATE) return;
-
     /* Create command arguments for CLUSTER SYNCSLOTS CONF ASM-TASK */
     robj *argv[5];
     argv[0] = createStringObject("CLUSTER", 7);
@@ -509,7 +507,6 @@ sds asmDumpActiveImportTask(void) {
     /* For master, dump the first active task. */
     if (!asmManager || listLength(asmManager->tasks) == 0) return NULL;
     asmTask *task = listNodeValue(listFirst(asmManager->tasks));
-    if (task->operation == ASM_MIGRATE) return NULL;
     if (task->state == ASM_NONE || task->state == ASM_FAILED ||
         task->state == ASM_COMPLETED) return NULL;
 
@@ -3021,17 +3018,9 @@ void asmTrimSlots(slotRangeArray *slots) {
 
 /* Schedule a trim job for the specified slot ranges. The job will be
  * deferred and handled later in asmBeforeSleep(). We delay the trim jobs to
- * asmBeforeSleep() to ensure it only runs when there is no write pause.
- * Attempting to process it during a write pause could trigger an assertion
- * in propagateNow(), as propagation is not allowed during a write pause. */
+ * asmBeforeSleep() to ensure it only runs when there is no write pause. */
 void asmTrimJobSchedule(slotRangeArray *slots) {
     listAddNodeTail(asmManager->pending_trim_jobs, slotRangeArrayDup(slots));
-
-    /* If we call this function from beforeSleep, or cluster gossip message
-     * handlers instead of normal command handlers, we can try to process the
-     * trim job immediately. */
-    if (server.execution_nesting == 0)
-        asmTrimJobProcessPending();
 }
 
 /* Process any pending trim jobs. */
@@ -3040,6 +3029,14 @@ void asmTrimJobProcessPending(void) {
     if (listLength(asmManager->pending_trim_jobs) == 0 ||
         asmManager->debug_trim_method == ASM_DEBUG_TRIM_NONE)
     {
+        return;
+    }
+
+    /* If this node is a replica, it should not initiate slot trimming actively.
+     * Cancel the trim job and unblock the master if it is blocked. */
+    if (clusterNodeIsSlave(getMyClusterNode())) {
+        asmCancelPendingTrimJobs();
+        asmUnblockMasterAfterTrim();
         return;
     }
 
@@ -3109,32 +3106,42 @@ void asmTrimSlotsIfNotOwned(slotRangeArray *slots) {
     slotRangeArrayFree(trim_slots);
 }
 
-/* Handle the master task when it is no longer used. And trim unowned
- * slots when the task is failed and this node is master. */
+/* Handle the master task when it is no longer used, trim unowned slots if necessary.
+ * This function is called when the replica is just promoted to master. */
 void asmFinalizeMasterTask(void) {
     if (!server.cluster_enabled) return;
 
     asmTask *task = asmManager->master_task;
     if (task == NULL) return;
-    serverAssert(task->operation == ASM_IMPORT);
 
-    sds slots_str = slotRangeArrayToString(task->slots);
-    serverLog(LL_WARNING, "Import task %s from old master failed: slots=%s",
-                           task->id, slots_str);
-    sdsfree(slots_str);
+    if (task->operation == ASM_IMPORT) {
+        /* Check if there is an ASM task that master did not finish. */
+        if (task->state != ASM_COMPLETED && task->state != ASM_FAILED) {
+            sds slots_str = slotRangeArrayToString(task->slots);
+            serverLog(LL_WARNING, "Import task %s from old master failed: slots=%s",
+                                task->id, slots_str);
+            sdsfree(slots_str);
+            /* Mark the task as failed and notify the replicas. */
+            task->state = ASM_FAILED;
+            asmNotifyStateChange(task, ASM_EVENT_IMPORT_FAILED);
+        }
 
-    /* Check if there is an ASM task that master did not finish. */
-    if (task->state != ASM_COMPLETED && task->state != ASM_FAILED) {
-        /* Mark the task as failed and notify the replicas. */
-        task->state = ASM_FAILED;
-        asmNotifyStateChange(task, ASM_EVENT_IMPORT_FAILED);
+        /* Trim the slots if the import task is failed. */
+        if (clusterNodeIsMaster(getMyClusterNode()) && task->state == ASM_FAILED) {
+            asmTrimSlotsIfNotOwned(task->slots);
+        }
+    } else if (task->operation == ASM_MIGRATE) {
+        /* For migrate tasks, attempt to trim slots if necessary. After ASM completed,
+         * the previous master may not have initiated slot trimming before the failover
+         * occurred. In that case, we need to initiate slot trimming here.
+         * However, if ASM failed, slot ownership did not change, so no slot trimming
+         * is needed. */
+        if (clusterNodeIsMaster(getMyClusterNode()) && task->state != ASM_FAILED) {
+            asmTrimSlotsIfNotOwned(task->slots);
+        }
     }
 
-    /* Trim the slots if the import task is failed. */
-    if (clusterNodeIsMaster(getMyClusterNode()) && task->state == ASM_FAILED)
-        asmTrimSlotsIfNotOwned(task->slots);
-
-    /* Clear the master task since it is not the master anymore. */
+    /* Clear the master task since it is not a replica anymore. */
     asmTaskFree(asmManager->master_task);
     asmManager->master_task = NULL;
 }
@@ -3142,6 +3149,13 @@ void asmFinalizeMasterTask(void) {
 /* The replicas handle the master import ASM task information. */
 int asmReplicaHandleMasterTask(sds task_info) {
     if (!server.cluster_enabled || !clusterNodeIsSlave(getMyClusterNode())) return C_ERR;
+
+    /* If the master task is migrating, just clear it when receiving a new task info,
+     * even the task info is empty since it means the master finished the task. */
+    if (asmManager->master_task && asmManager->master_task->operation == ASM_MIGRATE) {
+        asmTaskFree(asmManager->master_task);
+        asmManager->master_task = NULL;
+    }
 
     /* If the master task is empty, it means the master finished the task, the
      * replica should check the slot ownership to decide to raise completed or
@@ -3174,9 +3188,12 @@ int asmReplicaHandleMasterTask(sds task_info) {
 
     asmTask *task = asmTaskDeserialize(task_info);
     if (!task) return C_ERR;
-    if (task->operation != ASM_IMPORT) {
-        asmTaskFree(task);
-        return C_ERR;
+
+    /* For migrate task, replica just keeps the task info, doesn't notify any event. */
+    if (task->operation == ASM_MIGRATE) {
+        if (asmManager->master_task) asmTaskFree(asmManager->master_task);
+        asmManager->master_task = task;
+        return C_OK;
     }
 
     int notify_event = 0;
@@ -3200,6 +3217,23 @@ int asmReplicaHandleMasterTask(sds task_info) {
     return C_OK;
 }
 
+/* Cancel all pending trim jobs. */
+void asmCancelPendingTrimJobs(void) {
+    if (!asmManager) return;
+
+    listIter li;
+    listNode *ln;
+    listRewind(asmManager->pending_trim_jobs, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        slotRangeArray *slots = listNodeValue(ln);
+        listDelNode(asmManager->pending_trim_jobs, ln);
+        sds str = slotRangeArrayToString(slots);
+        serverLog(LL_NOTICE, "Cancelling the pending trim job for slots: %s", str);
+        sdsfree(str);
+        slotRangeArrayFree(slots);
+    }
+}
+
 /* Cancel all pending and active trim jobs. */
 void asmCancelTrimJobs(void) {
     if (!asmManager) return;
@@ -3208,14 +3242,7 @@ void asmCancelTrimJobs(void) {
     asmUnblockMasterAfterTrim();
 
     /* Cancel pending trim jobs */
-    listIter li;
-    listNode *ln;
-    listRewind(asmManager->pending_trim_jobs, &li);
-    while ((ln = listNext(&li)) != NULL) {
-        slotRangeArray *slots = listNodeValue(ln);
-        listDelNode(asmManager->pending_trim_jobs, ln);
-        slotRangeArrayFree(slots);
-    }
+    asmCancelPendingTrimJobs();
 
     /* Cancel active trim jobs */
     if (listLength(asmManager->active_trim_jobs) == 0)

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -2557,16 +2557,17 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
             }
 
             # Verify the trim events on destination (partially imported keys are trimmed)
-            # NOTE: only slot 0 has data, so only slot 0 is trimmed
+            # NOTE: after failover, the new master will initiate the slot trimming,
+            # and only slot 0 has data, so only slot 0 is trimmed
             if {$trim_method eq "active"} {
                 set trim_event_log [list \
-                    "sub: cluster-slot-migration-trim-started, slots:0-100" \
+                    "sub: cluster-slot-migration-trim-started, slots:0-0" \
                     "keyspace: key_trimmed, key: $key" \
-                    "sub: cluster-slot-migration-trim-completed, slots:0-100" \
+                    "sub: cluster-slot-migration-trim-completed, slots:0-0" \
                 ]
             } else {
                 set trim_event_log [list \
-                    "sub: cluster-slot-migration-trim-background, slots:0-100" \
+                    "sub: cluster-slot-migration-trim-background, slots:0-0" \
                 ]
             }
             wait_for_condition 500 20 {
@@ -2589,7 +2590,7 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
         }
         }
     }
-    
+
     foreach with_rdb {"with" "without"} {
         test "Test cluster module notifications when replica restart $with_rdb RDB during importing" {
             clear_module_event_log
@@ -2721,6 +2722,71 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
         assert_equal {} [R 4 asm.get_cluster_trim_event_log]
 
         R 0 CLUSTER MIGRATION IMPORT 0 100
+        wait_for_asm_done
+        clear_module_event_log
+        reset_default_trim_method
+        R 0 flushall
+        R 1 flushall
+    }
+
+    test "Test new master can trim slots when migration is completed and failover occurs on source side" {
+        R 0 asm.disable_trim ;# can not start slot trimming on source side
+        set slot0_key [slot_key 0 mykey]
+        R 0 set $slot0_key "value"
+
+        # migrate slot 0 from #0 to #1, and wait it completed, but not allow to trim slots
+        # on source node
+        set task_id [R 1 CLUSTER MIGRATION IMPORT 0 0]
+        wait_for_condition 1000 10 {
+            [string match {*completed*} [migration_status 0 $task_id state]] &&
+            [string match {*completed*} [migration_status 1 $task_id state]]
+        } else {
+            fail "ASM task did not complete"
+        }
+        # verify trim is not allowed on source node, and replica node doesn't have trim job either
+        wait_for_ofs_sync [Rn 0] [Rn 3]
+        assert_equal 1 [R 0 asm.trim_in_progress]
+        assert_equal "value" [R 0 asm.read_pending_trim_key $slot0_key]
+        assert_equal 0 [R 3 asm.trim_in_progress]
+        assert_equal "value" [R 3 asm.read_pending_trim_key $slot0_key]
+
+        set loglines [count_log_lines 0]
+
+        # failover happens on source node, instance #3 become slave, #0 become master
+        failover_and_wait_for_done 3
+        R 0 asm.enable_trim ;# enable trim on old master
+
+        # old master should cancel the pending trim job
+        wait_for_log_messages 0 {"*Cancelling the pending trim job*"} $loglines 1000 10
+
+        wait_for_ofs_sync [Rn 3] [Rn 0]
+        # verify trim is allowed on new master, and the key is trimmed
+        wait_for_condition 1000 10 {
+            [R 3 asm.trim_in_progress] == 0 &&
+            [R 3 asm.read_pending_trim_key $slot0_key] eq "" &&
+            [R 0 asm.trim_in_progress] == 0 &&
+            [R 0 asm.read_pending_trim_key $slot0_key] eq ""
+        } else {
+            fail "Trim did not complete"
+        }
+
+        # verify the trim events, use active trim since module is subscribed to trimmed event
+        set trim_event_log [list \
+            "sub: cluster-slot-migration-trim-started, slots:0-0" \
+            "keyspace: key_trimmed, key: $slot0_key" \
+            "sub: cluster-slot-migration-trim-completed, slots:0-0" \
+        ]
+        wait_for_condition 500 20 {
+            [R 0 asm.get_cluster_trim_event_log] eq $trim_event_log &&
+            [R 3 asm.get_cluster_trim_event_log] eq $trim_event_log &&
+            [R 6 asm.get_cluster_trim_event_log] eq $trim_event_log
+        } else {
+            fail "ASM destination trim event not received"
+        }
+
+        # cleanup
+        failover_and_wait_for_done 0
+        R 0 CLUSTER MIGRATION IMPORT 0 0
         wait_for_asm_done
         clear_module_event_log
         reset_default_trim_method

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -577,7 +577,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             # Start the slot 0 write load on the R 0
             set port [get_port 0]
             set key [slot_key 0 mykey]
-            set load_handle0 [start_write_load "127.0.0.1" $port 100 $key]
+            set load_handle0 [start_write_load "127.0.0.1" $port 100 $key 0 5]
         }
 
         # Start write traffic on node-1
@@ -586,7 +586,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             # Start the slot 6000 write load on the R 1
             set port [get_port 1]
             set key [slot_key 6000 mykey]
-            set load_handle1 [start_write_load "127.0.0.1" $port 100 $key]
+            set load_handle1 [start_write_load "127.0.0.1" $port 100 $key 0 5]
         }
 
         # Migrate keys
@@ -2329,6 +2329,9 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
         } else {
             fail "migrate failed"
         }
+
+        # Wait for config propagation before checking the slot ownership on replica
+        wait_for_cluster_propagation
 
         # Verify slots that are being trimmed are not local
         assert_equal 0 [R 0 asm.cluster_can_access_keys_in_slot 0]

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1391,11 +1391,8 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # start migration from #0 to #1
         set task_id [setup_slot_migration_with_delay 0 1 0 100]
 
-        # Create some traffic on slot 0, so the destination node will enter streaming buffer state
+        # Create 200 keys of 16k size traffic on slot 0, streaming buffer need 10s (200*50ms)
         populate_slot 200 -idx 0 -slot 0 -size 16384
-
-        # Start the slot 0 write load on the R 0
-        set load_handle [start_write_load "127.0.0.1" [get_port 0] 100 [slot_key 0 mykey] 500]
 
         # wait for streaming buffer state, then pause the destination node
         wait_for_condition 1000 20 {
@@ -1404,6 +1401,9 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             fail "ASM task did not stream buffer, state: [migration_status 1 $task_id state]"
         }
         pause_process $r1_pid
+
+        # Start the slot 0 write load on the R 0
+        set load_handle [start_write_load "127.0.0.1" [get_port 0] 100 [slot_key 0 mykey] 500]
 
         # the source node will fail after several seconds (including the time
         # to fill the socket buffer of source node), the main channel can not

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -177,6 +177,7 @@ start_cluster 2 2 [list tags {external:skip cluster modules} config_lines $modul
         $master2 set count_dels_{4oi} 1
         $master2 del count_dels_{4oi}
         assert_equal 1 [$master2 keyspace.get_dels]
+        wait_for_ofs_sync $master2 $replica2
         assert_equal 1 [$replica2 keyspace.get_dels]
         $master2 set count_dels_{4oi} 1
 


### PR DESCRIPTION
- Allow replicas to track master's migrate task state Previously, we only propagate import task info to replicas, but now we also support propagating migrate task info, so the new master can initiate slots trimming again if needed after failover, this can avoid data redundancy.

- Prevent replicas from initiating slot trimming actively Lack of data cleaning mechanism on source side, so we allow replicas to continue pending slot trimming, but it is not good idea to let replicas trim actively. As we introduce above feature, we can delete this logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances ASM coordination across failover and enforces trim ownership on masters.
> 
> - Replicate migrate task info: send `CLUSTER SYNCSLOTS CONF ASM-TASK` for migrate tasks; replicas deserialize, keep/clear `master_task`, and avoid emitting events; `asmDumpActiveImportTask`/notify paths no longer skip migrate tasks
> - Trim handling: replicas no longer initiate trimming; introduce `asmCancelPendingTrimJobs()` and call it when needed; `asmTrimJobProcessPending()` now runs only on masters, unblocks master if blocked; improved logging for cancelled pending jobs
> - Failover: on promotion, `asmFinalizeMasterTask()` marks incomplete import as failed and triggers trim; for completed migrate, new master triggers `asmTrimSlotsIfNotOwned()` if prior master didn’t trim
> - Minor ASM tweaks: defer trim scheduling only; ensure state changes are replicated to slaves; small logic/order cleanups
> - Tests: update cluster ASM tests to cover migrate task replication, replica propagation delays, and new-master trimming after failover; minor load generator arg changes; module API tests synced
> - Modules: `tests/modules/auth.c` uses a global `pthread_t` with `pthread_join` and frees resources on thread creation failure
> - CI: adjust macOS build matrix (`macos-14`, `macos-26`); move FreeBSD job to `ubuntu-latest` runner and bump cross-platform action to `v0.30.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 136218c2f8823f141c7a1bfc18b7ba0e36a5f24c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->