### PR TITLE
scan: return error for unknown TYPE names

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1797,9 +1797,8 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
             typename = c->argv[i+1]->ptr;
             type = getObjectTypeByName(typename);
             if (type == LLONG_MAX) {
-                /* TODO: uncomment in redis 8.0
                 addReplyErrorFormat(c, "unknown type name '%s'", typename);
-                return; */
+                return;
             }
             i+= 2;
         } else if (!strcasecmp(c->argv[i]->ptr, "novalues")) {

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -109,25 +109,9 @@ proc test_scan {type} {
 
         after 2
 
-        # TODO: remove this in redis 8.0
-        set cur 0
-        set keys {}
-        while 1 {
-            set res [r scan $cur type "string1"]
-            set cur [lindex $res 0]
-            set k [lindex $res 1]
-            lappend keys {*}$k
-            if {$cur == 0} break
-        }
-
-        assert_equal 0 [llength $keys]
-        # make sure that expired key have been removed by scan command
-        assert_equal 1000 [scan [regexp -inline {keys\=([\d]*)} [r info keyspace]] keys=%d]
-
-        # TODO: uncomment in redis 8.0
-        #assert_error "*unknown type name*" {r scan 0 type "string1"}
-        # expired key will be no touched by scan command
-        #assert_equal 1001 [scan [regexp -inline {keys\=([\d]*)} [r info keyspace]] keys=%d]
+        assert_error "*unknown type name*" {r scan 0 type "string1"}
+        # expired key will not be touched when scan fails on invalid type
+        assert_equal 1001 [scan [regexp -inline {keys\=([\d]*)} [r info keyspace]] keys=%d]
         r debug set-active-expire 1
     } {OK} {needs:debug}
 


### PR DESCRIPTION
## Summary
- restore error behavior for `SCAN ... TYPE` when the type name is unknown
- remove temporary compatibility branch that silently returned empty results
- update `tests/unit/scan.tcl` to assert the error and verify no passive expiration side effect when the command fails

## Testing
- docker (ubuntu:24.04)
- `make -j2 MALLOC=libc`
- `./runtest --single unit/scan`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `SCAN ... TYPE` behavior for invalid type names from silent empty results to an explicit error, which may break clients relying on the previous compatibility behavior. Runtime impact is otherwise limited to option parsing and test adjustments.
> 
> **Overview**
> Restores strict error handling for `SCAN ... TYPE <name>` when `<name>` does not map to a known builtin/module type, instead of silently returning an empty iteration.
> 
> Updates `unit/scan.tcl` to assert the `unknown type name` error and to verify that when the command fails early, it does **not** trigger passive expiration side effects (expired keys remain counted).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 705b0b0085659dd88d1ea9e819bd84da69ebf0fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->