### PR TITLE
Streams: garbage collection and node merging.

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -905,7 +905,7 @@ static unsigned char *streamListpackMerge(unsigned char *lp1, unsigned char *lp2
  * the original pointer is returned (so the caller can tell).
  *
  * When nodes become sparse after compaction, this function attempts to merge
- * with the next node if:
+ * with the next node if 'allow_merge' is true and:
  * 1. They have identical master entries. You may ask yourself: why this is
  *    needed? Because otherwise we would expand the "right" node entries to
  *    their full-size version of fields+values.
@@ -913,6 +913,12 @@ static unsigned char *streamListpackMerge(unsigned char *lp1, unsigned char *lp2
  * 3. The next node is NOT the last node in the stream (it does not make
  *    much sense to merge into the last node: it is target of new entries and
  *    must remain "partial" by design).
+ *
+ * The 'allow_merge' flag should be set to 0 when called from streamTrim()
+ * with delete strategies that require per-entry validation (DELREF/ACKED).
+ * In those cases, merging could absorb entries from the next node that
+ * haven't been checked against the trim criteria, causing the trim to
+ * skip entries that should have been processed.
  *
  * If a merge occurs, this function modifies the radix tree structure
  * (removing the next node). It repairs the provided iterator 'ri' so
@@ -922,7 +928,7 @@ static unsigned char *streamListpackMerge(unsigned char *lp1, unsigned char *lp2
  *
  * The caller is responsible for freeing the old listpack 'lp' ONLY
  * if the returned pointer is different from 'lp'. */
-static unsigned char *streamListpackCompaction(stream *s, raxIterator *ri, unsigned char *lp, int64_t entries, int64_t marked_deleted) {
+static unsigned char *streamListpackCompaction(stream *s, raxIterator *ri, unsigned char *lp, int64_t entries, int64_t marked_deleted, int allow_merge) {
     /* We only compact if there are deleted entries, and the ratio
      * of deleted entries is high enough. */
     if (marked_deleted == 0 ||           /* No deleted entries at all. */
@@ -1015,10 +1021,11 @@ static unsigned char *streamListpackCompaction(stream *s, raxIterator *ri, unsig
     /* 4. Resize the allocation. */
     new_lp = lpShrinkToFit(new_lp);
 
-    /* 5. Try to merge with next node if sparse. */
+    /* 5. Try to merge with next node if sparse and merging is allowed. */
     int merged = 0;
 
-    if (server.stream_node_max_entries > 0 &&
+    if (allow_merge &&
+        server.stream_node_max_entries > 0 &&
         entries < (server.stream_node_max_entries / STREAM_NODE_MERGE_SPARSITY_DIVISOR))
     {
         /* Safe Peek: Use a fresh iterator to check the next node.
@@ -1309,9 +1316,14 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         size_t newsize = lpBytes(lp);
         s->alloc_size += newsize - oldsize;
 
-        /* Perform garbage collection if needed. */
+        /* Perform garbage collection if needed. Merging is only allowed with
+         * KEEPREF strategy; other strategies (DELREF/ACKED) require per-entry
+         * validation, and merging would absorb unchecked entries from the
+         * next node. */
+        int allow_merge = (delete_strategy == DELETE_STRATEGY_KEEPREF);
         unsigned char *new_lp = streamListpackCompaction(s, &ri, lp, entries,
-                                                         marked_deleted);
+                                                         marked_deleted,
+                                                         allow_merge);
 
         /* If no compaction occurred (new_lp == lp), we still need to update
          * the rax node since lpReplaceInteger() may have reallocated the
@@ -1862,9 +1874,10 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
         size_t newsize = lpBytes(lp);
         s->alloc_size += newsize - oldsize;
 
-        /* Perform garbage collection if needed. */
+        /* Perform garbage collection if needed. Merging is always allowed
+         * here since XDEL processes one entry at a time without trim criteria. */
         unsigned char *new_lp =
-            streamListpackCompaction(s, &si->ri, lp, entries, marked_deleted+1);
+            streamListpackCompaction(s, &si->ri, lp, entries, marked_deleted+1, 1);
 
         /* If no compaction occurred (new_lp == lp), we still need to update
          * the rax node since lpReplaceInteger() may have reallocated the

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -907,7 +907,7 @@ static unsigned char *streamListpackMerge(unsigned char *lp1, unsigned char *lp2
  * When nodes become sparse after compaction, this function attempts to merge
  * with the next node if:
  * 1. They have identical master entries. You may ask yourself: why this is
- *    needed? Because otherwise we would expand the "right" node entires to
+ *    needed? Because otherwise we would expand the "right" node entries to
  *    their full-size version of fields+values.
  * 2. The combined size is within limits.
  * 3. The next node is NOT the last node in the stream (it does not make

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -33,6 +33,9 @@
  * will return NULL. */
 #define STREAM_LISTPACK_MAX_SIZE (1<<30)
 
+/* Merge if node is less than half full (by entries). */
+#define STREAM_NODE_MERGE_SPARSITY_DIVISOR 2
+
 void streamFreeCGGeneric(void *cg, void *s);
 void streamFreeNACK(stream *s, streamNACK *na);
 size_t streamReplyWithRangeFromConsumerPEL(client *c, stream *s, streamID *start, streamID *end, size_t count, streamCG *group, streamConsumer *consumer);
@@ -726,6 +729,388 @@ typedef struct {
 #define DELETE_STRATEGY_DELREF 2    /* Delete from pending entries list */
 #define DELETE_STRATEGY_ACKED 3     /* Only delete messages that are acknowledged */
 
+/* Check if two listpack nodes have identical master entries (field names and
+ * order), making them safe to merge without field reconciliation.
+ * Returns 1 if masters match, 0 otherwise. */
+static int streamListpackMasterMatch(unsigned char *lp1, unsigned char *lp2) {
+    unsigned char *p1 = lpFirst(lp1);
+    unsigned char *p2 = lpFirst(lp2);
+    unsigned int slen1, slen2;
+    long long lval1, lval2;
+    unsigned char *sval1, *sval2;
+
+    /* Skip count and deleted count in both listpacks. */
+    p1 = lpNext(lp1, p1); p1 = lpNext(lp1, p1);
+    p2 = lpNext(lp2, p2); p2 = lpNext(lp2, p2);
+
+    /* Get and compare field count. */
+    int64_t fields1 = lpGetInteger(p1);
+    int64_t fields2 = lpGetInteger(p2);
+    if (fields1 != fields2) return 0;
+    p1 = lpNext(lp1, p1);
+    p2 = lpNext(lp2, p2);
+
+    /* Compare each field name. */
+    for (int64_t i = 0; i < fields1; i++) {
+        sval1 = lpGetValue(p1, &slen1, &lval1);
+        sval2 = lpGetValue(p2, &slen2, &lval2);
+
+        /* Check if one is string and the other integer. */
+        if ((sval1 == NULL) != (sval2 == NULL)) return 0;
+
+        if (sval1) { /* Both are strings, compare them. */
+            if (slen1 != slen2 || memcmp(sval1, sval2, slen1) != 0) return 0;
+        } else { /* Both are integers, compare them. */
+            if (lval1 != lval2) return 0;
+        }
+
+        p1 = lpNext(lp1, p1);
+        p2 = lpNext(lp2, p2);
+    }
+
+    /* If we reached the end, the masters match. Also check the zero
+     * terminators match (always zero). */
+    if (lpGetInteger(p1) != 0 || lpGetInteger(p2) != 0) return 0;
+
+    return 1;
+}
+
+/* Merge the listpack 'lp2' into 'lp1'. Both listpacks must have identical
+ * master entries. 'lp1' is reallocated as needed to hold the merged data.
+ * The master IDs 'id1' and 'id2' are required to recalculate entry ID deltas.
+ * Returns the new pointer for 'lp1'. (Aborts on OOM per Redis convention).
+ * The caller is responsible for freeing 'lp2' and removing it from the rax.
+ *
+ * This function works by iterating over 'lp2' and appending each entry to 'lp1',
+ * recalculating the ID deltas and lp-count fields as it goes. Finally, it
+ * updates the stream-specific header (entry count, deleted count) in 'lp1'. */
+static unsigned char *streamListpackMerge(unsigned char *lp1, unsigned char *lp2, streamID *id1, streamID *id2) {
+    /* 1. Get counts from both nodes. */
+    unsigned char *p1_header = lpFirst(lp1);
+    int64_t count1 = lpGetInteger(p1_header);
+    p1_header = lpNext(lp1, p1_header);
+    p1_header = lpNext(lp1, p1_header); /* Skip deleted count, now at master fields count */
+
+    unsigned char *p2 = lpFirst(lp2);
+    p2 = lpNext(lp2, p2); /* Skip count */
+    p2 = lpNext(lp2, p2); /* Skip deleted count, now at master fields count */
+
+    int64_t master_fields_count = lpGetInteger(p1_header); /* Both are same */
+
+    /* 2. Skip master entry in lp2 to find start of data. */
+    p2 = lpNext(lp2, p2); /* Skip master fields count */
+    for (int64_t i = 0; i < master_fields_count; i++) {
+        p2 = lpNext(lp2, p2); /* Skip master field */
+    }
+    p2 = lpNext(lp2, p2); /* Skip zero terminator. */
+    /* 'p2' now points to the flags of the first data entry in lp2 */
+
+    /* 3. Append entries from lp2 to lp1, recalculating ID deltas and lp-count.
+     * We skip tombstones (deleted entries) since lp1 is already compacted,
+     * and we want the merged result to be fully compacted as well.
+     * We must use lpAppend* functions which take the base lp1 pointer,
+     * as they may reallocate it and return a new base pointer. */
+    int64_t copied = 0; /* Count of entries actually copied from lp2 */
+    while (p2) {
+        int64_t flags = lpGetInteger(p2);
+        int is_tombstone = flags & STREAM_ITEM_FLAG_DELETED;
+        p2 = lpNext(lp2, p2); /* Seek ms-diff. */
+
+        int64_t ms_diff_orig = lpGetInteger(p2);
+        p2 = lpNext(lp2, p2); /* Seek seq-diff. */
+        int64_t seq_diff_orig = lpGetInteger(p2);
+        p2 = lpNext(lp2, p2); /* Seek num-fields or value-1 */
+
+        int64_t num_fields;
+        if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) {
+            num_fields = master_fields_count;
+        } else {
+            num_fields = lpGetInteger(p2);
+            p2 = lpNext(lp2, p2); /* Seek first field. */
+        }
+
+        int64_t fields_to_process = (flags & STREAM_ITEM_FLAG_SAMEFIELDS) ?
+                                     num_fields : num_fields * 2;
+
+        if (is_tombstone) {
+            /* Skip this deleted entry's fields and lp-count. */
+            for (int64_t i = 0; i < fields_to_process; i++) {
+                p2 = lpNext(lp2, p2);
+            }
+            p2 = lpNext(lp2, p2); /* Skip lp-count */
+            continue;
+        }
+
+        /* Recalculate deltas relative to lp1's master ID */
+        streamID abs_id;
+        abs_id.ms = id2->ms + ms_diff_orig;
+        abs_id.seq = id2->seq + seq_diff_orig;
+
+        int64_t new_ms_diff = abs_id.ms - id1->ms;
+        int64_t new_seq_diff = abs_id.seq - id1->seq;
+
+        /* Append the fixed part of the entry */
+        lp1 = lpAppendInteger(lp1, flags);
+        lp1 = lpAppendInteger(lp1, new_ms_diff);
+        lp1 = lpAppendInteger(lp1, new_seq_diff);
+
+        int64_t lp_count = 3; /* flags, ms-diff, seq-diff */
+
+        if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) {
+            lp_count += num_fields;
+        } else {
+            lp1 = lpAppendInteger(lp1, num_fields);
+            lp_count += (num_fields * 2) + 1;
+        }
+
+        /* Append all fields and/or values */
+        for (int64_t i = 0; i < fields_to_process; i++) {
+            unsigned char *sval;
+            unsigned int slen;
+            long long lval;
+            sval = lpGetValue(p2, &slen, &lval);
+            if (sval) {
+                lp1 = lpAppend(lp1, sval, slen);
+            } else {
+                lp1 = lpAppendInteger(lp1, lval);
+            }
+            p2 = lpNext(lp2, p2);
+        }
+
+        /* Append the *new* lp-count */
+        lp1 = lpAppendInteger(lp1, lp_count);
+
+        /* Advance p2 past the old lp-count field to the next entry's flags */
+        p2 = lpNext(lp2, p2);
+        copied++;
+    }
+
+    /* 4. Update lp1's stream header with final counts.
+     * Since lp1 is already compacted (0 deleted) and we skipped tombstones
+     * from lp2, the result has 0 deleted entries. */
+    p1_header = lpFirst(lp1);
+    lp1 = lpReplaceInteger(lp1, &p1_header, count1 + copied);
+    p1_header = lpNext(lp1, p1_header);
+    lp1 = lpReplaceInteger(lp1, &p1_header, 0); /* No deleted entries */
+
+    /* 5. Shrink lp1 to its new final size. */
+    lp1 = lpShrinkToFit(lp1);
+    return lp1;
+}
+
+/* This is a helper function for streamTrim() and streamIteratorRemoveEntry()
+ * that rebuilds the listpack 'lp' to remove entries marked as deleted.
+ * The function updates the rax node with the new listpack.
+ * If the compaction did occur, it returns the new listpack pointer, otherwise
+ * the original pointer is returned (so the caller can tell).
+ *
+ * When nodes become sparse after compaction, this function attempts to merge
+ * with the next node if:
+ * 1. They have identical master entries.
+ * 2. The combined size is within limits.
+ * 3. The next node is NOT the last node in the stream (it does not make
+ *    much sense to merge into the last node: it is target of new entries and
+ *    must remain "partial" by design).
+ *
+ * If a merge occurs, this function modifies the radix tree structure
+ * (removing the next node). It repairs the provided iterator 'ri' so
+ * the caller can safely continue iterating.
+ *
+ * The function updates s->alloc_size to reflect the memory changes.
+ *
+ * The caller is responsible for freeing the old listpack 'lp' ONLY
+ * if the returned pointer is different from 'lp'. */
+static unsigned char *streamListpackCompaction(stream *s, raxIterator *ri, unsigned char *lp, int64_t entries, int64_t marked_deleted) {
+    /* We only compact if there are deleted entries, and the ratio
+     * of deleted entries is high enough. */
+    if (marked_deleted == 0 ||           /* No deleted entries at all. */
+        marked_deleted < entries)        /* Less than 50% deleted. */
+        return lp; /* No compaction needed. */
+
+    size_t old_lp_size = lpBytes(lp);
+
+    /* We pre-allocate half the old listpack size, this makes
+     * sense as we compact only if at least 50% of entries are deleted.
+     * However at the end we resize the allocation calling lpShrinkToFit() */
+    unsigned char *new_lp = lpNew(old_lp_size/2);
+    unsigned char *p = lpFirst(lp);
+    unsigned char *sval;
+    unsigned int slen;
+    long long lval;
+
+    /* 1. Write new header. */
+    new_lp = lpAppendInteger(new_lp, entries); /* New live entry count. */
+    new_lp = lpAppendInteger(new_lp, 0);       /* New deleted entry count. */
+
+    /* 2. Copy master entry. */
+    p = lpNext(lp, p); /* Skip old count. */
+    p = lpNext(lp, p); /* Skip old deleted. */
+    int64_t master_fields_count = lpGetInteger(p);
+    new_lp = lpAppendInteger(new_lp, master_fields_count); /* num-fields */
+    p = lpNext(lp, p);
+    for (int64_t i = 0; i < master_fields_count; i++) {
+        sval = lpGetValue(p, &slen, &lval);
+        if (sval)
+            new_lp = lpAppend(new_lp, sval, slen);
+        else
+            new_lp = lpAppendInteger(new_lp, lval);
+        p = lpNext(lp, p);
+    }
+    new_lp = lpAppendInteger(new_lp, 0); /* Master entry zero terminator. */
+    p = lpNext(lp, p); /* Skip old zero terminator. */
+
+    /* 3. Copy not-deleted stream entries. */
+    while(p) {
+        int64_t flags = lpGetInteger(p);
+        int copy = !(flags & STREAM_ITEM_FLAG_DELETED);
+
+        if (copy) new_lp = lpAppendInteger(new_lp, flags);
+        p = lpNext(lp, p); /* Seek ms-diff. */
+
+        int64_t ms_diff = lpGetInteger(p);
+        if (copy) new_lp = lpAppendInteger(new_lp, ms_diff);
+        p = lpNext(lp, p); /* Seek seq-diff. */
+
+        int64_t seq_diff = lpGetInteger(p);
+        if (copy) new_lp = lpAppendInteger(new_lp, seq_diff);
+        p = lpNext(lp, p); /* Seek num-fields or (if SAMEFIELDS) first value. */
+
+        int64_t num_fields;
+        int64_t lp_count = 3; /* flags, ms-diff, seq-diff */
+
+        /* Check how many fields we got. */
+        if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) {
+            num_fields = master_fields_count;
+            lp_count += num_fields; /* We just have N values. */
+        } else {
+            num_fields = lpGetInteger(p);
+            if (copy) new_lp = lpAppendInteger(new_lp, num_fields);
+            p = lpNext(lp, p); /* Seek first field. */
+            lp_count += (num_fields * 2) + 1; /* We have N field names,
+                                                 N values,
+                                                 1 num-fields integer. */
+        }
+
+        int64_t fields_to_process = (flags & STREAM_ITEM_FLAG_SAMEFIELDS) ?
+                                     num_fields : num_fields * 2;
+
+        for (int64_t i = 0; i < fields_to_process; i++) {
+            sval = lpGetValue(p, &slen, &lval);
+            if (copy) {
+                if (sval)
+                    new_lp = lpAppend(new_lp, sval, slen);
+                else
+                    new_lp = lpAppendInteger(new_lp, lval);
+            }
+            p = lpNext(lp, p);
+        }
+
+        /* Now p points to the lp-count field of the old entry. */
+        if (copy) new_lp = lpAppendInteger(new_lp, lp_count);
+        p = lpNext(lp, p); /* Go to the next stream entry's flags. */
+    }
+
+    /* 4. Resize the allocation. */
+    new_lp = lpShrinkToFit(new_lp);
+
+    /* 5. Try to merge with next node if sparse. */
+    int merged = 0;
+
+    if (server.stream_node_max_entries > 0 &&
+        entries < (server.stream_node_max_entries / STREAM_NODE_MERGE_SPARSITY_DIVISOR))
+    {
+        /* Safe Peek: Use a fresh iterator to check the next node.
+         * We seek strictly greater (">") to find the neighbor. */
+        raxIterator ri_next;
+        raxStart(&ri_next, s->rax);
+        raxSeek(&ri_next, ">", ri->key, ri->key_len);
+
+        if (raxNext(&ri_next)) { /* Found a neighbor node */
+            /* Check if this neighbor is the Last Node (Tail).
+             * We do not merge into the tail to avoid contention with XADD. */
+            int is_last_node = 0;
+            raxIterator ri_tail_check;
+            raxStart(&ri_tail_check, s->rax);
+            raxSeek(&ri_tail_check, ">", ri_next.key, ri_next.key_len);
+            if (!raxNext(&ri_tail_check)) is_last_node = 1;
+            raxStop(&ri_tail_check);
+
+            if (!is_last_node) {
+                unsigned char *next_lp = ri_next.data;
+                unsigned char *next_p = lpFirst(next_lp);
+                int64_t next_entries = lpGetInteger(next_p);
+
+                /* Size checks */
+                size_t combined_bytes_est = lpBytes(new_lp) + lpBytes(next_lp);
+                int64_t combined_entries = entries + next_entries;
+
+                int size_ok = (server.stream_node_max_bytes == 0) ||
+                              (combined_bytes_est < server.stream_node_max_bytes);
+
+                /* Hard limit check */
+                if (combined_bytes_est > STREAM_LISTPACK_MAX_SIZE) size_ok = 0;
+
+                int entries_ok = (server.stream_node_max_entries == 0) ||
+                                 (combined_entries < server.stream_node_max_entries);
+
+                /* Master field compatibility check */
+                if (size_ok && entries_ok && streamListpackMasterMatch(new_lp, next_lp))
+                {
+                    streamID id1, id2;
+                    streamDecodeID(ri->key, &id1);
+                    streamDecodeID(ri_next.key, &id2);
+
+                    /* Save next_lp size BEFORE merge - the merge function
+                     * reallocates and consumes both listpacks. */
+                    size_t next_lp_size = lpBytes(next_lp);
+
+                    /* Perform the merge. Note: new_lp is reallocated inside
+                     * streamListpackMerge, so the original pointer becomes invalid.
+                     * The function returns the new pointer (merged_lp). */
+                    unsigned char *merged_lp = streamListpackMerge(new_lp, next_lp, &id1, &id2);
+
+                    /* Update alloc_size: subtract old sizes, add merged size.
+                     * old_lp_size is the original lp (tracked in alloc_size).
+                     * next_lp is the neighbor being merged and freed.
+                     * Note: new_lp was never added to alloc_size - it's an
+                     * intermediate compacted copy that we're now merging. */
+                    s->alloc_size -= old_lp_size;  /* original lp being replaced */
+                    s->alloc_size -= next_lp_size; /* next_lp is consumed */
+                    s->alloc_size += lpBytes(merged_lp);
+
+                    /* 5a. Update Rax: Remove the neighbor node. */
+                    raxRemove(s->rax, ri_next.key, ri_next.key_len, NULL);
+                    lpFree(next_lp); /* Free the consumed listpack */
+                    /* Note: Don't free new_lp - it was reallocated by merge
+                     * and is now part of merged_lp's allocation. */
+
+                    /* 5b. Update Rax: Set the merged node at current key. */
+                    new_lp = merged_lp;
+                    raxSetData(ri->node, new_lp);
+
+                    /* 5c. Repair the Main Iterator ('ri').
+                     * removing a node invalidates the iterator stack.
+                     * re-seeking rebuilds it. */
+                    raxSeek(ri, ">=", ri->key, ri->key_len);
+
+                    merged = 1;
+                }
+            }
+        }
+        raxStop(&ri_next);
+    }
+
+    /* 6. Update alloc_size and radix tree if no merge happened. */
+    if (!merged) {
+        s->alloc_size -= old_lp_size;
+        s->alloc_size += lpBytes(new_lp);
+        raxSetData(ri->node, new_lp);
+    }
+
+    /* Note: It's up to the caller to free the old 'lp'. */
+    return new_lp;
+}
+
 /* Trim the stream 's' according to args->trim_strategy, and return the
  * number of elements removed from the stream. The 'approx' option, if non-zero,
  * specifies that the trimming must be performed in a approximated way in
@@ -914,19 +1299,29 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         int64_t marked_deleted = lpGetInteger(p);
         lp = lpReplaceInteger(lp,&p,marked_deleted+deleted_from_lp);
         p = lpNext(lp,p); /* Skip num-of-fields in the master entry. */
-        s->alloc_size -= oldsize;
-        s->alloc_size += lpBytes(lp);
 
-        /* Here we should perform garbage collection in case at this point
-         * there are too many entries deleted inside the listpack. */
+        /* Perform garbage collection if needed. */
         entries -= deleted_from_lp;
         marked_deleted += deleted_from_lp;
-        if (entries + marked_deleted > 10 && marked_deleted > entries/2) {
-            /* TODO: perform a garbage collection. */
-        }
 
-        /* Update the node with the new pointer. */
-        raxSetData(ri.node,lp);
+        size_t newsize = lpBytes(lp);
+        s->alloc_size += newsize - oldsize;
+
+        /* Perform garbage collection if needed. */
+        unsigned char *new_lp = streamListpackCompaction(s, &ri, lp, entries,
+                                                         marked_deleted);
+
+        /* If no compaction occurred (new_lp == lp), we still need to update
+         * the rax node since lpReplaceInteger() may have reallocated the
+         * listpack. If compaction occurred, the compaction function already
+         * updated the rax and adjusted alloc_size, so we just free the
+         * old listpack. */
+        if (new_lp == lp) {
+            raxSetData(ri.node, lp);
+        } else {
+            lpFree(lp);
+            lp = new_lp;
+        }
 
         /* If the node is eligible for removal but we couldn't remove it due to delete strategy
          * constraints (we need to check each entry individually), continue to the next node
@@ -1456,16 +1851,30 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
         raxRemove(s->rax,si->ri.key,si->ri.key_len,NULL);
     } else {
         /* In the base case we alter the counters of valid/deleted entries. */
-        lp = lpReplaceInteger(lp,&p,aux-1);
+        int64_t entries = aux-1;
+        lp = lpReplaceInteger(lp,&p,entries);
         p = lpNext(lp,p); /* Seek deleted field. */
-        aux = lpGetInteger(p);
-        lp = lpReplaceInteger(lp,&p,aux+1);
-        s->alloc_size -= oldsize;
-        s->alloc_size += lpBytes(lp);
+        int64_t marked_deleted = lpGetInteger(p);
+        lp = lpReplaceInteger(lp,&p,marked_deleted+1);
 
-        /* Update the listpack with the new pointer. */
-        if (si->lp != lp)
-            raxInsert(s->rax,si->ri.key,si->ri.key_len,lp,NULL);
+        size_t newsize = lpBytes(lp);
+        s->alloc_size += newsize - oldsize;
+
+        /* Perform garbage collection if needed. */
+        unsigned char *new_lp =
+            streamListpackCompaction(s, &si->ri, lp, entries, marked_deleted+1);
+
+        /* If no compaction occurred (new_lp == lp), we still need to update
+         * the rax node since lpReplaceInteger() may have reallocated the
+         * listpack. If compaction occurred, the compaction function already
+         * updated the rax and adjusted alloc_size, so we just free the
+         * old listpack. */
+        if (new_lp == lp) {
+            if (si->lp != lp)
+                raxInsert(s->rax,si->ri.key,si->ri.key_len,lp,NULL);
+        } else {
+            lpFree(lp);
+        }
     }
 
     /* Update the number of entries counter. */
@@ -1482,9 +1891,6 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     }
     streamIteratorStop(si);
     streamIteratorStart(si,s,&start,&end,si->rev);
-
-    /* TODO: perform a garbage collection here if the ratio between
-     * deleted and valid goes over a certain limit. */
 }
 
 /* Stop the stream iterator. The only cleanup we need is to free the rax

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1060,7 +1060,7 @@ static unsigned char *streamListpackCompaction(stream *s, raxIterator *ri, unsig
                 if (combined_bytes_est > STREAM_LISTPACK_MAX_SIZE) size_ok = 0;
 
                 int entries_ok = (server.stream_node_max_entries == 0) ||
-                                 (combined_entries < server.stream_node_max_entries);
+                                 (combined_entries <= server.stream_node_max_entries);
 
                 /* Master field compatibility check */
                 if (size_ok && entries_ok && streamListpackMasterMatch(new_lp, next_lp))

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -906,7 +906,9 @@ static unsigned char *streamListpackMerge(unsigned char *lp1, unsigned char *lp2
  *
  * When nodes become sparse after compaction, this function attempts to merge
  * with the next node if:
- * 1. They have identical master entries.
+ * 1. They have identical master entries. You may ask yourself: why this is
+ *    needed? Because otherwise we would expand the "right" node entires to
+ *    their full-size version of fields+values.
  * 2. The combined size is within limits.
  * 3. The next node is NOT the last node in the stream (it does not make
  *    much sense to merge into the last node: it is target of new entries and

--- a/tests/unit/type/stream-compaction.tcl
+++ b/tests/unit/type/stream-compaction.tcl
@@ -1,0 +1,745 @@
+# Tests for stream compaction features:
+# 1. Garbage collection: remove deleted entries from listpacks
+# 2. Node merging: merge sparse adjacent nodes
+
+# Helper to get the number of radix tree keys (nodes) in a stream
+proc stream_node_count {key} {
+    dict get [r XINFO STREAM $key] radix-tree-keys
+}
+
+# Helper to get stream length
+proc stream_len {key} {
+    r XLEN $key
+}
+
+start_server {tags {"stream"}} {
+    # ============================================================
+    # PART 1: Garbage Collection Tests
+    # ============================================================
+
+    test {GC - Basic: deleting >50% entries triggers compaction} {
+        r DEL mystream
+        r config set stream-node-max-entries 10
+
+        # Add exactly 10 entries to ensure they go into one node
+        set ids {}
+        for {set i 0} {$i < 10} {incr i} {
+            lappend ids [r XADD mystream * f $i]
+        }
+
+        # Initially we should have 1 node
+        set initial_nodes [stream_node_count mystream]
+        assert {$initial_nodes == 1}
+
+        # Delete 6 entries (>50%) - this should trigger GC
+        for {set i 0} {$i < 6} {incr i} {
+            r XDEL mystream [lindex $ids $i]
+        }
+
+        # The stream should still work correctly
+        assert_equal [stream_len mystream] 4
+
+        # Verify remaining entries are intact
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 4
+        for {set i 0} {$i < 4} {incr i} {
+            set expected_val [expr {$i + 6}]
+            assert_equal [lindex $remaining $i 1] [list f $expected_val]
+        }
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC - No compaction when <50% deleted} {
+        r DEL mystream
+        r config set stream-node-max-entries 10
+
+        set ids {}
+        for {set i 0} {$i < 10} {incr i} {
+            lappend ids [r XADD mystream * f $i]
+        }
+
+        # Delete only 4 entries (<50%) - no GC should happen
+        for {set i 0} {$i < 4} {incr i} {
+            r XDEL mystream [lindex $ids $i]
+        }
+
+        assert_equal [stream_len mystream] 6
+
+        # Verify all remaining entries are accessible
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 6
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC - Single-node stream stays intact} {
+        r DEL mystream
+        r config set stream-node-max-entries 5
+
+        # Create a stream with only one node
+        set ids {}
+        for {set i 0} {$i < 5} {incr i} {
+            lappend ids [r XADD mystream * f $i]
+        }
+
+        assert_equal [stream_node_count mystream] 1
+
+        # Delete all but one entry - last node should remain
+        for {set i 0} {$i < 4} {incr i} {
+            r XDEL mystream [lindex $ids $i]
+        }
+
+        # Stream should still have 1 entry
+        assert_equal [stream_len mystream] 1
+        assert_equal [stream_node_count mystream] 1
+
+        # The remaining entry should be accessible
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 1
+        assert_equal [lindex $remaining 0 1] {f 4}
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC - Multiple nodes, only non-last nodes get GC'd} {
+        r DEL mystream
+        r config set stream-node-max-entries 5
+
+        # Create stream with multiple nodes (at least 3 nodes)
+        set ids {}
+        for {set i 0} {$i < 15} {incr i} {
+            lappend ids [r XADD mystream * f $i]
+        }
+
+        set initial_nodes [stream_node_count mystream]
+        assert {$initial_nodes >= 3}
+
+        # Delete most entries from the first node (entries 0-3)
+        for {set i 0} {$i < 4} {incr i} {
+            r XDEL mystream [lindex $ids $i]
+        }
+
+        # Delete most entries from a middle node (entries 5-8)
+        for {set i 5} {$i < 9} {incr i} {
+            r XDEL mystream [lindex $ids $i]
+        }
+
+        # The stream should still be valid
+        assert_equal [stream_len mystream] 7
+
+        # All remaining entries should be accessible
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 7
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC - Stress test with random deletions} {
+        r DEL mystream
+        r config set stream-node-max-entries 10
+
+        # Add many entries to create multiple nodes
+        set ids {}
+        for {set i 0} {$i < 200} {incr i} {
+            lappend ids [r XADD mystream * f $i]
+        }
+
+        set initial_len [stream_len mystream]
+        assert_equal $initial_len 200
+
+        # Randomly delete about 70% of entries
+        set ids_to_delete [lrange [lshuffle $ids] 0 139]
+        foreach id $ids_to_delete {
+            r XDEL mystream $id
+        }
+
+        # Verify length
+        assert_equal [stream_len mystream] 60
+
+        # Verify all remaining entries are accessible via XRANGE
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 60
+
+        # Verify XREVRANGE works too
+        set rev_remaining [r XREVRANGE mystream + -]
+        assert_equal [llength $rev_remaining] 60
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC - Works correctly with XTRIM MAXLEN} {
+        r DEL mystream
+        r config set stream-node-max-entries 10
+
+        # Add entries
+        for {set i 0} {$i < 50} {incr i} {
+            r XADD mystream * f $i
+        }
+
+        # Trim to 10 entries
+        r XTRIM mystream MAXLEN = 10
+
+        assert_equal [stream_len mystream] 10
+
+        # Verify entries are the last 10
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 10
+        for {set i 0} {$i < 10} {incr i} {
+            set expected_val [expr {$i + 40}]
+            assert_equal [lindex $remaining $i 1] [list f $expected_val]
+        }
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC - Works correctly with XTRIM MINID} {
+        r DEL mystream
+        r config set stream-node-max-entries 10
+
+        # Add entries with specific IDs
+        set ids {}
+        for {set i 1} {$i <= 50} {incr i} {
+            lappend ids [r XADD mystream $i-0 f $i]
+        }
+
+        # Trim entries with ID < 40-0
+        r XTRIM mystream MINID = 40-0
+
+        assert_equal [stream_len mystream] 11
+
+        # Verify entries start from 40-0
+        set remaining [r XRANGE mystream - +]
+        assert_equal [lindex $remaining 0 0] "40-0"
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC - Entries with different field names (non-SAMEFIELDS)} {
+        r DEL mystream
+        r config set stream-node-max-entries 10
+
+        # Add entries with different field names
+        set ids {}
+        for {set i 0} {$i < 10} {incr i} {
+            lappend ids [r XADD mystream * field$i value$i]
+        }
+
+        # Delete 6 entries to trigger GC
+        for {set i 0} {$i < 6} {incr i} {
+            r XDEL mystream [lindex $ids $i]
+        }
+
+        assert_equal [stream_len mystream] 4
+
+        # Verify remaining entries have correct field names
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 4
+        for {set i 0} {$i < 4} {incr i} {
+            set expected_idx [expr {$i + 6}]
+            assert_equal [lindex $remaining $i 1] [list field$expected_idx value$expected_idx]
+        }
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC - Works with consumer groups} {
+        r DEL mystream
+        r config set stream-node-max-entries 10
+
+        # Add entries
+        set ids {}
+        for {set i 0} {$i < 10} {incr i} {
+            lappend ids [r XADD mystream * f $i]
+        }
+
+        # Create consumer group
+        r XGROUP CREATE mystream mygroup 0
+
+        # Read some entries
+        r XREADGROUP GROUP mygroup consumer1 COUNT 5 STREAMS mystream >
+
+        # Delete entries that were read (triggering GC)
+        for {set i 0} {$i < 6} {incr i} {
+            r XDEL mystream [lindex $ids $i]
+        }
+
+        assert_equal [stream_len mystream] 4
+
+        # Consumer group should still work
+        r XPENDING mystream mygroup
+        # The remaining unread entries should still be readable
+        set remaining [r XREADGROUP GROUP mygroup consumer1 STREAMS mystream >]
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC - Iterator continues correctly after GC during XDEL} {
+        r DEL mystream
+        r config set stream-node-max-entries 5
+
+        # Add entries to create multiple nodes
+        set ids {}
+        for {set i 0} {$i < 20} {incr i} {
+            lappend ids [r XADD mystream * f $i]
+        }
+
+        # Delete entries scattered across nodes
+        # This tests that the iterator re-seeks correctly after compaction
+        r XDEL mystream [lindex $ids 0]
+        r XDEL mystream [lindex $ids 1]
+        r XDEL mystream [lindex $ids 2]
+        r XDEL mystream [lindex $ids 5]
+        r XDEL mystream [lindex $ids 6]
+        r XDEL mystream [lindex $ids 7]
+        r XDEL mystream [lindex $ids 10]
+        r XDEL mystream [lindex $ids 11]
+        r XDEL mystream [lindex $ids 12]
+
+        # Verify remaining entries
+        assert_equal [stream_len mystream] 11
+
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 11
+
+        r config set stream-node-max-entries 100
+    }
+
+    # ============================================================
+    # PART 2: Node Merging Tests
+    #
+    # Merge happens when:
+    # 1. Current node is sparse (< 50% of max_entries)
+    # 2. Combined entries/bytes stay under max_entries/max_bytes
+    # 3. Next node is not the tail
+    # ============================================================
+
+    test {Merge - Basic: sparse nodes merge when combined fits} {
+        r DEL mystream
+        # With 100 max entries, a node becomes "sparse" when < 50 entries (50%)
+        r config set stream-node-max-entries 100
+
+        # Create 3 nodes with ~100 entries each
+        set ids1 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids1 [r XADD mystream * f $i]
+        }
+        set ids2 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids2 [r XADD mystream * f [expr {100 + $i}]]
+        }
+        set ids3 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids3 [r XADD mystream * f [expr {200 + $i}]]
+        }
+
+        set initial_nodes [stream_node_count mystream]
+        assert {$initial_nodes >= 3}
+
+        # FIRST: Make node 2 sparse by deleting most entries (keep ~15)
+        # This way when node 1 becomes sparse, combined (~20) < 100
+        for {set i 15} {$i < 100} {incr i} {
+            r XDEL mystream [lindex $ids2 $i]
+        }
+
+        # NOW: Make node 1 sparse (keep only 5 entries)
+        # This should trigger merge with sparse node 2
+        for {set i 5} {$i < 100} {incr i} {
+            r XDEL mystream [lindex $ids1 $i]
+        }
+
+        # Verify merge happened: should go from 3 nodes to 2
+        set final_nodes [stream_node_count mystream]
+        assert {$final_nodes < $initial_nodes}
+
+        # Verify stream data is correct
+        # Kept: 5 from node1 + 15 from node2 + 100 from node3 = 120
+        assert_equal [stream_len mystream] 120
+
+        # All remaining entries should be accessible
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 120
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {Merge - No merge when combined exceeds limit} {
+        r DEL mystream
+        r config set stream-node-max-entries 100
+
+        # Create 3 nodes with ~100 entries each
+        set ids1 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids1 [r XADD mystream * f $i]
+        }
+        set ids2 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids2 [r XADD mystream * f [expr {100 + $i}]]
+        }
+        set ids3 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids3 [r XADD mystream * f [expr {200 + $i}]]
+        }
+
+        set initial_nodes [stream_node_count mystream]
+
+        # Make node 1 sparse, but node 2 is still full (100 entries)
+        # Combined would be ~105 > 100, so NO merge
+        for {set i 5} {$i < 100} {incr i} {
+            r XDEL mystream [lindex $ids1 $i]
+        }
+
+        # Node count should remain the same (no merge possible)
+        set final_nodes [stream_node_count mystream]
+        assert_equal $final_nodes $initial_nodes
+
+        # Stream should still be correct
+        assert_equal [stream_len mystream] 205
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 205
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {Merge - Last node is never merged into} {
+        r DEL mystream
+        r config set stream-node-max-entries 20
+
+        # Create ONLY 2 nodes
+        set ids1 {}
+        for {set i 0} {$i < 20} {incr i} {
+            lappend ids1 [r XADD mystream * f $i]
+        }
+        set ids2 {}
+        for {set i 0} {$i < 5} {incr i} {
+            # Make node 2 sparse so combined would fit (1 + 5 = 6 < 20)
+            lappend ids2 [r XADD mystream * f [expr {20 + $i}]]
+        }
+
+        set initial_nodes [stream_node_count mystream]
+        assert {$initial_nodes >= 2}
+
+        # Delete most entries from node 1 (first node) to make it sparse
+        # Even though combined would fit (1 + 5 = 6 < 20), node 2 is the LAST
+        # node, so merge should NOT happen
+        for {set i 1} {$i < 20} {incr i} {
+            r XDEL mystream [lindex $ids1 $i]
+        }
+
+        # Node count should NOT decrease (no merge into last node)
+        set final_nodes [stream_node_count mystream]
+        assert_equal $final_nodes $initial_nodes
+
+        # The stream should still work correctly
+        assert_equal [stream_len mystream] 6
+
+        # All entries still accessible
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 6
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {Merge - Nodes with different master fields don't merge} {
+        r DEL mystream
+        r config set stream-node-max-entries 20
+
+        # Create 3 nodes with different field names to prevent merging
+        # Node 1: field name "a"
+        set ids1 {}
+        for {set i 0} {$i < 20} {incr i} {
+            lappend ids1 [r XADD mystream * a $i]
+        }
+        # Node 2: field name "b" (different master) - make it sparse
+        set ids2 {}
+        for {set i 0} {$i < 5} {incr i} {
+            lappend ids2 [r XADD mystream * b [expr {20 + $i}]]
+        }
+        # Node 3: field name "c" (different master)
+        set ids3 {}
+        for {set i 0} {$i < 20} {incr i} {
+            lappend ids3 [r XADD mystream * c [expr {40 + $i}]]
+        }
+
+        set initial_nodes [stream_node_count mystream]
+        assert {$initial_nodes >= 3}
+
+        # Delete most entries from node 1 to make it sparse
+        # Even though combined entries would fit (1 + 5 = 6 < 20),
+        # masters are different (a vs b), so NO merge
+        for {set i 1} {$i < 20} {incr i} {
+            r XDEL mystream [lindex $ids1 $i]
+        }
+
+        # Node count should NOT decrease (no merge due to different masters)
+        set final_nodes [stream_node_count mystream]
+        assert_equal $final_nodes $initial_nodes
+
+        # Stream should still be valid
+        assert_equal [stream_len mystream] 26
+
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 26
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {Merge - Size limits are respected} {
+        r DEL mystream
+        r config set stream-node-max-entries 100
+        r config set stream-node-max-bytes 1000
+
+        # Create entries that take up space
+        set ids1 {}
+        for {set i 0} {$i < 50} {incr i} {
+            # Add entries with larger values to consume bytes
+            lappend ids1 [r XADD mystream * f [string repeat "x" 10]]
+        }
+
+        set ids2 {}
+        for {set i 0} {$i < 50} {incr i} {
+            lappend ids2 [r XADD mystream * f [string repeat "y" 10]]
+        }
+
+        # Delete most entries from node 1
+        for {set i 1} {$i < 50} {incr i} {
+            r XDEL mystream [lindex $ids1 $i]
+        }
+
+        # Stream should still be valid regardless of whether merge happened
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 51
+
+        r config set stream-node-max-bytes 4096
+        r config set stream-node-max-entries 100
+    }
+
+    test {Merge - Data integrity after merge} {
+        r DEL mystream
+        r config set stream-node-max-entries 100
+
+        # Create 3 nodes
+        set all_ids {}
+        for {set node 0} {$node < 3} {incr node} {
+            for {set i 0} {$i < 100} {incr i} {
+                set val [expr {$node * 100 + $i}]
+                lappend all_ids [r XADD mystream * f $val]
+            }
+        }
+
+        set initial_nodes [stream_node_count mystream]
+
+        # FIRST: Make node 2 sparse by deleting most entries (keep 10)
+        for {set i 110} {$i < 200} {incr i} {
+            r XDEL mystream [lindex $all_ids $i]
+        }
+
+        # NOW: Make node 1 sparse (keep entries 0-4)
+        # Combined: 5 + 10 = 15 < 100, should merge
+        for {set i 5} {$i < 100} {incr i} {
+            r XDEL mystream [lindex $all_ids $i]
+        }
+
+        # Verify merge happened
+        set final_nodes [stream_node_count mystream]
+        assert {$final_nodes < $initial_nodes}
+
+        # Verify remaining data is correct
+        set remaining [r XRANGE mystream - +]
+
+        # We should have 5 from node1 + 10 from node2 + 100 from node3 = 115
+        assert_equal [llength $remaining] 115
+
+        # Verify first 5 entries (kept from first node, now in merged node)
+        for {set i 0} {$i < 5} {incr i} {
+            set entry [lindex $remaining $i]
+            assert_equal [lindex $entry 1] [list f $i]
+        }
+
+        # Verify entries from second node (indices 5-14)
+        for {set i 0} {$i < 10} {incr i} {
+            set entry [lindex $remaining [expr {5 + $i}]]
+            set expected_val [expr {100 + $i}]
+            assert_equal [lindex $entry 1] [list f $expected_val]
+        }
+
+        # Verify entries from third node (indices 15-114)
+        for {set i 0} {$i < 100} {incr i} {
+            set entry [lindex $remaining [expr {15 + $i}]]
+            set expected_val [expr {200 + $i}]
+            assert_equal [lindex $entry 1] [list f $expected_val]
+        }
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {Merge - Stress test with many deletions} {
+        r DEL mystream
+        r config set stream-node-max-entries 50
+
+        # Create many entries across many nodes
+        set all_ids {}
+        for {set i 0} {$i < 500} {incr i} {
+            lappend all_ids [r XADD mystream * f $i]
+        }
+
+        set initial_nodes [stream_node_count mystream]
+        assert {$initial_nodes >= 10}
+
+        # Randomly delete 80% of entries - this should trigger many GC and merge operations
+        set ids_shuffled [lshuffle $all_ids]
+        set ids_to_delete [lrange $ids_shuffled 0 399]
+
+        foreach id $ids_to_delete {
+            r XDEL mystream $id
+        }
+
+        # Verify stream integrity
+        assert_equal [stream_len mystream] 100
+
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 100
+
+        # Verify reverse range works
+        set rev_remaining [r XREVRANGE mystream + -]
+        assert_equal [llength $rev_remaining] 100
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {Merge - Multiple sequential merges} {
+        r DEL mystream
+        r config set stream-node-max-entries 20
+
+        # Create 5 nodes
+        set all_ids {}
+        for {set node 0} {$node < 5} {incr node} {
+            for {set i 0} {$i < 20} {incr i} {
+                lappend all_ids [r XADD mystream * f [expr {$node * 20 + $i}]]
+            }
+        }
+
+        set initial_nodes [stream_node_count mystream]
+        assert {$initial_nodes >= 5}
+
+        # Delete from alternating nodes to trigger multiple potential merges
+        # Delete most of node 1 (indices 20-39, keep 20-21)
+        for {set i 22} {$i < 40} {incr i} {
+            r XDEL mystream [lindex $all_ids $i]
+        }
+
+        # Delete most of node 3 (indices 60-79, keep 60-61)
+        for {set i 62} {$i < 80} {incr i} {
+            r XDEL mystream [lindex $all_ids $i]
+        }
+
+        # Verify stream integrity
+        set remaining [r XRANGE mystream - +]
+        set expected_count [expr {20 + 2 + 20 + 2 + 20}] ;# 64 entries
+        assert_equal [llength $remaining] $expected_count
+        assert_equal [stream_len mystream] $expected_count
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {Merge - Works with XREADGROUP after merge} {
+        r DEL mystream
+        r config set stream-node-max-entries 50
+
+        # Create entries
+        set ids {}
+        for {set i 0} {$i < 150} {incr i} {
+            lappend ids [r XADD mystream * f $i]
+        }
+
+        # Create consumer group
+        r XGROUP CREATE mystream mygroup 0
+
+        # Read some entries from first node
+        r XREADGROUP GROUP mygroup consumer1 COUNT 25 STREAMS mystream >
+
+        # Delete most of first node to trigger merge
+        for {set i 5} {$i < 50} {incr i} {
+            r XDEL mystream [lindex $ids $i]
+        }
+
+        # Continue reading - should work after merge
+        set result [r XREADGROUP GROUP mygroup consumer1 COUNT 50 STREAMS mystream >]
+
+        # Verify we can still read entries
+        assert {[llength $result] > 0}
+
+        r config set stream-node-max-entries 100
+    }
+}
+
+# Tests that require DEBUG commands
+start_server {tags {"stream needs:debug"}} {
+    test {Merge - RDB save/load preserves merged stream} {
+        r DEL mystream
+        r config set stream-node-max-entries 100
+
+        # Create 3 nodes
+        set ids1 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids1 [r XADD mystream * f $i]
+        }
+        set ids2 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids2 [r XADD mystream * f [expr {100 + $i}]]
+        }
+        set ids3 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids3 [r XADD mystream * f [expr {200 + $i}]]
+        }
+
+        # Delete most entries from first node to trigger merge
+        for {set i 5} {$i < 100} {incr i} {
+            r XDEL mystream [lindex $ids1 $i]
+        }
+
+        set nodes_before [dict get [r XINFO STREAM mystream] radix-tree-keys]
+        assert_equal [r XLEN mystream] 205
+
+        # Save and reload
+        r DEBUG RELOAD
+
+        # Verify stream is intact
+        assert_equal [r XLEN mystream] 205
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 205
+
+        # Verify node count is preserved
+        set nodes_after [dict get [r XINFO STREAM mystream] radix-tree-keys]
+        assert_equal $nodes_before $nodes_after
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC - RDB save/load preserves compacted stream} {
+        r DEL mystream
+        r config set stream-node-max-entries 10
+
+        set ids {}
+        for {set i 0} {$i < 10} {incr i} {
+            lappend ids [r XADD mystream * f $i]
+        }
+
+        # Delete entries to trigger GC
+        for {set i 0} {$i < 6} {incr i} {
+            r XDEL mystream [lindex $ids $i]
+        }
+
+        assert_equal [r XLEN mystream] 4
+
+        # Save and reload
+        r DEBUG RELOAD
+
+        # Verify stream is intact
+        assert_equal [r XLEN mystream] 4
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 4
+
+        r config set stream-node-max-entries 100
+    }
+}

--- a/tests/unit/type/stream-compaction.tcl
+++ b/tests/unit/type/stream-compaction.tcl
@@ -671,6 +671,183 @@ start_server {tags {"stream"}} {
 
         r config set stream-node-max-entries 100
     }
+
+    test {Merge - Tombstones from neighbor node are skipped during merge} {
+        r DEL mystream
+        r config set stream-node-max-entries 100
+
+        # Create 3 nodes with 100 entries each
+        set ids1 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids1 [r XADD mystream * f $i]
+        }
+        set ids2 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids2 [r XADD mystream * f [expr {100 + $i}]]
+        }
+        set ids3 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids3 [r XADD mystream * f [expr {200 + $i}]]
+        }
+
+        assert {[stream_node_count mystream] >= 3}
+
+        # Delete 40% from node 2 - this is < 50%, so NO GC happens.
+        # Node 2 now has 60 live entries + 40 tombstones.
+        for {set i 0} {$i < 40} {incr i} {
+            r XDEL mystream [lindex $ids2 $i]
+        }
+
+        # Delete 90% from node 1 - this triggers GC on node 1.
+        # After GC, node 1 has 10 live entries.
+        # Merge check: 10 + 60 = 70 < 100, so merge should happen.
+        # The key test: tombstones from node 2 must be SKIPPED during merge.
+        # If tombstones were copied, merged node would have 10 + 60 + 40 = 110 entries.
+        for {set i 10} {$i < 100} {incr i} {
+            r XDEL mystream [lindex $ids1 $i]
+        }
+
+        # Verify merge happened (should go from 3 nodes to 2)
+        assert {[stream_node_count mystream] == 2}
+
+        # Verify stream length: 10 + 60 + 100 = 170
+        assert_equal [stream_len mystream] 170
+
+        # Verify all remaining entries are accessible and correct
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 170
+
+        # Verify first 10 entries (from node 1)
+        for {set i 0} {$i < 10} {incr i} {
+            assert_equal [lindex $remaining $i 1] [list f $i]
+        }
+
+        # Verify next 60 entries (from node 2, indices 40-99)
+        for {set i 0} {$i < 60} {incr i} {
+            set expected_val [expr {100 + 40 + $i}]
+            assert_equal [lindex $remaining [expr {10 + $i}] 1] [list f $expected_val]
+        }
+
+        # Verify last 100 entries (from node 3)
+        for {set i 0} {$i < 100} {incr i} {
+            set expected_val [expr {200 + $i}]
+            assert_equal [lindex $remaining [expr {70 + $i}] 1] [list f $expected_val]
+        }
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC and Merge - Multiple fields per entry} {
+        r DEL mystream
+        r config set stream-node-max-entries 50
+
+        # Create entries with multiple fields (tests SAMEFIELDS handling)
+        set ids1 {}
+        for {set i 0} {$i < 50} {incr i} {
+            lappend ids1 [r XADD mystream * name user$i age $i city city$i]
+        }
+        set ids2 {}
+        for {set i 0} {$i < 50} {incr i} {
+            lappend ids2 [r XADD mystream * name user[expr {50+$i}] age [expr {50+$i}] city city[expr {50+$i}]]
+        }
+        set ids3 {}
+        for {set i 0} {$i < 50} {incr i} {
+            lappend ids3 [r XADD mystream * name user[expr {100+$i}] age [expr {100+$i}] city city[expr {100+$i}]]
+        }
+
+        assert {[stream_node_count mystream] >= 3}
+
+        # Make node 2 sparse (keep 10 entries)
+        for {set i 10} {$i < 50} {incr i} {
+            r XDEL mystream [lindex $ids2 $i]
+        }
+
+        # Make node 1 sparse to trigger GC + merge
+        for {set i 5} {$i < 50} {incr i} {
+            r XDEL mystream [lindex $ids1 $i]
+        }
+
+        # Verify merge happened
+        assert {[stream_node_count mystream] < 3}
+
+        # Verify stream length: 5 + 10 + 50 = 65
+        assert_equal [stream_len mystream] 65
+
+        # Verify all entries have correct multi-field data
+        set remaining [r XRANGE mystream - +]
+        assert_equal [llength $remaining] 65
+
+        # Check first 5 entries (from node 1)
+        for {set i 0} {$i < 5} {incr i} {
+            set entry [lindex $remaining $i 1]
+            assert_equal $entry [list name user$i age $i city city$i]
+        }
+
+        # Check next 10 entries (from node 2, indices 50-59)
+        for {set i 0} {$i < 10} {incr i} {
+            set idx [expr {50 + $i}]
+            set entry [lindex $remaining [expr {5 + $i}] 1]
+            assert_equal $entry [list name user$idx age $idx city city$idx]
+        }
+
+        # Check last 50 entries (from node 3)
+        for {set i 0} {$i < 50} {incr i} {
+            set idx [expr {100 + $i}]
+            set entry [lindex $remaining [expr {15 + $i}] 1]
+            assert_equal $entry [list name user$idx age $idx city city$idx]
+        }
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC and Merge - Memory usage consistency} {
+        r DEL mystream
+        r config set stream-node-max-entries 100
+
+        # Create 3 nodes
+        set ids1 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids1 [r XADD mystream * field value$i]
+        }
+        set ids2 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids2 [r XADD mystream * field value[expr {100+$i}]]
+        }
+        set ids3 {}
+        for {set i 0} {$i < 100} {incr i} {
+            lappend ids3 [r XADD mystream * field value[expr {200+$i}]]
+        }
+
+        set mem_before [r MEMORY USAGE mystream]
+
+        # Make node 2 sparse
+        for {set i 10} {$i < 100} {incr i} {
+            r XDEL mystream [lindex $ids2 $i]
+        }
+
+        # Make node 1 sparse to trigger GC + merge
+        for {set i 5} {$i < 100} {incr i} {
+            r XDEL mystream [lindex $ids1 $i]
+        }
+
+        set mem_after [r MEMORY USAGE mystream]
+
+        # Memory should decrease after deletions and compaction
+        assert {$mem_after < $mem_before}
+
+        # Verify stream is still functional
+        assert_equal [stream_len mystream] 115
+
+        # Memory should be reasonable (not zero, not negative internally)
+        assert {$mem_after > 0}
+
+        # Verify XINFO STREAM works (uses alloc_size internally)
+        set info [r XINFO STREAM mystream]
+        assert {[dict exists $info length]}
+        assert_equal [dict get $info length] 115
+
+        r config set stream-node-max-entries 100
+    }
 }
 
 # Tests that require DEBUG commands

