### PR TITLE
Fix missing getKeysFreeResult() in cross-slot error path

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1265,6 +1265,7 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
             /* The command has keys and was checked for cross-slot between its keys in preprocessCommand() */
             if (pcmd->read_error == CLIENT_READ_CROSS_SLOT) {
                 /* Error: multiple keys from different slots. */
+                if (!use_cache_keys_result) getKeysFreeResult(&result);
                 if (error_code)
                     *error_code = CLUSTER_REDIR_CROSS_SLOT;
                 return NULL;


### PR DESCRIPTION
This fix adds the missing cleanup for code consistency and to prevent potential memory leak from future code changes.

The potential leak can't be reproduced at the moment because it requires two conditions:
1. use_cache_keys_result == false, so getKeysFromCommand allocates heap memory
2. pcmd->read_error == CLIENT_READ_CROSS_SLOT, to trigger early return

However, the two conditions aren't met in practice:
- In preprocessCommand() (server.c), when CLIENT_READ_CROSS_SLOT is set, PENDING_CMD_KEYS_RESULT_VALID is always set too. This causes getClientCachedKeyResult() to return cached result, making use_cache_keys_result true and skipping heap allocation in getNodeByQuery().
- The other callers of getNodeByQuery() in script.c and module.c pass read_error = 0, so the condition 2 above is never met.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized memory-management change on an error-only early-return path; minimal behavior impact beyond preventing a potential leak.
> 
> **Overview**
> Fixes a missing cleanup in `getNodeByQuery()` (`src/cluster.c`) by calling `getKeysFreeResult(&result)` before returning on the `CLIENT_READ_CROSS_SLOT` error path when the keys result was heap-allocated (i.e., not from the cached `PENDING_CMD_KEYS_RESULT_VALID` path).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d65055c5f8b935900e079a8fd8954b2061cc8131. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->