### PR TITLE
Fix typos in test files

### DIFF
--- a/tests/unit/cluster/links.tcl
+++ b/tests/unit/cluster/links.tcl
@@ -259,7 +259,7 @@ start_cluster 3 0 {tags {external:skip cluster}} {
         set link_mem_after_pubs [getInfoProperty $res mem_cluster_links]
         
         # We expect the memory to have increased by more than
-        # the culmulative size of the publish messages
+        # the cumulative size of the publish messages
         set mem_diff_floor [expr $msg_size * $num_msgs]
         set mem_diff [expr $link_mem_after_pubs - $link_mem_before_pubs]
         assert {$mem_diff > $mem_diff_floor}

--- a/tests/unit/moduleapi/keymeta.tcl
+++ b/tests/unit/moduleapi/keymeta.tcl
@@ -297,7 +297,7 @@ start_server {tags {"modules" "external:skip" "cluster:skip"} overrides {enable-
         }
     }
 
-    test "KEYMETA - Verify metadta cleanup on lazyfree" {
+    test "KEYMETA - Verify metadata cleanup on lazyfree" {
         r config set lazyfree-lazy-user-del yes
         # Class 2 has UNLINKFREE flag, so it should call unlink callback when lazyfree is enabled
         # Class 1 does not have UNLINKFREE flag, so it should only call free callback

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -553,7 +553,7 @@ start_server {tags {"multi"}} {
         catch { $r2 exec; } e
         assert_match {EXECABORT*previous errors*} $e
         set xx [r get xx]
-        # make sure that either the whole transcation passed or none of it (we actually expect none)
+        # make sure that either the whole transaction passed or none of it (we actually expect none)
         assert { $xx == 1 || $xx == 3}
         # check that the connection is no longer in multi state
         set pong [$r2 ping asdf]
@@ -578,7 +578,7 @@ start_server {tags {"multi"}} {
         r script kill
         after 200 ; # Give some time to Lua to call the hook again...
         set xx [r get xx]
-        # make sure that either the whole transcation passed or none of it (we actually expect none)
+        # make sure that either the whole transaction passed or none of it (we actually expect none)
         assert { $xx == 1 || $xx == 3}
         # check that the connection is no longer in multi state
         set pong [$r2 ping asdf]
@@ -603,7 +603,7 @@ start_server {tags {"multi"}} {
         catch { $r2 exec; } e
         assert_match {EXECABORT*previous errors*} $e
         set xx [r get xx]
-        # make sure that either the whole transcation passed or none of it (we actually expect none)
+        # make sure that either the whole transaction passed or none of it (we actually expect none)
         assert { $xx == 1 || $xx == 3}
         # check that the connection is no longer in multi state
         set pong [$r2 ping asdf]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor spelling fixes in test files to improve readability; no logic or behavior changes.
> 
> - Corrects "culmulative" to "cumulative" in `tests/unit/cluster/links.tcl`
> - Corrects "metadta" to "metadata" in a test title in `tests/unit/moduleapi/keymeta.tcl`
> - Corrects "transcation" to "transaction" in comments across `tests/unit/multi.tcl`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 364a89c860f02a5d2283a4b1de7cff6ca06b9f74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->