### PR TITLE
Refactor idmp defrag

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -2133,6 +2133,30 @@ hll-sparse-max-bytes 3000
 stream-node-max-bytes 4096
 stream-node-max-entries 100
 
+# Redis Streams support Idempotent Message Producer (IDMP) tracking to prevent
+# duplicate message delivery. When producers send messages with IDMP identifiers
+# (using XADD with IDMP or IDMPAUTO parameters), Redis tracks these identifiers to
+# detect and reject duplicates within a configurable time window.
+#
+# stream-idmp-duration: Specifies how long (in seconds) Redis should remember
+# IDMP identifiers for duplicate detection. After this duration expires, old
+# identifiers are automatically removed. This prevents unbounded memory growth
+# while allowing reasonable duplicate detection windows.
+# Valid range: 1 to 86400 seconds (1 second to 24 hours)
+# Default: 100 seconds
+#
+# stream-idmp-maxsize: Maximum number of IDMP identifiers to track per producer
+# per stream. Once this limit is reached, the oldest identifiers are evicted to
+# make room for new ones. This caps memory usage for IDMP tracking.
+# Valid range: 1 to 10000 entries
+# Default: 100 entries
+#
+# Note: These are default values for new streams. Individual streams can override
+# these settings using the XCFGSET command.
+#
+# stream-idmp-duration 100
+# stream-idmp-maxsize 100
+
 # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
 # order to help rehashing the main Redis hash table (the one mapping top-level
 # keys to values). The hash table implementation Redis uses (see dict.c)

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -998,7 +998,8 @@ void defragStream(defragKeysCtx *ctx, kvobj *ob) {
     }
 
     if (s->idmp_producers) {
-        /* Defrag the producers and all idmpEntry structures in their linked lists */
+        /* Update idmp_producers back-pointer to new stream */
+        s->idmp_producers->alloc_size = &s->alloc_size;
         defragRadixTree(&s->idmp_producers, 0, defragIdmpProducerCallback, NULL);
     }
 }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -957,34 +957,15 @@ static void defragIdmpProducer(idmpProducer *producer) {
     }
 }
 
-/* Defrag all IDMP producers and their dict/linked list entries. */
-void defragStreamIdmpProducers(stream *s) {
-    if (s->idmp_producers == NULL) return;
-
-    /* Defrag the producers rax tree itself */
-    rax *newrax = activeDefragAlloc(s->idmp_producers);
-    if (newrax)
-        s->idmp_producers = newrax;
-
-    /* Defrag the rax head node */
-    defragRaxNode(&s->idmp_producers->head, NULL);
-
-    /* Iterate through all producers and defrag each one */
-    raxIterator ri;
-    raxStart(&ri, s->idmp_producers);
-    /* Set the node callback to defrag internal rax nodes */
-    ri.node_cb = defragRaxNode;
-    raxSeek(&ri, "^", NULL, 0);
-    while (raxNext(&ri)) {
-        idmpProducer *producer = ri.data;
-        idmpProducer *newproducer = activeDefragAlloc(producer);
-        if (newproducer) {
-            raxSetData(ri.node, ri.data=newproducer);
-            producer = newproducer;
-        }
-        defragIdmpProducer(producer);
+static void* defragIdmpProducerCallback(raxIterator *ri, void *privdata) {
+    UNUSED(privdata);
+    idmpProducer *producer = ri->data;
+    idmpProducer *newproducer = activeDefragAlloc(producer);
+    if (newproducer) {
+        producer = newproducer;
     }
-    raxStop(&ri);
+    defragIdmpProducer(producer);
+    return newproducer; /* returns NULL if producer was not defragged */
 }
 
 void defragStream(defragKeysCtx *ctx, kvobj *ob) {
@@ -1018,7 +999,7 @@ void defragStream(defragKeysCtx *ctx, kvobj *ob) {
 
     if (s->idmp_producers) {
         /* Defrag the producers and all idmpEntry structures in their linked lists */
-        defragStreamIdmpProducers(s);
+        defragRadixTree(&s->idmp_producers, 0, defragIdmpProducerCallback, NULL);
     }
 }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -856,7 +856,7 @@ int rdbLoadStreamIdmpEntries(rio *rdb, stream *s) {
     if (num_producers == 0) return 0;
 
     /* Create the producers rax tree. */
-    s->idmp_producers = raxNew();
+    s->idmp_producers = raxNewWithMetadata(0, &s->alloc_size);
     if (s->idmp_producers == NULL) {
         return -1;
     }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -5521,7 +5521,7 @@ static void idmpInsertEntry(stream *s, idmpProducer *producer, idmpEntry *entry,
 static idmpProducer *idmpGetOrCreateProducer(stream *s, const char *pid, size_t pid_len) {
     /* Create the producers rax tree if it doesn't exist */
     if (s->idmp_producers == NULL) {
-        s->idmp_producers = raxNew();
+        s->idmp_producers = raxNewWithMetadata(0, &s->alloc_size);
     }
 
     /* Look up the producer */


### PR DESCRIPTION
# Summary

Refactors IDMP producer defragmentation to use the generic `defragRadixTree` helper function instead of manually implementing radix tree iteration, improving code consistency and maintainability.

## Changes

* Replaced manual rax iteration in `defragStreamIdmpProducers` with `defragRadixTree` call
* Added `defragIdmpProducerCallback` function following the `raxDefragFunction` signature pattern
* Removed unnecessary wrapper function and inlined the call directly at the call site
* Made the callback function static since it's only used within `defrag.c`

## Benefits

**Code Consistency:** Now follows the same pattern used by other stream defrag functions (`defragStreamConsumer`, `defragStreamConsumerGroup`, etc.)
**Reduced Duplication:** Eliminates 20+ lines of boilerplate rax iteration code by leveraging the existing `defragRadixTree` helper
**Maintainability:** All rax defragmentation logic (tree struct, head node, internal nodes, data pointers) is now centralized in `defragRadixTree`
**Correctness:** Uses the proven, well-tested radix tree defragmentation logic consistently across all stream-related structures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes IDMP producer defrag to align with existing stream defrag patterns.
> 
> - Replace manual `defragStreamIdmpProducers` logic with `defragRadixTree` using static `defragIdmpProducerCallback`
> - Update `defragStream` to set `s->idmp_producers->alloc_size` and invoke `defragRadixTree`
> - Initialize `s->idmp_producers` via `raxNewWithMetadata(0, &s->alloc_size)` in `rdbLoadStreamIdmpEntries` and `idmpGetOrCreateProducer` to maintain back-pointers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24b03386db482bc20ce50c75a22b7089088931ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->