### PR TITLE
Optimize Redis XREADGROUP CLAIM

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -867,12 +867,26 @@ void* defragStreamConsumerPendingEntry(raxIterator *ri, void *privdata) {
     nack->cgroup_ref_node->value = ctx->cg; /* Update the value of cgroups_ref node to the consumer group. */
     newnack = activeDefragAlloc(nack);
     if (newnack) {
-        /* Update consumer group pointer to the nack.
-         * pel time list doesn't need updating since delivery time is unchanged
-         * and the list pointers are updated during pel traversal. */
+        /* Update consumer group pointer to the nack. */
         void *prev;
         raxInsert(ctx->cg->pel, ri->key, ri->key_len, newnack, &prev);
         serverAssert(prev==nack);
+        
+        /* Update the doubly-linked list pointers in adjacent nacks.
+         * When we move a nack to a new address, we need to update the
+         * pel_prev->pel_next and pel_next->pel_prev pointers. */
+        if (newnack->pel_prev) {
+            newnack->pel_prev->pel_next = newnack;
+        } else {
+            /* This is the head of the list */
+            ctx->cg->pel_time_head = newnack;
+        }
+        if (newnack->pel_next) {
+            newnack->pel_next->pel_prev = newnack;
+        } else {
+            /* This is the tail of the list */
+            ctx->cg->pel_time_tail = newnack;
+        }
     }
     return newnack;
 }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -868,7 +868,8 @@ void* defragStreamConsumerPendingEntry(raxIterator *ri, void *privdata) {
     newnack = activeDefragAlloc(nack);
     if (newnack) {
         /* Update consumer group pointer to the nack.
-         * pel_by_time doesn't need updating since delivery time is unchanged. */
+         * pel time list doesn't need updating since delivery time is unchanged
+         * and the list pointers are updated during pel traversal. */
         void *prev;
         raxInsert(ctx->cg->pel, ri->key, ri->key_len, newnack, &prev);
         serverAssert(prev==nack);
@@ -912,11 +913,7 @@ void* defragStreamConsumerGroup(raxIterator *ri, void *privdata) {
         cg->pel->alloc_size = &s->alloc_size;
         defragRadixTree(&cg->pel, 0, NULL, NULL);
     }
-    if (cg->pel_by_time) {
-        /* Update pel_by_time back-pointer to new stream */
-        cg->pel_by_time->alloc_size = &s->alloc_size;
-        defragRadixTree(&cg->pel_by_time, 0, NULL, NULL);
-    }
+    /* pel_time_head/tail are just pointers to NACKs in pel, no separate defrag needed */
     if (cg->consumers) {
         /* Update consumers back-pointer to new stream */
         cg->consumers->alloc_size = &s->alloc_size;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3233,8 +3233,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     decrRefCount(o);
                     return NULL;
                 }
-                streamNACK *nack = streamCreateNACK(s, NULL);
-                streamDecodeID(rawid, &nack->id);
+                streamID nack_id;
+                streamDecodeID(rawid, &nack_id);
+                streamNACK *nack = streamCreateNACK(s, NULL, &nack_id);
                 nack->delivery_time = rdbLoadMillisecondTime(rdb,RDB_VERSION);
                 nack->delivery_count = rdbLoadLen(rdb,NULL);
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, cgroup, rawid);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3240,14 +3240,18 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, cgroup, rawid);
                 if (rioGetReadError(rdb)) {
                     rdbReportReadError("Stream PEL NACK loading failed.");
-                    streamFreeNACK(s, nack);
+                    /* NACK is linked to cgroups_ref but not in pel_time list yet,
+                     * so use streamDestroyNACK to properly unlink from cgroups_ref. */
+                    streamDestroyNACK(s, nack, rawid);
                     decrRefCount(o);
                     return NULL;
                 }
                 if (!raxTryInsert(cgroup->pel,rawid,sizeof(rawid),nack,NULL)) {
                     rdbReportCorruptRDB("Duplicated global PEL entry "
                                             "loading stream consumer group");
-                    streamFreeNACK(s, nack);
+                    /* NACK is linked to cgroups_ref but not in pel_time list yet,
+                     * so use streamDestroyNACK to properly unlink from cgroups_ref. */
+                    streamDestroyNACK(s, nack, rawid);
                     decrRefCount(o);
                     return NULL;
                 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3241,18 +3241,14 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, cgroup, rawid);
                 if (rioGetReadError(rdb)) {
                     rdbReportReadError("Stream PEL NACK loading failed.");
-                    /* NACK is linked to cgroups_ref but not in pel_time list yet,
-                     * so use streamDestroyNACK to properly unlink from cgroups_ref. */
-                    streamDestroyNACK(s, nack, rawid);
+                    streamFreeNACK(s, nack);
                     decrRefCount(o);
                     return NULL;
                 }
                 if (!raxTryInsert(cgroup->pel,rawid,sizeof(rawid),nack,NULL)) {
                     rdbReportCorruptRDB("Duplicated global PEL entry "
                                             "loading stream consumer group");
-                    /* NACK is linked to cgroups_ref but not in pel_time list yet,
-                     * so use streamDestroyNACK to properly unlink from cgroups_ref. */
-                    streamDestroyNACK(s, nack, rawid);
+                    streamFreeNACK(s, nack);
                     decrRefCount(o);
                     return NULL;
                 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3234,6 +3234,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     return NULL;
                 }
                 streamNACK *nack = streamCreateNACK(s, NULL);
+                streamDecodeID(rawid, &nack->id);
                 nack->delivery_time = rdbLoadMillisecondTime(rdb,RDB_VERSION);
                 nack->delivery_count = rdbLoadLen(rdb,NULL);
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, cgroup, rawid);
@@ -3251,9 +3252,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                     return NULL;
                 }
 
-                streamID id;
-                streamDecodeID(rawid, &id);
-                raxInsertPelByTime(cgroup->pel_by_time, nack->delivery_time, &id);
+                /* Insert in sorted order since RDB entries may not be time-ordered */
+                pelListInsertSorted(cgroup, nack, nack->delivery_time);
             }
 
             /* Now that we loaded our global PEL, we need to load the

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3254,7 +3254,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 }
 
                 /* Insert in sorted order since RDB entries may not be time-ordered */
