### PR TITLE
tests/moduleapi: pipeline key generation in testrdb short-read test

### DIFF
--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -116,14 +116,37 @@ tags "modules external:skip" {
                     $master config set dynamic-hz no
                     $replica config set dynamic-hz no
                     set start [clock clicks -milliseconds]
+
+                    # Use deferred mode to reduce round-trips while generating data.
+                    set pipeline 16
+                    set pending 0
+                    r deferred 1
                     # Generate small keys
                     for {set k 0} {$k < 20000} {incr k} {
                         r testrdb.set.key keysmall$k [string repeat A [expr {int(rand()*100)}]]
+                        incr pending
+                        if {$pending == $pipeline} {
+                            for {set i 0} {$i < $pipeline} {incr i} {
+                                r read
+                            }
+                            set pending 0
+                        }
                     }
                     # Generate larger keys
                     for {set k 0} {$k < 30} {incr k} {
                         r testrdb.set.key key$k [string repeat A [expr {int(rand()*1000000)}]]
+                        incr pending
+                        if {$pending == $pipeline} {
+                            for {set i 0} {$i < $pipeline} {incr i} {
+                                r read
+                            }
+                            set pending 0
+                        }
                     }
+                    for {set i 0} {$i < $pending} {incr i} {
+                        r read
+                    }
+                    r deferred 0
 
                     if {$::verbose} {
                         set end [clock clicks -milliseconds]


### PR DESCRIPTION
## Summary
- do one thing only: use deferred read batching in `tests/unit/moduleapi/testrdb.tcl` while generating test keys
- this reduces round-trip overhead during test data fill in `diskless loading short read with module`

## Compatibility
- non-breaking API change: test-only update, no Redis command/API behavior changes

## Tested
- docker: `ubuntu:24.04`
- build: `make -j2 MALLOC=libc`
- test: `./runtest --single unit/moduleapi/testrdb`
- result: all tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that alters client command pipelining/response draining during data setup, which could only affect test timing or flakiness, not production behavior.
> 
> **Overview**
> Speeds up the `diskless loading short read with module` test setup by enabling `r deferred 1` and draining replies in batches while generating keys, reducing round-trips during the initial data fill.
> 
> Adds simple pipelining logic (`pipeline`/`pending`) and a final flush of remaining replies before restoring `r deferred 0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 219cdd3ecb29a107fd3c5ec989032494d41930e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->