### PR TITLE
Add security configuration warnings at startup

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6992,8 +6992,7 @@ void redisAsciiArt(void) {
 
 /* Warn if the default user allows unauthenticated access. */
 void warnAboutInsecureConfig(void) {
-    if ((DefaultUser->flags & USER_FLAG_NOPASS) &&
-        !(DefaultUser->flags & USER_FLAG_DISABLED)) {
+    if ((DefaultUser->flags & USER_FLAG_NOPASS) && !(DefaultUser->flags & USER_FLAG_DISABLED)) {
         /* Check if Redis listens on all network interfaces */
         int bind_all_interfaces = 0;
         for (int j = 0; j < server.bindaddr_count; j++) {
@@ -7008,16 +7007,16 @@ void warnAboutInsecureConfig(void) {
 
         if (!server.protected_mode && bind_all_interfaces) {
             serverLog(LL_WARNING,
-                "WARNING: Redis does not require a password and is not protected by network restrictions. "
+                "WARNING: Redis does not require authentication and is not protected by network restrictions. "
                 "Redis will accept connections from any IP address on any network interface.");
         } else if (!server.protected_mode) {
             serverLog(LL_WARNING,
-                "WARNING: Redis does not require a password. "
+                "WARNING: Redis does not require authentication. "
                 "Redis will accept connections from any IP address on the configured network interface.");
         } else {
             /* protected_mode is enabled */
             serverLog(LL_WARNING,
-                "WARNING: Redis does not require a password. "
+                "WARNING: Redis does not require authentication. "
                 "Redis will accept connections from any local client.");
         }
     }

--- a/src/server.c
+++ b/src/server.c
@@ -7905,6 +7905,23 @@ int main(int argc, char **argv) {
             }
             redisCommunicateSystemd("READY=1\n");
         }
+        /* Warning the user about security configuration. */
+        if (server.requirepass == NULL) {
+            if (!server.protected_mode && server.bindaddr_count == 0) {
+                serverLog(LL_WARNING,
+                    "WARNING: Redis does not require a password. "
+                    "Redis will accept connections from any IP address or any network interface.");
+            } else if (!server.protected_mode) {
+                serverLog(LL_WARNING,
+                    "WARNING: Redis does not require a password. "
+                    "Redis will accept connections from any IP address on the configured network interface.");
+            } else {
+                /* protected_mode is enabled */
+                serverLog(LL_WARNING,
+                    "WARNING: Redis does not require a password. "
+                    "Redis will accept connection from any local client.");
+            }
+        }
     } else {
         sentinelIsRunning();
         if (server.supervised_mode == SUPERVISED_SYSTEMD) {

--- a/src/server.c
+++ b/src/server.c
@@ -7905,12 +7905,13 @@ int main(int argc, char **argv) {
             }
             redisCommunicateSystemd("READY=1\n");
         }
-        /* Warning the user about security configuration. */
-        if (server.requirepass == NULL) {
+        /* Warn only when the default user is enabled and allows unauthenticated access. */
+        if ((DefaultUser->flags & USER_FLAG_NOPASS) &&
+            !(DefaultUser->flags & USER_FLAG_DISABLED)) {
             if (!server.protected_mode && server.bindaddr_count == 0) {
                 serverLog(LL_WARNING,
-                    "WARNING: Redis does not require a password. "
-                    "Redis will accept connections from any IP address or any network interface.");
+                    "WARNING: Redis does not require a password and is not protected by network restrictions. "
+                    "Redis will accept connections from any IP address on any network interface.");
             } else if (!server.protected_mode) {
                 serverLog(LL_WARNING,
                     "WARNING: Redis does not require a password. "
@@ -7918,8 +7919,8 @@ int main(int argc, char **argv) {
             } else {
                 /* protected_mode is enabled */
                 serverLog(LL_WARNING,
-                    "WARNING: Redis does not require a password. "
-                    "Redis will accept connection from any local client.");
+                    "WARNING: Redis does not require authentication. "
+                    "Redis will accept connections from any local client.");
             }
         }
     } else {

--- a/src/server.c
+++ b/src/server.c
@@ -6990,6 +6990,39 @@ void redisAsciiArt(void) {
     zfree(buf);
 }
 
+/* Warn if the default user allows unauthenticated access. */
+void warnAboutInsecureConfig(void) {
+    if ((DefaultUser->flags & USER_FLAG_NOPASS) &&
+        !(DefaultUser->flags & USER_FLAG_DISABLED)) {
+        /* Check if Redis listens on all network interfaces */
+        int bind_all_interfaces = 0;
+        for (int j = 0; j < server.bindaddr_count; j++) {
+            char *addr = server.bindaddr[j];
+            if (addr[0] == '-') addr++;
+            if (!strcmp(addr, "*") || !strcmp(addr, "0.0.0.0") ||
+                !strcmp(addr, "::") || !strcmp(addr, "::*")) {
+                bind_all_interfaces = 1;
+                break;
+            }
+        }
+
+        if (!server.protected_mode && bind_all_interfaces) {
+            serverLog(LL_WARNING,
+                "WARNING: Redis does not require a password and is not protected by network restrictions. "
+                "Redis will accept connections from any IP address on any network interface.");
+        } else if (!server.protected_mode) {
+            serverLog(LL_WARNING,
+                "WARNING: Redis does not require a password. "
+                "Redis will accept connections from any IP address on the configured network interface.");
+        } else {
+            /* protected_mode is enabled */
+            serverLog(LL_WARNING,
+                "WARNING: Redis does not require a password. "
+                "Redis will accept connections from any local client.");
+        }
+    }
+}
+
 /* Get the server listener by type name */
 connListener *listenerByType(const char *typename) {
     int conn_index;
@@ -7905,24 +7938,7 @@ int main(int argc, char **argv) {
             }
             redisCommunicateSystemd("READY=1\n");
         }
-        /* Warn only when the default user is enabled and allows unauthenticated access. */
-        if ((DefaultUser->flags & USER_FLAG_NOPASS) &&
-            !(DefaultUser->flags & USER_FLAG_DISABLED)) {
-            if (!server.protected_mode && server.bindaddr_count == 0) {
-                serverLog(LL_WARNING,
-                    "WARNING: Redis does not require a password and is not protected by network restrictions. "
-                    "Redis will accept connections from any IP address on any network interface.");
-            } else if (!server.protected_mode) {
-                serverLog(LL_WARNING,
-                    "WARNING: Redis does not require a password. "
-                    "Redis will accept connections from any IP address on the configured network interface.");
-            } else {
-                /* protected_mode is enabled */
-                serverLog(LL_WARNING,
-                    "WARNING: Redis does not require authentication. "
-                    "Redis will accept connections from any local client.");
-            }
-        }
+        warnAboutInsecureConfig();
     } else {
         sentinelIsRunning();
         if (server.supervised_mode == SUPERVISED_SYSTEMD) {

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1308,3 +1308,4 @@ start_server {overrides {user "default on nopass ~* +@all -flushdb"} tags {acl e
         assert_error {NOPERM *} {r flushdb}
     }
 }
+

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1308,4 +1308,3 @@ start_server {overrides {user "default on nopass ~* +@all -flushdb"} tags {acl e
         assert_error {NOPERM *} {r flushdb}
     }
 }
-

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1093,3 +1093,30 @@ test {Clients are evenly distributed among io threads} {
         }
     }
 }
+
+# Test insecure configuration warnings
+start_server {tags {introspection external:skip} overrides {protected-mode no bind "*"}} {
+    test {Warning shown when no auth and binding all interfaces} {
+        wait_for_log_messages 0 {"*WARNING: Redis does not require a password and is not protected by network restrictions*"} 0 10 100
+    }
+}
+
+start_server {tags {introspection external:skip} overrides {protected-mode no bind "127.0.0.1"}} {
+    test {Warning shown for configured interface when binding specific address} {
+        wait_for_log_messages 0 {"*WARNING: Redis does not require a password*configured network interface*"} 0 10 100
+    }
+}
+
+start_server {tags {introspection external:skip} overrides {protected-mode yes}} {
+    test {Warning shown for local clients when protected mode is on} {
+        wait_for_log_messages 0 {"*WARNING: Redis does not require a password*local client*"} 0 10 100
+    }
+}
+
+start_server {tags {introspection external:skip} overrides {requirepass secret}} {
+    test {No warning shown when password is set} {
+        # Check that the warning does NOT appear
+        set loglines [exec cat [srv 0 stdout]]
+        assert_equal 0 [string match "*WARNING: Redis does not require a password*" $loglines]
+    }
+}

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1097,19 +1097,19 @@ test {Clients are evenly distributed among io threads} {
 # Test insecure configuration warnings
 start_server {tags {introspection external:skip} overrides {protected-mode no bind "*"}} {
     test {Warning shown when no auth and binding all interfaces} {
-        wait_for_log_messages 0 {"*WARNING: Redis does not require a password and is not protected by network restrictions*"} 0 10 100
+        wait_for_log_messages 0 {"*WARNING: Redis does not require authentication and is not protected by network restrictions*"} 0 10 100
     }
 }
 
 start_server {tags {introspection external:skip} overrides {protected-mode no bind "127.0.0.1"}} {
     test {Warning shown for configured interface when binding specific address} {
-        wait_for_log_messages 0 {"*WARNING: Redis does not require a password*configured network interface*"} 0 10 100
+        wait_for_log_messages 0 {"*WARNING: Redis does not require authentication*configured network interface*"} 0 10 100
     }
 }
 
 start_server {tags {introspection external:skip} overrides {protected-mode yes}} {
     test {Warning shown for local clients when protected mode is on} {
-        wait_for_log_messages 0 {"*WARNING: Redis does not require a password*local client*"} 0 10 100
+        wait_for_log_messages 0 {"*WARNING: Redis does not require authentication*local client*"} 0 10 100
     }
 }
 
@@ -1117,6 +1117,6 @@ start_server {tags {introspection external:skip} overrides {requirepass secret}}
     test {No warning shown when password is set} {
         # Check that the warning does NOT appear
         set loglines [exec cat [srv 0 stdout]]
-        assert_equal 0 [string match "*WARNING: Redis does not require a password*" $loglines]
+        assert_equal 0 [string match "*WARNING: Redis does not require authentication*" $loglines]
     }
 }


### PR DESCRIPTION
Adds startup-time security warnings when the default user permits unauthenticated access, with behavior dependent on protected-mode and bind settings.
Warnings are skipped in Sentinel mode since it intentionally
disables protected-mode by design.

- No password + no protected-mode + no bind: warn about accepting
  connections from any IP/interface
- No password + no protected-mode: warn about accepting connections
  from any IP on configured interface
- No password + protected-mode enabled: warn about accepting
  connections from local clients




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces startup-time security warnings when the default user permits unauthenticated access.
> 
> - Adds `warnAboutInsecureConfig` in `server.c` to check `DefaultUser` flags, `bind` addresses, and `protected-mode`, logging tailored warnings; invoked after the server signals readiness (server mode only, not Sentinel)
> - Adds unit tests in `tests/unit/introspection.tcl` covering: bind to all interfaces without protected mode, specific interface without protected mode, protected mode enabled, and a password set (no warning expected)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7605d11608ad00a438c7e3e4a528ae56d26a7ed0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->