### PR TITLE
Skeleton of gh workflow for published release

### DIFF
--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -16,7 +16,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all history for git archive
-      
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
+
+      - name: Check for uploaded assets
+        run: |
+          ASSETS=$(gh api repos/${{ github.repository }}/releases/tags/${{ github.event.release.tag_name }} --jq '.assets')
+          echo "Assets: ${ASSETS}"
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
       - name: Extract and validate release information
         id: release-info
         env:

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -21,21 +21,19 @@ jobs:
         id: release-info
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
+          IS_LATEST: ${{ github.event.release.latest }}
         run: |
           # Extract tag name from the release event (via env var to prevent injection)
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "Release tag: ${TAG_NAME}"
 
-          # Validate tag format (MAJOR.MINOR.PATCH or MAJOR.MINOR-rcN)
-          if [[ "${TAG_NAME}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "release_type=stable" >> $GITHUB_OUTPUT
-            echo "Detected stable release: ${TAG_NAME}"
-          elif [[ "${TAG_NAME}" =~ ^[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
-            echo "release_type=rc" >> $GITHUB_OUTPUT
-            echo "Detected RC release: ${TAG_NAME}"
+          # Determine release type based on "latest" label
+          if [[ "${IS_LATEST}" == "true" ]]; then
+            echo "release_type=latest" >> $GITHUB_OUTPUT
+            echo "Detected latest release: ${TAG_NAME}"
           else
-            echo "Error: Invalid tag format. Expected MAJOR.MINOR.PATCH or MAJOR.MINOR-rcN"
-            exit 1
+            echo "release_type=non-latest" >> $GITHUB_OUTPUT
+            echo "Detected non-latest release: ${TAG_NAME}"
           fi
 
       - name: Set up environment variables
@@ -97,23 +95,23 @@ jobs:
 
           echo "✓ Release hashes update step (placeholder)"
 
-      - name: Approval gate for stable releases
-        if: steps.release-info.outputs.release_type == 'stable'
+      - name: Approval gate for latest releases
+        if: steps.release-info.outputs.release_type == 'latest'
         run: |
-          echo "Stable release detected. Manual approval required for production deployment."
+          echo "Latest release detected. Manual approval required for production deployment."
           # TODO: Implement approval workflow
           # This could use GitHub Environments with required reviewers
           # or a manual approval step
 
           echo "✓ Approval gate (placeholder)"
 
-      - name: Update stable symlink (stable releases only)
-        if: steps.release-info.outputs.release_type == 'stable'
+      - name: Update stable symlink (latest releases only)
+        if: steps.release-info.outputs.release_type == 'latest'
         id: update-stable
         run: |
-          echo "This is a stable release. Updating stable symlink after approval."
+          echo "This is a latest release. Updating stable symlink after approval."
           # TODO: Implement stable symlink update
-          # This step should only run for stable releases (not RC)
+          # This step should only run for latest releases (not non-latest)
           # It will update the redis-stable symlink on download.redis.io
           # This is part of the upload script (02_upload_tarball.sh)
 
@@ -132,7 +130,23 @@ jobs:
           echo "- Upload tarball: ${{ steps.upload-tarball.outcome }}" >> $GITHUB_STEP_SUMMARY
           echo "- Test release: ${{ steps.test-release.outcome }}" >> $GITHUB_STEP_SUMMARY
           echo "- Update hashes: ${{ steps.update-hashes.outcome }}" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ steps.release-info.outputs.release_type }}" == "stable" ]]; then
+          if [[ "${{ steps.release-info.outputs.release_type }}" == "latest" ]]; then
             echo "- Update stable symlink: ${{ steps.update-stable.outcome }}" >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Send Slack notification
+        if: always()
+        run: |
+          echo "Sending Slack notification for release ${RELEASE_TAG}..."
+          # TODO: Implement Slack notification
+          # This will require:
+          # - Slack webhook URL or bot token (stored in secrets)
+          # - Determine appropriate channel (e.g., #releases, #redis-releases)
+          # - Craft message with release information and workflow status
+          # Example using webhook:
+          # curl -X POST -H 'Content-type: application/json' \
+          #   --data '{"channel":"#releases","text":"Release ${RELEASE_TAG} automation completed"}' \
+          #   ${{ secrets.SLACK_WEBHOOK_URL }}
+
+          echo "✓ Slack notification step (placeholder)"
 

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -22,11 +22,13 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
           IS_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_ASSETS: ${{ toJSON(github.event.release.assets) }}
         run: |
           # Extract tag name from the release event (via env var to prevent injection)
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "Release tag: ${TAG_NAME}"
           echo "Is prerelease: ${IS_PRERELEASE}"
+          echo "Assets: ${RELEASE_ASSETS}"
 
           # Determine release type based on prerelease flag
           if [[ "${IS_PRERELEASE}" == "false" ]]; then

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -120,7 +120,6 @@ jobs:
           echo "### Steps Status" >> $GITHUB_STEP_SUMMARY
           echo "- Create tarball: ${{ steps.create-tarball.outcome }}" >> $GITHUB_STEP_SUMMARY
           echo "- Upload tarball: ${{ steps.upload-tarball.outcome }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Test release: ${{ steps.test-release.outcome }}" >> $GITHUB_STEP_SUMMARY
           echo "- Update hashes: ${{ steps.update-hashes.outcome }}" >> $GITHUB_STEP_SUMMARY
           if [[ "${{ steps.release-info.outputs.release_type }}" == "latest" ]]; then
             echo "- Update stable symlink: ${{ steps.update-stable.outcome }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -22,20 +22,14 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
           IS_PRERELEASE: ${{ github.event.release.prerelease }}
-          IS_LATEST: ${{ github.event.release.prerelease == 'false' }}
-          RELEASE_ASSETS: ${{ toJSON(github.event.release.assets) }}
         run: |
           # Extract tag name from the release event (via env var to prevent injection)
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "Release tag: ${TAG_NAME}"
           echo "Is prerelease: ${IS_PRERELEASE}"
 
-          # Log release asset labels
-          echo "Release assets and labels:"
-          echo "${RELEASE_ASSETS}" | jq -r '.[] | "  - Asset: \(.name), Label: \(.label // "none")"'
-
-          # Determine release type based on "latest" label
-          if [[ "${IS_LATEST}" == "true" ]]; then
+          # Determine release type based on prerelease flag
+          if [[ "${IS_PRERELEASE}" == "false" ]]; then
             echo "release_type=latest" >> $GITHUB_OUTPUT
             echo "Detected latest release: ${TAG_NAME}"
           else

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -8,7 +8,7 @@ jobs:
   automate-release-scripts:
     # Only run for the main redis/redis repository (not forks)
     # Note: Only users with write access can publish releases, providing implicit authorization
-    if: github.repository == 'redis/redis'
+    if: github.repository == 'redis/redis' || github.repository == 'stav-nachmias/fork-redis'
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -76,6 +76,17 @@ jobs:
 
           echo "✓ Tarball upload step (placeholder)"
 
+      - name: Test release tarball
+        id: test-release
+        run: |
+          echo "Testing release tarball for version ${RELEASE_TAG}..."
+          # TODO: Implement release testing using utils/releasetools/03_test_release.sh
+          # This will:
+          # - Download the uploaded tarball
+          # - Extract and build Redis
+
+          echo "✓ Release testing step (placeholder)"
+
       - name: Update release hashes
         id: update-hashes
         run: |
@@ -120,6 +131,7 @@ jobs:
           echo "### Steps Status" >> $GITHUB_STEP_SUMMARY
           echo "- Create tarball: ${{ steps.create-tarball.outcome }}" >> $GITHUB_STEP_SUMMARY
           echo "- Upload tarball: ${{ steps.upload-tarball.outcome }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Test release: ${{ steps.test-release.outcome }}" >> $GITHUB_STEP_SUMMARY
           echo "- Update hashes: ${{ steps.update-hashes.outcome }}" >> $GITHUB_STEP_SUMMARY
           if [[ "${{ steps.release-info.outputs.release_type }}" == "latest" ]]; then
             echo "- Update stable symlink: ${{ steps.update-stable.outcome }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -21,11 +21,13 @@ jobs:
         id: release-info
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-          IS_LATEST: ${{ github.event.release.latest }}
+          IS_LATEST: ${{ github.event.release.prerelease == 'false' }}
+          RELEASE_LABEL: ${{ github.event.release.label }}
         run: |
           # Extract tag name from the release event (via env var to prevent injection)
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "Release tag: ${TAG_NAME}"
+          echo "Release label: ${RELEASE_LABEL}"
 
           # Determine release type based on "latest" label
           if [[ "${IS_LATEST}" == "true" ]]; then

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -1,0 +1,146 @@
+name: Post-Release Automation
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  automate-release-scripts:
+    # Only run for the main redis/redis repository (not forks)
+    # Note: Only users with write access can publish releases, providing implicit authorization
+    # For testing on forks, change to: github.repository == 'stav-nachmias/fork-redis'
+    if: github.repository == 'redis/redis' || github.repository == 'stav-nachmias/fork-redis'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for git archive
+      
+      - name: Extract and validate release information
+        id: release-info
+        run: |
+          # Extract tag name from the release event
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
+          echo "Release tag: ${TAG_NAME}"
+          
+          # Validate tag format (MAJOR.MINOR.PATCH or MAJOR.MINOR-rcN)
+          if [[ "${TAG_NAME}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release_type=stable" >> $GITHUB_OUTPUT
+            echo "Detected stable release: ${TAG_NAME}"
+          elif [[ "${TAG_NAME}" =~ ^[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+            echo "release_type=rc" >> $GITHUB_OUTPUT
+            echo "Detected RC release: ${TAG_NAME}"
+          else
+            echo "Error: Invalid tag format. Expected MAJOR.MINOR.PATCH or MAJOR.MINOR-rcN"
+            exit 1
+          fi
+          
+          # Extract version components
+          VERSION="${TAG_NAME}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Version: ${VERSION}"
+      
+      - name: Set up environment variables
+        run: |
+          echo "RELEASE_TAG=${{ steps.release-info.outputs.tag_name }}" >> $GITHUB_ENV
+          echo "RELEASE_TYPE=${{ steps.release-info.outputs.release_type }}" >> $GITHUB_ENV
+          echo "VERSION=${{ steps.release-info.outputs.version }}" >> $GITHUB_ENV
+          echo "Environment variables set:"
+          echo "  RELEASE_TAG: ${{ steps.release-info.outputs.tag_name }}"
+          echo "  RELEASE_TYPE: ${{ steps.release-info.outputs.release_type }}"
+          echo "  VERSION: ${{ steps.release-info.outputs.version }}"
+      
+      - name: Create tarball
+        id: create-tarball
+        run: |
+          echo "Creating tarball for version ${VERSION}..."
+          # TODO: Implement tarball creation using utils/releasetools/01_create_tarball.sh
+          # ./utils/releasetools/01_create_tarball.sh ${VERSION}
+          
+          # Placeholder: Verify tarball was created
+          # TARBALL_PATH="/tmp/redis-${VERSION}.tar.gz"
+          # if [ ! -f "${TARBALL_PATH}" ]; then
+          #   echo "Error: Tarball not found at ${TARBALL_PATH}"
+          #   exit 1
+          # fi
+          # echo "tarball_path=${TARBALL_PATH}" >> $GITHUB_OUTPUT
+          
+          echo "✓ Tarball creation step (placeholder)"
+      
+      - name: Upload tarball
+        id: upload-tarball
+        run: |
+          echo "Uploading tarball for version ${VERSION}..."
+          # TODO: Implement tarball upload
+          # This will require:
+          # - SSH credentials/keys for upload to download.redis.io
+          # - Adaptation of utils/releasetools/02_upload_tarball.sh for CI environment
+          
+          echo "✓ Tarball upload step (placeholder)"
+      
+      - name: Test release tarball
+        id: test-release
+        run: |
+          echo "Testing release tarball for version ${VERSION}..."
+          # TODO: Implement release testing using utils/releasetools/03_test_release.sh
+          # This will:
+          # - Download the uploaded tarball
+          # - Extract and build Redis
+          # - Run test suites (runtest, runtest-sentinel, runtest-cluster, runtest-moduleapi)
+          
+          echo "✓ Release testing step (placeholder)"
+      
+      - name: Update release hashes
+        id: update-hashes
+        run: |
+          echo "Updating release hashes for version ${VERSION}..."
+          # TODO: Implement hash update using utils/releasetools/04_release_hash.sh
+          # This will require:
+          # - Access to redis-hashes repository
+          # - Git credentials for committing and pushing
+          
+          echo "✓ Release hashes update step (placeholder)"
+      
+      - name: Update stable symlink (stable releases only)
+        if: steps.release-info.outputs.release_type == 'stable'
+        id: update-stable
+        run: |
+          echo "This is a stable release. Stable symlink update will require approval."
+          # TODO: Implement stable symlink update
+          # This step should only run for stable releases (not RC)
+          # It will update the redis-stable symlink on download.redis.io
+          # This is part of the upload script (02_upload_tarball.sh)
+          
+          echo "✓ Stable symlink update step (placeholder)"
+      
+      - name: Approval gate for stable releases
+        if: steps.release-info.outputs.release_type == 'stable'
+        run: |
+          echo "Stable release detected. Manual approval required for production deployment."
+          # TODO: Implement approval workflow
+          # This could use GitHub Environments with required reviewers
+          # or a manual approval step
+          
+          echo "✓ Approval gate (placeholder)"
+      
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Post-Release Automation Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release Tag:** ${{ steps.release-info.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release Type:** ${{ steps.release-info.outputs.release_type }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** ${{ steps.release-info.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Steps Status" >> $GITHUB_STEP_SUMMARY
+          echo "- Create tarball: ${{ steps.create-tarball.outcome }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Upload tarball: ${{ steps.upload-tarball.outcome }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Test release: ${{ steps.test-release.outcome }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Update hashes: ${{ steps.update-hashes.outcome }}" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ steps.release-info.outputs.release_type }}" == "stable" ]]; then
+            echo "- Update stable symlink: ${{ steps.update-stable.outcome }}" >> $GITHUB_STEP_SUMMARY
+          fi
+

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -17,45 +17,27 @@ jobs:
         with:
           fetch-depth: 0  # Fetch all history for git archive
 
-      - name: Test GitHub token
-        run: |
-          gh auth status
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Get latest release
-        id: latest-release
-        run: |
-          LATEST_TAG=$(gh release view --json tagName --jq '.tagName')
-          echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
-          echo "Latest release tag: ${LATEST_TAG}"
-          
-          cli_cmd_red="$(gh release view)"
-          echo "cli_cmd_red=${cli_cmd_red}" >> $GITHUB_OUTPUT
-          echo "cli_cmd_red: ${cli_cmd_red}"
-        env:
-          GH_TOKEN: ${{ github.token }}
-
       - name: Extract and validate release information
         id: release-info
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-          IS_PRERELEASE: ${{ github.event.release.prerelease }}
-          RELEASE_ASSETS: ${{ toJSON(github.event.release.assets) }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Extract tag name from the release event (via env var to prevent injection)
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "Release tag: ${TAG_NAME}"
-          echo "Is prerelease: ${IS_PRERELEASE}"
-          echo "Assets: ${RELEASE_ASSETS}"
 
-          # Determine release type based on prerelease flag
-          if [[ "${IS_PRERELEASE}" == "false" ]]; then
+          # Get the latest release tag
+          LATEST_TAG=$(gh release view --json tagName --jq '.tagName')
+          echo "Latest release tag from gh cli: ${LATEST_TAG}"
+
+          # Determine release type by comparing with latest release
+          if [[ "${TAG_NAME}" == "${LATEST_TAG}" ]]; then
             echo "release_type=latest" >> $GITHUB_OUTPUT
             echo "Detected latest release: ${TAG_NAME}"
           else
             echo "release_type=non-latest" >> $GITHUB_OUTPUT
-            echo "Detected non-latest release: ${TAG_NAME}"
+            echo "Detected non-latest release: ${TAG_NAME} (latest is ${LATEST_TAG})"
           fi
 
       - name: Set up environment variables

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -21,13 +21,18 @@ jobs:
         id: release-info
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
           IS_LATEST: ${{ github.event.release.prerelease == 'false' }}
-          RELEASE_LABEL: ${{ github.event.release.label }}
+          RELEASE_ASSETS: ${{ toJSON(github.event.release.assets) }}
         run: |
           # Extract tag name from the release event (via env var to prevent injection)
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "Release tag: ${TAG_NAME}"
-          echo "Release label: ${RELEASE_LABEL}"
+          echo "Is prerelease: ${IS_PRERELEASE}"
+
+          # Log release asset labels
+          echo "Release assets and labels:"
+          echo "${RELEASE_ASSETS}" | jq -r '.[] | "  - Asset: \(.name), Label: \(.label // "none")"'
 
           # Determine release type based on "latest" label
           if [[ "${IS_LATEST}" == "true" ]]; then

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -8,8 +8,7 @@ jobs:
   automate-release-scripts:
     # Only run for the main redis/redis repository (not forks)
     # Note: Only users with write access can publish releases, providing implicit authorization
-    # For testing on forks, change to: github.repository == 'stav-nachmias/fork-redis'
-    if: github.repository == 'redis/redis' || github.repository == 'stav-nachmias/fork-redis'
+    if: github.repository == 'redis/redis'
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -19,12 +19,13 @@ jobs:
       
       - name: Extract and validate release information
         id: release-info
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          # Extract tag name from the release event
-          TAG_NAME="${{ github.event.release.tag_name }}"
+          # Extract tag name from the release event (via env var to prevent injection)
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "Release tag: ${TAG_NAME}"
-          
+
           # Validate tag format (MAJOR.MINOR.PATCH or MAJOR.MINOR-rcN)
           if [[ "${TAG_NAME}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "release_type=stable" >> $GITHUB_OUTPUT
@@ -36,85 +37,66 @@ jobs:
             echo "Error: Invalid tag format. Expected MAJOR.MINOR.PATCH or MAJOR.MINOR-rcN"
             exit 1
           fi
-          
-          # Extract version components
-          VERSION="${TAG_NAME}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "Version: ${VERSION}"
-      
+
       - name: Set up environment variables
         run: |
           echo "RELEASE_TAG=${{ steps.release-info.outputs.tag_name }}" >> $GITHUB_ENV
           echo "RELEASE_TYPE=${{ steps.release-info.outputs.release_type }}" >> $GITHUB_ENV
-          echo "VERSION=${{ steps.release-info.outputs.version }}" >> $GITHUB_ENV
           echo "Environment variables set:"
           echo "  RELEASE_TAG: ${{ steps.release-info.outputs.tag_name }}"
           echo "  RELEASE_TYPE: ${{ steps.release-info.outputs.release_type }}"
-          echo "  VERSION: ${{ steps.release-info.outputs.version }}"
       
       - name: Create tarball
         id: create-tarball
         run: |
-          echo "Creating tarball for version ${VERSION}..."
+          echo "Creating tarball for version ${RELEASE_TAG}..."
           # TODO: Implement tarball creation using utils/releasetools/01_create_tarball.sh
-          # ./utils/releasetools/01_create_tarball.sh ${VERSION}
-          
+          # ./utils/releasetools/01_create_tarball.sh ${RELEASE_TAG}
+
           # Placeholder: Verify tarball was created
-          # TARBALL_PATH="/tmp/redis-${VERSION}.tar.gz"
+          # TARBALL_PATH="/tmp/redis-${RELEASE_TAG}.tar.gz"
           # if [ ! -f "${TARBALL_PATH}" ]; then
           #   echo "Error: Tarball not found at ${TARBALL_PATH}"
           #   exit 1
           # fi
           # echo "tarball_path=${TARBALL_PATH}" >> $GITHUB_OUTPUT
-          
+
           echo "✓ Tarball creation step (placeholder)"
-      
+
       - name: Upload tarball
         id: upload-tarball
         run: |
-          echo "Uploading tarball for version ${VERSION}..."
+          echo "Uploading tarball for version ${RELEASE_TAG}..."
           # TODO: Implement tarball upload
           # This will require:
           # - SSH credentials/keys for upload to download.redis.io
           # - Adaptation of utils/releasetools/02_upload_tarball.sh for CI environment
-          
+
           echo "✓ Tarball upload step (placeholder)"
-      
+
       - name: Test release tarball
         id: test-release
         run: |
-          echo "Testing release tarball for version ${VERSION}..."
+          echo "Testing release tarball for version ${RELEASE_TAG}..."
           # TODO: Implement release testing using utils/releasetools/03_test_release.sh
           # This will:
           # - Download the uploaded tarball
           # - Extract and build Redis
           # - Run test suites (runtest, runtest-sentinel, runtest-cluster, runtest-moduleapi)
-          
+
           echo "✓ Release testing step (placeholder)"
-      
+
       - name: Update release hashes
         id: update-hashes
         run: |
-          echo "Updating release hashes for version ${VERSION}..."
+          echo "Updating release hashes for version ${RELEASE_TAG}..."
           # TODO: Implement hash update using utils/releasetools/04_release_hash.sh
           # This will require:
           # - Access to redis-hashes repository
           # - Git credentials for committing and pushing
-          
+
           echo "✓ Release hashes update step (placeholder)"
-      
-      - name: Update stable symlink (stable releases only)
-        if: steps.release-info.outputs.release_type == 'stable'
-        id: update-stable
-        run: |
-          echo "This is a stable release. Stable symlink update will require approval."
-          # TODO: Implement stable symlink update
-          # This step should only run for stable releases (not RC)
-          # It will update the redis-stable symlink on download.redis.io
-          # This is part of the upload script (02_upload_tarball.sh)
-          
-          echo "✓ Stable symlink update step (placeholder)"
-      
+
       - name: Approval gate for stable releases
         if: steps.release-info.outputs.release_type == 'stable'
         run: |
@@ -122,8 +104,20 @@ jobs:
           # TODO: Implement approval workflow
           # This could use GitHub Environments with required reviewers
           # or a manual approval step
-          
+
           echo "✓ Approval gate (placeholder)"
+
+      - name: Update stable symlink (stable releases only)
+        if: steps.release-info.outputs.release_type == 'stable'
+        id: update-stable
+        run: |
+          echo "This is a stable release. Updating stable symlink after approval."
+          # TODO: Implement stable symlink update
+          # This step should only run for stable releases (not RC)
+          # It will update the redis-stable symlink on download.redis.io
+          # This is part of the upload script (02_upload_tarball.sh)
+
+          echo "✓ Stable symlink update step (placeholder)"
       
       - name: Summary
         if: always()
@@ -132,7 +126,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Release Tag:** ${{ steps.release-info.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Release Type:** ${{ steps.release-info.outputs.release_type }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version:** ${{ steps.release-info.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Steps Status" >> $GITHUB_STEP_SUMMARY
           echo "- Create tarball: ${{ steps.create-tarball.outcome }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -8,7 +8,7 @@ jobs:
   automate-release-scripts:
     # Only run for the main redis/redis repository (not forks)
     # Note: Only users with write access can publish releases, providing implicit authorization
-    if: github.repository == 'redis/redis' || github.repository == 'stav-nachmias/fork-redis'
+    if: github.repository == 'redis/redis'
     runs-on: ubuntu-latest
     
     steps:
@@ -75,18 +75,6 @@ jobs:
           # - Adaptation of utils/releasetools/02_upload_tarball.sh for CI environment
 
           echo "✓ Tarball upload step (placeholder)"
-
-      - name: Test release tarball
-        id: test-release
-        run: |
-          echo "Testing release tarball for version ${RELEASE_TAG}..."
-          # TODO: Implement release testing using utils/releasetools/03_test_release.sh
-          # This will:
-          # - Download the uploaded tarball
-          # - Extract and build Redis
-          # - Run test suites (runtest, runtest-sentinel, runtest-cluster, runtest-moduleapi)
-
-          echo "✓ Release testing step (placeholder)"
 
       - name: Update release hashes
         id: update-hashes

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -17,19 +17,24 @@ jobs:
         with:
           fetch-depth: 0  # Fetch all history for git archive
 
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.DOCS_APP_ID }}
-          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
-
-      - name: Check for uploaded assets
+      - name: Test GitHub token
         run: |
-          ASSETS=$(gh api repos/${{ github.repository }}/releases/tags/${{ github.event.release.tag_name }} --jq '.assets')
-          echo "Assets: ${ASSETS}"
+          gh auth status
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Get latest release
+        id: latest-release
+        run: |
+          LATEST_TAG=$(gh release view --json tagName --jq '.tagName')
+          echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
+          echo "Latest release tag: ${LATEST_TAG}"
+          
+          cli_cmd_red="$(gh release view)"
+          echo "cli_cmd_red=${cli_cmd_red}" >> $GITHUB_OUTPUT
+          echo "cli_cmd_red: ${cli_cmd_red}"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Extract and validate release information
         id: release-info


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk since it only introduces a new workflow with mostly placeholder commands and no deployment/credential usage yet; it will run on `release.published` events in `redis/redis`.
> 
> **Overview**
> Adds a new `Post-Release Automation` GitHub Actions workflow triggered on `release.published` (guarded to only run on `redis/redis`).
> 
> The workflow extracts the release tag and determines whether it is the latest release, then stubs out the post-release pipeline (tarball creation/upload, tarball testing, and updating hashes) with a conditional *latest-only* approval gate and stable-symlink update placeholder, plus a run summary and placeholder Slack notification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7c9e373a5d745495370231f0fbc8f651964b36a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->