### PR TITLE
fix: replace 2 bare except clauses with except Exception

### DIFF
--- a/deps/jemalloc/scripts/gen_run_tests.py
+++ b/deps/jemalloc/scripts/gen_run_tests.py
@@ -31,7 +31,7 @@ for cc, cxx in (['gcc', 'g++'], ['clang', 'clang++']):
         cmd_ret = call([cc, "-v"])
         if cmd_ret == 0:
             possible_compilers.append((cc, cxx))
-    except:
+    except Exception:
         pass
 possible_compiler_opts = [
     '-m32',

--- a/modules/vector-sets/tests/filter_int.py
+++ b/modules/vector-sets/tests/filter_int.py
@@ -477,7 +477,7 @@ class VSIMFilterAdvanced(TestCase):
                                      *[str(x) for x in generate_random_vector(self.dim)],
                                      'FILTER', '.category === "books"')  # Triple equals is invalid
             assert False, "Expected error for invalid filter syntax"
-        except:
+        except Exception:
             print("Invalid filter syntax correctly raised an error")
 
         # Test with extremely long complex expression


### PR DESCRIPTION
Replace bare except clauses with except Exception.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Very small, behavior-preserving change limited to test tooling; only risk is slightly different handling of non-standard exceptions during test execution.
> 
> **Overview**
> This PR narrows two overly broad exception handlers by replacing bare `except` clauses with `except Exception`.
> 
> The change affects `deps/jemalloc/scripts/gen_run_tests.py` (compiler probing) and `modules/vector-sets/tests/filter_int.py` (invalid filter syntax test), ensuring non-`Exception` signals (e.g., `SystemExit`, `KeyboardInterrupt`) are not inadvertently swallowed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72f019015375b00e0eccdba1176e2e1d57373f43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->