### PR TITLE
Upgrade RediSearch module to v8.6.0

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.5.90
+MODULE_VERSION = v8.6.0
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
No changes since v8.5.90

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version bump in build configuration; risk is limited to potential upstream module behavior or compatibility changes at runtime/build time.
> 
> **Overview**
> Updates the RediSearch module build configuration to target **v8.6.0** (from `v8.5.90`) by changing `MODULE_VERSION` in `modules/redisearch/Makefile`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8aa1281974c88d7f976f251c73653392dc3d2371. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->