--- a/tests/unit/type/stream-compaction.tcl
+++ b/tests/unit/type/stream-compaction.tcl
@@ -848,6 +848,124 @@ start_server {tags {"stream"}} {
 
         r config set stream-node-max-entries 100
     }
+
+    test {GC with XTRIM ACKED - merge disabled, Node 2 entries processed} {
+        # Regression test for: merging during XTRIM with ACKED could skip
+        # processing entries from the merged node.
+        #
+        # Setup: 3 nodes where Node 1 becomes sparse after ACKED deletions,
+        # Node 2 is small enough to merge (if allowed), Node 3 exists so
+        # Node 2 is not the last node.
+        #
+        # Bug scenario (if merge were allowed):
+        # 1. Node 1 eligible for removal (all entries < MINID)
+        # 2. ACKED: process entries, delete acked ones, keep unacked
+        # 3. GC triggers, Node 1 sparse (5 entries), would merge with Node 2 (15 entries)
+        # 4. "if (node_eligible_for_remove) continue" -> skip to Node 3
+        # 5. Node 2's acked entries < MINID never get deleted!
+        #
+        # With fix: merge disabled, Node 2 processed normally.
+        r DEL mystream
+        r config set stream-node-max-entries 100
+
+        # Create 3 nodes: 100 + 15 + 100 = 215 entries
+        # Node 1: entries 1-100 (all < MINID 200-0)
+        for {set i 1} {$i <= 100} {incr i} {
+            r XADD mystream $i-0 f v
+        }
+        # Node 2: entries 101-115 (all < MINID 200-0) - small so merge would fit
+        for {set i 101} {$i <= 115} {incr i} {
+            r XADD mystream $i-0 f v
+        }
+        # Node 3: entries 201-300 (all >= MINID 200-0)
+        for {set i 201} {$i <= 300} {incr i} {
+            r XADD mystream $i-0 f v
+        }
+
+        set initial_nodes [stream_node_count mystream]
+        assert {$initial_nodes == 3}
+
+        # Create consumer group and read all entries
+        r XGROUP CREATE mystream mygroup 0
+        r XREADGROUP GROUP mygroup consumer1 STREAMS mystream >
+
+        # ACK entries 1-95 in Node 1 (leave 5 unacked: 96-100)
+        # ACK entries 101-110 in Node 2 (leave 5 unacked: 111-115)
+        for {set i 1} {$i <= 95} {incr i} {
+            r XACK mystream mygroup $i-0
+        }
+        for {set i 101} {$i <= 110} {incr i} {
+            r XACK mystream mygroup $i-0
+        }
+
+        # XTRIM MINID 200-0 ACKED:
+        # - Node 1: 95 acked entries deleted, 5 unacked remain (96-100)
+        #   GC triggers (95/100 > 50%), Node 1 becomes sparse (5 entries)
+        #   Merge check: 5 + 15 = 20 < 100, masters match -> would merge!
+        # - Node 2: 10 acked entries (101-110) should be deleted
+        #   If bug existed: Node 2 merged, entries 101-110 never processed
+        # - Node 3: entries >= MINID, not touched
+        set deleted [r XTRIM mystream MINID 200-0 ACKED]
+
+        # Should delete: 95 (Node 1 acked) + 10 (Node 2 acked) = 105
+        assert_equal $deleted 105
+
+        # Remaining: 5 (Node 1 unacked: 96-100) + 5 (Node 2 unacked: 111-115) + 100 (Node 3) = 110
+        assert_equal [r XLEN mystream] 110
+
+        # Verify Node 2's acked entries (101-110) were actually deleted
+        set node2_acked [r XRANGE mystream 101-0 110-0]
+        assert_equal [llength $node2_acked] 0
+
+        # Verify Node 2's unacked entries (111-115) still exist
+        set node2_unacked [r XRANGE mystream 111-0 115-0]
+        assert_equal [llength $node2_unacked] 5
+
+        r config set stream-node-max-entries 100
+    }
+
+    test {GC with XTRIM DELREF - merge disabled, all eligible entries deleted} {
+        # Similar regression test with DELREF strategy.
+        # DELREF deletes entries and removes PEL references.
+        r DEL mystream
+        r config set stream-node-max-entries 100
+
+        # Create 3 nodes
+        for {set i 1} {$i <= 100} {incr i} {
+            r XADD mystream $i-0 f v
+        }
+        for {set i 101} {$i <= 115} {incr i} {
+            r XADD mystream $i-0 f v
+        }
+        for {set i 201} {$i <= 300} {incr i} {
+            r XADD mystream $i-0 f v
+        }
+
+        assert_equal [stream_node_count mystream] 3
+
+        # Create consumer group and read all
+        r XGROUP CREATE mystream mygroup 0
+        r XREADGROUP GROUP mygroup consumer1 STREAMS mystream >
+
+        # XTRIM MINID 200-0 DELREF: delete all entries < 200-0
+        set deleted [r XTRIM mystream MINID 200-0 DELREF]
+
+        # Should delete all 115 entries from Node 1 and Node 2
+        assert_equal $deleted 115
+
+        # Only Node 3 entries remain (201-300)
+        assert_equal [r XLEN mystream] 100
+
+        # Verify entries 101-115 (Node 2) were deleted
+        set node2_entries [r XRANGE mystream 101-0 199-0]
+        assert_equal [llength $node2_entries] 0
+
+        # Verify PEL only has Node 3 entries
+        set pending [r XPENDING mystream mygroup]
+        assert_equal [lindex $pending 0] 100
+
+        r config set stream-node-max-entries 100
+    }
 }
 
 # Tests that require DEBUG commands


