### PR TITLE
Make cluster-slot-stats-enabled config multivalued

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1853,8 +1853,20 @@ aof-timestamp-enabled no
 # By enabling the 'cluster-slot-stats-enabled' config, the cluster will begin to capture advanced statistics.
 # These statistics can be leveraged to assess general slot usage trends, identify hot / cold slots,
 # migrate slots for a balanced cluster workload, and / or re-write application logic to better utilize slots.
-# Note that per slot **memory** statistics are collected only if 'cluster-slot-stats-enabled' is enabled
-# at startup, and later config changes don't affect it.
+#
+# The config accepts multiple values as a space-separated list:
+#   - cpu: Track CPU usage per slot (cpu-usec metric)
+#   - net: Track network bytes per slot (network-bytes-in, network-bytes-out metrics)
+#   - mem: Track memory usage per slot (memory-bytes metric)
+#   - yes: Enable all tracking (equivalent to "cpu net mem")
+#   - no: Disable all tracking (default)
+#
+# Example: cluster-slot-stats-enabled "cpu net"
+#
+# Note: Memory tracking (mem) can ONLY be enabled at startup. If you try to enable
+# memory tracking via CONFIG SET when it wasn't enabled at startup, the command will
+# fail. However, you can disable memory tracking at runtime by removing the 'mem' flag.
+# Once disabled, memory tracking cannot be re-enabled without restarting the server.
 #
 # cluster-slot-stats-enabled no
 

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -95,26 +95,33 @@ static void collectAndSortSlotStats(slotStatForSort slot_stats[], slotStatType o
 }
 
 static void addReplySlotStat(client *c, int slot) {
+    int cpu_enabled = server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_CPU;
+    int net_enabled = server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_NET;
+    int mem_enabled = (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_MEM) && server.memory_tracking_per_slot;
+
     addReplyArrayLen(c, 2); /* Array of size 2, where 0th index represents (int) slot,
                              * and 1st index represents (map) usage statistics. */
     addReplyLongLong(c, slot);
     /* Nested map representing slot usage statistics. */
     addReplyMapLen(c, 1 +                                        /* key-count */
-                   (server.memory_tracking_per_slot ? 1 : 0) +   /* memory-bytes */
-                   (server.cluster_slot_stats_enabled ? 3 : 0)); /* remaining fields */
+                   (mem_enabled ? 1 : 0) +                       /* memory-bytes */
+                   (cpu_enabled ? 1 : 0) +                       /* cpu-usec */
+                   (net_enabled ? 2 : 0));                       /* network-bytes-in/out */
     addReplyBulkCString(c, "key-count");
     addReplyLongLong(c, countKeysInSlot(slot));
 
     /* Any additional metrics aside from key-count come with a performance trade-off,
      * and are aggregated and returned based on its server config. */
     kvstoreDictMetadata *meta = getSlotMeta(slot, 0);
