### PR TITLE
added: stream-idmp-duration and stream-idmp-maxsize to redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -2133,6 +2133,30 @@ hll-sparse-max-bytes 3000
 stream-node-max-bytes 4096
 stream-node-max-entries 100
 
+# Redis Streams support Idempotent Message Producer (IDMP) tracking to prevent
+# duplicate message delivery. When producers send messages with IDMP identifiers
+# (using XADD with IDMP or IDMPAUTO parameters), Redis tracks these identifiers to
+# detect and reject duplicates within a configurable time window.
+#
+# stream-idmp-duration: Specifies how long (in seconds) Redis should remember
+# IDMP identifiers for duplicate detection. After this duration expires, old
+# identifiers are automatically removed. This prevents unbounded memory growth
+# while allowing reasonable duplicate detection windows.
+# Valid range: 1 to 86400 seconds (1 second to 24 hours)
+# Default: 100 seconds
+#
+# stream-idmp-maxsize: Maximum number of IDMP identifiers to track per producer
+# per stream. Once this limit is reached, the oldest identifiers are evicted to
+# make room for new ones. This caps memory usage for IDMP tracking.
+# Valid range: 1 to 10000 entries
+# Default: 100 entries
+#
+# Note: These are default values for new streams. Individual streams can override
+# these settings using the XCFGSET command.
+#
+# stream-idmp-duration 100
+# stream-idmp-maxsize 100
+
 # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
 # order to help rehashing the main Redis hash table (the one mapping top-level
 # keys to values). The hash table implementation Redis uses (see dict.c)


### PR DESCRIPTION
## Summary
Adds missing IDMP configuration parameters to redis.conf, previously ommitted in #14615

## Changes
- Added `stream-idmp-duration` configuration parameter with documentation
- Added `stream-idmp-maxsize` configuration parameter with documentation
- Both parameters were already implemented in the code (src/config.c, src/server.h) but were missing from redis.conf

## Configuration Parameters

### stream-idmp-duration
- **Purpose**: Duration (in seconds) to remember IDMP identifiers for duplicate detection
- **Range**: 1 to 86400 seconds (1 second to 24 hours)
- **Default**: 100 seconds
- **Modifiable**: Yes, via CONFIG SET at runtime

### stream-idmp-maxsize
- **Purpose**: Maximum number of IDMP identifiers to track per producer per stream
- **Range**: 1 to 10000 entries
- **Default**: 100 entries
- **Modifiable**: Yes, via CONFIG SET at runtime

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds missing Redis Streams IDMP configuration docs to `redis.conf`.
> 
> - Documents `stream-idmp-duration` (duplicate ID window, seconds; default 100; 1–86400) and `stream-idmp-maxsize` (tracked IDs cap per producer/stream; default 100; 1–10000)
> - Notes these are defaults for new streams and can be overridden via `XCFGSET`; entries remain commented (no behavioral change)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f14266d11179093fd18e202605f898f90bf03f69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->