### PR TITLE
Fix SDS header size calculation in kvobjSet

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -287,7 +287,7 @@ kvobj *kvobjSet(sds key, robj *val, uint32_t keyMetaBits) {
         /* Embed when the sum is less than a cache line (Metadata is discarded 
          * since we don't have to be accurate and it is placed before the object) */
         size_t size = sizeof(kvobj);
-        size += (key != NULL) * (sdslen(key) + 1 + sdshdrSize(sdsReqType(sdslen(key))) + 1); /* hdr size (1) + hdr + nullterm (1) */
+        size += (key != NULL) * (sdslen(key) + 1 + sdsHdrSize(sdsReqType(sdslen(key))) + 1); /* hdr size (1) + hdr + nullterm (1) */
         size += 4 + len; /* embstr header (3) + nullterm (1) */
         if (size <= CACHE_LINE_SIZE) {
             kv = kvobjCreateEmbedString(val->ptr, len, key, keyMetaBits);

--- a/src/object.c
+++ b/src/object.c
@@ -287,7 +287,7 @@ kvobj *kvobjSet(sds key, robj *val, uint32_t keyMetaBits) {
         /* Embed when the sum is less than a cache line (Metadata is discarded 
          * since we don't have to be accurate and it is placed before the object) */
         size_t size = sizeof(kvobj);
-        size += (key != NULL) * (sdslen(key) + 1 + sdsHdrSize(sdsType(key)) + 1); /* hdr size (1) + hdr + nullterm (1) */
+        size += (key != NULL) * (sdslen(key) + 1 + sdshdrSize(sdsReqType(sdslen(key))) + 1); /* hdr size (1) + hdr + nullterm (1) */
         size += 4 + len; /* embstr header (3) + nullterm (1) */
         if (size <= CACHE_LINE_SIZE) {
             kv = kvobjCreateEmbedString(val->ptr, len, key, keyMetaBits);

--- a/src/object.c
+++ b/src/object.c
@@ -287,7 +287,7 @@ kvobj *kvobjSet(sds key, robj *val, uint32_t keyMetaBits) {
         /* Embed when the sum is less than a cache line (Metadata is discarded 
          * since we don't have to be accurate and it is placed before the object) */
         size_t size = sizeof(kvobj);
-        size += (key != NULL) * (sdslen(key) + 3); /* hdr size (1) + hdr (1) + nullterm (1) */
+        size += (key != NULL) * (sdslen(key) + 1 + sdsHdrSize(sdsType(key)) + 1); /* hdr size (1) + hdr + nullterm (1) */
         size += 4 + len; /* embstr header (3) + nullterm (1) */
         if (size <= CACHE_LINE_SIZE) {
             kv = kvobjCreateEmbedString(val->ptr, len, key, keyMetaBits);


### PR DESCRIPTION
When calculating the size, the header (hdr) was fixed to 1, which does not match the actual possible values.
Test case: a key of 45 bytes, according to the original rule, the calculated size is 64 bytes, but the actual memory size is 66 bytes.
After the fix, the SDS header size for the key is correct, not fixed to 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes size estimation for embedded keys in `kvobjSet`.**
> 
> - Updates cache-line fit calculation to include the variable `sds` header size (`sdsHdrSize(sdsReqType(...))`) instead of a fixed byte, ensuring accurate sizing when deciding between embedded and raw string allocations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0867c154ba5f4c00e70b00b0efec654b53d2f272. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->