### PR TITLE
Fix crash when calling internal container command without arguments

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4140,28 +4140,31 @@ int commandCheckExistence(client *c, sds *err) {
         return 1;
     if (!err)
         return 0;
+
     if (isContainerCommandBySds(c->argv[0]->ptr)) {
-        /* If we can't find the command but argv[0] by itself is a command
-         * it means we're dealing with an invalid subcommand. Print Help. */
         sds cmd = sdsnew((char *)c->argv[0]->ptr);
         sdstoupper(cmd);
         *err = sdsnew(NULL);
-        if (c->argc >= 2) {
+
+        if (c->argc < 2) {
+            *err = sdscatprintf(*err, "missing subcommand. Try %s HELP.", cmd);
+        } else {
             *err = sdscatprintf(*err, "unknown subcommand '%.128s'. Try %s HELP.",
                                 (char *)c->argv[1]->ptr, cmd);
-        } else {
-            *err = sdscatprintf(*err, "unknown command '%.128s'", cmd);
         }
+
         sdsfree(cmd);
     } else {
-        sds args = sdsempty();
-        int i;
-        for (i=1; i < c->argc && sdslen(args) < 128; i++)
-            args = sdscatprintf(args, "'%.*s' ", 128-(int)sdslen(args), (char*)c->argv[i]->ptr);
         *err = sdsnew(NULL);
-        *err = sdscatprintf(*err, "unknown command '%.128s', with args beginning with: %s",
-                            (char*)c->argv[0]->ptr, args);
-        sdsfree(args);
+        *err = sdscatprintf(*err, "unknown command '%.128s'", (char *)c->argv[0]->ptr);
+
+        if (c->argc >= 2) {
+            sds args = sdsempty();
+            for (int i = 1; i < c->argc && sdslen(args) < 128; i++)
+                args = sdscatprintf(args, "'%.*s' ", 128 - (int)sdslen(args), (char *)c->argv[i]->ptr);
+            *err = sdscatprintf(*err, ", with args beginning with: %s", args);
+            sdsfree(args);
+        }
     }
     /* Make sure there are no newlines in the string, otherwise invalid protocol
      * is emitted (The args come from the user, they may contain any character). */

--- a/src/server.c
+++ b/src/server.c
@@ -4146,8 +4146,12 @@ int commandCheckExistence(client *c, sds *err) {
         sds cmd = sdsnew((char *)c->argv[0]->ptr);
         sdstoupper(cmd);
         *err = sdsnew(NULL);
-        *err = sdscatprintf(*err, "unknown subcommand '%.128s'. Try %s HELP.",
-                            (char *)c->argv[1]->ptr, cmd);
+        if (c->argc >= 2) {
+            *err = sdscatprintf(*err, "unknown subcommand '%.128s'. Try %s HELP.",
+                                (char *)c->argv[1]->ptr, cmd);
+        } else {
+            *err = sdscatprintf(*err, "unknown command '%.128s'", cmd);
+        }
         sdsfree(cmd);
     } else {
         sds args = sdsempty();

--- a/src/server.c
+++ b/src/server.c
@@ -4140,9 +4140,9 @@ int commandCheckExistence(client *c, sds *err) {
         return 1;
     if (!err)
         return 0;
-    /* If we can't find the command but argv[0] by itself is a container command,
-     * it means we're dealing with a missing or invalid subcommand. Print Help. */
     if (isContainerCommandBySds(c->argv[0]->ptr)) {
+        /* If we can't find the command but argv[0] by itself is a command
+         * it means we're dealing with an invalid subcommand. Print Help. */
         sds cmd = sdsnew((char *)c->argv[0]->ptr);
         sdstoupper(cmd);
         *err = sdsnew(NULL);

--- a/src/server.c
+++ b/src/server.c
@@ -4140,7 +4140,8 @@ int commandCheckExistence(client *c, sds *err) {
         return 1;
     if (!err)
         return 0;
-
+    /* If we can't find the command but argv[0] by itself is a container command,
+     * it means we're dealing with a missing or invalid subcommand. Print Help. */
     if (isContainerCommandBySds(c->argv[0]->ptr)) {
         sds cmd = sdsnew((char *)c->argv[0]->ptr);
         sdstoupper(cmd);

--- a/tests/modules/basics.c
+++ b/tests/modules/basics.c
@@ -895,7 +895,7 @@ int TestBasics(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (!TestAssertStringReply(ctx,RedisModule_CallReplyArrayElement(reply, 1),"1234",4)) goto fail;
 
     T("foo", "E");
-    if (!TestAssertErrorReply(ctx,reply,"ERR unknown command 'foo', with args beginning with: ",53)) goto fail;
+    if (!TestAssertErrorReply(ctx,reply,"ERR unknown command 'foo'",25)) goto fail;
 
     T("set", "Ec", "x");
     if (!TestAssertErrorReply(ctx,reply,"ERR wrong number of arguments for 'set' command",47)) goto fail;

--- a/tests/modules/subcommands.c
+++ b/tests/modules/subcommands.c
@@ -108,5 +108,12 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     /* Trying to create a sub-subcommand fails */
     RedisModule_Assert(RedisModule_CreateSubcommand(subcmd,"get",NULL,"",0,0,0) == REDISMODULE_ERR);
 
+    /* Internal container command for testing */
+    if (RedisModule_CreateCommand(ctx,"subcommands.internal_container",NULL,"internal",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    RedisModuleCommand *internal_parent = RedisModule_GetCommand(ctx,"subcommands.internal_container");
+    if (RedisModule_CreateSubcommand(internal_parent,"test",cmd_set,"internal",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
     return REDISMODULE_OK;
 }

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -229,7 +229,7 @@ foreach call_type {nested normal} {
         r config resetstat
 
         # simple module command that replies with string error
-        assert_error "ERR unknown command 'hgetalllll', with args beginning with:" {r do_rm_call hgetalllll}
+        assert_error "ERR unknown command 'hgetalllll'" {r do_rm_call hgetalllll}
         assert_equal [errorrstat ERR r] {count=1}
 
         # simple module command that replies with string error

--- a/tests/unit/moduleapi/internalsecret.tcl
+++ b/tests/unit/moduleapi/internalsecret.tcl
@@ -6,7 +6,7 @@ start_cluster 1 0 [list config_lines $modules] {
     set r [srv 0 client]
 
     test {Internal command without internal connection fails as an unknown command} {
-        assert_error {*unknown command*with args beginning with:*} {r internalauth.internalcommand}
+        assert_error {*unknown command*} {r internalauth.internalcommand}
     }
 
     test {Wrong internalsecret fails authentication} {

--- a/tests/unit/moduleapi/subcommands.tcl
+++ b/tests/unit/moduleapi/subcommands.tcl
@@ -51,8 +51,8 @@ start_server {tags {"modules external:skip"}} {
         assert_equal [lsearch $commands "set"] -1
     }
 
-    test "Internal container command without subcommand does not crash" {
-        assert_error {*unknown command*} {r subcommands.internal_container}
+    test "Internal container command without subcommand returns missing subcommand error" {
+        assert_error {*missing subcommand*} {r subcommands.internal_container}
     }
 
     test "Unload the module - subcommands" {

--- a/tests/unit/moduleapi/subcommands.tcl
+++ b/tests/unit/moduleapi/subcommands.tcl
@@ -51,6 +51,10 @@ start_server {tags {"modules external:skip"}} {
         assert_equal [lsearch $commands "set"] -1
     }
 
+    test "Internal container command without subcommand does not crash" {
+        assert_error {*unknown command*} {r subcommands.internal_container}
+    }
+
     test "Unload the module - subcommands" {
         assert_equal {OK} [r module unload subcommands]
     }


### PR DESCRIPTION
Addresses crash and clarifies errors around container commands.

- Update server.c to handle container commands with no subcommand: emit "missing subcommand. Try HELP."; keep "unknown subcommand" for invalid subcommands; for unknown commands, include args preview only when present
- Add a test module command subcommands.internal_container with a subcommand for validation
- Add unit test asserting missing subcommand error when calling the internal container command without arguments


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines command error handling and adds targeted tests.
> 
> - Update `server.c` to return `"missing subcommand. Try <CMD> HELP."` when a container command is called without a subcommand, keep `unknown subcommand` for invalid subcommands, and for unknown commands emit `"unknown command '<cmd>'"` with args preview only if arguments exist
> - Add test module command `subcommands.internal_container` (internal) with a `test` subcommand for validation
> - Adjust tests (`modules/basics.c`, `moduleapi/blockedclient.tcl`, `internalsecret.tcl`) to expect the new error formats and add a unit test asserting the missing subcommand error for `subcommands.internal_container`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0a69b4ccc81a6583fab4be67d8550517c025fcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->