### PR TITLE
Fix hotkey info metric names. Disable HOTKEY SLOTS param for non-cluster

### DIFF
--- a/src/commands/hotkeys-get.json
+++ b/src/commands/hotkeys-get.json
@@ -14,7 +14,7 @@
         "reply_schema": {
             "oneOf": [
                 {
-                    "description": "Flat array with various metrics(tracking-activated, sample-ratio, selected-slots, time/network statistics), collection info (collection-start-time-unix-ms, collection-duration-ms, total-cpu-time-user-ms, total-cpu-time-sys-ms, total-net-bytes), and the requested lists of Top-K hotkeys (available metrics: by-cpu-time, by-net-bytes) where at most K hotkeys are returned.",
+                    "description": "Flat array with various metrics(tracking-activated, sample-ratio, selected-slots, time/network statistics), collection info (collection-start-time-unix-ms, collection-duration-ms, total-cpu-time-user-ms, total-cpu-time-sys-ms, total-net-bytes), and the requested lists of Top-K hotkeys (available metrics: by-cpu-time-us, by-net-bytes) where at most K hotkeys are returned.",
                     "type": "array",
                     "items": {
                         "oneOf": [

--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -335,6 +335,11 @@ void hotkeysCommand(client *c) {
                 sample_ratio = (int)ratio_val;
                 j += 2;
             } else if (moreargs && !strcasecmp(c->argv[j]->ptr, "SLOTS")) {
+                if (!server.cluster_enabled) {
+                    addReplyError(c, "SLOTS parameter cannot be used in non-cluster mode");
+                    return;
+                }
+
                 if (slots) {
                     addReplyError(c, "SLOTS parameter already specified");
                     zfree(slots);
@@ -487,25 +492,25 @@ void hotkeysCommand(client *c) {
             addReplyLongLong(c, server.hotkeys->slots[i]);
         }
 
-        /* sampled-command-selected-slots-ms (conditional) */
+        /* sampled-command-selected-slots-us (conditional) */
         if (has_sampling && has_selected_slots) {
-            addReplyBulkCString(c, "sampled-command-selected-slots-ms");
-            addReplyLongLong(c, server.hotkeys->time_sampled_commands_selected_slots / 1000);
+            addReplyBulkCString(c, "sampled-command-selected-slots-us");
+            addReplyLongLong(c, server.hotkeys->time_sampled_commands_selected_slots);
 
             total_len += 2;
         }
 
-        /* all-commands-selected-slots-ms (conditional) */
+        /* all-commands-selected-slots-us (conditional) */
         if (has_selected_slots) {
-            addReplyBulkCString(c, "all-commands-selected-slots-ms");
-            addReplyLongLong(c, server.hotkeys->time_all_commands_selected_slots / 1000);
+            addReplyBulkCString(c, "all-commands-selected-slots-us");
+            addReplyLongLong(c, server.hotkeys->time_all_commands_selected_slots);
 
             total_len += 2;
         }
 
-        /* all-commands-all-slots-ms */
-        addReplyBulkCString(c, "all-commands-all-slots-ms");
-        addReplyLongLong(c, server.hotkeys->time_all_commands_all_slots / 1000);
+        /* all-commands-all-slots-us */
+        addReplyBulkCString(c, "all-commands-all-slots-us");
+        addReplyLongLong(c, server.hotkeys->time_all_commands_all_slots);
 
         /* net-bytes-sampled-commands-selected-slots (conditional) */
         if (has_sampling && has_selected_slots) {
@@ -558,7 +563,7 @@ void hotkeysCommand(client *c) {
 
         /* by-cpu-time - only if CPU tracking is enabled */
         if (server.hotkeys->tracked_metrics & HOTKEYS_TRACK_CPU) {
-            addReplyBulkCString(c, "by-cpu-time");
+            addReplyBulkCString(c, "by-cpu-time-us");
             /* Nested array of key-value pairs */
             addReplyArrayLen(c, 2 * cpu_count);
             for (int i = 0; i < cpu_count; ++i) {

--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -561,7 +561,7 @@ void hotkeysCommand(client *c) {
             total_len += 2;
         }
 
-        /* by-cpu-time - only if CPU tracking is enabled */
+        /* by-cpu-time-us - only if CPU tracking is enabled */
         if (server.hotkeys->tracked_metrics & HOTKEYS_TRACK_CPU) {
             addReplyBulkCString(c, "by-cpu-time-us");
             /* Nested array of key-value pairs */

--- a/src/server.h
+++ b/src/server.h
@@ -2543,8 +2543,7 @@ struct hotkeyStats {
     int *slots;
     int numslots;
 
-    /* Statistics counters. NOTE, time_* members are saved in microseconds for
-     * accuracy but displayed in milliseconds during HOTKEYS GET */
+    /* Statistics counters. */
     uint64_t time_sampled_commands_selected_slots;  /* microseconds */
     uint64_t time_all_commands_selected_slots;       /* microseconds */
     uint64_t time_all_commands_all_slots;            /* microseconds */

--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -192,7 +192,7 @@ start_server {tags {"hotkeys"}} {
         r hello 3
         catch {r hotkeys start METRICS 1 CPU SLOTS 2 0 5} err
         assert_match "*SLOTS parameter cannot be used in non-cluster mode*" $err
-    } {} {resp3}
+    } {} {resp3 cluster:skip}
 
     test {HOTKEYS STOP - basic functionality} {
         r hello 3

--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -29,7 +29,7 @@ start_server {tags {"hotkeys"}} {
 
         assert [dict exists $result "total-cpu-time-user-ms"]
         assert [dict exists $result "total-cpu-time-sys-ms"]
-        assert [dict exists $result "by-cpu-time"]
+        assert [dict exists $result "by-cpu-time-us"]
         assert {![dict exists $result "total-net-bytes"]}
         assert {![dict exists $result "by-net-bytes"]}
 
@@ -51,7 +51,7 @@ start_server {tags {"hotkeys"}} {
         assert [dict exists $result "by-net-bytes"]
         assert {![dict exists $result "total-cpu-time-user-ms"]}
         assert {![dict exists $result "total-cpu-time-sys-ms"]}
-        assert {![dict exists $result "by-cpu-time"]}
+        assert {![dict exists $result "by-cpu-time-us"]}
 
         assert_equal {OK} [r hotkeys reset]
     } {} {resp3}
@@ -69,7 +69,7 @@ start_server {tags {"hotkeys"}} {
 
         assert [dict exists $result "total-cpu-time-user-ms"]
         assert [dict exists $result "total-cpu-time-sys-ms"]
-        assert [dict exists $result "by-cpu-time"]
+        assert [dict exists $result "by-cpu-time-us"]
         assert [dict exists $result "total-net-bytes"]
         assert [dict exists $result "by-net-bytes"]
 
@@ -141,7 +141,7 @@ start_server {tags {"hotkeys"}} {
             set result [hotkeys_array_to_dict $result]
         }
 
-        set cpu_array [dict get $result "by-cpu-time"]
+        set cpu_array [dict get $result "by-cpu-time-us"]
         set net_array [dict get $result "by-net-bytes"]
 
         set cpu_count [expr {[llength $cpu_array] / 2}]
@@ -188,23 +188,10 @@ start_server {tags {"hotkeys"}} {
         assert_match "*SAMPLE ratio must be positive*" $err
     } {} {resp3}
 
-    test {HOTKEYS START - with SLOTS parameter} {
+    test {HOTKEYS START - Error: SLOTS not allowed in non-cluster mode} {
         r hello 3
-        assert_equal {OK} [r hotkeys start METRICS 2 CPU NET SLOTS 2 0 5]
-        assert_equal {OK} [r hotkeys stop]
-        assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
-
-    test {HOTKEYS START - Error: SLOTS count mismatch} {
-        r hello 3
-        catch {r hotkeys start METRICS 1 CPU SLOTS 2 0} err
-        assert_match "*not enough slot numbers provided*" $err
-    } {} {resp3}
-
-    test {HOTKEYS START - Error: duplicate slots} {
-        r hello 3
-        catch {r hotkeys start METRICS 1 CPU SLOTS 2 0 0} err
-        assert_match "*duplicate slot number*" $err
+        catch {r hotkeys start METRICS 1 CPU SLOTS 2 0 5} err
+        assert_match "*SLOTS parameter cannot be used in non-cluster mode*" $err
     } {} {resp3}
 
     test {HOTKEYS STOP - basic functionality} {
@@ -260,65 +247,6 @@ start_server {tags {"hotkeys"}} {
         assert_equal {OK} [r hotkeys reset]
     } {} {resp3}
 
-    test {HOTKEYS GET - selected-slots field} {
-        r hello 3
-        assert_equal {OK} [r hotkeys start METRICS 2 CPU NET SLOTS 2 0 5]
-        assert_equal {OK} [r hotkeys stop]
-
-        set result [r hotkeys get]
-        if {[llength $result] > 0 && [lindex $result 0] ne "tracking-active"} {
-            set result [hotkeys_array_to_dict $result]
-        }
-        set slots [dict get $result "selected-slots"]
-        assert_equal 2 [llength $slots]
-        assert_equal 0 [lindex $slots 0]
-        assert_equal 5 [lindex $slots 1]
-
-        assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
-
-    test {HOTKEYS GET - conditional fields with sample_ratio > 1 and selected slots} {
-        r hello 3
-        assert_equal {OK} [r hotkeys start METRICS 2 CPU NET SAMPLE 10 SLOTS 1 0]
-        r set key1 value1
-        assert_equal {OK} [r hotkeys stop]
-
-        set result [r hotkeys get]
-        if {[llength $result] > 0 && [lindex $result 0] ne "tracking-active"} {
-            set result [hotkeys_array_to_dict $result]
-        }
-
-        # Should have conditional fields
-        assert [dict exists $result "sampled-command-selected-slots-ms"]
-        assert [dict exists $result "all-commands-selected-slots-ms"]
-        assert [dict exists $result "net-bytes-sampled-commands-selected-slots"]
-        assert [dict exists $result "net-bytes-all-commands-selected-slots"]
-
-        assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
-
-    test {HOTKEYS GET - no conditional fields with sample_ratio = 1} {
-        r hello 3
-        assert_equal {OK} [r hotkeys start METRICS 2 CPU NET SLOTS 1 0]
-        r set key1 value1
-        assert_equal {OK} [r hotkeys stop]
-
-        set result [r hotkeys get]
-        if {[llength $result] > 0 && [lindex $result 0] ne "tracking-active"} {
-            set result [hotkeys_array_to_dict $result]
-        }
-
-        # Should NOT have sampled-commands fields (sample_ratio = 1)
-        assert {![dict exists $result "sampled-command-selected-slots-ms"]}
-        assert {![dict exists $result "net-bytes-sampled-commands-selected-slots"]}
-
-        # Should have all-commands-selected-slots fields
-        assert [dict exists $result "all-commands-selected-slots-ms"]
-        assert [dict exists $result "net-bytes-all-commands-selected-slots"]
-
-        assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
-
     test {HOTKEYS - nested commands} {
         r hello 3
         assert_equal {OK} [r hotkeys start METRICS 1 NET]
@@ -350,13 +278,13 @@ start_server {tags {"hotkeys"}} {
         }
 
         # Should NOT have selected-slots conditional fields
-        assert {![dict exists $result "sampled-command-selected-slots-ms"]}
-        assert {![dict exists $result "all-commands-selected-slots-ms"]}
+        assert {![dict exists $result "sampled-command-selected-slots-us"]}
+        assert {![dict exists $result "all-commands-selected-slots-us"]}
         assert {![dict exists $result "net-bytes-sampled-commands-selected-slots"]}
         assert {![dict exists $result "net-bytes-all-commands-selected-slots"]}
 
         # Should have all-slots fields
-        assert [dict exists $result "all-commands-all-slots-ms"]
+        assert [dict exists $result "all-commands-all-slots-us"]
         assert [dict exists $result "net-bytes-all-commands-all-slots"]
 
         assert_equal {OK} [r hotkeys reset]
@@ -402,7 +330,7 @@ start_server {tags {"hotkeys"}} {
                 set result [hotkeys_array_to_dict $result]
             }
 
-            set cpu_time_array [dict get $result "by-cpu-time"]
+            set cpu_time_array [dict get $result "by-cpu-time-us"]
             set net_bytes_array [dict get $result "by-net-bytes"]
 
             set returned_cpu_keys {}
@@ -444,6 +372,187 @@ start_server {tags {"hotkeys"}} {
 
             assert_equal {OK} [r hotkeys reset]
         } {} {resp3}
+    }
+}
+
+start_cluster 1 0 {tags {external:skip cluster hotkeys}} {
+
+    test {HOTKEYS START - with SLOTS parameter in cluster mode} {
+        R 0 hello 3
+        assert_equal {OK} [R 0 hotkeys start METRICS 2 CPU NET SLOTS 2 0 5]
+        assert_equal {OK} [R 0 hotkeys stop]
+        assert_equal {OK} [R 0 hotkeys reset]
+    }
+
+    test {HOTKEYS START - Error: SLOTS count mismatch} {
+        R 0 hello 3
+        catch {R 0 hotkeys start METRICS 1 CPU SLOTS 2 0} err
+        assert_match "*not enough slot numbers provided*" $err
+    }
+
+    test {HOTKEYS START - Error: duplicate slots} {
+        R 0 hello 3
+        catch {R 0 hotkeys start METRICS 1 CPU SLOTS 2 0 0} err
+        assert_match "*duplicate slot number*" $err
+    }
+
+    test {HOTKEYS START - Error: SLOTS already specified} {
+        R 0 hello 3
+        catch {R 0 hotkeys start METRICS 1 CPU SLOTS 1 0 SLOTS 1 5} err
+        assert_match "*SLOTS parameter already specified*" $err
+    }
+
+    test {HOTKEYS GET - selected-slots field} {
+        R 0 hello 3
+        assert_equal {OK} [R 0 hotkeys start METRICS 2 CPU NET SLOTS 2 0 5]
+        assert_equal {OK} [R 0 hotkeys stop]
+
+        set result [R 0 hotkeys get]
+        if {[llength $result] > 0 && [lindex $result 0] ne "tracking-active"} {
+            set result [hotkeys_array_to_dict $result]
+        }
+        set slots [dict get $result "selected-slots"]
+        assert_equal 2 [llength $slots]
+        assert_equal 0 [lindex $slots 0]
+        assert_equal 5 [lindex $slots 1]
+
+        assert_equal {OK} [R 0 hotkeys reset]
+    }
+
+    test {HOTKEYS GET - conditional fields with sample_ratio > 1 and selected slots} {
+        R 0 hello 3
+        assert_equal {OK} [R 0 hotkeys start METRICS 2 CPU NET SAMPLE 10 SLOTS 1 0]
+        R 0 set "{06S}key1" value1
+        assert_equal {OK} [R 0 hotkeys stop]
+
+        set result [R 0 hotkeys get]
+        if {[llength $result] > 0 && [lindex $result 0] ne "tracking-active"} {
+            set result [hotkeys_array_to_dict $result]
+        }
+
+        # Should have conditional fields
+        assert [dict exists $result "sampled-command-selected-slots-us"]
+        assert [dict exists $result "all-commands-selected-slots-us"]
+        assert [dict exists $result "net-bytes-sampled-commands-selected-slots"]
+        assert [dict exists $result "net-bytes-all-commands-selected-slots"]
+
+        assert_equal {OK} [R 0 hotkeys reset]
+    }
+
+    test {HOTKEYS GET - no conditional fields with sample_ratio = 1} {
+        R 0 hello 3
+        assert_equal {OK} [R 0 hotkeys start METRICS 2 CPU NET SLOTS 1 0]
+        R 0 set "{06S}key1" value1
+        assert_equal {OK} [R 0 hotkeys stop]
+
+        set result [R 0 hotkeys get]
+        if {[llength $result] > 0 && [lindex $result 0] ne "tracking-active"} {
+            set result [hotkeys_array_to_dict $result]
+        }
+
+        # Should NOT have sampled-commands fields (sample_ratio = 1)
+        assert {![dict exists $result "sampled-command-selected-slots-us"]}
+        assert {![dict exists $result "net-bytes-sampled-commands-selected-slots"]}
+
+        # Should have all-commands-selected-slots fields
+        assert [dict exists $result "all-commands-selected-slots-us"]
+        assert [dict exists $result "net-bytes-all-commands-selected-slots"]
+
+        assert_equal {OK} [R 0 hotkeys reset]
+    }
+
+    test {HOTKEYS - tracks only keys in selected slots} {
+        R 0 hello 3
+
+        # Get slots for keys with different hash tags
+        set key_slot0 "{06S}key"
+        set slot0 [R 0 cluster keyslot $key_slot0]
+
+        set key_other "{zzz}key"
+        set slot_other [R 0 cluster keyslot $key_other]
+
+        # Start tracking only slot 0
+        assert_equal {OK} [R 0 hotkeys start METRICS 1 NET SLOTS 1 $slot0]
+
+        # Set keys in both slots
+        for {set i 0} {$i < 100} {incr i} {
+            R 0 set "${key_slot0}_$i" "value_$i"
+            R 0 set "${key_other}_$i" "value_$i"
+        }
+
+        assert_equal {OK} [R 0 hotkeys stop]
+
+        set result [R 0 hotkeys get]
+        if {[llength $result] > 0 && [lindex $result 0] ne "tracking-active"} {
+            set result [hotkeys_array_to_dict $result]
+        }
+
+        # Check that by-net-bytes only contains keys from slot 0
+        set net_bytes_array [dict get $result "by-net-bytes"]
+        for {set i 0} {$i < [llength $net_bytes_array]} {incr i 2} {
+            set key [lindex $net_bytes_array $i]
+            # Keys should contain the slot0 hash tag
+            assert_match "*{06S}*" $key
+        }
+
+        assert_equal {OK} [R 0 hotkeys reset]
+    }
+
+    test {HOTKEYS - multiple selected slots} {
+        R 0 hello 3
+
+        # Get slots for keys with different hash tags
+        set key_slot0 "{06S}key"
+        set slot0 [R 0 cluster keyslot $key_slot0]
+
+        set key_slot1 "{4oi}key"
+        set slot1 [R 0 cluster keyslot $key_slot1]
+
+        set key_other "{zzz}key"
+        set slot_other [R 0 cluster keyslot $key_other]
+
+        # Start tracking slots 0 and 1
+        assert_equal {OK} [R 0 hotkeys start METRICS 1 NET SLOTS 2 $slot0 $slot1]
+
+        # Set keys in all three slots
+        for {set i 0} {$i < 50} {incr i} {
+            R 0 set "${key_slot0}_$i" "value_$i"
+            R 0 set "${key_slot1}_$i" "value_$i"
+            R 0 set "${key_other}_$i" "value_$i"
+        }
+
+        assert_equal {OK} [R 0 hotkeys stop]
+
+        set result [R 0 hotkeys get]
+        if {[llength $result] > 0 && [lindex $result 0] ne "tracking-active"} {
+            set result [hotkeys_array_to_dict $result]
+        }
+
+        # Verify selected-slots contains both slots
+        set slots [dict get $result "selected-slots"]
+        assert_equal 2 [llength $slots]
+
+        # Check that by-net-bytes contains keys from both selected slots
+        set net_bytes_array [dict get $result "by-net-bytes"]
+        set found_slot0 0
+        set found_slot1 0
+        for {set i 0} {$i < [llength $net_bytes_array]} {incr i 2} {
+            set key [lindex $net_bytes_array $i]
+            if {[string match "*{06S}*" $key]} {
+                set found_slot0 1
+            }
+            if {[string match "*{4oi}*" $key]} {
+                set found_slot1 1
+            }
+            # Keys should NOT contain the other hash tag
+            assert {![string match "*{zzz}*" $key]}
+        }
+
+        # Should have found keys from both selected slots
+        assert_equal 1 $found_slot0
+        assert_equal 1 $found_slot1
+
+        assert_equal {OK} [R 0 hotkeys reset]
     }
 }
 

--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -11,13 +11,11 @@ proc hotkeys_array_to_dict {arr} {
 
 start_server {tags {"hotkeys"}} {
     test {HOTKEYS START - METRICS required} {
-        r hello 3
         catch {r hotkeys start} err
         assert_match "*METRICS parameter is required*" $err
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - METRICS with CPU only} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 1 CPU]
         r set key1 value1
         assert_equal {OK} [r hotkeys stop]
@@ -34,10 +32,9 @@ start_server {tags {"hotkeys"}} {
         assert {![dict exists $result "by-net-bytes"]}
 
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - METRICS with NET only} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 1 NET]
         r set key1 value1
         assert_equal {OK} [r hotkeys stop]
@@ -54,10 +51,9 @@ start_server {tags {"hotkeys"}} {
         assert {![dict exists $result "by-cpu-time-us"]}
 
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - METRICS with both CPU and NET} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 2 CPU NET]
         r set key1 value1
         assert_equal {OK} [r hotkeys stop]
@@ -74,37 +70,33 @@ start_server {tags {"hotkeys"}} {
         assert [dict exists $result "by-net-bytes"]
 
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - Error: session already started} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 1 CPU]
         catch {r hotkeys start METRICS 1 NET} err
         assert_match "*hotkey tracking session already in progress*" $err
         assert_equal {OK} [r hotkeys stop]
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - Error: invalid METRICS count} {
-        r hello 3
         catch {r hotkeys start METRICS 0} err
         assert_match "*METRICS count*" $err
         catch {r hotkeys start METRICS -1} err
         assert_match "*METRICS count*" $err
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - Error: METRICS count mismatch} {
-        r hello 3
         catch {r hotkeys start METRICS 2 CPU} err
         assert_match "*METRICS count does not match number of metric types provided*" $err
         catch {r hotkeys start METRICS 1 CPU NET} err
         assert_match "*syntax error*" $err
         catch {r hotkeys start METRICS 3 CPU NET} err
         assert_match "*METRICS count*" $err
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - Error: METRICS invalid metrics} {
-        r hello 3
         catch {r hotkeys start METRICS 1 GPU} err
         assert_match "*METRICS no valid metrics*" $err
         catch {r hotkeys start METRICS 2 GPU NYET} err
@@ -115,19 +107,17 @@ start_server {tags {"hotkeys"}} {
 
         assert_equal {OK} [r hotkeys stop]
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - Error: METRICS same parameter} {
-        r hello 3
         catch {r hotkeys start METRICS 2 CPU CPU} err
         assert_match "*METRICS CPU*" $err
         catch {r hotkeys start METRICS 2 NET NET} err
         assert_match "*METRICS NET*" $err
-    } {} {resp3}
+    }
 
 
     test {HOTKEYS START - with COUNT parameter} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 2 CPU NET COUNT 20]
 
         for {set i 0} {$i < 30} {incr i} {
@@ -151,18 +141,16 @@ start_server {tags {"hotkeys"}} {
         assert_lessthan_equal $net_count 20
 
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - Error: COUNT out of range} {
-        r hello 3
         catch {r hotkeys start METRICS 1 CPU COUNT 0} err
         assert_match "*COUNT must be between 1 and 64*" $err
         catch {r hotkeys start METRICS 1 CPU COUNT 100} err
         assert_match "*COUNT must be between 1 and 64*" $err
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - with DURATION parameter} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 1 CPU DURATION 1]
         after 1500
 
@@ -173,29 +161,25 @@ start_server {tags {"hotkeys"}} {
         assert_equal 0 [dict get $result "tracking-active"]
 
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - with SAMPLE parameter} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 2 CPU NET SAMPLE 10]
         assert_equal {OK} [r hotkeys stop]
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - Error: SAMPLE ratio invalid} {
-        r hello 3
         catch {r hotkeys start METRICS 1 CPU SAMPLE 0} err
         assert_match "*SAMPLE ratio must be positive*" $err
-    } {} {resp3}
+    }
 
     test {HOTKEYS START - Error: SLOTS not allowed in non-cluster mode} {
-        r hello 3
         catch {r hotkeys start METRICS 1 CPU SLOTS 2 0 5} err
         assert_match "*SLOTS parameter cannot be used in non-cluster mode*" $err
-    } {} {resp3 cluster:skip}
+    } {} {cluster:skip}
 
     test {HOTKEYS STOP - basic functionality} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 2 CPU NET]
         assert_equal {OK} [r hotkeys stop]
 
@@ -206,35 +190,31 @@ start_server {tags {"hotkeys"}} {
         assert_equal 0 [dict get $result "tracking-active"]
 
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
     test {HOTKEYS RESET - basic functionality} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 1 CPU]
         assert_equal {OK} [r hotkeys stop]
         assert_equal {OK} [r hotkeys reset]
         # After reset, GET should return nil
         set result [r hotkeys get]
         assert_equal {} $result
-    } {} {resp3}
+    }
 
     test {HOTKEYS RESET - Error: session in progress} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 1 CPU]
         catch {r hotkeys reset} err
         assert_match "*hotkey tracking session in progress, stop tracking first*" $err
         assert_equal {OK} [r hotkeys stop]
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
     test {HOTKEYS GET - returns nil when not started} {
-        r hello 3
         set result [r hotkeys get]
         assert_equal {} $result
-    } {} {resp3}
+    }
 
     test {HOTKEYS GET - sample-ratio field} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 2 CPU NET SAMPLE 5]
         assert_equal {OK} [r hotkeys stop]
 
@@ -245,10 +225,9 @@ start_server {tags {"hotkeys"}} {
         assert_equal 5 [dict get $result "sample-ratio"]
 
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
     test {HOTKEYS - nested commands} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 1 NET]
         r eval "redis.call('set', 'x', 1)" 1 x
         r eval "redis.call('set', 'y', 1)" 1 y
@@ -262,12 +241,11 @@ start_server {tags {"hotkeys"}} {
 
         assert_equal {OK} [r hotkeys stop]
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
 
 
     test {HOTKEYS GET - no conditional fields without selected slots} {
-        r hello 3
         assert_equal {OK} [r hotkeys start METRICS 2 CPU NET SAMPLE 10]
         r set key1 value1
         assert_equal {OK} [r hotkeys stop]
@@ -288,12 +266,10 @@ start_server {tags {"hotkeys"}} {
         assert [dict exists $result "net-bytes-all-commands-all-slots"]
 
         assert_equal {OK} [r hotkeys reset]
-    } {} {resp3}
+    }
 
     foreach sample_ratio {1 100 500 1000} {
         test "HOTKEYS detection with biased key access, sample ratio = $sample_ratio" {
-            r hello 3
-
             # Generate 100 random keys
             set all_keys {}
             for {set i 0} {$i < 100} {incr i} {
@@ -371,39 +347,34 @@ start_server {tags {"hotkeys"}} {
             assert_morethan $res_net 5
 
             assert_equal {OK} [r hotkeys reset]
-        } {} {resp3}
+        }
     }
 }
 
 start_cluster 1 0 {tags {external:skip cluster hotkeys}} {
 
     test {HOTKEYS START - with SLOTS parameter in cluster mode} {
-        R 0 hello 3
         assert_equal {OK} [R 0 hotkeys start METRICS 2 CPU NET SLOTS 2 0 5]
         assert_equal {OK} [R 0 hotkeys stop]
         assert_equal {OK} [R 0 hotkeys reset]
     }
 
     test {HOTKEYS START - Error: SLOTS count mismatch} {
-        R 0 hello 3
         catch {R 0 hotkeys start METRICS 1 CPU SLOTS 2 0} err
         assert_match "*not enough slot numbers provided*" $err
     }
 
     test {HOTKEYS START - Error: duplicate slots} {
-        R 0 hello 3
         catch {R 0 hotkeys start METRICS 1 CPU SLOTS 2 0 0} err
         assert_match "*duplicate slot number*" $err
     }
 
     test {HOTKEYS START - Error: SLOTS already specified} {
-        R 0 hello 3
         catch {R 0 hotkeys start METRICS 1 CPU SLOTS 1 0 SLOTS 1 5} err
         assert_match "*SLOTS parameter already specified*" $err
     }
 
     test {HOTKEYS GET - selected-slots field} {
-        R 0 hello 3
         assert_equal {OK} [R 0 hotkeys start METRICS 2 CPU NET SLOTS 2 0 5]
         assert_equal {OK} [R 0 hotkeys stop]
 
@@ -420,7 +391,6 @@ start_cluster 1 0 {tags {external:skip cluster hotkeys}} {
     }
 
     test {HOTKEYS GET - conditional fields with sample_ratio > 1 and selected slots} {
-        R 0 hello 3
         assert_equal {OK} [R 0 hotkeys start METRICS 2 CPU NET SAMPLE 10 SLOTS 1 0]
         R 0 set "{06S}key1" value1
         assert_equal {OK} [R 0 hotkeys stop]
@@ -440,7 +410,6 @@ start_cluster 1 0 {tags {external:skip cluster hotkeys}} {
     }
 
     test {HOTKEYS GET - no conditional fields with sample_ratio = 1} {
-        R 0 hello 3
         assert_equal {OK} [R 0 hotkeys start METRICS 2 CPU NET SLOTS 1 0]
         R 0 set "{06S}key1" value1
         assert_equal {OK} [R 0 hotkeys stop]
@@ -462,8 +431,6 @@ start_cluster 1 0 {tags {external:skip cluster hotkeys}} {
     }
 
     test {HOTKEYS - tracks only keys in selected slots} {
-        R 0 hello 3
-
         # Get slots for keys with different hash tags
         set key_slot0 "{06S}key"
         set slot0 [R 0 cluster keyslot $key_slot0]
@@ -499,8 +466,6 @@ start_cluster 1 0 {tags {external:skip cluster hotkeys}} {
     }
 
     test {HOTKEYS - multiple selected slots} {
-        R 0 hello 3
-
         # Get slots for keys with different hash tags
         set key_slot0 "{06S}key"
         set slot0 [R 0 cluster keyslot $key_slot0]


### PR DESCRIPTION
Follow #14680

Some hotkeys cpu metrics display time in milliseconds others in microseconds.

Change the metrics showing time of command executions to all use microseconds and use the `-us` postfix to show that.

Also, disable the `SLOTS` param for `HOTKEYS START` if we are not in cluster mode. 
