### PR TITLE
Avoid 'sed -i' when building modules

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -83,7 +83,7 @@ ifeq ($(DISABLE_WERRORS),yes)
 			\( -name "Makefile" \
 			-o -name "*.mk" \
 			-o -name "CMakeLists.txt" \) \
-			-exec sed -i 's/-Werror//g' {} +; \
+			-exec sh -c 'for f do sed "s/-Werror//g" "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done' _ {} +; \
 	done
 endif
 


### PR DESCRIPTION
The macOS implementation of 'sed' has an -i option that is not compatible with GNU 'sed'. This leads to the following build error when running make with BUILD_WITH_MODULES=yes:

    Disabling -Werror for all modules
    Processing redisjson
    sed: rename(): No such file or directory
    Processing redistimeseries
    sed: rename(): No such file or directory
    Processing redisbloom
    sed: rename(): No such file or directory
    Processing redisearch
    sed: rename(): No such file or directory
    make[1]: *** [handle-werrors] Error 1

We can use the more portable method of redirecting the output to a temporary file and moving it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-script portability change that only affects the optional `DISABLE_WERRORS` path when patching module build files; main build logic is unchanged.
> 
> **Overview**
> Makes the `handle-werrors` step in `modules/Makefile` portable by replacing in-place `sed -i` edits with a temp-file rewrite (`sed` to `$$f.tmp` then `mv`).
> 
> This prevents macOS/BSD `sed` incompatibilities when stripping `-Werror` from module `Makefile`/`*.mk`/`CMakeLists.txt` files during module builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a63eb4064355edafabd2c9717f4ecb988553bc33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->