### PR TITLE
Fix ACL OOB for wrong-arity KEYNUM commands

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3139,10 +3139,11 @@ int getKeysUsingKeySpecs(struct redisCommand *cmd, robj **argv, int argc, int se
         } else if (spec->find_keys_type == KSPEC_FK_KEYNUM) {
             step = spec->fk.keynum.keystep;
             long long numkeys;
-            if (spec->fk.keynum.keynumidx >= argc)
+            long keynumidx = first + spec->fk.keynum.keynumidx;
+            if (keynumidx >= argc || keynumidx < 0)
                 goto invalid_spec;
 
-            sds keynum_str = argv[first + spec->fk.keynum.keynumidx]->ptr;
+            sds keynum_str = argv[keynumidx]->ptr;
             if (!string2ll(keynum_str,sdslen(keynum_str),&numkeys) || numkeys < 0) {
                 /* Unable to parse the numkeys argument or it was invalid */
                 goto invalid_spec;
@@ -3452,6 +3453,10 @@ int genericGetKeys(int storeKeyOfs, int keyCountOfs, int firstKeyOfs, int keySte
     int i, num;
     keyReference *keys;
 
+    if (keyCountOfs >= argc) {
+        result->numkeys = 0;
+        return 0;
+    }
     num = atoi(argv[keyCountOfs]->ptr);
     /* Sanity check. Don't return any key if the command is going to
      * reply with syntax error. (no input keys). */

--- a/src/module.c
+++ b/src/module.c
@@ -10410,6 +10410,7 @@ RedisModuleUser *RM_GetModuleUserFromUserName(RedisModuleString *name) {
  * REDISMODULE_ERR is returned and errno is set to the following values:
  *
  * * ENOENT: Specified command does not exist.
+ * * EINVAL: Invalid number of arguments for the specified command.
  * * EACCES: Command cannot be executed, according to ACL rules
  */
 int RM_ACLCheckCommandPermissions(RedisModuleUser *user, RedisModuleString **argv, int argc) {
@@ -10419,6 +10420,11 @@ int RM_ACLCheckCommandPermissions(RedisModuleUser *user, RedisModuleString **arg
     /* Find command */
     if ((cmd = lookupCommand(argv, argc)) == NULL) {
         errno = ENOENT;
+        return REDISMODULE_ERR;
+    }
+
+    if (!commandCheckArity(cmd, argc, NULL)) {
+        errno = EINVAL;
         return REDISMODULE_ERR;
     }
 

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -1132,6 +1132,9 @@ static int luaRedisAclCheckCmdPermissionsCommand(lua_State *lua) {
     if ((cmd = lookupCommand(argv, argc)) == NULL) {
         luaPushError(lua, "Invalid command passed to redis.acl_check_cmd()");
         raise_error = 1;
+    } else if (!commandCheckArity(cmd, argc, NULL)) {
+        luaPushError(lua, "Wrong number of args for redis.acl_check_cmd()");
+        raise_error = 1;
     } else {
         int keyidxptr;
         if (ACLCheckAllUserCommandPerm(rctx->original_client->user, cmd, argv, argc, NULL, &keyidxptr) != ACL_OK) {

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -17,6 +17,11 @@ start_server {tags {"modules acl external:skip"}} {
         assert {[dict get $entry context] eq {module}}
         assert {[dict get $entry object] eq {set}}
         assert {[dict get $entry reason] eq {command}}
+
+        # Wrong command arity must fail safely (no crash on KEYNUM keyspec path)
+        r acl setuser default on nopass resetkeys ~restricted:* +@all
+        catch {r aclcheck.rm_call.check.cmd eval script} e
+        assert_match {*DENIED*} $e
     }
         
     test {test module check acl for key prefix permission} {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -2686,3 +2686,15 @@ start_server {tags {"scripting"}} {
         }
     }
 }
+
+start_server {tags {"scripting"}} {
+    test "Wrong arity EVAL in acl_check_cmd returns error not crash" {
+        r acl setuser bob on {>123} {+@scripting} {+set} {~x*}
+        assert_equal [r auth bob 123] {OK}
+        # Must be the first Lua call in this server instance
+        catch {run_script {
+            return redis.acl_check_cmd('eval','script')
+        } 0} e
+        assert_match {*Wrong number of args*} $e
+    }
+}


### PR DESCRIPTION
`luaRedisAclCheckCmdPermissionsCommand` and `RM_ACLCheckCommandPermissions` now call `commandCheckArity()` to check command arity before calling `ACLCheckAllUserCommandPerm`, matching the behavior of `processCommand`, `scriptCall`, and `RM_Call`. Without this, KEYNUM keyspec commands like EVAL with wrong arity cause out-of-bounds argv access during key extraction.

Also fix KEYNUM index calculation (`first + keynumidx`) and add a bounds check in genericGetKeys().

Add scripting and module ACL tests for wrong-arity `EVAL` to lock in the non-crashing behavior.

Fixes #14843 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches command key-extraction and ACL-check paths used by modules and Lua scripting; mistakes could change authorization behavior or error handling for affected commands.
> 
> **Overview**
> Prevents crashes during ACL checks on wrong-arity commands by **validating command arity before ACL key/channel extraction** in both the module API (`RM_ACLCheckCommandPermissions`) and Lua (`redis.acl_check_cmd`).
> 
> Hardens key discovery for `KEYNUM` key-specs by computing the key-count index relative to the resolved `first` argument and guarding against negative/out-of-range `argv` access, plus an early bounds check in `genericGetKeys` when the key-count argument is missing.
> 
> Adds regression tests ensuring wrong-arity `EVAL` fails safely (returns an error/denial) in module ACL checks and in `redis.acl_check_cmd`, rather than crashing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3d1f31c12067831aa9988b82dc7ca7eecec9d32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->