### PR TITLE
Feature/pasten

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -1802,6 +1802,23 @@ struct COMMAND_ARG HELLO_Args[] = {
 {MAKE_ARG("arguments",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,3,NULL),.subargs=HELLO_arguments_Subargs},
 };
 
+/********** PASTEN ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* PASTEN history */
+#define PASTEN_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* PASTEN tips */
+#define PASTEN_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* PASTEN key specs */
+#define PASTEN_Keyspecs NULL
+#endif
+
 /********** PING ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -11733,6 +11750,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("client","A container for client connection commands.","Depends on subcommand.","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_History,0,CLIENT_Tips,0,NULL,-2,CMD_SENTINEL,0,CLIENT_Keyspecs,0,NULL,0),.subcommands=CLIENT_Subcommands},
 {MAKE_CMD("echo","Returns the given string.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,ECHO_History,0,ECHO_Tips,0,echoCommand,2,CMD_LOADING|CMD_STALE|CMD_FAST,ACL_CATEGORY_CONNECTION,ECHO_Keyspecs,0,NULL,1),.args=ECHO_Args},
 {MAKE_CMD("hello","Handshakes with the Redis server.","O(1)","6.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,HELLO_History,1,HELLO_Tips,0,helloCommand,-1,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_FAST|CMD_NO_AUTH|CMD_SENTINEL|CMD_ALLOW_BUSY,ACL_CATEGORY_CONNECTION,HELLO_Keyspecs,0,NULL,1),.args=HELLO_Args},
+{MAKE_CMD("pasten","PASTEN the connection.","O(1)","1.0.0",CMD_DOC_NONE,"just closing the connection",NULL,"connection",COMMAND_GROUP_CONNECTION,PASTEN_History,0,PASTEN_Tips,0,pastenCommand,-1,CMD_ALLOW_BUSY|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_FAST|CMD_NO_AUTH,ACL_CATEGORY_CONNECTION,PASTEN_Keyspecs,0,NULL,0)},
 {MAKE_CMD("ping","Returns the server's liveliness response.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,PING_History,0,PING_Tips,2,pingCommand,-1,CMD_FAST|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,PING_Keyspecs,0,NULL,1),.args=PING_Args},
 {MAKE_CMD("quit","Closes the connection.","O(1)","1.0.0",CMD_DOC_DEPRECATED,"just closing the connection","7.2.0","connection",COMMAND_GROUP_CONNECTION,QUIT_History,0,QUIT_Tips,0,quitCommand,-1,CMD_ALLOW_BUSY|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_FAST|CMD_NO_AUTH,ACL_CATEGORY_CONNECTION,QUIT_Keyspecs,0,NULL,0)},
 {MAKE_CMD("reset","Resets the connection.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,RESET_History,0,RESET_Tips,0,resetCommand,1,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_FAST|CMD_NO_AUTH|CMD_ALLOW_BUSY,ACL_CATEGORY_CONNECTION,RESET_Keyspecs,0,NULL,0)},

--- a/src/commands/pasten.json
+++ b/src/commands/pasten.json
@@ -1,0 +1,25 @@
+{
+    "PASTEN": {
+        "summary": "PASTEN the connection.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "1.0.0",
+        "arity": -1,
+        "function": "pastenCommand",
+        "replaced_by": "just closing the connection",
+        "command_flags": [
+            "ALLOW_BUSY",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "FAST",
+            "NO_AUTH"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "Poostanta"
+        }
+    }
+}

--- a/src/networking.c
+++ b/src/networking.c
@@ -4159,6 +4159,12 @@ void quitCommand(client *c) {
     c->flags |= CLIENT_CLOSE_AFTER_REPLY;
 }
 
+/* Pasten the current client */
+void pastenCommand(client *c) {
+    addReplyLongLong(c, 73);
+}
+
+
 void clientCommand(client *c) {
     listNode *ln;
     listIter li;

--- a/src/server.h
+++ b/src/server.h
@@ -4421,6 +4421,7 @@ void quitCommand(client *c);
 void resetCommand(client *c);
 void failoverCommand(client *c);
 void digestCommand(client *c);
+void pastenCommand(client *c);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new publicly reachable `NO_AUTH` command, increasing the unauthenticated command surface even though the handler currently returns a constant and does not mutate state.
> 
> **Overview**
> Introduces a new connection-level command, `PASTEN`, registered in `commands.def` and documented via the new `commands/pasten.json` entry.
> 
> Implements `pastenCommand` in `networking.c` (and declares it in `server.h`), which currently just replies with the integer `73`, and marks the command with `NO_AUTH` and other connection-safe flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e15fa0622b50e81a6fdfb752f3e51f0eec852b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->