### PR TITLE
Improve error log for ASM slot handoff failure

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2117,12 +2117,13 @@ slotRangeArray *clusterGetLocalSlotRanges(void) {
  *
  * Usage: SFLUSH <start-slot> <end slot> [<start-slot> <end slot>]* [SYNC|ASYNC]
  *
- * This is an initial implementation of SFLUSH (slots flush) which is limited to
- * flushing a single shard as a whole, but in the future the same command may be
- * used to partially flush a shard based on hash slots. Currently only if provided
- * slots cover entirely the slots of a node, the node will be flushed and the
- * return value will be pairs of slot ranges. Otherwise, a single empty set will 
- * be returned. If possible, SFLUSH SYNC will be run as blocking ASYNC as an 
+ * Redis will flush the slots that belong to this node and reply with the flushed 
+ * slot ranges. If no slot is flushed, an empty array will be returned.
+ * 
+ * e.g. Node owns slot 100-200, user issues SFLUSH 50 150
+ * Redis will flush slot 100-150 and reply with [100,150]
+ * 
+ * If possible, SFLUSH SYNC will be run as blocking ASYNC as an 
  * optimization.
  */
 void sflushCommand(client *c) {

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1031,7 +1031,7 @@ void asmLogTaskEvent(asmTask *task, int event) {
                       task->id, str, getKeyCountInSlotRangeArray(task->slots));
             break;
         case ASM_EVENT_MIGRATE_STARTED:
-            serverLog(LL_NOTICE, "Migrate task %s started for slots: %s (keys at start: %llu)",
+            serverLog(LL_NOTICE, "Migrate task %s started for slots: %s (number of keys at start: %llu)",
                       task->id, str, getKeyCountInSlotRangeArray(task->slots));
             break;
         case ASM_EVENT_MIGRATE_FAILED:
@@ -1213,6 +1213,11 @@ static void asmTaskCancel(asmTask *task, const char *reason) {
 void asmImportTakeover(asmTask *task) {
     serverAssert(task->state == ASM_WAIT_STREAM_EOF ||
                  task->state == ASM_STREAMING_BUF);
+
+    if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, ASM_TAKEOVER))) {
+        /* Do not take over slots to test timeout scenario. */
+        return;
+    }
 
     /* Free the main channel connection since it is no longer needed. */
     serverAssert(task->main_channel_conn != NULL);
@@ -2069,6 +2074,10 @@ void clusterSyncSlotsCommand(client *c) {
                 return;
             }
             task->dest_offset = offset;
+            /* Detailed ACK progress log (for debugging handoff/drain issues). */
+            serverLog(LL_DEBUG, "CLUSTER SYNCSLOTS ACK received, dest state: %s, "
+                                "updated dest offset to %lld, source offset: %lld",
+                asmTaskStateToString(dest_state), task->dest_offset, task->source_offset);
 
             /* Record the time when the destination finishes applying the accumulated buffer */
             if (task->dest_state == ASM_WAIT_STREAM_EOF && task->dest_accum_applied_time == 0)
@@ -2556,30 +2565,9 @@ void asmBeforeSleep(void) {
             return;
         }
 
-        if (task->state == ASM_HANDOFF || task->state == ASM_STREAM_EOF) {
-            /* In these states, writes are still paused while waiting for the 
-             * destination to broadcast the slot ownership change. If the 
-             * destination fails or becomes unreachable, the source could remain 
-             * paused indefinitely, so we enforce a timeout and fail the task.
-             * 
-             * NOTE: There is a tricky case where the destination node may 
-             * advertise ownership of the slot after the source node resumes 
-             * writes, causing a temporary configuration conflict. However, the
-             * configuration will eventually converge. In most cases, the
-             * destination node becomes the winner, since it bumps its config 
-             * epoch before taking over slot ownership. During this window, 
-             * writes accepted by the source will not be replicated to the
-             * destination and those writes will be lost.*/
-            if (server.mstime - task->paused_time >= server.asm_write_pause_timeout) {
-                asmTaskSetFailed(task, "Write pause timeout during slot handoff: destination did not take ownership within %lld ms.",
-                                 server.asm_write_pause_timeout);
-                return;
-            }
-
-            /* Send STREAM-EOF if the destination drained the command stream. */
-            if (task->state == ASM_HANDOFF)
-                asmSendStreamEofIfDrained(task);
-        }
+        /* Send STREAM-EOF if the destination drained the command stream. */
+        if (task->state == ASM_HANDOFF)
+            asmSendStreamEofIfDrained(task);
     }
 }
 
