### PR TITLE
Support Tcl 9.0 in Redis test suite

### DIFF
--- a/runtest
+++ b/runtest
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6 8.7"
+TCL_VERSIONS="8.5 8.6 8.7 9.0"
 TCLSH=""
 
 for VERSION in $TCL_VERSIONS; do

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -10,9 +10,9 @@
 # (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
 # GNU Affero General Public License v3 (AGPLv3).
 
-package require Tcl 8.5
+package require Tcl 8.5-10
 
-set tcl_precision 17
+if {$tcl_version < 9.0} { set tcl_precision 17 }
 source ../support/redis.tcl
 source ../support/util.tcl
 source ../support/aofmanifest.tcl

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -14,7 +14,7 @@
 # $c get foo
 # $c close
 
-package require Tcl 8.5
+package require Tcl 8.5-10
 package provide redis_cluster 0.1
 
 namespace eval redis_cluster {}

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -30,7 +30,7 @@
 #
 # vwait forever
 
-package require Tcl 8.5
+package require Tcl 8.5-10
 package provide redis 0.1
 
 source [file join [file dirname [info script]] "response_transformers.tcl"]

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -163,9 +163,19 @@ proc ::redis::__dispatch__raw__ {id method argv} {
     if {[info command ::redis::__method__$method] eq {}} {
         catch {unset ::redis::attributes($id)}
         set cmd "*[expr {[llength $argv]+1}]\r\n"
-        append cmd "$[string length $method]\r\n$method\r\n"
+        # Helper to encode if necessary
+        set encoded_method $method
+        if {[string match "*\[^\u0000-\u00ff\]*" $method]} {
+             set encoded_method [encoding convertto utf-8 $method]
+        }
+        append cmd "$[string length $encoded_method]\r\n$encoded_method\r\n"
+
         foreach a $argv {
-            append cmd "$[string length $a]\r\n$a\r\n"
+            set encoded_a $a
+            if {[string match "*\[^\u0000-\u00ff\]*" $a]} {
+                set encoded_a [encoding convertto utf-8 $a]
+            }
+            append cmd "$[string length $encoded_a]\r\n$encoded_a\r\n"
         }
         ::redis::redis_write $fd $cmd
         if {[catch {flush $fd}]} {

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -165,7 +165,9 @@ proc ::redis::__dispatch__raw__ {id method argv} {
         set cmd "*[expr {[llength $argv]+1}]\r\n"
         append cmd "$[string length $method]\r\n$method\r\n"
         foreach a $argv {
-            if {$tcl_version >= 9.0} {
+            # In Tcl 9.0, only convert to UTF-8 if the string contains non-byte characters
+            # to preserve binary data while handling unicode correctly
+            if {$::tcl_version >= 9.0 && [string match "*\[^\u0000-\u00ff\]*" $a]} {
                 set a [encoding convertto utf-8 $a]
             }
             append cmd "$[string length $a]\r\n$a\r\n"

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -163,19 +163,12 @@ proc ::redis::__dispatch__raw__ {id method argv} {
     if {[info command ::redis::__method__$method] eq {}} {
         catch {unset ::redis::attributes($id)}
         set cmd "*[expr {[llength $argv]+1}]\r\n"
-        # Helper to encode if necessary
-        set encoded_method $method
-        if {[string match "*\[^\u0000-\u00ff\]*" $method]} {
-             set encoded_method [encoding convertto utf-8 $method]
-        }
-        append cmd "$[string length $encoded_method]\r\n$encoded_method\r\n"
-
+        append cmd "$[string length $method]\r\n$method\r\n"
         foreach a $argv {
-            set encoded_a $a
-            if {[string match "*\[^\u0000-\u00ff\]*" $a]} {
-                set encoded_a [encoding convertto utf-8 $a]
+            if {$tcl_version >= 9.0} {
+                set a [encoding convertto utf-8 $a]
             }
-            append cmd "$[string length $encoded_a]\r\n$encoded_a\r\n"
+            append cmd "$[string length $a]\r\n$a\r\n"
         }
         ::redis::redis_write $fd $cmd
         if {[catch {flush $fd}]} {

--- a/tests/support/response_transformers.tcl
+++ b/tests/support/response_transformers.tcl
@@ -19,7 +19,7 @@
 # changes in many files) we decided to transform the response to RESP2
 # when running with --force-resp3
 
-package require Tcl 8.5
+package require Tcl 8.5-10
 
 namespace eval response_transformers {}
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -333,7 +333,7 @@ proc test_server_cron {} {
 }
 
 proc accept_test_clients {fd addr port} {
-    fconfigure $fd -encoding binary
+    fconfigure $fd -translation binary
     fileevent $fd readable [list read_from_test_client $fd]
 }
 
@@ -524,7 +524,7 @@ proc the_end {} {
 # to read the command, execute, reply... all this in a loop.
 proc test_client_main server_port {
     set ::test_server_fd [socket localhost $server_port]
-    fconfigure $::test_server_fd -encoding binary
+    fconfigure $::test_server_fd -translation binary
     send_data_packet $::test_server_fd ready [pid]
     while 1 {
         set bytes [gets $::test_server_fd]

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -13,9 +13,9 @@
 # Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
 #
 
-package require Tcl 8.5
+package require Tcl 8.5-10
 
-set tcl_precision 17
+if {$tcl_version < 9.0} { set tcl_precision 17 }
 source tests/support/redis.tcl
 source tests/support/aofmanifest.tcl
 source tests/support/server.tcl

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -226,7 +226,7 @@ start_server {tags {"other"}} {
             } else {
                 set fd2 [socket [srv host] [srv port]]
             }
-            fconfigure $fd2 -encoding binary -translation binary
+            fconfigure $fd2 -translation binary
             if {!$::singledb} {
                 puts -nonewline $fd2 "SELECT 9\r\n"
                 flush $fd2


### PR DESCRIPTION
## Summary
This PR adds support for running the Redis test suite using Tcl 9.0.

## Changes
- **runtest**: Added `9.0` to the list of Tcl versions the script searches for.
- **Version Requirements**: Updated `package require Tcl` from `8.5` to `8.5-10` in key test files. In Tcl, a simple version requirement like `8.5` is interpreted as "8.5 or higher within major version 8". Specifying the range `8.5-10` allows Tcl 9.0 to be used if the code is compatible.
- **Tcl Precision**: Wrapped `set tcl_precision 17` in a conditional check `if {$tcl_version < 9.0}`. In Tcl 9.0, `tcl_precision` has been removed as double-to-string conversions are now lossless by default.
- Adjusts the Tcl Redis client to preserve binary arguments under Tcl 9 by only UTF-8 converting strings that contain non-byte characters before building the RESP command.

## Testing
Verified that `tclsh9.0` successfully parses the updated `package require` and handles the conditional `tcl_precision` assignment. This allows the test suite to run on modern Linux distributions where Tcl 9.0 is the default version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes low-level test harness I/O and request encoding/serialization behavior, which could subtly affect protocol tests or binary payload handling across Tcl versions.
> 
> **Overview**
> Adds **Tcl 9.0 support** for running the Redis test suite by extending `runtest`’s version probe list and relaxing test scripts’ `package require Tcl` constraints to `8.5-10`.
> 
> Updates Tcl-specific behavior for 9.0: guards `tcl_precision` usage to pre-9.0, switches several sockets from `-encoding binary` to `-translation binary`, and adjusts the Tcl Redis client (`tests/support/redis.tcl`) to preserve binary arguments under Tcl 9 by only UTF-8 converting strings that contain non-byte characters before building the RESP command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2380964ef94df9f67afff7a3ece89afe4a1a318d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->