### PR TITLE
Fix integer underflow in `used_memory_dataset` calculation

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -1394,7 +1394,7 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
     mem_total += hotkeysGetMemoryUsage(server.hotkeys);
 
     mh->overhead_total = mem_total;
-    mh->dataset = zmalloc_used - mem_total;
+    mh->dataset = (zmalloc_used > mem_total) ? (zmalloc_used - mem_total) : 0;
     mh->peak_perc = (float)zmalloc_used*100/mh->peak_allocated;
 
     /* Metrics computed after subtracting the startup memory from


### PR DESCRIPTION
Prevent unsigned integer underflow when `mem_total` exceeds `zmalloc_used` in `getMemoryOverheadData()`.
This can occur during early startup or due to timing mismatches in memory sampling.

Add conditional check to set dataset to 0 when underflow would occur, matching the existing pattern used for `net_usage` calculation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized arithmetic guard in memory reporting; behavior only changes in edge cases where the previous value was incorrect due to underflow.
> 
> **Overview**
> Fixes an unsigned underflow in `getMemoryOverheadData()` by clamping `mh->dataset` to `0` when `mem_total` exceeds `zmalloc_used`, preventing bogus huge `used_memory_dataset`/`dataset.bytes` values during startup or sampling mismatches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d233819eed4eca398866f5c4b8c108e2373099e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->