@@ -2649,6 +2637,25 @@ void asmCron(void) {
                         (task->dest_accum_applied_time - task->dest_slots_snapshot_time) * 2))
             {
                 asmTaskSetFailed(task, "Sync buffer drain timeout");
+            }
+        } else if (task->state == ASM_HANDOFF || task->state == ASM_STREAM_EOF) {
+            /* In these states, writes are still paused while waiting for the 
+             * destination to broadcast the slot ownership change. If the 
+             * destination fails or becomes unreachable, the source could remain 
+             * paused indefinitely, so we enforce a timeout and fail the task.
+             * 
+             * NOTE: There is a tricky case where the destination node may 
+             * advertise ownership of the slot after the source node resumes 
+             * writes, causing a temporary configuration conflict. However, the
+             * configuration will eventually converge. In most cases, the
+             * destination node becomes the winner, since it bumps its config 
+             * epoch before taking over slot ownership. During this window, 
+             * writes accepted by the source will not be replicated to the
+             * destination and those writes will be lost.*/
+            if (server.mstime - task->paused_time >= server.asm_write_pause_timeout) {
+                asmTaskSetFailed(task, "Write pause timeout during slot handoff: destination did not take ownership within %lld ms.",
+                                 server.asm_write_pause_timeout);
+                return;
             }
         }
     }
@@ -2997,7 +3004,48 @@ void asmTriggerBackgroundTrim(slotRangeArray *slots, int migration_cleanup) {
     asmUnblockMasterAfterTrim();
 }
 
