### PR TITLE
docs: fix duplicated words in HNSW inline comments

### DIFF
--- a/modules/vector-sets/hnsw.c
+++ b/modules/vector-sets/hnsw.c
@@ -1038,7 +1038,7 @@ void hnsw_add_node(HNSW *index, hnswNode *node) {
  * can be accepted or not based on its associated value. In this case
  * a callback 'filter_callback' should be passed, together with a maximum
  * effort for the search (number of candidates to evaluate), since even
- * with a a low "EF" value we risk that there are too few nodes that satisfy
+ * with a low "EF" value we risk that there are too few nodes that satisfy
  * the provided filter, and we could trigger a full scan. */
 pqueue *search_layer_with_filter(
                     HNSW *index, hnswNode *query, hnswNode *entry_point,
@@ -2425,7 +2425,7 @@ hnswNode *hnsw_random_node(HNSW *index, int slot) {
  *   many levels it has, its ID, the list of neighbors for each level (as node
  *   IDs), and so forth.
  *
- * You need to to save your own node->value in some way as well, but it already
+ * You need to save your own node->value in some way as well, but it already
  * belongs to the user of the API, since, for this library, it's just a pointer,
  * so the user should know how to serialized its private data.
  *


### PR DESCRIPTION
## Summary
- fix two duplicated-word typos in `modules/vector-sets/hnsw.c` comments:
  - `with a a low` -> `with a low`
  - `need to to save` -> `need to save`

## Guideline alignment
- guideline reference: https://github.com/redis/redis/blob/unstable/CONTRIBUTING.md
- docs/comment-only cleanup in source comments
- no behavior, API, or test changes

## Validation
- comment-only change
- CI checks are green
