### PR TITLE
Allow comment lines in ACL files

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2337,8 +2337,8 @@ sds ACLLoadFromFile(const char *filename) {
 
         lines[i] = sdstrim(lines[i]," \t\r\n");
 
-        /* Skip blank lines */
-        if (lines[i][0] == '\0') continue;
+        /* Skip blank lines and comments */
+        if (lines[i][0] == '\0' || lines[i][0] == '#') continue;
 
         /* Split into arguments */
         argv = sdssplitlen(lines[i],sdslen(lines[i])," ",1,&argc);

--- a/tests/assets/commentuser.acl
+++ b/tests/assets/commentuser.acl
@@ -1,0 +1,7 @@
+# Admin users
+user alice on allcommands allkeys &* >alice
+
+# Read-only users
+user bob on -@all +@set +acl ~set* &* >bob
+
+user default on nopass ~* &* +@all

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1300,6 +1300,31 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
     } {} {external:skip}
 }
 
+set server_path [tmpdir "comments.acl"]
+exec cp -f tests/assets/commentuser.acl $server_path
+start_server [list overrides [list "dir" $server_path "aclfile" "commentuser.acl"] tags [list "external:skip"]] {
+    test {ACL file with comments is loaded correctly} {
+        assert {[r ACL GETUSER alice] != ""}
+        assert_equal [dict get [r ACL GETUSER alice] commands] "+@all"
+        assert {[r ACL GETUSER bob] != ""}
+        assert {[r ACL GETUSER default] != ""}
+    }
+
+    test {ACL LOAD handles comments in ACL file} {
+        set fd [open $server_path/commentuser.acl w]
+        puts $fd "# Full-line comment"
+        puts $fd "  # Indented comment"
+        puts $fd ""
+        puts $fd "user default on nopass ~* &* +@all"
+        puts $fd "# Trailing comment"
+        close $fd
+        r ACL LOAD
+        assert {[r ACL GETUSER default] != ""}
+        # alice should no longer exist after reload
+        assert {[r ACL GETUSER alice] eq ""}
+    }
+}
+
 start_server {overrides {user "default on nopass ~* +@all -flushdb"} tags {acl external:skip}} {
     test {ACL from config file and config rewrite} {
         assert_error {NOPERM *} {r flushdb}


### PR DESCRIPTION
The ACL file parser in ACLLoadFromFile() skips blank lines but rejects
lines starting with '#', unlike the config file parser in config.c which
handles both. This adds comment support to ACL files, matching the
existing config.c behavior (line 473).

Comments are stripped on ACL SAVE since the file is regenerated from
in-memory state, consistent with CONFIG REWRITE.

Fixes #14403

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized parsing change that only broadens accepted ACL file syntax, covered by new unit tests.
> 
> **Overview**
> ACL file parsing in `ACLLoadFromFile()` now skips full-line `#` comments in addition to blank lines, aligning ACL-file behavior with other config parsing.
> 
> Adds a new ACL fixture (`tests/assets/commentuser.acl`) and unit tests in `tests/unit/acl.tcl` to verify comment-containing ACL files load correctly at startup and via `ACL LOAD` (including indented comment lines).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a045307d9d2af42310b59f1e781af5a90f35bea0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->