### PR DESCRIPTION
Streams have a fundamental problem with deleted entries: they are just marked as deleted (STREAM_ITEM_FLAG_DELETED) but the memory is never reclaimed. Over time, streams with heavy XDEL usage accumulate garbage in the listpack nodes. This issue remained inside the code TODO list since my first implementation, and was never solved. Maybe it is time to act, as we are seeing that many users are choosing Redis for its streaming capabilities in recent times.

This commit implements two complementary optimizations:

1. Garbage collection: when a listpack node has more than 50% deleted entries, we rebuild the listpack keeping only live entries. This happens automatically during XDEL, XTRIM, and similar operations.

2. Node merging: after compaction, if a node becomes sparse (less than 50% of stream-node-max-entries), we attempt to merge it with the next node, provided:
   - Both nodes have identical master entries (same field names)
   - Combined size stays within configured limits
   - The next node is NOT the last node in the stream

The last point is important: the last node is never a candidate for merging because it's the target of new XADD operations. Merging into it would defeat the purpose, and keeping it "partial" is by design.

The implementation adds:
- streamListpackCompaction(): rebuilds a listpack without deleted entries
- streamListpackMerge(): merges two listpacks with matching masters
- streamListpackMasterMatch(): checks if two nodes can be merged

Note that the implementation is not allowing the user to configure the levels for GC or merging. I believe this is "too much" for most users and it is more likely to cause errors than optimizing things, in the practice. As it is right now, this change is in the class of the best features possible, conceptually:
- It adds zero complexity, user facing.
- It makes the system work better in certain workloads.
- There are basically no cases where one would disable this feature, given the current thresholds.
- We can always add configuration later if really needed.

Tests added in tests/unit/type/stream-compaction.tcl cover both GC and merging scenarios with various edge cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves stream memory efficiency and node density without user-facing changes.
> 
> - Adds `streamListpackCompaction()` to rebuild listpacks without tombstones and update `rax`/`alloc_size`
> - Adds `streamListpackMasterMatch()` and `streamListpackMerge()` to merge adjacent nodes when master fields match, sizes fit, and the neighbor isn’t the tail; skips tombstones and recalculates ID deltas
> - Integrates compaction/merge into `XDEL` and `XTRIM` paths; guards merging when delete strategy requires per-entry validation (e.g., `DELREF`/`ACKED`)
> - Updates iterator repair after structural changes and tightens size accounting (`STREAM_LISTPACK_MAX_SIZE`, `STREAM_NODE_MERGE_SPARSITY_DIVISOR`)
> - Adds comprehensive tests (`tests/unit/type/stream-compaction.tcl`) covering GC, merging conditions, consumer groups, XTRIM strategies, RDB reload, and memory usage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d740a938e3f20db38711fb3413286fbcc34a72f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->