### PR TITLE
Add hotkeys memory to memory-overhead and fix hotkeys info keys

### DIFF
--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -185,14 +185,14 @@ size_t hotkeysGetMemoryUsage(hotkeyStats *hotkeys) {
     if (!hotkeys) return 0;
 
     size_t memory_usage = sizeof(hotkeyStats);
-    if (server.hotkeys->cpu) {
+    if (hotkeys->cpu) {
         memory_usage += chkTopKGetMemoryUsage(hotkeys->cpu);
     }
-    if (server.hotkeys->net) {
+    if (hotkeys->net) {
         memory_usage += chkTopKGetMemoryUsage(hotkeys->net);
     }
     /* Add memory for slots array if present */
-    if (server.hotkeys->slots) {
+    if (hotkeys->slots) {
         memory_usage += sizeof(int) * hotkeys->numslots;
     }
 

--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -181,6 +181,24 @@ void hotkeyStatsPostCurrentCmd(hotkeyStats *hotkeys) {
     hotkeys->is_in_selected_slots = 0;
 }
 
+size_t hotkeysGetMemoryUsage(hotkeyStats *hotkeys) {
+    if (!hotkeys) return 0;
+
+    size_t memory_usage = sizeof(hotkeyStats);
+    if (server.hotkeys->cpu) {
+        memory_usage += chkTopKGetMemoryUsage(hotkeys->cpu);
+    }
+    if (server.hotkeys->net) {
+        memory_usage += chkTopKGetMemoryUsage(hotkeys->net);
+    }
+    /* Add memory for slots array if present */
+    if (server.hotkeys->slots) {
+        memory_usage += sizeof(int) * hotkeys->numslots;
+    }
+
+    return memory_usage;
+}
+
 static int64_t time_diff_ms(struct timeval a, struct timeval b) {
     int64_t sec = (int64_t)(a.tv_sec - b.tv_sec);
     int64_t usec = (int64_t)(a.tv_usec - b.tv_usec);

--- a/src/object.c
+++ b/src/object.c
@@ -1390,6 +1390,9 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
         mh->db_dict_rehashing_count += kvstoreDictRehashingCount(db->expires);
     }
 
+    /* Hotkeys memory overhead */
+    mem_total += hotkeysGetMemoryUsage(server.hotkeys);
+
     mh->overhead_total = mem_total;
     mh->dataset = zmalloc_used - mem_total;
     mh->peak_perc = (float)zmalloc_used*100/mh->peak_allocated;

--- a/src/server.c
+++ b/src/server.c
@@ -6624,27 +6624,12 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
     if (server.hotkeys &&
         (all_sections || (dictFind(section_dict,"hotkeys") != NULL)))
     {
-        if (sections++) info = sdscat(info,"\r\n");
-
-        /* Calculate memory usage on-the-fly */
-        size_t memory_usage = sizeof(hotkeyStats);
-        if (server.hotkeys->cpu) {
-            memory_usage += chkTopKGetMemoryUsage(server.hotkeys->cpu);
-        }
-        if (server.hotkeys->net) {
-            memory_usage += chkTopKGetMemoryUsage(server.hotkeys->net);
-        }
-        /* Add memory for slots array if present */
-        if (server.hotkeys->slots) {
-            memory_usage += sizeof(int) * server.hotkeys->numslots;
-        }
+        if (sections++) info = sdscat(info,"\r\n"); 
 
         info = sdscatprintf(info, "# Hotkeys\r\n"
-            "tracking-active:%d\r\n"
-            "used-memory:%zu\r\n"
-            "cpu-time:%lld\r\n",
+            "hotkeys-tracking-active:%d\r\n"
+            "hotkeys-cmd-cpu-time:%lld\r\n",
             server.hotkeys->active ? 1 : 0,
-            memory_usage,
             server.hotkeys->cpu_time);
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -4075,6 +4075,7 @@ void hotkeyStatsRelease(hotkeyStats *hotkeys);
 void hotkeyStatsPreCurrentCmd(hotkeyStats *hotkeys, client *c);
 void hotkeyStatsUpdateCurrentCmd(hotkeyStats *hotkeys, hotkeyMetrics metrics);
 void hotkeyStatsPostCurrentCmd(hotkeyStats *hotkeys);
+size_t hotkeysGetMemoryUsage(hotkeyStats *hotkeys);
 
 /* Commands prototypes */
 void authCommand(client *c);


### PR DESCRIPTION
Follow #14680
Add the memory overhead of the hotkeyStats structure to `used_memory_overhead`, add `hotkeys-` prefix to hotkey keys in INFO and remove `used_memory` in the hotkeys info section as it's unneeded (too little memory for us to care about).

Tnx @oranagra for pointing [this](https://github.com/redis/redis/pull/14680#discussion_r2702151804) out.
