### PR TITLE
Capture and report server crash after RESTORE in corrupt-dump-fuzzer test

### DIFF
--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -145,7 +145,16 @@ foreach sanitize_dump {no yes} {
                         }
                     }
                 } else {
-                    r ping ;# an attempt to check if the server didn't terminate (this will throw an error that will terminate the tests)
+                    # an attempt to check if the server didn't terminate
+                    if { [catch { r ping } err] } {
+                        set restore_failed true
+                        set report_and_restart true
+                        incr stat_terminated_in_restore
+                        write_log_line 0 "corrupt payload: $printable_dump"
+                        if {$sanitize_dump == yes} {
+                            puts "Server crashed after RESTORE with payload: $printable_dump"
+                        }
+                    }
                 }
 
                 set print_commands false

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -150,6 +150,8 @@ foreach sanitize_dump {no yes} {
                         set restore_failed true
                         set report_and_restart true
                         incr stat_terminated_in_restore
+                        set by_signal [count_log_message 0 "crashed by signal"]
+                        incr stat_terminated_by_signal $by_signal
                         write_log_line 0 "corrupt payload: $printable_dump"
                         if {$sanitize_dump == yes} {
                             puts "Server crashed after RESTORE with payload: $printable_dump"

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -145,17 +145,12 @@ foreach sanitize_dump {no yes} {
                         }
                     }
                 } else {
-                    # an attempt to check if the server didn't terminate
+                    # an attempt to check if the server didn't terminate (this will throw an error that will terminate the tests)
                     if { [catch { r ping } err] } {
-                        set restore_failed true
-                        set report_and_restart true
-                        incr stat_terminated_in_restore
-                        set by_signal [count_log_message 0 "crashed by signal"]
-                        incr stat_terminated_by_signal $by_signal
-                        write_log_line 0 "corrupt payload: $printable_dump"
-                        if {$sanitize_dump == yes} {
-                            puts "Server crashed after RESTORE with payload: $printable_dump"
-                        }
+                        set msg "Server crashed after RESTORE with payload: $printable_dump"
+                        write_log_line 0 $msg
+                        puts $msg
+                        error $err
                     }
                 }
 


### PR DESCRIPTION

## Problem

In `corrupt-dump-fuzzer.tcl`, after a successful `RESTORE` with a corrupted payload, the test did a bare `r ping` to check whether the server was still alive:

```tcl
                if { [catch { r restore "_$k" 0 $dump REPLACE } err] } {
                    set restore_failed true
                    # skip if return failed with an error response.
                    if {[string match "ERR*" $err]} {
                        incr stat_rejected_restore
                    } else {
                        set report_and_restart true
                        incr stat_terminated_in_restore
                        write_log_line 0 "corrupt payload: $printable_dump"
                        if {$sanitize_dump == yes} {
                            puts "Server crashed in RESTORE with payload: $printable_dump"
                        }
                    }
                } else {
                    r ping ;# an attempt to check if the server didn't terminate (this will throw an error that will terminate the tests)
                }
```

If the server crashed at this point, the uncaught exception would **silently terminate the entire test** without printing the payload that caused the crash, making the issue extremely hard to reproduce and debug.

Failed daily CI: https://github.com/redis/redis/actions/runs/22466906432/job/65074897523


Related comment about this problem: 
- https://github.com/redis/redis/pull/14827#issuecomment-3977218022
- https://github.com/redis/redis/pull/14827#issuecomment-3977267865

## Fix

Wrap `r ping` with catch to ensure failures trigger the same reporting and restart logic as `RESTORE`. This ensures offending payloads are logged for reproduction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to an integration test and only affect how failures are detected and reported.
> 
> **Overview**
> Improves `tests/integration/corrupt-dump-fuzzer.tcl` crash diagnostics by wrapping the post-`RESTORE` liveness check (`r ping`) in `catch`.
> 
> If the server dies immediately after a seemingly successful `RESTORE`, the test now logs and prints the offending corrupted payload before re-raising the error, instead of terminating silently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d37c9e7e26eccf554c71e1afebfd200d98a62b45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->