### PR TITLE
MOD-13504: Update Search to RC1 8.5.90

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.4.2
+MODULE_VERSION = v8.5.90
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
Update Search to 8.6 RC1 version 8.5.90

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates build to target the latest Redisearch release.
> 
> - Bumps `MODULE_VERSION` from `v8.4.2` to `v8.5.90` in `modules/redisearch/Makefile` to fetch/build that version
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4946928e10c1e358c706ef38ea185ce0104e61dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->