### PR TITLE
[fix] Memory leak in fetchClusterConfiguration() in src/redis-benchmark

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1081,6 +1081,7 @@ static clusterNode **addClusterNode(clusterNode *node) {
  */
 static int fetchClusterConfiguration(void) {
     int success = 1;
+    int firstNodeAdded = 0;
     redisContext *ctx = NULL;
     redisReply *reply =  NULL;
     ctx = getRedisContext(config.conn_info.hostip, config.conn_info.hostport, config.hostsocket);
@@ -1235,12 +1236,14 @@ static int fetchClusterConfiguration(void) {
             success = 0;
             goto cleanup;
         }
+        if (node == firstNode) firstNodeAdded = 1;
     }
 cleanup:
     if (ctx) redisFree(ctx);
     if (!success) {
         if (config.cluster_nodes) freeClusterNodes();
     }
+    if (firstNode && !firstNodeAdded) freeClusterNode(firstNode);
     if (reply) freeReplyObject(reply);
     return success;
 }


### PR DESCRIPTION
### Problem

In `fetchClusterConfiguration()` (`src/redis-benchmark.c`), `firstNode` is allocated early via `createClusterNode()`:

```c
clusterNode *firstNode = createClusterNode((char *) config.conn_info.hostip,
                                           config.conn_info.hostport);
```

Several error paths jump to `cleanup:` before the node is ever passed to `addClusterNode()`. The `cleanup:` section only frees nodes already stored in `config.cluster_nodes` via `freeClusterNodes()`, so `firstNode` is leaked in these cases:

- `reply == NULL` → `goto cleanup`
- `reply->type == REDIS_REPLY_ERROR` → `goto cleanup`
- `flags == NULL` → `goto cleanup`
- `addr == NULL` → `goto cleanup`
- `createClusterNode()` returns `NULL` for a non-myself node → `goto cleanup`
- `addClusterNode()` fails → `goto cleanup`
- `myself` node has `slots_count == 0` → `continue` (leaks even on the success path)

### Fix

Track whether `firstNode` was successfully added to `config.cluster_nodes` using a `firstNodeAdded` flag. Free it in `cleanup` if it was not.

### Verification

Reproduced and verified using Valgrind (`MALLOC=libc`, `-O0`) against a standalone Redis server,
which returns `ERR This instance has cluster support disabled` for `CLUSTER NODES`,
triggering the `REDIS_REPLY_ERROR → goto cleanup` path.

```bash
valgrind --leak-check=full --show-leak-kinds=all --num-callers=20 ./src/redis-benchmark --cluster -h 127.0.0.1 -p 6399 -n 1 -t get
```

<details>
<summary>Valgrind output — before fix</summary>

```
==20253== LEAK SUMMARY:
==20253==    definitely lost: 104 bytes in 1 blocks
==20253==    indirectly lost: 65,536 bytes in 1 blocks
==20253==      possibly lost: 23 bytes in 2 blocks
==20253==    still reachable: 164,072 bytes in 7 blocks
==20253==         suppressed: 0 bytes in 0 blocks
```

- `104 bytes` = `clusterNode` struct (`zmalloc(sizeof(*node))`)
- `65,536 bytes` = `node->slots` array (`CLUSTER_SLOTS * sizeof(int)` = 16384 × 4)

</details>

<details>
<summary>Valgrind output — after fix</summary>

```
==23663== LEAK SUMMARY:
==23663==    definitely lost: 0 bytes in 0 blocks
==23663==    indirectly lost: 0 bytes in 0 blocks
==23663==      possibly lost: 23 bytes in 2 blocks
==23663==    still reachable: 164,072 bytes in 7 blocks
==23663==         suppressed: 0 bytes in 0 blocks
```

</details>

Fixes #14861


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to `fetchClusterConfiguration()` cleanup logic to avoid leaking `clusterNode` allocations on error/skip paths, with no effect on request execution behavior.
> 
> **Overview**
> Fixes a leak in `fetchClusterConfiguration()` by tracking whether the initially allocated `firstNode` was successfully added to `config.cluster_nodes`.
> 
> On any error path (or when the node is skipped due to having no slots), `cleanup` now frees `firstNode` if it wasn’t inserted into the global cluster node list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1571fb76da580b0da6b1535007b7a949c889f187. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->