### PR TITLE
ci: declare explicit token permissions in maintenance workflows

### DIFF
--- a/.github/workflows/redis_docs_sync.yaml
+++ b/.github/workflows/redis_docs_sync.yaml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   redis_docs_sync:
     if: github.repository == 'redis/redis'

--- a/.github/workflows/reply-schemas-linter.yml
+++ b/.github/workflows/reply-schemas-linter.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'src/commands/*.json'
 
+permissions:
+  contents: read
+
 jobs:
   reply-schemas-linter:
     runs-on: ubuntu-latest
@@ -19,4 +22,3 @@ jobs:
         run: npm install ajv
       - name: linter
         run: node ./utils/reply_schema_linter.js
-

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -9,6 +9,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Spellcheck


### PR DESCRIPTION
## Summary
Add explicit `GITHUB_TOKEN` permissions to maintenance workflows:

- `.github/workflows/spell-check.yml`
  - `contents: read`
- `.github/workflows/reply-schemas-linter.yml`
  - `contents: read`
- `.github/workflows/redis_docs_sync.yaml`
  - `permissions: {}`

## Why
These workflows currently rely on implicit default token scopes. Declaring minimal required permissions improves least-privilege security and makes access intent explicit.

## Notes
`redis_docs_sync` uses a dedicated GitHub App token from `actions/create-github-app-token`, so it doesn't require `GITHUB_TOKEN` scopes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that narrows token scopes; low chance of impact aside from potential permission-related workflow failures.
> 
> **Overview**
> Declares explicit `permissions` for maintenance GitHub Actions workflows to avoid relying on default `GITHUB_TOKEN` scopes.
> 
> `spell-check.yml` and `reply-schemas-linter.yml` now request only `contents: read`, while `redis_docs_sync.yaml` sets `permissions: {}` since it uses a separate GitHub App token.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8132cc65b321793986468e540a5fc766fd1b32d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->