### PR TITLE
Fix hotkeys result key name

### DIFF
--- a/src/commands/hotkeys-get.json
+++ b/src/commands/hotkeys-get.json
@@ -44,7 +44,7 @@
                                 },
                                 "description": "Array of slot ranges. Each element is an array: single-element [slot] for individual slots, or two-element [start, end] for inclusive ranges."
                             },
-                            "sampled-command-selected-slots-us": {
+                            "sampled-commands-selected-slots-us": {
                                 "type": "integer",
                                 "description": "CPU time in microseconds for sampled commands in selected slots (only present when sampling and slots are configured)."
                             },

--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -545,9 +545,9 @@ void hotkeysCommand(client *c) {
         addReplyBulkCString(c, "selected-slots");
         addReplySelectedSlots(c, server.hotkeys);
 
-        /* sampled-command-selected-slots-us (conditional) */
+        /* sampled-commands-selected-slots-us (conditional) */
         if (has_sampling && has_selected_slots) {
-            addReplyBulkCString(c, "sampled-command-selected-slots-us");
+            addReplyBulkCString(c, "sampled-commands-selected-slots-us");
             addReplyLongLong(c, server.hotkeys->time_sampled_commands_selected_slots);
 
             total_len++;

--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -312,7 +312,7 @@ start_server {tags {external:skip "hotkeys"}} {
         }
 
         # Should NOT have selected-slots conditional fields
-        assert {![dict exists $result "sampled-command-selected-slots-us"]}
+        assert {![dict exists $result "sampled-commands-selected-slots-us"]}
         assert {![dict exists $result "all-commands-selected-slots-us"]}
         assert {![dict exists $result "net-bytes-sampled-commands-selected-slots"]}
         assert {![dict exists $result "net-bytes-all-commands-selected-slots"]}
@@ -571,7 +571,7 @@ start_cluster 1 0 {tags {external:skip cluster hotkeys}} {
         }
 
         # Should have conditional fields
-        assert [dict exists $result "sampled-command-selected-slots-us"]
+        assert [dict exists $result "sampled-commands-selected-slots-us"]
         assert [dict exists $result "all-commands-selected-slots-us"]
         assert [dict exists $result "net-bytes-sampled-commands-selected-slots"]
         assert [dict exists $result "net-bytes-all-commands-selected-slots"]
@@ -590,7 +590,7 @@ start_cluster 1 0 {tags {external:skip cluster hotkeys}} {
         }
 
         # Should NOT have sampled-commands fields (sample_ratio = 1)
-        assert {![dict exists $result "sampled-command-selected-slots-us"]}
+        assert {![dict exists $result "sampled-commands-selected-slots-us"]}
         assert {![dict exists $result "net-bytes-sampled-commands-selected-slots"]}
 
         # Should have all-commands-selected-slots fields


### PR DESCRIPTION
Key in the result of HOTKEYS `sampled-command-selected-slots-us` changed to `sampled-commands-selected-slots-us` in order to be aligned with the other key names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only API key rename plus schema/test updates; functional tracking logic is unchanged, with main risk being client compatibility with the old field name.
> 
> **Overview**
> Renames the `HOTKEYS GET` reply field `sampled-command-selected-slots-us` to `sampled-commands-selected-slots-us` to match the naming pattern of other metrics.
> 
> Updates the command reply schema (`hotkeys-get.json`) and unit tests to assert the new key name in both presence/absence cases for conditional sampled/selected-slots metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45c202f8c2db4b96f5cf081247de83dc33dd463a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->