### PR TITLE
fix typo Reids -> Redis in readwrite subcommand summary

### DIFF
--- a/src/commands/readwrite.json
+++ b/src/commands/readwrite.json
@@ -1,6 +1,6 @@
 {
     "READWRITE": {
-        "summary": "Enables read-write queries for a connection to a Reids Cluster replica node.",
+        "summary": "Enables read-write queries for a connection to a Redis Cluster replica node.",
         "complexity": "O(1)",
         "group": "cluster",
         "since": "3.0.0",


### PR DESCRIPTION
Noticed this typo of Redis in the summary when I typed "help @cluster" in the cli.  Change is to spell Redis correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only string change with no behavior or API impact.
> 
> **Overview**
> Fixes a typo in the `READWRITE` command metadata by correcting “Reids” to “Redis” in the command `summary` shown in CLI help.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22f2dc3181c215356b9ec76598651f30c40d40ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->