### PR TITLE
Add instruction make in readme when building from source for the firs…

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ cd src
 ./redis-cli
 ```
 
+Note: `redis-cli` is a generated binary. It will not exist until `make` is run.
+If `./redis-cli` is missing [eg. "zsh: no such file or directory: ./redis-cli"], build Redis from source first.
+
+```sh
+make
+```
+
+
 ```text
 redis> ping
 PONG


### PR DESCRIPTION
We shouldn’t assume ./src/redis-cli exists in a fresh clone—it's created only after running make. 

Added a note to check for the built binary instead of treating it as a source file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a missing build step; no runtime or behavior impact.
> 
> **Overview**
> Clarifies the `redis-cli` quickstart in `README.md` by noting that `./src/redis-cli` is a **generated** binary and may be missing in a fresh clone.
> 
> Adds an explicit `make` step (with a brief example error message) so readers know to build Redis from source before attempting to run `./redis-cli`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 411a6048fd3c5567bc98bddc00956b099ceb0acf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->