### PR TITLE
docs: normalize behavior spelling in comments

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -707,7 +707,7 @@ static inline unsigned char *lpGetWithSize(unsigned char *p, int64_t *count, uns
 
 /* Return the listpack element pointed by 'p'.
  *
- * The function has the same behaviour as lpGetWithSize when 'entry_size' is NULL,
+ * The function has the same behavior as lpGetWithSize when 'entry_size' is NULL,
  * but avoids a lot of unecesarry branching performance penalties. */
 static inline unsigned char *lpGetWithBuf(unsigned char *p, int64_t *count, unsigned char *intbuf) {
     int64_t val;

--- a/src/sds.c
+++ b/src/sds.c
@@ -812,7 +812,7 @@ void sdssubstr(sds s, size_t start, size_t len) {
  *
  * The string is modified in-place.
  *
- * NOTE: this function can be misleading and can have unexpected behaviour,
+ * NOTE: this function can be misleading and can have unexpected behavior,
  * specifically when you want the length of the new string to be 0.
  * Having start==end will result in a string with one character.
  * please consider using sdssubstr instead.

--- a/src/util.c
+++ b/src/util.c
@@ -1247,7 +1247,7 @@ int reclaimFilePageCache(int fd, size_t offset, size_t length) {
 }
 
 /** An async signal safe version of fgets().
- * Has the same behaviour as standard fgets(): reads a line from fd and stores it into the dest buffer.
+ * Has the same behavior as standard fgets(): reads a line from fd and stores it into the dest buffer.
  * It stops when either (buff_size-1) characters are read, the newline character is read, or the end-of-file is reached,
  * whichever comes first.
  *

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -219,7 +219,7 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         $rd BLPOP $key 0
         wait_for_blocked_clients_count 1
         set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
-        # When the client is blocked, no accumulation is made. This behaviour is identical to INFO COMMANDSTATS.
+        # When the client is blocked, no accumulation is made. This behavior is identical to INFO COMMANDSTATS.
         assert_empty_slot_stats $slot_stats $metrics_to_assert
 
         # Unblocking command.
@@ -269,7 +269,7 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         $r1 SET $key value
         $r1 GET $key
 
-        # CPU metric is not accumulated until EXEC is reached. This behaviour is identical to INFO COMMANDSTATS.
+        # CPU metric is not accumulated until EXEC is reached. This behavior is identical to INFO COMMANDSTATS.
         set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
         assert_empty_slot_stats $slot_stats $metrics_to_assert
 


### PR DESCRIPTION
## Summary
Normalize `behaviour` -> `behavior` spelling in four source/test comments.

## Scope
- comments only
- no runtime or behavioral code changes
