### PR TITLE
Update Redisearch module version to v8.4.5

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.4.2
+MODULE_VERSION = v8.4.5
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
**Bug Fixes:**

* [#7385](https://github.com/RediSearch/RediSearch/pull/7385) Fix high temporary memory consumption when loading multiple search indexes from RDB
* [#7430](https://github.com/RediSearch/RediSearch/pull/7430) Fix a potential deadlock in `FT.HYBRID` in cluster mode during updates.
* [#7454](https://github.com/RediSearch/RediSearch/pull/7454) Fix a garbage collection performence regression
* [#7460](https://github.com/RediSearch/RediSearch/pull/7460) Fix potential double-free in Fork GC error paths
* [#7455](https://github.com/RediSearch/RediSearch/pull/7455) Fix internal cursors not being deleted promptly in cluster mode
* [#7667](https://github.com/RediSearch/RediSearch/pull/7667) Fix a cursor logical leak upon dropping the index
* [#7796](https://github.com/RediSearch/RediSearch/pull/7796) Fix a potential use-after-free when removing connections
* [#7792](https://github.com/RediSearch/RediSearch/pull/7792) Fix string comparison for binary data with embedded NULLs in TOLIST reducer in FT.AGGREGATE
* [#7704](https://github.com/RediSearch/RediSearch/pull/7704) Use asynchronous jobs for GC in SVS to accelerate execution  
* [#7823](https://github.com/RediSearch/RediSearch/pull/7823) Update `FT.HYBRID` to accept vector blobs only via parameters
* [#7903](https://github.com/RediSearch/RediSearch/pull/7903) Fix a memory leak in Hybrid ASM
* [#8052](https://github.com/RediSearch/RediSearch/pull/8052) Fix `FT.HYBRID` behavior when used with `LOAD *`
* [#8082](https://github.com/RediSearch/RediSearch/pull/8082) Fix incorrect FULLTEXT field metric counts
* [#8089](https://github.com/RediSearch/RediSearch/pull/8089) Fix an edge case in `CLUSTERSET` handling
* [#8152](https://github.com/RediSearch/RediSearch/pull/8152) Fix configuration registration issues

**Improvements:**

* [#7427](https://github.com/RediSearch/RediSearch/pull/7427) Enhance `FT.PROFILE` with vector search execution details
* [#7431](https://github.com/RediSearch/RediSearch/pull/7431) Ensure full `FT.PROFILE` output is returned on timeout with RETURN policy
* [#7507](https://github.com/RediSearch/RediSearch/pull/7507) Track timeout warnings and errors in INFO
* [#7576](https://github.com/RediSearch/RediSearch/pull/7576) Track OOM warnings and errors in INFO
* [#7612](https://github.com/RediSearch/RediSearch/pull/7612) Track `maxprefixexpansions` warnings and errors in INFO
* [#7960](https://github.com/RediSearch/RediSearch/pull/7960) Persist query warnings across cursor reads
* [#7551](https://github.com/RediSearch/RediSearch/pull/7551), [#7616](https://github.com/RediSearch/RediSearch/pull/7616), [#7622](https://github.com/RediSearch/RediSearch/pull/7622), [#7625](https://github.com/RediSearch/RediSearch/pull/7625) Add runtime thread and pending-jobs metrics
* [#7589](https://github.com/RediSearch/RediSearch/pull/7589) Support multiple slot ranges in `search.CLUSTERSET`
* [#7707](https://github.com/RediSearch/RediSearch/pull/7707) Add `WITHCOUNT` support to `FT.AGGREGATE`
* [#7862](https://github.com/RediSearch/RediSearch/pull/7862) Add support for subquery `COUNT` in `FT.HYBRID`
* [#8087](https://github.com/RediSearch/RediSearch/pull/8087) Add warnings when cursor results may be affected by ASM and expose ASM warnings in `FT.PROFILE`
* [#8049](https://github.com/RediSearch/RediSearch/pull/8049) Add logging for index-related commands
* [#8150](https://github.com/RediSearch/RediSearch/pull/8150) Fix shard total profile time reporting in `FT.PROFILE`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the RediSearch module version reference.
> 
> - Bumps `MODULE_VERSION` in `modules/redisearch/Makefile` from `v8.4.2` to `v8.4.5`, ensuring builds pull the newer upstream module
> - No local code changes; behavior changes come solely from upstream v8.4.5
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1528ed9552f1333744ea4dc0904dd209fd5aab19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->