### PR TITLE
Filter expired IDMP entries during RDB save and load

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4033,6 +4033,16 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                     estoreAdd(db->subexpires, getKeySlot(key), kv, minExpiredField);
             }
 
+            /* Register streams with IDMP producers for cron-based expiration. */
+            if (kv->type == OBJ_STREAM) {
+                stream *s = kv->ptr;
+                if (s->idmp_producers != NULL) {
+                    robj *kobj = createStringObject(key, sdslen(key));
+                    if (dictAddRaw(db->stream_idmp_keys, kobj, NULL) == NULL)
+                        decrRefCount(kobj);
+                }
+            }
+
             /* Set usage information (for eviction). */
             objectSetLRUOrLFU(val,lfu_freq,lru_idle,lru_clock,1000);
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -812,12 +812,13 @@ ssize_t rdbSaveStreamIdmpEntries(rio *rdb, stream *s) {
         /* Find the first non-expired entry. The linked list is ordered by
          * timestamp, so all entries after the first valid one are also valid. */
         idmpEntry *first_valid = producer->idmp_head;
-        while (first_valid && first_valid->id.ms <= expire_time)
+        size_t expired = 0;
+        while (first_valid && first_valid->id.ms <= expire_time) {
             first_valid = first_valid->next;
+            expired++;
+        }
 
-        /* Count non-expired entries. */
-        size_t count = 0;
-        for (idmpEntry *e = first_valid; e != NULL; e = e->next) count++;
+        size_t count = dictSize(producer->idmp_dict) - expired;
         if ((n = rdbSaveLen(rdb, count)) == -1) {
             raxStop(&ri);
             return -1;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -780,6 +780,8 @@ ssize_t rdbSaveStreamPEL(rio *rdb, rax *pel, int nacks) {
 
 /* Serialize the IDMP entries for a stream into the RDB file.
  * This saves all the idempotent producer tracking entries (IID -> stream ID mappings).
+ * Expired entries are filtered out. Producers whose entries all expired are still
+ * written with count=0; the load side skips them.
  * Format: num_producers, then for each producer: pid, num_entries, entries... */
 ssize_t rdbSaveStreamIdmpEntries(rio *rdb, stream *s) {
     ssize_t n, nwritten = 0;
@@ -790,6 +792,8 @@ ssize_t rdbSaveStreamIdmpEntries(rio *rdb, stream *s) {
     nwritten += n;
 
     if (num_producers == 0) return nwritten;
+
+    uint64_t expire_time = server.mstime - (s->idmp_duration * 1000);
 
     /* Iterate through all producers. */
     raxIterator ri;
@@ -805,16 +809,23 @@ ssize_t rdbSaveStreamIdmpEntries(rio *rdb, stream *s) {
         }
         nwritten += n;
 
-        /* Save the number of entries for this producer. */
-        size_t count = dictSize(producer->idmp_dict);
+        /* Find the first non-expired entry. The linked list is ordered by
+         * timestamp, so all entries after the first valid one are also valid. */
+        idmpEntry *first_valid = producer->idmp_head;
+        while (first_valid && first_valid->id.ms <= expire_time)
+            first_valid = first_valid->next;
+
+        /* Count non-expired entries. */
+        size_t count = 0;
+        for (idmpEntry *e = first_valid; e != NULL; e = e->next) count++;
         if ((n = rdbSaveLen(rdb, count)) == -1) {
             raxStop(&ri);
             return -1;
         }
         nwritten += n;
 
-        /* Iterate through the linked list and save each entry in insertion order. */
-        idmpEntry *entry = producer->idmp_head;
+        /* Save each non-expired entry in insertion order. */
+        idmpEntry *entry = first_valid;
         while (entry != NULL) {
             /* Save the IID string (length + data). */
             if ((n = rdbSaveRawString(rdb,(unsigned char *)entry->iid,entry->iid_len)) == -1) {
@@ -855,24 +866,34 @@ int rdbLoadStreamIdmpEntries(rio *rdb, stream *s) {
 
     if (num_producers == 0) return 0;
 
+    uint64_t expire_time = server.mstime - (s->idmp_duration * 1000);
+
     /* Create the producers rax tree. */
     s->idmp_producers = raxNewWithMetadata(0, &s->alloc_size);
     if (s->idmp_producers == NULL) {
         return -1;
     }
 
+    /* Track pid across error paths so cleanup can free it. */
+    char *pid = NULL;
+    size_t pid_len = 0;
+
     /* Load each producer. */
     for (uint64_t p = 0; p < num_producers; p++) {
         /* Load the producer ID (pid). */
-        size_t pid_len;
-        char *pid = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, &pid_len);
+        pid = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, &pid_len);
         if (pid == NULL) goto cleanup;
 
         /* Load the number of entries for this producer. */
         uint64_t count = rdbLoadLen(rdb, NULL);
-        if (count == RDB_LENERR) {
+        if (count == RDB_LENERR) goto cleanup;
+
+        /* Skip producers with 0 entries (written by save when all entries
+         * were expired). Just consume the RDB data and move on. */
+        if (count == 0) {
             sdsfree(pid);
-            goto cleanup;
+            pid = NULL;
+            continue;
         }
 
         /* Create the producer. */
@@ -880,7 +901,6 @@ int rdbLoadStreamIdmpEntries(rio *rdb, stream *s) {
 
         /* Insert producer into rax tree. */
         int inserted = raxTryInsert(s->idmp_producers, (unsigned char *)pid, pid_len, producer, NULL);
-        sdsfree(pid);
         if (!inserted) {
             idmpProducerFree(producer, &s->alloc_size);
             goto cleanup;
@@ -900,6 +920,12 @@ int rdbLoadStreamIdmpEntries(rio *rdb, stream *s) {
             if (rioGetReadError(rdb)) {
                 sdsfree(iid);
                 goto cleanup;
+            }
+
+            /* Skip entries that have already expired. */
+            if (id.ms <= expire_time) {
+                sdsfree(iid);
+                continue;
             }
 
             /* Create the idmpEntry. */
@@ -926,10 +952,26 @@ int rdbLoadStreamIdmpEntries(rio *rdb, stream *s) {
                 }
             }
         }
+
+        /* If all entries were expired, remove the empty producer. */
+        if (producer->idmp_head == NULL) {
+            raxRemove(s->idmp_producers, (unsigned char *)pid, pid_len, NULL);
+            idmpProducerFree(producer, &s->alloc_size);
+        }
+        sdsfree(pid);
+        pid = NULL;
     }
+
+    /* If no producers remain after filtering, free the rax tree. */
+    if (raxSize(s->idmp_producers) == 0) {
+        raxFree(s->idmp_producers);
+        s->idmp_producers = NULL;
+    }
+
     return 0;
 
 cleanup:
+    if (pid) sdsfree(pid);
     /* Clean up partially constructed producers tree on error.
      * This prevents use-after-free when the stream is later freed. */
     if (s->idmp_producers) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4033,16 +4033,6 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                     estoreAdd(db->subexpires, getKeySlot(key), kv, minExpiredField);
             }
 
-            /* Register streams with IDMP producers for cron-based expiration. */
-            if (kv->type == OBJ_STREAM) {
-                stream *s = kv->ptr;
-                if (s->idmp_producers != NULL) {
-                    robj *kobj = createStringObject(key, sdslen(key));
-                    if (dictAddRaw(db->stream_idmp_keys, kobj, NULL) == NULL)
-                        decrRefCount(kobj);
-                }
-            }
-
             /* Set usage information (for eviction). */
             objectSetLRUOrLFU(val,lfu_freq,lru_idle,lru_clock,1000);
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -818,6 +818,7 @@ ssize_t rdbSaveStreamIdmpEntries(rio *rdb, stream *s) {
             expired++;
         }
 
+        /* Save the number of entries for this producer. */
         size_t count = dictSize(producer->idmp_dict) - expired;
         if ((n = rdbSaveLen(rdb, count)) == -1) {
             raxStop(&ri);

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -927,47 +927,6 @@ start_server {
         assert_equal $id3 [r XADD mystream IDMP p3 "req-1" * field "dup"]
     } {} {external:skip}
 
-    test {XADD IDMP cron expiration works after RDB load} {
-        r DEL mystream
-
-        # Create stream and set IDMP-DURATION before adding entries,
-        # since XCFGSET clears existing entries when the duration changes.
-        r XADD mystream IDMP p1 "init" * field "init"
-        r XCFGSET mystream IDMP-DURATION 3
-        r XADD mystream IDMP p1 "req-1" * field "v1"
-        r XADD mystream IDMP p2 "req-1" * field "v2"
-
-        set reply [r XINFO STREAM mystream]
-        assert_equal 2 [dict get $reply pids-tracked]
-        assert_equal 2 [dict get $reply iids-tracked]
-
-        # Save and restart — this triggers RDB load which should
-        # register the stream in stream_idmp_keys for cron cleanup.
-        # IDMP-DURATION is 5s so entries survive the load-side filtering.
-        r SAVE
-        restart_server 0 true false
-
-        # Verify entries survived the load (not filtered as expired)
-        set reply [r XINFO STREAM mystream]
-        assert_equal 2 [dict get $reply pids-tracked]
-        assert_equal 2 [dict get $reply iids-tracked]
-
-        # Wait for IDMP entries to expire and for the cron to clean them up.
-        # The cron runs every 1s; IDMP-DURATION is 5s, so 7s is enough margin.
-        after 5000
-
-        # If stream_idmp_keys was populated during load, the cron will have
-        # cleaned up the expired entries; pids-tracked and iids-tracked go to 0.
-        set reply [r XINFO STREAM mystream]
-        assert_equal 0 [dict get $reply pids-tracked]
-        assert_equal 0 [dict get $reply iids-tracked]
-
-        # Expired IIDs should be re-addable as new entries
-        set new_id [r XADD mystream IDMP p1 "req-1" * field "new"]
-        assert {$new_id ne ""}
-        assert_equal 4 [r XLEN mystream]
-    } {} {external:skip}
-
     test {XADD IDMP multiple producers concurrent access} {
         r DEL mystream
         

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -927,6 +927,47 @@ start_server {
         assert_equal $id3 [r XADD mystream IDMP p3 "req-1" * field "dup"]
     } {} {external:skip}
 
+    test {XADD IDMP cron expiration works after RDB load} {
+        r DEL mystream
+
+        # Create stream and set IDMP-DURATION before adding entries,
+        # since XCFGSET clears existing entries when the duration changes.
+        r XADD mystream IDMP p1 "init" * field "init"
+        r XCFGSET mystream IDMP-DURATION 3
+        r XADD mystream IDMP p1 "req-1" * field "v1"
+        r XADD mystream IDMP p2 "req-1" * field "v2"
+
+        set reply [r XINFO STREAM mystream]
+        assert_equal 2 [dict get $reply pids-tracked]
+        assert_equal 2 [dict get $reply iids-tracked]
+
+        # Save and restart — this triggers RDB load which should
+        # register the stream in stream_idmp_keys for cron cleanup.
+        # IDMP-DURATION is 5s so entries survive the load-side filtering.
+        r SAVE
+        restart_server 0 true false
+
+        # Verify entries survived the load (not filtered as expired)
+        set reply [r XINFO STREAM mystream]
+        assert_equal 2 [dict get $reply pids-tracked]
+        assert_equal 2 [dict get $reply iids-tracked]
+
+        # Wait for IDMP entries to expire and for the cron to clean them up.
+        # The cron runs every 1s; IDMP-DURATION is 5s, so 7s is enough margin.
+        after 5000
+
+        # If stream_idmp_keys was populated during load, the cron will have
+        # cleaned up the expired entries; pids-tracked and iids-tracked go to 0.
+        set reply [r XINFO STREAM mystream]
+        assert_equal 0 [dict get $reply pids-tracked]
+        assert_equal 0 [dict get $reply iids-tracked]
+
+        # Expired IIDs should be re-addable as new entries
+        set new_id [r XADD mystream IDMP p1 "req-1" * field "new"]
+        assert {$new_id ne ""}
+        assert_equal 4 [r XLEN mystream]
+    } {} {external:skip}
+
     test {XADD IDMP multiple producers concurrent access} {
         r DEL mystream
         


### PR DESCRIPTION
**Summary**

Filters expired IDMP entries during RDB save and load, reducing RDB file size and memory usage on restart by not persisting or loading entries that have already exceeded their `idmp_duration`.

**Changes**

- **`rdbSaveStreamIdmpEntries`**: Added single-pass expiration filtering that skips expired entries when writing. Leverages the timestamp-ordered linked list to find the first valid entry, then counts and writes only non-expired entries. Producers with all entries expired are written with `count=0`.
- **`rdbLoadStreamIdmpEntries`**: Added expiration filtering that skips individual entries whose `id.ms <= expire_time`. Producers loaded with `count=0` are skipped entirely. Producers that become empty after entry-level filtering are removed from the rax tree. If no producers remain, the rax tree is freed.

**Benefits**

- **Smaller RDB files**: Expired entries are no longer serialized, reducing file size proportional to the number of stale IDMP entries.
- **Faster restarts**: Loading skips expired entries and empty producers, avoiding unnecessary allocations that would be immediately cleaned up by the cron.
- **Defense in depth**: Filtering on both save *and* load handles the case where an RDB was written by an older version (without save filtering) and loaded by a newer version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stream RDB persistence for IDMP state; a bug could drop valid producer entries or mishandle cleanup during load, affecting idempotency behavior after restart.
> 
> **Overview**
> **Filters expired Stream IDMP state during RDB persistence.** `rdbSaveStreamIdmpEntries` now computes an expiration cutoff and serializes only non-expired IID->ID mappings, while still emitting producers whose entries are all expired with `count=0`.
> 
> **Hardens IDMP loading and cleanup.** `rdbLoadStreamIdmpEntries` now skips producers with `count=0`, drops already-expired entries while reading, removes producers that end up empty after filtering, frees the `idmp_producers` rax tree if it becomes empty, and fixes error-path ownership of `pid` to avoid leaks/UAF during partial loads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d93837744b361e251d0cc5b93d03c041af7dfa6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->