### PR TITLE
Fix null pointer dereference and printf format mismatches

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -271,6 +271,8 @@ static int64_t usUntilEarliestTimer(aeEventLoop *eventLoop) {
         te = te->next;
     }
 
+    if (earliest == NULL) return -1;
+
     monotime now = getMonotonicUs();
     return (now >= earliest->when) ? 0 : earliest->when - now;
 }

--- a/src/dict.c
+++ b/src/dict.c
@@ -1882,7 +1882,7 @@ size_t dictGetStatsMsg(char *buf, size_t bufsize, dictStats *stats, int full) {
             if (stats->clvector[i] == 0) continue;
             if (l >= bufsize) break;
             l += snprintf(buf + l, bufsize - l,
-                          "   %ld: %ld (%.02f%%)\n",
+                          "   %lu: %lu (%.02f%%)\n",
                           i, stats->clvector[i], ((float) stats->clvector[i] / stats->htSize) * 100);
         }
     }

--- a/src/mstr.c
+++ b/src/mstr.c
@@ -247,7 +247,7 @@ void mstrPrint(mstr s, struct mstrKind *kind, int verbose) {
             if (tmp & 0x1) {
                 int mSize = kind->metaSize[i];
                 void *mRef = mstrMetaRef(s, kind, i);
-                printf("[%p] >> meta[%d]:", mRef, i);
+                printf("[%p] >> meta[%u]:", mRef, i);
                 for (int j = 0 ; j < mSize ; ++j) {
                     printf(" 0x%02x", ((unsigned char *) mRef)[j]);
                 }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -8644,7 +8644,7 @@ static void vsetRecallMode(void) {
     unsigned int dim = reply->integer;
     freeReplyObject(reply);
 
-    printf("\n# Testing recall for vector set: %s (dimension: %d)\n",
+    printf("\n# Testing recall for vector set: %s (dimension: %u)\n",
            config.vset_recall_key, dim);
     printf("# Mixing %d random element vectors, top %d results, EF=%d\n\n",
            ele_count, vsim_count, vsim_ef);


### PR DESCRIPTION
## Summary
Fixes #13992

Fix four bugs identified by **CppCheck** (v2.20) static analysis.

### Bug 1: Null pointer dereference in `ae.c` (`usUntilEarliestTimer`)

**Severity:** High — potential crash

When `timeEventHead` is non-NULL but all timer events in the linked list have `id == AE_DELETED_EVENT_ID`, the filtering loop at line 269 skips every entry, leaving `earliest` as NULL. The code then unconditionally dereferences `earliest->when` at line 278, causing a null pointer dereference.

**Fix:** Add a `NULL` check for `earliest` after the loop, returning `-1` (no timer), consistent with the existing guard at function entry.

### Bug 2: Wrong printf format in `dict.c` (`dictGetStatsMsg`)

`%ld` (signed long) was used for `unsigned long` values (`i` and `stats->clvector[i]`). Changed to `%lu`.

### Bug 3: Wrong printf format in `mstr.c` (`mstrPrint`)

`%d` (signed int) was used for an `unsigned int` loop variable `i`. Changed to `%u`.

### Bug 4: Wrong printf format in `redis-cli.c` (`vsetRecallMode`)

`%d` (signed int) was used for `unsigned int` variable `dim`. Changed to `%u`.

### Testing

- CppCheck no longer reports these warnings after the fix.
- `make` compiles cleanly with no new warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: minimal defensive check in the event loop timer path plus format-specifier fixes; behavior changes only in an edge case that previously could crash.
> 
> **Overview**
> Prevents a potential NULL dereference in `usUntilEarliestTimer` (`src/ae.c`) by returning `-1` when all time events are filtered out as `AE_DELETED_EVENT_ID`.
> 
> Fixes several `printf` format-specifier mismatches for unsigned values in `dictGetStatsMsg` (`%lu`), `mstrPrint` (`%u`), and `redis-cli` vector recall output (`%u`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d506d4d9642347a28fbae78db29c070b2ff0862c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->