### PR TITLE
Avoid unnecessary command rewriting for SET command with expiration

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -4415,13 +4415,10 @@ void replaceClientCommandVector(client *c, int argc, robj **argv) {
             c->all_argv_len_sum += pcmd->argv_len_sum;
         }
     }
-    /* Only re-lookup the command if the command name (argv[0]) changed. */
-    if (c->original_argv[0] != c->argv[0]) {
-        c->cmd = lookupCommandOrOriginal(c->argv,c->argc);
-        if (pcmd)
-            pcmd->cmd = c->cmd;
-        serverAssertWithInfo(c,NULL,c->cmd != NULL);
-    }
+    c->cmd = lookupCommandOrOriginal(c->argv,c->argc);
+    if (pcmd)
+        pcmd->cmd = c->cmd;
+    serverAssertWithInfo(c,NULL,c->cmd != NULL);
 }
 
 /* Rewrite a single item in the command vector.

--- a/src/networking.c
+++ b/src/networking.c
@@ -4415,10 +4415,13 @@ void replaceClientCommandVector(client *c, int argc, robj **argv) {
             c->all_argv_len_sum += pcmd->argv_len_sum;
         }
     }
-    c->cmd = lookupCommandOrOriginal(c->argv,c->argc);
-    if (pcmd)
-        pcmd->cmd = c->cmd;
-    serverAssertWithInfo(c,NULL,c->cmd != NULL);
+    /* Only re-lookup the command if the command name (argv[0]) changed. */
+    if (c->original_argv[0] != c->argv[0]) {
+        c->cmd = lookupCommandOrOriginal(c->argv,c->argc);
+        if (pcmd)
+            pcmd->cmd = c->cmd;
+        serverAssertWithInfo(c,NULL,c->cmd != NULL);
+    }
 }
 
 /* Rewrite a single item in the command vector.

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -168,7 +168,15 @@ void setGenericCommand(client *c, int flags, robj *key, robj **valref, robj *exp
          * EX/PX/EXAT flag. */
         if (!(flags & OBJ_PXAT)) {
             robj *milliseconds_obj = createStringObjectFromLongLong(milliseconds);
-            rewriteClientCommandVector(c, 5, shared.set, key, *valref, shared.pxat, milliseconds_obj);
+            /* If command is exactly "SET key value EX/PX/EXAT ttl", we can just
+             * replace the expire type and value in-place. Otherwise, we need to
+             * rewrite the entire command to strip extra flags (NX, XX, GET, etc). */
+            if (c->argc == 5) {
+                rewriteClientCommandArgument(c, 3, shared.pxat);
+                rewriteClientCommandArgument(c, 4, milliseconds_obj);
+            } else {
+                rewriteClientCommandVector(c, 5, shared.set, key, *valref, shared.pxat, milliseconds_obj);
+            }
             decrRefCount(milliseconds_obj);
         }
         notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -171,7 +171,7 @@ void setGenericCommand(client *c, int flags, robj *key, robj **valref, robj *exp
             /* If command is exactly "SET key value EX/PX/EXAT ttl", we can just
              * replace the expire type and value in-place. Otherwise, we need to
              * rewrite the entire command to strip extra flags (NX, XX, GET, etc). */
-            if (c->argc == 5) {
+            if ((c->cmd->proc == setCommand) && c->argc == 5) {
                 rewriteClientCommandArgument(c, 3, shared.pxat);
                 rewriteClientCommandArgument(c, 4, milliseconds_obj);
             } else {


### PR DESCRIPTION
This PR optimizes SET commands with expiration options (EX/PX/EXAT) by using in-place argument replacement instead of full command vector rewrite during replication propagation/AOF.

We've moved from rewriteClientCommandVector taking ~6% of CPU cycles on mixed SET+GET benchmark with expiration 
 
<img width="463" height="457" alt="image" src="https://github.com/user-attachments/assets/f58f918d-0034-41f0-81d2-d62b36b75d09" />

to using rewriteClientCommandArgument and taking 1.01% CPU cycles. 

<img width="463" height="457" alt="image" src="https://github.com/user-attachments/assets/409a075a-6e59-4430-b361-73daecca5cc1" />

  <summary>Full Environment Results for Test: memtier_benchmark-1Mkeys-string-set-get-short-expiration-512B:</summary>

|        Environment         |Baseline /redis unstable (median obs. +- std.dev)|Comparison filipecosta90/redis optimize.set.ex (median obs. +- std.dev)|% change (higher-better)|        Note         |
|----------------------------|-------------------------------------------------|----------------------------------------------------------------------:|------------------------|---------------------|
|oss-standalone              | 542866 +- 0.5% (2 datapoints)                   |                                                                 554765|2.2%                    |potential IMPROVEMENT|
|oss-standalone-08-io-threads| 1295174 +- 3.1% (2 datapoints)                  |                                                                1391245|7.4%                    |IMPROVEMENT          |




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes propagation/AOF rewriting for `SET` with expiration.
> 
> - In `setGenericCommand`, when the command is exactly `SET key value EX|PX|EXAT ttl` (`argc==5`), replace expiration type/value in-place to `PXAT <ms>` using `rewriteClientCommandArgument`.
> - For other forms (with flags like `NX`, `XX`, `GET`, etc.), continue using `rewriteClientCommandVector` to strip extra flags and propagate `SET ... PXAT <ms>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50a07bcdb0692dbeaa28a1b9535fc6fea48fb3f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->