### PR TITLE
fix Rust binary checksums

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -40,24 +40,24 @@ ifeq ($(INSTALL_RUST_TOOLCHAIN),yes)
 		'x86_64') \
 			if [ "$${LIBC_TYPE}" = "musl" ]; then \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-x86_64-unknown-linux-musl"; \
-				RUST_SHA256="5a6c766ce05ad7229aadbb365bad2c9c809c9e378706f123c156821fe6ab2711"; \
+				RUST_SHA256="6a57ddfffa77bfa97ab325586b08fc1e96c3acb82ecc9f554cdb2ef748466ef2"; \
 			else \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-x86_64-unknown-linux-gnu"; \
-				RUST_SHA256="fa99eb4e823fdeb8ee25e486c7973b4803013ac68c64e8f74880da788db9739c"; \
+				RUST_SHA256="518872275a3648f735471d7add854d39171c5a6b17f423c4d7f931f52120c2af"; \
 			fi ;; \
 		'aarch64') \
 			if [ "$${LIBC_TYPE}" = "musl" ]; then \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-aarch64-unknown-linux-musl"; \
-				RUST_SHA256="859d2e973ba1b0106aaeb5df7db72673cb82b9de417339e28ae9b5074756db5b"; \
+				RUST_SHA256="34f0ffb0cd3e334aeae344daae09984f951eeb842386406d4bdf11cd0b4c2b36"; \
 			else \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-aarch64-unknown-linux-gnu"; \
-				RUST_SHA256="bbe822f0aae2c1d31fa950a78446d4749e07ed67e974f87bf0c69146df2a9d9c"; \
+				RUST_SHA256="701d55b62286bed013ceb2393ff7687d0953205605afaa15c62e2cd18024c32c"; \
 			fi ;; \
 		*) echo >&2 "Unsupported architecture: '$${ARCH}'"; exit 1 ;; \
 	esac; \
 	echo "Downloading and installing Rust standalone installer: $${RUST_INSTALLER}"; \
 	wget --quiet -O $${RUST_INSTALLER}.tar.xz https://static.rust-lang.org/dist/$${RUST_INSTALLER}.tar.xz; \
-	echo "$${RUST_SHA256} $${RUST_INSTALLER}.tar.xz" | sha256sum -c --quiet || { echo "Rust standalone installer checksum failed!"; exit 1; }; \
+	echo "$${RUST_SHA256} $${RUST_INSTALLER}.tar.xz" | sha256sum -c --status || { echo "Rust standalone installer checksum failed!"; exit 1; }; \
 	tar -xf $${RUST_INSTALLER}.tar.xz; \
 	(cd $${RUST_INSTALLER} && ./install.sh); \
 	rm -rf $${RUST_INSTALLER}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build-script-only change that updates pinned checksums and a verification flag; main risk is breaking Rust toolchain installation if the new hashes are incorrect.
> 
> **Overview**
> Updates the `modules/Makefile` Rust toolchain bootstrap to use new SHA256 checksums for the Rust 1.93.1 standalone installers across `x86_64`/`aarch64` and `musl`/`gnu` targets.
> 
> Also changes the checksum verification command to use `sha256sum -c --status` (instead of `--quiet`) while keeping the same failure behavior, reducing noisy output during successful installs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30ab5a3ba63cd77e7ce10ab66f771e69bad9db77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->