### PR TITLE
Add HOTKEYS HELP command coverage

### DIFF
--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -16,6 +16,7 @@ start_server {tags {"other"}} {
         assert_match "*CONFIG <subcommand> *" [r CONFIG HELP]
         assert_match "*FUNCTION <subcommand> *" [r FUNCTION HELP]
         assert_match "*MODULE <subcommand> *" [r MODULE HELP]
+        assert_match "*HOTKEYS <subcommand> *" [r HOTKEYS HELP]
     }
 
     test {Coverage: MEMORY MALLOC-STATS} {


### PR DESCRIPTION
Add coverage for HOTKEYS HELP command. Now reply schema test in Daily CI does not fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds a single assertion; no production behavior is modified.
> 
> **Overview**
> Extends the `Coverage: HELP commands` unit test to also validate the reply schema for `HOTKEYS HELP`, ensuring the command is included in HELP coverage and preventing CI schema test failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a885324b422a02aea65d34299d78af6f0f85b485. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->