### PR TITLE
Avoid zmalloc_size() in kvobjAllocSize() and approximate instead

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -1236,8 +1236,16 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
 }
 
 size_t kvobjAllocSize(kvobj *o) {
-    /* All kv-objects has at least kvobj header and embedded key */
-    size_t asize = zmalloc_size(kvobjGetAllocPtr(o));
+    debugServerAssert(o->iskvobj);
+    size_t asize = sizeof(kvobj);
+    /* Add metadata size */
+    asize += getNumMeta(o->metabits) * sizeof(uint64_t);
+    /* Add embedded key size */
+    asize += 1; /* embedded key header size */
+    asize += sdsAllocSize(kvobjGetKey(o));
+    /* Add embedded string size */
+    if (o->encoding == OBJ_ENCODING_EMBSTR)
+        asize += sdsAllocSize(o->ptr);
 
     if (o->type == OBJ_STRING) {
         asize += stringObjectAllocSize(o);

--- a/src/object.c
+++ b/src/object.c
@@ -1235,6 +1235,12 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
     serverPanic("Unknown object type");
 }
 
+/* Returns the size in bytes consumed by the object header, key and value in RAM.
+ * Note that the returned value is accurate approximation of the actual allocated
+ * size. For performance reasons it accumulates requested size instead in several
+ * cases (e.g. kvobj allocation, type 5 sds, listpacks, etc) but it does so in a
+ * self-consistent way.
+ */
 size_t kvobjAllocSize(kvobj *o) {
     debugServerAssert(o->iskvobj);
     size_t asize = sizeof(kvobj);


### PR DESCRIPTION
Avoid zmalloc_size() in kvobjAllocSize() and use approximation instead.

Since for ongoing key allocation histograms work (#14695) we need to call
kvobjAllocSize() more often on hot paths, using zmalloc_size() would cause
unnecessary performance overhead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal memory accounting only; reported sizes may differ slightly from true allocator usage but behavior is unchanged aside from approximation.
> 
> **Overview**
> **`kvobjAllocSize()`** no longer calls **`zmalloc_size()`** on the kvobj’s real allocation pointer. It now **sums an explicit approximation**: `sizeof(kvobj)`, metadata slots, the 1-byte embedded key header plus **`sdsAllocSize()`** for the key, optional EMBSTR value SDS size, and the existing per-type helpers (`stringObjectAllocSize`, `listTypeAllocSize`, etc.).
> 
> Documentation is updated to describe this as a **self-consistent approximate** size (not exact allocator bytes), traded for speed because the function is invoked more often on hot paths (e.g. per-slot memory tracking and upcoming key allocation histogram work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b40bcaa57bb08c06e0d654535a78ebec753ce2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->