### PR TITLE
Optimize prefetching commands

### DIFF
--- a/src/iothread.c
+++ b/src/iothread.c
@@ -492,6 +492,7 @@ int prefetchIOThreadCommands(IOThread *t) {
         c[i] = listNodeValue(ln);
         redis_prefetch_read(c[i]);
         redis_prefetch_read(&c[i]->pending_cmds);
+        redis_prefetch_read(&c[i]->io_deferred_objects);
     }
     /* Phase 2: Access client data (now likely in cache) and add to batch.
      * Also prefetch additional fields (reply, mem_usage_bucket) that will be
@@ -500,6 +501,7 @@ int prefetchIOThreadCommands(IOThread *t) {
         if (addCommandToBatch(c[i]) == C_ERR) break;
         if (c[i]->reply) redis_prefetch_read(c[i]->reply);
         redis_prefetch_read(&c[i]->mem_usage_bucket);
+        if (c[i]->io_deferred_objects) redis_prefetch_read(c[i]->io_deferred_objects);
         clients++;
     }
     /* Prefetch the commands in the batch. */

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -400,7 +400,8 @@ int addCommandToBatch(client *c) {
      * a proxy for key count to ensure all keys from a client are either fully
      * prefetched together or not prefetched at all. */
     if (batch->key_count > 0 &&
-        c->pending_cmds.ready_len + batch->key_count > batch->max_prefetch_size)
+        c->pending_cmds.ready_len + batch->key_count > batch->max_prefetch_size &&
+        c->pending_cmds.ready_len + batch->pcmd_count > batch->max_prefetch_size)
     {
         return C_ERR;
     }

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -345,14 +345,6 @@ void prefetchCommands(void) {
         }
     }
 
-    /* Prefetch io_deferred_objects for all clients */
-    for (size_t i = 0; i < batch->client_count; i++) {
-        client *c = batch->clients[i];
-        if (!c->io_deferred_objects || c->io_deferred_objects_num == 0) continue;
-        for (int j = 0; j < c->io_deferred_objects_num; j++)
-            redis_prefetch_read(c->io_deferred_objects[j]);
-    }
-
     /* Prefetch the argv->ptr if required */
     for (size_t i = 0; i < batch->pcmd_count; i++) {
         pendingCommand *pcmd = batch->pending_cmds[i];
@@ -362,6 +354,14 @@ void prefetchCommands(void) {
                 redis_prefetch_read(pcmd->argv[j]->ptr);
             }
         }
