### PR TITLE
Use rax memory accounting for RedisModuleDict

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -15001,6 +15001,8 @@ RedisModuleDict *RM_DefragRedisModuleDict(RedisModuleDefragCtx *ctx, RedisModule
         rax* newrax = NULL;
         if ((newdict = activeDefragAlloc(dict)))
             dict = newdict;
+        /* Update rax back-pointer to dict */
+        dict->rax->alloc_size = &dict->alloc_size;
         if ((newrax = activeDefragAlloc(dict->rax)))
             dict->rax = newrax;
     }

--- a/src/module.c
+++ b/src/module.c
@@ -338,6 +338,7 @@ static list *modulePostExecUnitJobs;
 /* Data structures related to the exported dictionary data structure. */
 typedef struct RedisModuleDict {
     rax *rax;                       /* The radix tree. */
+    size_t alloc_size;              /* Total memory used (in bytes) by this dict. */
 } RedisModuleDict;
 
 typedef struct RedisModuleDictIter {
@@ -10728,8 +10729,10 @@ RedisModuleString *RM_GetClientCertificate(RedisModuleCtx *ctx, uint64_t client_
  *    Next / Prev dictionary iterator calls.
  */
 RedisModuleDict *RM_CreateDict(RedisModuleCtx *ctx) {
-    struct RedisModuleDict *d = zmalloc(sizeof(*d));
-    d->rax = raxNew();
+    size_t usable;
+    RedisModuleDict *d = zmalloc_usable(sizeof(*d), &usable);
+    d->alloc_size = usable;
+    d->rax = raxNewWithMetadata(0, &d->alloc_size);
     if (ctx != NULL) autoMemoryAdd(ctx,REDISMODULE_AM_DICT,d);
     return d;
 }
@@ -11682,11 +11685,7 @@ size_t RM_MallocSizeString(RedisModuleString* str) {
  * it does not include the allocation size of the keys and values.
  */
 size_t RM_MallocSizeDict(RedisModuleDict* dict) {
-    size_t size = sizeof(RedisModuleDict) + sizeof(rax);
-    size += dict->rax->numnodes * sizeof(raxNode);
-    /* For more info about this weird line, see streamRadixTreeMemoryUsage */
-    size += dict->rax->numnodes * sizeof(long)*30;
-    return size;
+    return dict->alloc_size;
 }
 
 /* Return the a number between 0 to 1 indicating the amount of memory


### PR DESCRIPTION
Use rax memory accounting for RedisModuleDict.

Suggested-by: debing.sun <debing.sun@redis.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes module dict allocation and memory-size reporting to rely on rax’s internal accounting, which can affect module memory introspection and defrag correctness if the accounting pointer is mishandled.
> 
> **Overview**
> Switches `RedisModuleDict` memory tracking to use rax’s built-in allocation accounting instead of estimating node sizes.
> 
> `RM_CreateDict` now allocates the dict with `zmalloc_usable`, stores the initial allocation in a new `alloc_size` field, and creates the underlying rax via `raxNewWithMetadata(..., &dict->alloc_size)` so rax updates the same counter. `RM_MallocSizeDict` is simplified to return `dict->alloc_size`, and defrag logic updates `dict->rax->alloc_size` to keep the accounting pointer valid after `RedisModuleDict` relocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60f79c82b4d7ac09e74919d946d641a09c9d0844. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->