-                pelListInsertSorted(cgroup, nack, nack->delivery_time);
+                pelListInsertSorted(cgroup, nack);
             }
 
             /* Now that we loaded our global PEL, we need to load the

--- a/src/stream.h
+++ b/src/stream.h
@@ -174,7 +174,7 @@ streamCG *streamLookupCG(stream *s, sds groupname);
 streamConsumer *streamLookupConsumer(streamCG *cg, sds name);
 streamConsumer *streamCreateConsumer(stream *s, streamCG *cg, sds name, robj *key, int dbid, int flags);
 streamCG *streamCreateCG(stream *s, char *name, size_t namelen, streamID *id, long long entries_read);
-streamNACK *streamCreateNACK(stream *s, streamConsumer *consumer);
+streamNACK *streamCreateNACK(stream *s, streamConsumer *consumer, streamID *id);
 void streamDecodeID(void *buf, streamID *id);
 int streamCompareID(streamID *a, streamID *b);
 void streamFreeNACK(stream *s, streamNACK *na);

--- a/src/stream.h
+++ b/src/stream.h
@@ -86,6 +86,9 @@ typedef struct streamIterator {
     unsigned char value_buf[LP_INTBUF_SIZE];
 } streamIterator;
 
+/* Forward declarations */
+typedef struct streamNACK streamNACK;
+
 /* Consumer group. */
 typedef struct streamCG {
     streamID last_id;       /* Last delivered (not acknowledged) ID for this
@@ -102,11 +105,12 @@ typedef struct streamCG {
                                as processed. The key of the radix tree is the
                                ID as a 64 bit big endian number, while the
                                associated value is a streamNACK structure.*/
-    rax *pel_by_time;       /* A radix tree mapping delivery time to pending
-                               entries, so that we can query faster PEL entries
-                               by time. The key is a pelTimeKey structure containing
-                               both delivery_time and stream ID. All information is
-                               in the key; no value is stored. */
+    streamNACK *pel_time_head; /* Head of time-ordered doubly-linked list of pending
+                               entries (oldest delivery_time). Used for efficient
+                               CLAIM operations. O(1) access to oldest entries. */
+    streamNACK *pel_time_tail; /* Tail of time-ordered doubly-linked list of pending
+                               entries (newest delivery_time). O(1) append for
+                               updates that set delivery_time to current time. */
     rax *consumers;         /* A radix tree representing the consumers by name
                                and their associated representation in the form
                                of streamConsumer structures. */
@@ -135,6 +139,9 @@ typedef struct streamNACK {
     streamConsumer *consumer;   /* The consumer this message was delivered to
                                    in the last delivery. */
     listNode *cgroup_ref_node; /* Reference to this NACK in the cgroups_ref list. */
+    streamID id;                /* Stream ID for this pending entry. */
+    struct streamNACK *pel_prev; /* Previous NACK in time-ordered doubly-linked list. */
+    struct streamNACK *pel_next; /* Next NACK in time-ordered doubly-linked list. */
 } streamNACK;
 
 /* Stream propagation information, passed to functions in order to propagate
@@ -143,12 +150,6 @@ typedef struct streamPropInfo {
     robj *keyname;
     robj *groupname;
 } streamPropInfo;
-
-/* Pending entry in the consumer group's PEL, indexed by delivery time. */
-typedef struct pelTimeKey {
-    uint64_t delivery_time;
-    streamID id;
-} pelTimeKey;
 
 /* Prototypes of exported APIs. */
 struct client;
@@ -193,10 +194,8 @@ int64_t streamTrimByID(stream *s, streamID minid, int approx);
 
 listNode *streamLinkCGroupToEntry(stream *s, streamCG *cg, unsigned char *key);
 
-void encodePelTimeKey(void* buf, pelTimeKey *timeKey);
-void decodePelTimeKey(void *buf, pelTimeKey *timeKey);
-void raxInsertPelByTime(rax *pel_by_time, uint64_t delivery_time, streamID *id);
-void raxRemovePelByTime(rax *pel_by_time, uint64_t delivery_time, streamID *id);
+/* PEL time list management (used by RDB loading) */
+void pelListInsertSorted(streamCG *cg, streamNACK *nack, mstime_t delivery_time);
 
 /* IDMP functions */
 idmpEntry *idmpEntryCreate(const char *iid, size_t iid_len, size_t *alloc_size);

--- a/src/stream.h
+++ b/src/stream.h
@@ -178,6 +178,7 @@ streamNACK *streamCreateNACK(stream *s, streamConsumer *consumer);
 void streamDecodeID(void *buf, streamID *id);
 int streamCompareID(streamID *a, streamID *b);
 void streamFreeNACK(stream *s, streamNACK *na);
+void streamDestroyNACK(stream *s, streamNACK *na, unsigned char *key);
 int streamIncrID(streamID *id);
 int streamDecrID(streamID *id);
 void streamPropagateConsumerCreation(client *c, robj *key, robj *groupname, sds consumername);

--- a/src/stream.h
+++ b/src/stream.h
@@ -196,7 +196,7 @@ int64_t streamTrimByID(stream *s, streamID minid, int approx);
 listNode *streamLinkCGroupToEntry(stream *s, streamCG *cg, unsigned char *key);
 
 /* PEL time list management (used by RDB loading) */
-void pelListInsertSorted(streamCG *cg, streamNACK *nack, mstime_t delivery_time);
+void pelListInsertSorted(streamCG *cg, streamNACK *nack);
 
 /* IDMP functions */
 idmpEntry *idmpEntryCreate(const char *iid, size_t iid_len, size_t *alloc_size);

--- a/src/stream.h
+++ b/src/stream.h
@@ -106,11 +106,11 @@ typedef struct streamCG {
                                ID as a 64 bit big endian number, while the
                                associated value is a streamNACK structure.*/
     streamNACK *pel_time_head; /* Head of time-ordered doubly-linked list of pending
-                               entries (oldest delivery_time). Used for efficient
-                               CLAIM operations. O(1) access to oldest entries. */
+                                  entries (oldest delivery_time). Used for efficient
+                                  CLAIM operations. O(1) access to oldest entries. */
     streamNACK *pel_time_tail; /* Tail of time-ordered doubly-linked list of pending
-                               entries (newest delivery_time). O(1) append for
-                               updates that set delivery_time to current time. */
+                                  entries (newest delivery_time). O(1) append for
+                                  updates that set delivery_time to current time. */
     rax *consumers;         /* A radix tree representing the consumers by name
                                and their associated representation in the form
                                of streamConsumer structures. */

--- a/src/stream.h
+++ b/src/stream.h
@@ -133,7 +133,7 @@ typedef struct streamConsumer {
 } streamConsumer;
 
 /* Pending (yet not acknowledged) message in a consumer group. */
-typedef struct streamNACK {
+struct streamNACK {
     mstime_t delivery_time;     /* Last time this message was delivered. */
     uint64_t delivery_count;    /* Number of times this message was delivered.*/
     streamConsumer *consumer;   /* The consumer this message was delivered to
@@ -142,7 +142,7 @@ typedef struct streamNACK {
     streamID id;                /* Stream ID for this pending entry. */
     struct streamNACK *pel_prev; /* Previous NACK in time-ordered doubly-linked list. */
     struct streamNACK *pel_next; /* Next NACK in time-ordered doubly-linked list. */
-} streamNACK;
+};
 
 /* Stream propagation information, passed to functions in order to propagate
  * XCLAIM commands to AOF and slaves. */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1969,10 +1969,10 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
     if (group && min_idle_time != -1) {
         arraylen_ptr = addReplyDeferredLen(c);
         /* Scan and process the group's pending entries list (PEL) in a single loop.
-         * To prevent a dead loop caused by pelListUpdate() reordering the linked list,
-         * we store the current tail pointer before processing. We iterate only up to
-         * this pre-determined boundary, ensuring we never process entries that are
-         * added or moved during iteration.
+         * To prevent a dead loop caused by pelListUpdate() moving elements from the
+         * beginning to the end of the list, we store the current tail pointer before
+         * processing. We iterate only up to this pre-determined boundary, ensuring we
+         * never process entries that are added or moved during iteration.
          *
          * The iteration can terminate early when:
          * 1. We find an entry that hasn't been idle long enough
@@ -1992,8 +1992,6 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
             if (idle < (uint64_t)min_idle_time) break;
 
             /* Process and claim this entry */
-            unsigned char buf[sizeof(streamID)];
-            streamEncodeID(buf, &nack->id);
             uint64_t delivery_count = nack->delivery_count;
 
             streamID pel_id;
@@ -2018,12 +2016,14 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
 
                 /* Transfer ownership if needed */
                 if (nack->consumer != consumer) {
+                    unsigned char buf[sizeof(streamID)];
+                    streamEncodeID(buf, &nack->id);
                     raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
                     nack->consumer = consumer;
                     raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
                 }
                 nack->delivery_count++;
-                pelListUpdate(group, nack, cmd_time_snapshot); /* May reorder list */
+                pelListUpdate(group, nack, cmd_time_snapshot); /* Moves element from beginning to end of list */
 
                 consumer->active_time = cmd_time_snapshot;
 
@@ -5229,7 +5229,7 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep) {
  * ordered by delivery_time. Almost all NACK updates set delivery_time to current
  * time, making this an append-to-tail workload. The doubly-linked list provides
  * O(1) unlink from any position, O(1) append to tail, O(1) access to oldest
- * entries for CLAIM operations, and better cache locality than tree traversal. */
+ * entries for CLAIM operations. */
 
 /* Insert a NACK at the tail of the PEL time-ordered list. This is used when
  * delivery_time is set to current time, which is the common case. */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -55,6 +55,11 @@ static idmpProducer *idmpGetOrCreateProducer(stream *s, const char *pid, size_t 
 static int createIdempotencyHash(robj **argv, int64_t numfields, XXH128_hash_t *out_hash);
 static void idmpEvictOldestEntry(stream *s, idmpProducer *producer);
 
+/* Forward declarations for PEL time list functions */
+static void pelListInsertAtTail(streamCG *cg, streamNACK *nack);
+static void pelListUnlink(streamCG *cg, streamNACK *nack);
+static void pelListUpdate(streamCG *cg, streamNACK *nack, mstime_t new_delivery_time);
+
 /* -----------------------------------------------------------------------
  * Low level stream encoding: a radix tree of listpacks.
  * ----------------------------------------------------------------------- */
@@ -240,14 +245,14 @@ robj *streamDup(robj *o) {
         while(raxNext(&ri_cg_pel)){
             streamNACK *nack = ri_cg_pel.data;
             streamNACK *new_nack = streamCreateNACK(new_s, NULL);
+            streamDecodeID(ri_cg_pel.key, &new_nack->id);
             new_nack->delivery_time = nack->delivery_time;
             new_nack->delivery_count = nack->delivery_count;
             new_nack->cgroup_ref_node = streamLinkCGroupToEntry(new_s, new_cg, ri_cg_pel.key);
             raxInsert(new_cg->pel, ri_cg_pel.key, sizeof(streamID), new_nack, NULL);
 
-            streamID id;
-            streamDecodeID(ri_cg_pel.key, &id);
-            raxInsertPelByTime(new_cg->pel_by_time, new_nack->delivery_time, &id);
+            /* Insert in sorted order to preserve ordering */
+            pelListInsertSorted(new_cg, new_nack, new_nack->delivery_time);
         }
         raxStop(&ri_cg_pel);
 
@@ -1972,32 +1977,31 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
          * them inline because:
          * 1. We cannot safely modify a radix tree while iterating over it
          * 2. The claiming process requires removing and re-inserting entries in
-         *    both pel_by_time and the consumer PELs
+         *    both pel time list and the consumer PELs
          *
          * The iteration can terminate early in two cases:
          * 1. We find an entry that hasn't been idle long enough - due to time-based
          *    ordering, all subsequent entries will be even newer
          * 2. We've collected enough entries to satisfy the requested count limit */
         list *eligible_pels = listCreate();
-        listSetFreeMethod(eligible_pels, zfree);
-        raxIterator ri;
-        raxStart(&ri, group->pel_by_time);
-        raxSeek(&ri, "^", NULL, 0);
-        while (raxNext(&ri)) {
-            pelTimeKey pelKey;
-            decodePelTimeKey(ri.key, &pelKey);
-            uint64_t idle = cmd_time_snapshot - pelKey.delivery_time;
+        streamNACK *nack = group->pel_time_head;
+        while (nack) {
+            uint64_t idle = cmd_time_snapshot - nack->delivery_time;
             if (idle < (uint64_t)min_idle_time)
                 break;
 
-            /* Store a copy of the key for later processing */
-            pelTimeKey *keyCopy = zmalloc(sizeof(pelTimeKey));
-            memcpy(keyCopy, &pelKey, sizeof(pelTimeKey));
-            listAddNodeTail(eligible_pels, keyCopy);
+            /* Skip entries that no longer exist in the stream (trimmed) */
+            if (!streamEntryExists(s, &nack->id)) {
+                nack = nack->pel_next;
+                continue;
+            }
+
+            /* Store NACK pointer directly */
+            listAddNodeTail(eligible_pels, nack);
             
             if (count && listLength(eligible_pels) >= count) break;
+            nack = nack->pel_next;
         }
-        raxStop(&ri);
 
         /* Process each eligible pending entry, claiming it for the current consumer.
          * For each entry we:
@@ -2009,21 +2013,14 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
         listNode *ln;
         listRewind(eligible_pels, &li);
         while ((ln = listNext(&li))) {
-            pelTimeKey *pelKey = (pelTimeKey*)listNodeValue(ln);
+            streamNACK *nack = (streamNACK*)listNodeValue(ln);
             unsigned char buf[sizeof(streamID)];
-            streamEncodeID(buf, &pelKey->id);
+            streamEncodeID(buf, &nack->id);
 
-            void *result;
-            streamNACK *nack = NULL;
-            uint64_t delivery_count = 0;
-            /* Must exist, we got the ID from pel_by_time */
-            serverAssert(raxFind(group->pel,buf,sizeof(buf),&result));
-
-            nack = (streamNACK*)result;
-            delivery_count = nack->delivery_count;
+            uint64_t delivery_count = nack->delivery_count;
 
             streamID pel_id;
-            streamIteratorStart(&si,s,&pelKey->id,&pelKey->id,rev);
+            streamIteratorStart(&si,s,&nack->id,&nack->id,rev);
             if (streamIteratorGetID(&si,&pel_id,&numfields)) {
                 /* Emit a four elements array: ID, array of field-value pairs,
                  * idle time and delivery count. */
@@ -2041,20 +2038,18 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
                     addReplyBulkCBuffer(c,value,value_len);
                 }
 
-                uint64_t idle = cmd_time_snapshot - pelKey->delivery_time;
+                uint64_t idle = cmd_time_snapshot - nack->delivery_time;
                 addReplyLongLong(c, idle);
                 addReplyLongLong(c, delivery_count);
 
                 /* Remove the NACK from old consumer and time-based PEL. */
                 raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
-                raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &pel_id);
 
                 /* Transfer NACK to new consumer with updated metadata. */
                 nack->consumer = consumer;
-                nack->delivery_time = cmd_time_snapshot;
                 nack->delivery_count++;
                 raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
-                raxInsertPelByTime(group->pel_by_time, nack->delivery_time, &pel_id);
+                pelListUpdate(group, nack, cmd_time_snapshot);
 
                 consumer->active_time = cmd_time_snapshot;
 
@@ -2169,6 +2164,7 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
              * will not require extra lookups. We'll fix the problem later
              * if we find that there is already an entry for this ID. */
             streamNACK *nack = streamCreateNACK(s, consumer);
+            nack->id = id;  /* Set the stream ID */
             int group_inserted =
                 raxTryInsert(group->pel,buf,sizeof(buf),nack,NULL);
             int consumer_inserted =
@@ -2184,22 +2180,20 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
                 serverAssert(found);
                 nack = result;
                 raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
-                /* Remove old entry from the PEL by time. */
-                raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &id);
                 /* Update the consumer and NACK metadata. */
                 nack->consumer = consumer;
-                nack->delivery_time = cmd_time_snapshot;
                 nack->delivery_count = 1;
                 /* Add the entry in the new consumer local PEL. */
                 raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
+                /* Update delivery time and reposition in time list */
+                pelListUpdate(group, nack, cmd_time_snapshot);
             } else if (group_inserted == 1 && consumer_inserted == 1) {
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, group, buf);
+                /* Insert new NACK into time list */
+                pelListInsertAtTail(group, nack);
             } else if (group_inserted == 1 && consumer_inserted == 0) {
                 serverPanic("NACK half-created. Should not be possible.");
             }
-
-            /* We have new NACK or updated existing one. */
-            raxInsertPelByTime(group->pel_by_time, nack->delivery_time, &id);
 
             consumer->active_time = cmd_time_snapshot;
 
@@ -2272,12 +2266,8 @@ size_t streamReplyWithRangeFromConsumerPEL(client *c, stream *s, streamID *start
             addReplyNullArray(c);
         } else {
             streamNACK *nack = ri.data;
-            raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &thisid);
-
-            nack->delivery_time = commandTimeSnapshot();
             nack->delivery_count++;
-
-            raxInsertPelByTime(group->pel_by_time, nack->delivery_time, &thisid);
+            pelListUpdate(group, nack, commandTimeSnapshot());
         }
         arraylen++;
     }
