### PR TITLE
Fix DB hash tables not expanding during RDB load

### DIFF
--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -385,9 +385,10 @@ unsigned long long kvstoreScan(kvstore *kvs, unsigned long long cursor,
  */
 int kvstoreExpand(kvstore *kvs, uint64_t newsize, int try_expand, kvstoreExpandShouldSkipDictIndex *skip_cb) {
     for (int i = 0; i < kvs->num_dicts; i++) {
+        if (skip_cb && skip_cb(i)) continue;
         dict *d = createDictIfNeeded(kvs, i);
-        if (!d || (skip_cb && skip_cb(i)))
-            continue;
+        if (!d) continue;
+
         int result = try_expand ? dictTryExpand(d, newsize) : dictExpand(d, newsize);
         if (try_expand && result == DICT_ERR)
             return 0;

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -385,7 +385,7 @@ unsigned long long kvstoreScan(kvstore *kvs, unsigned long long cursor,
  */
 int kvstoreExpand(kvstore *kvs, uint64_t newsize, int try_expand, kvstoreExpandShouldSkipDictIndex *skip_cb) {
     for (int i = 0; i < kvs->num_dicts; i++) {
-        dict *d = kvstoreGetDict(kvs, i);
+        dict *d = createDictIfNeeded(kvs, i);
         if (!d || (skip_cb && skip_cb(i)))
             continue;
         int result = try_expand ? dictTryExpand(d, newsize) : dictExpand(d, newsize);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3902,6 +3902,8 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             dbExpand(db, db_size, 0);
             dbExpandExpires(db, expires_size, 0);
             should_expand_db = 0;
+            serverLog(LL_VERBOSE, "DB %d resized: %lu key buckets, %lu expire buckets",
+                        db->id, kvstoreBuckets(db->keys), kvstoreBuckets(db->expires));
         }
 
         /* With metadata, type = RDB_OPCODE_KEY_META. Layout: [<META>,]<TYPE>,<KEY>,<VALUE> */

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -80,6 +80,23 @@ start_server [list overrides [list "dir" $server_path] keep_persistence true] {
     r del stream
 }
 
+start_server {overrides {loglevel verbose}} {
+    test {RDB load applies RESIZEDB hint to expand hash tables} {
+        # Populate keys and save RDB
+        r flushall sync
+        regexp {db=(\d+)} [r client info] -> dbid
+        # 500 keys with 3600 second expiration, 500 without
+        populate 500 "key1:" 3 0 false 3600
+        populate 500 "key2:" 3 0 false 0
+        r save
+
+        restart_server 0 true false
+
+        # Verify DB resize log message
+        verify_log_message 0 "*DB $dbid resized*1024 key*512 expire*" 0
+    }
+}
+
 # Helper function to start a server and kill it, just to check the error
 # logged.
 set defaults {}


### PR DESCRIPTION
In standalone mode, we create dicts on demand. by default, there is no dicts, and RESIZEDB hint doesn't expand dict actually. so we should create dict first when expanding if the dict does not exist.

internal ticket: RED-182685

introduced in https://github.com/redis/redis/pull/12822.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core kvstore resizing behavior and RDB load path; while the change is small, it can affect memory allocation patterns and startup performance during loading.
> 
> **Overview**
> Fixes a standalone-mode bug where the RDB `RESIZEDB` hint could be ignored because per-slot kvstore dictionaries were allocated on-demand and not created during `kvstoreExpand`, preventing actual hashtable expansion.
> 
> `kvstoreExpand` now skips indices first and then calls `createDictIfNeeded()` before expanding, `rdb.c` logs a verbose message after applying the resize hint (including resulting bucket counts), and `tests/integration/rdb.tcl` adds an integration test that saves/restores an RDB and asserts the resize log message appears.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa037a514c45d12b78ceb78dae93347b7f80fc3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->