### PR TITLE
Fix memory leak in `clusterManagerFixSlotsCoverage()` in `src/redis-cli.c`

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6152,6 +6152,8 @@ static int clusterManagerFixSlotsCoverage(char *all_slots) {
                     fixed = -1;
                     if (reply) freeReplyObject(reply);
                     if (slot_nodes) listRelease(slot_nodes);
+                    sdsfree(slot_nodes_str);
+                    sdsfree(slot);
                     goto cleanup;
                 }
                 assert(reply->type == REDIS_REPLY_ARRAY);


### PR DESCRIPTION
### Bug Description

While reviewing `clusterManagerFixSlotsCoverage()` in the Redis cluster manager code, I noticed a memory leak on an error path inside the uncovered slot scanning loop.

Inside the loop, the function allocates several heap objects (lines **6139-6141**):

```c
sds slot = sdsfromlonglong((long long) i);
list *slot_nodes = listCreate();
sds slot_nodes_str = sdsempty();
```

Later, when sending the `CLUSTER GETKEYSINSLOT` command to a node, the code checks the reply (lines **6149-6156**):

```c
redisReply *reply = CLUSTER_MANAGER_COMMAND(n,
    "CLUSTER GETKEYSINSLOT %d %d", i, 1);
if (!clusterManagerCheckRedisReply(n, reply, NULL)) {
    fixed = -1;
    if (reply) freeReplyObject(reply);
    if (slot_nodes) listRelease(slot_nodes);
    goto cleanup;
}
```

If `clusterManagerCheckRedisReply()` fails, execution jumps to `cleanup`. However, at this point the previously allocated SDS objects `slot` and `slot_nodes_str` are not freed, which results in a memory leak.

### Suggested Fix

Free the allocated SDS objects before jumping to the cleanup label. This issue has already been fixed in the corresponding commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds missing `sdsfree` calls on an existing error path in `clusterManagerFixSlotsCoverage()`, reducing leaks without altering normal control flow.
> 
> **Overview**
> Fixes a memory leak in `clusterManagerFixSlotsCoverage()` by freeing the per-slot SDS strings (`slot` and `slot_nodes_str`) before jumping to `cleanup` when `clusterManagerCheckRedisReply()` fails while scanning uncovered slots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65f1e4d006376e666b6974ce70c414eb6be7a687. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->