### PR TITLE
Fix implicit conversion warning in timeout.c for newer Clang versions

### DIFF
--- a/src/timeout.c
+++ b/src/timeout.c
@@ -154,7 +154,7 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
             return C_ERR;
 
         ftval *= 1000.0;  /* seconds => millisec */
-        if (ftval > (long double) LLONG_MAX) {
+        if (ftval > (long double)LLONG_MAX) {
             addReplyError(c, "timeout is out of range");
             return C_ERR;
         }

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -154,7 +154,7 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
             return C_ERR;
 
         ftval *= 1000.0;  /* seconds => millisec */
-        if (ftval > LLONG_MAX) {
+        if (ftval > (long double) LLONG_MAX) {
             addReplyError(c, "timeout is out of range");
             return C_ERR;
         }


### PR DESCRIPTION

## Problem

Build fails on macOS with Xcode 26.4 beta (Clang 21):

```
timeout.c:157:21: error: implicit conversion from 'long long' to 'long double' changes value from 9223372036854775807 to 9223372036854775808 [-Werror,-Wimplicit-const-int-float-conversion]
  157 |         if (ftval > LLONG_MAX) {
      |                   ~ ^~~~~~~~~
/Applications/Xcode_26.4_beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/21/include/limits.h:109:20: note: expanded from macro 'LLONG_MAX'
  109 | #define LLONG_MAX  __LONG_LONG_MAX__
      |                    ^~~~~~~~~~~~~~~~~
<built-in>:64:27: note: expanded from macro '__LONG_LONG_MAX__'
   64 | #define __LONG_LONG_MAX__ 9223372036854775807LL
      |                           ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[1]: *** [timeout.o] Error 1
make: *** [all] Error 2
```

Failed daily action: https://github.com/redis/redis/actions/runs/22330628430/job/64611897671

## Cause

Comparing `long double` with `LLONG_MAX` causes implicit conversion with precision loss. Clang 21 has stricter warnings for this, and `-Werror` treats it as an error.

## Fix

Add explicit cast to make the conversion intentional:

```c
if (ftval > (long double) LLONG_MAX) {
```

**Verified**: https://github.com/vitahlin/redis/actions/runs/22354656895




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line, compile-time warning fix limited to a timeout range check; runtime behavior should remain unchanged.
> 
> **Overview**
> Fixes a build failure with newer Clang by making the `long double` vs `LLONG_MAX` comparison in `getTimeoutFromObjectOrReply` explicit (`(long double)LLONG_MAX`), avoiding an implicit conversion warning treated as an error.
> 
> No functional behavior change is intended; it’s a type-safety/portability tweak in timeout range checking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2b3e668e02fbe86f6bf63c81d20b54e256ed7e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->