### PR TITLE
Add separate statistics for active expiration of keys and hash fields

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2659,7 +2659,9 @@ long long getExpire(redisDb *db, sds key, kvobj *kv) {
  * amount of memory freed due to the trimming (may be NULL)
  *
  * lazy indicates whether the expiration is lazy expire or active expire. */
-static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type, long long *key_mem_freed, int lazy) {
+static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type,
+                                  long long *key_mem_freed, int lazy)
+{
     mstime_t latency;
     int del_flag = notify_type == NOTIFY_EXPIRED ? DB_FLAG_KEY_EXPIRED : DB_FLAG_KEY_EVICTED;
     int lazy_flag = notify_type == NOTIFY_EXPIRED ? server.lazyfree_lazy_expire : server.lazyfree_lazy_eviction;

--- a/src/db.c
+++ b/src/db.c
@@ -2656,10 +2656,7 @@ long long getExpire(redisDb *db, sds key, kvobj *kv) {
  * which config to look for lazy free, stats var to increment, and so on.
  *
  * key_mem_freed is an out parameter which contains the estimated
- * amount of memory freed due to the trimming (may be NULL)
- *
- * active_expire is only used when notify_type is NOTIFY_EXPIRED, indicates
- * whether it's active expire (1) or lazy expire (0). */
+ * amount of memory freed due to the trimming (may be NULL) */
 static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type, long long *key_mem_freed) {
     mstime_t latency;
     int del_flag = notify_type == NOTIFY_EXPIRED ? DB_FLAG_KEY_EXPIRED : DB_FLAG_KEY_EVICTED;

--- a/src/db.c
+++ b/src/db.c
@@ -2658,9 +2658,10 @@ long long getExpire(redisDb *db, sds key, kvobj *kv) {
  * key_mem_freed is an out parameter which contains the estimated
  * amount of memory freed due to the trimming (may be NULL)
  *
- * lazy indicates whether the expiration is lazy expire or active expire. */
+ * active_expire is only used when notify_type is NOTIFY_EXPIRED, indicates
+ * whether it's active expire (1) or lazy expire (0). */
 static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type,
-                                  long long *key_mem_freed, int lazy)
+                                  long long *key_mem_freed, int active_expire)
 {
     mstime_t latency;
     int del_flag = notify_type == NOTIFY_EXPIRED ? DB_FLAG_KEY_EXPIRED : DB_FLAG_KEY_EVICTED;
@@ -2704,7 +2705,7 @@ static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type,
 
     if (notify_type == NOTIFY_EXPIRED) {
         server.stat_expiredkeys++;
-        if (!lazy) server.stat_expiredkeys_active++;
+        if (active_expire) server.stat_expiredkeys_active++;
     } else {
         server.stat_evictedkeys++;
     }
@@ -2714,8 +2715,8 @@ static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type,
 }
 
 /* Delete the specified expired key and propagate. */
-void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj, int lazy) {
-    deleteKeyAndPropagate(db, keyobj, NOTIFY_EXPIRED, NULL, lazy);
+void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj, int active_expire) {
+    deleteKeyAndPropagate(db, keyobj, NOTIFY_EXPIRED, NULL, active_expire);
 }
 
 /* Delete the specified evicted key and propagate. */
