### PR TITLE
Fix prefetch size

### DIFF
--- a/src/iothread.c
+++ b/src/iothread.c
@@ -381,7 +381,7 @@ int prefetchIOThreadCommands(IOThread *t) {
         if (c[i]->reply) redis_prefetch_read(c[i]->reply);
         redis_prefetch_read(&c[i]->mem_usage_bucket);
         clients++;
-     }
+    }
     /* Prefetch the commands in the batch. */
     prefetchCommands();
     return clients;

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -319,7 +319,7 @@ int determinePrefetchCount(int len) {
 
     /* The batch max size is double of the configured size. */
     int config_size = batch->max_prefetch_size / 2;
-    return len < server.prefetch_batch_max_size ? len : config_size;
+    return len < (int)batch->max_prefetch_size ? len : config_size;
 }
 
 /* Prefetch command-related data:


### PR DESCRIPTION
in #14017
> Prefetching in very small batches tends to be ineffective because the technique
> relies on a small gap—typically a few CPU cycles—between issuing the prefetch
> and performing the actual memory access. If the batch is too small, this delay
> cannot be effectively inserted, and the prefetching yields little to no benefit.
> 
> To avoid wasting effort, when the remaining data is small (less than twice the
> maximum batch size), we simply prefetch all of it at once. Otherwise, we only
> prefetch a limited portion, capped at the configured maximum. 
> 
> for example, prefetch_batch_max_size is 16, if there are 18 keys, we want to prefetch
> them in a batch instead of two batches: 16 and 2.
> if there are 33 keys to prefetch, we will have two batches 16 and 17.

we expect as above, but actually we did not, this commit is fixing that

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix prefetch sizing logic**
> 
> - Update `determinePrefetchCount` to compare `len` against `batch->max_prefetch_size` (with cast), aligning with the doubled batch strategy and ensuring small remaining sets are prefetched in one pass.
> 
> **Minor cleanup**
> 
> - Fix misplaced closing brace in `prefetchIOThreadCommands` loop in `iothread.c`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6ebb6641044c2e6f4d33491b1325ba858813a9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->