### PR TITLE
Fix memory leak in trackingRememberKeys() for PUBSUB commands

### DIFF
--- a/src/tracking.c
+++ b/src/tracking.c
@@ -200,6 +200,13 @@ void enableTracking(client *c, uint64_t redirect_to, uint64_t options, robj **pr
  * that should receive an invalidation message with certain groups of keys
  * are modified. */
 void trackingRememberKeys(client *tracking, client *executing) {
+    /* Shard channels are treated as special keys for client
+     * library to rely on `COMMAND` command to discover the node
+     * to connect to. These channels don't need to be tracked. */
+    if (executing->cmd->flags & CMD_PUBSUB) {
+        return;
+    }
+
     /* Return if we are in optin/out mode and the right CACHING command
      * was/wasn't given in order to modify the default behavior. */
     uint64_t optin = tracking->flags & CLIENT_TRACKING_OPTIN;
@@ -210,13 +217,6 @@ void trackingRememberKeys(client *tracking, client *executing) {
     getKeysResult result = GETKEYS_RESULT_INIT;
     int numkeys = getKeysFromCommand(executing->cmd,executing->argv,executing->argc,&result);
     if (!numkeys) {
-        getKeysFreeResult(&result);
-        return;
-    }
-    /* Shard channels are treated as special keys for client
-     * library to rely on `COMMAND` command to discover the node
-     * to connect to. These channels don't need to be tracked. */
-    if (executing->cmd->flags & CMD_PUBSUB) {
         getKeysFreeResult(&result);
         return;
     }

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -215,8 +215,9 @@ void trackingRememberKeys(client *tracking, client *executing) {
     }
     /* Shard channels are treated as special keys for client
      * library to rely on `COMMAND` command to discover the node
-     * to connect to. These channels doesn't need to be tracked. */
+     * to connect to. These channels don't need to be tracked. */
     if (executing->cmd->flags & CMD_PUBSUB) {
+        getKeysFreeResult(&result);
         return;
     }
 


### PR DESCRIPTION
When handling PUBSUB commands, the function was returning early without calling `getKeysFreeResult()`, leading to a leak.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small control-flow change limited to client-side caching key tracking; it primarily prevents a memory leak and should not affect non-PUBSUB tracking behavior.
> 
> **Overview**
> Fixes a memory leak in `trackingRememberKeys()` by returning early for `CMD_PUBSUB` commands *before* calling `getKeysFromCommand()`, avoiding an allocated `getKeysResult` that previously wasn’t freed on the PUBSUB fast path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 890ec87c61926284730b2df1bde10596ec855444. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->