### PR TITLE
docs: remove duplicate word in string dictionary comments

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -707,7 +707,7 @@ dictType migrateCacheDictType = {
     NULL                        /* allow to expand */
 };
 
-/* Dict for for case-insensitive search using null terminated C strings.
+/* Dict for case-insensitive search using null terminated C strings.
  * The keys stored in dict are sds though. */
 dictType stringSetDictType = {
     dictCStrCaseHash,           /* hash function */
@@ -719,7 +719,7 @@ dictType stringSetDictType = {
     NULL                        /* allow to expand */
 };
 
-/* Dict for for case-insensitive search using null terminated C strings.
+/* Dict for case-insensitive search using null terminated C strings.
  * The key and value do not have a destructor. */
 dictType externalStringType = {
     dictCStrCaseHash,           /* hash function */


### PR DESCRIPTION
## Summary
- remove duplicated `for` in two dictionary-type comments in `src/server.c`

## Guideline alignment
- guideline reference: https://github.com/redis/redis/blob/unstable/CONTRIBUTING.md
- this PR only updates inline source comments (not end-user documentation), so the `redis-doc` documentation-repo guidance does not apply
- no behavior, API, or test changes

## Validation
- comment-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in `src/server.c` with no behavioral or API impact, so risk is minimal.
> 
> **Overview**
> Fixes a duplicated word in two inline comments describing the `stringSetDictType` and `externalStringType` dictionary types in `src/server.c`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaebd101684ec9b3b7b8467f95b57ebb6463c096. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->