### PR TITLE
Fix overflow in relative expire time

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -233,7 +233,12 @@ static int getExpireMillisecondsOrReply(client *c, robj *expire, int flags, int 
     if (unit == UNIT_SECONDS) *milliseconds *= 1000;
 
     if ((flags & OBJ_PX) || (flags & OBJ_EX)) {
-        *milliseconds += commandTimeSnapshot();
+        long long now = commandTimeSnapshot();
+        if (*milliseconds > LLONG_MAX - now) {
+            addReplyErrorExpireTime(c);
+            return C_ERR;
+        }
+        *milliseconds += now;
     }
 
     if (*milliseconds <= 0) {
@@ -1214,4 +1219,3 @@ void digestCommand(client *c) {
 
     addReplyBulkSds(c, stringDigest(o));
 }
-


### PR DESCRIPTION
## Summary
Fix signed overflow in relative expire time calculation.

## Root Cause
In `getExpireMillisecondsOrReply()` (`src/t_string.c`), relative EX/PX adds `commandTimeSnapshot()` to the user-supplied milliseconds without checking the upper bound.
For large PX values this can overflow `long long` (UB).

## Fix
Check `*milliseconds > LLONG_MAX - now` before addition and reject invalid expire times.

## Repro (UBSan)

make MALLOC=libc \
CFLAGS="-O1 -g -fsanitize=undefined -fno-sanitize-recover=undefined" \
LDFLAGS="-fsanitize=undefined"

./src/redis-server --port 6380 --save "" --appendonly no

./src/redis-cli -p 6380 SET k v PX 9223372036854775807


Expected server log:
  `runtime error: signed integer overflow`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized validation change that only rejects previously-accepted (but invalid) huge EX/PX values; behavior otherwise unchanged.
> 
> **Overview**
> Fixes a signed overflow in `getExpireMillisecondsOrReply()` when handling relative `EX`/`PX` by checking `LLONG_MAX - now` before adding the current `commandTimeSnapshot()` and returning `invalid expire time` on overflow.
> 
> Also removes a trailing blank line at the end of `digestCommand()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72f95a06b694b5b270ca6f7b6ae1f5a5ff42f7e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->