### PR TITLE
Fix X509 memory leak in connTLSGetPeerCert

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -1181,6 +1181,7 @@ static sds connTLSGetPeerCert(connection *conn_) {
     BIO *bio = BIO_new(BIO_s_mem());
     if (bio == NULL || !PEM_write_bio_X509(bio, cert)) {
         if (bio != NULL) BIO_free(bio);
+        X509_free(cert);
         return NULL;
     }
 
@@ -1188,6 +1189,7 @@ static sds connTLSGetPeerCert(connection *conn_) {
     long long bio_len = BIO_get_mem_data(bio, &bio_ptr);
     sds cert_pem = sdsnewlen(bio_ptr, bio_len);
     BIO_free(bio);
+    X509_free(cert);
 
     return cert_pem;
 }


### PR DESCRIPTION
`connTLSGetPeerCert()` calls `SSL_get_peer_certificate()` which increments the X509 reference count, but never calls `X509_free()` to release it. This leaks an X509 object on each call to `RM_GetClientCertificate()`. This PR adds `X509_free(cert)` before returns.

The existing `test module getclientcert api` test in `tests/unit/moduleapi/misc.tcl` exercises this code path. But the leak was not caught because the ASAN CI job does not enable TLS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds missing `X509_free()` calls on both success and error paths, with no behavioral change beyond preventing a leak.
> 
> **Overview**
> Prevents a per-call memory leak when exporting the client certificate (e.g., via `RM_GetClientCertificate`) by freeing the `X509 *cert` obtained from `SSL_get_peer_certificate()` in `connTLSGetPeerCert()` on both the failure path and after building the PEM string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d96221058209e7ec8a6eac7d41fe60c706f67b55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->