### PR TITLE
Add DEBUG_ASSERT_KEYSPACE build flag and daily CI test

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,16 +2,13 @@ name: Daily
 
 on:
   pull_request:
-    branches:
-      # any PR to a release branch.
-      - '[0-9].[0-9]'
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       skipjobs:
         description: 'jobs to skip (delete the ones you wanna keep, do not leave empty)'
-        default: 'valgrind,sanitizer,tls,freebsd,macos,alpine,32bit,iothreads,ubuntu,centos,malloc,specific,fortify,reply-schema,oldTC,defrag,vectorset'
+        default: 'valgrind,sanitizer,tls,freebsd,macos,alpine,32bit,iothreads,ubuntu,centos,malloc,specific,fortify,reply-schema,oldTC,defrag,vectorset,assert-keyspace'
       skiptests:
         description: 'tests to skip (delete the ones you wanna keep, do not leave empty)'
         default: 'redis,modules,sentinel,cluster,unittest'
@@ -67,6 +64,47 @@ jobs:
     - name: unittest
       if: true && !contains(github.event.inputs.skiptests, 'unittest')
       run: ./src/redis-server test all --accurate
+
+  # Test with DEBUG_ASSERT_KEYSPACE enabled to verify keyspace consistency.
+  # This enables additional runtime checks after each command for:
+  # - Info keysizes histogram
+  # - Cluster slot stats
+  # Skips slow and defrag tests to avoid timeouts while maintaining good coverage.
+  # TODO: Fix ASM (atomic slot migration) compatibility with keysizes histogram tracking
+  test-debug-assert-keyspace:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
+      !contains(github.event.inputs.skipjobs, 'assert-keyspace')
+    timeout-minutes: 14400
+    steps:
+    - name: prep
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "GITHUB_REPOSITORY=${{github.event.inputs.use_repo}}" >> $GITHUB_ENV
+        echo "GITHUB_HEAD_REF=${{github.event.inputs.use_git_ref}}" >> $GITHUB_ENV
+        echo "skipjobs: ${{github.event.inputs.skipjobs}}"
+        echo "skiptests: ${{github.event.inputs.skiptests}}"
+        echo "test_args: ${{github.event.inputs.test_args}}"
+        echo "cluster_test_args: ${{github.event.inputs.cluster_test_args}}"
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ env.GITHUB_REPOSITORY }}
+        ref: ${{ env.GITHUB_HEAD_REF }}
+    - name: make
+      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST -DDEBUG_ASSERT_KEYSPACE'
+    - name: testprep
+      run: sudo apt-get install tcl8.6 tclx
+    - name: test
+      if: true && !contains(github.event.inputs.skiptests, 'redis')
+      run: |
+        ./runtest --verbose --tags "-slow -defrag" \
+          --skipunit unit/cluster/slot-stats \
+          --skipunit unit/cluster/atomic-slot-migration \
+          --dump-logs ${{github.event.inputs.test_args}}
+    - name: cluster tests
+      if: true && !contains(github.event.inputs.skiptests, 'cluster')
+      run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
   test-ubuntu-jemalloc-fortify:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,6 +2,9 @@ name: Daily
 
 on:
   pull_request:
+    branches:
+      # any PR to a release branch.
+      - '[0-9].[0-9]'
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:

