### PR TITLE
Fix touchWatchedKey() break skipping remaining expired watchers

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -404,7 +404,10 @@ void touchWatchedKey(redisDb *db, robj *key) {
                 wk->expired = 0;
                 goto skip_client;
             }
-            break;
+            /* Key was expired at WATCH time but has been re-created
+             * (dbFind != NULL). This is a logical change that should
+             * invalidate the transaction. Fall through to flag the
+             * client as dirty. */
         }
 
         c->flags |= CLIENT_DIRTY_CAS;

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -904,6 +904,162 @@ start_server {tags {"multi"}} {
         r flushall
         r ping
      }
+
+}
+
+# ---------------------------------------------------------------------------
+# Regression tests for touchWatchedKey() skipping expired watchers.
+#
+# These tests use a writable replica where a key is locally expired (via
+# PEXPIREAT) while remaining alive on the master. When the master later
+# writes to the same key, the replicated command arrives without a
+# preceding DEL (since the key was not expired on the master). The replica
+# processes it with CLIENT_MASTER flag, so expireIfNeeded() returns
+# KEY_VALID without deleting the expired key. This results in a single
+# touchWatchedKey() call where expired watchers must be correctly flagged.
+# ---------------------------------------------------------------------------
+start_server {tags {"repl external:skip"}} {
+    start_server {} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+        set replica [srv -1 client]
+        set replica_host [srv -1 host]
+        set replica_port [srv -1 port]
+
+        # Configure writable replica and start replication
+        $replica config set replica-read-only no
+        $replica replicaof $master_host $master_port
+
+        wait_for_condition 50 100 {
+            [string match {*master_link_status:up*} [$replica info replication]]
+        } else {
+            fail "Replica didn't connect to master"
+        }
+
+        test {EXEC fail on expired WATCHed key re-created via replication on writable replica (3 watchers)} {
+            # 3 expired watchers on a key that is re-created via a replicated
+            # SET from the master. All three EXEC should return {} (aborted).
+
+            $replica debug set-active-expire 0
+
+            # Master creates key with NO TTL (never expires on master)
+            $master set tx2key mastervalue
+            $master wait 1 5000
+
+            # Locally set a near-future expiry on the writable replica.
+            # Using a future timestamp avoids the delete-on-PEXPIREAT path
+            # (checkAlreadyExpired returns false for future timestamps).
+            # No watchers exist yet, so touchWatchedKey is a no-op.
+            set expire_at [expr {[clock milliseconds] + 100}]
+            $replica pexpireat tx2key $expire_at
+
+            # Wait for the key to expire on replica (but not on master)
+            after 200
+
+            # All three watch the expired key (wk->expired=1 for each)
+            set c_a [redis_client -1]
+            set c_b [redis_client -1]
+            set c_c [redis_client -1]
+            $c_a watch tx2key
+            $c_b watch tx2key
+            $c_c watch tx2key
+
+            # All begin transactions with side-effect writes
+            $c_a multi
+            $c_a set tx2side_A A_ran
+            $c_b multi
+            $c_b set tx2side_B B_ran
+            $c_c multi
+            $c_c set tx2side_C C_ran
+
+            # Master SET: key is alive on master (no TTL), so NO DEL is
+            # propagated. Only SET tx2key newvalue arrives at the replica.
+            # On replica: CLIENT_MASTER flag -> expireIfNeeded returns
+            # KEY_VALID -> single touchWatchedKey with dbFind!=NULL -> break.
+            $master set tx2key newvalue
+            $master wait 1 5000
+
+            # Execute transactions
+            set res_a [$c_a exec]
+            set res_b [$c_b exec]
+            set res_c [$c_c exec]
+
+            # Check side effects
+            set side_a [$replica get tx2side_A]
+            set side_b [$replica get tx2side_B]
+            set side_c [$replica get tx2side_C]
+
+            # Cleanup
+            $c_a close
+            $c_b close
+            $c_c close
+            $replica debug set-active-expire 1
+            catch { $master del tx2key tx2side_A tx2side_B tx2side_C }
+
+            # All watchers should be aborted (EXEC returns {})
+            assert_equal $res_a {}
+            assert_equal $res_b {}
+            assert_equal $res_c {}
+            assert_equal $side_a {}
+            assert_equal $side_b {}
+            assert_equal $side_c {}
+        } {} {needs:debug}
+
+        test {EXEC fail on expired WATCHed key re-created via replication on writable replica (2 watchers)} {
+            # Minimal reproduction: 2 expired watchers on a key that is
+            # re-created via a replicated SET. Both EXEC should return {}.
+
+            $replica debug set-active-expire 0
+
+            # Master creates key with NO TTL
+            $master set tx2key3 mastervalue
+            $master wait 1 5000
+
+            # Locally set near-future expiry on writable replica
+            set expire_at [expr {[clock milliseconds] + 100}]
+            $replica pexpireat tx2key3 $expire_at
+
+            # Wait for key to expire on replica only
+            after 200
+
+            # Both watchers watch the expired key (wk->expired=1)
+            set c_b [redis_client -1]
+            set c_c [redis_client -1]
+            $c_b watch tx2key3
+            $c_c watch tx2key3
+
+            # Both begin transactions
+            $c_b multi
+            $c_b set tx2min_B B_ran
+            $c_c multi
+            $c_c set tx2min_C C_ran
+
+            # Master SET triggers single touchWatchedKey on replica
+            $master set tx2key3 newvalue
+            $master wait 1 5000
+
+            # Execute transactions
+            set res_b [$c_b exec]
+            set res_c [$c_c exec]
+
+            # Check side effects
+            set side_b [$replica get tx2min_B]
+            set side_c [$replica get tx2min_C]
+
+            # Cleanup
+            $c_b close
+            $c_c close
+            $replica debug set-active-expire 1
+            catch { $master del tx2key3 tx2min_B tx2min_C }
+
+            # Both watchers should be aborted
+            assert_equal $res_b {}
+            assert_equal $res_c {}
+            assert_equal $side_b {}
+            assert_equal $side_c {}
+        } {} {needs:debug}
+    }
 }
 
 start_server {overrides {appendonly {yes} appendfilename {appendonly.aof} appendfsync always} tags {external:skip}} {


### PR DESCRIPTION
## Summary

`touchWatchedKey()` in `multi.c` has a `break` statement that exits the watcher iteration loop early when it encounters a watcher with `wk->expired == 1` whose key still exists in the DB (`dbFind != NULL`). This causes all subsequent watchers in the list to never be visited — they never receive `CLIENT_DIRTY_CAS`, and their `MULTI/EXEC` transactions incorrectly succeed instead of being aborted.

**The fix:** Remove the `break` and let the code fall through to the existing `CLIENT_DIRTY_CAS` / `unwatchAllKeys()` path, which correctly flags the client as dirty.

## Root Cause Analysis

The relevant code in `touchWatchedKey()` handles watchers whose key was already expired at `WATCH` time (`wk->expired == 1`):

```c
if (wk->expired) {
    if (db == wk->db &&
        equalStringObjects(key, wk->key) &&
        dbFind(db, key->ptr) == NULL)
    {
        /* Expired key is deleted — no logical change. Clear flag. */
        wk->expired = 0;
        goto skip_client;
    }
    break;  // <-- BUG: exits entire loop, skipping remaining watchers
}

c->flags |= CLIENT_DIRTY_CAS;
unwatchAllKeys(c);
```

When `dbFind != NULL` (the expired key has been re-created), the `break` exits the `while` loop entirely. Every watcher after the current one in the list is silently skipped.

## How to Trigger

On a **standalone master**, this bug is unreachable. Lazy expiry (`expireIfNeeded` with `EXPIRE_FORCE_DELETE_EXPIRED`) always deletes the expired key *before* the write creates a new value. This produces two `touchWatchedKey` calls: first with `dbFind == NULL` (which clears `wk->expired` flags via the `goto skip_client` path), then with `dbFind != NULL` (which notifies watchers normally since expired flags are already cleared). The `break` is never reached.

The bug **is triggered on writable replicas** (`replica-read-only no`) when a key is locally expired on the replica but remains alive on the master:

1. Master creates a key with no TTL (key never expires on master)
2. The key is replicated to the writable replica
3. On the replica, a local `PEXPIREAT` sets a short expiry (this local change is not replicated back)
4. The key expires on the replica; multiple clients `WATCH` it (`wk->expired = 1`)
5. Master does `SET` on the same key — since the key is **not** expired on the master, no `DEL` is propagated
6. The replica receives the replicated `SET` with `CLIENT_MASTER` flag
7. `expireIfNeeded()` returns `KEY_VALID` without deleting the expired key (due to `CLIENT_MASTER` check at `db.c:2888`)
8. A single `touchWatchedKey()` call occurs with `dbFind != NULL`
9. The `break` fires at the first expired watcher, skipping all remaining watchers
10. Skipped watchers' transactions incorrectly succeed on `EXEC`

This can also occur through clock skew between master and replica, where a key naturally expires on the replica before the master.

## Changes

- **`src/multi.c`**: Replace `break` with a comment explaining the fall-through to the `CLIENT_DIRTY_CAS` path. When a key was expired at `WATCH` time but has since been re-created, this is a logical state change that should invalidate the transaction.

- **`tests/unit/multi.tcl`**: Two regression tests using a writable replica setup:
  - 3 expired watchers: verifies all three transactions are aborted when the watched key is re-created via replication
  - 2 expired watchers: minimal reproduction case


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `WATCH`/`MULTI/EXEC` invalidation logic for expired watched keys, which can affect transaction outcomes in replication edge cases. Scope is small but touches core concurrency/replication correctness paths.
> 
> **Overview**
> Fixes `touchWatchedKey()` so encountering an already-expired watcher no longer exits the watcher-iteration early when the key has been re-created; instead it falls through to mark the client `CLIENT_DIRTY_CAS` and `UNWATCH`, ensuring all remaining watchers are invalidated.
> 
> Adds regression coverage in `tests/unit/multi.tcl` using a writable replica scenario where a key expires locally but is later re-written via replication, asserting that multiple clients `WATCH`ing the expired key all have their `EXEC` aborted (no side effects).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f01552563929eb57072a3d59f879422dfabd2d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->