@@ -2881,11 +2882,11 @@ keyStatus expireIfNeeded(redisDb *db, robj *key, kvobj *kv, int flags) {
 
     /* Perform deletion */
     if (key) {
-        deleteExpiredKeyAndPropagate(db, key, 1);
+        deleteExpiredKeyAndPropagate(db, key, 0);
     } else {
         sds keyname = kvobjGetKey(kv);
         robj *tmpkey = createStringObject(keyname, sdslen(keyname));
-        deleteExpiredKeyAndPropagate(db, tmpkey, 1);
+        deleteExpiredKeyAndPropagate(db, tmpkey, 0);
         decrRefCount(tmpkey);
     }
     return KEY_DELETED;

--- a/src/db.c
+++ b/src/db.c
@@ -2660,9 +2660,7 @@ long long getExpire(redisDb *db, sds key, kvobj *kv) {
  *
  * active_expire is only used when notify_type is NOTIFY_EXPIRED, indicates
  * whether it's active expire (1) or lazy expire (0). */
-static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type,
-                                  long long *key_mem_freed, int active_expire)
-{
+static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type, long long *key_mem_freed) {
     mstime_t latency;
     int del_flag = notify_type == NOTIFY_EXPIRED ? DB_FLAG_KEY_EXPIRED : DB_FLAG_KEY_EVICTED;
     int lazy_flag = notify_type == NOTIFY_EXPIRED ? server.lazyfree_lazy_expire : server.lazyfree_lazy_eviction;
@@ -2703,25 +2701,23 @@ static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type,
     keyModified(NULL, db, keyobj, NULL, 1);
     propagateDeletion(db, keyobj, lazy_flag);
 
-    if (notify_type == NOTIFY_EXPIRED) {
+    if (notify_type == NOTIFY_EXPIRED)
         server.stat_expiredkeys++;
-        if (active_expire) server.stat_expiredkeys_active++;
-    } else {
+    else
         server.stat_evictedkeys++;
-    }
 
     if (static_key)
         decrRefCount(keyobj);
 }
 
 /* Delete the specified expired key and propagate. */
-void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj, int active_expire) {
-    deleteKeyAndPropagate(db, keyobj, NOTIFY_EXPIRED, NULL, active_expire);
+void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj) {
+    deleteKeyAndPropagate(db, keyobj, NOTIFY_EXPIRED, NULL);
 }
 
 /* Delete the specified evicted key and propagate. */
 void deleteEvictedKeyAndPropagate(redisDb *db, robj *keyobj, long long *key_mem_freed) {
-    deleteKeyAndPropagate(db, keyobj, NOTIFY_EVICTED, key_mem_freed, 0);
+    deleteKeyAndPropagate(db, keyobj, NOTIFY_EVICTED, key_mem_freed);
 }
 
 /* Propagate an implicit key deletion into replicas and the AOF file.
@@ -2882,11 +2878,11 @@ keyStatus expireIfNeeded(redisDb *db, robj *key, kvobj *kv, int flags) {
 
     /* Perform deletion */
     if (key) {
-        deleteExpiredKeyAndPropagate(db, key, 0);
+        deleteExpiredKeyAndPropagate(db, key);
     } else {
         sds keyname = kvobjGetKey(kv);
         robj *tmpkey = createStringObject(keyname, sdslen(keyname));
-        deleteExpiredKeyAndPropagate(db, tmpkey, 0);
+        deleteExpiredKeyAndPropagate(db, tmpkey);
         decrRefCount(tmpkey);
     }
     return KEY_DELETED;

--- a/src/db.c
+++ b/src/db.c
@@ -2656,8 +2656,10 @@ long long getExpire(redisDb *db, sds key, kvobj *kv) {
  * which config to look for lazy free, stats var to increment, and so on.
  *
  * key_mem_freed is an out parameter which contains the estimated
- * amount of memory freed due to the trimming (may be NULL) */
-static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type, long long *key_mem_freed) {
+ * amount of memory freed due to the trimming (may be NULL)
+ *
+ * lazy indicates whether the expiration is lazy expire or active expire. */
+static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type, long long *key_mem_freed, int lazy) {
     mstime_t latency;
     int del_flag = notify_type == NOTIFY_EXPIRED ? DB_FLAG_KEY_EXPIRED : DB_FLAG_KEY_EVICTED;
     int lazy_flag = notify_type == NOTIFY_EXPIRED ? server.lazyfree_lazy_expire : server.lazyfree_lazy_eviction;
@@ -2698,23 +2700,25 @@ static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type, lo
     keyModified(NULL, db, keyobj, NULL, 1);
     propagateDeletion(db, keyobj, lazy_flag);
 
-    if (notify_type == NOTIFY_EXPIRED)
+    if (notify_type == NOTIFY_EXPIRED) {
         server.stat_expiredkeys++;
-    else
+        if (!lazy) server.stat_expiredkeys_active++;
+    } else {
         server.stat_evictedkeys++;
+    }
 
     if (static_key)
         decrRefCount(keyobj);
 }
 
 /* Delete the specified expired key and propagate. */
