### PR TITLE
Refactor asmTask: remove source_node, use clusterLookupNode

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1567,7 +1567,7 @@ void asmSyncWithSource(connection *conn) {
         /* Create RDB channel connection */
         clusterNode *source_node = clusterLookupNode(task->source, CLUSTER_NAMELEN);
         if (!source_node) {
-            task_error_msg = sdsnew("Source node is forgotten");
+            task_error_msg = sdscatfmt(sdsempty(), "Source node %.40s was not found", task->source);
             goto error;
         }
         char *ip = clusterNodeIp(source_node);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -32,7 +32,6 @@ typedef struct asmTask {
     int dest_state;                         /* Destination node's main state (approximate) */
     char source[CLUSTER_NAMELEN];           /* Source node name */
     char dest[CLUSTER_NAMELEN];             /* Destination node name */
-    clusterNode *source_node;               /* Source node */
     connection *main_channel_conn;          /* Main channel connection */
     connection *rdb_channel_conn;           /* RDB channel connection */
     int rdb_channel_state;                  /* State of the RDB channel */
@@ -337,7 +336,6 @@ asmTask *asmTaskCreate(const char *task_id) {
     task->error = sdsempty();
     asmTaskReset(task);
     task->slots = NULL;
-    task->source_node = NULL;
     task->retry_count = 0;
     task->create_time = server.mstime;
     task->start_time = -1;
@@ -827,7 +825,6 @@ asmTask *asmCreateImportTask(const char *task_id, slotRangeArray *slots, sds *er
     task->slots = slots;
     task->state = ASM_NONE;
     task->operation = ASM_IMPORT;
-    task->source_node = source;
     memcpy(task->source, clusterNodeGetName(source), CLUSTER_NAMELEN);
     memcpy(task->dest, getMyClusterId(), CLUSTER_NAMELEN);
 
@@ -1194,7 +1191,6 @@ void asmTaskFinalize(asmTask *task) {
     listNode *ln = listFirst(asmManager->tasks);
     serverAssert(ln->value == task);
 
-    task->source_node = NULL; /* Should never access it */
     task->end_time = server.mstime;
 
     if (task->operation == ASM_IMPORT) {
@@ -1569,9 +1565,14 @@ void asmSyncWithSource(connection *conn) {
 
     if (task->state == ASM_INIT_RDBCHANNEL) {
         /* Create RDB channel connection */
-        char *ip = clusterNodeIp(task->source_node);
-        int port = server.tls_replication ? clusterNodeTlsPort(task->source_node) :
-                                            clusterNodeTcpPort(task->source_node);
+        clusterNode *source_node = clusterLookupNode(task->source, CLUSTER_NAMELEN);
+        if (!source_node) {
+            task_error_msg = sdsnew("Source node is forgotten");
+            goto error;
+        }
+        char *ip = clusterNodeIp(source_node);
+        int port = server.tls_replication ? clusterNodeTlsPort(source_node) :
+                                            clusterNodeTcpPort(source_node);
         task->rdb_channel_conn = connCreate(server.el, connTypeOfReplication());
         if (connConnect(task->rdb_channel_conn, ip, port,
                         server.bind_source_addr, asmRdbChannelSyncWithSource) == C_ERR)
@@ -1802,8 +1803,7 @@ static void asmStartImportTask(asmTask *task) {
         return;
     }
     /* Change the source node if needed. */
-    if (source != task->source_node) {
-        task->source_node = source;
+    if (memcmp(task->source, clusterNodeGetName(source), CLUSTER_NAMELEN)) {
         memcpy(task->source, clusterNodeGetName(source), CLUSTER_NAMELEN);
         serverLog(LL_NOTICE, "Import task %s source node changed: slots=%s, "
                              "new_source=%.40s", task->id, slots_str, clusterNodeGetName(source));
@@ -1815,9 +1815,9 @@ static void asmStartImportTask(asmTask *task) {
     asmNotifyStateChange(task, ASM_EVENT_IMPORT_STARTED);
 
     task->main_channel_conn = connCreate(server.el, connTypeOfReplication());
-    char *ip = clusterNodeIp(task->source_node);
-    int port = server.tls_replication ? clusterNodeTlsPort(task->source_node) :
-                                        clusterNodeTcpPort(task->source_node);
+    char *ip = clusterNodeIp(source);
+    int port = server.tls_replication ? clusterNodeTlsPort(source) :
+                                        clusterNodeTcpPort(source);
     if (connConnect(task->main_channel_conn, ip, port, server.bind_source_addr,
                     asmSyncWithSource) == C_ERR)
     {
@@ -2732,8 +2732,7 @@ int clusterAsmCancelByNode(void *node, const char *reason) {
         asmTask *task = listNodeValue(ln);
         /* Cancel the task if the source node is the one to be deleted, or
          * the dest node is the one to be deleted. */
-        if (task->source_node == n ||
-            !memcmp(task->dest, clusterNodeGetName(n), CLUSTER_NAMELEN) ||
+        if (!memcmp(task->dest, clusterNodeGetName(n), CLUSTER_NAMELEN) ||
             !memcmp(task->source, clusterNodeGetName(n), CLUSTER_NAMELEN))
         {
             asmTaskCancel(task, reason);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -32,7 +32,6 @@ typedef struct asmTask {
     int dest_state;                         /* Destination node's main state (approximate) */
     char source[CLUSTER_NAMELEN];           /* Source node name */
     char dest[CLUSTER_NAMELEN];             /* Destination node name */
-    clusterNode *source_node;               /* Source node */
     connection *main_channel_conn;          /* Main channel connection */
     connection *rdb_channel_conn;           /* RDB channel connection */
     int rdb_channel_state;                  /* State of the RDB channel */
@@ -337,7 +336,6 @@ asmTask *asmTaskCreate(const char *task_id) {
     task->error = sdsempty();
     asmTaskReset(task);
     task->slots = NULL;
-    task->source_node = NULL;
     task->retry_count = 0;
     task->create_time = server.mstime;
     task->start_time = -1;
@@ -827,7 +825,6 @@ asmTask *asmCreateImportTask(const char *task_id, slotRangeArray *slots, sds *er
     task->slots = slots;
     task->state = ASM_NONE;
     task->operation = ASM_IMPORT;
-    task->source_node = source;
     memcpy(task->source, clusterNodeGetName(source), CLUSTER_NAMELEN);
     memcpy(task->dest, getMyClusterId(), CLUSTER_NAMELEN);
 
@@ -1194,7 +1191,6 @@ void asmTaskFinalize(asmTask *task) {
     listNode *ln = listFirst(asmManager->tasks);
     serverAssert(ln->value == task);
 
-    task->source_node = NULL; /* Should never access it */
     task->end_time = server.mstime;
 
     if (task->operation == ASM_IMPORT) {
@@ -1569,9 +1565,11 @@ void asmSyncWithSource(connection *conn) {
 
     if (task->state == ASM_INIT_RDBCHANNEL) {
         /* Create RDB channel connection */
-        char *ip = clusterNodeIp(task->source_node);
-        int port = server.tls_replication ? clusterNodeTlsPort(task->source_node) :
-                                            clusterNodeTcpPort(task->source_node);
+        clusterNode *source_node = clusterLookupNode(task->source, CLUSTER_NAMELEN);
+        serverAssert(source_node);
+        char *ip = clusterNodeIp(source_node);
+        int port = server.tls_replication ? clusterNodeTlsPort(source_node) :
+                                            clusterNodeTcpPort(source_node);
         task->rdb_channel_conn = connCreate(server.el, connTypeOfReplication());
         if (connConnect(task->rdb_channel_conn, ip, port,
                         server.bind_source_addr, asmRdbChannelSyncWithSource) == C_ERR)
@@ -1802,8 +1800,7 @@ static void asmStartImportTask(asmTask *task) {
         return;
     }
     /* Change the source node if needed. */
-    if (source != task->source_node) {
-        task->source_node = source;
+    if (memcmp(task->source, clusterNodeGetName(source), CLUSTER_NAMELEN)) {
         memcpy(task->source, clusterNodeGetName(source), CLUSTER_NAMELEN);
         serverLog(LL_NOTICE, "Import task %s source node changed: slots=%s, "
                              "new_source=%.40s", task->id, slots_str, clusterNodeGetName(source));
@@ -1815,9 +1812,9 @@ static void asmStartImportTask(asmTask *task) {
     asmNotifyStateChange(task, ASM_EVENT_IMPORT_STARTED);
 
     task->main_channel_conn = connCreate(server.el, connTypeOfReplication());
-    char *ip = clusterNodeIp(task->source_node);
-    int port = server.tls_replication ? clusterNodeTlsPort(task->source_node) :
-                                        clusterNodeTcpPort(task->source_node);
+    char *ip = clusterNodeIp(source);
+    int port = server.tls_replication ? clusterNodeTlsPort(source) :
+                                        clusterNodeTcpPort(source);
     if (connConnect(task->main_channel_conn, ip, port, server.bind_source_addr,
                     asmSyncWithSource) == C_ERR)
     {
@@ -2732,8 +2729,7 @@ int clusterAsmCancelByNode(void *node, const char *reason) {
         asmTask *task = listNodeValue(ln);
         /* Cancel the task if the source node is the one to be deleted, or
          * the dest node is the one to be deleted. */
-        if (task->source_node == n ||
-            !memcmp(task->dest, clusterNodeGetName(n), CLUSTER_NAMELEN) ||
+        if (!memcmp(task->dest, clusterNodeGetName(n), CLUSTER_NAMELEN) ||
             !memcmp(task->source, clusterNodeGetName(n), CLUSTER_NAMELEN))
         {
             asmTaskCancel(task, reason);


### PR DESCRIPTION
Description
This PR refactors the Async Slot Migration (ASM) implementation to improve the encapsulation and isolation between the ASM module and the core Cluster module.

Motivation
Previously, the `asmTask` structure maintained a long-lived raw pointer (clusterNode *source_node) to the source node of a migration. This introduced a tight coupling between the ASM and cluster impl, that has caused some trouble for my attempt to replace the cluster impl.


I'm not sure whether I need to declare AI usage. This PR was completed with  assistance of Gemini.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async slot migration connection setup and task cancellation logic; mistakes could break import/migration handshakes or cause unexpected task failures when cluster topology changes.
> 
> **Overview**
> **Async Slot Migration tasks no longer keep a long-lived `clusterNode *source_node` pointer.** Instead, tasks store only the source node ID (`task->source`) and resolve it on-demand.
> 
> Connection setup for the import RDB channel now uses `clusterLookupNode(task->source, ...)` (and fails the task with a clear error if the node can’t be found), and import startup/cancellation logic compares node IDs rather than pointer equality when detecting source changes or cancelling tasks for a removed node.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fc9584771b77f3c140271de6ac66d99b784eb45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->