### PR TITLE
Fix deferring free object that refcount is more than 1

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -687,7 +687,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
         }
     }
 
-    if (server.io_threads_num > 1 && old->encoding == OBJ_ENCODING_RAW) {
+    if (server.io_threads_num > 1 && old->encoding == OBJ_ENCODING_RAW && old->refcount == 1) {
         /* In multi-threaded mode, the OBJ_ENCODING_RAW string object usually is
          * allocated in the IO thread, so we defer the free to the IO thread.
          * Besides, we never free a string object in BIO threads, so, even with


### PR DESCRIPTION
in https://github.com/redis/redis/pull/14440, we remove the refcount check in [tryDeferFreeClientObject](https://github.com/redis/redis/commit/235e688b010b38496ea1de06b0bfc2786b1ebc63#diff-252bce0cc340542712f0c1adf62e9035ea47a4a064321fbf40ec3dd4b814aaf2R1509), it is ok in 8.4 version, since after command execution, the refcount of a kvobject always is 1.
but in #14608 (8.6 RC1) we change this assumption, increment refcount when a client refer a kvobject in reply, so now if the refcount of kvobject is more than 1, we may let the io thread call `decrRefCount`, there is data race, maybe it causes memory leak.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Narrows IO-thread deferred free behavior for string values during `dbSetValue`.
> 
> - Now defers freeing only if `server.io_threads_num > 1`, object is `OBJ_ENCODING_RAW`, and `old->refcount == 1`
> - Otherwise uses existing lazy free (`freeObjAsync`) or immediate `decrRefCount` paths
> 
> This prevents IO threads from `decrRefCount` on shared objects, avoiding potential data races/leaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a273e36ccc1296d9d8db7b683c53a21cfb527cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->