### PR TITLE
Redact user input in selected logs.

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2701,7 +2701,7 @@ static void deleteKeyAndPropagate(redisDb *db, robj *keyobj, int notify_type, lo
         keyobj = createStringObject(keyobj->ptr, sdslen(keyobj->ptr));
     }
 
-    serverLog(LL_DEBUG,"key %s %s: deleting it", (char*)keyobj->ptr, notify_type == NOTIFY_EXPIRED ? "expired" : "evicted");
+    serverLog(LL_DEBUG,"key %s %s: deleting it", redactLogCstr((char*)keyobj->ptr), notify_type == NOTIFY_EXPIRED ? "expired" : "evicted");
 
     /* We compute the amount of memory freed by db*Delete() alone.
      * It is possible that actually the memory needed to propagate

--- a/src/debug.c
+++ b/src/debug.c
@@ -1098,6 +1098,10 @@ NULL
         server.dict_resizing = atoi(c->argv[2]->ptr);
         addReply(c, shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"script") && c->argc == 3) {
+        if (server.hide_user_data_from_log) {
+            addReplyError(c, "DEBUG SCRIPT is disabled when hide-user-data-from-log is enabled");
+            return;
+        }
         if (!strcasecmp(c->argv[2]->ptr,"list")) {
             dictIterator di;
             dictEntry *de;
@@ -1268,7 +1272,7 @@ void serverLogObjectDebugInfo(const robj *o) {
      * random memory portion to be "leaked" into the logfile. */
     if (o->type == OBJ_STRING && sdsEncodedObject(o)) {
         serverLog(LL_WARNING,"Object raw string len: %zu", sdslen(o->ptr));
-        if (sdslen(o->ptr) < 4096) {
+        if (!server.hide_user_data_from_log && sdslen(o->ptr) < 4096) {
             sds repr = sdscatrepr(sdsempty(),o->ptr,sdslen(o->ptr));
             serverLog(LL_WARNING,"Object raw string content: %s", repr);
             sdsfree(repr);
@@ -2250,7 +2254,7 @@ void logCurrentClient(client *cc, const char *title) {
         robj *key = getDecodedObject(cc->argv[1]);
         kvobj *kv = dbFind(cc->db, key->ptr);
         if (kv) {
-            serverLog(LL_WARNING,"key '%s' found in DB containing the following object:", (char*)key->ptr);
+            serverLog(LL_WARNING,"key '%s' found in DB containing the following object:", redactLogCstr((char*)key->ptr));
             serverLogObjectDebugInfo(kv);
         }
         decrRefCount(key);

--- a/src/module.c
+++ b/src/module.c
@@ -12976,7 +12976,7 @@ void moduleLoadFromQueue(void) {
         dictEntry *de;
         dictInitIterator(&di, server.module_configs_queue);
         while ((de = dictNext(&di)) != NULL) {
-            serverLog(LL_WARNING, ">>> '%s %s'", (char *)dictGetKey(de), (char *)dictGetVal(de));
+            serverLog(LL_WARNING, ">>> '%s %s'", redactLogCstr((char *)dictGetKey(de)), redactLogCstr((char *)dictGetVal(de)));
         }
         dictResetIterator(&di);
         serverLog(LL_WARNING, "Module Configuration detected without loadmodule directive or no ApplyConfig call: aborting");
@@ -13647,7 +13647,7 @@ int loadModuleConfigs(RedisModule *module) {
         /* If found in the queue, set the value. Otherwise, set the default value. */
         if (de) {
             if (!performModuleConfigSetFromName(dictGetKey(de), dictGetVal(de), &err)) {
-                serverLog(LL_WARNING, "Issue during loading of configuration %s : %s", (sds) dictGetKey(de), err);
+                serverLog(LL_WARNING, "Issue during loading of configuration %s : %s", redactLogCstr((char *)dictGetKey(de)), err);
                 dictFreeUnlinkedEntry(server.module_configs_queue, de);
                 dictEmpty(server.module_configs_queue, NULL);
                 return REDISMODULE_ERR;

--- a/src/module.c
+++ b/src/module.c
@@ -13122,7 +13122,7 @@ int parseLoadexArguments(RedisModuleString ***module_argv, int *module_argc) {
             }
             break;
         } else {
-            serverLog(LL_NOTICE, "Syntax Error from arguments to loadex around %s.", arg_val);
+            serverLog(LL_NOTICE, "Syntax Error from arguments to loadex around %s.", redactLogCstr(arg_val));
             return REDISMODULE_ERR;
         }
     }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3932,7 +3932,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
              * continue loading. */
             if (error == RDB_LOAD_ERR_EMPTY_KEY) {
                 if(empty_keys_skipped++ < 10)
-                    serverLog(LL_NOTICE, "rdbLoadObject skipping empty key: %s", key);
+                    serverLog(LL_NOTICE, "rdbLoadObject skipping empty key: %s", redactLogCstr(key));
                 sdsfree(key);
             } else {
                 sdsfree(key);

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -1168,10 +1168,6 @@ static int luaLogCommand(lua_State *lua) {
         return luaError(lua);
     }
     if (level < server.verbosity) return 0;
-    if (server.hide_user_data_from_log) {
-        serverLogRaw(level, "*redacted*");
-        return 0;
-    }
 
     /* Glue together all the arguments */
     log = sdsempty();

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -1168,6 +1168,10 @@ static int luaLogCommand(lua_State *lua) {
         return luaError(lua);
     }
     if (level < server.verbosity) return 0;
+    if (server.hide_user_data_from_log) {
+        serverLogRaw(level, "*redacted*");
+        return 0;
+    }
 
     /* Glue together all the arguments */
     log = sdsempty();
@@ -1331,7 +1335,7 @@ static int luaNewIndexAllowList(lua_State *lua) {
             }
         }
         if (!*c && !deprecated) {
-            serverLog(LL_WARNING, "A key '%s' was added to Lua globals which is not on the globals allow list nor listed on the deny list.", variable_name);
+            serverLog(LL_WARNING, "A key '%s' was added to Lua globals which is not on the globals allow list nor listed on the deny list.", redactLogCstr(variable_name));
         }
     } else {
         lua_rawset(lua, -3);


### PR DESCRIPTION
This PR continues the work #14645 , to further ensure sensitive user data is not exposed in logs when hide_user_data_from_log is enabled.


- Redact empty key notices during RDB load.
- Redact key names in eviction/expiration debug logs.

- Block DEBUG SCRIPT output and suppress raw string dump in crash object debug when redaction is enabled.

- Redact malformed MODULE LOAD argument snippets and unresolved module configuration logs.

- Redact empty key notices during RDB load.

- Redact key names during Lua globals allow‑list warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to log output/visibility and debug-command gating; core data-path behavior is unchanged, with low risk aside from reduced diagnostic detail when redaction is enabled.
> 
> **Overview**
> Extends `hide_user_data_from_log` coverage by redacting user-provided strings (keys/args/config values) in additional log messages, including eviction/expiration deletion logs, module load/config errors, RDB empty-key notices, and Lua globals warnings.
> 
> Also tightens debug/crash logging by blocking `DEBUG SCRIPT` when redaction is enabled and avoiding printing raw string contents in crash reports; debug output that mentions keys now uses `redactLogCstr()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc4b21c5d8ef56b4708a524dfdbef39b8a7b77a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->