### PR TITLE
Fix rss_extra_bytes type from size_t to ssize_t in redisMemOverhead

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1779,7 +1779,7 @@ struct redisMemOverhead {
     float allocator_rss;
     ssize_t allocator_rss_bytes;
     float rss_extra;
-    size_t rss_extra_bytes;
+    ssize_t rss_extra_bytes;
     size_t num_dbs;
     size_t overhead_db_hashtable_lut;
     size_t overhead_db_hashtable_rehashing;


### PR DESCRIPTION
The `rss_extra_bytes` field in `struct redisMemOverhead` was declared as `size_t` (unsigned), while all other similar fields (`total_frag_bytes`, `allocator_frag_bytes`, `allocator_rss_bytes`) use `ssize_t` (signed).

This causes two issues when `process_rss < allocator_resident` (which happens in practice, visible when `rss_overhead_ratio < 1.0`):

1. The unsigned subtraction wraps to a very large value, making the `MEMORY DOCTOR` check `mh->rss_extra_bytes > 10<<20` a potential false positive (though currently masked by the ratio check).

2. The `INFO memory` output uses `%zd` (signed) format for this field, which is technically undefined behavior with a `size_t` argument. It happens to print correctly on most platforms due to two's complement representation, but the mismatch is still a latent bug.

The fix changes `size_t` to `ssize_t` to match the other `*_bytes` fields in the same struct. No behavioral change for the common case where `process_rss >= allocator_resident`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header-only type correction that aligns with existing signed arithmetic/format usage; behavior changes only in edge cases where the previous unsigned value could wrap.
> 
> **Overview**
> Fixes `struct redisMemOverhead` by changing `rss_extra_bytes` from `size_t` to `ssize_t`, aligning it with other signed `*_bytes` fields.
> 
> This prevents unsigned underflow when `process_rss < allocator_resident` and avoids type/format mismatches when emitting `INFO memory` and `MEMORY` stats/doctor checks that treat the value as signed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4048eb19c592ddd1a1d197b728cd444106681f2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->