-void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj) {
-    deleteKeyAndPropagate(db, keyobj, NOTIFY_EXPIRED, NULL);
+void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj, int lazy) {
+    deleteKeyAndPropagate(db, keyobj, NOTIFY_EXPIRED, NULL, lazy);
 }
 
 /* Delete the specified evicted key and propagate. */
 void deleteEvictedKeyAndPropagate(redisDb *db, robj *keyobj, long long *key_mem_freed) {
-    deleteKeyAndPropagate(db, keyobj, NOTIFY_EVICTED, key_mem_freed);
+    deleteKeyAndPropagate(db, keyobj, NOTIFY_EVICTED, key_mem_freed, 0);
 }
 
 /* Propagate an implicit key deletion into replicas and the AOF file.
@@ -2875,11 +2879,11 @@ keyStatus expireIfNeeded(redisDb *db, robj *key, kvobj *kv, int flags) {
 
     /* Perform deletion */
     if (key) {
-        deleteExpiredKeyAndPropagate(db, key);
+        deleteExpiredKeyAndPropagate(db, key, 1);
     } else {
         sds keyname = kvobjGetKey(kv);
         robj *tmpkey = createStringObject(keyname, sdslen(keyname));
-        deleteExpiredKeyAndPropagate(db, tmpkey);
+        deleteExpiredKeyAndPropagate(db, tmpkey, 1);
         decrRefCount(tmpkey);
     }
     return KEY_DELETED;

