### PR TITLE
chore: Bump Rust stable version from 1.88.0 to 1.92.0

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -32,7 +32,7 @@ clean_environment: uninstall-rust
 # Keep all of the Rust stuff in one place
 install-rust:
 ifeq ($(INSTALL_RUST_TOOLCHAIN),yes)
-	@RUST_VERSION=1.88.0; \
+	@RUST_VERSION=1.92.0; \
 	ARCH="$$(uname -m)"; \
 	if ldd --version 2>&1 | grep -q musl; then LIBC_TYPE="musl"; else LIBC_TYPE="gnu"; fi; \
 	echo "Detected architecture: $${ARCH} and libc: $${LIBC_TYPE}"; \
@@ -40,18 +40,18 @@ ifeq ($(INSTALL_RUST_TOOLCHAIN),yes)
 		'x86_64') \
 			if [ "$${LIBC_TYPE}" = "musl" ]; then \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-x86_64-unknown-linux-musl"; \
-				RUST_SHA256="200bcf3b5d574caededba78c9ea9d27e7afc5c6df4154ed0551879859be328e1"; \
+				RUST_SHA256="1a257be51efac7bea14d5566e521777b85c473ee42524a38abb181c6443c38e4"; \
 			else \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-x86_64-unknown-linux-gnu"; \
-				RUST_SHA256="7b5437c1d18a174faae253a18eac22c32288dccfc09ff78d5ee99b7467e21bca"; \
+				RUST_SHA256="6e5efd6c25953b2732d4e6b1842512536650c68cf72a8b99a0fc566012dd6ca5"; \
 			fi ;; \
 		'aarch64') \
 			if [ "$${LIBC_TYPE}" = "musl" ]; then \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-aarch64-unknown-linux-musl"; \
-				RUST_SHA256="f8b3a158f9e5e8cc82e4d92500dd2738ac7d8b5e66e0f18330408856235dec35"; \
+				RUST_SHA256="ad412daf7b31aadbeb12f836ed14983f5d1d0717bd444e305f94ee68ea822fcd"; \
 			else \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-aarch64-unknown-linux-gnu"; \
-				RUST_SHA256="d5decc46123eb888f809f2ee3b118d13586a37ffad38afaefe56aa7139481d34"; \
+				RUST_SHA256="c812028423c3d7dd7ba99f66101e9e1aa3f66eab44a1285f41c363825d49dca4"; \
 			fi ;; \
 		*) echo >&2 "Unsupported architecture: '$${ARCH}'"; exit 1 ;; \
 	esac; \


### PR DESCRIPTION
It should fix the latest nightly build failure for RediSearch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Build tooling:** bump Rust toolchain.
> 
> - Update `install-rust` to use Rust `1.92.0` (was `1.88.0`) in `modules/Makefile`
> - Refresh SHA256 checksums for `x86_64` and `aarch64` installers across `gnu`/`musl`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 074e6703a27b95245aa57bf2a0e3b8dfc7733388. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->