### PR TITLE
Fix memory leak in lpBatchInsert()

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1208,7 +1208,10 @@ unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
 
     uint64_t old_listpack_bytes = lpGetTotalBytes(lp);
     uint64_t new_listpack_bytes = old_listpack_bytes + addedlen;
-    if (new_listpack_bytes > UINT32_MAX) return NULL;
+    if (new_listpack_bytes > UINT32_MAX) {
+        if (enc != tmp) lp_free(enc);
+        return NULL;
+    }
 
     /* Store the offset of the element 'p', so that we can obtain its
      * address again after a reallocation. */
@@ -1218,7 +1221,10 @@ unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
     /* Realloc before: we need more room. */
     if (new_listpack_bytes > old_listpack_bytes &&
         new_listpack_bytes > lp_malloc_size(lp)) {
-        if ((lp = lp_realloc(lp,new_listpack_bytes)) == NULL) return NULL;
+        if ((lp = lp_realloc(lp,new_listpack_bytes)) == NULL) {
+            if (enc != tmp) lp_free(enc);
+            return NULL;
+        }
         dst = lp + poff;
     }
 


### PR DESCRIPTION
### Problem

In `lpBatchInsert()` (`src/listpack.c`), when `len > 3`, the function heap-allocates a temporary buffer of encoded entries:

```c
struct listpackInsertEntry tmp[3];   /* Encoded entries */
struct listpackInsertEntry *enc = tmp;

if (len > sizeof(tmp) / sizeof(struct listpackInsertEntry)) {
        /* If 'len' is larger than local buffer size, allocate on heap. */
        enc = zmalloc(len * sizeof(struct listpackInsertEntry));
}
```

The normal exit path at the bottom of the function correctly frees this buffer:

```c
if (enc != tmp) lp_free(enc);
return lp;
```

However, two early `return NULL` paths bypass this cleanup entirely:

**Leak path 1** — listpack size exceeds the 4 GB limit:
```c
if (new_listpack_bytes > UINT32_MAX) return NULL;  /* enc leaked */
```

**Leak path 2** — `lp_realloc()` fails (OOM):
```c
if ((lp = lp_realloc(lp, new_listpack_bytes)) == NULL) return NULL;  /* enc leaked */
```

In both cases, if `enc` was heap-allocated (`enc != tmp`), the memory is permanently leaked.

### Fix

Add the missing `if (enc != tmp) lp_free(enc)` cleanup before each early `return NULL`.
The `enc != tmp` guard ensures we only free heap allocations — when `len <= 3`, `enc` points to the stack buffer `tmp` and must not be freed.

### Testing & Verification

The fix is verified by code inspection: both `return NULL` statements skip the existing cleanup line. The `lp_free(enc)` mechanism already existed — it was simply unreachable on these paths.

**leak paths cannot be triggered easily:**:
will need A single listpack exceeding 4 GB of data, not practically reachable or Simulated OOM conditions.


Fixes #14864

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to error/early-return paths in `lpBatchInsert`, only affecting cleanup on size overflow or `lp_realloc` failure.
> 
> **Overview**
> Fixes a memory leak in `lpBatchInsert()` by freeing the heap-allocated temporary `enc` buffer on early `return NULL` paths (listpack size would exceed `UINT32_MAX` or `lp_realloc()` fails). No functional changes to the success path; it only adds missing cleanup for these failure cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcfcbbe8f4f072f0d4da10dae1d30d7eb12f6464. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->