### PR TITLE
MOD-13505 Update DataType Modules to 8.5.90

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.4.0
+MODULE_VERSION = v8.5.90
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 

--- a/modules/redisjson/Makefile
+++ b/modules/redisjson/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.4.0
+MODULE_VERSION = v8.5.90
 MODULE_REPO = https://github.com/redisjson/redisjson
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/rejson.so
 

--- a/modules/redistimeseries/Makefile
+++ b/modules/redistimeseries/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.4.0
+MODULE_VERSION = v8.5.90
 MODULE_REPO = https://github.com/redistimeseries/redistimeseries
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redistimeseries.so
 


### PR DESCRIPTION
update data type modules to 8.6 RC1
time series v8.5.90
bloom v8.5.90
json v8.5.90

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps Redis module versions in build configs.
> 
> - Updates `MODULE_VERSION` from `v8.4.0` to `v8.5.90` in `modules/redisbloom/Makefile`, `modules/redisjson/Makefile`, and `modules/redistimeseries/Makefile`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af528735b94a13276c44a18517a83c8cd1079a92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->