-    if (server.memory_tracking_per_slot) {
+    if (mem_enabled) {
         addReplyBulkCString(c, "memory-bytes");
         addReplyLongLong(c, meta ? meta->alloc_size : 0);
     }
-    if (server.cluster_slot_stats_enabled) {
+    if (cpu_enabled) {
         addReplyBulkCString(c, "cpu-usec");
         addReplyLongLong(c, meta ? meta->cpu_usec : 0);
+    }
+    if (net_enabled) {
         addReplyBulkCString(c, "network-bytes-in");
         addReplyLongLong(c, meta ? meta->network_bytes_in : 0);
         addReplyBulkCString(c, "network-bytes-out");
@@ -143,7 +150,7 @@ static void addReplySortedSlotStats(client *c, slotStatForSort slot_stats[], lon
 }
 
 static int canAddNetworkBytesOut(client *c) {
-    return clusterSlotStatsEnabled() && c->slot != INVALID_CLUSTER_SLOT;
+    return clusterSlotStatsNetEnabled() && c->slot != INVALID_CLUSTER_SLOT;
 }
 
 /* Accumulates egress bytes upon sending RESP responses back to user clients. */
@@ -235,8 +242,7 @@ void clusterSlotStatResetAll(void) {
  * would equate to repeating the same calculation twice.
  */
 static int canAddCpuDuration(client *c) {
-    return server.cluster_slot_stats_enabled &&  /* Config should be enabled. */
-           server.cluster_enabled &&             /* Cluster mode should be enabled. */
+    return clusterSlotStatsCpuEnabled() &&       /* CPU tracking should be enabled. */
            c->slot != INVALID_CLUSTER_SLOT &&    /* Command should be slot specific. */
            (!server.execution_nesting ||         /* Either command should not be nested, */
             (c->realcmd->flags & CMD_BLOCKING)); /* or it must be due to unblocking. */
@@ -259,12 +265,12 @@ void clusterSlotStatsInvalidateSlotIfApplicable(scriptRunCtx *ctx) {
 }
 
 static int canAddNetworkBytesIn(client *c) {
-    /* First, cluster mode must be enabled.
+    /* First, network tracking must be enabled.
      * Second, command should target a specific slot.
      * Third, blocked client is not aggregated, to avoid duplicate aggregation upon unblocking.
      * Fourth, the server is not under a MULTI/EXEC transaction, to avoid duplicate aggregation of
      * EXEC's 14 bytes RESP upon nested call()'s afterCommand(). */
-    return clusterSlotStatsEnabled() && c->slot != INVALID_CLUSTER_SLOT &&
+    return clusterSlotStatsNetEnabled() && c->slot != INVALID_CLUSTER_SLOT &&
         !(c->flags & CLIENT_BLOCKED) && !server.in_exec;
 }
 
@@ -313,15 +319,18 @@ void clusterSlotStatsCommand(client *c) {
         /* CLUSTER SLOT-STATS ORDERBY metric [LIMIT limit] [ASC | DESC] */
         int desc = 1;
         slotStatType order_by = INVALID;
+        int cpu_enabled = server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_CPU;
+        int net_enabled = server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_NET;
+        int mem_enabled = (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_MEM) && server.memory_tracking_per_slot;
         if (!strcasecmp(c->argv[3]->ptr, "key-count")) {
             order_by = KEY_COUNT;
-        } else if (!strcasecmp(c->argv[3]->ptr, "cpu-usec") && server.cluster_slot_stats_enabled) {
+        } else if (!strcasecmp(c->argv[3]->ptr, "cpu-usec") && cpu_enabled) {
             order_by = CPU_USEC;
-        } else if (!strcasecmp(c->argv[3]->ptr, "memory-bytes") && server.cluster_slot_stats_enabled && server.memory_tracking_per_slot) {
+        } else if (!strcasecmp(c->argv[3]->ptr, "memory-bytes") && mem_enabled) {
             order_by = MEMORY_BYTES;
-        } else if (!strcasecmp(c->argv[3]->ptr, "network-bytes-in") && server.cluster_slot_stats_enabled) {
+        } else if (!strcasecmp(c->argv[3]->ptr, "network-bytes-in") && net_enabled) {
             order_by = NETWORK_BYTES_IN;
-        } else if (!strcasecmp(c->argv[3]->ptr, "network-bytes-out") && server.cluster_slot_stats_enabled) {
+        } else if (!strcasecmp(c->argv[3]->ptr, "network-bytes-out") && net_enabled) {
             order_by = NETWORK_BYTES_OUT;
         } else {
             addReplyError(c, "Unrecognized sort metric for ORDERBY.");

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -150,7 +150,7 @@ static void addReplySortedSlotStats(client *c, slotStatForSort slot_stats[], lon
 }
 
 static int canAddNetworkBytesOut(client *c) {
-    return clusterSlotStatsNetEnabled() && c->slot != INVALID_CLUSTER_SLOT;
+    return clusterSlotStatsEnabled(CLUSTER_SLOT_STATS_NET) && c->slot != INVALID_CLUSTER_SLOT;
 }
 
 /* Accumulates egress bytes upon sending RESP responses back to user clients. */
@@ -242,7 +242,7 @@ void clusterSlotStatResetAll(void) {
  * would equate to repeating the same calculation twice.
  */
 static int canAddCpuDuration(client *c) {
-    return clusterSlotStatsCpuEnabled() &&       /* CPU tracking should be enabled. */
+    return clusterSlotStatsEnabled(CLUSTER_SLOT_STATS_CPU) && /* CPU tracking should be enabled. */
            c->slot != INVALID_CLUSTER_SLOT &&    /* Command should be slot specific. */
            (!server.execution_nesting ||         /* Either command should not be nested, */
             (c->realcmd->flags & CMD_BLOCKING)); /* or it must be due to unblocking. */
@@ -270,7 +270,7 @@ static int canAddNetworkBytesIn(client *c) {
      * Third, blocked client is not aggregated, to avoid duplicate aggregation upon unblocking.
      * Fourth, the server is not under a MULTI/EXEC transaction, to avoid duplicate aggregation of
      * EXEC's 14 bytes RESP upon nested call()'s afterCommand(). */
-    return clusterSlotStatsNetEnabled() && c->slot != INVALID_CLUSTER_SLOT &&
+    return clusterSlotStatsEnabled(CLUSTER_SLOT_STATS_NET) && c->slot != INVALID_CLUSTER_SLOT &&
         !(c->flags & CLIENT_BLOCKED) && !server.in_exec;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -95,6 +95,15 @@ configEnum shutdown_on_sig_enum[] = {
     {NULL, 0}
 };
 
+configEnum cluster_slot_stats_enum[] = {
+    {"no", 0},
+    {"yes", CLUSTER_SLOT_STATS_ALL},
+    {"cpu", CLUSTER_SLOT_STATS_CPU},
+    {"net", CLUSTER_SLOT_STATS_NET},
+    {"mem", CLUSTER_SLOT_STATS_MEM},
+    {NULL, 0}
+};
+
 configEnum repl_diskless_load_enum[] = {
     {"disabled", REPL_DISKLESS_LOAD_DISABLED},
     {"on-empty-db", REPL_DISKLESS_LOAD_WHEN_DB_EMPTY},
@@ -2401,6 +2410,28 @@ static int isValidShutdownOnSigFlags(int val, const char **err) {
     return 1;
 }
 
+static int isValidClusterSlotStats(int val, const char **err) {
+    /* Memory tracking can only be enabled at startup.
+     * If memory tracking is not currently enabled and the new config
+     * includes MEM flag, reject the change. */
+    if (server.cronloops > 0 && (val & CLUSTER_SLOT_STATS_MEM) && !server.memory_tracking_per_slot) {
+        *err = "memory tracking cannot be enabled at runtime";
+        return 0;
+    }
+    return 1;
+}
+
+static int updateMemoryTrackingEnabled(const char **err) {
+    UNUSED(err);
+    int memory_tracking_enabled = (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_MEM);
+    if (!server.memory_tracking_per_slot && memory_tracking_enabled) {
+        *err = "memory tracking cannot be enabled at runtime";
+        return 0;
+    }
+    server.memory_tracking_per_slot = memory_tracking_enabled;
+    return 1;
+}
+
 static int isValidAnnouncedNodename(char *val,const char **err) {
     if (!(isValidAuxString(val,sdslen(val)))) {
         *err = "Announced human node name contained invalid character";
@@ -3130,7 +3161,7 @@ standardConfig static_configs[] = {
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 0, NULL, NULL),
     createBoolConfig("lazyexpire-nested-arbitrary-keys", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.lazyexpire_nested_arbitrary_keys, 1, NULL, NULL),
-    createBoolConfig("cluster-slot-stats-enabled", NULL, MODIFIABLE_CONFIG, server.cluster_slot_stats_enabled, 0, NULL, NULL),
+    createEnumConfig("cluster-slot-stats-enabled", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, cluster_slot_stats_enum, server.cluster_slot_stats_enabled, 0, isValidClusterSlotStats, updateMemoryTrackingEnabled),
     createBoolConfig("lua-enable-deprecated-api", NULL, IMMUTABLE_CONFIG | HIDDEN_CONFIG, server.lua_enable_deprecated_api, 0, NULL, NULL),
 
     /* String Configs */

--- a/src/config.c
+++ b/src/config.c
@@ -2410,19 +2410,7 @@ static int isValidShutdownOnSigFlags(int val, const char **err) {
     return 1;
 }
 
-static int isValidClusterSlotStats(int val, const char **err) {
-    /* Memory tracking can only be enabled at startup.
-     * If memory tracking is not currently enabled and the new config
-     * includes MEM flag, reject the change. */
-    if (server.cronloops > 0 && (val & CLUSTER_SLOT_STATS_MEM) && !server.memory_tracking_per_slot) {
-        *err = "memory tracking cannot be enabled at runtime";
-        return 0;
-    }
-    return 1;
-}
-
 static int updateMemoryTrackingEnabled(const char **err) {
-    UNUSED(err);
     int memory_tracking_enabled = (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_MEM);
     if (!server.memory_tracking_per_slot && memory_tracking_enabled) {
         *err = "memory tracking cannot be enabled at runtime";
@@ -3161,7 +3149,7 @@ standardConfig static_configs[] = {
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 0, NULL, NULL),
     createBoolConfig("lazyexpire-nested-arbitrary-keys", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.lazyexpire_nested_arbitrary_keys, 1, NULL, NULL),
-    createEnumConfig("cluster-slot-stats-enabled", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, cluster_slot_stats_enum, server.cluster_slot_stats_enabled, 0, isValidClusterSlotStats, updateMemoryTrackingEnabled),
+    createEnumConfig("cluster-slot-stats-enabled", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, cluster_slot_stats_enum, server.cluster_slot_stats_enabled, 0, NULL, updateMemoryTrackingEnabled),
     createBoolConfig("lua-enable-deprecated-api", NULL, IMMUTABLE_CONFIG | HIDDEN_CONFIG, server.lua_enable_deprecated_api, 0, NULL, NULL),
 
     /* String Configs */

--- a/src/config.c
+++ b/src/config.c
@@ -2411,7 +2411,7 @@ static int isValidShutdownOnSigFlags(int val, const char **err) {
 }
 
 static int updateMemoryTrackingEnabled(const char **err) {
-    int memory_tracking_enabled = clusterSlotStatsMemEnabled();
+    int memory_tracking_enabled = clusterSlotStatsEnabled(CLUSTER_SLOT_STATS_MEM);
     if (!server.memory_tracking_per_slot && memory_tracking_enabled) {
         *err = "memory tracking cannot be enabled at runtime";
         return 0;

--- a/src/config.c
+++ b/src/config.c
@@ -2411,7 +2411,7 @@ static int isValidShutdownOnSigFlags(int val, const char **err) {
 }
 
 static int updateMemoryTrackingEnabled(const char **err) {
-    int memory_tracking_enabled = (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_MEM);
+    int memory_tracking_enabled = clusterSlotStatsMemEnabled();
     if (!server.memory_tracking_per_slot && memory_tracking_enabled) {
         *err = "memory tracking cannot be enabled at runtime";
         return 0;

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -483,7 +483,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
         while ((entry = dictNext(&iter)) != NULL) {
             client *c = dictGetKey(entry);
             addReplyPubsubMessage(c,channel,message,*type.messageBulk);
-            if (clusterSlotStatsEnabled())
+            if (clusterSlotStatsNetEnabled())
                 clusterSlotStatsAddNetworkBytesOutForShardedPubSubInternalPropagation(c, slot);
             updateClientMemUsageAndBucket(c);
             receivers++;

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -483,7 +483,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
         while ((entry = dictNext(&iter)) != NULL) {
             client *c = dictGetKey(entry);
             addReplyPubsubMessage(c,channel,message,*type.messageBulk);
-            if (clusterSlotStatsNetEnabled())
+            if (clusterSlotStatsEnabled(CLUSTER_SLOT_STATS_NET))
                 clusterSlotStatsAddNetworkBytesOutForShardedPubSubInternalPropagation(c, slot);
             updateClientMemUsageAndBucket(c);
             receivers++;

--- a/src/server.c
+++ b/src/server.c
@@ -509,11 +509,11 @@ static int kvstoreCanFreeDict(kvstore *kvs, int didx) {
     /* Free if not in cluster */
     if (!server.cluster_enabled) return 1;
 
-    if (server.cluster_slot_stats_enabled &&
-        (meta->cpu_usec || meta->network_bytes_in || meta->network_bytes_out) &&
-        clusterIsMySlot(didx))
-    {
-        /* Don't free if we have stats for this slot */
+    /* Don't free if we have stats for this slot and the relevant tracking is enabled. */
+    int has_cpu_stats = (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_CPU) && meta->cpu_usec;
+    int has_net_stats = (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_NET) &&
+                        (meta->network_bytes_in || meta->network_bytes_out);
+    if ((has_cpu_stats || has_net_stats) && clusterIsMySlot(didx)) {
         return 0;
     }
 
@@ -2897,11 +2897,12 @@ void initServer(void) {
     server.reply_buffer_resizing_enabled = 1;
     server.reply_copy_avoidance_enabled = 1;
     server.client_mem_usage_buckets = NULL;
-    /* Enable per slot memory accounting only if cluster-slot-stats-enabled is
-     * enabled on startup and disregard future configuration changes.
-     * The reason behind this behavior is we want to avoid situation where we
-     * would need to catch up or iterate over all slots and kvobjs. */
-    server.memory_tracking_per_slot = clusterSlotStatsEnabled();
+    /* Enable per slot memory accounting only if cluster-slot-stats-enabled
+     * includes 'mem' at startup. Memory tracking can be disabled at runtime
+     * but cannot be re-enabled, to avoid situation where we would need to
+     * catch up or iterate over all slots and kvobjs. */
+    server.memory_tracking_per_slot = server.cluster_enabled &&
+                                      (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_MEM);
     resetReplicationBuffer();
 
     /* Make sure the locale is set on startup based on the config file. */

--- a/src/server.c
+++ b/src/server.c
@@ -2901,7 +2901,7 @@ void initServer(void) {
      * includes 'mem' at startup. Memory tracking can be disabled at runtime
      * but cannot be re-enabled, to avoid situation where we would need to
      * catch up or iterate over all slots and kvobjs. */
-    server.memory_tracking_per_slot = clusterSlotStatsMemEnabled();
+    server.memory_tracking_per_slot = clusterSlotStatsEnabled(CLUSTER_SLOT_STATS_MEM);
     resetReplicationBuffer();
 
     /* Make sure the locale is set on startup based on the config file. */

--- a/src/server.c
+++ b/src/server.c
@@ -2901,8 +2901,7 @@ void initServer(void) {
      * includes 'mem' at startup. Memory tracking can be disabled at runtime
      * but cannot be re-enabled, to avoid situation where we would need to
      * catch up or iterate over all slots and kvobjs. */
-    server.memory_tracking_per_slot = server.cluster_enabled &&
-                                      (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_MEM);
+    server.memory_tracking_per_slot = clusterSlotStatsMemEnabled();
     resetReplicationBuffer();
 
     /* Make sure the locale is set on startup based on the config file. */

--- a/src/server.h
+++ b/src/server.h
@@ -703,6 +703,12 @@ typedef enum {
 #define SHUTDOWN_NOW 4          /* Don't wait for replicas to catch up. */
 #define SHUTDOWN_FORCE 8        /* Don't let errors prevent shutdown. */
 
+/* Cluster slot stats flags */
+#define CLUSTER_SLOT_STATS_CPU 1  /* Track CPU usage per slot. */
+#define CLUSTER_SLOT_STATS_NET 2  /* Track network bytes per slot. */
+#define CLUSTER_SLOT_STATS_MEM 4  /* Track memory usage per slot. */
+#define CLUSTER_SLOT_STATS_ALL (CLUSTER_SLOT_STATS_CPU | CLUSTER_SLOT_STATS_NET | CLUSTER_SLOT_STATS_MEM)
+
 /* IO thread pause status */
 #define IO_THREAD_UNPAUSED      0
 #define IO_THREAD_PAUSING       1
@@ -3784,6 +3790,8 @@ int allowProtectedAction(int config, client *c);
 void initServerClientMemUsageBuckets(void);
 void freeServerClientMemUsageBuckets(void);
 static inline int clusterSlotStatsEnabled(void) { return server.cluster_enabled && server.cluster_slot_stats_enabled; }
+static inline int clusterSlotStatsCpuEnabled(void) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_CPU); }
+static inline int clusterSlotStatsNetEnabled(void) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_NET); }
 
 /* Module Configuration */
 typedef struct ModuleConfig ModuleConfig;

--- a/src/server.h
+++ b/src/server.h
@@ -3789,9 +3789,7 @@ sds getConfigDebugInfo(void);
 int allowProtectedAction(int config, client *c);
 void initServerClientMemUsageBuckets(void);
 void freeServerClientMemUsageBuckets(void);
-static inline int clusterSlotStatsCpuEnabled(void) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_CPU); }
-static inline int clusterSlotStatsNetEnabled(void) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_NET); }
-static inline int clusterSlotStatsMemEnabled(void) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_MEM); }
+static inline int clusterSlotStatsEnabled(int stat) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & stat); }
 
 /* Module Configuration */
 typedef struct ModuleConfig ModuleConfig;

--- a/src/server.h
+++ b/src/server.h
@@ -3792,6 +3792,7 @@ void freeServerClientMemUsageBuckets(void);
 static inline int clusterSlotStatsEnabled(void) { return server.cluster_enabled && server.cluster_slot_stats_enabled; }
 static inline int clusterSlotStatsCpuEnabled(void) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_CPU); }
 static inline int clusterSlotStatsNetEnabled(void) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_NET); }
+static inline int clusterSlotStatsMemEnabled(void) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_MEM); }
 
 /* Module Configuration */
 typedef struct ModuleConfig ModuleConfig;

--- a/src/server.h
+++ b/src/server.h
@@ -3789,7 +3789,6 @@ sds getConfigDebugInfo(void);
 int allowProtectedAction(int config, client *c);
 void initServerClientMemUsageBuckets(void);
 void freeServerClientMemUsageBuckets(void);
-static inline int clusterSlotStatsEnabled(void) { return server.cluster_enabled && server.cluster_slot_stats_enabled; }
 static inline int clusterSlotStatsCpuEnabled(void) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_CPU); }
 static inline int clusterSlotStatsNetEnabled(void) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_NET); }
 static inline int clusterSlotStatsMemEnabled(void) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_MEM); }

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -877,6 +877,12 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY $orderby}
         set orderby "network-bytes-out"
         assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY $orderby}
+        set orderby "memory-bytes"
+        assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY $orderby}
+
+        # When only cpu net is enabled, memory-bytes ORDERBY should fail
+        R 0 CONFIG SET cluster-slot-stats-enabled "cpu net"
+        assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY memory-bytes}
     }
 
 }
