### PR TITLE
fix: Add check for stack overflow to prevent server crashes in luaReplyToRedisReply

### DIFF
--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -579,7 +579,7 @@ int luaError(lua_State *lua) {
 
 /* Reply to client 'c' converting the top element in the Lua stack to a
  * Redis reply. As a side effect the element is consumed from the stack.  */
-#define MAX_STACK_DEPTH (LUA_MINSTACK/2)
+#define MAX_STACK_DEPTH 500
 static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lua, int level) {
     int t = lua_type(lua,-1);
 
@@ -594,7 +594,7 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
     }
 
     if (level++ == MAX_STACK_DEPTH) {
-        // This case is for preventing server crashes when the C stack limit is reached first
+        /* This case is for preventing server crashes when the C stack limit is reached first */
         addReplyError(c, "max recursion level reached");
         lua_pop(lua,1);
         return;

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -593,7 +593,7 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
         return;
     }
 
-    if (level++ == MAX_STACK_DEPTH) {
+    if (++level > MAX_STACK_DEPTH) {
         /* This case is for preventing server crashes when the C stack limit is reached first */
         addReplyError(c, "max recursion level reached");
         lua_pop(lua,1);

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -135,7 +135,7 @@ static void redisProtocolToLuaType_Double(void *ctx, double d, const char *proto
 static void redisProtocolToLuaType_BigNumber(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len);
 static void redisProtocolToLuaType_VerbatimString(void *ctx, const char *format, const char *str, size_t len, const char *proto, size_t proto_len);
 static void redisProtocolToLuaType_Attribute(struct ReplyParser *parser, void *ctx, size_t len, const char *proto);
-static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lua);
+static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lua, int level);
 
 /*
  * Save the give pointer on Lua registry, used to save the Lua context and
@@ -579,7 +579,8 @@ int luaError(lua_State *lua) {
 
 /* Reply to client 'c' converting the top element in the Lua stack to a
  * Redis reply. As a side effect the element is consumed from the stack.  */
-static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lua) {
+#define MAX_STACK_DEPTH (LUA_MINSTACK/2)
+static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lua, int level) {
     int t = lua_type(lua,-1);
 
     if (!lua_checkstack(lua, 4)) {
@@ -589,6 +590,13 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
          * require push 4 elements to the Lua stack.*/
         addReplyError(c, "reached lua stack limit");
         lua_pop(lua,1); /* pop the element from the stack */
+        return;
+    }
+
+    if (level++ == MAX_STACK_DEPTH) {
+        // This case is for preventing server crashes when the C stack limit is reached first
+        addReplyError(c, "max recursion level reached");
+        lua_pop(lua,1);
         return;
     }
 
@@ -708,8 +716,8 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
             while (lua_next(lua,-2)) {
                 /* Stack now: table, key, value */
                 lua_pushvalue(lua,-2);        /* Dup key before consuming. */
-                luaReplyToRedisReply(c, script_client, lua); /* Return key. */
-                luaReplyToRedisReply(c, script_client, lua); /* Return value. */
+                luaReplyToRedisReply(c, script_client, lua, level); /* Return key. */
+                luaReplyToRedisReply(c, script_client, lua, level); /* Return value. */
                 /* Stack now: table, key. */
                 maplen++;
             }
@@ -732,7 +740,7 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
                 /* Stack now: table, key, true */
                 lua_pop(lua,1);               /* Discard the boolean value. */
                 lua_pushvalue(lua,-1);        /* Dup key before consuming. */
-                luaReplyToRedisReply(c, script_client, lua); /* Return key. */
+                luaReplyToRedisReply(c, script_client, lua, level); /* Return key. */
                 /* Stack now: table, key. */
                 setlen++;
             }
@@ -754,7 +762,7 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
                 lua_pop(lua,1);
                 break;
             }
-            luaReplyToRedisReply(c, script_client, lua);
+            luaReplyToRedisReply(c, script_client, lua, level);
             mbulklen++;
         }
         setDeferredArrayLen(c,replylen,mbulklen);