@@ -2849,7 +2839,7 @@ void xreadCommand(client *c) {
     /* Try to serve the client synchronously. */
     size_t arraylen = 0;
     void *arraylen_ptr = NULL;
-    uint64_t min_pel_delivery_time = UINT64_MAX;
+    mstime_t min_pel_delivery_time = LLONG_MAX;
     for (int i = 0; i < streams_count; i++) {
         kvobj *o = lookupKeyRead(c->db, c->argv[streams_arg + i]);
         if (o == NULL) continue;
@@ -2869,26 +2859,20 @@ void xreadCommand(client *c) {
              * get the minimum delivery time in the PEL, in order to use it 
              * later if block option is set. */
             if (min_idle_time != -1) {
-                raxIterator ri;
-                raxStart(&ri, groups[i]->pel_by_time);
-                raxSeek(&ri, "^", NULL, 0);
-                while(raxNext(&ri)) {
-                    pelTimeKey timeKey;
-                    decodePelTimeKey(ri.key, &timeKey);
-                    if (!streamEntryExists(s, &timeKey.id))
-                        continue;
+                streamNACK *nack = groups[i]->pel_time_head;
+                if (nack) {
+                    /* Check if the first entry still exists */
+                    if (streamEntryExists(s, &nack->id)) {
+                        if (nack->delivery_time < min_pel_delivery_time) {
+                            min_pel_delivery_time = nack->delivery_time;
+                        }
 
-                    if (timeKey.delivery_time < min_pel_delivery_time) {
-                        min_pel_delivery_time = timeKey.delivery_time;
+                        uint64_t idle = commandTimeSnapshot() - nack->delivery_time;
+                        if (idle >= (uint64_t)min_idle_time) {
+                            serve_claimed = 1;
+                        }
                     }
-
-                    uint64_t idle = commandTimeSnapshot() - timeKey.delivery_time;
-                    if (idle >= (uint64_t)min_idle_time) {
-                        serve_claimed = 1;
-                    }
-                    break;
                 }
-                raxStop(&ri);
             }
 
             /* If the consumer is blocked on a group, we always serve it
@@ -3013,7 +2997,7 @@ void xreadCommand(client *c) {
          * If there are no entries in the PELs we will unblock the client after min_idle_time. */
         if (min_idle_time != -1) {
             uint64_t pel_expire_time = min_idle_time;
-            if (min_pel_delivery_time != UINT64_MAX)
+            if (min_pel_delivery_time != LLONG_MAX)
                 pel_expire_time += min_pel_delivery_time;
             else
                 pel_expire_time += commandTimeSnapshot();
@@ -3114,8 +3098,8 @@ void streamCleanupEntryCGroupRefs(stream *s, streamID *id) {
         serverAssert(raxFind(group->pel, buf, sizeof(buf), (void **)&nack));
         
         /* Remove from group and consumer PELs */
+        pelListUnlink(group, nack);
         raxRemove(group->pel, buf, sizeof(buf), NULL);
-        raxRemovePelByTime(group->pel_by_time, nack->delivery_time, id);
         raxRemove(nack->consumer->pel, buf, sizeof(buf), NULL);
         /* Since we're removing all references from the cgroups_ref, we can directly
          * free the NACK without unlinking it from the cgroups_ref. */
@@ -3175,6 +3159,9 @@ streamNACK *streamCreateNACK(stream *s, streamConsumer *consumer) {
     nack->delivery_count = 1;
     nack->consumer = consumer;
     nack->cgroup_ref_node = NULL;  /* Will be set when added to cgroups_ref */
+    nack->id = (streamID){0, 0};   /* Will be set by caller */
+    nack->pel_prev = NULL;
+    nack->pel_next = NULL;
     return nack;
 }
 
@@ -3186,9 +3173,11 @@ void streamFreeNACK(stream *s, streamNACK *na) {
 }
 
 /* Free a NACK entry and remove its reference from the cgroups_ref.
- * This ensures proper cleanup of the consumer group list associated with the message ID. */
+ * This ensures proper cleanup of the consumer group list associated with the message ID.
+ * Note: Caller must ensure NACK is unlinked from pel_time list before calling. */
 void streamDestroyNACK(stream *s, streamNACK *na, unsigned char *key) {
     size_t usable;
+    serverAssert(na->pel_prev == NULL && na->pel_next == NULL);
     streamUnlinkEntryFromCGroupRef(s, na, key);
     zfree_usable(na, &usable);
     s->alloc_size -= usable;
@@ -3233,7 +3222,8 @@ streamCG *streamCreateCG(stream *s, char *name, size_t namelen, streamID *id, lo
     streamCG *cg = zmalloc_usable(sizeof(*cg), &usable);
     s->alloc_size += usable;
     cg->pel = raxNewWithMetadata(0, &s->alloc_size);
-    cg->pel_by_time = raxNewWithMetadata(0, &s->alloc_size);
+    cg->pel_time_head = NULL;
+    cg->pel_time_tail = NULL;
     cg->consumers = raxNewWithMetadata(0, &s->alloc_size);
     cg->last_id.ms = 0;
     cg->last_id.seq = 0;
@@ -3245,8 +3235,23 @@ streamCG *streamCreateCG(stream *s, char *name, size_t namelen, streamID *id, lo
 
 /* Free a consumer group and all its associated data. */
 static void streamFreeCG(stream *s, streamCG *cg) {
+    /* First, unlink all NACKs from the pel_time list before freeing them.
+     * We iterate the pel to unlink each NACK from the time list. */
+    raxIterator it;
+    raxStart(&it, cg->pel);
+    raxSeek(&it, "^", NULL, 0);
+    while (raxNext(&it)) {
+        streamNACK *nack = it.data;
+        pelListUnlink(cg, nack);
+    }
+    raxStop(&it);
+    
+    /* Now free the pel (which contains the NACKs) */
     raxFreeWithCbAndContext(cg->pel, streamFreeNACKGeneric, s);
-    raxFree(cg->pel_by_time);
+    
+    /* pel_time_head/tail should now be NULL after unlinking all NACKs */
+    serverAssert(cg->pel_time_head == NULL && cg->pel_time_tail == NULL);
+    
     raxFreeWithCbAndContext(cg->consumers, streamFreeConsumerGeneric, s);
     size_t usable;
     zfree_usable(cg, &usable);
@@ -3337,7 +3342,7 @@ void streamDelConsumer(stream *s, streamCG *cg, streamConsumer *consumer) {
         streamID id;
         streamDecodeID(ri.key, &id);
 
-        raxRemovePelByTime(cg->pel_by_time, nack->delivery_time, &id);
+        pelListUnlink(cg, nack);
         raxRemove(cg->pel,ri.key,ri.key_len,NULL);
 
         streamFreeNACK(s, nack);
@@ -3673,7 +3678,7 @@ void xackCommand(client *c) {
         void *result;
         if (raxFind(group->pel,buf,sizeof(buf),&result)) {
             streamNACK *nack = result;
-            raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &ids[j-3]);
+            pelListUnlink(group, nack);
             raxRemove(group->pel,buf,sizeof(buf),NULL);
             raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
             streamDestroyNACK(kv->ptr, nack, buf);
@@ -3749,7 +3754,7 @@ void xackdelCommand(client *c) {
         void *result;
         if (raxFind(group->pel,buf,sizeof(buf),&result)) {
             streamNACK *nack = result;
-            raxRemovePelByTime(group->pel_by_time, nack->delivery_time, id);
+            pelListUnlink(group, nack);
             raxRemove(group->pel,buf,sizeof(buf),NULL);
             raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
             streamDestroyNACK(s, nack, buf);
@@ -4189,7 +4194,7 @@ void xclaimCommand(client *c) {
                 propagate_last_id = 0; /* Will be propagated by XCLAIM itself. */
                 server.dirty++;
                 /* Release the NACK */
-                raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &id);
+                pelListUnlink(group, nack);
                 raxRemove(group->pel,buf,sizeof(buf),NULL);
                 raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
                 streamDestroyNACK(s, nack, buf);
@@ -4205,8 +4210,9 @@ void xclaimCommand(client *c) {
         if (force && nack == NULL) {
             /* Create the NACK. */
             nack = streamCreateNACK(s,NULL);
+            nack->id = id;  /* Set the stream ID */
             raxInsert(group->pel,buf,sizeof(buf),nack,NULL);
-            raxInsertPelByTime(group->pel_by_time, nack->delivery_time, &id);
+            pelListInsertAtTail(group, nack);
             nack->cgroup_ref_node = streamLinkCGroupToEntry(s, group, buf);
         }
 
@@ -4231,9 +4237,7 @@ void xclaimCommand(client *c) {
                 }
             }
 
-            raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &id);
-            nack->delivery_time = deliverytime;
-            raxInsertPelByTime(group->pel_by_time, nack->delivery_time, &id);
+            pelListUpdate(group, nack, deliverytime);
 
             /* Set the delivery attempts counter if given, otherwise
              * autoincrement unless JUSTID option provided */
@@ -4391,7 +4395,7 @@ void xautoclaimCommand(client *c) {
             decrRefCount(idstr);
             server.dirty++;
             /* Clear this entry from the PEL, it no longer exists */
-            raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &id);
+            pelListUnlink(group, nack);
             raxRemove(group->pel,ri.key,ri.key_len,NULL);
             raxRemove(nack->consumer->pel,ri.key,ri.key_len,NULL);
             streamDestroyNACK(s, nack, ri.key);
@@ -4418,9 +4422,7 @@ void xautoclaimCommand(client *c) {
         }
 
         /* Update the consumer and idle time. */
-        raxRemovePelByTime(group->pel_by_time, nack->delivery_time, &id);
-        nack->delivery_time = now;
-        raxInsertPelByTime(group->pel_by_time, nack->delivery_time, &id);
+        pelListUpdate(group, nack, now);
 
         /* Increment the delivery attempts counter unless JUSTID option provided */
         if (!justid)
@@ -5229,51 +5231,126 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep) {
     return 1;
 }
 
-/* Convert the specified pelTimeKey as a 192 bit big endian number, so
- * that the key can be sorted lexicographically. */
-void encodePelTimeKey(void *buf, pelTimeKey *key) {
-    uint64_t e[3];
-    e[0] = htonu64(key->delivery_time);
-    e[1] = htonu64(key->id.ms);
-    e[2] = htonu64(key->id.seq);
-    memcpy(buf,e,sizeof(e));
+/* ======================== PEL Time-Ordered List Helpers =====================
+ * 
+ * The following functions manage a doubly-linked list of pending entries (NACKs)
+ * ordered by delivery_time. This replaces the previous pel_by_time rax tree
+ * for O(1) append operations when delivery_time is set to current time (99% case).
+ * 
+ * Key insight: Almost all NACK updates set delivery_time to current time, making
+ * this an append-to-tail workload. The doubly-linked list provides:
+ * - O(1) unlink from any position
+ * - O(1) append to tail (common case)
+ * - O(1) access to oldest entries (CLAIM operations)
+ * - Better cache locality than tree traversal
+ * ============================================================================ */
+
+/* Insert a NACK at the tail of the PEL time-ordered list.
+ * This is used when delivery_time is set to current time (99% of cases).
+ * Complexity: O(1) */
+static void pelListInsertAtTail(streamCG *cg, streamNACK *nack) {
+    serverAssert(nack != NULL);
+    serverAssert(nack->pel_prev == NULL && nack->pel_next == NULL);
+    
+    nack->pel_prev = cg->pel_time_tail;
+    nack->pel_next = NULL;
+    
+    if (cg->pel_time_tail) {
+        serverAssert(cg->pel_time_head != NULL);
+        cg->pel_time_tail->pel_next = nack;
+    } else {
+        serverAssert(cg->pel_time_head == NULL);
+        cg->pel_time_head = nack;
+    }
+    cg->pel_time_tail = nack;
 }
 
-/* This is the reverse of encodePelTimeKey(): the decoded key will be stored
- * in the 'key' structure passed by reference. The buffer 'buf' must point
- * to a 192 bit big-endian encoded key. */
-void decodePelTimeKey(void *buf, pelTimeKey *key) {
-    uint64_t e[3];
-    memcpy(e,buf,sizeof(e));
-    key->delivery_time = ntohu64(e[0]);
-    key->id.ms = ntohu64(e[1]);
-    key->id.seq = ntohu64(e[2]);
+/* Unlink a NACK from the PEL time-ordered list.
+ * Complexity: O(1) */
+static void pelListUnlink(streamCG *cg, streamNACK *nack) {
+    serverAssert(nack != NULL);
+    
+    if (nack->pel_prev) {
+        nack->pel_prev->pel_next = nack->pel_next;
+    } else {
+        /* Removing head */
+        serverAssert(cg->pel_time_head == nack);
+        cg->pel_time_head = nack->pel_next;
+    }
+    
+    if (nack->pel_next) {
+        nack->pel_next->pel_prev = nack->pel_prev;
+    } else {
+        /* Removing tail */
+        serverAssert(cg->pel_time_tail == nack);
+        cg->pel_time_tail = nack->pel_prev;
+    }
+    
+    nack->pel_prev = nack->pel_next = NULL;
 }
 
-/* Helper function to prepare an encoded PEL time key.
- * This encapsulates the creation and encoding of a pelTimeKey structure. */
-static inline void preparePelTimeKey(unsigned char *keyBuf, uint64_t delivery_time, streamID *id) {
-    pelTimeKey timeKey;
-    timeKey.delivery_time = delivery_time;
-    timeKey.id = *id;
-    encodePelTimeKey(keyBuf, &timeKey);
+/* Insert a NACK in sorted order by delivery_time.
+ * Used for edge cases where delivery_time is set to past time.
+ * Also used by RDB loading where entries may not be time-ordered.
+ * Complexity: O(N) worst case, but typically O(1) since we scan from tail
+ * and past times are usually close to current time. */
+void pelListInsertSorted(streamCG *cg, streamNACK *nack, mstime_t delivery_time) {
+    serverAssert(nack != NULL);
+    serverAssert(nack->pel_prev == NULL && nack->pel_next == NULL);
+    
+    /* Empty list */
+    if (cg->pel_time_head == NULL) {
+        cg->pel_time_head = cg->pel_time_tail = nack;
+        nack->pel_prev = nack->pel_next = NULL;
+        return;
+    }
+    
+    /* Append to tail (common case: delivery_time >= tail time) */
+    if (delivery_time >= cg->pel_time_tail->delivery_time) {
+        pelListInsertAtTail(cg, nack);
+        return;
+    }
+    
+    /* Prepend to head (rare: delivery_time < head time) */
+    if (delivery_time < cg->pel_time_head->delivery_time) {
+        nack->pel_next = cg->pel_time_head;
+        nack->pel_prev = NULL;
+        cg->pel_time_head->pel_prev = nack;
+        cg->pel_time_head = nack;
+        return;
+    }
+    
+    /* Insert in middle - scan backwards from tail since most times are recent */
+    streamNACK *curr = cg->pel_time_tail;
+    while (curr && curr->delivery_time > delivery_time) {
+        curr = curr->pel_prev;
+    }
+    
+    /* Insert after curr */
+    serverAssert(curr != NULL);
+    nack->pel_next = curr->pel_next;
+    nack->pel_prev = curr;
+    if (curr->pel_next) {
+        curr->pel_next->pel_prev = nack;
+    }
+    curr->pel_next = nack;
 }
 
-/* Helper function to insert a NACK into the PEL by time index.
- * This encapsulates the encoding and insertion into the pel_by_time rax tree. */
-void raxInsertPelByTime(rax *pel_by_time, uint64_t delivery_time, streamID *id) {
-    unsigned char keyBuf[sizeof(pelTimeKey)];
-    preparePelTimeKey(keyBuf, delivery_time, id);
-    raxInsert(pel_by_time, keyBuf, sizeof(keyBuf), NULL, NULL);
+/* Update a NACK's delivery_time and reposition in the time-ordered list.
+ * Complexity: O(1) for current_time updates (99% case), O(N) for past times */
+static void pelListUpdate(streamCG *cg, streamNACK *nack, mstime_t new_delivery_time) {
+    serverAssert(nack != NULL);
+    
+    /* Unlink from current position */
+    pelListUnlink(cg, nack);
+    
+    /* Update time */
+    nack->delivery_time = new_delivery_time;
+    
+    /* Re-insert in sorted position */
+    pelListInsertSorted(cg, nack, new_delivery_time);
 }
 
-/* Helper function to remove a NACK from the PEL by time index.
- * This encapsulates the encoding and removal from the pel_by_time rax tree. */
-void raxRemovePelByTime(rax *pel_by_time, uint64_t delivery_time, streamID *id) {
-    unsigned char keyBuf[sizeof(pelTimeKey)];
-    preparePelTimeKey(keyBuf, delivery_time, id);
-    raxRemove(pel_by_time, keyBuf, sizeof(keyBuf), NULL);
-}
 
 /* Register stream keys for monitoring of expired pending entries to enable
  * reactive blocking behavior for XREADGROUP commands with CLAIM. When a client

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2149,8 +2149,6 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
             nack->id = id;  /* Set the stream ID */
             int group_inserted =
                 raxTryInsert(group->pel,buf,sizeof(buf),nack,NULL);
-            int consumer_inserted =
-                raxTryInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
 
             /* Now we can check if the entry was already busy, and
              * in that case reassign the entry to the new consumer,
@@ -2161,20 +2159,20 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
                 int found = raxFind(group->pel,buf,sizeof(buf),&result);
                 serverAssert(found);
                 nack = result;
-                raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
-                /* Update the consumer and NACK metadata. */
-                nack->consumer = consumer;
+                /* Only transfer between consumers if they're different */
+                if (nack->consumer != consumer) {
+                    raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
+                    nack->consumer = consumer;
+                    raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
+                }
                 nack->delivery_count = 1;
-                /* Add the entry in the new consumer local PEL. */
-                raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
                 /* Update delivery time and reposition in time list */
                 pelListUpdate(group, nack, cmd_time_snapshot);
-            } else if (group_inserted == 1 && consumer_inserted == 1) {
+            } else {
+                /* New NACK - insert into consumer's PEL and time list */
+                raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, group, buf);
-                /* Insert new NACK into time list */
                 pelListInsertAtTail(group, nack);
-            } else if (group_inserted == 1 && consumer_inserted == 0) {
-                serverPanic("NACK half-created. Should not be possible.");
             }
 
             consumer->active_time = cmd_time_snapshot;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1968,68 +1968,48 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
 
     if (group && min_idle_time != -1) {
         arraylen_ptr = addReplyDeferredLen(c);
-        /* Scan the group's pending entries list (PEL) to find messages that have been
-         * idle for at least min_idle_time milliseconds. The pel_by_time radix tree
-         * stores entries ordered by their last delivery timestamp, allowing us to
-         * efficiently iterate from oldest to newest.
+        /* Scan and process the group's pending entries list (PEL) in a single loop.
+         * To prevent a dead loop caused by pelListUpdate() reordering the linked list,
+         * we store the current tail pointer before processing. We iterate only up to
+         * this pre-determined boundary, ensuring we never process entries that are
+         * added or moved during iteration.
          *
-         * We collect eligible entries into a temporary list rather than processing
-         * them inline because:
-         * 1. We cannot safely modify a radix tree while iterating over it
-         * 2. The claiming process requires removing and re-inserting entries in
-         *    both pel time list and the consumer PELs
-         *
-         * The iteration can terminate early in two cases:
-         * 1. We find an entry that hasn't been idle long enough - due to time-based
-         *    ordering, all subsequent entries will be even newer
-         * 2. We've collected enough entries to satisfy the requested count limit */
-        list *eligible_pels = listCreate();
+         * The iteration can terminate early when:
+         * 1. We find an entry that hasn't been idle long enough
+         * 2. We've processed enough entries to satisfy the count limit
+         * 3. We reach the pre-stored tail boundary */
+        
+        /* Store the current tail to prevent infinite loops */
+        streamNACK *tail = group->pel_time_tail;
+        size_t processed = 0;
+        
         streamNACK *nack = group->pel_time_head;
         while (nack) {
+            /* Capture next pointer BEFORE modifications (pelListUpdate may reorder) */
+            streamNACK *next = nack->pel_next;
+            
             uint64_t idle = cmd_time_snapshot - nack->delivery_time;
-            if (idle < (uint64_t)min_idle_time)
-                break;
+            if (idle < (uint64_t)min_idle_time) break;
 
-            /* Skip entries that no longer exist in the stream (trimmed) */
+            /* Skip trimmed entries */
             if (!streamEntryExists(s, &nack->id)) {
-                nack = nack->pel_next;
                 continue;
             }
 
-            /* Store NACK pointer directly */
-            listAddNodeTail(eligible_pels, nack);
-            
-            if (count && listLength(eligible_pels) >= count) break;
-            nack = nack->pel_next;
-        }
-
-        /* Process each eligible pending entry, claiming it for the current consumer.
-         * For each entry we:
-         * 1. Fetch the actual message data from the stream
-         * 2. Send the message to the client with metadata (idle time, delivery count)
-         * 3. Transfer ownership from the previous consumer to the current consumer
-         * 4. Update all relevant data structures and propagate the claim operation */
-        listIter li;
-        listNode *ln;
-        listRewind(eligible_pels, &li);
-        while ((ln = listNext(&li))) {
-            streamNACK *nack = (streamNACK*)listNodeValue(ln);
+            /* Process and claim this entry */
             unsigned char buf[sizeof(streamID)];
             streamEncodeID(buf, &nack->id);
-
             uint64_t delivery_count = nack->delivery_count;
 
             streamID pel_id;
             streamIteratorStart(&si,s,&nack->id,&nack->id,rev);
             if (streamIteratorGetID(&si,&pel_id,&numfields)) {
-                /* Emit a four elements array: ID, array of field-value pairs,
-                 * idle time and delivery count. */
                 robj *idarg = createObjectFromStreamID(&pel_id);
                 addReplyArrayLen(c,4);
                 addReplyBulk(c,idarg);
                 addReplyArrayLen(c,numfields*2);
 
-                /* Emit the field-value pairs. */
+                /* Emit field-value pairs */
                 while (numfields--) {
                     unsigned char *key, *value;
                     int64_t key_len, value_len;
@@ -2038,25 +2018,21 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
                     addReplyBulkCBuffer(c,value,value_len);
                 }
 
-                uint64_t idle = cmd_time_snapshot - nack->delivery_time;
                 addReplyLongLong(c, idle);
                 addReplyLongLong(c, delivery_count);
 
-                /* Transfer NACK to new consumer only if different. */
+                /* Transfer ownership if needed */
                 if (nack->consumer != consumer) {
-                    /* Remove the NACK from old consumer's PEL. */
                     raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
-
-                    /* Transfer NACK to new consumer. */
                     nack->consumer = consumer;
                     raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
                 }
                 nack->delivery_count++;
-                pelListUpdate(group, nack, cmd_time_snapshot);
+                pelListUpdate(group, nack, cmd_time_snapshot); /* May reorder list */
 
                 consumer->active_time = cmd_time_snapshot;
 
-                /* Propagate as XCLAIM. */
+                /* Propagate as XCLAIM */
                 if (spi) {
                     robj *delivery_count = createStringObjectFromLongLong(nack->delivery_count);
                     streamPropagateXCLAIMCopyFree(db_id,spi->keyname,group_last_id,spi->groupname,idarg,consumername,delivery_time,delivery_count);
@@ -2065,10 +2041,18 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
                 }
                 decrRefCount(idarg);
                 arraylen++;
+                
+                /* Check count limit */
+                if (count && ++processed >= count) {
+                    streamIteratorStop(&si);
+                    break;
+                }
             }
-            streamIteratorStop(&si);   
+            streamIteratorStop(&si);
+            
+            /* Advance to next, stopping if we reached the tail */
+            nack = (nack == tail) ? NULL : next;
         }
-        listRelease(eligible_pels);
     }
     /* If the client is asking for some history, we serve it using a
      * different function, so that we return entries *solely* from its

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -244,8 +244,9 @@ robj *streamDup(robj *o) {
         raxSeek(&ri_cg_pel,"^",NULL,0);
         while(raxNext(&ri_cg_pel)){
             streamNACK *nack = ri_cg_pel.data;
-            streamNACK *new_nack = streamCreateNACK(new_s, NULL);
-            streamDecodeID(ri_cg_pel.key, &new_nack->id);
+            streamID nack_id;
+            streamDecodeID(ri_cg_pel.key, &nack_id);
+            streamNACK *new_nack = streamCreateNACK(new_s, NULL, &nack_id);
             new_nack->delivery_time = nack->delivery_time;
             new_nack->delivery_count = nack->delivery_count;
             new_nack->cgroup_ref_node = streamLinkCGroupToEntry(new_s, new_cg, ri_cg_pel.key);
@@ -2145,8 +2146,7 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
             /* Try to add a new NACK. Most of the time this will work and
              * will not require extra lookups. We'll fix the problem later
              * if we find that there is already an entry for this ID. */
-            streamNACK *nack = streamCreateNACK(s, consumer);
-            nack->id = id;  /* Set the stream ID */
+            streamNACK *nack = streamCreateNACK(s, consumer, &id);
             int group_inserted =
                 raxTryInsert(group->pel,buf,sizeof(buf),nack,NULL);
 
@@ -3136,7 +3136,7 @@ int streamEntryIsReferenced(stream *s, streamID *id) {
 /* Create a NACK entry setting the delivery count to 1 and the delivery
  * time to the current time. The NACK consumer will be set to the one
  * specified as argument of the function. */
-streamNACK *streamCreateNACK(stream *s, streamConsumer *consumer) {
+streamNACK *streamCreateNACK(stream *s, streamConsumer *consumer, streamID *id) {
     size_t usable;
     streamNACK *nack = zmalloc_usable(sizeof(*nack), &usable);
     s->alloc_size += usable;
@@ -3144,7 +3144,7 @@ streamNACK *streamCreateNACK(stream *s, streamConsumer *consumer) {
     nack->delivery_count = 1;
     nack->consumer = consumer;
     nack->cgroup_ref_node = NULL;  /* Will be set when added to cgroups_ref */
-    nack->id = (streamID){0, 0};   /* Will be set by caller */
+    nack->id = *id;
     nack->pel_prev = NULL;
     nack->pel_next = NULL;
     return nack;
@@ -3168,9 +3168,18 @@ void streamDestroyNACK(stream *s, streamNACK *na, unsigned char *key) {
     s->alloc_size -= usable;
 }
 
-/* Generic version of streamFreeNACK. */
-void streamFreeNACKGeneric(void *na, void *s) {
-    streamFreeNACK((stream *)s, (streamNACK *)na);
+/* Context for streamFreeNACKGeneric callback. */
+typedef struct {
+    stream *s;
+    streamCG *cg;
+} streamFreeNACKCtx;
+
+/* Generic version of streamFreeNACK with PEL list unlinking. */
+void streamFreeNACKGeneric(void *na, void *ctx) {
+    streamFreeNACKCtx *c = (streamFreeNACKCtx *)ctx;
+    streamNACK *nack = (streamNACK *)na;
+    pelListUnlink(c->cg, nack);
+    streamFreeNACK(c->s, nack);
 }
 
 /* Free a consumer and associated data structures. Note that this function
@@ -3220,19 +3229,9 @@ streamCG *streamCreateCG(stream *s, char *name, size_t namelen, streamID *id, lo
 
 /* Free a consumer group and all its associated data. */
 static void streamFreeCG(stream *s, streamCG *cg) {
-    /* First, unlink all NACKs from the pel_time list before freeing them.
-     * We iterate the pel to unlink each NACK from the time list. */
-    raxIterator it;
-    raxStart(&it, cg->pel);
-    raxSeek(&it, "^", NULL, 0);
-    while (raxNext(&it)) {
-        streamNACK *nack = it.data;
-        pelListUnlink(cg, nack);
-    }
-    raxStop(&it);
-    
-    /* Now free the pel (which contains the NACKs) */
-    raxFreeWithCbAndContext(cg->pel, streamFreeNACKGeneric, s);
+    /* Free the pel, unlinking each NACK from the time list in the callback */
+    streamFreeNACKCtx ctx = {s, cg};
+    raxFreeWithCbAndContext(cg->pel, streamFreeNACKGeneric, &ctx);
     
     /* pel_time_head/tail should now be NULL after unlinking all NACKs */
     serverAssert(cg->pel_time_head == NULL && cg->pel_time_tail == NULL);
@@ -4193,8 +4192,7 @@ void xclaimCommand(client *c) {
          * and replication of consumer groups. */
         if (force && nack == NULL) {
             /* Create the NACK. */
-            nack = streamCreateNACK(s,NULL);
-            nack->id = id;  /* Set the stream ID */
+            nack = streamCreateNACK(s, NULL, &id);
             raxInsert(group->pel,buf,sizeof(buf),nack,NULL);
             pelListInsertAtTail(group, nack);
             nack->cgroup_ref_node = streamLinkCGroupToEntry(s, group, buf);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -5216,30 +5216,23 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep) {
     return 1;
 }
 
-/* ======================== PEL Time-Ordered List Helpers =====================
- * 
- * The following functions manage a doubly-linked list of pending entries (NACKs)
- * ordered by delivery_time. This replaces the previous pel_by_time rax tree
- * for O(1) append operations when delivery_time is set to current time (99% case).
- * 
- * Key insight: Almost all NACK updates set delivery_time to current time, making
- * this an append-to-tail workload. The doubly-linked list provides:
- * - O(1) unlink from any position
- * - O(1) append to tail (common case)
- * - O(1) access to oldest entries (CLAIM operations)
- * - Better cache locality than tree traversal
- * ============================================================================ */
+/* -----------------------------------------------------------------------
+ * PEL Time-Ordered List Helpers
+ * ----------------------------------------------------------------------- */
 
-/* Insert a NACK at the tail of the PEL time-ordered list.
- * This is used when delivery_time is set to current time (99% of cases).
- * Complexity: O(1) */
+/* The following functions manage a doubly-linked list of pending entries (NACKs)
+ * ordered by delivery_time. Almost all NACK updates set delivery_time to current
+ * time, making this an append-to-tail workload. The doubly-linked list provides
+ * O(1) unlink from any position, O(1) append to tail, O(1) access to oldest
+ * entries for CLAIM operations, and better cache locality than tree traversal. */
+
+/* Insert a NACK at the tail of the PEL time-ordered list. This is used when
+ * delivery_time is set to current time, which is the common case. */
 static void pelListInsertAtTail(streamCG *cg, streamNACK *nack) {
     serverAssert(nack != NULL);
     serverAssert(nack->pel_prev == NULL && nack->pel_next == NULL);
-    
     nack->pel_prev = cg->pel_time_tail;
     nack->pel_next = NULL;
-    
     if (cg->pel_time_tail) {
         serverAssert(cg->pel_time_head != NULL);
         cg->pel_time_tail->pel_next = nack;
@@ -5250,53 +5243,46 @@ static void pelListInsertAtTail(streamCG *cg, streamNACK *nack) {
     cg->pel_time_tail = nack;
 }
 
-/* Unlink a NACK from the PEL time-ordered list.
- * Complexity: O(1) */
+/* Unlink a NACK from the PEL time-ordered list. */
 static void pelListUnlink(streamCG *cg, streamNACK *nack) {
     serverAssert(nack != NULL);
-    
     if (nack->pel_prev) {
         nack->pel_prev->pel_next = nack->pel_next;
     } else {
-        /* Removing head */
-        serverAssert(cg->pel_time_head == nack);
+        serverAssert(cg->pel_time_head == nack); /* Removing head. */
         cg->pel_time_head = nack->pel_next;
     }
-    
     if (nack->pel_next) {
         nack->pel_next->pel_prev = nack->pel_prev;
     } else {
-        /* Removing tail */
-        serverAssert(cg->pel_time_tail == nack);
+        serverAssert(cg->pel_time_tail == nack); /* Removing tail. */
         cg->pel_time_tail = nack->pel_prev;
     }
-    
     nack->pel_prev = nack->pel_next = NULL;
 }
 
-/* Insert a NACK in sorted order by delivery_time.
- * Used for edge cases where delivery_time is set to past time.
- * Also used by RDB loading where entries may not be time-ordered.
- * Complexity: O(N) worst case, but typically O(1) since we scan from tail
- * and past times are usually close to current time. */
+/* Insert a NACK in sorted order by delivery_time. Used for edge cases where
+ * delivery_time is set to a past time, and also by RDB loading where entries
+ * may not be time-ordered. We scan backwards from the tail since most times
+ * are recent, so the common case is still fast. */
 void pelListInsertSorted(streamCG *cg, streamNACK *nack, mstime_t delivery_time) {
     serverAssert(nack != NULL);
     serverAssert(nack->pel_prev == NULL && nack->pel_next == NULL);
-    
-    /* Empty list */
+
+    /* Empty list. */
     if (cg->pel_time_head == NULL) {
         cg->pel_time_head = cg->pel_time_tail = nack;
         nack->pel_prev = nack->pel_next = NULL;
         return;
     }
-    
-    /* Append to tail (common case: delivery_time >= tail time) */
+
+    /* Append to tail (common case: delivery_time >= tail time). */
     if (delivery_time >= cg->pel_time_tail->delivery_time) {
         pelListInsertAtTail(cg, nack);
         return;
     }
-    
-    /* Prepend to head (rare: delivery_time < head time) */
+
+    /* Prepend to head (rare: delivery_time < head time). */
     if (delivery_time < cg->pel_time_head->delivery_time) {
         nack->pel_next = cg->pel_time_head;
         nack->pel_prev = NULL;
@@ -5304,14 +5290,14 @@ void pelListInsertSorted(streamCG *cg, streamNACK *nack, mstime_t delivery_time)
         cg->pel_time_head = nack;
         return;
     }
-    
-    /* Insert in middle - scan backwards from tail since most times are recent */
+
+    /* Insert in middle: scan backwards from tail since most times are recent. */
     streamNACK *curr = cg->pel_time_tail;
     while (curr && curr->delivery_time > delivery_time) {
         curr = curr->pel_prev;
     }
-    
-    /* Insert after curr */
+
+    /* Insert after curr. */
     serverAssert(curr != NULL);
     nack->pel_next = curr->pel_next;
     nack->pel_prev = curr;
@@ -5321,18 +5307,11 @@ void pelListInsertSorted(streamCG *cg, streamNACK *nack, mstime_t delivery_time)
     curr->pel_next = nack;
 }
 
-/* Update a NACK's delivery_time and reposition in the time-ordered list.
- * Complexity: O(1) for current_time updates (99% case), O(N) for past times */
+/* Update a NACK's delivery_time and reposition it in the time-ordered list. */
 static void pelListUpdate(streamCG *cg, streamNACK *nack, mstime_t new_delivery_time) {
     serverAssert(nack != NULL);
-    
-    /* Unlink from current position */
     pelListUnlink(cg, nack);
-    
-    /* Update time */
     nack->delivery_time = new_delivery_time;
-    
-    /* Re-insert in sorted position */
     pelListInsertSorted(cg, nack, new_delivery_time);
 }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1991,11 +1991,6 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
             uint64_t idle = cmd_time_snapshot - nack->delivery_time;
             if (idle < (uint64_t)min_idle_time) break;
 
-            /* Skip trimmed entries */
-            if (!streamEntryExists(s, &nack->id)) {
-                continue;
-            }
-
             /* Process and claim this entry */
             unsigned char buf[sizeof(streamID)];
             streamEncodeID(buf, &nack->id);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -253,7 +253,7 @@ robj *streamDup(robj *o) {
             raxInsert(new_cg->pel, ri_cg_pel.key, sizeof(streamID), new_nack, NULL);
 
             /* Insert in sorted order to preserve ordering */
-            pelListInsertSorted(new_cg, new_nack, new_nack->delivery_time);
+            pelListInsertSorted(new_cg, new_nack);
         }
         raxStop(&ri_cg_pel);
 
@@ -5232,15 +5232,11 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep) {
 /* Insert a NACK at the tail of the PEL time-ordered list. This is used when
  * delivery_time is set to current time, which is the common case. */
 static void pelListInsertAtTail(streamCG *cg, streamNACK *nack) {
-    serverAssert(nack != NULL);
-    serverAssert(nack->pel_prev == NULL && nack->pel_next == NULL);
     nack->pel_prev = cg->pel_time_tail;
     nack->pel_next = NULL;
     if (cg->pel_time_tail) {
-        serverAssert(cg->pel_time_head != NULL);
         cg->pel_time_tail->pel_next = nack;
     } else {
-        serverAssert(cg->pel_time_head == NULL);
         cg->pel_time_head = nack;
     }
     cg->pel_time_tail = nack;
@@ -5248,17 +5244,16 @@ static void pelListInsertAtTail(streamCG *cg, streamNACK *nack) {
 
 /* Unlink a NACK from the PEL time-ordered list. */
 static void pelListUnlink(streamCG *cg, streamNACK *nack) {
-    serverAssert(nack != NULL);
     if (nack->pel_prev) {
         nack->pel_prev->pel_next = nack->pel_next;
     } else {
-        serverAssert(cg->pel_time_head == nack); /* Removing head. */
+        /* Removing head. */
         cg->pel_time_head = nack->pel_next;
     }
     if (nack->pel_next) {
         nack->pel_next->pel_prev = nack->pel_prev;
     } else {
-        serverAssert(cg->pel_time_tail == nack); /* Removing tail. */
+        /* Removing tail. */
         cg->pel_time_tail = nack->pel_prev;
     }
     nack->pel_prev = nack->pel_next = NULL;
@@ -5268,10 +5263,7 @@ static void pelListUnlink(streamCG *cg, streamNACK *nack) {
  * delivery_time is set to a past time, and also by RDB loading where entries
  * may not be time-ordered. We scan backwards from the tail since most times
  * are recent, so the common case is still fast. */
-void pelListInsertSorted(streamCG *cg, streamNACK *nack, mstime_t delivery_time) {
-    serverAssert(nack != NULL);
-    serverAssert(nack->pel_prev == NULL && nack->pel_next == NULL);
-
+void pelListInsertSorted(streamCG *cg, streamNACK *nack) {
     /* Empty list. */
     if (cg->pel_time_head == NULL) {
         cg->pel_time_head = cg->pel_time_tail = nack;
@@ -5280,13 +5272,13 @@ void pelListInsertSorted(streamCG *cg, streamNACK *nack, mstime_t delivery_time)
     }
 
     /* Append to tail (common case: delivery_time >= tail time). */
-    if (delivery_time >= cg->pel_time_tail->delivery_time) {
+    if (nack->delivery_time >= cg->pel_time_tail->delivery_time) {
         pelListInsertAtTail(cg, nack);
         return;
     }
 
     /* Prepend to head (rare: delivery_time < head time). */
-    if (delivery_time < cg->pel_time_head->delivery_time) {
+    if (nack->delivery_time < cg->pel_time_head->delivery_time) {
         nack->pel_next = cg->pel_time_head;
         nack->pel_prev = NULL;
         cg->pel_time_head->pel_prev = nack;
@@ -5296,12 +5288,11 @@ void pelListInsertSorted(streamCG *cg, streamNACK *nack, mstime_t delivery_time)
 
     /* Insert in middle: scan backwards from tail since most times are recent. */
     streamNACK *curr = cg->pel_time_tail;
-    while (curr && curr->delivery_time > delivery_time) {
+    while (curr && curr->delivery_time > nack->delivery_time) {
         curr = curr->pel_prev;
     }
 
     /* Insert after curr. */
-    serverAssert(curr != NULL);
     nack->pel_next = curr->pel_next;
     nack->pel_prev = curr;
     if (curr->pel_next) {
@@ -5312,10 +5303,9 @@ void pelListInsertSorted(streamCG *cg, streamNACK *nack, mstime_t delivery_time)
 
 /* Update a NACK's delivery_time and reposition it in the time-ordered list. */
 static void pelListUpdate(streamCG *cg, streamNACK *nack, mstime_t new_delivery_time) {
-    serverAssert(nack != NULL);
     pelListUnlink(cg, nack);
     nack->delivery_time = new_delivery_time;
-    pelListInsertSorted(cg, nack, new_delivery_time);
+    pelListInsertSorted(cg, nack);
 }
 
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2042,13 +2042,16 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
                 addReplyLongLong(c, idle);
                 addReplyLongLong(c, delivery_count);
 
-                /* Remove the NACK from old consumer and time-based PEL. */
-                raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
+                /* Transfer NACK to new consumer only if different. */
+                if (nack->consumer != consumer) {
+                    /* Remove the NACK from old consumer's PEL. */
+                    raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
 
-                /* Transfer NACK to new consumer with updated metadata. */
-                nack->consumer = consumer;
+                    /* Transfer NACK to new consumer. */
+                    nack->consumer = consumer;
+                    raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
+                }
                 nack->delivery_count++;
-                raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
                 pelListUpdate(group, nack, cmd_time_snapshot);
 
                 consumer->active_time = cmd_time_snapshot;
@@ -2860,18 +2863,23 @@ void xreadCommand(client *c) {
              * later if block option is set. */
             if (min_idle_time != -1) {
                 streamNACK *nack = groups[i]->pel_time_head;
-                if (nack) {
-                    /* Check if the first entry still exists */
-                    if (streamEntryExists(s, &nack->id)) {
-                        if (nack->delivery_time < min_pel_delivery_time) {
-                            min_pel_delivery_time = nack->delivery_time;
-                        }
-
-                        uint64_t idle = commandTimeSnapshot() - nack->delivery_time;
-                        if (idle >= (uint64_t)min_idle_time) {
-                            serve_claimed = 1;
-                        }
+                /* Iterate through PEL entries to find the first one that exists */
+                while (nack) {
+                    /* Skip entries that don't exist in the stream anymore */
+                    if (!streamEntryExists(s, &nack->id)) {
+                        nack = nack->pel_next;
+                        continue;
                     }
+
+                    if (nack->delivery_time < min_pel_delivery_time) {
+                        min_pel_delivery_time = nack->delivery_time;
+                    }
+
+                    uint64_t idle = commandTimeSnapshot() - nack->delivery_time;
+                    if (idle >= (uint64_t)min_idle_time) {
+                        serve_claimed = 1;
+                    }
+                    break; /* Found a valid entry, stop searching */
                 }
             }
 


### PR DESCRIPTION
## Overview
This PR optimizes Redis Streams consumer group performance by replacing the `pel_by_time` rax tree with a doubly-linked list, delivering significant performance improvements for NACK updates and XREADGROUP CLAIM operations while also reducing memory usage.

## The Problem
Consumer groups maintain a time-ordered index of pending entries using a radix tree (`pel_by_time`). Every time a pending entry is reclaimed or delivered, we need to update its delivery time, which currently requires:

```c
raxRemovePelByTime(group->pel_by_time, old_time, &id);  // O(k) where k=key length
nack->delivery_time = current_time;
raxInsertPelByTime(group->pel_by_time, current_time, &id); // O(k) where k=key length
```

## The Key Insight

**99% of delivery_time updates set the value to the current time** — which means they're appending to the tail of a time-ordered structure.

We're using a radix tree (O(k) operations where k is key length, plus tree traversal overhead) for what is essentially an append-only workload (should be O(1)).

## The Solution

Replace the rax tree with a doubly-linked list embedded directly in each `streamNACK`:

```c
typedef struct streamNACK {
    mstime_t delivery_time;
    uint64_t delivery_count;
    streamConsumer *consumer;
    listNode *cgroup_ref_node;
    streamID id;                    // NEW
    struct streamNACK *pel_prev;    // NEW
    struct streamNACK *pel_next;    // NEW
} streamNACK;
```

Now updating a NACK becomes:
```c
pelListUpdate(group, nack, current_time);  // O(1): unlink + append
```

## Why This Works

**Typical case (99%):** Delivery time = current time
- Unlink from current position: O(1) — just update 2-4 pointers
- Append to tail: O(1) — update tail pointer and link

**Edge case (1%):** XCLAIM with explicit past IDLE time
- Still handled correctly by `pelListInsertSorted()` which scans backward from tail
- Rare enough that O(N) worst case doesn't matter

## Memory Reduction

The linked list approach uses less memory than the rax tree:

**What we add:**
- 3 new fields in `streamNACK`: `id` (16 bytes) + `pel_prev` (8 bytes) + `pel_next` (8 bytes) = 32 bytes per entry

**What we remove:**
- Entire `pel_by_time` rax tree with its node overhead (~40-50 bytes per entry)

**Net result:** Lower memory footprint per pending entry, plus better cache locality from eliminating the separate tree structure.

## Performance Impact

### Theoretical Analysis

| Operation | Before | After |
|-----------|--------|-------|
| NACK update | O(k) × 2 + tree overhead | O(1) |
| CLAIM iteration | O(k) per entry + traversal | O(1) per entry |

*k = key length (32 bytes: timestamp + stream ID)*

For a consumer group with 10,000 pending entries claiming 100 oldest:
- **Before:** Tree traversal + key comparisons for each operation
- **After:** Simple pointer updates

### Benchmark Results

Real-world performance test using memtier-benchmark with 2M messages:

**Test Setup:**
- XADD: 2M messages to stream
- XREADGROUP: Read all with `CLAIM 100 COUNT 1000`
- 10 iterations, average of middle 8 runs

**Results:**

| Implementation | XREADGROUP RPS | Latency (avg) | P99 Latency | Improvement |
|----------------|----------------|---------------|-------------|-------------|
| **Before (Rax Tree)** | 4,935 ops/sec | 0.195 ms | 0.212 ms | Baseline |
| **After (Linked List)** | 6,321 ops/sec | 0.152 ms | 0.168 ms | **+28%** |

**Key Findings:**
- **28% higher throughput** for XREADGROUP with CLAIM
- **22% lower average latency** (0.195ms → 0.152ms)
- **21% lower P99 latency** (0.212ms → 0.168ms)
- XADD performance unchanged (69K ops/sec both implementations)

## Backward Compatibility

Fully backward compatible:
- RDB format unchanged
- AOF format unchanged  
- No protocol changes
- All existing commands work identically


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the consumer-group `pel_by_time` rax index with a time-ordered doubly-linked list embedded in `streamNACK`, optimizing updates and CLAIM scans.
> 
> - Adds `streamNACK` fields: `id`, `pel_prev`, `pel_next`; `streamCG` now tracks `pel_time_head/tail`; removes `pel_by_time` and related helpers
> - Introduces `pelListInsertSorted/Unlink/Update` and updates all paths: XREADGROUP CLAIM/serve, XCLAIM, XACK, consumer deletion, CG free/destroy, duplication, and RDB load to maintain list order
> - Changes `streamCreateNACK(s,consumer, id)` signature and adjusts callers; ensures consumer transfers update both consumer PEL and time list
> - Updates active defrag to relocate `streamNACK` and fix adjacent list pointers; CG defrag no longer processes `pel_by_time`
> - Maintains RDB/AOF compatibility; refactors min-idle-time checks to use list head and adjusts blocking timeout computation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c1591981a4306c4baa20184a87a836211b97aef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->