### PR TITLE
Fix missing keymeta module test in runtest-moduleapi

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -59,4 +59,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/crash \
 --single unit/moduleapi/internalsecret \
 --single unit/moduleapi/configaccess \
+--single unit/moduleapi/keymeta\
 "${@}"

--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -59,5 +59,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/crash \
 --single unit/moduleapi/internalsecret \
 --single unit/moduleapi/configaccess \
---single unit/moduleapi/keymeta\
+--single unit/moduleapi/keymeta \
 "${@}"


### PR DESCRIPTION
Fix missing `unit/moduleapi/keymeta` in `run-moduleapi` test suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the test runner to execute an additional existing unit test, with no production code changes.
> 
> **Overview**
> Adds the missing `unit/moduleapi/keymeta` invocation to the `runtest-moduleapi` script so the Module API *key metadata* unit test is run as part of the standard moduleapi test suite.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90ef69a775f37dcb815b67fa1cc4b77b2c8b8577. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->