### PR TITLE
Fix some test timing issues in replication.tcl and maxmemory.tcl

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1822,10 +1822,13 @@ start_server {tags {"repl external:skip"}} {
 
             # Connect to an invalid master
             $slave slaveof $master_host 0
-            after 1000
 
             # Expect current sync attempts to increase
-            assert {[status $slave master_current_sync_attempts] >= 2}
+            wait_for_condition 100 50 {
+                [status $slave master_current_sync_attempts] >= 2
+            } else {
+                fail "Timeout waiting for master_current_sync_attempts"
+            }
         }
     }
 }

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -640,7 +640,7 @@ start_server {tags {"maxmemory" "external:skip"}} {
         r set src value
         after 2000
         r rename src dst
-        assert_lessthan [r object idletime dst] 1
+        assert_lessthan_equal [r object idletime dst] 1
     } {} {slow}
 
     test {LRM: XREADGROUP updates stream LRM} {


### PR DESCRIPTION
1) Replace fixed sleep with wait_for_condition to avoid flaky test failures when checking master_current_sync_attempts counter.

Failed CI: https://github.com/sundb/redis/actions/runs/21159401517/job/60850843932
```
*** [err]: Replication current attempts counter behavior in tests/integration/replication.tcl
Expected [status ::redis::redisHandle105 master_current_sync_attempts] >= 2 (context: type eval line 19 cmd {assert {[status $slave master_current_sync_attempts] >= 2}} proc ::test)
```

2) Similar to https://github.com/redis/redis/pull/14674, use assert_lessthan_equal instead of assert_lessthan to verify the idle time.

Failed CI: https://github.com/sundb/redis/actions/runs/21159401519/job/60850844187

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves test robustness and timing tolerance.
> 
> - Replace fixed `after 1000` + immediate assert with `wait_for_condition` for `master_current_sync_attempts >= 2` in `tests/integration/replication.tcl`
> - Relax LRM RENAME timing check in `tests/unit/maxmemory.tcl` by using `assert_lessthan_equal` for `object idletime` of `dst`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2863230f3e852155140760715e9ffd82574e6fe3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->