### PR TITLE
Fix HOTKEYS to track each command in a MULTI/EXEC block

### DIFF
--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -112,8 +112,9 @@ void hotkeyStatsUpdateCurrentCmd(hotkeyStats *hotkeys, hotkeyMetrics metrics) {
     if (!hotkeys || !hotkeys->active) return;
     if (hotkeys->keys_result.numkeys == 0) return;
 
-    /* Don't update stats for nested calls */
-    if (server.execution_nesting) return;
+    /* Don't update stats for nested calls, except when inside MULTI/EXEC
+     * where we want to track each individual command. */
+    if (server.execution_nesting && !server.in_exec) return;
 
     serverAssert(hotkeys->current_client);
 

--- a/src/server.c
+++ b/src/server.c
@@ -3974,12 +3974,13 @@ void call(client *c, int flags) {
 
     /* Populate the per-key hotkey stats. Before updating stats for a command
      * we need to do some setup on the hotkeyStats structure. We only do this
-     * once during the outer-most call in case of nesting.
+     * once during the outer-most call in case of nesting. However, when we are
+     * inside a MULTI/EXEC block, we want to track each individual command.
      * NOTE: even though we update the network bytes during nested calls we
      * only update the duration, since the outer-most call records the whole
      * duration. */
     if (update_command_stats && !(c->flags & CLIENT_BLOCKED) &&
-        !server.execution_nesting)
+        (!server.execution_nesting || server.in_exec))
     {
         /* First we need to prepare the hotkeyStats for updates */
         hotkeyStatsPreCurrentCmd(server.hotkeys, c);
@@ -4078,8 +4079,9 @@ void call(client *c, int flags) {
         hotkeyStatsUpdateCurrentCmd(server.hotkeys, metrics);
 
         /* Just like curr cmd setup we only do the cleanup in case we are not in
-         * a nested command. */
-        if (!server.execution_nesting)
+         * a nested command. For MULTI/EXEC, we do cleanup for each individual
+         * command. */
+        if (!server.execution_nesting || server.in_exec)
             hotkeyStatsPostCurrentCmd(server.hotkeys);
     }
 

--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -244,8 +244,8 @@ start_server {tags {"hotkeys"}} {
     }
 
     test {HOTKEYS - commands inside MULTI/EXEC} {
-        set key1 "\{t\}key1"
-        set key2 "\{t\}key2"
+        set key1 "key1\{t\}"
+        set key2 "key2\{t\}"
 
         assert_equal {OK} [r hotkeys start METRICS 2 CPU NET]
         r multi

--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -249,10 +249,14 @@ start_server {tags {"hotkeys"}} {
 
         assert_equal {OK} [r hotkeys start METRICS 2 CPU NET]
         r multi
-        r set $key1 value1
-        r set $key2 value1
-        r set $key1 value2
-        r set $key1 value3
+        # Send multiple commands to avoid <1us cpu for $key2 which we assert
+        # at end of test
+        for {set i 0} {$i < 7} {incr i} {
+            r set $key1 value1
+            r set $key2 value1
+            r set $key1 value2
+            r set $key1 value3
+        }
         r exec
 
         assert_equal {OK} [r hotkeys stop]

--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -255,7 +255,9 @@ start_server {tags {"hotkeys"}} {
         r set $key1 value3
         r exec
 
+        assert_equal {OK} [r hotkeys stop]
         set result [r hotkeys get]
+        assert_equal {OK} [r hotkeys reset]
 
         # Check NET metrics
         set net_result [dict get $result "by-net-bytes"]
@@ -270,9 +272,6 @@ start_server {tags {"hotkeys"}} {
         # Both keys should be tracked from within the MULTI/EXEC block
         assert [dict exists $cpu_result $key1]
         assert [dict exists $cpu_result $key2]
-
-        assert_equal {OK} [r hotkeys stop]
-        assert_equal {OK} [r hotkeys reset]
     }
 
     test {HOTKEYS GET - no conditional fields without selected slots} {

--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -270,8 +270,6 @@ start_server {tags {"hotkeys"}} {
         # Both keys should be tracked from within the MULTI/EXEC block
         assert [dict exists $cpu_result $key1]
         assert [dict exists $cpu_result $key2]
-        # key1 should have more CPU time than key2 since it's accessed more times
-        assert {[dict get $cpu_result $key1] >= [dict get $cpu_result $key2]}
 
         assert_equal {OK} [r hotkeys stop]
         assert_equal {OK} [r hotkeys reset]

--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -244,12 +244,15 @@ start_server {tags {"hotkeys"}} {
     }
 
     test {HOTKEYS - commands inside MULTI/EXEC} {
+        set key1 "\{t\}key1"
+        set key2 "\{t\}key2"
+
         assert_equal {OK} [r hotkeys start METRICS 2 CPU NET]
         r multi
-        r set multi_key1 value1
-        r set multi_key2 value1
-        r set multi_key1 value2
-        r set multi_key1 value3
+        r set $key1 value1
+        r set $key2 value1
+        r set $key1 value2
+        r set $key1 value3
         r exec
 
         set result [r hotkeys get]
@@ -257,18 +260,18 @@ start_server {tags {"hotkeys"}} {
         # Check NET metrics
         set net_result [dict get $result "by-net-bytes"]
         # Both keys should be tracked from within the MULTI/EXEC block
-        assert [dict exists $net_result "multi_key1"]
-        assert [dict exists $net_result "multi_key2"]
-        # multi_key1 should have more bytes than multi_key2 since it's accessed more times
-        assert {[dict get $net_result "multi_key1"] > [dict get $net_result "multi_key2"]}
+        assert [dict exists $net_result $key1]
+        assert [dict exists $net_result $key2]
+        # key1 should have more bytes than key2 since it's accessed more times
+        assert {[dict get $net_result $key1] > [dict get $net_result $key2]}
 
         # Check CPU metrics
         set cpu_result [dict get $result "by-cpu-time-us"]
         # Both keys should be tracked from within the MULTI/EXEC block
-        assert [dict exists $cpu_result "multi_key1"]
-        assert [dict exists $cpu_result "multi_key2"]
-        # multi_key1 should have more CPU time than multi_key2 since it's accessed more times
-        assert {[dict get $cpu_result "multi_key1"] >= [dict get $cpu_result "multi_key2"]}
+        assert [dict exists $cpu_result $key1]
+        assert [dict exists $cpu_result $key2]
+        # key1 should have more CPU time than key2 since it's accessed more times
+        assert {[dict get $cpu_result $key1] >= [dict get $cpu_result $key2]}
 
         assert_equal {OK} [r hotkeys stop]
         assert_equal {OK} [r hotkeys reset]

--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -243,7 +243,36 @@ start_server {tags {"hotkeys"}} {
         assert_equal {OK} [r hotkeys reset]
     }
 
+    test {HOTKEYS - commands inside MULTI/EXEC} {
+        assert_equal {OK} [r hotkeys start METRICS 2 CPU NET]
+        r multi
+        r set multi_key1 value1
+        r set multi_key2 value1
+        r set multi_key1 value2
+        r set multi_key1 value3
+        r exec
 
+        set result [r hotkeys get]
+
+        # Check NET metrics
+        set net_result [dict get $result "by-net-bytes"]
+        # Both keys should be tracked from within the MULTI/EXEC block
+        assert [dict exists $net_result "multi_key1"]
+        assert [dict exists $net_result "multi_key2"]
+        # multi_key1 should have more bytes than multi_key2 since it's accessed more times
+        assert {[dict get $net_result "multi_key1"] > [dict get $net_result "multi_key2"]}
+
+        # Check CPU metrics
+        set cpu_result [dict get $result "by-cpu-time-us"]
+        # Both keys should be tracked from within the MULTI/EXEC block
+        assert [dict exists $cpu_result "multi_key1"]
+        assert [dict exists $cpu_result "multi_key2"]
+        # multi_key1 should have more CPU time than multi_key2 since it's accessed more times
+        assert {[dict get $cpu_result "multi_key1"] >= [dict get $cpu_result "multi_key2"]}
+
+        assert_equal {OK} [r hotkeys stop]
+        assert_equal {OK} [r hotkeys reset]
+    }
 
     test {HOTKEYS GET - no conditional fields without selected slots} {
         assert_equal {OK} [r hotkeys start METRICS 2 CPU NET SAMPLE 10]

--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -274,6 +274,29 @@ start_server {tags {"hotkeys"}} {
         assert [dict exists $cpu_result $key2]
     }
 
+    test {HOTKEYS - EVAL inside MULTI/EXEC with nested calls} {
+        set key1 "evalkey1\{t\}"
+        set key2 "evalkey2\{t\}"
+
+        assert_equal {OK} [r hotkeys start METRICS 1 NET]
+        r multi
+        r eval {redis.call('set', KEYS[1], 'value1')} 1 $key1
+        r eval {redis.call('set', KEYS[1], 'value2'); redis.call('set', KEYS[1], 'value3')} 1 $key1
+        r eval {redis.call('set', KEYS[1], 'value4')} 1 $key2
+        r exec
+
+        assert_equal {OK} [r hotkeys stop]
+        set result [r hotkeys get]
+        assert_equal {OK} [r hotkeys reset]
+
+        # Check NET metrics - both keys should be tracked through EVAL commands
+        set net_result [dict get $result "by-net-bytes"]
+        assert [dict exists $net_result $key1]
+        assert [dict exists $net_result $key2]
+        # key1 should have more bytes than key2 since it's accessed by more EVAL commands
+        assert {[dict get $net_result $key1] > [dict get $net_result $key2]}
+    }
+
     test {HOTKEYS GET - no conditional fields without selected slots} {
         assert_equal {OK} [r hotkeys start METRICS 2 CPU NET SAMPLE 10]
         r set key1 value1


### PR DESCRIPTION
Fix HOTKEYS to track each command in a MULTI/EXEC block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core command execution accounting to change when `HOTKEYS` per-command setup/teardown runs; mistakes could skew metrics or leak per-command state across nested calls. Functional impact is limited to hotkey tracking/statistics.
> 
> **Overview**
> `HOTKEYS` now updates per-key CPU/NET stats for *each command inside* a `MULTI/EXEC` transaction, instead of skipping updates due to `execution_nesting`.
> 
> This adjusts the gating in `server.c` and `hotkeys.c` so hotkey pre/post bookkeeping and nested-call suppression treat `server.in_exec` as a special case, and adds unit tests covering both plain MULTI workloads and `EVAL` commands within MULTI that trigger nested execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 208b9a234dfbb606d49470d9593e714f0bc4f63f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->