@@ -1055,21 +1061,39 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         assert {[dict get $stats memory-bytes] > 0}
     }
 
-    test "CLUSTER SLOT-STATS memory-bytes field still present after disabling cluster-slot-stats-enabled" {
+    test "CLUSTER SLOT-STATS memory-bytes field not present after disabling cluster-slot-stats-enabled" {
         R 0 CONFIG SET cluster-slot-stats-enabled no
         set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
         set slot_stats [convert_array_into_dict $slot_stats]
 
-        # Verify memory-bytes field is still present even after disabling config
+        # Verify memory-bytes field is not present after disabling config
+        # (memory tracking is disabled when MEM flag is removed)
         assert {[dict exists $slot_stats $key_slot]}
         set stats [dict get $slot_stats $key_slot]
-        assert {[dict exists $stats memory-bytes]}
-        assert {[dict get $stats memory-bytes] > 0}
+        assert {![dict exists $stats memory-bytes]}
 
         # Verify other stats fields are not present
         assert {![dict exists $stats cpu-usec]}
         assert {![dict exists $stats network-bytes-in]}
         assert {![dict exists $stats network-bytes-out]}
+    }
+
+    test "CLUSTER SLOT-STATS memory tracking cannot be re-enabled after being disabled" {
+        # Once memory tracking is disabled, it cannot be re-enabled at runtime
+        assert_error "ERR*memory tracking cannot be enabled at runtime*" {R 0 CONFIG SET cluster-slot-stats-enabled yes}
+        assert_error "ERR*memory tracking cannot be enabled at runtime*" {R 0 CONFIG SET cluster-slot-stats-enabled mem}
+
+        # But cpu and net can still be enabled
+        R 0 CONFIG SET cluster-slot-stats-enabled "cpu net"
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        set slot_stats [convert_array_into_dict $slot_stats]
+
+        assert {[dict exists $slot_stats $key_slot]}
+        set stats [dict get $slot_stats $key_slot]
+        assert {![dict exists $stats memory-bytes]}
+        assert {[dict exists $stats cpu-usec]}
+        assert {[dict exists $stats network-bytes-in]}
+        assert {[dict exists $stats network-bytes-out]}
     }
 }
 
