### PR TITLE
Pause dict auto-resize during multi-field deletion

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2946,6 +2946,7 @@ void hdelCommand(client *c) {
     }
     if (!keyremoved && o->encoding == OBJ_ENCODING_HT) {
         dictResumeAutoResize((dict*)o->ptr);
+        dictShrinkIfNeeded((dict*)o->ptr);
     }
     if (server.memory_tracking_enabled && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldsize, kvobjAllocSize(o));

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1,6 +1,9 @@
 /*
  * Copyright (c) 2009-Present, Redis Ltd.
  * All rights reserved.
+ * 
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
  *
  * Licensed under your choice of (a) the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2926,6 +2926,8 @@ void hdelCommand(client *c) {
      * field with expiration and removes it from global HFE DS. */
     int isHFE = hashTypeIsFieldsWithExpire(o);
 
+    if (o->encoding == OBJ_ENCODING_HT)
+        dictPauseAutoResize((dict*)o->ptr);
     for (j = 2; j < c->argc; j++) {
         if (hashTypeDelete(o,c->argv[j]->ptr)) {
             deleted++;
@@ -2938,6 +2940,9 @@ void hdelCommand(client *c) {
                 break;
             }
         }
+    }
+    if (!keyremoved && o->encoding == OBJ_ENCODING_HT) {
+        dictResumeAutoResize((dict*)o->ptr);
     }
     if (server.memory_tracking_enabled && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldsize, kvobjAllocSize(o));

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -657,6 +657,8 @@ void sremCommand(client *c) {
     if (server.memory_tracking_enabled)
         oldsize = kvobjAllocSize(set);
 
+    if (set->encoding == OBJ_ENCODING_HT)
+        dictPauseAutoResize((dict*)set->ptr);
     for (j = 2; j < c->argc; j++) {
         if (setTypeRemove(set,c->argv[j]->ptr)) {
             deleted++;
@@ -668,6 +670,9 @@ void sremCommand(client *c) {
                 break;
             }
         }
+    }
+    if (!keyremoved && set->encoding == OBJ_ENCODING_HT) {
+        dictResumeAutoResize((dict*)set->ptr);
     }
     if (server.memory_tracking_enabled && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), set, oldsize, kvobjAllocSize(set));

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -673,6 +673,7 @@ void sremCommand(client *c) {
     }
     if (!keyremoved && set->encoding == OBJ_ENCODING_HT) {
         dictResumeAutoResize((dict*)set->ptr);
+        dictShrinkIfNeeded((dict*)set->ptr);
     }
     if (server.memory_tracking_enabled && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), set, oldsize, kvobjAllocSize(set));

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2118,6 +2118,8 @@ void zremCommand(client *c) {
     int64_t oldlen = (int64_t) zsetLength(zobj);
     if (server.memory_tracking_enabled)
         oldsize = kvobjAllocSize(zobj);
+    if (zobj->encoding == OBJ_ENCODING_SKIPLIST)
+        dictPauseAutoResize(((zset*)zobj->ptr)->dict);
     for (j = 2; j < c->argc; j++) {
         if (zsetDel(zobj, c->argv[j]->ptr)) deleted++;
         if (zsetLength(zobj) == 0) {
@@ -2128,6 +2130,9 @@ void zremCommand(client *c) {
             keyremoved = 1;
             break;
         }
+    }
+    if (!keyremoved && zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+        dictResumeAutoResize(((zset*)zobj->ptr)->dict);
     }
 
     if (server.memory_tracking_enabled && !keyremoved)

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2133,6 +2133,7 @@ void zremCommand(client *c) {
     }
     if (!keyremoved && zobj->encoding == OBJ_ENCODING_SKIPLIST) {
         dictResumeAutoResize(((zset*)zobj->ptr)->dict);
+        dictShrinkIfNeeded(((zset*)zobj->ptr)->dict);
     }
 
     if (server.memory_tracking_enabled && !keyremoved)

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1026,7 +1026,14 @@ foreach type {single multiple single_multiple} {
                 break
             }
         }
-        r srem $myset {*}$members
+        r deferred 1
+        foreach m $members {
+            r srem $myset $m
+        }
+        foreach m $members {
+            r read
+        }
+        r deferred 0
     }
 
     proc verify_rehashing_completed_key {myset table_size keys} {


### PR DESCRIPTION
The idea comes directly from ValKey: https://github.com/valkey-io/valkey/pull/3144

Deleting many fields from a hash/zset/set stored as a dict can trigger repeated shrink/rehash work during the loop.

Co-authored-by: Binbin binloveplay1314@qq.com


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core write-path commands and dict resizing behavior; while intended as a performance optimization, incorrect pause/resume or shrink timing could affect memory usage or trigger edge-case regressions under heavy deletion workloads.
> 
> **Overview**
> Improves deletion performance for hash/set/zset values backed by dicts by pausing dict auto-resize during `HDEL`, `SREM`, and `ZREM` multi-argument loops, then resuming and calling `dictShrinkIfNeeded()` once if the key wasn’t removed.
> 
> Updates the set rehashing unit test to issue `SREM` commands in a deferred pipeline (instead of a single variadic call) to better exercise the new resize/shrink behavior during repeated deletions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d4671fc7541fd30adfbaa6ada8f1c6e8150b9e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->