### PR TITLE
SECURITY.md: update Redis versions; clarifies OSes/CPUs/compilers in-scope for vulnerability reports

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,12 +44,12 @@ consider your request based on the above criteria.
 
 ## Support across Operating Systems, Architectures, and Compilers
 
-Redis is primarily tested on modern Linux distributions, using contemporary 
+Redis is primarily tested on modern Linux distributions, using contemporary
 Intel and AMD x86_64 CPUs, as well as ARM-based CPUs, and recent versions of
 the GCC compiler.
-Vulnerability reports that rely on unsupported or uncommon environments 
+Vulnerability reports that rely on unsupported or uncommon environments
 (for example, 32-bit architectures, non-Linux operating systems, or outdated
-toolchains) may be considered out of scope, even if the issue is technically 
+toolchains) may be considered out of scope, even if the issue is technically
 valid. Such reports will be evaluated on a case-by-case basis at our discretion.
 
 ## License Compatibility

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ unless this is not possible or feasible with a reasonable effort.
 | 7.4.x   | :white_check_mark:                                                     |
 | 7.2.x   | :white_check_mark: support extended till 7.4 end of support            |
 | < 7.2.x | :x:                                                                    |
-| 6.2.x   | :white_check_mark: support extended - may be removed after end of 2025 |
+| 6.2.x   | :white_check_mark: support extended                                    |
 | < 6.2.x | :x:                                                                    |
 
 ## Reporting a Vulnerability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,10 @@ unless this is not possible or feasible with a reasonable effort.
 
 | Version | Supported                                                              |
 |---------|------------------------------------------------------------------------|
+| 8.6.x   | :white_check_mark:                                                     |
+| 8.4.x   | :white_check_mark:                                                     |
 | 8.2.x   | :white_check_mark:                                                     |
-| 8.0.x   | :white_check_mark:                                                     |
+| 8.0.x   | :x:                                                                    |
 | 7.4.x   | :white_check_mark:                                                     |
 | 7.2.x   | :white_check_mark: support extended till 7.4 end of support            |
 | < 7.2.x | :x:                                                                    |
@@ -39,6 +41,16 @@ embargo on public disclosure.
 
 If you believe you should be on the list, please contact us and we will
 consider your request based on the above criteria.
+
+## Support across Operating Systems, Architectures, and Compilers
+
+Redis is primarily tested on modern Linux distributions, using contemporary 
+Intel and AMD x86_64 CPUs, as well as ARM-based CPUs, and recent versions of
+the GCC compiler.
+Vulnerability reports that rely on unsupported or uncommon environments 
+(for example, 32-bit architectures, non-Linux operating systems, or outdated
+toolchains) may be considered out of scope, even if the issue is technically 
+valid. Such reports will be evaluated on a case-by-case basis at our discretion.
 
 ## License Compatibility
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `SECURITY.md` to reflect current support and environment scope.
> 
> - Updates supported versions table: adds `8.6.x` and `8.4.x`; marks `8.0.x` unsupported; adjusts `6.2.x` extended support note
> - Adds "Support across Operating Systems, Architectures, and Compilers" detailing primary testing on modern Linux with x86_64 and ARM CPUs and recent GCC; clarifies that 32-bit, non-Linux, and outdated toolchains may be out of scope for vulnerability reports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 491f751c709d8ec1e1040b662376f3363f0b9522. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->