### PR TITLE
add graceful shutdown for TLS in redis-cli

### DIFF
--- a/deps/hiredis/hiredis.c
+++ b/deps/hiredis/hiredis.c
@@ -731,6 +731,12 @@ void redisFree(redisContext *c) {
     if (c == NULL)
         return;
 
+     /* We need to gracefully terminate the TLS session before closing fd. */
+    if (c->funcs && c->funcs->free_privctx) {
+        c->funcs->free_privctx(c->privctx);
+        c->privctx = NULL;
+    }
+
     if (c->funcs && c->funcs->close) {
         c->funcs->close(c);
     }
@@ -746,9 +752,6 @@ void redisFree(redisContext *c) {
 
     if (c->privdata && c->free_privdata)
         c->free_privdata(c->privdata);
-
-    if (c->funcs && c->funcs->free_privctx)
-        c->funcs->free_privctx(c->privctx);
 
     memset(c, 0xff, sizeof(*c));
     hi_free(c);

--- a/deps/hiredis/ssl.c
+++ b/deps/hiredis/ssl.c
@@ -476,12 +476,9 @@ static void redisSSLFree(void *privctx){
 
     if (!rsc) return;
     if (rsc->ssl) {
-
-        /**
-         * Should not be called if a previous fatal error has occurred on a connection;
+        /* Should not be called if a previous fatal error has occurred on a connection;
          * i.e., if SSL_get_error(3) has returned SSL_ERROR_SYSCALL or SSL_ERROR_SSL.
-         * (https://docs.openssl.org/3.3/man3/SSL_shutdown/#description).
-         */
+         * (https://docs.openssl.org/3.3/man3/SSL_shutdown/#description). */
         SSL_shutdown(rsc->ssl);
         SSL_free(rsc->ssl);
         rsc->ssl = NULL;

--- a/deps/hiredis/ssl.c
+++ b/deps/hiredis/ssl.c
@@ -476,6 +476,13 @@ static void redisSSLFree(void *privctx){
 
     if (!rsc) return;
     if (rsc->ssl) {
+
+        /**
+         * Should not be called if a previous fatal error has occurred on a connection;
+         * i.e., if SSL_get_error(3) has returned SSL_ERROR_SYSCALL or SSL_ERROR_SSL.
+         * (https://docs.openssl.org/3.3/man3/SSL_shutdown/#description).
+         */
+        SSL_shutdown(rsc->ssl);
         SSL_free(rsc->ssl);
         rsc->ssl = NULL;
     }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3585,6 +3585,7 @@ static void repl(void) {
             if (strcasecmp(argv[0],"quit") == 0 ||
                 strcasecmp(argv[0],"exit") == 0)
             {
+                redisFree(context);
                 exit(0);
             } else if (argv[0][0] == ':') {
                 cliSetPreferences(argv,argc,1);
@@ -3644,6 +3645,8 @@ static void repl(void) {
         /* linenoise() returns malloc-ed lines like readline() */
         linenoiseFree(line);
     }
+
+    redisFree(context);
     exit(0);
 }
 
@@ -11135,9 +11138,13 @@ int main(int argc, char **argv) {
     /* Otherwise, we have some arguments to execute */
     if (config.eval) {
         if (cliConnect(0) != REDIS_OK) exit(1);
-        return evalMode(argc,argv);
+        int res = evalMode(argc,argv);
+        redisFree(context);
+        return res;
     } else {
         cliConnect(CC_QUIET);
-        return noninteractive(argc,argv);
+        int res = noninteractive(argc,argv);
+        redisFree(context);
+        return res;
     }
 }


### PR DESCRIPTION
Currently, redis-cli doesn't explicitly close the connection upon completion, which looks like an incorrect termination for any server supporting the RESP protocol and TLS connections. I've added a correct connection termination for redis-cli.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection teardown in `hiredis` and adds new `redisFree(context)` calls in multiple redis-cli exit paths, which could affect resource cleanup and TLS shutdown behavior across clients. Risk is moderate due to potential edge cases around SSL fatal errors and shutdown ordering.
> 
> **Overview**
> Ensures TLS connections are **gracefully terminated** by changing `hiredis` context cleanup to free the SSL private context (and perform `SSL_shutdown`) *before* closing the underlying socket.
> 
> Updates `redis-cli` to **always call** `redisFree(context)` on `quit`/`exit` and on normal termination of interactive, `--eval`, and non-interactive command execution, avoiding abrupt connection drops and leaked context resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 562309adabf6eb937327c638ac5ce1a67ad51836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->