### PR TITLE
Allow comments in ACL files (issue #14403)

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2282,10 +2282,10 @@ int ACLLoadConfiguredUsers(void) {
  *
  *  user <username> ... rules ...
  *
- * Note that this function considers comments starting with '#' as errors
- * because the ACL file is meant to be rewritten, and comments would be
- * lost after the rewrite. Yet empty lines are allowed to avoid being too
- * strict.
+ * Lines starting with '#' are treated as comments and skipped. Note that
+ * comments will not be preserved if the ACL file is rewritten via ACL SAVE,
+ * since the file is regenerated from the in-memory user data. Empty lines
+ * are also skipped.
  *
  * One important part of implementing ACL LOAD, that uses this function, is
  * to avoid ending with broken rules if the ACL file is invalid for some
@@ -2339,6 +2339,9 @@ sds ACLLoadFromFile(const char *filename) {
 
         /* Skip blank lines */
         if (lines[i][0] == '\0') continue;
+
+        /* Skip comments */
+        if (lines[i][0] == '#') continue;
 
         /* Split into arguments */
         argv = sdssplitlen(lines[i],sdslen(lines[i])," ",1,&argc);

--- a/tests/assets/user.acl
+++ b/tests/assets/user.acl
@@ -1,3 +1,4 @@
+# This is a comment in the ACL file
 user alice on allcommands allkeys &* >alice
 user bob on -@all +@set +acl ~set* &* >bob
 user doug on resetchannels &test +@all ~* >doug

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1255,6 +1255,21 @@ exec cp -f tests/assets/user.acl $server_path
 exec cp -f tests/assets/default.conf $server_path
 start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags [list "external:skip"]] {
 
+    test {Test loading an ACL file with comments} {
+        exec cp -f tests/assets/user.acl $server_path
+        r ACL LOAD
+        # Comments should be silently skipped; all users must load correctly
+        assert {[r ACL GETUSER alice] != ""}
+        assert {[r ACL GETUSER bob] != ""}
+        assert {[r ACL GETUSER default] != ""}
+
+        # An inline comment mid-file must also be skipped without error
+        exec cp -f tests/assets/user.acl $server_path
+        exec echo "# another comment" >> $server_path/user.acl
+        r ACL LOAD
+        assert {[r ACL GETUSER alice] != ""}
+    }
+
     test {Test loading an ACL file with duplicate users} {
         exec cp -f tests/assets/user.acl $server_path
 


### PR DESCRIPTION
## Summary

Fixes #14403.

Lines beginning with `#` are now silently skipped when parsing an ACL
file, consistent with how `redis.conf` handles comments. Previously,
any `#`-prefixed line caused an error and prevented the entire file
from loading.

**Note:** Comments are not preserved by `ACL SAVE` — that command
regenerates the file from the in-memory user table, so comments will
be lost on rewrite. This is documented in the updated function comment.

## Changes

- **`src/acl.c`**: skip `#`-prefixed lines in `ACLLoadFromFile`; update
  the function comment to reflect the new behaviour.
- **`tests/assets/user.acl`**: add a comment line to the shared test fixture.
- **`tests/unit/acl.tcl`**: add test verifying comment lines are skipped
  without error and all users still load correctly.

## Test plan

- [ ] `./runtest tests/unit/acl.tcl` passes
- [ ] ACL file with `#` comment lines loads without error (`ACL LOAD`)
- [ ] ACL file without comments continues to work as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small parsing change limited to skipping full-line `#` comments in ACL file loading, plus tests; no changes to ACL rule semantics or authorization checks.
> 
> **Overview**
> `ACLLoadFromFile` now treats lines starting with `#` as comments and skips them during `ACL LOAD` parsing, instead of failing the entire file load; the in-code documentation is updated to note that such comments will be dropped on `ACL SAVE` rewrites.
> 
> Tests are updated to include a comment in `tests/assets/user.acl` and a new unit test in `tests/unit/acl.tcl` validating comment lines (including appended mid-file comments) load without errors and users are still created.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89aa4c96659dde4fe9a08daa0d35fbb2871b82fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->