### PR TITLE
Optimize BITOP operations with AVX512

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1328,7 +1328,6 @@ void bitopCommand(client *c) {
         j = 0;
 
 #if defined(HAVE_AVX512)
-        /* Heuristic: AVX-512 helps for larger bitmaps and many keys */
         if (BITOP_USE_AVX512 && (minlen >= 10000) && (numkeys >= 8)) {
             useAVX512 = 1;
         }
@@ -1355,16 +1354,19 @@ void bitopCommand(client *c) {
 #endif
 
 #if !defined(USE_ALIGNED_ACCESS)
-        /* We don't have AVX2/AVX512 but we still have fast path:
+        /* We don't have AVX2 but we still have fast path:
          * as far as we have data for all the input bitmaps we
          * can take a fast path that performs much better than the
          * vanilla algorithm. On ARM we skip the fast path since it will
          * result in GCC compiling the code using multiple-words load/store
-         * operations that are not supported even in ARM >= v6.
-         * If we already used AVX512/AVX2, skip this path - the SIMD paths
-         * already handled the bulk of the data and will have left less than
-         * their step size remaining. */
+         * operations that are not supported even in ARM >= v6. */
         if (!useAVX2 && minlen >= sizeof(unsigned long)*4) {
+            /* We can't have entered the AVX2 path since minlen >= sizeof(unsigned long)*4
+             * AVX2 path operates on steps of sizeof(__m256i) which for 64-bit
+             * machines (the only ones supporting AVX2) is equal to
+             * sizeof(unsigned long)*4. That means after the AVX2
+             * path minlen will necessarily be < sizeof(unsigned long)*4. */
+            serverAssert(!useAVX2);
 
             unsigned long **lp = (unsigned long**)src;
             unsigned long *lres = (unsigned long*) res;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1356,19 +1356,12 @@ void bitopCommand(client *c) {
 #endif
 
 #if !defined(USE_ALIGNED_ACCESS)
-        /* We don't have AVX2 but we still have fast path:
-         * as far as we have data for all the input bitmaps we
-         * can take a fast path that performs much better than the
-         * vanilla algorithm. On ARM we skip the fast path since it will
-         * result in GCC compiling the code using multiple-words load/store
-         * operations that are not supported even in ARM >= v6. */
+        /* If no SIMD path was used (no AVX2/AVX51), fall back 
+         * to a word-at-a-time fast path that is still much better 
+         * than the byte-by-byte loop below. On ARM we skip this since 
+         * it would cause GCC to emit multiple-word load/store ops
+         * not supported even on ARM >= v6. */
         if (!useAVX2 && minlen >= sizeof(unsigned long)*4) {
-            /* We can't have entered the AVX2 path since minlen >= sizeof(unsigned long)*4
-             * AVX2 path operates on steps of sizeof(__m256i) which for 64-bit
-             * machines (the only ones supporting AVX2) is equal to
-             * sizeof(unsigned long)*4. That means after the AVX2
-             * path minlen will necessarily be < sizeof(unsigned long)*4. */
-            serverAssert(!useAVX2);
 
             unsigned long **lp = (unsigned long**)src;
             unsigned long *lres = (unsigned long*) res;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1173,8 +1173,10 @@ unsigned long bitopCommandAVX512(unsigned char **keys, unsigned char *res,
 
             for (i = 1; i < numkeys; i++) {
                 __m512i lkey = _mm512_loadu_si512((__m512i*)(keys[i]+processed));
-                __m512i common = _mm512_and_si512(lres, lkey);
-                common_bits = _mm512_or_si512(common_bits, common);
+                /* Use ternary-logic to replace the separate AND+OR sequence. 
+                 * Truth-table imm8 0xF8 implements: c | (a & b). 
+                 * common_bits = common_bits | (lres & lkey). */
+                common_bits = _mm512_ternarylogic_epi32(lres, lkey, common_bits, 0xF8);
 
                 lres = _mm512_xor_si512(lres, lkey);
             }

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -941,21 +941,13 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         return 0;
     }
 
-    /* Unlike other operations that do the same with all source keys
-     * DIFF, DIFF1 and ANDOR all compute the disjunction of all the source keys
-     * but the first one. We first store that disjunction in `lres` and later 
-     * compute the final operation using the first source key. */
-    if (op != BITOP_DIFF && op != BITOP_DIFF1 && op != BITOP_ANDOR) {
-        memcpy(res, keys[0], minlen);
-    }
-
     const __m256i max256 = _mm256_set1_epi64x(-1);
     const __m256i zero256 = _mm256_set1_epi64x(0);
 
     switch (op) {
     case BITOP_AND:
         while (minlen >= step) {
-            __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+            __m256i lres = _mm256_lddqu_si256((__m256i*)(keys[0]+processed));
 
             for (i = 1; i < numkeys; i++) {
                 __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
@@ -972,7 +964,9 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
     case BITOP_ANDOR:
     case BITOP_OR:
         while (minlen >= step) {
-            __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+            __m256i lres = (op == BITOP_OR) ?
+                _mm256_lddqu_si256((__m256i*)(keys[0]+processed)) :
+                zero256;
 
             for (i = 1; i < numkeys; i++) {
                 __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
@@ -986,7 +980,7 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         break;
     case BITOP_XOR:
         while (minlen >= step) {
-            __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+            __m256i lres = _mm256_lddqu_si256((__m256i*)(keys[0]+processed));
 
             for (i = 1; i < numkeys; i++) {
                 __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
@@ -1000,7 +994,7 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         break;
     case BITOP_NOT:
         while (minlen >= step) {
-             __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+             __m256i lres = _mm256_lddqu_si256((__m256i*)(keys[0]+processed));
             lres = _mm256_xor_si256(lres, max256);
             _mm256_storeu_si256((__m256i*)res, lres);
             res += step;
@@ -1010,7 +1004,7 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         break;
     case BITOP_ONE:
         while (minlen >= step) {
-            __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+            __m256i lres = _mm256_lddqu_si256((__m256i*)(keys[0]+processed));
             __m256i common_bits = zero256;
 
             for (i = 1; i < numkeys; i++) {
@@ -1099,21 +1093,12 @@ unsigned long bitopCommandAVX512(unsigned char **keys, unsigned char *res,
         return 0;
     }
 
-    /* Unlike other operations that do the same with all source keys
-     * DIFF, DIFF1 and ANDOR all compute the disjunction of all the source keys
-     * but the first one. We first store that disjunction in `lres` and later 
-     * compute the final operation using the first source key. */
-    if (op != BITOP_DIFF && op != BITOP_DIFF1 && op != BITOP_ANDOR) {
-        memcpy(res, keys[0], minlen);
-    }
-
     const __m512i max512 = _mm512_set1_epi64(-1);
     const __m512i zero512 = _mm512_set1_epi64(0);
-
     switch (op) {
     case BITOP_AND:
         while (minlen >= step) {
-            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+            __m512i lres = _mm512_loadu_si512((__m512i*)(keys[0]+processed));
 
             for (i = 1; i < numkeys; i++) {
                 __m512i lkey = _mm512_loadu_si512((__m512i*)(keys[i]+processed));
@@ -1130,7 +1115,9 @@ unsigned long bitopCommandAVX512(unsigned char **keys, unsigned char *res,
     case BITOP_ANDOR:
     case BITOP_OR:
         while (minlen >= step) {
-            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+            __m512i lres = (op == BITOP_OR) ?
+                _mm512_loadu_si512((__m512i*)(keys[0]+processed)) :
+                zero512;
 
             for (i = 1; i < numkeys; i++) {
                 __m512i lkey = _mm512_loadu_si512((__m512i*)(keys[i]+processed));
@@ -1144,7 +1131,7 @@ unsigned long bitopCommandAVX512(unsigned char **keys, unsigned char *res,
         break;
     case BITOP_XOR:
         while (minlen >= step) {
-            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+            __m512i lres = _mm512_loadu_si512((__m512i*)(keys[0]+processed));
 
             for (i = 1; i < numkeys; i++) {
                 __m512i lkey = _mm512_loadu_si512((__m512i*)(keys[i]+processed));
@@ -1158,7 +1145,7 @@ unsigned long bitopCommandAVX512(unsigned char **keys, unsigned char *res,
         break;
     case BITOP_NOT:
         while (minlen >= step) {
-            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+            __m512i lres = _mm512_loadu_si512((__m512i*)(keys[0]+processed));
             lres = _mm512_xor_si512(lres, max512);
             _mm512_storeu_si512((__m512i*)res, lres);
             res += step;
@@ -1168,7 +1155,7 @@ unsigned long bitopCommandAVX512(unsigned char **keys, unsigned char *res,
         break;
     case BITOP_ONE:
         while (minlen >= step) {
-            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+            __m512i lres = _mm512_loadu_si512((__m512i*)(keys[0]+processed));
             __m512i common_bits = zero512;
 
             for (i = 1; i < numkeys; i++) {

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1349,19 +1349,16 @@ void bitopCommand(client *c) {
 #endif
 
 #if !defined(USE_ALIGNED_ACCESS)
-        /* We don't have AVX2 but we still have fast path:
+        /* We don't have AVX2/AVX512 but we still have fast path:
          * as far as we have data for all the input bitmaps we
          * can take a fast path that performs much better than the
          * vanilla algorithm. On ARM we skip the fast path since it will
          * result in GCC compiling the code using multiple-words load/store
-         * operations that are not supported even in ARM >= v6. */
-        if (minlen >= sizeof(unsigned long)*4) {
-            /* We can't have entered the AVX2 path since minlen >= sizeof(unsigned long)*4
-             * AVX2 path operates on steps of sizeof(__m256i) which for 64-bit
-             * machines (the only ones supporting AVX2) is equal to
-             * sizeof(unsigned long)*4. That means after the AVX2
-             * path minlen will necessarily be < sizeof(unsigned long)*4. */
-            serverAssert(!useAVX2);
+         * operations that are not supported even in ARM >= v6.
+         * If we already used AVX512/AVX2, skip this path - the SIMD paths
+         * already handled the bulk of the data and will have left less than
+         * their step size remaining. */
+        if (!useAVX2 && minlen >= sizeof(unsigned long)*4) {
 
             unsigned long **lp = (unsigned long**)src;
             unsigned long *lres = (unsigned long*) res;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1351,7 +1351,7 @@ void bitopCommand(client *c) {
 #endif
 
 #if !defined(USE_ALIGNED_ACCESS)
-        /* If no SIMD path was used (no AVX2/AVX51), fall back 
+        /* If no SIMD path was used (no AVX2/AVX512), fall back 
          * to a word-at-a-time fast path that is still much better 
          * than the byte-by-byte loop below. On ARM we skip this since 
          * it would cause GCC to emit multiple-word load/store ops

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -37,7 +37,7 @@
 
 /* AArch64 NEON support is determined at compile time via HAVE_AARCH64_NEON */
 #ifdef HAVE_AVX512
-#define BITOP_USE_AVX512 (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512vpopcntdq"))
+#define BITOP_USE_AVX512 (__builtin_cpu_supports("avx512f"))
 #else
 #define BITOP_USE_AVX512 0
 #endif
@@ -923,7 +923,7 @@ void getbitCommand(client *c) {
  * 256-bit registers so if `minlen` is not a multiple of 32 some of the bytes
  * will be skipped. They will be taken care for in the unoptimized loop in the
  * main bitopCommand function. */
-ATTRIBUTE_TARGET_AVX2_POPCOUNT
+ATTRIBUTE_TARGET_AVX2
 unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res, 
                               unsigned long op, unsigned long numkeys,
                               unsigned long minlen)
@@ -1075,6 +1075,164 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
 }
 #endif /* HAVE_AVX2 */
 
+#ifdef HAVE_AVX512
+/* Compute the given bitop operation using AVX512 intrinsics.
+ * Return how many bytes were successfully processed, as AVX512 operates on
+ * 512-bit registers so if `minlen` is not a multiple of 64 some of the bytes
+ * will be skipped. They will be taken care for in the unoptimized loop in the
+ * main bitopCommand function. */
+ATTRIBUTE_TARGET_AVX512
+unsigned long bitopCommandAVX512(unsigned char **keys, unsigned char *res, 
+                                 unsigned long op, unsigned long numkeys,
+                                 unsigned long minlen)
+{
+    const unsigned long step = sizeof(__m512i);  /* 64 bytes */
+
+    unsigned long i;
+    unsigned long processed = 0;
+    unsigned char *res_start = res;
+    unsigned char *fst_key = keys[0];
+
+    if (minlen < step) {
+        return 0;
+    }
+
+    /* Unlike other operations that do the same with all source keys
+     * DIFF, DIFF1 and ANDOR all compute the disjunction of all the source keys
+     * but the first one. We first store that disjunction in `lres` and later 
+     * compute the final operation using the first source key. */
+    if (op != BITOP_DIFF && op != BITOP_DIFF1 && op != BITOP_ANDOR) {
+        memcpy(res, keys[0], minlen);
+    }
+
+    const __m512i max512 = _mm512_set1_epi64(-1);
+    const __m512i zero512 = _mm512_set1_epi64(0);
+
+    switch (op) {
+    case BITOP_AND:
+        while (minlen >= step) {
+            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+
+            for (i = 1; i < numkeys; i++) {
+                __m512i lkey = _mm512_loadu_si512((__m512i*)(keys[i]+processed));
+                lres = _mm512_and_si512(lres, lkey);
+            }
+            _mm512_storeu_si512((__m512i*)res, lres);
+            res += step;
+            processed += step;
+            minlen -= step;
+        }
+        break;
+    case BITOP_DIFF:
+    case BITOP_DIFF1:
+    case BITOP_ANDOR:
+    case BITOP_OR:
+        while (minlen >= step) {
+            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+
+            for (i = 1; i < numkeys; i++) {
+                __m512i lkey = _mm512_loadu_si512((__m512i*)(keys[i]+processed));
+                lres = _mm512_or_si512(lres, lkey);
+            }
+            _mm512_storeu_si512((__m512i*)res, lres);
+            res += step;
+            processed += step;
+            minlen -= step;
+        }
+        break;
+    case BITOP_XOR:
+        while (minlen >= step) {
+            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+
+            for (i = 1; i < numkeys; i++) {
+                __m512i lkey = _mm512_loadu_si512((__m512i*)(keys[i]+processed));
+                lres = _mm512_xor_si512(lres, lkey);
+            }
+            _mm512_storeu_si512((__m512i*)res, lres);
+            res += step;
+            processed += step;
+            minlen -= step;
+        }
+        break;
+    case BITOP_NOT:
+        while (minlen >= step) {
+            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+            lres = _mm512_xor_si512(lres, max512);
+            _mm512_storeu_si512((__m512i*)res, lres);
+            res += step;
+            processed += step;
+            minlen -= step;
+        }
+        break;
+    case BITOP_ONE:
+        while (minlen >= step) {
+            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+            __m512i common_bits = zero512;
+
+            for (i = 1; i < numkeys; i++) {
+                __m512i lkey = _mm512_loadu_si512((__m512i*)(keys[i]+processed));
+                __m512i common = _mm512_and_si512(lres, lkey);
+                common_bits = _mm512_or_si512(common_bits, common);
+
+                lres = _mm512_xor_si512(lres, lkey);
+            }
+            lres = _mm512_andnot_si512(common_bits, lres);
+            _mm512_storeu_si512((__m512i*)res, lres);
+            res += step;
+            processed += step;
+            minlen -= step;
+        }
+        break;
+    default:
+        break;
+    }
+
+    res = res_start;
+    switch (op) {
+    case BITOP_DIFF:
+        for (i = 0; i < processed; i += step) {
+            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+            __m512i fkey = _mm512_loadu_si512((__m512i*)fst_key);
+
+            lres = _mm512_andnot_si512(lres, fkey);
+            _mm512_storeu_si512((__m512i*)res, lres);
+
+            res += step;
+            fst_key += step;
+        }
+        break;
+    case BITOP_DIFF1:
+        for (i = 0; i < processed; i += step) {
+            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+            __m512i fkey = _mm512_loadu_si512((__m512i*)fst_key);
+
+            lres = _mm512_andnot_si512(fkey, lres);
+            _mm512_storeu_si512((__m512i*)res, lres);
+
+            res += step;
+            fst_key += step;
+        }
+        break;
+    case BITOP_ANDOR:
+        for (i = 0; i < processed; i += step) {
+            __m512i lres = _mm512_loadu_si512((__m512i*)res);
+            __m512i fkey = _mm512_loadu_si512((__m512i*)fst_key);
+
+            lres = _mm512_and_si512(fkey, lres);
+            _mm512_storeu_si512((__m512i*)res, lres);
+
+            res += step;
+            fst_key += step;
+        }
+        break;
+    default:
+        break;
+    }
+
+    return processed;
+}
+#endif /* HAVE_AVX512 */
+
 /* BITOP op_name target_key src_key1 src_key2 src_key3 ... src_keyN */
 REDIS_NO_SANITIZE("alignment")
 void bitopCommand(client *c) {
@@ -1168,8 +1326,19 @@ void bitopCommand(client *c) {
         /* Number of bytes processed from each source key */
         j = 0;
 
+#if defined(HAVE_AVX512)
+        if (BITOP_USE_AVX512) {
+            j = bitopCommandAVX512(src, res, op, numkeys, minlen);
+
+            serverAssert(minlen >= j);
+            minlen -= j;
+
+            useAVX2 = 1;
+        }
+#endif
+
 #if defined(HAVE_AVX2)
-        if (BITOP_USE_AVX2) {
+        if (!useAVX2 && BITOP_USE_AVX2) {
             j = bitopCommandAVX(src, res, op, numkeys, minlen);
 
             serverAssert(minlen >= j);

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1322,12 +1322,18 @@ void bitopCommand(client *c) {
         unsigned char output, byte, disjunction, common_bits;
         unsigned long i;
         int useAVX2 = 0;
+        int useAVX512 = 0;
 
         /* Number of bytes processed from each source key */
         j = 0;
 
 #if defined(HAVE_AVX512)
-        if (BITOP_USE_AVX512) {
+        /* Heuristic: AVX-512 helps for larger bitmaps. */
+        if (BITOP_USE_AVX512 && (minlen >= 10000)) {
+            useAVX512 = 1;
+        }
+
+        if (useAVX512) {
             j = bitopCommandAVX512(src, res, op, numkeys, minlen);
 
             serverAssert(minlen >= j);

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1173,10 +1173,9 @@ unsigned long bitopCommandAVX512(unsigned char **keys, unsigned char *res,
 
             for (i = 1; i < numkeys; i++) {
                 __m512i lkey = _mm512_loadu_si512((__m512i*)(keys[i]+processed));
-                /* Use ternary-logic to replace the separate AND+OR sequence. 
-                 * Truth-table imm8 0xF8 implements: c | (a & b). 
-                 * common_bits = common_bits | (lres & lkey). */
-                common_bits = _mm512_ternarylogic_epi32(lres, lkey, common_bits, 0xF8);
+                /* common_bits |= (lres & lkey): ternary-logic with imm8 0xEA == c|(a&b)
+                 * (a=lres, b=lkey, c=common_bits), replacing a separate AND+OR. */
+                common_bits = _mm512_ternarylogic_epi32(lres, lkey, common_bits, 0xEA);
 
                 lres = _mm512_xor_si512(lres, lkey);
             }

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -959,6 +959,10 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
             minlen -= step;
         }
         break;
+    /* Unlike other operations that do the same with all source keys
+     * DIFF, DIFF1 and ANDOR all compute the disjunction of all the source keys
+     * but the first one. We first store that disjunction in `lres` and later
+     * compute the final operation using the first source key. */
     case BITOP_DIFF:
     case BITOP_DIFF1:
     case BITOP_ANDOR:
@@ -1110,6 +1114,10 @@ unsigned long bitopCommandAVX512(unsigned char **keys, unsigned char *res,
             minlen -= step;
         }
         break;
+    /* Unlike other operations that do the same with all source keys
+     * DIFF, DIFF1 and ANDOR all compute the disjunction of all the source keys
+     * but the first one. We first store that disjunction in `lres` and later
+     * compute the final operation using the first source key. */
     case BITOP_DIFF:
     case BITOP_DIFF1:
     case BITOP_ANDOR:

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -38,8 +38,10 @@
 /* AArch64 NEON support is determined at compile time via HAVE_AARCH64_NEON */
 #ifdef HAVE_AVX512
 #define BITOP_USE_AVX512 (__builtin_cpu_supports("avx512f"))
+#define POPCOUNT_USE_AVX512 (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512vpopcntdq"))
 #else
 #define BITOP_USE_AVX512 0
+#define POPCOUNT_USE_AVX512 0
 #endif
 
 
@@ -364,7 +366,7 @@ long long redisPopCountAvx2(void *s, long count) {
 /* Automatically select the best available popcount implementation */
 static inline long long redisPopcountAuto(const unsigned char *p, long count) {
 #ifdef HAVE_AVX512
-    if (BITOP_USE_AVX512) {
+    if (POPCOUNT_USE_AVX512) {
         return redisPopCountAvx512((void*)p, count);
     }
 #endif

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1328,8 +1328,8 @@ void bitopCommand(client *c) {
         j = 0;
 
 #if defined(HAVE_AVX512)
-        /* Heuristic: AVX-512 helps for larger bitmaps. */
-        if (BITOP_USE_AVX512 && (minlen >= 10000)) {
+        /* Heuristic: AVX-512 helps for larger bitmaps and many keys */
+        if (BITOP_USE_AVX512 && (minlen >= 10000) && (numkeys >= 8)) {
             useAVX512 = 1;
         }
 

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -38,10 +38,10 @@
 /* AArch64 NEON support is determined at compile time via HAVE_AARCH64_NEON */
 #ifdef HAVE_AVX512
 #define BITOP_USE_AVX512 (__builtin_cpu_supports("avx512f"))
-#define POPCOUNT_USE_AVX512 (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512vpopcntdq"))
+#define BITOPS_USE_AVX512_POPCOUNT  (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512vpopcntdq"))
 #else
 #define BITOP_USE_AVX512 0
-#define POPCOUNT_USE_AVX512 0
+#define BITOPS_USE_AVX512_POPCOUNT  0
 #endif
 
 
@@ -366,7 +366,7 @@ long long redisPopCountAvx2(void *s, long count) {
 /* Automatically select the best available popcount implementation */
 static inline long long redisPopcountAuto(const unsigned char *p, long count) {
 #ifdef HAVE_AVX512
-    if (POPCOUNT_USE_AVX512) {
+    if (BITOPS_USE_AVX512_POPCOUNT) {
         return redisPopCountAvx512((void*)p, count);
     }
 #endif

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1324,17 +1324,12 @@ void bitopCommand(client *c) {
         unsigned char output, byte, disjunction, common_bits;
         unsigned long i;
         int useAVX2 = 0;
-        int useAVX512 = 0;
 
         /* Number of bytes processed from each source key */
         j = 0;
 
 #if defined(HAVE_AVX512)
         if (BITOP_USE_AVX512 && (minlen >= 10000) && (numkeys >= 8)) {
-            useAVX512 = 1;
-        }
-
-        if (useAVX512) {
             j = bitopCommandAVX512(src, res, op, numkeys, minlen);
 
             serverAssert(minlen >= j);

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1323,7 +1323,7 @@ void bitopCommand(client *c) {
         res = (unsigned char*) sdsnewlen(NULL,maxlen);
         unsigned char output, byte, disjunction, common_bits;
         unsigned long i;
-        int useAVX2 = 0;
+        int useAVX = 0;
 
         /* Number of bytes processed from each source key */
         j = 0;
@@ -1335,18 +1335,18 @@ void bitopCommand(client *c) {
             serverAssert(minlen >= j);
             minlen -= j;
 
-            useAVX2 = 1;
+            useAVX = 1;
         }
 #endif
 
 #if defined(HAVE_AVX2)
-        if (!useAVX2 && BITOP_USE_AVX2) {
+        if (!useAVX && BITOP_USE_AVX2) {
             j = bitopCommandAVX(src, res, op, numkeys, minlen);
 
             serverAssert(minlen >= j);
             minlen -= j;
 
-            useAVX2 = 1;
+            useAVX = 1;
         }
 #endif
 
@@ -1356,7 +1356,7 @@ void bitopCommand(client *c) {
          * than the byte-by-byte loop below. On ARM we skip this since 
          * it would cause GCC to emit multiple-word load/store ops
          * not supported even on ARM >= v6. */
-        if (!useAVX2 && minlen >= sizeof(unsigned long)*4) {
+        if (!useAVX && minlen >= sizeof(unsigned long)*4) {
 
             unsigned long **lp = (unsigned long**)src;
             unsigned long *lres = (unsigned long*) res;

--- a/src/config.h
+++ b/src/config.h
@@ -361,6 +361,7 @@ void setcpuaffinity(const char *cpulist);
 #if defined (__x86_64__) && ((defined(__GNUC__) && __GNUC__ >= 5) || (defined(__clang__) && __clang_major__ >= 4))
 #if defined(__has_attribute) && __has_attribute(target)
 #define HAVE_AVX512
+#define ATTRIBUTE_TARGET_AVX512 __attribute__((target("avx512f")))
 #define ATTRIBUTE_TARGET_AVX512_POPCOUNT __attribute__((target("avx512f,avx512vpopcntdq")))
 #endif
 #endif

--- a/tests/unit/bitops.tcl
+++ b/tests/unit/bitops.tcl
@@ -313,6 +313,31 @@ start_server {tags {"bitops"}} {
         }
     }
 
+    # The AVX-512 BITOP path is triggered when minlen >= 10000 and numkeys >= 8.
+    foreach op {and or xor diff diff1 andor one} {
+        test "BITOP $op with large values (AVX-512 path)" {
+            set min_args 1
+            if {$op eq "diff" || $op eq "diff1" || $op eq "andor"} {
+                set min_args 2
+            }
+            # Test at and above the 10000-byte / 8-key threshold.
+            foreach {numvec strlen} {8 10000 10 10001 10 12000} {
+                assert {$numvec >= $min_args}
+                r flushall
+                set vec {}
+                set veckeys {}
+                for {set j 0} {$j < $numvec} {incr j} {
+                    set str [randstring $strlen $strlen]
+                    lappend vec $str
+                    lappend veckeys vector_$j{t}
+                    r set vector_$j{t} $str
+                }
+                r bitop $op target{t} {*}$veckeys
+                assert_equal [r get target{t}] [simulate_bit_op $op {*}$vec]
+            }
+        }
+    }
+
     test {BITOP with integer encoded source objects} {
         r set a{t} 1
         r set b{t} 2


### PR DESCRIPTION
The AVX512 optimizations help only for large values (e.g. 10K bytes - based on my testing). Thus, the AVX512 implementation is only utilized for larger values. For smaller values, it may cause performance degradation. For some large values (e.g. 10MB) it could help a lot - up to 80% in my experiments. 

Performance results attached. The results were conducted on an IceLake server. The redis process and the memtier benchmark were pinned to separate CPUs for more consistent results. 

[avx2_vs_avx512_8keysmin.txt](https://github.com/user-attachments/files/25111126/avx2_vs_avx512_8keysmin.txt)

The following script was used for benchmarking: https://github.com/slice4e/bench_script
This is very similar to the original script used to evaluate the bitop commands: https://github.com/minchopaskal/bench_script

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches performance-critical SIMD paths and CPU feature detection in `BITOP`/popcount, where subtle correctness issues or illegal-instruction crashes can occur on specific CPUs/toolchains. Behavior is unchanged but the new thresholds and vectorized implementations warrant extra cross-platform testing.
> 
> **Overview**
> **Adds an AVX-512 implementation for `BITOP`** via new `bitopCommandAVX512()`, processing 64-byte chunks and handling `DIFF`/`DIFF1`/`ANDOR` with a second pass over the first key.
> 
> `bitopCommand()` now prefers AVX-512 when `avx512f` is available and the workload is large (`minlen >= 10000` and `numkeys >= 8`), otherwise falls back to AVX2; the non-SIMD word fast-path is now explicitly skipped when a SIMD path ran. AVX-512 capability checks are split so `BITCOUNT`’s AVX-512 popcount still requires `avx512vpopcntdq`, and new unit tests validate `BITOP` correctness at the AVX-512 threshold.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d37354fe2b2029bd588513f4b043e780756f714b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->