### PR TITLE
Clean up sampling accounting in performEvictions

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -594,22 +594,23 @@ int performEvictions(void) {
                     unsigned long sampled_keys = 0;
                     unsigned long current_db_keys = kvstoreSize(kvs);
                     if (current_db_keys == 0) continue;
+                    /* If there are not a lot of keys in the current db, dict/s may be very
+                     * sparsely populated, so avoid sampling repeatedly. */
+                    int is_sparse_db = current_db_keys < (unsigned long) server.maxmemory_samples*10;
 
                     total_keys += current_db_keys;
                     int l = kvstoreNumNonEmptyDicts(kvs);
                     /* Do not exceed the number of non-empty slots when looping. */
                     while (l--) {
                         sampled_keys += evictionPoolPopulate(db, kvs, pool);
-                        total_sampled_keys += sampled_keys;
                         /* We have sampled enough keys in the current db, exit the loop. */
                         if (sampled_keys >= (unsigned long) server.maxmemory_samples)
                             break;
-                        /* If there are not a lot of keys in the current db, dict/s may be very
-                         * sparsely populated, exit the loop without meeting the sampling
-                         * requirement. */
-                        if (current_db_keys < (unsigned long) server.maxmemory_samples*10)
+                        /* For sparse DBs, exit early without meeting the sampling. */
+                        if (is_sparse_db)
                             break;
                     }
+                    total_sampled_keys += sampled_keys;
                 }
                 if (!total_keys) break; /* No keys to evict. */
 


### PR DESCRIPTION
This change computes the sparse-DB condition once per DB and reuses it
inside the slot sampling loop, avoiding redundant checks.

It also updates total_sampled_keys to accumulate per-DB sampled totals,
rather than repeatedly adding the running sampled_keys value. The counter
is only used to detect the case where no keys were sampled at all, so this
does not change eviction behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in eviction sampling that mainly adjusts accounting and avoids redundant sparse-DB checks; eviction selection logic should be unchanged aside from more accurate sampled-key counting used for a loop-break condition.
> 
> **Overview**
> Cleans up eviction sampling in `performEvictions()` by computing the *sparse DB* condition once per DB and reusing it inside the slot-sampling loop.
> 
> Fixes `total_sampled_keys` accounting to accumulate per-DB `sampled_keys` once after sampling, instead of repeatedly adding the running total each iteration (used only to detect the "no keys sampled" case).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baf08a298d2a665e77e7a9b8265feae0f27f6de0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->