### PR TITLE
Initialize strOldSize in bitfieldGeneric to avoid undefined behavior

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1722,7 +1722,7 @@ void bitfieldGeneric(client *c, int flags) {
     kvobj *o;
     uint64_t bitoffset;
     int j, numops = 0, changes = 0;
-    size_t strOldSize, strGrowSize = 0;
+    size_t strOldSize = 0, strGrowSize = 0;
     struct bitfieldOp *ops = NULL; /* Array of ops to execute at end. */
     int owtype = BFOVERFLOW_WRAP; /* Overflow type. */
     int readonly = 1;


### PR DESCRIPTION
In `bitfieldGeneric()`, `strOldSize` is declared but only `strGrowSize`
gets initialized to 0:

```c
size_t strOldSize, strGrowSize = 0;
```

When the command is read-only, `lookupStringForBitCommand()` is never
called, so `strOldSize` remains uninitialized. The value is technically
unreachable at runtime because `changes` will be 0 in the read-only
path, but this is fragile -- any future refactoring could accidentally
introduce a real uninitialized read.

This just initializes `strOldSize` to 0 alongside `strGrowSize` for
safety and clarity. @sundb and @moticless already discussed this in the
issue and agreed it should be fixed.

Fixes #14315

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Trivial initialization-only change with no behavioral impact expected beyond avoiding future undefined behavior.
> 
> **Overview**
> Initializes `strOldSize` to `0` in `bitfieldGeneric()` (BITFIELD/BITFIELD_RO) alongside `strGrowSize`, removing a potential uninitialized variable/undefined-behavior hazard in read-only paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7d9bf3c54d5ac922448301b566cae16eb6457ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->