### PR TITLE
Fix timeout waiting for blocked clients in pause test

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -1001,7 +1001,7 @@ proc wait_for_blocked_clients_count {count {maxtries 100} {delay 10} {idx 0}} {
     wait_for_condition $maxtries $delay  {
         [s $idx blocked_clients] == $count
     } else {
-        fail "Timeout waiting for blocked clients"
+        fail "Timeout waiting for blocked clients (expected $count, actual [s $idx blocked_clients])"
     }
 }
 

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -40,6 +40,7 @@ start_server {tags {"pause network"}} {
         #   preserve most restrictive configuration among multiple settings.
         set rd [redis_deferring_client]
         $rd SET FOO BAR
+        $rd read
 
         set test_start_time [clock milliseconds]
         r client PAUSE 200 ALL

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -46,8 +46,10 @@ start_server {tags {"pause network"}} {
         r client PAUSE 20 WRITE
         after 50
         $rd get FOO
+        $rd read
         set elapsed [expr {[clock milliseconds]-$test_start_time}]
         assert_lessthan 200 $elapsed
+        $rd close
     }
 
     test "Test new pause time is smaller than old one, then old time preserved" {


### PR DESCRIPTION
Failed CI: https://github.com/redis/redis/actions/runs/21121021310/job/60733781846

To verify the pause duration, we need to wait for the client to be unpause and the command to complete, so add `$rd read` to wait for the command to finish.

The test failure was caused by $rd still being blocked and not closed in the previous test, so the next test would get 2 blocked clients instead of 1 client, causing the test to fail.

The following runtest can easily reproduce this failure:
```
taskset -c 0 ./runtest --config io-threads 4 --accurate --verbose --tags network --dump-logs --single unit/pause  --loop --stop
```

we can see the failed log
```
[err]: Test new pause time is smaller than old one, then old time preserved in tests/unit/pause.tcl
Timeout waiting for blocked clients (expected 1, actual 2)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability and diagnostics of pause-related tests.
> 
> - In `tests/unit/pause.tcl`, ensure deferring client commands complete by adding `$rd read` after `SET/GET` and close the client, preventing lingering blocked clients that affected subsequent tests
> - In `tests/support/util.tcl`, enhance `wait_for_blocked_clients_count` failure message to show `expected` and `actual` `[s $idx blocked_clients]`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c4f6a9d0b2b927b0a6eb0ccd66e1088f305918a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->