+    }
+
+    /* Prefetch io_deferred_objects for all clients */
+    for (size_t i = 0; i < batch->client_count; i++) {
+        client *c = batch->clients[i];
+        if (!c->io_deferred_objects || c->io_deferred_objects_num == 0) continue;
+        for (int j = 0; j < c->io_deferred_objects_num; j++)
+            redis_prefetch_read(c->io_deferred_objects[j]);
     }
 
     /* Get the keys ptrs - we do it here after the key obj was prefetched. */

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -339,7 +339,7 @@ void prefetchCommands(void) {
     /* Prefetch argv's for all pending commands */
     for (size_t i = 0; i < batch->pcmd_count; i++) {
         pendingCommand *pcmd = batch->pending_cmds[i];
-        if (!pcmd || pcmd->argc <= 1) continue;
+        if (unlikely(pcmd->argc <= 0)) continue;
         for (int j = 0; j < pcmd->argc; j++) {
             redis_prefetch_read(pcmd->argv[j]);
         }
@@ -348,7 +348,8 @@ void prefetchCommands(void) {
     /* Prefetch the argv->ptr if required */
     for (size_t i = 0; i < batch->pcmd_count; i++) {
         pendingCommand *pcmd = batch->pending_cmds[i];
-        if (!pcmd || pcmd->argc <= 1) continue;
+        if (unlikely(pcmd->argc <= 1)) continue;
+        /* Skip the first argument (command name), as it's typically short */
         for (int j = 1; j < pcmd->argc; j++) {
             if (pcmd->argv[j]->encoding == OBJ_ENCODING_RAW) {
                 redis_prefetch_read(pcmd->argv[j]->ptr);

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -394,14 +394,14 @@ int addCommandToBatch(client *c) {
         return C_ERR;
     }
 
-    /* Avoid partial prefetching: if the batch already has keys and adding this
+    /* Avoid partial prefetching: if the batch already has commands and adding this
      * client's ready commands would likely exceed the batch size limit, reject
      * the entire client. This is a conservative estimate using command count as
      * a proxy for key count to ensure all keys from a client are either fully
      * prefetched together or not prefetched at all. */
-    if (batch->key_count > 0 &&
-        c->pending_cmds.ready_len + batch->key_count > batch->max_prefetch_size &&
-        c->pending_cmds.ready_len + batch->pcmd_count > batch->max_prefetch_size)
+    if (batch->pcmd_count > 0 &&
+        (c->pending_cmds.ready_len + batch->key_count > batch->max_prefetch_size ||
+         c->pending_cmds.ready_len + batch->pcmd_count > batch->max_prefetch_size))
     {
         return C_ERR;
     }

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -330,7 +330,8 @@ int determinePrefetchCount(int len) {
 /* Prefetch command-related data:
  * 1. Prefetch the command arguments allocated by the I/O thread to bring them
  *    closer to the L1 cache.
- * 2. Prefetch the keys and values for all commands in the current batch from
+ * 2. Prefetch the io_deferred_objects for all clients.
+ * 3. Prefetch the keys and values for all commands in the current batch from
  *    the main dictionaries. */
 void prefetchCommands(void) {
     if (!batch) return;
@@ -344,6 +345,14 @@ void prefetchCommands(void) {
         }
     }
 
+    /* Prefetch io_deferred_objects for all clients */
+    for (size_t i = 0; i < batch->client_count; i++) {
+        client *c = batch->clients[i];
+        if (!c->io_deferred_objects || c->io_deferred_objects_num == 0) continue;
+        for (int j = 0; j < c->io_deferred_objects_num; j++)
+            redis_prefetch_read(c->io_deferred_objects[j]);
+    }
+
     /* Prefetch the argv->ptr if required */
     for (size_t i = 0; i < batch->pcmd_count; i++) {
         pendingCommand *pcmd = batch->pending_cmds[i];
@@ -353,14 +362,6 @@ void prefetchCommands(void) {
                 redis_prefetch_read(pcmd->argv[j]->ptr);
             }
         }
-    }
-
-    /* Prefetch io_deferred_objects for all clients */
-    for (size_t i = 0; i < batch->client_count; i++) {
-        client *c = batch->clients[i];
-        if (!c->io_deferred_objects || c->io_deferred_objects_num == 0) continue;
-        for (int j = 0; j < c->io_deferred_objects_num; j++)
-            redis_prefetch_read(c->io_deferred_objects[j]);
     }
 
     /* Get the keys ptrs - we do it here after the key obj was prefetched. */
@@ -409,7 +410,6 @@ int addCommandToBatch(client *c) {
     pendingCommand *pcmd = c->pending_cmds.head;
     while (pcmd != NULL && batch->pcmd_count < batch->max_prefetch_size) {
         if (pcmd->next) redis_prefetch_read(pcmd->next);
-        redis_prefetch_read(pcmd->argv);
 
         /* Skip commands that have not been preprocessed, or have errors. */
         if ((pcmd->flags & PENDING_CMD_FLAG_INCOMPLETE) || !pcmd->cmd || pcmd->read_error) break;

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -73,9 +73,11 @@ typedef struct PrefetchCommandsBatch {
     size_t cur_idx;                 /* Index of the current key being processed */
     size_t key_count;               /* Number of keys in the current batch */
     size_t client_count;            /* Number of clients in the current batch */
+    size_t pcmd_count;              /* Number of pending commands in the current batch */
     size_t max_prefetch_size;       /* Maximum number of keys to prefetch in a batch */
     void **keys;                    /* Array of keys to prefetch in the current batch */
     client **clients;               /* Array of clients in the current batch */
+    pendingCommand **pending_cmds;  /* Array of pending commands in the current batch */
     dict **keys_dicts;              /* Main dict for each key */
     dict **current_dicts;           /* Points to dict to prefetch from */
     KeyPrefetchInfo *prefetch_info; /* Prefetch info for each key */
@@ -90,6 +92,7 @@ void freePrefetchCommandsBatch(void) {
     }
 
     zfree(batch->clients);
+    zfree(batch->pending_cmds);
     zfree(batch->keys);
     zfree(batch->keys_dicts);
     zfree(batch->prefetch_info);
@@ -112,6 +115,7 @@ void prefetchCommandsBatchInit(void) {
     batch = zcalloc(sizeof(PrefetchCommandsBatch));
     batch->max_prefetch_size = max_prefetch_size;
     batch->clients = zcalloc(max_prefetch_size * sizeof(client *));
+    batch->pending_cmds = zcalloc(max_prefetch_size * sizeof(pendingCommand *));
     batch->keys = zcalloc(max_prefetch_size * sizeof(void *));
     batch->keys_dicts = zcalloc(max_prefetch_size * sizeof(dict *));
     batch->prefetch_info = zcalloc(max_prefetch_size * sizeof(KeyPrefetchInfo));
@@ -299,6 +303,7 @@ void resetCommandsBatch(void) {
     batch->cur_idx = 0;
     batch->key_count = 0;
     batch->client_count = 0;
+    batch->pcmd_count = 0;
 
     /* Handle the case where the max prefetch size has been changed. */
     if (batch->max_prefetch_size != (size_t)server.prefetch_batch_max_size * 2) {
@@ -330,26 +335,32 @@ int determinePrefetchCount(int len) {
 void prefetchCommands(void) {
     if (!batch) return;
 
-    /* Prefetch argv's for all clients */
-    for (size_t i = 0; i < batch->client_count; i++) {
-        client *c = batch->clients[i];
-        if (!c || c->argc <= 1) continue;
-        /* Skip prefetching first argv (cmd name) it was already looked up by
-         * the I/O thread, and the main thread will not touch argv[0]. */
-        for (int j = 1; j < c->argc; j++) {
-            redis_prefetch_read(c->argv[j]);
+    /* Prefetch argv's for all pending commands */
+    for (size_t i = 0; i < batch->pcmd_count; i++) {
+        pendingCommand *pcmd = batch->pending_cmds[i];
+        if (!pcmd || pcmd->argc <= 1) continue;
+        for (int j = 0; j < pcmd->argc; j++) {
+            redis_prefetch_read(pcmd->argv[j]);
         }
     }
 
     /* Prefetch the argv->ptr if required */
-    for (size_t i = 0; i < batch->client_count; i++) {
-        client *c = batch->clients[i];
-        if (!c || c->argc <= 1) continue;
-        for (int j = 1; j < c->argc; j++) {
-            if (c->argv[j]->encoding == OBJ_ENCODING_RAW) {
-                redis_prefetch_read(c->argv[j]->ptr);
+    for (size_t i = 0; i < batch->pcmd_count; i++) {
+        pendingCommand *pcmd = batch->pending_cmds[i];
+        if (!pcmd || pcmd->argc <= 1) continue;
+        for (int j = 1; j < pcmd->argc; j++) {
+            if (pcmd->argv[j]->encoding == OBJ_ENCODING_RAW) {
+                redis_prefetch_read(pcmd->argv[j]->ptr);
             }
         }
+    }
+
+    /* Prefetch io_deferred_objects for all clients */
+    for (size_t i = 0; i < batch->client_count; i++) {
+        client *c = batch->clients[i];
+        if (!c->io_deferred_objects || c->io_deferred_objects_num == 0) continue;
+        for (int j = 0; j < c->io_deferred_objects_num; j++)
+            redis_prefetch_read(c->io_deferred_objects[j]);
     }
 
     /* Get the keys ptrs - we do it here after the key obj was prefetched. */
@@ -376,7 +387,8 @@ int addCommandToBatch(client *c) {
      * We also check the client count to handle cases where
      * no keys exist for the clients' commands. */
     if (batch->client_count == batch->max_prefetch_size ||
-        batch->key_count == batch->max_prefetch_size)
+        batch->key_count == batch->max_prefetch_size ||
+        batch->pcmd_count == batch->max_prefetch_size)
     {
         return C_ERR;
     }
@@ -395,9 +407,14 @@ int addCommandToBatch(client *c) {
     batch->clients[batch->client_count++] = c;
 
     pendingCommand *pcmd = c->pending_cmds.head;
-    while (pcmd != NULL) {
+    while (pcmd != NULL && batch->pcmd_count < batch->max_prefetch_size) {
+        if (pcmd->next) redis_prefetch_read(pcmd->next);
+        redis_prefetch_read(pcmd->argv);
+
         /* Skip commands that have not been preprocessed, or have errors. */
         if ((pcmd->flags & PENDING_CMD_FLAG_INCOMPLETE) || !pcmd->cmd || pcmd->read_error) break;
+
+        batch->pending_cmds[batch->pcmd_count++] = pcmd;
 
         serverAssert(pcmd->flags & PENDING_CMD_KEYS_RESULT_VALID);
         for (int i = 0; i < pcmd->keys_result.numkeys && batch->key_count < batch->max_prefetch_size; i++) {


### PR DESCRIPTION
- After https://github.com/redis/redis/pull/14440, the IO thread can parse all command in pipeline instead of only the header, so we should prefetch all pending commands when prefetching.

- Since the main thread will access the `io_deferred_objects`, we should prefetch them.

What i am worried is that we try to prefetch too much data in cache, maybe we should use better strategies, but the test result shows it is good.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches performance-critical prefetch logic on the main thread; main risk is over-prefetching/increased cache pressure or subtle batch-limit/iteration issues affecting throughput under heavy pipelines.
> 
> **Overview**
> Improves the prefetch pipeline by batching at the `pendingCommand` level: the prefetch batch now tracks `pending_cmds` separately and prefetches argv/`argv[j]->ptr` for *all* ready pipelined commands rather than relying on client-level argv.
> 
> Also adds cache prefetching for per-client `io_deferred_objects` (including their elements) and tightens batch sizing/overflow checks (introducing `pcmd_count`, freeing/resetting the new arrays, and early exit when a client would exceed the batch limits).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eff9009513223143a984f9c04746b2def3cda75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->