--- a/src/db.c
+++ b/src/db.c
@@ -206,6 +206,12 @@ static void dbgAssertHist(kvstore *kvs, keysizesHist hist,
  * Triggered by DEBUG KEYSIZES-HIST-ASSERT 1 and tested after each command.
  */
 void dbgAssertKeysizesHist(redisDb *db) {
+    /* Don't assert during nested calls. Intermediate state may be inconsistent. */
+    if (server.execution_nesting) return;
+
+    /* Don't assert during RDB loading. Database may be in inconsistent state. */
+    if (server.loading || server.async_loading) return;
+
     kvstoreMetadata *meta = kvstoreGetMetadata(db->keys);
     dbgAssertHist(db->keys, meta->keysizes_hist, getObjectLength, "dbgAssertKeysizesHist");
     if (server.memory_tracking_enabled)
@@ -217,6 +223,12 @@ void dbgAssertKeysizesHist(redisDb *db) {
  * Triggered by DEBUG ALLOCSIZE-SLOTS-ASSERT 1 and tested after each command.
  */
 void dbgAssertAllocSizePerSlot(redisDb *db) {
+    /* Don't assert during nested calls. Intermediate state may be inconsistent. */
+    if (server.execution_nesting) return;
+
+    /* Don't assert during RDB loading. Database may be in inconsistent state. */
+    if (server.loading || server.async_loading) return;
+
     if (!server.memory_tracking_enabled) return;
     size_t slot_sizes[CLUSTER_SLOTS] = {0};
     dictEntry *de;

--- a/src/module.c
+++ b/src/module.c
@@ -4741,6 +4741,8 @@ int RM_StringTruncate(RedisModuleKey *key, size_t newlen) {
         }
         if (server.memory_tracking_enabled)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), key->kv, oldsize, kvobjAllocSize(key->kv));
+        if (curlen != newlen)
+            updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_STRING, curlen, newlen);
     }
     return REDISMODULE_OK;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -2304,8 +2304,13 @@ void initServerConfig(void) {
     server.configfile = NULL;
     server.executable = NULL;
     server.arch_bits = (sizeof(long) == 8) ? 64 : 32;
-    server.dbg_assert_keysizes = 0; /* Disabled by default */
-    server.dbg_assert_alloc_per_slot = 0; /* Disabled by default */
+#if DEBUG_ASSERT_KEYSPACE
+    server.dbg_assert_keysizes = 1;
+    server.dbg_assert_alloc_per_slot = 1;
+#else
+    server.dbg_assert_keysizes = 0;
+    server.dbg_assert_alloc_per_slot = 0;
+#endif
     server.bindaddr_count = CONFIG_DEFAULT_BINDADDR_COUNT;
     for (j = 0; j < CONFIG_DEFAULT_BINDADDR_COUNT; j++)
         server.bindaddr[j] = zstrdup(default_bindaddr[j]);


### PR DESCRIPTION
Introduces `DEBUG_ASSERT_KEYSPACE` compile-time flag that enables runtime assertions for keyspace consistency after each command invocation:
* Info keysizes histogram validation
* Cluster slot allocation size tracking

# Changes

1. New daily CI job (test-debug-assert-keyspace) that builds with -DDEBUG_ASSERT_KEYSPACE and runs tests
2. Skip assertions during:
- Nested command execution (intermediate state may be inconsistent)
- RDB loading (database may be in inconsistent state)
3. Fix RM_StringTruncate to update keysizes histogram when truncating strings

# Known limitation (TODO)
ASM (atomic slot migration) tests are skipped due to known compatibility issues with keysizes histogram tracking. To be fixed separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core server/debug assertion and module string mutation paths and adds a new CI build mode; incorrect gating or histogram updates could cause spurious panics in debug builds or mask real inconsistencies.
> 
> **Overview**
> Adds a new `test-debug-assert-keyspace` job to the Daily GitHub Actions workflow that builds with `-DDEBUG_ASSERT_KEYSPACE` and runs a reduced test set (skipping slow/defrag and a couple cluster units), plus updates `skipjobs` defaults to include `assert-keyspace`.
> 
> Introduces a `DEBUG_ASSERT_KEYSPACE` compile-time switch that turns on keyspace consistency debug assertions by default at startup, and hardens those assertions to skip nested command execution and RDB loading states. Also fixes `RM_StringTruncate` to update the keysizes histogram when a module truncates or grows a string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 019b146cb49cb1d47f80aa26a20cccd8589642b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->