### PR TITLE
Fix compilation warning: Use macro for seq_buffer_max_length

### DIFF
--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -1060,15 +1060,15 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                 if (seq[1] >= '0' && seq[1] <= '9') {
                     /* Extended escape, read additional bytes.
                      * Examples: ESC [1;5C  ESC [3~ */
-                    const int seq_buffer_max_length = 8;
-                    char seq_buffer[seq_buffer_max_length];
+                    enum { SEQ_BUFFER_MAX_LENGTH = 8 };
+                    char seq_buffer[SEQ_BUFFER_MAX_LENGTH];
                     int i = 0;
                     seq_buffer[i++] = seq[1];
 
                     /* Read more bytes until we see a CSI final byte (range @..~).
-                     * Use seq_buffer_max_length-1 to reserve one position for '\0'. */
+                     * Use SEQ_BUFFER_MAX_LENGTH-1 to reserve one position for '\0'. */
                     char seq_char;
-                    while (i < seq_buffer_max_length-1 && read(l.ifd, &seq_char, 1) == 1) {
+                    while (i < SEQ_BUFFER_MAX_LENGTH - 1 && read(l.ifd, &seq_char, 1) == 1) {
                         seq_buffer[i++] = seq_char;
                         if (seq_char >= '@' && seq_char <= '~') break; /* CSI final byte */
                     }

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -120,6 +120,7 @@
 #include <assert.h>
 #include "linenoise.h"
 
+#define SEQ_BUFFER_MAX_LENGTH 8
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
 #define LINENOISE_MAX_LINE 4096
 static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
@@ -1060,7 +1061,6 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                 if (seq[1] >= '0' && seq[1] <= '9') {
                     /* Extended escape, read additional bytes.
                      * Examples: ESC [1;5C  ESC [3~ */
-                    enum { SEQ_BUFFER_MAX_LENGTH = 8 };
                     char seq_buffer[SEQ_BUFFER_MAX_LENGTH];
                     int i = 0;
                     seq_buffer[i++] = seq[1];


### PR DESCRIPTION
## Description

This PR fixes a compilation warning in `deps/linenoise/linenoise.c` by converting the local constant variable `seq_buffer_max_length` to an enum constant `SEQ_BUFFER_MAX_LENGTH`.

<img width="2078" height="334" alt="CleanShot 2026-02-25 at 17 16 10@2x" src="https://github.com/user-attachments/assets/69955762-d3a5-4189-b368-b6a2bcb20562" />


### Changes Made
- Replaced the local `const int seq_buffer_max_length = 8;` declaration with a macro constant.

<img width="1532" height="186" alt="CleanShot 2026-02-25 at 17 20 05@2x" src="https://github.com/user-attachments/assets/00e0055e-cc87-4750-bcbc-4f3d718b5327" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small constant refactor in terminal escape-sequence parsing; behavior should be unchanged aside from eliminating a compiler warning.
> 
> **Overview**
> Fixes a compilation warning in `deps/linenoise/linenoise.c` by replacing a function-local `const int seq_buffer_max_length` with a file-level `#define SEQ_BUFFER_MAX_LENGTH 8`.
> 
> Updates the extended `ESC [` parsing logic to size `seq_buffer` and its bounds checks/comments using `SEQ_BUFFER_MAX_LENGTH`, with no functional behavior change intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4755e43b3e93127e648e7d9b7ecb245ba9191855. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->