### PR TITLE
XADD, update keyModified and dirty counter when increasing iids_duplicates

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2474,6 +2474,8 @@ void xaddCommand(client *c) {
         if (idmpLookupAndReply(s, producer, entry, c)) {
             /* IID already exists, free the entry and return */
             idmpEntryFree(entry, &s->alloc_size);
+            keyModified(c,c->db,c->argv[1],kv,0);
+            server.dirty++;
             return;
         }
     }


### PR DESCRIPTION
we're saving iids_duplicates to the rdb file, so when it changes, we need to increment the dirty counter, and also mark the key as modified (being metadata, no signal is needed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `XADD`’s write path and replication/AOF bookkeeping by updating `keyModified()`/`server.dirty` on an early-return duplicate-IID case; incorrect handling could impact persistence/replica consistency of stream metadata.
> 
> **Overview**
> Ensures `XADD` with `IDMP`/`IDMPAUTO` that hits an existing IID (early-return path) now records the metadata change by calling `keyModified(..., 0)` and incrementing `server.dirty`, since `s->iids_duplicates` is persisted (RDB) and must replicate even when no stream entry is added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e7370c1a14dcac53462aa2296ae0e426858ad06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->