### PR TITLE
Quick user ACL permission verification

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1857,6 +1857,15 @@ int ACLCheckAllUserCommandPerm(user *u, struct redisCommand *cmd, robj **argv, i
     /* If there is no associated user, the connection can run anything. */
     if (u == NULL) return ACL_OK;
 
+    /* Quick check if the user has all permissions, return early if so. */
+    if (likely(listFirst(u->selectors) != NULL)) {
+        aclSelector *s = listNodeValue(listFirst(u->selectors));
+        const uint32_t all_perms = SELECTOR_FLAG_ALLCOMMANDS |
+                                   SELECTOR_FLAG_ALLKEYS |
+                                   SELECTOR_FLAG_ALLCHANNELS;
+        if ((s->flags & all_perms) == all_perms) return ACL_OK;
+    }
+
     /* We have to pick a single error to log, the logic for picking is as follows:
      * 1) If no selector can execute the command, return the command.
      * 2) Return the last key or channel that no selector could match. */


### PR DESCRIPTION
the ACL check costs much when io threads is enabled in pipeline mode
<img width="1213" height="382" alt="截屏2026-01-20 10 27 57" src="https://github.com/user-attachments/assets/4e6b6383-77f4-4b13-9c95-6df05ee70dee" />

if we use legacy authorization, the user has all permission, so we can have a quick check, now the flamegraph is as follow
<img width="641" height="129" alt="截屏2026-01-20 10 38 38" src="https://github.com/user-attachments/assets/cf082e98-a4d6-4bb8-b38f-4750d553c1a7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes ACL evaluation by adding a fast path for fully privileged users.
> 
> - In `ACLCheckAllUserCommandPerm`, if the first selector’s flags include `SELECTOR_FLAG_ALLCOMMANDS | SELECTOR_FLAG_ALLKEYS | SELECTOR_FLAG_ALLCHANNELS`, return `ACL_OK` immediately
> - Skips per-selector checks, key/channel extraction, and cache setup when the user has unrestricted permissions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4ef25053c90b1d10f2f00de551b9f8e3038ffce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->