### PR TITLE
Fix typos in vector-sets README: dobule->double, accessig->accessing

### DIFF
--- a/modules/vector-sets/README.md
+++ b/modules/vector-sets/README.md
@@ -425,7 +425,7 @@ Attributes are accessed using dot notation:
 
 Expressions can work with:
 
-- Numbers (dobule precision floats)
+- Numbers (double precision floats)
 - Strings (enclosed in single or double quotes)
 - Booleans (no native type: they are represented as 1 for true, 0 for false)
 - Arrays (for use with the `in` operator: `value in [1, 2, 3]`)
@@ -437,7 +437,7 @@ JSON attributes are converted in this way:
 - Booleans to 0 or 1 number.
 - Arrays to tuples (for "in" operator), but only if composed of just numbers and strings.
 
-Any other type is ignored, and accessig it will make the expression evaluate to false.
+Any other type is ignored, and accessing it will make the expression evaluate to false.
 
 ### The IN operator
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Minor documentation cleanup in `modules/vector-sets/README.md`.
> 
> - Fixes typos in the JSON/expressions data types section: "dobule"→"double", "accessig"→"accessing" and formatting of a bullet
> - No behavioral or code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e15807fca35791b44864a80e7a57350cfcb3913. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->