### PR TITLE
RED-188967: Port active clients stats to OSS

### DIFF
--- a/src/iothread.c
+++ b/src/iothread.c
@@ -611,6 +611,10 @@ int processClientsFromIOThread(IOThread *t) {
 
         /* Process the pending command and input buffer. */
         if (!isClientReadErrorFatal(c) && c->io_flags & CLIENT_IO_PENDING_COMMAND) {
+            /* IO-thread reads may enqueue one-by-one complete commands that are
+             * executed in main thread without re-entering processInputBuffer().
+             * Account this client as active before processing that handoff path. */
+            statsUpdateActiveClients(c);
             c->flags |= CLIENT_PENDING_COMMAND;
             if (processPendingCommandAndInputBuffer(c) == C_ERR) {
                 /* If the client is no longer valid, it must be freed safely. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -3514,8 +3514,9 @@ int isClientReadErrorFatal(client *c) {
 int processInputBuffer(client *c) {
     atomicIncr(server.stat_total_client_process_input_buff_events, 1);
 
-    /* Keep active-client window updates in main thread only to avoid races
-     * with serverCron() maintenance of the circular slots. */
+    /* Keep active-client window updates on main-thread paths only (here and
+     * in IO-thread handoff processing) to avoid races with serverCron()
+     * maintenance of the circular slots. */
     if (c->running_tid == IOTHREAD_MAIN_THREAD_ID)
         statsUpdateActiveClients(c);
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -249,6 +249,10 @@ client *createClient(connection *conn) {
     c->net_input_bytes = 0;
     c->net_output_bytes = 0;
     c->commands_processed = 0;
+    c->last_ts_when_counted_as_active = 0;
+    c->stat_total_read_events = 0;
+    c->stat_avg_pipeline_length_sum = 0;
+    c->stat_avg_pipeline_length_cnt = 0;
     c->task = NULL;
     c->node_id = NULL;
     atomicSet(c->pending_read, 0);
@@ -3508,6 +3512,8 @@ int isClientReadErrorFatal(client *c) {
  * pending query buffer, already representing a full command, to process.
  * return C_ERR in case the client was freed during the processing */
 int processInputBuffer(client *c) {
+    server.stat_total_client_process_input_buff_events++;
+
     /* We limit the lookahead for unauthenticated connections to 1.
      * This is both to reduce memory overhead, and to prevent errors: AUTH can
      * affect the handling of succeeding commands. Parsing of "large"
@@ -3542,6 +3548,7 @@ int processInputBuffer(client *c) {
         /* Determine if we need to parse more commands from the query buffer.
          * Only parse when there are no ready commands waiting to be processed. */
         const int parse_more = !c->pending_cmds.ready_len;
+        int pending_cmd_before_reading = c->pending_cmds.ready_len;
 
         /* Parse up to lookahead commands only if we don't have enough ready commands */
         while (parse_more && c->pending_cmds.ready_len < lookahead &&
@@ -3595,6 +3602,14 @@ int processInputBuffer(client *c) {
             preprocessCommand(c, pcmd);
             pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
             resetClientQbufState(c);
+        }
+
+        if (c->pending_cmds.ready_len != pending_cmd_before_reading) {
+            server.stat_avg_pipeline_length_sum += c->pending_cmds.ready_len;
+            server.stat_avg_pipeline_length_cnt++;
+
+            c->stat_avg_pipeline_length_sum += c->pending_cmds.ready_len;
+            c->stat_avg_pipeline_length_cnt++;
         }
 
         /* Try to consume the next ready command from the pending command list. */
@@ -3706,6 +3721,9 @@ void readQueryFromClient(connection *conn) {
     }
 
     c->read_error = 0;
+
+    c->stat_total_read_events++;
+    statsUpdateActiveClients(c);
 
     /* Update the number of reads of io threads on server */
     atomicIncr(server.stat_io_reads_processed[c->running_tid], 1);
@@ -4006,7 +4024,10 @@ sds catClientInfoString(sds s, client *client) {
         " io-thread=%i", client->tid,
         " tot-net-in=%U", client->net_input_bytes,
         " tot-net-out=%U", client->net_output_bytes,
-        " tot-cmds=%U", client->commands_processed));
+        " tot-cmds=%U", client->commands_processed,
+        " read-events=%U", (unsigned long long)client->stat_total_read_events,
+        " avg-pipeline-len-sum=%U", (unsigned long long)client->stat_avg_pipeline_length_sum,
+        " avg-pipeline-len-cnt=%U", (unsigned long long)client->stat_avg_pipeline_length_cnt));
 
     if (paused) resumeIOThread(client->running_tid);
     return ret;

--- a/src/networking.c
+++ b/src/networking.c
@@ -3610,10 +3610,11 @@ int processInputBuffer(client *c) {
         }
 
         if (c->pending_cmds.ready_len != pending_cmd_before_reading) {
-            atomicIncr(server.stat_avg_pipeline_length_sum, c->pending_cmds.ready_len);
+            int newly_parsed_cmds = c->pending_cmds.ready_len - pending_cmd_before_reading;
+            atomicIncr(server.stat_avg_pipeline_length_sum, newly_parsed_cmds);
             atomicIncr(server.stat_avg_pipeline_length_cnt, 1);
 
-            c->stat_avg_pipeline_length_sum += c->pending_cmds.ready_len;
+            c->stat_avg_pipeline_length_sum += newly_parsed_cmds;
             c->stat_avg_pipeline_length_cnt++;
         }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -3512,7 +3512,12 @@ int isClientReadErrorFatal(client *c) {
  * pending query buffer, already representing a full command, to process.
  * return C_ERR in case the client was freed during the processing */
 int processInputBuffer(client *c) {
-    server.stat_total_client_process_input_buff_events++;
+    atomicIncr(server.stat_total_client_process_input_buff_events, 1);
+
+    /* Keep active-client window updates in main thread only to avoid races
+     * with serverCron() maintenance of the circular slots. */
+    if (c->running_tid == IOTHREAD_MAIN_THREAD_ID)
+        statsUpdateActiveClients(c);
 
     /* We limit the lookahead for unauthenticated connections to 1.
      * This is both to reduce memory overhead, and to prevent errors: AUTH can
@@ -3605,8 +3610,8 @@ int processInputBuffer(client *c) {
         }
 
         if (c->pending_cmds.ready_len != pending_cmd_before_reading) {
-            server.stat_avg_pipeline_length_sum += c->pending_cmds.ready_len;
-            server.stat_avg_pipeline_length_cnt++;
+            atomicIncr(server.stat_avg_pipeline_length_sum, c->pending_cmds.ready_len);
+            atomicIncr(server.stat_avg_pipeline_length_cnt, 1);
 
             c->stat_avg_pipeline_length_sum += c->pending_cmds.ready_len;
             c->stat_avg_pipeline_length_cnt++;
@@ -3723,7 +3728,6 @@ void readQueryFromClient(connection *conn) {
     c->read_error = 0;
 
     c->stat_total_read_events++;
-    statsUpdateActiveClients(c);
 
     /* Update the number of reads of io threads on server */
     atomicIncr(server.stat_io_reads_processed[c->running_tid], 1);

--- a/src/server.c
+++ b/src/server.c
@@ -83,6 +83,11 @@ double R_Zero, R_PosInf, R_NegInf, R_Nan;
 /* Global vars */
 struct redisServer server; /* Server global state */
 
+/* Snapshot of server.stat_total_client_process_input_buff_events taken in
+ * afterSleep() and compared in beforeSleep() to detect event loop cycles
+ * where client input buffers were processed. */
+size_t stat_prev_total_client_process_input_buff_events = 0;
+
 /*============================ Internal prototypes ========================== */
 
 static inline int isShutdownInitiated(void);
@@ -1532,6 +1537,10 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
                                  current_time, factor);
         trackInstantaneousMetric(STATS_METRIC_EL_DURATION, server.duration_stats[EL_DURATION_TYPE_EL].sum,
                                  server.duration_stats[EL_DURATION_TYPE_EL].cnt, 1);
+
+        /* Periodic cleanup of active clients sliding window to clear stale slots
+         * when no client activity occurs for extended periods */
+        statsUpdateActiveClients(NULL);
     }
 
     /* We have just LRU_BITS bits per object for LRU information.
@@ -2029,6 +2038,10 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     server.el_cron_duration += duration_before_aof + duration_after_write;
     durationAddSample(EL_DURATION_TYPE_CRON, server.el_cron_duration);
     server.el_cron_duration = 0;
+
+    if (stat_prev_total_client_process_input_buff_events != server.stat_total_client_process_input_buff_events)
+        server.stat_eventloop_cycles_with_clients_input_buff_processing++;
+
     /* Record max command count per cycle. */
     if (server.stat_numcommands > server.el_cmd_cnt_start) {
         long long el_command_cnt = server.stat_numcommands - server.el_cmd_cnt_start;
@@ -2077,6 +2090,8 @@ void afterSleep(struct aeEventLoop *eventLoop) {
         server.el_start = getMonotonicUs();
         /* Set the eventloop command count at start. */
         server.el_cmd_cnt_start = server.stat_numcommands;
+
+        stat_prev_total_client_process_input_buff_events = server.stat_total_client_process_input_buff_events;
     }
 
     /* Set running after waking up */
@@ -2851,6 +2866,10 @@ void resetServerStats(void) {
     server.stat_cluster_incompatible_ops = 0;
     server.stat_total_prefetch_batches = 0;
     server.stat_total_prefetch_entries = 0;
+    server.stat_avg_pipeline_length_sum = 0;
+    server.stat_avg_pipeline_length_cnt = 0;
+    server.stat_total_client_process_input_buff_events = 0;
+    server.stat_eventloop_cycles_with_clients_input_buff_processing = 0;
     memset(server.duration_stats, 0, sizeof(durationStats) * EL_DURATION_TYPE_NUM);
     server.el_cmd_cnt_max = 0;
     lazyfreeResetStats();
@@ -5969,6 +5988,66 @@ const char *getSafeInfoString(const char *s, size_t len, char **tmp) {
                        sizeof(unsafe_info_chars)-1);
 }
 
+/* Active Clients Sliding Window
+ *
+ * Tracks unique clients with read activity in a sliding time window.
+ * Uses a circular buffer where each slot covers SLOT_DURATION_MS milliseconds.
+ * When a client becomes active, it increments the current slot and decrements
+ * its previous slot (if it was already active within the window).
+ * The total active count is the sum of all slots in the window.
+ *
+ * Slot duration and number of slots are constant powers of 2 to enable the compiler
+ * to optimize division and modulo operations into bit shifts and bitwise ANDs. */
+
+#define WINDOW_SLOTS 4
+#define SLOT_DURATION_MS_BITS 7
+#define SLOT_DURATION_MS (1LL << SLOT_DURATION_MS_BITS) /* 128ms per slot */
+#define WINDOW_DURATION_MS (WINDOW_SLOTS * SLOT_DURATION_MS) /* 512ms total */
+
+static_assert((WINDOW_SLOTS & (WINDOW_SLOTS - 1)) == 0, "WINDOW_SLOTS must be a power of 2");
+
+static int active_clients_window[WINDOW_SLOTS];
+static long long active_clients_window_ts = 0;
+
+void statsUpdateActiveClients(client *c) {
+    mstime_t now = server.mstime;
+    int current_slot = (now / SLOT_DURATION_MS) % WINDOW_SLOTS;
+    long long current_window_ts = (now / SLOT_DURATION_MS) * SLOT_DURATION_MS;
+
+    if (current_window_ts != active_clients_window_ts) {
+        if (current_window_ts - active_clients_window_ts >= WINDOW_DURATION_MS) {
+            memset(active_clients_window, 0, sizeof(active_clients_window));
+        } else {
+            active_clients_window[current_slot] = 0;
+        }
+        active_clients_window_ts = current_window_ts;
+    }
+
+    /* Called periodically from serverCron() with c==NULL to clear stale slots
+     * when no client activity has occurred. */
+    if (!c)
+        return;
+
+    active_clients_window[current_slot]++;
+
+    /* If the client was already counted in the window, decrement its old slot
+     * so each client is counted at most once across the entire window. */
+    if (c->last_ts_when_counted_as_active >= now - WINDOW_DURATION_MS) {
+        int old_slot = (c->last_ts_when_counted_as_active / SLOT_DURATION_MS) % WINDOW_SLOTS;
+        active_clients_window[old_slot]--;
+    }
+
+    c->last_ts_when_counted_as_active = now;
+}
+
+int getActiveClientsInWindow(void) {
+    int count = 0;
+    for (int i = 0; i < WINDOW_SLOTS; i++) {
+        count += active_clients_window[i];
+    }
+    return count;
+}
+
 sds genRedisInfoStringCommandStats(sds info, dict *commands) {
     struct redisCommand *c;
     dictEntry *de;
@@ -6245,6 +6324,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "pubsub_clients:%d\r\n", server.pubsub_clients,
             "watching_clients:%d\r\n", server.watching_clients,
             "clients_in_timeout_table:%llu\r\n", (unsigned long long) raxSize(server.clients_timeout_table),
+            "active_clients:%d\r\n", getActiveClientsInWindow(),
             "total_watched_keys:%lu\r\n", watched_keys,
             "total_blocking_keys:%lu\r\n", blocking_keys,
             "total_blocking_keys_on_nokey:%lu\r\n", blocking_keys_on_nokey));
@@ -6557,7 +6637,12 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "eventloop_duration_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_EL].sum,
             "eventloop_duration_cmd_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_CMD].sum,
             "instantaneous_eventloop_cycles_per_sec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_CYCLE),
-            "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION)));
+            "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION),
+            "eventloop_cycles_with_clients_processing:%lu\r\n", server.stat_eventloop_cycles_with_clients_input_buff_processing,
+            "total_client_processing_events:%lu\r\n", server.stat_total_client_process_input_buff_events,
+            "avg_pipeline_length_sum:%lld\r\n", server.stat_avg_pipeline_length_sum,
+            "avg_pipeline_length_cnt:%lld\r\n", server.stat_avg_pipeline_length_cnt,
+            "avg_pipeline_length:%.2f\r\n", server.stat_avg_pipeline_length_cnt ? (float)server.stat_avg_pipeline_length_sum / server.stat_avg_pipeline_length_cnt : 0));
         info = genRedisInfoStringACLStats(info);
         if (!server.cluster_enabled && server.cluster_compatibility_sample_ratio) {
             info = sdscatprintf(info, "cluster_incompatible_ops:%lld\r\n", server.stat_cluster_incompatible_ops);

--- a/src/server.c
+++ b/src/server.c
@@ -2039,10 +2039,15 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     durationAddSample(EL_DURATION_TYPE_CRON, server.el_cron_duration);
     server.el_cron_duration = 0;
 
-    long long total_client_process_input_buff_events;
-    atomicGet(server.stat_total_client_process_input_buff_events, total_client_process_input_buff_events);
-    if (stat_prev_total_client_process_input_buff_events != total_client_process_input_buff_events)
-        server.stat_eventloop_cycles_with_clients_input_buff_processing++;
+    /* The snapshot is refreshed in afterSleep() only for regular event-loop
+     * cycles. Skip mini-cycles from processEventsWhileBlocked() to avoid
+     * repeatedly comparing against a stale snapshot. */
+    if (!ProcessingEventsWhileBlocked) {
+        long long total_client_process_input_buff_events;
+        atomicGet(server.stat_total_client_process_input_buff_events, total_client_process_input_buff_events);
+        if (stat_prev_total_client_process_input_buff_events != total_client_process_input_buff_events)
+            server.stat_eventloop_cycles_with_clients_input_buff_processing++;
+    }
 
     /* Record max command count per cycle. */
     if (server.stat_numcommands > server.el_cmd_cnt_start) {

--- a/src/server.c
+++ b/src/server.c
@@ -86,7 +86,7 @@ struct redisServer server; /* Server global state */
 /* Snapshot of server.stat_total_client_process_input_buff_events taken in
  * afterSleep() and compared in beforeSleep() to detect event loop cycles
  * where client input buffers were processed. */
-size_t stat_prev_total_client_process_input_buff_events = 0;
+long long stat_prev_total_client_process_input_buff_events = 0;
 
 /*============================ Internal prototypes ========================== */
 
@@ -2039,7 +2039,9 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     durationAddSample(EL_DURATION_TYPE_CRON, server.el_cron_duration);
     server.el_cron_duration = 0;
 
-    if (stat_prev_total_client_process_input_buff_events != server.stat_total_client_process_input_buff_events)
+    long long total_client_process_input_buff_events;
+    atomicGet(server.stat_total_client_process_input_buff_events, total_client_process_input_buff_events);
+    if (stat_prev_total_client_process_input_buff_events != total_client_process_input_buff_events)
         server.stat_eventloop_cycles_with_clients_input_buff_processing++;
 
     /* Record max command count per cycle. */
@@ -2091,7 +2093,7 @@ void afterSleep(struct aeEventLoop *eventLoop) {
         /* Set the eventloop command count at start. */
         server.el_cmd_cnt_start = server.stat_numcommands;
 
-        stat_prev_total_client_process_input_buff_events = server.stat_total_client_process_input_buff_events;
+        atomicGet(server.stat_total_client_process_input_buff_events, stat_prev_total_client_process_input_buff_events);
     }
 
     /* Set running after waking up */
@@ -2866,10 +2868,11 @@ void resetServerStats(void) {
     server.stat_cluster_incompatible_ops = 0;
     server.stat_total_prefetch_batches = 0;
     server.stat_total_prefetch_entries = 0;
-    server.stat_avg_pipeline_length_sum = 0;
-    server.stat_avg_pipeline_length_cnt = 0;
-    server.stat_total_client_process_input_buff_events = 0;
+    atomicSet(server.stat_avg_pipeline_length_sum, 0);
+    atomicSet(server.stat_avg_pipeline_length_cnt, 0);
+    atomicSet(server.stat_total_client_process_input_buff_events, 0);
     server.stat_eventloop_cycles_with_clients_input_buff_processing = 0;
+    stat_prev_total_client_process_input_buff_events = 0;
     memset(server.duration_stats, 0, sizeof(durationStats) * EL_DURATION_TYPE_NUM);
     server.el_cmd_cnt_max = 0;
     lazyfreeResetStats();
@@ -6555,6 +6558,9 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
     if (all_sections  || (dictFind(section_dict,"stats") != NULL)) {
         long long stat_net_input_bytes, stat_net_output_bytes;
         long long stat_net_repl_input_bytes, stat_net_repl_output_bytes;
+        long long stat_total_client_process_input_buff_events;
+        long long stat_avg_pipeline_length_sum;
+        long long stat_avg_pipeline_length_cnt;
         long long current_eviction_exceeded_time = server.stat_last_eviction_exceeded_time ?
             (long long) elapsedUs(server.stat_last_eviction_exceeded_time): 0;
         long long current_active_defrag_time = server.stat_last_active_defrag_time ?
@@ -6565,6 +6571,9 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         atomicGet(server.stat_net_repl_input_bytes, stat_net_repl_input_bytes);
         atomicGet(server.stat_net_repl_output_bytes, stat_net_repl_output_bytes);
         atomicGet(server.stat_client_qbuf_limit_disconnections, stat_client_qbuf_limit_disconnections);
+        atomicGet(server.stat_total_client_process_input_buff_events, stat_total_client_process_input_buff_events);
+        atomicGet(server.stat_avg_pipeline_length_sum, stat_avg_pipeline_length_sum);
+        atomicGet(server.stat_avg_pipeline_length_cnt, stat_avg_pipeline_length_cnt);
 
         /* If we calculated the total reads and writes in the threads section,
          * we don't need to do it again, and also keep the values consistent. */
@@ -6646,10 +6655,10 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "instantaneous_eventloop_cycles_per_sec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_CYCLE),
             "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION),
             "eventloop_cycles_with_clients_processing:%zu\r\n", server.stat_eventloop_cycles_with_clients_input_buff_processing,
-            "total_client_processing_events:%zu\r\n", server.stat_total_client_process_input_buff_events,
-            "avg_pipeline_length_sum:%lld\r\n", server.stat_avg_pipeline_length_sum,
-            "avg_pipeline_length_cnt:%lld\r\n", server.stat_avg_pipeline_length_cnt,
-            "avg_pipeline_length:%.2f\r\n", server.stat_avg_pipeline_length_cnt ? (float)server.stat_avg_pipeline_length_sum / server.stat_avg_pipeline_length_cnt : 0));
+            "total_client_processing_events:%lld\r\n", stat_total_client_process_input_buff_events,
+            "avg_pipeline_length_sum:%lld\r\n", stat_avg_pipeline_length_sum,
+            "avg_pipeline_length_cnt:%lld\r\n", stat_avg_pipeline_length_cnt,
+            "avg_pipeline_length:%.2f\r\n", stat_avg_pipeline_length_cnt ? (float)stat_avg_pipeline_length_sum / stat_avg_pipeline_length_cnt : 0));
         info = genRedisInfoStringACLStats(info);
         if (!server.cluster_enabled && server.cluster_compatibility_sample_ratio) {
             info = sdscatprintf(info, "cluster_incompatible_ops:%lld\r\n", server.stat_cluster_incompatible_ops);

--- a/src/server.c
+++ b/src/server.c
@@ -6020,10 +6020,10 @@ void statsUpdateActiveClients(client *c) {
     if (current_window_ts != active_clients_window_ts) {
         /* Clear every slot crossed since the last update. Cap at one full
          * window so large time gaps still clear each slot exactly once. */
-        int slots_to_clear = (current_window_ts - active_clients_window_ts) / SLOT_DURATION_MS;
+        long long slots_to_clear = (current_window_ts - active_clients_window_ts) / SLOT_DURATION_MS;
         if (slots_to_clear > WINDOW_SLOTS) slots_to_clear = WINDOW_SLOTS;
         int prev_slot = (active_clients_window_ts / SLOT_DURATION_MS) % WINDOW_SLOTS;
-        for (int i = 1; i <= slots_to_clear; i++) {
+        for (int i = 1; i <= (int)slots_to_clear; i++) {
             active_clients_window[(prev_slot + i) % WINDOW_SLOTS] = 0;
         }
         active_clients_window_ts = current_window_ts;
@@ -6658,7 +6658,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "total_client_processing_events:%lld\r\n", stat_total_client_process_input_buff_events,
             "avg_pipeline_length_sum:%lld\r\n", stat_avg_pipeline_length_sum,
             "avg_pipeline_length_cnt:%lld\r\n", stat_avg_pipeline_length_cnt,
-            "avg_pipeline_length:%.2f\r\n", stat_avg_pipeline_length_cnt ? (float)stat_avg_pipeline_length_sum / stat_avg_pipeline_length_cnt : 0));
+            "avg_pipeline_length:%.2f\r\n", stat_avg_pipeline_length_cnt ? (double)stat_avg_pipeline_length_sum / stat_avg_pipeline_length_cnt : 0));
         info = genRedisInfoStringACLStats(info);
         if (!server.cluster_enabled && server.cluster_compatibility_sample_ratio) {
             info = sdscatprintf(info, "cluster_incompatible_ops:%lld\r\n", server.stat_cluster_incompatible_ops);

--- a/src/server.c
+++ b/src/server.c
@@ -83,9 +83,9 @@ double R_Zero, R_PosInf, R_NegInf, R_Nan;
 /* Global vars */
 struct redisServer server; /* Server global state */
 
-/* Snapshot of server.stat_total_client_process_input_buff_events taken in
- * afterSleep() and compared in beforeSleep() to detect event loop cycles
- * where client input buffers were processed. */
+/* Snapshot of server.stat_total_client_process_input_buff_events used in
+ * beforeSleep() to detect event loop cycles where client input buffers
+ * were processed. */
 long long stat_prev_total_client_process_input_buff_events = 0;
 
 /*============================ Internal prototypes ========================== */
@@ -2003,6 +2003,17 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
         }
     }
 
+    /* Detect cycles with client input processing.
+     * Compare and refresh the snapshot here (not in afterSleep()) so IO-thread updates during aeApiPoll() are not missed.
+     * Run this before dispatching new IO-thread work. */
+    if (!ProcessingEventsWhileBlocked) {
+        long long total_client_process_input_buff_events;
+        atomicGet(server.stat_total_client_process_input_buff_events, total_client_process_input_buff_events);
+        if (stat_prev_total_client_process_input_buff_events != total_client_process_input_buff_events)
+            server.stat_eventloop_cycles_with_clients_input_buff_processing++;
+        stat_prev_total_client_process_input_buff_events = total_client_process_input_buff_events;
+    }
+
     /* Handle writes with pending output buffers. */
     handleClientsWithPendingWrites();
 
@@ -2038,16 +2049,6 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     server.el_cron_duration += duration_before_aof + duration_after_write;
     durationAddSample(EL_DURATION_TYPE_CRON, server.el_cron_duration);
     server.el_cron_duration = 0;
-
-    /* The snapshot is refreshed in afterSleep() only for regular event-loop
-     * cycles. Skip mini-cycles from processEventsWhileBlocked() to avoid
-     * repeatedly comparing against a stale snapshot. */
-    if (!ProcessingEventsWhileBlocked) {
-        long long total_client_process_input_buff_events;
-        atomicGet(server.stat_total_client_process_input_buff_events, total_client_process_input_buff_events);
-        if (stat_prev_total_client_process_input_buff_events != total_client_process_input_buff_events)
-            server.stat_eventloop_cycles_with_clients_input_buff_processing++;
-    }
 
     /* Record max command count per cycle. */
     if (server.stat_numcommands > server.el_cmd_cnt_start) {
@@ -2097,8 +2098,6 @@ void afterSleep(struct aeEventLoop *eventLoop) {
         server.el_start = getMonotonicUs();
         /* Set the eventloop command count at start. */
         server.el_cmd_cnt_start = server.stat_numcommands;
-
-        atomicGet(server.stat_total_client_process_input_buff_events, stat_prev_total_client_process_input_buff_events);
     }
 
     /* Set running after waking up */

--- a/src/server.c
+++ b/src/server.c
@@ -2049,7 +2049,6 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     server.el_cron_duration += duration_before_aof + duration_after_write;
     durationAddSample(EL_DURATION_TYPE_CRON, server.el_cron_duration);
     server.el_cron_duration = 0;
-
     /* Record max command count per cycle. */
     if (server.stat_numcommands > server.el_cmd_cnt_start) {
         long long el_command_cnt = server.stat_numcommands - server.el_cmd_cnt_start;

--- a/src/server.c
+++ b/src/server.c
@@ -6645,8 +6645,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "eventloop_duration_cmd_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_CMD].sum,
             "instantaneous_eventloop_cycles_per_sec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_CYCLE),
             "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION),
-            "eventloop_cycles_with_clients_processing:%lu\r\n", server.stat_eventloop_cycles_with_clients_input_buff_processing,
-            "total_client_processing_events:%lu\r\n", server.stat_total_client_process_input_buff_events,
+            "eventloop_cycles_with_clients_processing:%zu\r\n", server.stat_eventloop_cycles_with_clients_input_buff_processing,
+            "total_client_processing_events:%zu\r\n", server.stat_total_client_process_input_buff_events,
             "avg_pipeline_length_sum:%lld\r\n", server.stat_avg_pipeline_length_sum,
             "avg_pipeline_length_cnt:%lld\r\n", server.stat_avg_pipeline_length_cnt,
             "avg_pipeline_length:%.2f\r\n", server.stat_avg_pipeline_length_cnt ? (float)server.stat_avg_pipeline_length_sum / server.stat_avg_pipeline_length_cnt : 0));

--- a/src/server.c
+++ b/src/server.c
@@ -6015,10 +6015,13 @@ void statsUpdateActiveClients(client *c) {
     long long current_window_ts = (now / SLOT_DURATION_MS) * SLOT_DURATION_MS;
 
     if (current_window_ts != active_clients_window_ts) {
-        if (current_window_ts - active_clients_window_ts >= WINDOW_DURATION_MS) {
-            memset(active_clients_window, 0, sizeof(active_clients_window));
-        } else {
-            active_clients_window[current_slot] = 0;
+        /* Clear every slot crossed since the last update. Cap at one full
+         * window so large time gaps still clear each slot exactly once. */
+        int slots_to_clear = (current_window_ts - active_clients_window_ts) / SLOT_DURATION_MS;
+        if (slots_to_clear > WINDOW_SLOTS) slots_to_clear = WINDOW_SLOTS;
+        int prev_slot = (active_clients_window_ts / SLOT_DURATION_MS) % WINDOW_SLOTS;
+        for (int i = 1; i <= slots_to_clear; i++) {
+            active_clients_window[(prev_slot + i) % WINDOW_SLOTS] = 0;
         }
         active_clients_window_ts = current_window_ts;
     }
@@ -6031,8 +6034,12 @@ void statsUpdateActiveClients(client *c) {
     active_clients_window[current_slot]++;
 
     /* If the client was already counted in the window, decrement its old slot
-     * so each client is counted at most once across the entire window. */
-    if (c->last_ts_when_counted_as_active >= now - WINDOW_DURATION_MS) {
+     * so each client is counted at most once across the entire window.
+     * Use slot-aligned timestamps to match the granularity of window
+     * maintenance — otherwise a slot cleared by advancement may still
+     * appear "within the window" by exact-timestamp comparison. */
+    long long old_slot_boundary = (c->last_ts_when_counted_as_active / SLOT_DURATION_MS) * SLOT_DURATION_MS;
+    if (old_slot_boundary >= active_clients_window_ts - (WINDOW_SLOTS - 1) * SLOT_DURATION_MS) {
         int old_slot = (c->last_ts_when_counted_as_active / SLOT_DURATION_MS) % WINDOW_SLOTS;
         active_clients_window[old_slot]--;
     }

--- a/src/server.h
+++ b/src/server.h
@@ -2101,9 +2101,9 @@ struct redisServer {
     long long stat_cluster_incompatible_ops; /* Number of operations that are incompatible with cluster mode */
     long long stat_total_prefetch_entries;  /* Total number of prefetched dict entries */
     long long stat_total_prefetch_batches;  /* Total number of prefetched batches */
-    long long stat_avg_pipeline_length_sum; /* Sum of pipeline lengths for computing average */
-    long long stat_avg_pipeline_length_cnt; /* Count of pipeline length samples */
-    size_t stat_total_client_process_input_buff_events; /* Number of times processInputBuffer() was called */
+    redisAtomic long long stat_avg_pipeline_length_sum; /* Sum of pipeline lengths for computing average */
+    redisAtomic long long stat_avg_pipeline_length_cnt; /* Count of pipeline length samples */
+    redisAtomic long long stat_total_client_process_input_buff_events; /* Number of times processInputBuffer() was called */
     size_t stat_eventloop_cycles_with_clients_input_buff_processing; /* Event loop cycles with client input buffer processing */
     /* The following two are used to track instantaneous metrics, like
      * number of operations per second, network traffic. */

--- a/src/server.h
+++ b/src/server.h
@@ -1602,6 +1602,11 @@ typedef struct client {
 
     redisAtomic int pending_read; /* Flag indicating an IO thread client residing
                                    * in main thread has received a read event. */
+
+    mstime_t last_ts_when_counted_as_active; /* Timestamp of last time this client was counted as active */
+    size_t stat_total_read_events; /* Number of times readQueryFromClient() was called */
+    size_t stat_avg_pipeline_length_sum; /* Sum of pipeline lengths for computing average */
+    size_t stat_avg_pipeline_length_cnt; /* Count of pipeline length samples */
 } client;
 
 typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) {
@@ -2096,6 +2101,10 @@ struct redisServer {
     long long stat_cluster_incompatible_ops; /* Number of operations that are incompatible with cluster mode */
     long long stat_total_prefetch_entries;  /* Total number of prefetched dict entries */
     long long stat_total_prefetch_batches;  /* Total number of prefetched batches */
+    long long stat_avg_pipeline_length_sum; /* Sum of pipeline lengths for computing average */
+    long long stat_avg_pipeline_length_cnt; /* Count of pipeline length samples */
+    size_t stat_total_client_process_input_buff_events; /* Number of times processInputBuffer() was called */
+    size_t stat_eventloop_cycles_with_clients_input_buff_processing; /* Event loop cycles with client input buffer processing */
     /* The following two are used to track instantaneous metrics, like
      * number of operations per second, network traffic. */
     struct {
@@ -3111,6 +3120,8 @@ void setDeferredAttributeLen(client *c, void *node, long length);
 void setDeferredPushLen(client *c, void *node, long length);
 int isClientReadErrorFatal(client *c);
 int processInputBuffer(client *c);
+void statsUpdateActiveClients(client *c);
+int getActiveClientsInWindow(void);
 void acceptCommonHandler(connection *conn, int flags, char *ip);
 void readQueryFromClient(connection *conn);
 int prepareClientToWrite(client *c);

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -607,6 +607,40 @@ start_server {tags {"info" "external:skip"}} {
     }
 }
 
+start_server {tags {"info" "external:skip"} overrides {io-threads 4 io-threads-do-reads yes}} {
+    test {clients: active_clients with io-thread one-by-one commands} {
+        r config resetstat
+
+        set clients {}
+        set clients_num 16
+        for {set i 0} {$i < $clients_num} {incr i} {
+            lappend clients [redis_client]
+        }
+
+        # Run request/response (non-pipelined) traffic on many clients.
+        for {set round 0} {$round < 5} {incr round} {
+            set i 0
+            foreach c $clients {
+                $c set key:$round:$i value
+                incr i
+            }
+        }
+
+        # We are still within the 512ms active-client window.
+        set info [r info clients]
+        set ac [getInfoProperty $info active_clients]
+
+        foreach c $clients {
+            $c close
+        }
+
+        # The query client itself is active; additional active clients should
+        # also be counted. If this is <= 1, IO-thread one-by-one traffic was
+        # likely missed by active-client accounting.
+        assert_morethan_equal $ac 2
+    }
+}
+
 start_server {tags {"info" "external:skip"}} {
     test {memory: database and pubsub overhead and rehashing dict count} {
         r flushall

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -509,6 +509,101 @@ start_server {tags {"info" "external:skip"}} {
             $r2 close
             wait_for_watched_clients_count 0
         }
+ 
+        test {clients: active_clients} {
+            set info [r info clients]
+            set ac [getInfoProperty $info active_clients]
+            # The test connection just ran a command, so at least 1 client is active
+            assert_morethan_equal $ac 1
+
+            # Create additional clients and make them active
+            set r2 [redis_client]
+            set r3 [redis_client]
+            $r2 ping
+            $r3 ping
+
+            # Within the 512ms window, all 3 clients should be counted
+            set info [r info clients]
+            set ac [getInfoProperty $info active_clients]
+            assert_morethan_equal $ac 3
+
+            # After the window expires (512ms), idle clients should drop off
+            wait_for_condition 20 100 {
+                [getInfoProperty [r info clients] active_clients] <= 1
+            } else {
+                fail "active_clients did not drop after window expired"
+            }
+
+            $r2 close
+            $r3 close
+        }
+
+        test {stats: client processing and pipeline metrics} {
+            set info1 [r info stats]
+            set proc_events1 [getInfoProperty $info1 total_client_processing_events]
+            set cycles1 [getInfoProperty $info1 eventloop_cycles_with_clients_processing]
+            set plsum1 [getInfoProperty $info1 avg_pipeline_length_sum]
+            set plcnt1 [getInfoProperty $info1 avg_pipeline_length_cnt]
+
+            # Issue several commands
+            r ping
+            r ping
+            r ping
+
+            set info2 [r info stats]
+            set proc_events2 [getInfoProperty $info2 total_client_processing_events]
+            set cycles2 [getInfoProperty $info2 eventloop_cycles_with_clients_processing]
+            set plsum2 [getInfoProperty $info2 avg_pipeline_length_sum]
+            set plcnt2 [getInfoProperty $info2 avg_pipeline_length_cnt]
+            set plavg2 [getInfoProperty $info2 avg_pipeline_length]
+
+            # processInputBuffer was called for 3 PINGs + the INFO call = at least 4
+            assert_morethan_equal [expr {$proc_events2 - $proc_events1}] 4
+
+            # At least one eventloop cycle processed client input
+            assert_morethan $cycles2 $cycles1
+
+            # Cycles with clients can never exceed total processInputBuffer calls
+            assert_morethan_equal $proc_events2 $cycles2
+
+            # Pipeline sum and cnt increased (3 PINGs + INFO, each batch of 1)
+            assert_morethan_equal [expr {$plsum2 - $plsum1}] 4
+            assert_morethan_equal [expr {$plcnt2 - $plcnt1}] 4
+
+            # Average pipeline length is a valid positive number
+            assert_morethan $plavg2 0
+        }
+
+        test {stats: client processing metrics reset with CONFIG RESETSTAT} {
+            # Build up meaningful counter values
+            for {set i 0} {$i < 20} {incr i} { r ping }
+
+            set info_before [r info stats]
+            set proc_before [getInfoProperty $info_before total_client_processing_events]
+            set cycles_before [getInfoProperty $info_before eventloop_cycles_with_clients_processing]
+            set plsum_before [getInfoProperty $info_before avg_pipeline_length_sum]
+            set plcnt_before [getInfoProperty $info_before avg_pipeline_length_cnt]
+
+            # Verify counters are meaningfully large before resetting
+            assert_morethan $proc_before 10
+            assert_morethan $cycles_before 0
+            assert_morethan $plsum_before 10
+            assert_morethan $plcnt_before 10
+
+            r config resetstat
+
+            set info_after [r info stats]
+            set proc_after [getInfoProperty $info_after total_client_processing_events]
+            set cycles_after [getInfoProperty $info_after eventloop_cycles_with_clients_processing]
+            set plsum_after [getInfoProperty $info_after avg_pipeline_length_sum]
+            set plcnt_after [getInfoProperty $info_after avg_pipeline_length_cnt]
+
+            # Counters should be near zero (only RESETSTAT + INFO ran after reset)
+            assert_lessthan_equal $proc_after 3
+            assert_lessthan_equal $cycles_after 3
+            assert_lessthan_equal $plsum_after 3
+            assert_lessthan_equal $plcnt_after 3
+        }
     }
 }
 

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -21,9 +21,9 @@ start_server {tags {"introspection"}} {
     test {CLIENT LIST} {
         set client_list [r client list]
         if {[lindex [r config get io-threads] 1] == 1} {
-            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=*} $client_list
+            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=* read-events=* avg-pipeline-len-sum=* avg-pipeline-len-cnt=*} $client_list
         } else {
-            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=*} $client_list
+            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=* read-events=* avg-pipeline-len-sum=* avg-pipeline-len-cnt=*} $client_list
         }
     }
 
@@ -36,9 +36,9 @@ start_server {tags {"introspection"}} {
     test {CLIENT INFO} {
         set client [r client info]
         if {[lindex [r config get io-threads] 1] == 1} {
-            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=*} $client
+            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=* read-events=* avg-pipeline-len-sum=* avg-pipeline-len-cnt=*} $client
         } else {
-            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=*} $client
+            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=* read-events=* avg-pipeline-len-sum=* avg-pipeline-len-cnt=*} $client
         }
     } 
 
@@ -139,6 +139,74 @@ start_server {tags {"introspection"}} {
 
         # We executed 3 commands - EVAL, which in turn executed PING and finally CLIENT INFO
         assert_equal [expr $tot_cmd_before+3] $tot_cmd_after
+    }
+
+    test {CLIENT INFO read-events and pipeline-length stats} {
+        # Use a fresh client so counters start from a known state
+        set r2 [redis_client]
+
+        # Baseline: the redis_client constructor issues some commands internally,
+        # so capture the current state rather than assuming zeros.
+        set info1 [$r2 client info]
+        set re1 [get_field_in_client_info $info1 "read-events"]
+        set plsum1 [get_field_in_client_info $info1 "avg-pipeline-len-sum"]
+        set plcnt1 [get_field_in_client_info $info1 "avg-pipeline-len-cnt"]
+
+        # Send 3 sequential (non-pipelined) commands
+        $r2 ping
+        $r2 ping
+        $r2 ping
+
+        set info2 [$r2 client info]
+        set re2 [get_field_in_client_info $info2 "read-events"]
+        set plsum2 [get_field_in_client_info $info2 "avg-pipeline-len-sum"]
+        set plcnt2 [get_field_in_client_info $info2 "avg-pipeline-len-cnt"]
+
+        # read-events should have increased (3 PINGs + the CLIENT INFO itself)
+        assert_morethan_equal $re2 [expr {$re1 + 4}]
+
+        # For sequential commands each batch has exactly 1 command,
+        # so delta of sum should equal delta of cnt (average pipeline length = 1.0)
+        set delta_sum [expr {$plsum2 - $plsum1}]
+        set delta_cnt [expr {$plcnt2 - $plcnt1}]
+        assert_morethan $delta_sum 0
+        assert_equal $delta_sum $delta_cnt
+
+        $r2 close
+    }
+
+    test {CLIENT INFO pipeline-length stats for pipelined commands} {
+        set rd [redis_deferring_client]
+        $rd client id
+        set rd_id [$rd read]
+
+        # Capture baseline from CLIENT LIST
+        set info_list [r client list]
+        set plsum1 [get_field_in_client_list $rd_id $info_list "avg-pipeline-len-sum"]
+        set plcnt1 [get_field_in_client_list $rd_id $info_list "avg-pipeline-len-cnt"]
+
+        # Send 5 pipelined commands without reading replies
+        for {set i 0} {$i < 5} {incr i} {
+            $rd ping
+        }
+
+        # Read all 5 replies to ensure they have been processed
+        for {set i 0} {$i < 5} {incr i} {
+            $rd read
+        }
+
+        set info_list [r client list]
+        set plsum2 [get_field_in_client_list $rd_id $info_list "avg-pipeline-len-sum"]
+        set plcnt2 [get_field_in_client_list $rd_id $info_list "avg-pipeline-len-cnt"]
+
+        # All 5 commands must have been counted in the sum
+        set delta_sum [expr {$plsum2 - $plsum1}]
+        set delta_cnt [expr {$plcnt2 - $plcnt1}]
+        assert_equal $delta_sum 5
+        assert_morethan $delta_cnt 0
+        assert_morethan_equal $delta_sum $delta_cnt
+
+        $rd close
     }
 
     test {CLIENT KILL with illegal arguments} {


### PR DESCRIPTION
## Overview
Add monitoring metrics that provide visibility into client activity and command pipeline behavior. These include a real-time count of active clients, per-client read and pipeline statistics, and server-level counters for input buffer processing and pipeline depth.

## Changes
### Active Clients Sliding Window (`server.c`, `server.h`)
A circular buffer of 4 slots (128ms each, 512ms total window) tracks unique clients with recent read activity. Each client is counted at most once via timestamp-based deduplication. `serverCron()` calls the update function periodically to clear stale slots during idle periods.
- New INFO clients field: `active_clients`
- New client struct field: `last_ts_when_counted_as_active`

Sliding-window implementation details:
- The code clears all skipped slots when window advancement jumps more than one slot.
- Old-slot decrement checks use slot-aligned timestamp comparison, so the code does not decrement slots that were already cleared after wraparound.

Threading behavior:
- `statsUpdateActiveClients(c)` runs only when the client is running on the main thread (in `processInputBuffer`), avoiding unsynchronized updates of the static window state from IO threads.

### Per-Client Statistics (`networking.c`, `server.h`)
Three new fields in CLIENT LIST / CLIENT INFO output:
- `read-events` — number of `readQueryFromClient()` calls for this client
- `avg-pipeline-len-sum` — cumulative sum of commands parsed per batch
- `avg-pipeline-len-cnt` — number of parse batches

Average pipeline length = sum / cnt. For non-pipelined clients the average is 1.0; for pipelined clients it reflects the effective batching depth (capped by the `lookahead` config).

### Server-Level Statistics (`server.c`, `networking.c`, `server.h`)
New INFO stats fields:
- `total_client_processing_events` — total `processInputBuffer()` calls
- `eventloop_cycles_with_clients_processing` — event loop cycles where client input buffers were processed (uses before/after-sleep snapshot)
- `avg_pipeline_length_sum`, `avg_pipeline_length_cnt`, `avg_pipeline_length` — global pipeline depth aggregates

IO-thread behavior for server-level counters:
- The shared global counters updated from `processInputBuffer()` are stored as atomic server fields and updated with Redis atomic helpers.
- Snapshot/reset/read paths (`beforeSleep`, `afterSleep`, `resetServerStats`, INFO generation) use atomic loads/stores consistently.

All server-level counters are reset by `CONFIG RESETSTAT`. Per-client counters are connection-lifetime.

## Files Changed
| File | Changes |
|------|---------|
| `src/server.h` | Client struct fields, server struct fields, function declarations |
| `src/server.c` | Sliding window implementation, `serverCron` cleanup call, `beforeSleep`/`afterSleep` cycle detection, INFO output, stat initialization in `resetServerStats` |
| `src/networking.c` | `createClient` initialization, `readQueryFromClient` call sites, `processInputBuffer` pipeline stats, `catClientInfoString` output |

## Testing
| File | Tests |
|------|-------|
| `tests/unit/introspection.tcl` | Updated CLIENT LIST/CLIENT INFO pattern matches; new tests for `read-events` and `avg-pipeline-len-sum/cnt` (sequential and pipelined) |
| `tests/unit/info.tcl` | New tests for `active_clients` (sliding window behavior), server-level pipeline and processing metrics, `CONFIG RESETSTAT` reset verification, and an IO-threads stress test validating monotonic/cross-metric counter invariants |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core request parsing and event-loop paths (`processInputBuffer`, IO-thread handoff) to record new stats; while mostly additive, bugs here could affect performance or introduce subtle concurrency issues.
> 
> **Overview**
> Adds an **active-clients sliding window** (512ms) and exposes it as `active_clients` in `INFO clients`, with accounting updated on main-thread input processing and IO-thread command handoff plus periodic window cleanup in `serverCron()`.
> 
> Introduces new **per-client and server-wide metrics** for read events, pipeline depth, and input-buffer processing: `CLIENT LIST`/`CLIENT INFO` now include `read-events` and pipeline sum/cnt fields; `INFO stats` now reports `total_client_processing_events`, `eventloop_cycles_with_clients_processing`, and average pipeline length (sum/cnt/avg). These counters are reset via `CONFIG RESETSTAT`, and unit tests are extended to validate the new fields and behavior (including IO-thread scenarios).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a92d75eb51989c7e30f110b43453f6266f09b2df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->