### PR TITLE
Remove unused comment in ebuckets.c

### DIFF
--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -301,7 +301,6 @@ static int ebTrySegSplit(EbucketsType *type, FirstSegHdr *seg, EBucketNew *newBu
      * balanced (Or won't be possible to split at all if all have the same exp-time!)
      */
     for (int i = 0 ; i < EB_SEG_MAX_ITEMS-1 ; i++) {
-        //printf ("i=%d\n", i);
         mNext = type->getExpireMeta(mIter->next);
         if (EB_BUCKET_KEY(ebGetMetaExpTime(mNext)) > EB_BUCKET_KEY(
                                                          ebGetMetaExpTime(mIter))) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Minor cleanup; no functional changes.
> 
> - Removes a commented-out debug `printf` in `ebTrySegSplit` within `src/ebuckets.c`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2492af1ea8a0070560a3636549ce94cca092328. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->