### PR TITLE
Modify the condition for adding CLIENT_IO_CLOSE_ASAP flag

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2216,7 +2216,7 @@ void freeClientAsync(client *c) {
         int main_thread = pthread_equal(pthread_self(), server.main_thread_id);
         /* Make sure the main thread can access IO thread data safely. */
         if (main_thread) pauseIOThread(c->tid);
-        if (!(c->flags & CLIENT_IO_CLOSE_ASAP)) {
+        if (!(c->io_flags & CLIENT_IO_CLOSE_ASAP)) {
             c->io_flags |= CLIENT_IO_CLOSE_ASAP;
             enqueuePendingClientsToMainThread(c, 1);
         }


### PR DESCRIPTION
  1. CLIENT_IO_CLOSE_ASAP is a flag for c->io_flags, which does not match c->flags. The flag corresponding to c->flags is CLIENT_CLOSE_ASAP.
  2. If we want to asynchronously free a client running on an io-thread, we should check its c->io_flags to determine if CLIENT_IO_CLOSE_ASAP has already been added. If it hasn't been added before, then CLIENT_IO_CLOSE_ASAP should be added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts async client-free logic to reference the correct flag field.
> 
> - In `freeClientAsync`, the condition now checks `c->io_flags` for `CLIENT_IO_CLOSE_ASAP` before setting/enqueuing, instead of `c->flags`.
> - Affects IO-thread clients when scheduling safe asynchronous closure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cfccfb4fc6e4d23bb7e2680cfab379d588e15f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->