### PR TITLE
Chore complete Tcl 9 support and fix regressions in test suite

### DIFF
--- a/runtest-cluster
+++ b/runtest-cluster
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6 8.7"
+TCL_VERSIONS="8.5 8.6 8.7 9.0"
 TCLSH=""
 
 for VERSION in $TCL_VERSIONS; do

--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6 8.7"
+TCL_VERSIONS="8.5 8.6 8.7 9.0"
 TCLSH=""
 [ -z "$MAKE" ] && MAKE=make
 

--- a/runtest-sentinel
+++ b/runtest-sentinel
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6 8.7"
+TCL_VERSIONS="8.5 8.6 8.7 9.0"
 TCLSH=""
 
 for VERSION in $TCL_VERSIONS; do

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -54,6 +54,14 @@ array set ::redis::testing_resp3 {} ;# Indicating if the current client is using
 set ::force_resp3 0
 set ::log_req_res 0
 
+# Returns 1 if the string contains at least one character with a code point
+# above U+00FF (i.e. a character that cannot be represented as a single byte).
+# Uses regexp rather than "string match *[^\u0000-\u00ff]*" to avoid the
+# catastrophic backtracking bug in Tcl 9.0's glob engine.
+proc has_unicode_above_255 {s} {
+    return [regexp {[^\u0000-\u00ff]} $s]
+}
+
 proc redis {{server 127.0.0.1} {port 6379} {defer 0} {tls 0} {tlsoptions {}} {readraw 0}} {
     if {$tls} {
         package require tls
@@ -165,9 +173,10 @@ proc ::redis::__dispatch__raw__ {id method argv} {
         set cmd "*[expr {[llength $argv]+1}]\r\n"
         append cmd "$[string length $method]\r\n$method\r\n"
         foreach a $argv {
-            # In Tcl 9.0, only convert to UTF-8 if the string contains non-byte characters
-            # to preserve binary data while handling unicode correctly
-            if {$::tcl_version >= 9.0 && [string match "*\[^\u0000-\u00ff\]*" $a]} {
+            # Tcl 9.0: encode non-byte characters as UTF-8 so the byte length
+            # sent in the RESP header matches the actual payload size.
+            # Pure-binary arguments are left untouched to avoid corruption.
+            if {$::tcl_version >= 9.0 && [has_unicode_above_255 $a]} {
                 set a [encoding convertto utf-8 $a]
             }
             append cmd "$[string length $a]\r\n$a\r\n"

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -54,14 +54,6 @@ array set ::redis::testing_resp3 {} ;# Indicating if the current client is using
 set ::force_resp3 0
 set ::log_req_res 0
 
-# Returns 1 if the string contains at least one character with a code point
-# above U+00FF (i.e. a character that cannot be represented as a single byte).
-# Uses regexp rather than "string match *[^\u0000-\u00ff]*" to avoid the
-# catastrophic backtracking bug in Tcl 9.0's glob engine.
-proc has_unicode_above_255 {s} {
-    return [regexp {[^\u0000-\u00ff]} $s]
-}
-
 proc redis {{server 127.0.0.1} {port 6379} {defer 0} {tls 0} {tlsoptions {}} {readraw 0}} {
     if {$tls} {
         package require tls
@@ -173,10 +165,11 @@ proc ::redis::__dispatch__raw__ {id method argv} {
         set cmd "*[expr {[llength $argv]+1}]\r\n"
         append cmd "$[string length $method]\r\n$method\r\n"
         foreach a $argv {
-            # Tcl 9.0: encode non-byte characters as UTF-8 so the byte length
-            # sent in the RESP header matches the actual payload size.
-            # Pure-binary arguments are left untouched to avoid corruption.
-            if {$::tcl_version >= 9.0 && [has_unicode_above_255 $a]} {
+            # In Tcl 9.0, only convert to UTF-8 if the string contains non-byte characters
+            # to preserve binary data while handling unicode correctly
+            # Uses regexp rather than "string match *[^\u0000-\u00ff]*" to avoid the
+            # catastrophic backtracking bug in Tcl 9.0's glob engine.
+            if {$::tcl_version >= 9.0 && [regexp {[^\u0000-\u00ff]} $a]} {
                 set a [encoding convertto utf-8 $a]
             }
             append cmd "$[string length $a]\r\n$a\r\n"

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -354,7 +354,7 @@ proc accept_test_clients {fd addr port} {
 #       ready to accept a new task.
 proc read_from_test_client fd {
     set bytes [gets $fd]
-    set payload [read $fd $bytes]
+    set payload [encoding convertfrom utf-8 [read $fd $bytes]]
     foreach {status data elapsed} $payload break
     set ::last_progress [clock seconds]
 
@@ -528,7 +528,7 @@ proc test_client_main server_port {
     send_data_packet $::test_server_fd ready [pid]
     while 1 {
         set bytes [gets $::test_server_fd]
-        set payload [read $::test_server_fd $bytes]
+        set payload [encoding convertfrom utf-8 [read $::test_server_fd $bytes]]
         foreach {cmd data} $payload break
         if {$cmd eq {run}} {
             execute_test_file $data
@@ -543,8 +543,14 @@ proc test_client_main server_port {
 
 proc send_data_packet {fd status data {elapsed 0}} {
     set payload [list $status $data $elapsed]
-    puts $fd [string length $payload]
-    puts -nonewline $fd $payload
+    # Convert to UTF-8 bytes before sending so that:
+    # 1. The byte count is accurate (Tcl 9.0 string length returns character
+    #    count, which differs from byte count for non-ASCII Unicode chars).
+    # 2. Characters above U+00FF (not representable in the channel's iso8859-1
+    #    encoding) are safely transmitted as multi-byte UTF-8 sequences.
+    set payload_bytes [encoding convertto utf-8 $payload]
+    puts $fd [string length $payload_bytes]
+    puts -nonewline $fd $payload_bytes
     flush $fd
 }
 

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -878,28 +878,28 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
     test {DIGEST basic usage with plain string} {
         r set mykey "hello world"
         set digest [r digest mykey]
-        # Ensure reply is hex string
-        assert {[string is wideinteger -strict "0x$digest"]}
+        # Ensure reply is exactly 16 hex characters (works across all Tcl versions)
+        assert {[string length $digest] == 16 && [string is xdigit -strict $digest]}
     }
 
     test {DIGEST with empty string} {
         r set mykey ""
         set digest [r digest mykey]
-        assert {[string is wideinteger -strict "0x$digest"]}
+        assert {[string length $digest] == 16 && [string is xdigit -strict $digest]}
     }
 
     test {DIGEST with integer-encoded value} {
         r set mykey 12345
         assert_encoding int mykey
         set digest [r digest mykey]
-        assert {[string is wideinteger -strict "0x$digest"]}
+        assert {[string length $digest] == 16 && [string is xdigit -strict $digest]}
     }
 
     test {DIGEST with negative integer} {
         r set mykey -999
         assert_encoding int mykey
         set digest [r digest mykey]
-        assert {[string is wideinteger -strict "0x$digest"]}
+        assert {[string length $digest] == 16 && [string is xdigit -strict $digest]}
     }
 
     test {DIGEST returns consistent hash for same value} {
@@ -928,20 +928,20 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
     test {DIGEST with binary data} {
         r set mykey "\x00\x01\x02\x03\xff\xfe"
         set digest [r digest mykey]
-        assert {[string is wideinteger -strict "0x$digest"]}
+        assert {[string length $digest] == 16 && [string is xdigit -strict $digest]}
     }
 
     test {DIGEST with unicode characters} {
         r set mykey "Hello 世界"
         set digest [r digest mykey]
-        assert {[string is wideinteger -strict "0x$digest"]}
+        assert {[string length $digest] == 16 && [string is xdigit -strict $digest]}
     }
 
     test {DIGEST with very long string} {
         set longstring [string repeat "Lorem ipsum dolor sit amet. " 1000]
         r set mykey $longstring
         set digest [r digest mykey]
-        assert {[string is wideinteger -strict "0x$digest"]}
+        assert {[string length $digest] == 16 && [string is xdigit -strict $digest]}
     }
 
     test {DIGEST against non-existing key} {
@@ -981,7 +981,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
     test {DIGEST with special characters and whitespace} {
         r set mykey "  spaces  \t\n\r"
         set digest [r digest mykey]
-        assert {[string is wideinteger -strict "0x$digest"]}
+        assert {[string length $digest] == 16 && [string is xdigit -strict $digest]}
     }
 
     test {DIGEST consistency across SET operations} {
@@ -1037,7 +1037,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         assert_equal 0 [r exists mykey]
 
         r set mykey "hello"
-        set wrong_digest [format %x [expr [scan [r digest mykey] %x] + 1]]
+        set wrong_digest [format %016x [expr ([scan [r digest mykey] %x] + 1) & 0xffffffffffffffff]]
         assert_equal 0 [r delex mykey IFDEQ $wrong_digest]
         assert_equal 1 [r exists mykey]
         assert_equal "hello" [r get mykey]
@@ -1045,7 +1045,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
 
     test {DELEX basic usage with IFDNE} {
         r set mykey "hello"
-        set wrong_digest [format %x [expr [scan [r digest mykey] %x] + 1]]
+        set wrong_digest [format %016x [expr ([scan [r digest mykey] %x] + 1) & 0xffffffffffffffff]]
         assert_equal 1 [r delex mykey IFDNE $wrong_digest]
         assert_equal 0 [r exists mykey]
 
@@ -1273,7 +1273,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
 
     test {Extended SET with IFDEQ - key exists but digest doesn't match} {
         r set mykey "hello"
-        set wrong_digest [format %x [expr [scan [r digest mykey] %x] + 1]]
+        set wrong_digest [format %016x [expr ([scan [r digest mykey] %x] + 1) & 0xffffffffffffffff]]
         assert_equal {} [r set mykey "world" IFDEQ $wrong_digest]
         assert_equal "hello" [r get mykey]
     }
@@ -1287,7 +1287,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
 
     test {Extended SET with IFDNE - key exists and digest doesn't match} {
         r set mykey "hello"
-        set wrong_digest [format %x [expr [scan [r digest mykey] %x] + 1]]
+        set wrong_digest [format %016x [expr ([scan [r digest mykey] %x] + 1) & 0xffffffffffffffff]]
         assert_equal "OK" [r set mykey "world" IFDNE $wrong_digest]
         assert_equal "world" [r get mykey]
     }
@@ -1351,7 +1351,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
 
     test {Extended SET with IFDEQ and GET - key exists but digest doesn't match} {
         r set mykey "hello"
-        set wrong_digest [format %x [expr [scan [r digest mykey] %x] + 1]]
+        set wrong_digest [format %016x [expr ([scan [r digest mykey] %x] + 1) & 0xffffffffffffffff]]
         assert_equal "hello" [r set mykey "world" IFDEQ $wrong_digest GET]
         assert_equal "hello" [r get mykey]
     }
@@ -1365,7 +1365,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
 
     test {Extended SET with IFDNE and GET - key exists and digest doesn't match} {
         r set mykey "hello"
-        set wrong_digest [format %x [expr [scan [r digest mykey] %x] + 1]]
+        set wrong_digest [format %016x [expr ([scan [r digest mykey] %x] + 1) & 0xffffffffffffffff]]
         assert_equal "hello" [r set mykey "world" IFDNE $wrong_digest GET]
         assert_equal "world" [r get mykey]
     }
@@ -1408,7 +1408,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
 
     test {Extended SET with IFDNE and expiration} {
         r set mykey "hello"
-        set wrong_digest [format %x [expr [scan [r digest mykey] %x] + 1]]
+        set wrong_digest [format %016x [expr ([scan [r digest mykey] %x] + 1) & 0xffffffffffffffff]]
         assert_equal "OK" [r set mykey "world" IFDNE $wrong_digest EX 10]
         assert_equal "world" [r get mykey]
         assert_range [r ttl mykey] 5 10
@@ -1540,7 +1540,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
     test {Extended SET with negative digest} {
         r set mykey "test"
         set digest [r digest mykey]
-        set wrong_digest [format %x [expr [scan [r digest mykey] %x] + 1]]
+        set wrong_digest [format %016x [expr ([scan [r digest mykey] %x] + 1) & 0xffffffffffffffff]]
         assert_equal "OK" [r set mykey "world" IFDNE $wrong_digest]
         assert_equal "world" [r get mykey]
     }


### PR DESCRIPTION
## Problem

PR https://github.com/redis/redis/pull/14787 introduced **Tcl 9 support for the test suite**, but it still fails on my machine (**macOS 26.3, Tcl 9.0.3**). Some tests fail and the runner may hang.

Example:

```bash
$ tclsh <<<'puts $tcl_version'
9.0.3

$ make test
[err]: BITCOUNT against test vector #2
Expected [r bitcount str] == 4
```

This is caused by **behavior changes in Tcl 9**, including:

- `string length` returning **character count** instead of **byte count**
- binary sockets rejecting characters with code points **>255**
- differences in `string is wideinteger`

Parts of the Redis Tcl test framework rely on **byte-oriented behavior**, which breaks under Tcl 9.



## Changes

### 1. Fix IPC payload encoding in test runner

`tests/unit/memefficiency.tcl` contains a **non-ASCII quote character**:

https://github.com/redis/redis/blob/fe16003e667407973296ae11b039baa2f9d088c2/tests/unit/memefficiency.tcl#L826

Under Tcl 9 this can corrupt the IPC stream when the test runner serializes Tcl code blocks, causing the runner to hang.

Instead of fixing only this character, the IPC payload is now explicitly encoded using:

```tcl
encoding convertto utf-8
```

This makes the protocol robust against future non-ASCII characters.



### 2. Avoid Tcl 9 glob backtracking issue

Replaced:

```tcl
string match "*[^\u0000-\u00ff]*" $a
```

with:

```tcl
regexp {[^\u0000-\u00ff]} $a
```

This avoids a **catastrophic backtracking issue in Tcl 9's glob matcher** while preserving the same behavior.


### 3. Update DIGEST validation

The previous check relied on:`string is wideinteger` which behaves differently in Tcl 9.

The assertion now validates the **expected DIGEST format directly**.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the test runner’s server/client IPC framing and encoding, so a mistake could cause hangs or garbled status reporting across all tests, though changes are confined to the test harness (not Redis runtime).
> 
> **Overview**
> **Improves Tcl 9 compatibility in the Redis test harness.** Test launcher scripts now consider `tclsh9.0`, and the Redis Tcl client avoids Tcl 9’s glob backtracking pitfall by switching the non-byte detection check from `string match` to `regexp`.
> 
> **Hardens test-runner IPC against Unicode/byte-count differences in Tcl 9.** The server/client protocol in `tests/test_helper.tcl` now UTF-8 encodes payloads before sending (so the length prefix is byte-accurate) and decodes payloads on receipt, preventing hangs/corruption when non-ASCII appears in transmitted test data.
> 
> **Updates string DIGEST tests to be version-robust.** Assertions now validate a 16-char hex digest directly (instead of `string is wideinteger`), and “wrong digest” generation is fixed to always produce a zero-padded 64-bit value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f477d1225d7efb11fb164077d6979de76f20646c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->