### PR TITLE
Fix typo in comment: 'to given' -> 'to give'

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3042,7 +3042,7 @@ static void setProtocolError(const char *errstr, client *c) {
     if (server.verbosity <= LL_VERBOSE || c->flags & CLIENT_MASTER) {
         sds client = catClientInfoString(sdsempty(),c);
 
-        /* Sample some protocol to given an idea about what was inside. */
+        /* Sample some protocol to give an idea about what was inside. */
         char buf[256];
         if (server.hide_user_data_from_log) {
             snprintf(buf,sizeof(buf),"Query buffer during protocol error: '*redacted*'");  


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Corrects a comment typo in `setProtocolError` in `src/networking.c` ("to given" → "to give").
> 
> - Comment-only change; no functional or behavioral impact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afe96ab9abab53db8cb8851d264e5d2583458a37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->