### PR TITLE
Update RediSearch 8.2.9

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.2.5
+MODULE_VERSION = v8.2.9
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
**Bug Fixes:**

* [#7219](https://github.com/RediSearch/RediSearch/pull/7219) Fix a concurrency issue on Reducer in `FT.AGGREGATE`
* [#7255](https://github.com/RediSearch/RediSearch/pull/7255) Fix `BM25STD` underflow wraparound
* [#7275](https://github.com/RediSearch/RediSearch/pull/7275) Report used memory as `unsigned long long` to avoid underflows
* [#7264](https://github.com/RediSearch/RediSearch/pull/7264) Fix `totalDocsLen` updates
* [#6995](https://github.com/RediSearch/RediSearch/pull/6995) Do not fanout `FT.INFO` to replicas
* [#7350](https://github.com/RediSearch/RediSearch/pull/7350) Fix `FT.CREATE` failure with LeanVec parameters on non-Intel architectures
* [#7694](https://github.com/RediSearch/RediSearch/pull/7694) Use asynchronous jobs for GC in SVS to accelerate execution
* [#7384](https://github.com/RediSearch/RediSearch/pull/7384) Fix index load from RDB temporary memory overhead
* [#7459](https://github.com/RediSearch/RediSearch/pull/7459) Fix Fork GC potential double-free on error path
* [#7458](https://github.com/RediSearch/RediSearch/pull/7458) Fix a GC performence regression
* [#7470](https://github.com/RediSearch/RediSearch/pull/7470) Avoid draining worker thread pool from FLUSH callback to avoid deadlocks
* [#7554](https://github.com/RediSearch/RediSearch/pull/7554) Handle the case where `SCORE` is sent alone without extra fields (coordinator)
* [#7685](https://github.com/RediSearch/RediSearch/pull/7685) Fix cursor logical leak
* [#7794](https://github.com/RediSearch/RediSearch/pull/7794) Fix `cmp_strings()` to correctly handle binary data with embedded NULLs in TOLIST reducer in FT.AGGREGATE
* [#7873](https://github.com/RediSearch/RediSearch/pull/7873) Handle warnings in empty `FT.AGGREGATE` replies (cluster)
* [#7886](https://github.com/RediSearch/RediSearch/pull/7886) Remove non-TEXT fields from the spec keys dictionary
* [#7904](https://github.com/RediSearch/RediSearch/pull/7904) Refactor keys dictionary handling
* [#7901](https://github.com/RediSearch/RediSearch/pull/7901) Support multiple warnings in reply
* [#8083](https://github.com/RediSearch/RediSearch/pull/8083) Fix incorrect FULLTEXT field metric counts
* [#8153](https://github.com/RediSearch/RediSearch/pull/8153) Fix configuration registration issues

**Improvements:**

* [#7154](https://github.com/RediSearch/RediSearch/pull/7154) `FT.AGGREGATE` can return Background Indexing OOM warnings
* [#7083](https://github.com/RediSearch/RediSearch/pull/7083) Add the default text scorer as a configuration option
* [#7341](https://github.com/RediSearch/RediSearch/pull/7341) Rename `FT.PROFILE` counter fields
* [#7436](https://github.com/RediSearch/RediSearch/pull/7436) Enhance `FT.PROFILE` with vector search execution details
* [#7435](https://github.com/RediSearch/RediSearch/pull/7435) Ensure full `FT.PROFILE` output on timeout with RETURN policy
* [#7534](https://github.com/RediSearch/RediSearch/pull/7534) Reduce the number of worker threads asynchronously to avoid deadlocks during queries
* [#7614](https://github.com/RediSearch/RediSearch/pull/7614) Track timeout warnings and errors in INFO
* [#7646](https://github.com/RediSearch/RediSearch/pull/7646) Track `maxprefixexpansions` warnings and errors in INFO
* [#7577](https://github.com/RediSearch/RediSearch/pull/7577) Track query syntax/argument errors (basis for query error tracking)
* [#7737](https://github.com/RediSearch/RediSearch/pull/7737) Add `Internal cursor reads` metric to cluster `FT.PROFILE` output
* [#7759](https://github.com/RediSearch/RediSearch/pull/7759) Extend indexing metrics
* [#7710](https://github.com/RediSearch/RediSearch/pull/7710) Support `WITHCOUNT` keyword in `FT.AGGREGATE`
* [#7957](https://github.com/RediSearch/RediSearch/pull/7957) Persist query warnings across cursor reads
* [#8054](https://github.com/RediSearch/RediSearch/pull/8054) Add logging for index-related commands
* [#8151](https://github.com/RediSearch/RediSearch/pull/8151) Fix shard total profile time reporting in `FT.PROFILE`
* [#8103](https://github.com/RediSearch/RediSearch/pull/8103) Output current thread IndexSpec information on crash