### PR TITLE
tests: fix typos in cluster links and keymeta tests

### DIFF
--- a/tests/unit/cluster/links.tcl
+++ b/tests/unit/cluster/links.tcl
@@ -259,7 +259,7 @@ start_cluster 3 0 {tags {external:skip cluster}} {
         set link_mem_after_pubs [getInfoProperty $res mem_cluster_links]
         
         # We expect the memory to have increased by more than
-        # the culmulative size of the publish messages
+        # the cumulative size of the publish messages
         set mem_diff_floor [expr $msg_size * $num_msgs]
         set mem_diff [expr $link_mem_after_pubs - $link_mem_before_pubs]
         assert {$mem_diff > $mem_diff_floor}

--- a/tests/unit/moduleapi/keymeta.tcl
+++ b/tests/unit/moduleapi/keymeta.tcl
@@ -297,7 +297,7 @@ start_server {tags {"modules" "external:skip" "cluster:skip"} overrides {enable-
         }
     }
 
-    test "KEYMETA - Verify metadta cleanup on lazyfree" {
+    test "KEYMETA - Verify metadata cleanup on lazyfree" {
         r config set lazyfree-lazy-user-del yes
         # Class 2 has UNLINKFREE flag, so it should call unlink callback when lazyfree is enabled
         # Class 1 does not have UNLINKFREE flag, so it should only call free callback


### PR DESCRIPTION
## Summary
- fix typo in links.tcl comment: "culmulative" -> "cumulative"
- fix typo in keymeta test title: "metadta" -> "metadata"

## Why
- improves readability and consistency in test files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and test-name string changes only; no runtime behavior or assertions are modified.
> 
> **Overview**
> Fixes two typos in test code: corrects a comment in `tests/unit/cluster/links.tcl` (“cumulative”) and renames a `KEYMETA` lazyfree test title in `tests/unit/moduleapi/keymeta.tcl` (“metadata”).
> 
> No functional behavior changes; this is strictly a readability/consistency update to test descriptions/comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b481ebb5fb147b97df96dc221bec3eeffa201178. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->