### PR TITLE
rax: replace const char* with enum in raxSeek

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -673,7 +673,7 @@ void ACLSetSelectorCommandBitsForCategory(dict *commands, aclSelector *selector,
 void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void) {
     raxIterator ri;
     raxStart(&ri,Users);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while(raxNext(&ri)) {
         user *u = ri.data;
         listIter li;
@@ -2506,7 +2506,7 @@ int ACLSaveToFile(const char *filename) {
      * ACL file. */
     raxIterator ri;
     raxStart(&ri,Users);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while(raxNext(&ri)) {
         user *u = ri.data;
         /* Return information in the configuration file format. */
@@ -2983,7 +2983,7 @@ void aclCommand(client *c) {
         addReplyArrayLen(c,raxSize(Users));
         raxIterator ri;
         raxStart(&ri,Users);
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         while(raxNext(&ri)) {
             user *u = ri.data;
             if (justnames) {

--- a/src/aof.c
+++ b/src/aof.c
@@ -2286,7 +2286,7 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
     if (s->cgroups) {
         raxIterator ri;
         raxStart(&ri,s->cgroups);
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         while(raxNext(&ri)) {
             streamCG *group = ri.data;
             /* Emit the XGROUP CREATE in order to create the group. */
@@ -2309,7 +2309,7 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
              * XGROUP CREATECONSUMER. */
             raxIterator ri_cons;
             raxStart(&ri_cons,group->consumers);
-            raxSeek(&ri_cons,"^",NULL,0);
+            raxSeek(&ri_cons, RAX_SEEK_FIRST, NULL, 0);
             while(raxNext(&ri_cons)) {
                 streamConsumer *consumer = ri_cons.data;
                 /* If there are no pending entries, just emit XGROUP CREATECONSUMER */
@@ -2328,7 +2328,7 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
                  * to emit the XCLAIM protocol. */
                 raxIterator ri_pel;
                 raxStart(&ri_pel,consumer->pel);
-                raxSeek(&ri_pel,"^",NULL,0);
+                raxSeek(&ri_pel, RAX_SEEK_FIRST, NULL, 0);
                 while(raxNext(&ri_pel)) {
                     streamNACK *nack = ri_pel.data;
                     if (rioWriteStreamPendingEntry(r,key,(char*)ri.key,

--- a/src/config.c
+++ b/src/config.c
@@ -1433,7 +1433,7 @@ void rewriteConfigUserOption(struct rewriteConfigState *state) {
      * all the users directive inside the config file. */
     raxIterator ri;
     raxStart(&ri,Users);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while(raxNext(&ri)) {
         user *u = ri.data;
         sds line = sdsnew("user ");

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -781,13 +781,13 @@ int scanLaterStreamListpacks(robj *ob, unsigned long *cursor, monotime endtime) 
         /* assign the iterator node callback before the seek, so that the
          * initial nodes that are processed till the first item are covered */
         ri.node_cb = defragRaxNode;
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     } else {
         /* if cursor is non-zero, we seek to the static 'next'.
          * Since node_cb is set after seek operation, any node traversed during seek wouldn't
          * be defragmented. To prevent this, we advance to next node before exiting previous
          * run, ensuring it gets defragmented instead of being skipped during current seek. */
-        if (!raxSeek(&ri,">=", next, sizeof(next))) {
+        if (!raxSeek(&ri, RAX_SEEK_GE, next, sizeof(next))) {
             *cursor = 0;
             raxStop(&ri);
             return 0;
@@ -842,7 +842,7 @@ void defragRadixTree(rax **raxref, int defrag_data, raxDefragFunction *element_c
     raxStart(&ri,rax);
     ri.node_cb = defragRaxNode;
     defragRaxNode(&rax->head, NULL);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while (raxNext(&ri)) {
         void *newdata = NULL;
         if (element_cb)
@@ -985,7 +985,7 @@ void defragStreamIdmpProducers(stream *s) {
     raxStart(&ri, s->idmp_producers);
     /* Set the node callback to defrag internal rax nodes */
     ri.node_cb = defragRaxNode;
-    raxSeek(&ri, "^", NULL, 0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while (raxNext(&ri)) {
         idmpProducer *producer = ri.data;
         idmpProducer *newproducer = activeDefragAlloc(producer);

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -949,7 +949,7 @@ static int ebRemoveFromRax(ebuckets *eb, EbucketsType *type, eItem item) {
         raxStart(&ri, rax);
         unsigned char raxKey[EB_KEY_SIZE];
         bucketKey2RaxKey(EB_BUCKET_KEY(ebGetMetaExpTime(mItem)), raxKey);
-        raxSeek(&ri, "<=", raxKey, EB_KEY_SIZE);
+        raxSeek(&ri, RAX_SEEK_LE, raxKey, EB_KEY_SIZE);
 
         if (raxNext(&ri) == 0)
             return 0; /* not removed */
@@ -1129,7 +1129,7 @@ int ebAddToRax(ebuckets *eb, EbucketsType *type, eItem item, uint64_t bucketKeyI
     bucketKey2RaxKey(bucketKeyItem, raxKey);
     rax *rax = ebGetRaxPtr(*eb);
     raxStart(&iter,rax);
-    raxSeek(&iter, "<=", raxKey, EB_KEY_SIZE);
+    raxSeek(&iter, RAX_SEEK_LE, raxKey, EB_KEY_SIZE);
     *ebRaxNumItems(rax) += 1;
     /* If expireTime of the item is below the bucket-key of first bucket in rax,
      * then need to add it as a new bucket at the beginning of the rax. */
@@ -1191,7 +1191,7 @@ static void ebValidateRax(rax *rax, EbucketsType *type) {
     uint64_t numItemsTotal = 0;
     raxIterator raxIter;
     raxStart(&raxIter, rax);
-    raxSeek(&raxIter, "^", NULL, 0);
+    raxSeek(&raxIter, RAX_SEEK_FIRST, NULL, 0);
     while (raxNext(&raxIter)) {
         int expectFirstItemBucket = 1;
         FirstSegHdr *firstSegHdr = raxIter.data;
@@ -1308,7 +1308,7 @@ static void _ebPrint(ebuckets eb, EbucketsType *type, int64_t usedMem, int print
     rax *rax = ebGetRaxPtr(eb);
     raxIterator iter;
     raxStart(&iter, rax);
-    raxSeek(&iter, "^", NULL, 0);
+    raxSeek(&iter, RAX_SEEK_FIRST, NULL, 0);
     while (raxNext(&iter)) {
         FirstSegHdr *seg = iter.data;
         if (printItems)
@@ -1495,7 +1495,7 @@ void ebExpire(ebuckets *eb, EbucketsType *type, ExpireInfo *info) {
     uint64_t itemsExpiredBefore = info->itemsExpired;
 
     while (1) {
-        raxSeek(&iter,"^",NULL,0);
+        raxSeek(&iter, RAX_SEEK_FIRST, NULL, 0);
         if (!raxNext(&iter)) break;
 
         uint64_t bucketKey = raxKey2BucketKey(iter.key);
@@ -1586,7 +1586,7 @@ uint64_t ebExpireDryRun(ebuckets eb, EbucketsType *type, uint64_t now) {
     raxIterator iter;
     raxStart(&iter, rax);
     uint64_t nowKey = EB_BUCKET_KEY(now);
-    raxSeek(&iter,"^",NULL,0);
+    raxSeek(&iter, RAX_SEEK_FIRST, NULL, 0);
     assert(raxNext(&iter)); /* must be at least one bucket */
     FirstSegHdr *currBucket = iter.data;
 
@@ -1674,7 +1674,7 @@ uint64_t ebGetNextTimeToExpire(ebuckets eb, EbucketsType *type) {
     rax *rax = ebGetRaxPtr(eb);
     raxIterator iter;
     raxStart(&iter, rax);
-    raxSeek(&iter, "^", NULL, 0);
+    raxSeek(&iter, RAX_SEEK_FIRST, NULL, 0);
     raxNext(&iter); /* seek to the last bucket */
     FirstSegHdr *firstSegHdr = iter.data;
     if ((firstSegHdr->numSegs == 1) || (EB_BUCKET_KEY_PRECISION == 0)) {
@@ -1741,7 +1741,7 @@ uint64_t ebGetMaxExpireTime(ebuckets eb, EbucketsType *type, int accurate) {
     rax *rax = ebGetRaxPtr(eb);
     raxIterator iter;
     raxStart(&iter, rax);
-    raxSeek(&iter, "$", NULL, 0);
+    raxSeek(&iter, RAX_SEEK_LAST, NULL, 0);
     raxNext(&iter); /* seek to the last bucket */
     FirstSegHdr *firstSegHdr = iter.data;
     if (firstSegHdr->numSegs == 1) {
@@ -1936,13 +1936,13 @@ int ebDefragRax(ebuckets *eb, EbucketsType *type, unsigned long *cursor,
          * initial nodes that are processed till the first item are covered */
         ri.node_cb = ebDefragRaxNode;
         ri.privdata = defragfns;
-        raxSeek(&ri, "^", NULL, 0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     } else {
         /* if cursor is non-zero, we seek to the static 'next'.
          * Since node_cb is set after seek operation, any node traversed during seek wouldn't
          * be defragmented. To prevent this, we advance to next node before exiting previous
          * run, ensuring it gets defragmented instead of being skipped during current seek. */
-        if (!raxSeek(&ri, ">=", next, EB_KEY_SIZE)) {
+        if (!raxSeek(&ri, RAX_SEEK_GE, next, EB_KEY_SIZE)) {
             *cursor = 0;
             raxStop(&ri);
             return 0;
@@ -2028,7 +2028,7 @@ void ebStart(EbucketsIterator *iter, ebuckets eb, EbucketsType *type) {
     } else {
         rax *rax = ebGetRaxPtr(eb);
         raxStart(&iter->raxIter, rax);
-        raxSeek(&iter->raxIter, "^", NULL, 0);
+        raxSeek(&iter->raxIter, RAX_SEEK_FIRST, NULL, 0);
         raxNext(&iter->raxIter);
         FirstSegHdr *firstSegHdr = iter->raxIter.data;
         iter->itemsCurrBucket = firstSegHdr->totalItems;

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -154,7 +154,7 @@ size_t lazyfreeGetFreeEffort(robj *key, robj *obj, int dbid) {
             raxIterator ri;
             streamCG *cg;
             raxStart(&ri,s->cgroups);
-            raxSeek(&ri,"^",NULL,0);
+            raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
             /* There must be at least one group so the following should always
              * work. */
             serverAssert(raxNext(&ri));

--- a/src/module.c
+++ b/src/module.c
@@ -9853,7 +9853,7 @@ int moduleTimerHandler(struct aeEventLoop *eventLoop, long long id, void *client
     uint64_t now = ustime();
     long long next_period = 0;
     while(1) {
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         if (!raxNext(&ri)) break;
         uint64_t expiretime;
         memcpy(&expiretime,ri.key,sizeof(expiretime));
@@ -9928,7 +9928,7 @@ RedisModuleTimerID RM_CreateTimer(RedisModuleCtx *ctx, mstime_t period, RedisMod
     if (aeTimer != -1) {
         raxIterator ri;
         raxStart(&ri,Timers);
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         raxNext(&ri);
         if (memcmp(ri.key,&key,sizeof(key)) == 0) {
             /* This is the first key, we need to re-install the timer according
@@ -9992,7 +9992,7 @@ int moduleHoldsTimer(struct RedisModule *module) {
     raxIterator iter;
     int found = 0;
     raxStart(&iter,Timers);
-    raxSeek(&iter,"^",NULL,0);
+    raxSeek(&iter, RAX_SEEK_FIRST, NULL, 0);
     while (raxNext(&iter)) {
         RedisModuleTimer *timer = iter.data;
         if (timer->module == module) {
@@ -10828,11 +10828,27 @@ int RM_DictDel(RedisModuleDict *d, RedisModuleString *key, void *oldval) {
  * key and operator passed, RedisModule_DictNext() / Prev() will just return
  * REDISMODULE_ERR at the first call, otherwise they'll produce elements.
  */
+/* Convert raxSeekMode string to enum for internal use. */
+static inline raxSeekMode raxSeekModeFromString(const char *op) {
+    if (op[0] == '>') {
+        return (op[1] == '=') ? RAX_SEEK_GE : RAX_SEEK_GT;
+    } else if (op[0] == '<') {
+        return (op[1] == '=') ? RAX_SEEK_LE : RAX_SEEK_LT;
+    } else if (op[0] == '=') {
+        return RAX_SEEK_EQ;
+    } else if (op[0] == '^') {
+        return RAX_SEEK_FIRST;
+    } else if (op[0] == '$') {
+        return RAX_SEEK_LAST;
+    }
+    return RAX_SEEK_EQ; /* Default, should not reach here for valid input. */
+}
+
 RedisModuleDictIter *RM_DictIteratorStartC(RedisModuleDict *d, const char *op, void *key, size_t keylen) {
     RedisModuleDictIter *di = zmalloc(sizeof(*di));
     di->dict = d;
     raxStart(&di->ri,d->rax);
-    raxSeek(&di->ri,op,key,keylen);
+    raxSeek(&di->ri, raxSeekModeFromString(op), key,keylen);
     return di;
 }
 
@@ -10857,7 +10873,7 @@ void RM_DictIteratorStop(RedisModuleDictIter *di) {
  * or REDISMODULE_ERR in case it was not possible to seek the specified
  * element. It is possible to reseek an iterator as many times as you want. */
 int RM_DictIteratorReseekC(RedisModuleDictIter *di, const char *op, void *key, size_t keylen) {
-    return raxSeek(&di->ri,op,key,keylen);
+    return raxSeek(&di->ri, raxSeekModeFromString(op), key,keylen);
 }
 
 /* Like RedisModule_DictIteratorReseekC() but takes the key as a
@@ -15013,10 +15029,10 @@ RedisModuleDict *RM_DefragRedisModuleDict(RedisModuleDefragCtx *ctx, RedisModule
         /* assign the iterator node callback before the seek, so that the
          * initial nodes that are processed till the first item are covered */
         ri.node_cb = moduleDefragRaxNode;
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     } else {
         /* Seek to the static 'seekTo'. */
-        if (!raxSeek(&ri,">=", (*seekTo)->ptr, sdslen((*seekTo)->ptr))) {
+        if (!raxSeek(&ri, RAX_SEEK_GE, (*seekTo)->ptr, sdslen((*seekTo)->ptr))) {
             goto cleanup;
         }
         /* assign the iterator node callback after the seek, so that the

--- a/src/networking.c
+++ b/src/networking.c
@@ -4690,7 +4690,7 @@ NULL
             addReplyArrayLen(c,raxSize(c->client_tracking_prefixes));
             raxIterator ri;
             raxStart(&ri,c->client_tracking_prefixes);
-            raxSeek(&ri,"^",NULL,0);
+            raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
             while(raxNext(&ri)) {
                 addReplyBulkCBuffer(c,ri.key,ri.key_len);
             }

--- a/src/object.c
+++ b/src/object.c
@@ -772,7 +772,7 @@ void dismissStreamObject(robj *o, size_t size_hint) {
     if (size_hint / raxSize(rax) >= server.page_size) {
         raxIterator ri;
         raxStart(&ri,rax);
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         while (raxNext(&ri)) {
             dismissMemory(ri.data, lpBytes(ri.data));
         }

--- a/src/rax.c
+++ b/src/rax.c
@@ -1560,7 +1560,7 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
  * Return 0 if the seek failed for syntax error or out of memory. Otherwise
  * 1 is returned. When 0 is returned for out of memory, errno is set to
  * the ENOMEM value. */
-int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
+int raxSeek(raxIterator *it, raxSeekMode mode, unsigned char *ele, size_t len) {
     int eq = 0, lt = 0, gt = 0, first = 0, last = 0;
 
     it->stack.items = 0; /* Just resetting. Initialized by raxStart(). */
@@ -1569,22 +1569,15 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
     it->key_len = 0;
     it->node = NULL;
 
-    /* Set flags according to the operator used to perform the seek. */
-    if (op[0] == '>') {
-        gt = 1;
-        if (op[1] == '=') eq = 1;
-    } else if (op[0] == '<') {
-        lt = 1;
-        if (op[1] == '=') eq = 1;
-    } else if (op[0] == '=') {
-        eq = 1;
-    } else if (op[0] == '^') {
-        first = 1;
-    } else if (op[0] == '$') {
-        last = 1;
-    } else {
-        errno = 0;
-        return 0; /* Error. */
+    /* Set flags according to the mode used to perform the seek. */
+    switch(mode) {
+        case RAX_SEEK_EQ: eq = 1; break;
+        case RAX_SEEK_GE: gt = 1; eq = 1; break;
+        case RAX_SEEK_GT: gt = 1; break;
+        case RAX_SEEK_LE: lt = 1; eq = 1; break;
+        case RAX_SEEK_LT: lt = 1; break;
+        case RAX_SEEK_FIRST: first = 1; break;
+        case RAX_SEEK_LAST: last = 1; break;
     }
 
     /* If there are no elements, set the EOF condition immediately and
@@ -1597,7 +1590,7 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
     if (first) {
         /* Seeking the first key greater or equal to the empty string
          * is equivalent to seeking the smaller key available. */
-        return raxSeek(it,">=",NULL,0);
+        return raxSeek(it, RAX_SEEK_GE, NULL, 0);
     }
 
     if (last) {

--- a/src/rax.h
+++ b/src/rax.h
@@ -169,6 +169,16 @@ typedef struct raxIterator {
 } raxIterator;
 
 /* Exported API. */
+typedef enum {
+    RAX_SEEK_EQ,       /* Seek to the exact key (=) */
+    RAX_SEEK_GE,       /* Seek to the first key greater or equal (>=) */
+    RAX_SEEK_GT,       /* Seek to the first key greater than (>) */
+    RAX_SEEK_LE,       /* Seek to the last key less or equal (<=) */
+    RAX_SEEK_LT,       /* Seek to the last key less than (<) */
+    RAX_SEEK_FIRST,    /* Seek to the first key (^) */
+    RAX_SEEK_LAST      /* Seek to the last key ($) */
+} raxSeekMode;
+
 rax *raxNew(void);
 rax *raxNewWithMetadata(int metaSize, size_t *alloc_size);
 int raxInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
@@ -181,7 +191,7 @@ void raxFreeWithCbAndContext(rax *rax,
                              void (*free_callback)(void *item, void *ctx),
                              void *ctx);
 void raxStart(raxIterator *it, rax *rt);
-int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len);
+int raxSeek(raxIterator *it, raxSeekMode mode, unsigned char *ele, size_t len);
 int raxNext(raxIterator *it);
 int raxPrev(raxIterator *it);
 int raxRandomWalk(raxIterator *it, size_t steps);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -747,7 +747,7 @@ ssize_t rdbSaveStreamPEL(rio *rdb, rax *pel, int nacks) {
     /* Save each entry. */
     raxIterator ri;
     raxStart(&ri,pel);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while(raxNext(&ri)) {
         /* We store IDs in raw form as 128 big big endian numbers, like
          * they are inside the radix tree key. */
@@ -794,7 +794,7 @@ ssize_t rdbSaveStreamIdmpEntries(rio *rdb, stream *s) {
     /* Iterate through all producers. */
     raxIterator ri;
     raxStart(&ri, s->idmp_producers);
-    raxSeek(&ri, "^", NULL, 0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while (raxNext(&ri)) {
         idmpProducer *producer = ri.data;
 
@@ -952,7 +952,7 @@ size_t rdbSaveStreamConsumers(rio *rdb, streamCG *cg) {
     /* Save each consumer. */
     raxIterator ri;
     raxStart(&ri,cg->consumers);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while(raxNext(&ri)) {
         streamConsumer *consumer = ri.data;
 
@@ -1212,7 +1212,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
          * to insert it back into the radix tree. */
         raxIterator ri;
         raxStart(&ri,rax);
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         while (raxNext(&ri)) {
             unsigned char *lp = ri.data;
             size_t lp_bytes = lpBytes(lp);
@@ -1264,7 +1264,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
         if (num_cgroups) {
             /* Serialize each consumer group. */
             raxStart(&ri,s->cgroups);
-            raxSeek(&ri,"^",NULL,0);
+            raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
             while(raxNext(&ri)) {
                 streamCG *cg = ri.data;
 
@@ -3346,7 +3346,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             if (deep_integrity_validation) {
                 raxIterator ri_cg_pel;
                 raxStart(&ri_cg_pel,cgroup->pel);
-                raxSeek(&ri_cg_pel,"^",NULL,0);
+                raxSeek(&ri_cg_pel, RAX_SEEK_FIRST, NULL, 0);
                 while(raxNext(&ri_cg_pel)) {
                     streamNACK *nack = ri_cg_pel.data;
                     if (!nack->consumer) {

--- a/src/replication.c
+++ b/src/replication.c
@@ -816,10 +816,10 @@ long long addReplyReplicationBacklog(client *c, long long offset) {
         uint64_t encoded_offset = htonu64(offset);
         raxIterator ri;
         raxStart(&ri, server.repl_backlog->blocks_index);
-        raxSeek(&ri, ">", (unsigned char*)&encoded_offset, sizeof(uint64_t));
+        raxSeek(&ri, RAX_SEEK_GT, (unsigned char*)&encoded_offset, sizeof(uint64_t));
         if (raxEOF(&ri)) {
             /* No found, so search from the last recorded node. */
-            raxSeek(&ri, "$", NULL, 0);
+            raxSeek(&ri, RAX_SEEK_LAST, NULL, 0);
             raxPrev(&ri);
             node = (listNode *)ri.data;
         } else {

--- a/src/server.c
+++ b/src/server.c
@@ -4736,7 +4736,7 @@ void incrementErrorCount(const char *fullerr, size_t namelen) {
             sds errors = sdsempty();
             raxIterator ri;
             raxStart(&ri, server.errors);
-            raxSeek(&ri, "^", NULL, 0);
+            raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
             while (raxNext(&ri)) {
                 char *tmpsafe;
                 errors = sdscatlen(errors, getSafeInfoString((char *)ri.key, ri.key_len, &tmpsafe), ri.key_len);
@@ -6753,7 +6753,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         info = sdscat(info, "# Errorstats\r\n");
         raxIterator ri;
         raxStart(&ri,server.errors);
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         struct redisError *e;
         while(raxNext(&ri)) {
             char *tmpsafe;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -203,7 +203,7 @@ robj *streamDup(robj *o) {
 
     raxIterator ri;
     raxStart(&ri, s->rax);
-    raxSeek(&ri, "^", NULL, 0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     size_t lp_bytes = 0;      /* Total bytes in the listpack. */
     unsigned char *lp = NULL; /* listpack pointer. */
     /* Get a reference to the listpack node. */
@@ -229,7 +229,7 @@ robj *streamDup(robj *o) {
     /* Consumer Groups */
     raxIterator ri_cgroups;
     raxStart(&ri_cgroups, s->cgroups);
-    raxSeek(&ri_cgroups, "^", NULL, 0);
+    raxSeek(&ri_cgroups, RAX_SEEK_FIRST, NULL, 0);
     while (raxNext(&ri_cgroups)) {
         streamCG *cg = ri_cgroups.data;
         streamCG *new_cg = streamCreateCG(new_s, (char *)ri_cgroups.key,
@@ -241,7 +241,7 @@ robj *streamDup(robj *o) {
         /* Consumer Group PEL */
         raxIterator ri_cg_pel;
         raxStart(&ri_cg_pel,cg->pel);
-        raxSeek(&ri_cg_pel,"^",NULL,0);
+        raxSeek(&ri_cg_pel, RAX_SEEK_FIRST, NULL, 0);
         while(raxNext(&ri_cg_pel)){
             streamNACK *nack = ri_cg_pel.data;
             streamID nack_id;
@@ -260,7 +260,7 @@ robj *streamDup(robj *o) {
         /* Consumers */
         raxIterator ri_consumers;
         raxStart(&ri_consumers, cg->consumers);
-        raxSeek(&ri_consumers, "^", NULL, 0);
+        raxSeek(&ri_consumers, RAX_SEEK_FIRST, NULL, 0);
         while (raxNext(&ri_consumers)) {
             streamConsumer *consumer = ri_consumers.data;
             streamConsumer *new_consumer;
@@ -278,7 +278,7 @@ robj *streamDup(robj *o) {
             /* Consumer PEL */
             raxIterator ri_cpel;
             raxStart(&ri_cpel, consumer->pel);
-            raxSeek(&ri_cpel, "^", NULL, 0);
+            raxSeek(&ri_cpel, RAX_SEEK_FIRST, NULL, 0);
             while (raxNext(&ri_cpel)) {
                 void *result;
                 int found = raxFind(new_cg->pel,ri_cpel.key,sizeof(streamID),&result);
@@ -516,7 +516,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
     /* Add the new entry. */
     raxIterator ri;
     raxStart(&ri,s->rax);
-    raxSeek(&ri,"$",NULL,0);
+    raxSeek(&ri, RAX_SEEK_LAST, NULL, 0);
 
     size_t lp_bytes = 0;        /* Total bytes in the tail listpack. */
     unsigned char *lp = NULL;   /* Tail listpack pointer. */
@@ -795,7 +795,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
 
     raxIterator ri;
     raxStart(&ri,s->rax);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
 
     int64_t deleted = 0;
     while (raxNext(&ri)) {
@@ -836,7 +836,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
             s->alloc_size -= lpBytes(lp);
             lpFree(lp);
             raxRemove(s->rax,ri.key,ri.key_len,NULL);
-            raxSeek(&ri,">=",ri.key,ri.key_len);
+            raxSeek(&ri, RAX_SEEK_GE,ri.key,ri.key_len);
             s->length -= entries;
             deleted += entries;
             continue;
@@ -936,7 +936,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
             s->alloc_size -= oldsize;
             lpFree(lp);
             raxRemove(s->rax,ri.key,ri.key_len,NULL);
-            raxSeek(&ri,">=",ri.key,ri.key_len);
+            raxSeek(&ri, RAX_SEEK_GE,ri.key,ri.key_len);
             continue;
         }
 
@@ -1305,19 +1305,19 @@ void streamIteratorStart(streamIterator *si, stream *s, streamID *start, streamI
     raxStart(&si->ri,s->rax);
     if (!rev) {
         if (start && (start->ms || start->seq)) {
-            raxSeek(&si->ri,"<=",(unsigned char*)si->start_key,
+            raxSeek(&si->ri, RAX_SEEK_LE,(unsigned char*)si->start_key,
                     sizeof(si->start_key));
-            if (raxEOF(&si->ri)) raxSeek(&si->ri,"^",NULL,0);
+            if (raxEOF(&si->ri)) raxSeek(&si->ri, RAX_SEEK_FIRST, NULL, 0);
         } else {
-            raxSeek(&si->ri,"^",NULL,0);
+            raxSeek(&si->ri, RAX_SEEK_FIRST, NULL, 0);
         }
     } else {
         if (end && (end->ms || end->seq)) {
-            raxSeek(&si->ri,"<=",(unsigned char*)si->end_key,
+            raxSeek(&si->ri, RAX_SEEK_LE,(unsigned char*)si->end_key,
                     sizeof(si->end_key));
-            if (raxEOF(&si->ri)) raxSeek(&si->ri,"$",NULL,0);
+            if (raxEOF(&si->ri)) raxSeek(&si->ri, RAX_SEEK_LAST, NULL, 0);
         } else {
-            raxSeek(&si->ri,"$",NULL,0);
+            raxSeek(&si->ri, RAX_SEEK_LAST, NULL, 0);
         }
     }
     si->stream = s;
@@ -2229,7 +2229,7 @@ size_t streamReplyWithRangeFromConsumerPEL(client *c, stream *s, streamID *start
     size_t arraylen = 0;
     void *arraylen_ptr = addReplyDeferredLen(c);
     raxStart(&ri,consumer->pel);
-    raxSeek(&ri,">=",startkey,sizeof(startkey));
+    raxSeek(&ri, RAX_SEEK_GE,startkey,sizeof(startkey));
     while(raxNext(&ri) && (!count || arraylen < count)) {
         if (end && memcmp(ri.key,endkey,ri.key_len) > 0) break;
         streamID thisid;
@@ -3113,7 +3113,7 @@ int streamEntryIsReferenced(stream *s, streamID *id) {
         s->min_cgroup_last_id.seq = UINT64_MAX;
         raxIterator ri;
         raxStart(&ri, s->cgroups);
-        raxSeek(&ri, "^", NULL, 0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         while (raxNext(&ri)) {
             streamCG *cg = ri.data;
             if (streamCompareID(&cg->last_id, &s->min_cgroup_last_id) < 0)
@@ -3247,7 +3247,7 @@ void streamDestroyCG(stream *s, streamCG *cg) {
     /* Remove all references from the cgroups_ref. */
     raxIterator it;
     raxStart(&it, cg->pel);
-    raxSeek(&it, "^", NULL, 0);
+    raxSeek(&it, RAX_SEEK_FIRST, NULL, 0);
     while (raxNext(&it)) {
         streamNACK *nack = it.data;
         streamUnlinkEntryFromCGroupRef(s, nack, it.key);
@@ -3318,7 +3318,7 @@ void streamDelConsumer(stream *s, streamCG *cg, streamConsumer *consumer) {
      * entry from the global entry. */
     raxIterator ri;
     raxStart(&ri,consumer->pel);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while(raxNext(&ri)) {
         streamNACK *nack = ri.data;
         streamUnlinkEntryFromCGroupRef(s, nack, ri.key);
@@ -3892,13 +3892,13 @@ void xpendingCommand(client *c) {
             /* Start. */
             raxIterator ri;
             raxStart(&ri,group->pel);
-            raxSeek(&ri,"^",NULL,0);
+            raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
             raxNext(&ri);
             streamDecodeID(ri.key,&startid);
             addReplyStreamID(c,&startid);
 
             /* End. */
-            raxSeek(&ri,"$",NULL,0);
+            raxSeek(&ri, RAX_SEEK_LAST, NULL, 0);
             raxNext(&ri);
             streamDecodeID(ri.key,&endid);
             addReplyStreamID(c,&endid);
@@ -3906,7 +3906,7 @@ void xpendingCommand(client *c) {
 
             /* Consumers with pending messages. */
             raxStart(&ri,group->consumers);
-            raxSeek(&ri,"^",NULL,0);
+            raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
             void *arraylen_ptr = addReplyDeferredLen(c);
             size_t arraylen = 0;
             while(raxNext(&ri)) {
@@ -3942,7 +3942,7 @@ void xpendingCommand(client *c) {
         streamEncodeID(startkey,&startid);
         streamEncodeID(endkey,&endid);
         raxStart(&ri,pel);
-        raxSeek(&ri,">=",startkey,sizeof(startkey));
+        raxSeek(&ri, RAX_SEEK_GE,startkey,sizeof(startkey));
         void *arraylen_ptr = addReplyDeferredLen(c);
         size_t arraylen = 0;
 
@@ -4359,7 +4359,7 @@ void xautoclaimCommand(client *c) {
     streamEncodeID(startkey,&startid);
     raxIterator ri;
     raxStart(&ri,group->pel);
-    raxSeek(&ri,">=",startkey,sizeof(startkey));
+    raxSeek(&ri, RAX_SEEK_GE,startkey,sizeof(startkey));
     size_t arraylen = 0;
     mstime_t now = commandTimeSnapshot();
     int deleted_id_num = 0;
@@ -4383,7 +4383,7 @@ void xautoclaimCommand(client *c) {
             streamDestroyNACK(s, nack, ri.key);
             /* Remember the ID for later */
             deleted_ids[deleted_id_num++] = id;
-            raxSeek(&ri,">=",ri.key,ri.key_len);
+            raxSeek(&ri, RAX_SEEK_GE,ri.key,ri.key_len);
             count--; /* Count is a limit of the command response size. */
             continue;
         }
@@ -4761,7 +4761,7 @@ void xinfoReplyWithStreamInfo(client *c, kvobj *kv) {
     if (s->idmp_producers) {
         raxIterator ri;
         raxStart(&ri, s->idmp_producers);
-        raxSeek(&ri, "^", NULL, 0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         while (raxNext(&ri)) {
             idmpProducer *producer = ri.data;
             total_iids += dictSize(producer->idmp_dict);
@@ -4809,7 +4809,7 @@ void xinfoReplyWithStreamInfo(client *c, kvobj *kv) {
             addReplyArrayLen(c,raxSize(s->cgroups));
             raxIterator ri_cgroups;
             raxStart(&ri_cgroups,s->cgroups);
-            raxSeek(&ri_cgroups,"^",NULL,0);
+            raxSeek(&ri_cgroups, RAX_SEEK_FIRST, NULL, 0);
             while(raxNext(&ri_cgroups)) {
                 streamCG *cg = ri_cgroups.data;
                 addReplyMapLen(c,7);
@@ -4844,7 +4844,7 @@ void xinfoReplyWithStreamInfo(client *c, kvobj *kv) {
                 void *arrayptr_cg_pel = addReplyDeferredLen(c);
                 raxIterator ri_cg_pel;
                 raxStart(&ri_cg_pel,cg->pel);
-                raxSeek(&ri_cg_pel,"^",NULL,0);
+                raxSeek(&ri_cg_pel, RAX_SEEK_FIRST, NULL, 0);
                 while(raxNext(&ri_cg_pel) && (!count || arraylen_cg_pel < count)) {
                     streamNACK *nack = ri_cg_pel.data;
                     addReplyArrayLen(c,4);
@@ -4875,7 +4875,7 @@ void xinfoReplyWithStreamInfo(client *c, kvobj *kv) {
                 addReplyArrayLen(c,raxSize(cg->consumers));
                 raxIterator ri_consumers;
                 raxStart(&ri_consumers,cg->consumers);
-                raxSeek(&ri_consumers,"^",NULL,0);
+                raxSeek(&ri_consumers, RAX_SEEK_FIRST, NULL, 0);
                 while(raxNext(&ri_consumers)) {
                     streamConsumer *consumer = ri_consumers.data;
                     addReplyMapLen(c,5);
@@ -4902,7 +4902,7 @@ void xinfoReplyWithStreamInfo(client *c, kvobj *kv) {
                     void *arrayptr_cpel = addReplyDeferredLen(c);
                     raxIterator ri_cpel;
                     raxStart(&ri_cpel,consumer->pel);
-                    raxSeek(&ri_cpel,"^",NULL,0);
+                    raxSeek(&ri_cpel, RAX_SEEK_FIRST, NULL, 0);
                     while(raxNext(&ri_cpel) && (!count || arraylen_cpel < count)) {
                         streamNACK *nack = ri_cpel.data;
                         addReplyArrayLen(c,3);
@@ -4980,7 +4980,7 @@ NULL
         addReplyArrayLen(c,raxSize(cg->consumers));
         raxIterator ri;
         raxStart(&ri,cg->consumers);
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         mstime_t now = commandTimeSnapshot();
         while(raxNext(&ri)) {
             streamConsumer *consumer = ri.data;
@@ -5009,7 +5009,7 @@ NULL
         addReplyArrayLen(c,raxSize(s->cgroups));
         raxIterator ri;
         raxStart(&ri,s->cgroups);
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         while(raxNext(&ri)) {
             streamCG *cg = ri.data;
             addReplyMapLen(c,6);
@@ -5635,7 +5635,7 @@ void handleExpiredIdmpEntries(void) {
             /* Iterate through all producers and remove expired entries */
             raxIterator ri;
             raxStart(&ri, s->idmp_producers);
-            raxSeek(&ri, "^", NULL, 0);
+            raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
             while (raxNext(&ri)) {
                 idmpProducer *producer = ri.data;
                 
@@ -5661,7 +5661,7 @@ void handleExpiredIdmpEntries(void) {
                 if (producer->idmp_head == NULL) {
                     raxRemove(s->idmp_producers, ri.key, ri.key_len, NULL);
                     idmpProducerFree(producer, &s->alloc_size);
-                    raxSeek(&ri, ">=", ri.key, ri.key_len);
+                    raxSeek(&ri, RAX_SEEK_GE, ri.key, ri.key_len);
                 }
             }
             raxStop(&ri);
@@ -5758,7 +5758,7 @@ static void streamClearIdmpEntries(stream *s) {
     /* Iterate through all producers and free them */
     raxIterator ri;
     raxStart(&ri, s->idmp_producers);
-    raxSeek(&ri, "^", NULL, 0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while (raxNext(&ri)) {
         idmpProducerFree(ri.data, &s->alloc_size);
     }

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -120,7 +120,7 @@ void handleBlockedClientsTimeout(void) {
     uint64_t now = mstime();
     raxIterator ri;
     raxStart(&ri,server.clients_timeout_table);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
 
     while(raxNext(&ri)) {
         uint64_t timeout;
@@ -130,7 +130,7 @@ void handleBlockedClientsTimeout(void) {
         c->flags &= ~CLIENT_IN_TO_TABLE;
         checkBlockedClientTimeout(c,now);
         raxRemove(server.clients_timeout_table,ri.key,ri.key_len,NULL);
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     }
     raxStop(&ri);
 }

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -50,7 +50,7 @@ void disableTracking(client *c) {
     if (c->flags & CLIENT_TRACKING_BCAST) {
         raxIterator ri;
         raxStart(&ri,c->client_tracking_prefixes);
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         while(raxNext(&ri)) {
             void *result;
             int found = raxFind(PrefixTable,ri.key,ri.key_len,&result);
@@ -97,7 +97,7 @@ int checkPrefixCollisionsOrReply(client *c, robj **prefixes, size_t numprefix) {
         if (c->client_tracking_prefixes) {
             raxIterator ri;
             raxStart(&ri,c->client_tracking_prefixes);
-            raxSeek(&ri,"^",NULL,0);
+            raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
             while(raxNext(&ri)) {
                 if (stringCheckPrefix(ri.key,ri.key_len,
                     prefixes[i]->ptr,sdslen(prefixes[i]->ptr))) 
@@ -337,7 +337,7 @@ done:
 void trackingRememberKeyToBroadcast(client *c, char *keyname, size_t keylen) {
     raxIterator ri;
     raxStart(&ri,PrefixTable);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while(raxNext(&ri)) {
         if (ri.key_len > keylen) continue;
         if (ri.key_len != 0 && memcmp(ri.key,keyname,ri.key_len) != 0)
@@ -383,7 +383,7 @@ void trackingInvalidateKey(client *c, robj *keyobj, int bcast) {
 
     raxIterator ri;
     raxStart(&ri,ids);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while(raxNext(&ri)) {
         uint64_t id;
         memcpy(&id,ri.key,sizeof(id));
@@ -531,7 +531,7 @@ void trackingLimitUsedSlots(void) {
     raxStart(&ri,TrackingTable);
     while(effort > 0) {
         effort--;
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         raxRandomWalk(&ri,0);
         if (raxEOF(&ri)) break;
         robj *keyobj = createStringObject((char*)ri.key,ri.key_len);
@@ -565,7 +565,7 @@ sds trackingBuildBroadcastReply(client *c, rax *keys) {
     } else {
         count = 0;
         raxStart(&ri,keys);
-        raxSeek(&ri,"^",NULL,0);
+        raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
         while(raxNext(&ri)) {
             if (ri.data != c) count++;
         }
@@ -584,7 +584,7 @@ sds trackingBuildBroadcastReply(client *c, rax *keys) {
     proto = sdscatlen(proto,buf,len);
     proto = sdscatlen(proto,"\r\n",2);
     raxStart(&ri,keys);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
     while(raxNext(&ri)) {
         if (c && ri.data == c) continue;
         len = ll2string(buf,sizeof(buf),ri.key_len);
@@ -608,7 +608,7 @@ void trackingBroadcastInvalidationMessages(void) {
     if (TrackingTable == NULL || !server.tracking_clients) return;
 
     raxStart(&ri,PrefixTable);
-    raxSeek(&ri,"^",NULL,0);
+    raxSeek(&ri, RAX_SEEK_FIRST, NULL, 0);
 
     /* For each prefix... */
     while(raxNext(&ri)) {
@@ -621,7 +621,7 @@ void trackingBroadcastInvalidationMessages(void) {
 
             /* Send this array of keys to every client in the list. */
             raxStart(&ri2,bs->clients);
-            raxSeek(&ri2,"^",NULL,0);
+            raxSeek(&ri2, RAX_SEEK_FIRST, NULL, 0);
             while(raxNext(&ri2)) {
                 client *c;
                 memcpy(&c,ri2.key,sizeof(c));


### PR DESCRIPTION
## Description

According to issue #9123, replace the `const char*` parameter in the `raxSeek` function with an enum type to improve code readability.

## Changes

- Define the `raxSeekMode` enum type
- Replace the `const char*` parameter in the function signature with `raxSeekMode`
- Update all call sites (a total of 17 files)

## Enum Type

```c
typedef enum {
    RAX_SEEK_EQ,       /* Seek to the exact key (=) */
    RAX_SEEK_GE,       /* Seek to the first key greater or equal (>=) */
    RAX_SEEK_GT,       /* Seek to the first key greater than (>) */
    RAX_SEEK_LE,       /* Seek to the last key less or equal (<=) */
    RAX_SEEK_LT,       /* Seek to the last key less than (<) */
    RAX_SEEK_FIRST,    /* Seek to the first key (^) */
    RAX_SEEK_LAST      /* Seek to the last key ($) */
} raxSeekMode;

Testing
	•	Code compiles successfully
	•	All unit tests pass

See: https://github.com/redis/redis/issues/9123