### PR TITLE
Don't use reply copy avoidance for module to prevent potential UAF

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3424,7 +3424,10 @@ int RM_ReplyWithCString(RedisModuleCtx *ctx, const char *buf) {
 int RM_ReplyWithString(RedisModuleCtx *ctx, RedisModuleString *str) {
     client *c = moduleGetReplyClient(ctx);
     if (c == NULL) return REDISMODULE_OK;
-    addReplyBulk(c,str);
+    /* Disable reply copy avoidance: the module string may belong to a datatype
+     * that could be lazy-freed by BIO thread, causing UAF if we hold a reference
+     * to it in the client reply list. */
+    addReplyBulkWithFlag(c,str,0);
     return REDISMODULE_OK;
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1263,13 +1263,14 @@ static int tryAvoidBulkStrCopyToReply(client *c, robj *obj, size_t len) {
     return C_OK;
 }
 
-/* Add a Redis Object as a bulk reply */
-void addReplyBulk(client *c, robj *obj) {
+/* Add a Redis Object as a bulk reply.
+ * If avoid_copy is non-zero, attempt to use copy avoidance optimization. */
+void addReplyBulkWithFlag(client *c, robj *obj, int avoid_copy) {
     if (_prepareClientToWrite(c) != C_OK) return;
 
     if (sdsEncodedObject(obj)) {
         const size_t len = sdslen(obj->ptr);
-        if (tryAvoidBulkStrCopyToReply(c, obj, len) == C_OK)
+        if (avoid_copy && tryAvoidBulkStrCopyToReply(c, obj, len) == C_OK)
             return;
         _addReplyLongLongBulk(c, len);
         _addReplyToBufferOrList(c,obj->ptr,len);
@@ -1287,6 +1288,11 @@ void addReplyBulk(client *c, robj *obj) {
     } else {
         serverPanic("Wrong obj->encoding in addReply()");
     }
+}
+
+/* Add a Redis Object as a bulk reply */
+void addReplyBulk(client *c, robj *obj) {
+    addReplyBulkWithFlag(c, obj, 1);
 }
 
 /* Add a C buffer as bulk reply */

--- a/src/server.h
+++ b/src/server.h
@@ -3121,6 +3121,7 @@ void addReplyVerbatim(client *c, const char *s, size_t len, const char *ext);
 void addReplyProto(client *c, const char *s, size_t len);
 void AddReplyFromClient(client *c, client *src);
 void addReplyBulk(client *c, robj *obj);
+void addReplyBulkWithFlag(client *c, robj *obj, int avoid_copy);
 void addReplyBulkCString(client *c, const char *s);
 void addReplyBulkCBuffer(client *c, const void *p, size_t len);
 void addReplyBulkLongLong(client *c, long long ll);


### PR DESCRIPTION
This PR disables reply copy avoidance for module strings.
The module string's lifecycle is not controlled by Redis, it may belong to a datatype element that gets lazy-freed by BIO thread. If copy avoidance holds a reference to it in the reply list, this causes UAF when IO thread accesses the freed robj.