### PR TITLE
Fix minor inconsistency in connFormatAddr size argument

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1591,7 +1591,7 @@ void acceptCommonHandler(connection *conn, int flags, char *ip) {
         char addr[NET_ADDR_STR_LEN] = {0};
         char laddr[NET_ADDR_STR_LEN] = {0};
         connFormatAddr(conn, addr, sizeof(addr), 1);
-        connFormatAddr(conn, laddr, sizeof(addr), 0);
+        connFormatAddr(conn, laddr, sizeof(laddr), 0);
         serverLog(LL_VERBOSE,
                   "Accepted client connection in error state: %s (addr=%s laddr=%s)",
                   connGetLastError(conn), addr, laddr);
@@ -1630,7 +1630,7 @@ void acceptCommonHandler(connection *conn, int flags, char *ip) {
         char addr[NET_ADDR_STR_LEN] = {0};
         char laddr[NET_ADDR_STR_LEN] = {0};
         connFormatAddr(conn, addr, sizeof(addr), 1);
-        connFormatAddr(conn, laddr, sizeof(addr), 0);
+        connFormatAddr(conn, laddr, sizeof(laddr), 0);
         serverLog(LL_WARNING,
                   "Error registering fd event for the new client connection: %s (addr=%s laddr=%s)",
                   connGetLastError(conn), addr, laddr);


### PR DESCRIPTION
**Type**: Refactoring / Code Cleanup

**Description**: While reviewing the connection layer logic, I noticed a minor inconsistency in how buffer sizes are passed to `connFormatAddr`.

In the error handling block of `acceptCommonHandler`, `sizeof(addr)` is currently used for both the remote address and the local address buffers. While both addr and laddr are defined with the same size (`NET_ADDR_STR_LEN`), it is more idiomatic and safer to use the sizeof of the actual buffer being populated.

**This change ensures:**
- Defensive Programming: Prevents potential buffer overflows or truncation issues if the array sizes are changed independently in the future.
- Code Clarity: Removes ambiguity for future maintainers and ensures the logic is self-consistent.


**Code Comparison:**
```c
// Before
char addr[NET_ADDR_STR_LEN] = {0};
char laddr[NET_ADDR_STR_LEN] = {0};
connFormatAddr(conn, addr, sizeof(addr), 1);
connFormatAddr(conn, laddr, sizeof(addr), 0); // Using size of the wrong buffer

// After
char addr[NET_ADDR_STR_LEN] = {0};
char laddr[NET_ADDR_STR_LEN] = {0};
connFormatAddr(conn, addr, sizeof(addr), 1);
connFormatAddr(conn, laddr, sizeof(laddr), 0); // Correctly uses sizeof(laddr)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor defensive fix in connection accept error handling.
> 
> - In `acceptCommonHandler`, replace `sizeof(addr)` with `sizeof(laddr)` for two `connFormatAddr` calls populating `laddr` to ensure the correct buffer size is used
> - Reduces future risk of overflow/truncation if `addr` and `laddr` sizes diverge; no behavioral changes beyond safer logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcaf89a7835f7d6e7d83f953627b5f927335624a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->