### PR TITLE
No checksum performed on diskless replication

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4019,7 +4019,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
         if (rioRead(rdb,&cksum,8) == 0) goto eoferr;
         if (server.rdb_checksum && !server.skip_checksum_validation) {
             memrev64ifbe(&cksum);
-            if (cksum == 0 || rdb->flags & RIO_FLAG_NO_CHECKSUM) {
+            if (cksum == 0 || (rdb->flags & RIO_FLAG_NO_CHECKSUM)) {
                 serverLog(LL_NOTICE,"RDB file was saved with checksum disabled: no check performed.");
             } else if (cksum != expected) {
                 serverLog(LL_WARNING,"Wrong RDB checksum expected: (%llx) but "

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3550,6 +3550,7 @@ void updateLoadingFileName(char* filename) {
 void stopLoading(int success) {
     server.loading = 0;
     server.async_loading = 0;
+    server.loading_skip_checksum = 0;
     blockingOperationEnds();
     rdbFileBeingLoaded = NULL;
 
@@ -3587,7 +3588,7 @@ void stopSaving(int success) {
 /* Track loading progress in order to serve client's from time to time
    and if needed calculate rdb checksum  */
 void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
-    if (server.rdb_checksum && !(r->flags & RIO_FLAG_NO_CHECKSUM))
+    if (server.rdb_checksum && !server.loading_skip_checksum)
         rioGenericUpdateChecksum(r, buf, len);
     if (server.loading_process_events_interval_bytes &&
         (r->processed_bytes + len)/server.loading_process_events_interval_bytes > r->processed_bytes/server.loading_process_events_interval_bytes)
@@ -4017,9 +4018,9 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
         uint64_t cksum, expected = rdb->cksum;
 
         if (rioRead(rdb,&cksum,8) == 0) goto eoferr;
-        if (server.rdb_checksum && !server.skip_checksum_validation) {
+        if (server.rdb_checksum && !server.loading_skip_checksum && !server.skip_checksum_validation) {
             memrev64ifbe(&cksum);
-            if (cksum == 0 || (rdb->flags & RIO_FLAG_NO_CHECKSUM)) {
+            if (cksum == 0) {
                 serverLog(LL_NOTICE,"RDB file was saved with checksum disabled: no check performed.");
             } else if (cksum != expected) {
                 serverLog(LL_WARNING,"Wrong RDB checksum expected: (%llx) but "

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4301,11 +4301,10 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
         redisSetProcTitle("redis-rdb-to-slaves");
         redisSetCpuAffinity(server.bgsave_cpulist);
 
-        /* Disable RDB compression if requested. */
+        /* Disable RDB compression and checksum in the fork child if requested.
+         * The parent's configuration is not affected. */
         if (req & SLAVE_REQ_RDB_NO_COMPRESS)
             server.rdb_compression = 0;
-
-        /* Disable RDB checksum if requested. */
         if (req & SLAVE_REQ_RDB_NO_CHECKSUM)
             server.rdb_checksum = 0;
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3587,7 +3587,7 @@ void stopSaving(int success) {
 /* Track loading progress in order to serve client's from time to time
    and if needed calculate rdb checksum  */
 void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
-    if (server.rdb_checksum)
+    if (server.rdb_checksum && !(r->flags & RIO_FLAG_NO_CHECKSUM))
         rioGenericUpdateChecksum(r, buf, len);
     if (server.loading_process_events_interval_bytes &&
         (r->processed_bytes + len)/server.loading_process_events_interval_bytes > r->processed_bytes/server.loading_process_events_interval_bytes)
@@ -4017,7 +4017,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
         if (rioRead(rdb,&cksum,8) == 0) goto eoferr;
         if (server.rdb_checksum && !server.skip_checksum_validation) {
             memrev64ifbe(&cksum);
-            if (cksum == 0) {
+            if (cksum == 0 || rdb->flags & RIO_FLAG_NO_CHECKSUM) {
                 serverLog(LL_NOTICE,"RDB file was saved with checksum disabled: no check performed.");
             } else if (cksum != expected) {
                 serverLog(LL_WARNING,"Wrong RDB checksum expected: (%llx) but "
@@ -4302,6 +4302,10 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
         /* Disable RDB compression if requested. */
         if (req & SLAVE_REQ_RDB_NO_COMPRESS)
             server.rdb_compression = 0;
+
+        /* Disable RDB checksum if requested. */
+        if (req & SLAVE_REQ_RDB_NO_CHECKSUM)
+            server.rdb_checksum = 0;
 
         if (req & SLAVE_REQ_SLOTS_SNAPSHOT) {
             /* Slots snapshot is required */

--- a/src/replication.c
+++ b/src/replication.c
@@ -2438,9 +2438,10 @@ void readSyncBulkPayload(connection *conn) {
         /* Set disklessLoadingRio before calling emptyData() which may yield
          * back to networking. */
         rioInitWithConn(&rdb,conn,server.repl_transfer_size);
-        /* Disable checksum verification when diskless loading, and we requested
-         * master to not send checksum either. */
-        rdb.flags |= RIO_FLAG_NO_CHECKSUM;
+        /* Disable checksum verification when diskless on both master and replica.
+         * The RDB checksum is designed to detect disk corruption, but if the data
+         * never touched disk, we can skip verification. */
+        if (usemark) rdb.flags |= RIO_FLAG_NO_CHECKSUM;
         disklessLoadingRio = &rdb;
 
         /* Empty db */

--- a/src/replication.c
+++ b/src/replication.c
@@ -2438,11 +2438,12 @@ void readSyncBulkPayload(connection *conn) {
         /* Set disklessLoadingRio before calling emptyData() which may yield
          * back to networking. */
         rioInitWithConn(&rdb,conn,server.repl_transfer_size);
+        disklessLoadingRio = &rdb;
+
         /* Disable checksum verification when diskless on both master and replica.
          * The RDB checksum is designed to detect disk corruption, but if the data
          * never touched disk, we can skip verification. */
-        if (usemark) rdb.flags |= RIO_FLAG_NO_CHECKSUM;
-        disklessLoadingRio = &rdb;
+        if (usemark) server.loading_skip_checksum = 1;
 
         /* Empty db */
         loadingSetFlags(NULL, server.repl_transfer_size, asyncLoading);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1549,9 +1549,11 @@ void replconfCommand(client *c) {
                 return;
             }
             c->main_ch_client_id = (uint64_t)client_id;
-            /* Inherit the rdb-no-compress request from the main channel. */
+            /* Inherit the rdb-no-compress and rdb-no-checksum request from the main channel. */
             if (main_ch->slave_req & SLAVE_REQ_RDB_NO_COMPRESS)
                 c->slave_req |= SLAVE_REQ_RDB_NO_COMPRESS;
+            if (main_ch->slave_req & SLAVE_REQ_RDB_NO_CHECKSUM)
+                c->slave_req |= SLAVE_REQ_RDB_NO_CHECKSUM;
         } else if (!strcasecmp(c->argv[j]->ptr, "rdb-no-compress")) {
             long rdb_no_compress = 0;
             if (getRangeLongFromObjectOrReply(c, c->argv[j + 1], 0, 1, &rdb_no_compress, NULL) != C_OK)
@@ -1560,6 +1562,15 @@ void replconfCommand(client *c) {
                 c->slave_req |= SLAVE_REQ_RDB_NO_COMPRESS;
             } else {
                 c->slave_req &= ~SLAVE_REQ_RDB_NO_COMPRESS;
+            }
+        } else if (!strcasecmp(c->argv[j]->ptr, "rdb-no-checksum")) {
+            long rdb_no_checksum = 0;
+            if (getRangeLongFromObjectOrReply(c, c->argv[j + 1], 0, 1, &rdb_no_checksum, NULL) != C_OK)
+                return;
+            if (rdb_no_checksum == 1) {
+                c->slave_req |= SLAVE_REQ_RDB_NO_CHECKSUM;
+            } else {
+                c->slave_req &= ~SLAVE_REQ_RDB_NO_CHECKSUM;
             }
         } else {
             addReplyErrorFormat(c,"Unrecognized REPLCONF option: %s",
@@ -2427,6 +2438,9 @@ void readSyncBulkPayload(connection *conn) {
         /* Set disklessLoadingRio before calling emptyData() which may yield
          * back to networking. */
         rioInitWithConn(&rdb,conn,server.repl_transfer_size);
+        /* Disable checksum verification when diskless loading, and we requested
+         * master to not send checksum either. */
+        rdb.flags |= RIO_FLAG_NO_CHECKSUM;
         disklessLoadingRio = &rdb;
 
         /* Empty db */
@@ -3008,7 +3022,7 @@ void syncWithMaster(connection *conn) {
     char tmpfile[256], *err = NULL;
     int dfd = -1, maxtries = 5;
     int psync_result;
-    static int replconf_rdb_no_compress = 0;
+    static int no_compress_checksum = 0;
 
     /* If this event fired after the user turned the instance into a master
      * with SLAVEOF NO ONE we must just return ASAP. */
@@ -3108,11 +3122,13 @@ void syncWithMaster(connection *conn) {
         }
 
         /* If we are not going to save the RDB to disk, request that RDB
-         * compression be disabled, which speeds up RDB delivery. */
-        replconf_rdb_no_compress = 0;
+         * compression and checksum be disabled, which speeds up RDB delivery
+         * and loading. */
+        no_compress_checksum = 0;
         if (useDisklessLoad()) {
-            replconf_rdb_no_compress = 1;
-            err = sendCommand(conn, "REPLCONF", "rdb-no-compress", "1", NULL);
+            no_compress_checksum = 1;
+            err = sendCommand(conn, "REPLCONF", "rdb-no-compress", "1",
+                                    "rdb-no-checksum", "1", NULL);
             if (err) goto write_error;
         }
 
@@ -3166,7 +3182,7 @@ void syncWithMaster(connection *conn) {
     }
 
     if (server.repl_state == REPL_STATE_RECEIVE_IP_REPLY && !server.slave_announce_ip)
-        server.repl_state = REPL_STATE_RECEIVE_COMP_REPLY;
+        server.repl_state = REPL_STATE_RECEIVE_REQ_REPLY;
 
     /* Receive REPLCONF ip-address reply. */
     if (server.repl_state == REPL_STATE_RECEIVE_IP_REPLY) {
@@ -3179,22 +3195,22 @@ void syncWithMaster(connection *conn) {
                                 "REPLCONF ip-address: %s", err);
         }
         sdsfree(err);
-        server.repl_state = REPL_STATE_RECEIVE_COMP_REPLY;
+        server.repl_state = REPL_STATE_RECEIVE_REQ_REPLY;
         return;
     }
 
-    if (server.repl_state == REPL_STATE_RECEIVE_COMP_REPLY && !replconf_rdb_no_compress)
+    if (server.repl_state == REPL_STATE_RECEIVE_REQ_REPLY && !no_compress_checksum)
         server.repl_state = REPL_STATE_RECEIVE_CAPA_REPLY;
 
-    /* Receive REPLCONF rdb-no-compress reply. */
-    if (server.repl_state == REPL_STATE_RECEIVE_COMP_REPLY) {
+    /* Receive REPLCONF REQUEST reply (rdb-no-compress and rdb-no-checksum). */
+    if (server.repl_state == REPL_STATE_RECEIVE_REQ_REPLY) {
         err = receiveSynchronousResponse(conn);
         if (err == NULL) goto no_response_error;
         /* Ignore the error if any, not all the Redis versions support
-         * REPLCONF rdb-no-compress. */
+         * REPLCONF rdb-no-compress and rdb-no-checksum. */
         if (err[0] == '-') {
             serverLog(LL_NOTICE,"(Non critical) Master does not understand "
-                                "REPLCONF rdb-no-compress: %s", err);
+                                "REPLCONF rdb-no-compress/checksum: %s", err);
         }
         sdsfree(err);
         server.repl_state = REPL_STATE_RECEIVE_CAPA_REPLY;

--- a/src/rio.h
+++ b/src/rio.h
@@ -23,7 +23,6 @@
 
 #define RIO_FLAG_READ_ERROR (1<<0)
 #define RIO_FLAG_WRITE_ERROR (1<<1)
-#define RIO_FLAG_NO_CHECKSUM (1<<2)
 
 #define RIO_TYPE_FILE (1<<0)
 #define RIO_TYPE_BUFFER (1<<1)

--- a/src/rio.h
+++ b/src/rio.h
@@ -23,6 +23,7 @@
 
 #define RIO_FLAG_READ_ERROR (1<<0)
 #define RIO_FLAG_WRITE_ERROR (1<<1)
+#define RIO_FLAG_NO_CHECKSUM (1<<2)
 
 #define RIO_TYPE_FILE (1<<0)
 #define RIO_TYPE_BUFFER (1<<1)

--- a/src/server.h
+++ b/src/server.h
@@ -2032,6 +2032,7 @@ struct redisServer {
     off_t loading_loaded_bytes;
     time_t loading_start_time;
     off_t loading_process_events_interval_bytes;
+    int loading_skip_checksum; /* Skip checksum verification during diskless loading */
     /* Fields used only for stats */
     time_t stat_starttime;          /* Server start time */
     long long stat_numcommands;     /* Number of processed commands */

--- a/src/server.h
+++ b/src/server.h
@@ -520,7 +520,7 @@ typedef enum {
     REPL_STATE_RECEIVE_AUTH_REPLY,  /* Wait for AUTH reply */
     REPL_STATE_RECEIVE_PORT_REPLY,  /* Wait for REPLCONF reply */
     REPL_STATE_RECEIVE_IP_REPLY,    /* Wait for REPLCONF reply */
-    REPL_STATE_RECEIVE_COMP_REPLY,  /* Wait for REPLCONF reply */
+    REPL_STATE_RECEIVE_REQ_REPLY,   /* Wait for REPLCONF reply */
     REPL_STATE_RECEIVE_CAPA_REPLY,  /* Wait for REPLCONF reply */
     REPL_STATE_SEND_PSYNC,          /* Send PSYNC */
     REPL_STATE_RECEIVE_PSYNC_REPLY, /* Wait for PSYNC reply */
@@ -587,6 +587,7 @@ typedef enum {
 #define SLAVE_REQ_SLOTS_SNAPSHOT        (1 << 2) /* Only slots snapshot is required */
 #define SLAVE_REQ_RDB_CHANNEL           (1 << 3) /* Use rdb channel replication, transfer RDB background */
 #define SLAVE_REQ_RDB_NO_COMPRESS       (1 << 4) /* Don't enable RDB compression */
+#define SLAVE_REQ_RDB_NO_CHECKSUM       (1 << 4) /* Don't enable RDB checksum */
 /* Mask of all bits in the slave requirements bitfield that represent non-standard (filtered) RDB requirements */
 #define SLAVE_REQ_RDB_MASK (SLAVE_REQ_RDB_EXCLUDE_DATA | SLAVE_REQ_RDB_EXCLUDE_FUNCTIONS | SLAVE_REQ_SLOTS_SNAPSHOT)
 

--- a/src/server.h
+++ b/src/server.h
@@ -587,7 +587,7 @@ typedef enum {
 #define SLAVE_REQ_SLOTS_SNAPSHOT        (1 << 2) /* Only slots snapshot is required */
 #define SLAVE_REQ_RDB_CHANNEL           (1 << 3) /* Use rdb channel replication, transfer RDB background */
 #define SLAVE_REQ_RDB_NO_COMPRESS       (1 << 4) /* Don't enable RDB compression */
-#define SLAVE_REQ_RDB_NO_CHECKSUM       (1 << 4) /* Don't enable RDB checksum */
+#define SLAVE_REQ_RDB_NO_CHECKSUM       (1 << 5) /* Don't enable RDB checksum */
 /* Mask of all bits in the slave requirements bitfield that represent non-standard (filtered) RDB requirements */
 #define SLAVE_REQ_RDB_MASK (SLAVE_REQ_RDB_EXCLUDE_DATA | SLAVE_REQ_RDB_EXCLUDE_FUNCTIONS | SLAVE_REQ_SLOTS_SNAPSHOT)
 

--- a/src/server.h
+++ b/src/server.h
@@ -580,7 +580,10 @@ typedef enum {
 #define SLAVE_CAPA_PSYNC2           (1<<1) /* Supports PSYNC2 protocol. */
 #define SLAVE_CAPA_RDB_CHANNEL_REPL (1<<2) /* Supports rdb channel replication during full sync */
 
-/* Slave requirements */
+/* Slave requirements. NO_COMPRESS and NO_CHECKSUM are hints rather than strict
+ * requirements - the replica can handle compressed/checksummed RDB either way,
+ * but prefers to skip them for diskless loading since they become redundant.
+ * We reuse the REQ mechanism for simplicity, avoiding a separate HINT bitfield. */
 #define SLAVE_REQ_NONE                  0
 #define SLAVE_REQ_RDB_EXCLUDE_DATA      (1 << 0) /* Exclude data from RDB */
 #define SLAVE_REQ_RDB_EXCLUDE_FUNCTIONS (1 << 1) /* Exclude functions from RDB */


### PR DESCRIPTION
In #14575, we disable rdb compression when using diskless replication.
Actually rdb checksum also costs much CPU, and it is used to check RDB disk file instead of replication stream, so when using diskless replication (`diskless sync` is enabled on master, `diskless load` is enabled on replica), we don't store/load any rdb file into/from disk, so we can skip the checksum in this scenario to accelerate rdb delivery. 

People may argue the checksum for replication stream can recognize the network data corruption, but actually we can not recognize the network data corruption issue for incremental replication-stream/commands, so it is limited, we should use `tls` feature to ensure the data correctness.

I tested on AWS, ec2 type is c8g.2xlarge, data size is 12.37GB, all keys are string type, keys size is 1024.
- If master and replica are different ec2 instances but in the same placement group, the full synchronization time reduced from 16s to 11s. 
- If the master and replica are in the same ec2 instance, the full synchronization time reduced from 15s to 10s.
-  If master and replica are different ec2 instances but not in the same placement group, there is no change.

It seems network latency is the bottleneck now.

And after #14575 and this PR, the full synchronization time reduced from 35s to 11s when master and replica instances are in the same placement group. A decrease of nearly 68.5% !


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches replication handshake/state machine and RDB load/save checksum behavior; mistakes could break full resync compatibility across versions or reduce integrity checks during diskless transfers.
> 
> **Overview**
> Skips RDB checksum computation/validation during *diskless* full synchronization to reduce CPU overhead: replicas request `rdb-no-checksum` alongside `rdb-no-compress`, masters disable checksum generation in the forked RDB transfer child, and replicas set `server.loading_skip_checksum` to bypass checksum updates and final verification while loading from a socket.
> 
> Extends replication protocol parsing to support/inherit the new `REPLCONF rdb-no-checksum` option (including for RDB-channel replication), and renames the handshake wait state from `REPL_STATE_RECEIVE_COMP_REPLY` to `REPL_STATE_RECEIVE_REQ_REPLY` to cover the combined request reply.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16b173b2736d985a6c88479a602e64d5ab47088f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->