### PR TITLE
Fix flaky test failures in  caused by clock precision issues with monotonic clock.

### DIFF
--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -160,7 +160,8 @@ foreach call_type {nested normal} {
 
         # make sure we didn't get BUSY error, it simply blocked till the command was done
         r ping
-        assert_morethan_equal [expr [clock clicks -milliseconds]-$start] 200
+        # The command blocks for 200ms, allow 1-2ms clock skew (1%)
+        assert_morethan_equal [expr [clock clicks -milliseconds]-$start] 198
         $rd read
 
         $rd close

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -161,7 +161,7 @@ foreach call_type {nested normal} {
         # make sure we didn't get BUSY error, it simply blocked till the command was done
         r ping
         # The command blocks for 200ms, allow 1-2ms clock skew (1%)
-        # to accomodate differences between using of monotonic timer and ustime
+        # to accommodate differences between using of monotonic timer and ustime
         assert_morethan_equal [expr [clock clicks -milliseconds]-$start] 198
         $rd read
 

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -161,6 +161,7 @@ foreach call_type {nested normal} {
         # make sure we didn't get BUSY error, it simply blocked till the command was done
         r ping
         # The command blocks for 200ms, allow 1-2ms clock skew (1%)
+        # to accomodate differences between using of monotonic timer and ustime
         assert_morethan_equal [expr [clock clicks -milliseconds]-$start] 198
         $rd read
 


### PR DESCRIPTION
Fix flaky test failures in `tests/unit/moduleapi/blockedclient.tcl` caused by
clock precision issues with monotonic clock.

The test runs a command that blocks for 200ms and then asserts the elapsed time
is >= 200ms. Due to clock skew and timing precision differences, the measured
time occasionally comes back as 199ms, causing spurious test failures:
https://github.com/redis/redis-extra-ci/actions/runs/20977220403/job/60300687524

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces flakiness in `tests/unit/moduleapi/blockedclient.tcl` by allowing minor clock skew.
> 
> - Adjusts timing assertion for 200ms block to `>= 198ms` and adds comments explaining monotonic vs ustime skew
> - Test-only change; no production code modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19c8fed916e7b7291c713e294c637ea96ed138fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->