### PR TITLE
update data type modules with bloom 8.2.9, json 8.2.9, timeseries 8.2.5

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.2.8
+MODULE_VERSION = v8.2.9
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 

--- a/modules/redisjson/Makefile
+++ b/modules/redisjson/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.2.1
+MODULE_VERSION = v8.2.9
 MODULE_REPO = https://github.com/redisjson/redisjson
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/rejson.so
 

--- a/modules/redistimeseries/Makefile
+++ b/modules/redistimeseries/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.2.0
+MODULE_VERSION = v8.2.5
 MODULE_REPO = https://github.com/redistimeseries/redistimeseries
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redistimeseries.so
 


### PR DESCRIPTION
…me series 8.2.0 -> 8.2.5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates build targets to newer upstream Redis data type module versions.
> 
> - Bump `redisbloom` from `v8.2.8` to `v8.2.9`
> - Bump `redisjson` from `v8.2.1` to `v8.2.9`
> - Bump `redistimeseries` from `v8.2.0` to `v8.2.5`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4136d14d8aab9759957ac9474310d48a0458b7ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->