--- a/src/expire.c
+++ b/src/expire.c
@@ -44,7 +44,8 @@ int activeExpireCycleTryExpire(redisDb *db, kvobj *kv, long long now) {
     enterExecutionUnit(1, 0);
     sds key = kvobjGetKey(kv);
     robj *keyobj = createStringObject(key,sdslen(key));
-    deleteExpiredKeyAndPropagate(db,keyobj,1);
+    deleteExpiredKeyAndPropagate(db,keyobj);
+    server.stat_expiredkeys_active++;
     decrRefCount(keyobj);
     exitExecutionUnit();
     /* Propagate the DEL command */

--- a/src/expire.c
+++ b/src/expire.c
@@ -44,7 +44,7 @@ int activeExpireCycleTryExpire(redisDb *db, kvobj *kv, long long now) {
     enterExecutionUnit(1, 0);
     sds key = kvobjGetKey(kv);
     robj *keyobj = createStringObject(key,sdslen(key));
-    deleteExpiredKeyAndPropagate(db,keyobj);
+    deleteExpiredKeyAndPropagate(db,keyobj,0);
     decrRefCount(keyobj);
     exitExecutionUnit();
     /* Propagate the DEL command */
@@ -177,8 +177,8 @@ static ExpireAction activeSubexpiresCb(eItem item, void *ctx) {
 
     /* currently we only support hash type sub-expire */
     assert(kv->type == OBJ_HASH);
-    uint64_t nextExpTime = hashTypeActiveExpire(subexCtx->db,kv,
-                                          &subexCtx->fieldsToExpireQuota, 0);
+    uint64_t nextExpTime = hashTypeActiveExpire(subexCtx->db, kv,
+                                          &subexCtx->fieldsToExpireQuota, 0, 0);
 
     /* If hash has no more fields to expire or got deleted, indicate
      * to remove it from HFE DB to the caller ebExpire() */

--- a/src/expire.c
+++ b/src/expire.c
@@ -44,7 +44,7 @@ int activeExpireCycleTryExpire(redisDb *db, kvobj *kv, long long now) {
     enterExecutionUnit(1, 0);
     sds key = kvobjGetKey(kv);
     robj *keyobj = createStringObject(key,sdslen(key));
-    deleteExpiredKeyAndPropagate(db,keyobj,0);
+    deleteExpiredKeyAndPropagate(db,keyobj,1);
     decrRefCount(keyobj);
     exitExecutionUnit();
     /* Propagate the DEL command */
@@ -177,8 +177,7 @@ static ExpireAction activeSubexpiresCb(eItem item, void *ctx) {
 
     /* currently we only support hash type sub-expire */
     assert(kv->type == OBJ_HASH);
-    uint64_t nextExpTime = hashTypeActiveExpire(subexCtx->db, kv,
-                                          &subexCtx->fieldsToExpireQuota, 0, 0);
+    uint64_t nextExpTime = hashTypeExpire(subexCtx->db, kv, &subexCtx->fieldsToExpireQuota, 0, 1);
 
     /* If hash has no more fields to expire or got deleted, indicate
      * to remove it from HFE DB to the caller ebExpire() */

--- a/src/server.c
+++ b/src/server.c
@@ -2782,7 +2782,9 @@ void resetServerStats(void) {
     server.stat_numcommands = 0;
     server.stat_numconnections = 0;
     server.stat_expiredkeys = 0;
+    server.stat_expiredkeys_active = 0;
     server.stat_expired_subkeys = 0;
+    server.stat_expired_subkeys_active = 0;
     server.stat_expired_stale_perc = 0;
     server.stat_expired_time_cap_reached_count = 0;
     server.stat_expire_cycle_time_used = 0;
@@ -6435,7 +6437,9 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "sync_partial_ok:%lld\r\n", server.stat_sync_partial_ok,
             "sync_partial_err:%lld\r\n", server.stat_sync_partial_err,
             "expired_subkeys:%lld\r\n", server.stat_expired_subkeys,
+            "expired_subkeys_active:%lld\r\n", server.stat_expired_subkeys_active,
             "expired_keys:%lld\r\n", server.stat_expiredkeys,
+            "expired_keys_active:%lld\r\n", server.stat_expiredkeys_active,
             "expired_stale_perc:%.2f\r\n", server.stat_expired_stale_perc*100,
             "expired_time_cap_reached_count:%lld\r\n", server.stat_expired_time_cap_reached_count,
             "expire_cycle_cpu_milliseconds:%lld\r\n", server.stat_expire_cycle_time_used/1000,

--- a/src/server.h
+++ b/src/server.h
@@ -2032,7 +2032,9 @@ struct redisServer {
     long long stat_numcommands;     /* Number of processed commands */
     long long stat_numconnections;  /* Number of connections received */
     long long stat_expiredkeys;     /* Number of expired keys */
+    long long stat_expiredkeys_active; /* Number of expired keys by active expire */
     long long stat_expired_subkeys; /* Number of expired subkeys (Currently only hash-fields) */
+    long long stat_expired_subkeys_active; /* Number of expired subkeys by active expire */
     double stat_expired_stale_perc; /* Percentage of keys probably expired */
     long long stat_expired_time_cap_reached_count; /* Early expire cycle stops.*/
     long long stat_expire_cycle_time_used; /* Cumulative microseconds used. */
@@ -3755,7 +3757,7 @@ int hashTypeGetValueObject(redisDb *db, kvobj *kv, sds field, int hfeFlags,
                            robj **val, uint64_t *expireTime, int *isHashDeleted);
 int hashTypeSet(redisDb *db, kvobj *kv, sds field, sds value, int flags);
 robj *hashTypeDup(kvobj *kv, uint64_t *minHashExpire);
-uint64_t hashTypeActiveExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexpires);
+uint64_t hashTypeActiveExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexpires, int lazy);
 void hashTypeFree(robj *o);
 int hashTypeIsExpired(const robj *o, uint64_t expireAt);
 unsigned char *hashTypeListpackGetLp(robj *o);
@@ -3881,7 +3883,7 @@ void updateSlotAllocSize(redisDb *db, int didx, size_t oldsize, size_t newsize);
 void dbgAssertKeysizesHist(redisDb *db);
 void dbgAssertAllocSizePerSlot(redisDb *db);
 int removeExpire(redisDb *db, robj *key);
-void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj);
+void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj, int lazy);
 void deleteEvictedKeyAndPropagate(redisDb *db, robj *keyobj, long long *key_mem_freed);
 void propagateDeletion(redisDb *db, robj *key, int lazy);
 int keyIsExpired(redisDb *db, sds key, kvobj *kv);

--- a/src/server.h
+++ b/src/server.h
@@ -3883,7 +3883,7 @@ void updateSlotAllocSize(redisDb *db, int didx, size_t oldsize, size_t newsize);
 void dbgAssertKeysizesHist(redisDb *db);
 void dbgAssertAllocSizePerSlot(redisDb *db);
 int removeExpire(redisDb *db, robj *key);
-void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj, int active_expire);
+void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj);
 void deleteEvictedKeyAndPropagate(redisDb *db, robj *keyobj, long long *key_mem_freed);
 void propagateDeletion(redisDb *db, robj *key, int lazy);
 int keyIsExpired(redisDb *db, sds key, kvobj *kv);

--- a/src/server.h
+++ b/src/server.h
@@ -3757,7 +3757,7 @@ int hashTypeGetValueObject(redisDb *db, kvobj *kv, sds field, int hfeFlags,
                            robj **val, uint64_t *expireTime, int *isHashDeleted);
 int hashTypeSet(redisDb *db, kvobj *kv, sds field, sds value, int flags);
 robj *hashTypeDup(kvobj *kv, uint64_t *minHashExpire);
-uint64_t hashTypeActiveExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexpires, int lazy);
+uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexpires, int activeEx);
 void hashTypeFree(robj *o);
 int hashTypeIsExpired(const robj *o, uint64_t expireAt);
 unsigned char *hashTypeListpackGetLp(robj *o);
