### PR TITLE
Rename getPositiveLongFromObjectOrReply to getNonNegativeLongFromObjectOrReply

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -754,7 +754,7 @@ NULL
         robj *key, *val;
         char buf[128];
 
-        if (getPositiveLongFromObjectOrReply(c, c->argv[2], &keys, NULL) != C_OK)
+        if (getNonNegativeLongFromObjectOrReply(c, c->argv[2], &keys, NULL) != C_OK)
             return;
 
         if (server.loading || server.async_loading) {
@@ -767,7 +767,7 @@ NULL
             return;
         }
         long valsize = 0;
-        if ( c->argc == 5 && getPositiveLongFromObjectOrReply(c, c->argv[4], &valsize, NULL) != C_OK ) 
+        if ( c->argc == 5 && getNonNegativeLongFromObjectOrReply(c, c->argv[4], &valsize, NULL) != C_OK ) 
             return;
 
         for (j = 0; j < keys; j++) {

--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -360,7 +360,8 @@ void hotkeysCommand(client *c) {
                 j += 2;
             } else if (moreargs && !strcasecmp(c->argv[j]->ptr, "SAMPLE")) {
                 long ratio_val;
-                if (getPositiveLongFromObjectOrReply(c, c->argv[j+1], &ratio_val, "SAMPLE ratio must be positive") != C_OK)
+                if (getRangeLongFromObjectOrReply(c, c->argv[j+1], 1, INT_MAX,
+                        &ratio_val, "SAMPLE ratio must be positive") != C_OK)
                 {
                     slotRangeArrayFree(slots);
                     return;

--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -360,8 +360,7 @@ void hotkeysCommand(client *c) {
                 j += 2;
             } else if (moreargs && !strcasecmp(c->argv[j]->ptr, "SAMPLE")) {
                 long ratio_val;
-                if (getRangeLongFromObjectOrReply(c, c->argv[j+1], 1, INT_MAX,
-                        &ratio_val, "SAMPLE ratio must be positive") != C_OK)
+                if (getPositiveLongFromObjectOrReply(c, c->argv[j+1], &ratio_val, "SAMPLE ratio must be positive") != C_OK)
                 {
                     slotRangeArrayFree(slots);
                     return;

--- a/src/networking.c
+++ b/src/networking.c
@@ -4316,8 +4316,8 @@ NULL
                 if (!strcasecmp(c->argv[i]->ptr,"id") && moreargs) {
                     long tmp;
 
-                    if (getRangeLongFromObjectOrReply(c, c->argv[i+1], 1, LONG_MAX, &tmp,
-                                                      "client-id should be greater than 0") != C_OK)
+                    if (getPositiveLongFromObjectOrReply(c, c->argv[i+1], &tmp,
+                                                         "client-id should be greater than 0") != C_OK)
                         return;
                     id = tmp;
                 } else if (!strcasecmp(c->argv[i]->ptr,"maxage") && moreargs) {

--- a/src/object.c
+++ b/src/object.c
@@ -1180,11 +1180,19 @@ int getRangeLongFromObjectOrReply(client *c, robj *o, long min, long max, long *
     return C_OK;
 }
 
-int getPositiveLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg) {
+int getNonNegativeLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg) {
     if (msg) {
         return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, msg);
     } else {
-        return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, "value is out of range, must be positive");
+        return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, "value is out of range, can't be negative");
+    }
+}
+
+int getPositiveLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg) {
+    if (msg) {
+        return getRangeLongFromObjectOrReply(c, o, 1, LONG_MAX, target, msg);
+    } else {
+        return getRangeLongFromObjectOrReply(c, o, 1, LONG_MAX, target, "value is out of range, must be positive");
     }
 }
 

--- a/src/object.h
+++ b/src/object.h
@@ -163,6 +163,7 @@ robj *createZsetListpackObject(void);
 robj *createStreamObject(void);
 robj *createModuleObject(struct RedisModuleType *mt, void *value);
 int getLongFromObjectOrReply(struct client *c, robj *o, long *target, const char *msg);
+int getNonNegativeLongFromObjectOrReply(struct client *c, robj *o, long *target, const char *msg);
 int getPositiveLongFromObjectOrReply(struct client *c, robj *o, long *target, const char *msg);
 int getRangeLongFromObjectOrReply(struct client *c, robj *o, long min, long max, long *target, const char *msg);
 int checkType(struct client *c, robj *o, int type);

--- a/src/replication.c
+++ b/src/replication.c
@@ -4726,7 +4726,7 @@ void waitaofCommand(client *c) {
     /* Argument parsing. */
     if (getRangeLongFromObjectOrReply(c,c->argv[1],0,1,&numlocal,NULL) != C_OK)
         return;
-    if (getPositiveLongFromObjectOrReply(c,c->argv[2],&numreplicas,NULL) != C_OK)
+    if (getNonNegativeLongFromObjectOrReply(c,c->argv[2],&numreplicas,NULL) != C_OK)
         return;
     if (getTimeoutFromObjectOrReply(c,c->argv[3],&timeout,UNIT_MILLISECONDS) != C_OK)
         return;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2690,8 +2690,8 @@ void hgetdelCommand(client *c) {
     }
 
     /* Read number of fields */
-    if (getRangeLongFromObjectOrReply(c, c->argv[3], 1, LONG_MAX, &num_fields,
-                                      "Number of fields must be a positive integer") != C_OK)
+    if (getPositiveLongFromObjectOrReply(c, c->argv[3], &num_fields,
+                                         "Number of fields must be a positive integer") != C_OK)
         return;
 
     /* Verify `numFields` is consistent with number of arguments */
@@ -3644,8 +3644,8 @@ static void httlGenericCommand(client *c, const char *cmd, long long basetime, i
     }
 
     /* Read number of fields */
-    if (getRangeLongFromObjectOrReply(c, c->argv[numFieldsAt], 1, LONG_MAX,
-                                      &numFields, "Number of fields must be a positive integer") != C_OK)
+    if (getPositiveLongFromObjectOrReply(c, c->argv[numFieldsAt], &numFields,
+                                         "Number of fields must be a positive integer") != C_OK)
         return;
 
     /* Verify `numFields` is consistent with number of arguments */
@@ -3959,8 +3959,8 @@ void hpersistCommand(client *c) {
     }
 
     /* Read number of fields */
-    if (getRangeLongFromObjectOrReply(c, c->argv[numFieldsAt], 1, LONG_MAX,
-                                      &numFields, "Number of fields must be a positive integer") != C_OK)
+    if (getPositiveLongFromObjectOrReply(c, c->argv[numFieldsAt], &numFields,
+                                         "Number of fields must be a positive integer") != C_OK)
         return;
 
     /* Verify `numFields` is consistent with number of arguments */

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -819,7 +819,7 @@ void popGenericCommand(client *c, int where) {
         return;
     } else if (hascount) {
         /* Parse the optional count argument. */
-        if (getPositiveLongFromObjectOrReply(c,c->argv[2],&count,NULL) != C_OK) 
+        if (getNonNegativeLongFromObjectOrReply(c,c->argv[2],&count,NULL) != C_OK) 
             return;
     }
 
@@ -1025,12 +1025,12 @@ void lposCommand(client *c) {
             }
         } else if (!strcasecmp(opt,"COUNT") && moreargs) {
             j++;
-            if (getPositiveLongFromObjectOrReply(c, c->argv[j], &count,
+            if (getNonNegativeLongFromObjectOrReply(c, c->argv[j], &count,
               "COUNT can't be negative") != C_OK)
                 return;
         } else if (!strcasecmp(opt,"MAXLEN") && moreargs) {
             j++;
-            if (getPositiveLongFromObjectOrReply(c, c->argv[j], &maxlen, 
+            if (getNonNegativeLongFromObjectOrReply(c, c->argv[j], &maxlen, 
               "MAXLEN can't be negative") != C_OK)
                 return;
         } else {
@@ -1419,8 +1419,8 @@ void lmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
     long count = -1;       /* Reply will consist of up to count elements, depending on the list's length. */
 
     /* Parse the numkeys. */
-    if (getRangeLongFromObjectOrReply(c, c->argv[numkeys_idx], 1, LONG_MAX,
-                                      &numkeys, "numkeys should be greater than 0") != C_OK)
+    if (getPositiveLongFromObjectOrReply(c, c->argv[numkeys_idx],
+                                         &numkeys, "numkeys should be greater than 0") != C_OK)
         return;
 
     /* Parse the where. where_idx: the index of where in the c->argv. */
@@ -1439,8 +1439,8 @@ void lmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
 
         if (count == -1 && !strcasecmp(opt, "COUNT") && moreargs) {
             j++;
-            if (getRangeLongFromObjectOrReply(c, c->argv[j], 1, LONG_MAX,
-                                              &count,"count should be greater than 0") != C_OK)
+            if (getPositiveLongFromObjectOrReply(c, c->argv[j], &count,
+                                                 "count should be greater than 0") != C_OK)
                 return;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -826,7 +826,7 @@ void spopWithCountCommand(client *c) {
     size_t oldsize = 0;
 
     /* Get the count argument */
-    if (getPositiveLongFromObjectOrReply(c,c->argv[2],&l,NULL) != C_OK) return;
+    if (getNonNegativeLongFromObjectOrReply(c,c->argv[2],&l,NULL) != C_OK) return;
     count = (unsigned long) l;
 
     /* Make sure a key with the name inputted exists, and that it's type is
@@ -1601,8 +1601,8 @@ void sinterCardCommand(client *c) {
     long numkeys = 0; /* Number of keys. */
     long limit = 0;   /* 0 means not limit. */
 
-    if (getRangeLongFromObjectOrReply(c, c->argv[1], 1, LONG_MAX,
-                                      &numkeys, "numkeys should be greater than 0") != C_OK)
+    if (getPositiveLongFromObjectOrReply(c, c->argv[1], &numkeys,
+                                         "numkeys should be greater than 0") != C_OK)
         return;
     if (numkeys > (c->argc - 2)) {
         addReplyError(c, "Number of keys can't be greater than number of args");
@@ -1615,7 +1615,7 @@ void sinterCardCommand(client *c) {
 
         if (!strcasecmp(opt, "LIMIT") && moreargs) {
             j++;
-            if (getPositiveLongFromObjectOrReply(c, c->argv[j], &limit,
+            if (getNonNegativeLongFromObjectOrReply(c, c->argv[j], &limit,
                                                  "LIMIT can't be negative") != C_OK)
                 return;
         } else {

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1224,8 +1224,8 @@ static int streamParseAckDelArgsOrReply(client *c, int start_pos, streamAckDelAr
             j++;
         } else if (!strcasecmp(opt, "IDS") && j+1 < c->argc) {
             /* Parse the number of IDs */
-            if (getRangeLongFromObjectOrReply(c, c->argv[j+1], 1, LONG_MAX,
-                &args->numids, "Number of IDs must be a positive integer") != C_OK)
+            if (getPositiveLongFromObjectOrReply(c, c->argv[j+1], &args->numids,
+                "Number of IDs must be a positive integer") != C_OK)
             {
                 return 0;
             }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2975,7 +2975,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
                        !strcasecmp(c->argv[j]->ptr, "limit"))
             {
                 j++; remaining--;
-                if (getPositiveLongFromObjectOrReply(c, c->argv[j], &limit,
+                if (getNonNegativeLongFromObjectOrReply(c, c->argv[j], &limit,
                                                      "LIMIT can't be negative") != C_OK)
                 {
                     zfree(src);
@@ -4363,7 +4363,7 @@ void zpopMinMaxCommand(client *c, int where) {
     }
 
     long count = -1; /* -1 for plain single pop. */
-    if (c->argc == 3 && getPositiveLongFromObjectOrReply(c, c->argv[2], &count, NULL) != C_OK)
+    if (c->argc == 3 && getNonNegativeLongFromObjectOrReply(c, c->argv[2], &count, NULL) != C_OK)
         return;
 
     /* Respond with a single (flat) array in RESP2 or if count is -1
@@ -4749,8 +4749,8 @@ void zmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
     long count = -1;       /* Reply will consist of up to count elements, depending on the zset's length. */
 
     /* Parse the numkeys. */
-    if (getRangeLongFromObjectOrReply(c, c->argv[numkeys_idx], 1, LONG_MAX,
-                                      &numkeys, "numkeys should be greater than 0") != C_OK)
+    if (getPositiveLongFromObjectOrReply(c, c->argv[numkeys_idx], &numkeys,
+                                         "numkeys should be greater than 0") != C_OK)
         return;
 
     /* Parse the where. where_idx: the index of where in the c->argv. */
@@ -4775,8 +4775,8 @@ void zmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
 
         if (count == -1 && !strcasecmp(opt, "COUNT") && moreargs) {
             j++;
-            if (getRangeLongFromObjectOrReply(c, c->argv[j], 1, LONG_MAX,
-                                              &count,"count should be greater than 0") != C_OK)
+            if (getPositiveLongFromObjectOrReply(c, c->argv[j], &count,
+                                                 "count should be greater than 0") != C_OK)
                 return;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1156,13 +1156,13 @@ start_server {tags {"zset"}} {
 
             test "$pop with negative count" {
                 r set zset foo
-                assert_error "ERR *must be positive" {r $pop zset -1}
+                assert_error "ERR *can't be negative" {r $pop zset -1}
 
                 r del zset
-                assert_error "ERR *must be positive" {r $pop zset -2}
+                assert_error "ERR *can't be negative" {r $pop zset -2}
 
                 r zadd zset 1 a 2 b 3 c
-                assert_error "ERR *must be positive" {r $pop zset -3}
+                assert_error "ERR *can't be negative" {r $pop zset -3}
             }
         }
 


### PR DESCRIPTION
## What

As per title.

## Why

The version of `getPositiveLongFromObjectOrReply` in `unstable` checks for range [0, LONG_MAX], but the `Positive` implies range of [1, LONG_MAX], so the function was renamed to `getNonNegativeLongFromObjectOrReply`.

## Additionally

After renaming a new version of `getPositiveLongFromObjectOrReply` was introduced which checks for range [1, LONG_MAX]. The new version was used in certain places that were using `getRangeFromLong` with range [1, LONG_MAX]


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches argument validation across many commands, which can subtly change accepted inputs (notably allowing zero where previously rejected) and error messages, but the changes are localized to parsing helpers and call-site swaps.
> 
> **Overview**
> Adds `getNonNegativeLongFromObjectOrReply` (0..`LONG_MAX`) and redefines `getPositiveLongFromObjectOrReply` to be strictly positive (1..`LONG_MAX`), updating `object.h`/`object.c` accordingly.
> 
> Updates multiple commands to use the correct helper based on semantics: switches count/limit-like args that allow zero to the new non-negative helper (e.g. list/set/zset pop counts, `SINTERCARD LIMIT`, `WAITAOF` replicas), while converting several prior `getRangeLongFromObjectOrReply(1..)` call sites to the now-strict `getPositiveLongFromObjectOrReply` (e.g. `numkeys`, `numfields`, `client id`, stream `IDS` count). Test expectations are adjusted for the new non-negative error wording ("can’t be negative").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf22bbf71fb4c5cbcc5880f44e478c4a1a5c8253. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->