### PR TITLE
Fix XADD/XCFGSET IDMP argument types

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -10040,23 +10040,16 @@ struct COMMAND_ARG XADD_condition_Subargs[] = {
 {MAKE_ARG("acked",ARG_TYPE_PURE_TOKEN,-1,"ACKED",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
-/* XADD idmp idmpauto_with_pid argument table */
-struct COMMAND_ARG XADD_idmp_idmpauto_with_pid_Subargs[] = {
-{MAKE_ARG("idmpauto-token",ARG_TYPE_PURE_TOKEN,-1,"IDMPAUTO",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("pid",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-};
-
-/* XADD idmp idmp_with_pid_iid argument table */
-struct COMMAND_ARG XADD_idmp_idmp_with_pid_iid_Subargs[] = {
-{MAKE_ARG("idmp-token",ARG_TYPE_PURE_TOKEN,-1,"IDMP",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+/* XADD idmp idmp argument table */
+struct COMMAND_ARG XADD_idmp_idmp_Subargs[] = {
 {MAKE_ARG("pid",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("iid",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
 /* XADD idmp argument table */
 struct COMMAND_ARG XADD_idmp_Subargs[] = {
-{MAKE_ARG("idmpauto-with-pid",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=XADD_idmp_idmpauto_with_pid_Subargs},
-{MAKE_ARG("idmp-with-pid-iid",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,3,NULL),.subargs=XADD_idmp_idmp_with_pid_iid_Subargs},
+{MAKE_ARG("pid",ARG_TYPE_STRING,-1,"IDMPAUTO",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("idmp",ARG_TYPE_BLOCK,-1,"IDMP",NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=XADD_idmp_idmp_Subargs},
 };
 
 /* XADD trim strategy argument table */
@@ -10096,7 +10089,7 @@ struct COMMAND_ARG XADD_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("nomkstream",ARG_TYPE_PURE_TOKEN,-1,"NOMKSTREAM",NULL,"6.2.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("condition",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,3,NULL),.subargs=XADD_condition_Subargs},
-{MAKE_ARG("idmp",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=XADD_idmp_Subargs},
+{MAKE_ARG("idmp",ARG_TYPE_ONEOF,-1,NULL,NULL,"8.6.0",CMD_ARG_OPTIONAL,2,NULL),.subargs=XADD_idmp_Subargs},
 {MAKE_ARG("trim",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,4,NULL),.subargs=XADD_trim_Subargs},
 {MAKE_ARG("id-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=XADD_id_selector_Subargs},
 {MAKE_ARG("data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=XADD_data_Subargs},
@@ -10155,23 +10148,11 @@ keySpec XCFGSET_Keyspecs[1] = {
 };
 #endif
 
-/* XCFGSET idmp_duration_block argument table */
-struct COMMAND_ARG XCFGSET_idmp_duration_block_Subargs[] = {
-{MAKE_ARG("idmp-duration-token",ARG_TYPE_PURE_TOKEN,-1,"IDMP-DURATION",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("duration",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-};
-
-/* XCFGSET idmp_maxsize_block argument table */
-struct COMMAND_ARG XCFGSET_idmp_maxsize_block_Subargs[] = {
-{MAKE_ARG("idmp-maxsize-token",ARG_TYPE_PURE_TOKEN,-1,"IDMP-MAXSIZE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("maxsize",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-};
-
 /* XCFGSET argument table */
 struct COMMAND_ARG XCFGSET_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("idmp-duration-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=XCFGSET_idmp_duration_block_Subargs},
-{MAKE_ARG("idmp-maxsize-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=XCFGSET_idmp_maxsize_block_Subargs},
+{MAKE_ARG("idmp-duration",ARG_TYPE_INTEGER,-1,"IDMP-DURATION",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("idmp-maxsize",ARG_TYPE_INTEGER,-1,"IDMP-MAXSIZE",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
 };
 
 /********** XCLAIM ********************/

--- a/src/commands/xadd.json
+++ b/src/commands/xadd.json
@@ -91,32 +91,19 @@
                 "name": "idmp",
                 "type": "oneof",
                 "optional": true,
+                "since": "8.6.0",
                 "arguments": [
                     {
-                        "name": "idmpauto-with-pid",
-                        "type": "block",
-                        "arguments": [
-                            {
-                                "token": "IDMPAUTO",
-                                "name": "idmpauto-token",
-                                "type": "pure-token"
-                            },
-                            {
-                                "name": "pid",
-                                "type": "string",
-                                "display_text": "producer-id"
-                            }
-                        ]
+                        "token": "IDMPAUTO",
+                        "type": "string",
+                        "name": "pid",
+                        "display_text": "producer-id"
                     },
                     {
-                        "name": "idmp-with-pid-iid",
+                        "token": "IDMP",
                         "type": "block",
+                        "name": "idmp",
                         "arguments": [
-                            {
-                                "token": "IDMP",
-                                "name": "idmp-token",
-                                "type": "pure-token"
-                            },
                             {
                                 "name": "pid",
                                 "type": "string",

--- a/src/commands/xcfgset.json
+++ b/src/commands/xcfgset.json
@@ -43,36 +43,16 @@
                 "key_spec_index": 0
             },
             {
-                "name": "idmp-duration-block",
-                "type": "block",
-                "optional": true,
-                "arguments": [
-                    {
-                        "name": "idmp-duration-token",
-                        "type": "pure-token",
-                        "token": "IDMP-DURATION"
-                    },
-                    {
-                        "name": "duration",
-                        "type": "integer"
-                    }
-                ]
+                "name": "idmp-duration",
+                "type": "integer",
+                "token": "IDMP-DURATION",
+                "optional": true
             },
             {
-                "name": "idmp-maxsize-block",
-                "type": "block",
-                "optional": true,
-                "arguments": [
-                    {
-                        "name": "idmp-maxsize-token",
-                        "type": "pure-token",
-                        "token": "IDMP-MAXSIZE"
-                    },
-                    {
-                        "name": "maxsize",
-                        "type": "integer"
-                    }
-                ]
+                "name": "idmp-maxsize",
+                "type": "integer",
+                "token": "IDMP-MAXSIZE",
+                "optional": true
             }
         ]
     }

--- a/tests/modules/cmdintrospection.c
+++ b/tests/modules/cmdintrospection.c
@@ -87,33 +87,19 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
             {
                 .name = "idmp",
                 .type = REDISMODULE_ARG_TYPE_ONEOF,
+                .since = "8.6.0",
                 .flags = REDISMODULE_CMD_ARG_OPTIONAL,
                 .subargs = (RedisModuleCommandArg[]){
                     {
-                        .name = "idmpauto-with-pid",
-                        .type = REDISMODULE_ARG_TYPE_BLOCK,
-                        .subargs = (RedisModuleCommandArg[]){
-                            {
-                                .name = "idmpauto-token",
-                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                                .token = "IDMPAUTO"
-                            },
-                            {
-                                .name = "pid",
-                                .type = REDISMODULE_ARG_TYPE_STRING,
-                            },
-                            {0}
-                        }
+                        .name = "pid",
+                        .type = REDISMODULE_ARG_TYPE_STRING,
+                        .token = "IDMPAUTO"
                     },
                     {
-                        .name = "idmp-with-pid-iid",
+                        .name = "idmp",
                         .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .token = "IDMP",
                         .subargs = (RedisModuleCommandArg[]){
-                            {
-                                .name = "idmp-token",
-                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                                .token = "IDMP"
-                            },
                             {
                                 .name = "pid",
                                 .type = REDISMODULE_ARG_TYPE_STRING,


### PR DESCRIPTION
# Description 
Recently added parameters in `XADD` and the new `XCFGSET` command use pure tokens for arguments
when they should be regular tokens as they have associated values. 

## XADD
- `IDMPAUTO` should not be a block argument and instead just a `string` argument as it only contains one value
- `IDMP` should be a block argument with two arguments (not including the token itself)

## XCFGSET
- `IDMP-DURATION` should not be a block argument and instead an integer argument
- `IDMP-MAXSIZE` should not be a block argument and instead an integer argument


# Side effect
- Added `since` attributed for `IDMP` block in `XADD`

# Related PR:
- #14615 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Updates command argument metadata for `XADD` and `XCFGSET`, which could affect command introspection/help output and client generators but not core data-path logic.
> 
> **Overview**
> Fixes the command-argument schemas for stream IDMP options.
> 
> `XADD` now models `IDMPAUTO` as a single `string` argument and `IDMP` as a `block` containing only `pid`/`iid` values (and marks the `idmp` option group as `since: 8.6.0`). `XCFGSET` now exposes `IDMP-DURATION` and `IDMP-MAXSIZE` as direct `integer` arguments instead of token+value blocks, and updates the cmd-introspection test expectations accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcd94eb958b9f11b3adc0c34e0a93d5cea638731. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->