@@ -3883,7 +3883,7 @@ void updateSlotAllocSize(redisDb *db, int didx, size_t oldsize, size_t newsize);
 void dbgAssertKeysizesHist(redisDb *db);
 void dbgAssertAllocSizePerSlot(redisDb *db);
 int removeExpire(redisDb *db, robj *key);
-void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj, int lazy);
+void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj, int active_expire);
 void deleteEvictedKeyAndPropagate(redisDb *db, robj *keyobj, long long *key_mem_freed);
 void propagateDeletion(redisDb *db, robj *key, int lazy);
 int keyIsExpired(redisDb *db, sds key, kvobj *kv);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -357,7 +357,7 @@ static uint64_t listpackExGetMinExpire(robj *o) {
 }
 
 /* Walk over fields and delete the expired ones. */
-void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info, int active_expire) {
+void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info, int activeEx) {
     serverAssert(kv->encoding == OBJ_ENCODING_LISTPACK_EX);
     uint64_t expired = 0, min = EB_EXPIRE_TIME_INVALID;
     unsigned char *ptr;
@@ -386,7 +386,7 @@ void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info, int active_expir
 
         propagateHashFieldDeletion(db, key, (char *)((fref) ? fref : intbuf), flen);
         server.stat_expired_subkeys++;
-        if (active_expire) server.stat_expired_subkeys_active++;
+        if (activeEx) server.stat_expired_subkeys_active++;
 
         ptr = lpNext(lpt->lp, ptr);
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -122,6 +122,7 @@ EbucketsType hashFieldExpireBucketsType = {
 typedef struct OnFieldExpireCtx {
     robj *hashObj;
     redisDb *db;
+    int lazy;  /* 1 for lazy expire, 0 for active expire */
 } OnFieldExpireCtx;
 
 /* The implementation of hashes by dict was modified from storing fields as sds
@@ -356,7 +357,7 @@ static uint64_t listpackExGetMinExpire(robj *o) {
 }
 
 /* Walk over fields and delete the expired ones. */
-void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info) {
+void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info, int lazy) {
     serverAssert(kv->encoding == OBJ_ENCODING_LISTPACK_EX);
     uint64_t expired = 0, min = EB_EXPIRE_TIME_INVALID;
     unsigned char *ptr;
@@ -385,6 +386,7 @@ void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info) {
 
         propagateHashFieldDeletion(db, key, (char *)((fref) ? fref : intbuf), flen);
         server.stat_expired_subkeys++;
+        if (!lazy) server.stat_expired_subkeys_active++;
 
         ptr = lpNext(lpt->lp, ptr);
 
@@ -1870,7 +1872,7 @@ void hashTypeRandomElement(robj *hashobj, unsigned long hashsize, CommonEntry *k
  * - 0 if hash got deleted
  * - EB_EXPIRE_TIME_INVALID if no more fields to expire
  */
-uint64_t hashTypeActiveExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexpires) {
+uint64_t hashTypeActiveExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexpires, int lazy) {
     uint64_t noExpireLeftRes = EB_EXPIRE_TIME_INVALID;
     ExpireInfo info = {0};
 
@@ -1880,14 +1882,14 @@ uint64_t hashTypeActiveExpire(redisDb *db, kvobj *o, uint32_t *quota, int update
                 .now = commandTimeSnapshot(),
                 .itemsExpired = 0};
 
-        listpackExExpire(db, o, &info);
+        listpackExExpire(db, o, &info, lazy);
     } else {
         serverAssert(o->encoding == OBJ_ENCODING_HT);
 
         dict *d = o->ptr;
         htMetadataEx *dictExpireMeta = htGetMetadataEx(d);
 
-        OnFieldExpireCtx onFieldExpireCtx = { .hashObj = o, .db = db };
+        OnFieldExpireCtx onFieldExpireCtx = { .hashObj = o, .db = db, .lazy = lazy };
 
         info = (ExpireInfo){
             .maxToExpire = *quota,
@@ -1962,7 +1964,7 @@ static int hashTypeExpireIfNeeded(redisDb *db, kvobj *o) {
 
     /* Take care to expire all the fields */
     uint32_t quota = UINT32_MAX;
-    nextExpireTime = hashTypeActiveExpire(db, o, &quota, 1);
+    nextExpireTime = hashTypeActiveExpire(db, o, &quota, 1, 1);
     /* return 1 if the entire hash was deleted */
     return nextExpireTime == 0;
 }
@@ -3504,6 +3506,8 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     if (server.memory_tracking_per_slot)
         updateSlotAllocSize(expCtx->db, getKeySlot(key), oldsize, hashTypeAllocSize(kv));
     server.stat_expired_subkeys++;
+    if (!expCtx->lazy)
+        server.stat_expired_subkeys_active++;
     return ACT_REMOVE_EXP_ITEM;
 }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -122,7 +122,7 @@ EbucketsType hashFieldExpireBucketsType = {
 typedef struct OnFieldExpireCtx {
     robj *hashObj;
     redisDb *db;
-    int lazy;  /* 1 for lazy expire, 0 for active expire */
+    int activeEx; /* 1 for active expire, 0 for lazy expire */
 } OnFieldExpireCtx;
 
 /* The implementation of hashes by dict was modified from storing fields as sds
@@ -357,7 +357,7 @@ static uint64_t listpackExGetMinExpire(robj *o) {
 }
 
 /* Walk over fields and delete the expired ones. */
-void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info, int lazy) {
+void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info, int active_expire) {
     serverAssert(kv->encoding == OBJ_ENCODING_LISTPACK_EX);
     uint64_t expired = 0, min = EB_EXPIRE_TIME_INVALID;
     unsigned char *ptr;
@@ -386,7 +386,7 @@ void listpackExExpire(redisDb *db, kvobj *kv, ExpireInfo *info, int lazy) {
 
         propagateHashFieldDeletion(db, key, (char *)((fref) ? fref : intbuf), flen);
         server.stat_expired_subkeys++;
-        if (!lazy) server.stat_expired_subkeys_active++;
+        if (active_expire) server.stat_expired_subkeys_active++;
 
         ptr = lpNext(lpt->lp, ptr);
 
@@ -1872,7 +1872,7 @@ void hashTypeRandomElement(robj *hashobj, unsigned long hashsize, CommonEntry *k
  * - 0 if hash got deleted
  * - EB_EXPIRE_TIME_INVALID if no more fields to expire
  */
-uint64_t hashTypeActiveExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexpires, int lazy) {
+uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexpires, int activeEx) {
     uint64_t noExpireLeftRes = EB_EXPIRE_TIME_INVALID;
     ExpireInfo info = {0};
 
@@ -1882,14 +1882,14 @@ uint64_t hashTypeActiveExpire(redisDb *db, kvobj *o, uint32_t *quota, int update
                 .now = commandTimeSnapshot(),
                 .itemsExpired = 0};
 
-        listpackExExpire(db, o, &info, lazy);
+        listpackExExpire(db, o, &info, activeEx);
     } else {
         serverAssert(o->encoding == OBJ_ENCODING_HT);
 
         dict *d = o->ptr;
         htMetadataEx *dictExpireMeta = htGetMetadataEx(d);
 
-        OnFieldExpireCtx onFieldExpireCtx = { .hashObj = o, .db = db, .lazy = lazy };
+        OnFieldExpireCtx onFieldExpireCtx = { .hashObj = o, .db = db, .activeEx = activeEx };
 
         info = (ExpireInfo){
             .maxToExpire = *quota,
@@ -1964,7 +1964,7 @@ static int hashTypeExpireIfNeeded(redisDb *db, kvobj *o) {
 
     /* Take care to expire all the fields */
     uint32_t quota = UINT32_MAX;
-    nextExpireTime = hashTypeActiveExpire(db, o, &quota, 1, 1);
+    nextExpireTime = hashTypeExpire(db, o, &quota, 1, 0);
     /* return 1 if the entire hash was deleted */
     return nextExpireTime == 0;
 }
@@ -3506,7 +3506,7 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     if (server.memory_tracking_per_slot)
         updateSlotAllocSize(expCtx->db, getKeySlot(key), oldsize, hashTypeAllocSize(kv));
     server.stat_expired_subkeys++;
-    if (!expCtx->lazy)
+    if (expCtx->activeEx)
         server.stat_expired_subkeys_active++;
     return ACT_REMOVE_EXP_ITEM;
 }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -847,6 +847,48 @@ start_server {tags {"expire"}} {
         close_replication_stream $repl
         assert_equal [r debug set-active-expire 1] {OK}
     } {} {needs:debug}
+
+    test {Lazy expire should increment expired_keys but not expired_keys_active} {
+        r flushall
+        r config resetstat
+        r debug set-active-expire 0
+
+        # Set keys that will expire
+        r set foo1 bar PX 1
+        r set foo2 bar PX 1
+        r set foo3 bar PX 1
+        after 2
+
+        # Trigger lazy expire by accessing the keys
+        assert_equal {{} {} {}} [r mget foo1 foo2 foo3]
+
+        # Verify that expired_keys was incremented but expired_keys_active was not
+        assert_equal [s expired_keys] 3
+        assert_equal [s expired_keys_active] 0
+
+        assert_equal [r debug set-active-expire 1] {OK}
+    } {} {needs:debug}
+
+    test {Active expire should increment both expired_keys and expired_keys_active} {
+        r flushall
+        r config resetstat
+
+        # Set keys that will expire soon
+        r set foo1 bar PX 1
+        r set foo2 bar PX 1
+        r set foo3 bar PX 1
+
+        # Wait for active expire to kick in
+        wait_for_condition 50 100 {
+            [s expired_keys] == 3
+        } else {
+            fail "Keys were not expired"
+        }
+
+        # Verify that both expired_keys and expired_keys_active were incremented
+        assert_equal [s expired_keys] 3
+        assert_equal [s expired_keys_active] 3
+    } {}
 }
 
 start_cluster 1 0 {tags {"expire external:skip cluster"}} {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -854,13 +854,13 @@ start_server {tags {"expire"}} {
         r debug set-active-expire 0
 
         # Set keys that will expire
-        r set foo1 bar PX 1
-        r set foo2 bar PX 1
-        r set foo3 bar PX 1
+        r set foo1{t} bar PX 1
+        r set foo2{t} bar PX 1
+        r set foo3{t} bar PX 1
         after 2
 
         # Trigger lazy expire by accessing the keys
-        assert_equal {{} {} {}} [r mget foo1 foo2 foo3]
+        assert_equal {{} {} {}} [r mget foo1{t} foo2{t} foo3{t}]
 
         # Verify that expired_keys was incremented but expired_keys_active was not
         assert_equal [s expired_keys] 3

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -1435,6 +1435,46 @@ start_server {tags {"external:skip needs:debug"}} {
         }
     }
 
+    test "Statistics - Lazy expire increments expired_subkeys but not expired_subkeys_active ($type)" {
+        r flushall
+        r config resetstat
+        r debug set-active-expire 0
+
+        # Create hash with fields that will expire
+        r hset myhash f1 v1 f2 v2 f3 v3 f4 v4 f5 v5
+        r hpexpire myhash 1 FIELDS 3 f1 f2 f3
+        after 2
+
+        # Trigger lazy expire by accessing the fields
+        assert_equal {{} {} {}} [r hmget myhash f1 f2 f3]
+
+        # Verify that expired_subkeys was incremented but expired_subkeys_active was not
+        assert_equal [s expired_subkeys] 3
+        assert_equal [s expired_subkeys_active] 0
+
+        r debug set-active-expire 1
+    }
+
+    test "Statistics - Active expire increments both expired_subkeys and expired_subkeys_active ($type)" {
+        r flushall
+        r config resetstat
+
+        # Create hash with fields that will expire soon
+        r hset myhash f1 v1 f2 v2 f3 v3 f4 v4 f5 v5
+        r hpexpire myhash 1 FIELDS 3 f1 f2 f3
+
+        # Wait for active expire to kick in
+        wait_for_condition 50 100 {
+            [s expired_subkeys] == 3
+        } else {
+            fail "Hash fields were not expired"
+        }
+
+        # Verify that both expired_subkeys and expired_subkeys_active were incremented
+        assert_equal [s expired_subkeys] 3
+        assert_equal [s expired_subkeys_active] 3
+    }
+
     test "HFE commands against wrong type" {
         r set wrongtype somevalue
         assert_error "WRONGTYPE Operation against a key*" {r hexpire wrongtype 10 fields 1 f1}


### PR DESCRIPTION
### Summary

Adds `expired_keys_active` and `expired_subkeys_active` counters to track keys and hash fields expired by the active expiration cycle, distinguishing them from lazy expirations.
These new metrics are exposed in INFO stats output.

### Motivation

Currently, Redis tracks the total number of expired keys (expired_keys) and expired hash fields (expired_subkeys), but there's no way to differentiate between expirations triggered by active expire and lazy expire.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces distinct metrics for active expiration and wires them through the expire paths.
> 
> - Adds `server.stat_expiredkeys_active` and `server.stat_expired_subkeys_active`; exposes via INFO as `expired_keys_active` and `expired_subkeys_active`, and resets them in `resetServerStats`
> - Increments `expired_keys_active` during active key expiry (`activeExpireCycleTryExpire`)
> - Refactors hash-field expiry: rename `hashTypeActiveExpire` to `hashTypeExpire(..., activeEx)` and plumb `activeEx` through `listpackExExpire` and `onFieldExpire` to conditionally increment `expired_subkeys_active`
> - Updates active sub-expire callback to use the new API; no functional changes beyond metrics
> - Adds tests verifying lazy vs active increments for keys and hash fields
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16783036570517d7a640fd950043b144d38fff90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->