### PR TITLE
RDB Channel connections mistakenly discovered by Sentinel (#14728)

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -3724,7 +3724,11 @@ static int rdbChannelSendHandshake(connection *conn, sds *err) {
 
     *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1",
                        "rdb-channel", "1", "main-ch-client-id", cid,
-                       "listening-port", buf, NULL);
+                       "listening-port", buf,
+                       server.slave_announce_ip ? "ip-address" : NULL,
+                       server.slave_announce_ip ? server.slave_announce_ip : NULL,
+                       NULL);
+    
     if (*err) {
         serverLog(LL_WARNING, "Error sending REPLCONF command to master in rdb channel handshake: %s", *err);
         return C_ERR;


### PR DESCRIPTION
Fix RDB Channel connections mistakenly discovered by Sentinel

During fullsync, if the main replication connection is interrupted, but the rdbchannel connection is still active, it will be visible in the "info replication" output. Currently, the rdbchannel connection does not send `REPLCONF ip-address`, and in a meshed scenario, when the source IP addresses of both connections differ, Sentinel will treat them as separate replicas. This commit adds `REPLCONF ip-address` to rdbchannel replica handshake if `server.slave_announce_ip` is enabled.

fixes: https://github.com/redis/redis/issues/14728


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes RDB channel replica identification**
> 
> - In `replication.c`, the RDB channel handshake now conditionally includes `REPLCONF ip-address` when `server.slave_announce_ip` is configured.
> - Ensures the side-channel reports the same announced IP as the main replication channel, preventing tools (e.g., Sentinel) from misidentifying it as a separate replica in meshed/port-forwarded setups.
> 
> *Risk/Scope*: Minimal, scoped to rdb-channel handshakes and gated by `slave_announce_ip`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd83484bdb38936e4116922f843efc30dfa21857. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->