@@ -1734,7 +1742,7 @@ void luaCallFunction(scriptRunCtx* run_ctx, lua_State *lua, robj** keys, size_t 
     } else {
         /* On success convert the Lua return value into Redis protocol, and
          * send it to * the client. */
-        luaReplyToRedisReply(c, run_ctx->c, lua); /* Convert and consume the reply. */
+        luaReplyToRedisReply(c, run_ctx->c, lua, 0); /* Convert and consume the reply. */
     }
 
     /* Perform some cleanup that we need to do both on error and success. */

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1056,6 +1056,25 @@ start_server {tags {"scripting"}} {
     }
     }
 
+    if {!$::log_req_res} {
+        test {new test} {
+            r readraw 1
+            set res [run_script {
+                local t = {} for i=1,5000 do t = {t} end return t
+            } 0]
+            
+            while {true} {
+                if {$res == "-ERR max recursion level reached"} {
+                    break
+                }
+                assert_equal $res "*1"
+                set res [r read]
+            }
+            r readraw 0
+            assert_equal [r ping] {PONG}
+        }
+    }
+
     test {Script check unpack with massive arguments} {
         run_script {
             local a = {}
@@ -2686,15 +2705,4 @@ start_server {tags {"scripting"}} {
         }
     }
 
-    test {EVAL - recursion protection in reply conversion} {        
-        assert_error {*max recursion level reached*} {
-            r eval {
-                local t = {}
-                for i=1,50000 do
-                    t = {t}
-                end
-                return t
-            } 0
-        }
-    }
 }

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1044,7 +1044,7 @@ start_server {tags {"scripting"}} {
         set res [run_script {local a = {}; local b = {a}; a[1] = b; return a} 0]
         # drain the response
         while {true} {
-            if {$res == "-ERR reached lua stack limit"} {
+            if {$res == "-ERR max recursion level reached"} {
                 break
             }
             assert_equal $res "*1"
@@ -1056,24 +1056,25 @@ start_server {tags {"scripting"}} {
     }
     }
 
-    if {!$::log_req_res} {
-        test {new test} {
-            r readraw 1
-            set res [run_script {
-                local t = {} for i=1,5000 do t = {t} end return t
-            } 0]
-            
-            while {true} {
-                if {$res == "-ERR max recursion level reached"} {
-                    break
-                }
-                assert_equal $res "*1"
-                set res [r read]
+    
+    test {recursion protection in reply conversion} {
+        r readraw 1
+        run_script {
+            local t = {} for i=1,500 do t = {t} end return t
+        } 0
+        set res [r read]
+        # drain the response
+        while {true} {
+            if {$res == "-ERR max recursion level reached"} {
+                break
             }
-            r readraw 0
-            assert_equal [r ping] {PONG}
+            assert_equal $res "*1"
+            set res [r read]
         }
+        r readraw 0
+        assert_equal [r ping] {PONG}
     }
+
 
     test {Script check unpack with massive arguments} {
         run_script {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -2685,4 +2685,16 @@ start_server {tags {"scripting"}} {
             r eval "error({})" 0
         }
     }
+
+    test {EVAL - recursion protection in reply conversion} {        
+        assert_error {*max recursion level reached*} {
+            r eval {
+                local t = {}
+                for i=1,50000 do
+                    t = {t}
+                end
+                return t
+            } 0
+        }
+    }
 }


### PR DESCRIPTION
Fixes #14687 

This PR adds a `level` argument to the `luaReplyToRedisReply` function in order to track its recursion depth, if it reaches a particular limit, we send an error message back to the user instead of crashing in low memory environments.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents crashes from excessively deep Lua return structures by bounding recursion during reply conversion.
> 
> - Change `luaReplyToRedisReply` signature to include `level` and enforce `MAX_STACK_DEPTH` (500); on overflow reply with `-ERR max recursion level reached`
> - Propagate `level` in recursive table/map/set/array handling and update caller to pass `0`
> - Update existing test to expect the new error string for recursive objects; add a new test creating a 500-deep nested table to validate recursion protection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6607ca12d0b5ec0801e29acda05674db15c02d07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->