### PR TITLE
Fix test failure when using bind "*" in introspection.tcl

### DIFF
--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1101,7 +1101,7 @@ test {Clients are evenly distributed among io threads} {
 }
 
 # Test insecure configuration warnings
-start_server {tags {introspection external:skip} overrides {protected-mode no bind "*"}} {
+start_server {tags {introspection external:skip} overrides {protected-mode no bind "*"} wait_ready false} {
     test {Warning shown when no auth and binding all interfaces} {
         wait_for_log_messages 0 {"*WARNING: Redis does not require authentication and is not protected by network restrictions*"} 0 10 100
     }


### PR DESCRIPTION
The reason for the failure is that when starting server with bind *, the host will be set to *. At this time, when reconnect, the client will not recognize this host.
So this fix skipped checking whether the server was ready.

```tcl
        if {[dict exists $config bind]} { set host [dict get $config bind]
...
        if {$wait_ready} {
            while 1 {
                # check that the server actually started and is ready for connections
                if {[count_message_lines $stdout "Ready to accept"] > $previous_ready_count} {
                    break
                }
                after 10
            }

            # connect client (after server dict is put on the stack)
            reconnect
        }
```

failed CI: https://github.com/redis/redis/actions/runs/21379077234/job/61541850232
```
[exception]: Executing test client: couldn't open socket: host is unreachable (nodename nor servname provided, or not known).
couldn't open socket: host is unreachable (nodename nor servname provided, or not known)
    while executing
"socket $server $port"
    (procedure "redis" line 7)
    invoked from within
"redis $host $port 0 $::tls"
    (procedure "reconnect" line 11)
    invoked from within
"reconnect"
    (procedure "start_server" line 252)
    invoked from within
"start_server {tags {introspection external:skip} overrides {protected-mode no bind "*"}} {
    test {Warning shown when no auth and binding all interf..."
    (file "tests/unit/introspection.tcl" line 1104)
    invoked from within
"source $path"
    (procedure "execute_test_file" line 4)
    invoked from within
"execute_test_file $data"
    (procedure "test_client_main" line 10)
    invoked from within
"test_client_main $::test_server_port "
Killing still running Redis server 13297
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the insecure configuration warning test by preventing client reconnect to host `"*"`.
> 
> - In `tests/unit/introspection.tcl`, updates `start_server` for `overrides {protected-mode no bind "*"}` to include `wait_ready false`, ensuring the test relies on log inspection without attempting an invalid reconnect
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 264412b14b70b8b87b35999214d0ab3563ed57ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->