@@ -1093,8 +1117,15 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         assert {[dict get $stats key-count] == 1}
     }
 
-    test "CLUSTER SLOT-STATS memory-bytes field not present after enabling cluster-slot-stats-enabled via CONFIG SET" {
-        R 0 CONFIG SET cluster-slot-stats-enabled yes
+    test "CLUSTER SLOT-STATS enabling mem at runtime fails when not enabled at startup" {
+        # Trying to enable memory tracking at runtime should fail
+        assert_error "ERR*memory tracking cannot be enabled at runtime*" {R 0 CONFIG SET cluster-slot-stats-enabled mem}
+        assert_error "ERR*memory tracking cannot be enabled at runtime*" {R 0 CONFIG SET cluster-slot-stats-enabled yes}
+        assert_error "ERR*memory tracking cannot be enabled at runtime*" {R 0 CONFIG SET cluster-slot-stats-enabled "cpu net mem"}
+    }
+
+    test "CLUSTER SLOT-STATS enabling cpu and net at runtime works" {
+        R 0 CONFIG SET cluster-slot-stats-enabled "cpu net"
         set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
         set slot_stats [convert_array_into_dict $slot_stats]
 

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -1061,6 +1061,33 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         assert {[dict get $stats memory-bytes] > 0}
     }
 
+    test "CLUSTER SLOT-STATS net mem combination shows only net and mem stats" {
+        R 0 CONFIG SET cluster-slot-stats-enabled "net mem"
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        set slot_stats [convert_array_into_dict $slot_stats]
+
+        set stats [dict get $slot_stats $key_slot]
+        assert {[dict exists $stats memory-bytes]}
+        assert {[dict exists $stats network-bytes-in]}
+        assert {[dict exists $stats network-bytes-out]}
+        assert {![dict exists $stats cpu-usec]}
+    }
+
+    test "CLUSTER SLOT-STATS cpu mem combination shows only cpu and mem stats" {
+        R 0 CONFIG SET cluster-slot-stats-enabled "cpu mem"
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        set slot_stats [convert_array_into_dict $slot_stats]
+
+        set stats [dict get $slot_stats $key_slot]
+        assert {[dict exists $stats memory-bytes]}
+        assert {[dict exists $stats cpu-usec]}
+        assert {![dict exists $stats network-bytes-in]}
+        assert {![dict exists $stats network-bytes-out]}
+
+        # Restore to yes for subsequent tests
+        R 0 CONFIG SET cluster-slot-stats-enabled yes
+    }
+
     test "CLUSTER SLOT-STATS memory-bytes field not present after disabling cluster-slot-stats-enabled" {
         R 0 CONFIG SET cluster-slot-stats-enabled no
         set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]


### PR DESCRIPTION
This allows users to specify exactly what per slot statistics to be collected -- CPU, network traffic and/or memory used.

The config accepts multiple values as a space-separated list:
  - cpu: Track CPU usage per slot (cpu-usec metric)
  - net: Track network bytes per slot (network-bytes-in, network-bytes-out metrics) 
  - mem: Track memory usage per slot (memory-bytes metric)
  - yes: Enable all tracking (equivalent to "cpu net mem")
  - no: Disable all tracking (default)

Note: Memory tracking (mem) can ONLY be enabled at startup. If you try to enable
memory tracking via CONFIG SET when it wasn't enabled at startup, the command will
fail. However, you can disable memory tracking at runtime by removing the 'mem' flag.
Once disabled, memory tracking cannot be re-enabled without restarting the server.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces fine-grained control over per-slot stats and aligns code paths to check specific metrics.
> 
> - Config: `cluster-slot-stats-enabled` is now an enum accepting multiple values (`cpu`, `net`, `mem`, `yes`, `no`); parses via `createEnumConfig` with `cluster_slot_stats_enum`. Adds startup-only enforcement for `mem` and runtime disable via `updateMemoryTrackingEnabled`.
> - Runtime behavior: `clusterSlotStatsEnabled(stat)` now checks specific flags; `memory_tracking_per_slot` initialized from `mem` at startup and cannot be re-enabled later.
> - Command/output: `CLUSTER SLOT-STATS` only aggregates/returns enabled metrics; `ORDERBY` validation depends on flags. Network/cpu accounting gated by their flags.
> - Internals: Adjust kvstore free-guard to consider only enabled stats; pubsub/sharded propagation and replication accounting respect NET flag.
> - Docs/Tests: Update `redis.conf` docs with examples and constraints; add/modify tests to cover combinations, disabling `mem`, and rejection of enabling `mem` at runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a865956feffe13d862379eb2c522248131a9166f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->