### PR TITLE
Fix test assertion except from TSAN case

### DIFF
--- a/tests/integration/failover.tcl
+++ b/tests/integration/failover.tcl
@@ -180,19 +180,16 @@ start_server {overrides {save {}}} {
 
         assert_equal [count_log_message -2 "time out exceeded, failing over."] 1
 
-        # We should accept both psyncs, although this is the condition we might
-        # not meet since we didn't catch up. This happens often if TSan is
-        # enabled as it slows down the execution time significantly.
+        # We should accept both psyncs and full syncs, although this is the condition we might
+        # not meet since we didn't catch up. This happens often in slow environments
+        # (TSAN, IO threads, etc) which can force a full resync instead of a partial
+        # one. Count both partial and full syncs and verify the total increments by two.
         set psyncs [expr [s 0 sync_partial_ok] - $initial_psyncs]
         set full_syncs [expr [s 0 sync_full] - $initial_syncs]
-        if {$::tsan} {
-            assert_lessthan_equal $psyncs 2
-            assert_morethan_equal $full_syncs 0
-            assert_equal [expr $psyncs + $full_syncs] 2
-        } else {
-            assert_equal $psyncs 2
-            assert_equal $full_syncs 0
-        }
+        # Either we get 2 partial syncs, or some combination of partial/full that totals 2
+        assert_lessthan_equal $psyncs 2
+        assert_morethan_equal $full_syncs 0
+        assert_equal [expr $psyncs + $full_syncs] 2
         assert_digests_match $node_0 $node_1 $node_2
     }
 


### PR DESCRIPTION
Fix #14835

Executed `failover` with `force` argument in slow environments (TSAN, IO threads, etc) can force a full resync instead of a partial one. e3c38aab6 adds TSAN-only workaround in integration/failover test, test failure occurs in `test‑ubuntu‑io‑threads` job, drop TSAN-only condition and always check the sum of partial+full syncs will fix it.

Steps to reproduce:
My setup: Hardware: MacBook Pro (Apple chip)

1. Build docker image with Dockerfile below and run the container:
```
FROM ubuntu:22.04

# avoid interactive prompts
ENV DEBIAN_FRONTEND=noninteractive

RUN apt-get update && \
    apt-get install -y --no-install-recommends \
    build-essential \
    tcl8.6 \
    tclx \
    tcl-tls \
    pkg-config \
    ca-certificates \
    git \
    bash \
    vim \
    wget \
    curl \
    && rm -rf /var/lib/apt/lists/*

WORKDIR /opt/redis

# if you prefer to copy the source during build uncomment the next line
# COPY . /opt/redis

# configure a non-root user if desired; we stay root for simplicity

# default command keeps you in a shell
CMD ["/bin/bash"]

```

Execute the command:

```
cd /path/to/redis
docker build -f Dockerfile.io-threads -t redis-test-io .
docker run --rm -it --cpuset-cpus=0 --cpus=0.1 -v $(pwd):/opt/redis redis-test-io /bin/bash
```
2. Inside the container you can then run the same commands as the CI job:
```
make REDIS_CFLAGS='-Werror'
./runtest --single integration/failover --config io-threads 4 --tags "failover" --verbose --accurate --loop --stop
```
If the container still seems too fast, lower `--cpus` further (e.g. 0.05), or run the whole driver under `cpulimit`:
```
apt-get update && apt-get install -y cpulimit
cpulimit -l 1 -- ./runtest --single integration/failover --config io-threads 4 --tags "failover" --verbose --accurate --loop --stop
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only an integration test assertion to tolerate full resyncs in addition to partial resyncs, reducing flakiness in slow/TSAN/IO-threaded environments.
> 
> **Overview**
> Updates `tests/integration/failover.tcl` to remove the TSAN-only assertion branch in the "failover to a replica with force works" test.
> 
> The test now always allows any mix of partial (`sync_partial_ok`) and full (`sync_full`) syncs as long as their total increment is `2`, preventing failures in slow environments where a full resync can occur.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c32ec55fbf23aed25886328b4d6a97077c7c2e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->