-/* Trim the slots, return the trim method used.
+/* Trimming of slots can be triggered in several cases: 
+ *  - After a successful ASM migrate operation: slots are migrated away from
+ *    this node and keys that are no longer owned must be removed.
+ *  - After a failed ASM import operation: partially imported slot data must
+ *    be cleaned up.
+ *  - Due to user initiated SFLUSH command.
+ * 
+ * Redis supports two trimming methods: background trim and active trim.
+ * 
+ * Background trim: In cluster mode, Redis maintains per-slot data structures 
+ * for keys, expires, and subexpires. This makes it possible to efficiently 
+ * detach all data associated with a given slot in a single step. During trimming, 
+ * these slot-specific data structures are handed off to a BIO thread for 
+ * asynchronous cleanup, similar to how FLUSHALL or FLUSHDB operate. This is the 
+ * default trimming method.
+ * 
+ * Active trim: Unlike Redis itself, some modules may not maintain per-slot data
+ * structures and therefore cannot drop related slots data in a single operation.
+ * To support these cases, Redis introduces active trim, where key deletion 
+ * occurs in the main thread instead. This is not a blocking operation, trimming
+ * runs concurrently in the main thread, periodically removing keys during the
+ * cron loop. Each deletion triggers a keyspace notification so that modules can
+ * react to individual key removals. While active trim is less efficient, it 
+ * ensures backward compatibility for modules during the transition period.
+
+ * Before starting the trim, Redis checks whether any module is subscribed to 
+ * REDISMODULE_NOTIFY_KEY_TRIMMED keyspace event. If such subscribers exist,
+ * active trim is used; otherwise, background trim is triggered. Going forward,
+ * modules are expected to adopt background trim and active trim will be phased 
+ * out once modules migrate to the new method.
+ *
+ * Active trim is also preferred if there is any client that is using client
+ * tracking feature (client-side caching). In the client tracking protocol, 
+ * there is currently no mechanism to signal that only specific slots have been
+ * flushed. So, iterating over all keys in the slots and sending invalidation 
+ * notifications would be a blocking operation. To avoid this, if there is any 
+ * client that is using client tracking feature, Redis triggers active trim. 
+ * During trimming, it sends invalidation notifications for each key being trimmed.
+ * In the future, the client tracking protocol can be extended to support slot-based
+ * invalidation, allowing background trim to be used in this case as well.
+ * 
+ * Trim the slots, return the trim method used.
  * If client_id is non-zero, the client will be unblocked when trim completes.
  * If migration_cleanup is true, this is a migration cleanup of slots no longer owned. */
 int asmTrimSlots(struct slotRangeArray *slots, uint64_t client_id, int migration_cleanup) {
@@ -3026,14 +3074,15 @@ int asmTrimSlots(struct slotRangeArray *slots, uint64_t client_id, int migration
 
 /* Schedule a trim job for the specified slot ranges. The job will be
  * deferred and handled later in asmBeforeSleep(). We delay the trim jobs to
- * asmBeforeSleep() to ensure it only runs when there is no write pause. */
+ * asmBeforeSleep() to ensure it only runs when there is no write pause. 
+ * For trim method details, see asmTrimSlots(). */
 void asmTrimJobSchedule(slotRangeArray *slots) {
     listAddNodeTail(asmManager->pending_trim_jobs, slotRangeArrayDup(slots));
 }
 
 /* Process any pending trim jobs. */
 void asmTrimJobProcessPending(void) {
-    /* Check if there is any pending trim job and we can propagate it. */
+    /* Check if there is any pending trim jobs. */
     if (listLength(asmManager->pending_trim_jobs) == 0 ||
         asmManager->debug_trim_method == ASM_DEBUG_TRIM_NONE)
     {
@@ -3050,7 +3099,7 @@ void asmTrimJobProcessPending(void) {
 
     /* Determine if we can start the trim job:
      * - require client writes not paused (so key deletions are allowed)
-     * - require replicas not paused (so TRIMSLOTS can be propagated).
+     * - require replica traffic is not paused (so TRIMSLOTS can be propagated).
      * - require trim is not disabled via RedisModule_ClusterDisableTrim().
      */
     static int logged = 0;

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -2069,9 +2069,6 @@ void clusterSyncSlotsCommand(client *c) {
                 return;
             }
             task->dest_offset = offset;
-            serverLog(LL_DEBUG, "CLUSTER SYNCSLOTS ACK received, dest state: %s, "
-                                "updated dest offset to %lld, source offset: %lld",
-                asmTaskStateToString(dest_state), task->dest_offset, task->source_offset);
 
             /* Record the time when the destination finishes applying the accumulated buffer */
             if (task->dest_state == ASM_WAIT_STREAM_EOF && task->dest_accum_applied_time == 0)
@@ -2559,27 +2556,29 @@ void asmBeforeSleep(void) {
             return;
         }
 
-        if (task->state == ASM_HANDOFF) {
-            /* To avoid long pause, we fail the task if the pause takes too long. */
+        if (task->state == ASM_HANDOFF || task->state == ASM_STREAM_EOF) {
+            /* In these states, writes are still paused while waiting for the 
+             * destination to broadcast the slot ownership change. If the 
+             * destination fails or becomes unreachable, the source could remain 
+             * paused indefinitely, so we enforce a timeout and fail the task.
+             * 
+             * NOTE: There is a tricky case where the destination node may 
+             * advertise ownership of the slot after the source node resumes 
+             * writes, causing a temporary configuration conflict. However, the
+             * configuration will eventually converge. In most cases, the
+             * destination node becomes the winner, since it bumps its config 
+             * epoch before taking over slot ownership. During this window, 
+             * writes accepted by the source will not be replicated to the
+             * destination and those writes will be lost.*/
             if (server.mstime - task->paused_time >= server.asm_write_pause_timeout) {
-                asmTaskSetFailed(task, "Server paused timeout");
+                asmTaskSetFailed(task, "Write pause timeout during slot handoff: destination did not take ownership within %lld ms.",
+                                 server.asm_write_pause_timeout);
                 return;
             }
-            asmSendStreamEofIfDrained(task);
-        } else if (task->state == ASM_STREAM_EOF) {
-            /* In state ASM_STREAM_EOF (server is still paused), we are waiting
-             * for the destination node to broadcast the slot ownership change.
-             * But maybe the destination node is failed or network is not available,
-             * the source node may be paused forever. So we fail the task if it
-             * takes too long.
-             *
-             * NOTE: There is a tricky case where the destination node may advertise
-             * ownership of the slot, causing a temporary configuration conflict.
-             * However, the configuration will eventually converge. In most cases,
-             * the destination node becomes the winner, since it bumps its config
-             * epoch before taking over slot ownership. */
-            if (server.mstime - task->paused_time >= server.asm_write_pause_timeout)
-                asmTaskSetFailed(task, "Server paused timeout");
+
+            /* Send STREAM-EOF if the destination drained the command stream. */
+            if (task->state == ASM_HANDOFF)
+                asmSendStreamEofIfDrained(task);
         }
     }
 }

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1316,7 +1316,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         if {[string match {*stream-done*} [migration_status 0 $task_id state]]} {
             wait_for_condition 1000 20 {
                 [string match {*failed*} [migration_status 0 $task_id state]] &&
-                [string match {*Server paused*} [migration_status 0 $task_id last_error]]
+                [string match {*Write pause timeout*} [migration_status 0 $task_id last_error]]
             } else {
                 fail "ASM task did not fail"
             }
@@ -1433,7 +1433,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 flushall
     }
 
-    test "Source server paused timeout" {
+    test "Source write pause timeout" {
         # set timeout to 0, so the task will fail immediately when checking timeout
         R 0 config set cluster-slot-migration-write-pause-timeout 0
 
@@ -1444,10 +1444,10 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         set slot0_key [slot_key 0 mykey]
         set load_handle [start_write_load "127.0.0.1" [get_port 0] 100 $slot0_key]
 
-        # node 0 will fail since server paused timeout
+        # node 0 will fail due to write pause timeout
         wait_for_condition 2000 10 {
             [string match {*failed*} [migration_status 0 $task_id state]] &&
-            [string match {*Server paused timeout*} \
+            [string match {*Write pause timeout*} \
                 [migration_status 0 $task_id last_error]]
         } else {
             fail "ASM task did not fail"

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1436,6 +1436,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     test "Source write pause timeout" {
         # set timeout to 0, so the task will fail immediately when checking timeout
         R 0 config set cluster-slot-migration-write-pause-timeout 0
+        R 1 debug asm-failpoint "import-main-channel" "takeover"
 
         # start migration from node 0 to 1
         set task_id [setup_slot_migration_with_delay 0 1 0 100]
@@ -1459,6 +1460,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 config set cluster-slot-migration-write-pause-timeout 10000
         R 0 cluster migration cancel id $task_id
         R 1 cluster migration cancel id $task_id
+        R 1 debug asm-failpoint "" ""
     }
 
     test "Sync buffer drain timeout" {


### PR DESCRIPTION
This PR improves the wording of a specific error message in an ASM scenario. It also includes minor comment fixes. 
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ASM handoff timeout/paused-write logic in cluster migrations, which can affect availability and data safety during slot ownership transitions. Changes are mostly behavioral/logging plus test-only failpoints, but could alter when migrations fail/resume under adverse network conditions.
> 
> **Overview**
> Improves **atomic slot migration (ASM) handoff failure reporting and behavior** by moving the “write paused too long” timeout handling into `asmCron()` for `ASM_HANDOFF`/`ASM_STREAM_EOF`, and emitting a more explicit error message about the destination not taking slot ownership within the configured timeout.
> 
> Adds additional diagnostics and test hooks: a new ASM failpoint prevents `asmImportTakeover()` to exercise the timeout path, `CLUSTER SYNCSLOTS ACK` progress is now logged at `LL_DEBUG`, and migrate-start logging is clarified. Unit tests are updated to match the new timeout wording and to use/reset the new failpoint.
> 
> Separately updates `SFLUSH` documentation/comments to describe partial flushing of only the local node’s owned slot subset and the returned flushed slot ranges (instead of the prior “single-shard only” limitation text).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13a8d78494cc3294bfa9fafffb274f736f22e66d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->