### PR TITLE
Add metric: time spent by main thread on prcoessing clients dispatched from IO threads

### DIFF
--- a/src/iothread.c
+++ b/src/iothread.c
@@ -557,7 +557,10 @@ int processClientsFromIOThread(IOThread *t) {
     size_t processed = listLength(mainThreadProcessingClients[t->id]);
     if (processed == 0) return 0;
 
-    monotime start = getMonotonicUs();
+    monotime start = 0;
+    if (server.execution_nesting == 0) {
+        start = getMonotonicUs();
+    }
 
     int prefetch_clients = 0;
     /* We may call processClientsFromIOThread reentrantly, so we need to
@@ -656,7 +659,9 @@ int processClientsFromIOThread(IOThread *t) {
     /* Accumulate time spent by main thread for clients from IO threads.
      * Because this metric increases linearly with the number of requests, 
      * it is well-suited for determining whether the main thread has become a bottleneck. */
-    server.io_threaded_client_processed_time += getMonotonicUs() - start;
+    if (server.execution_nesting == 0) {
+        server.io_threaded_client_processed_time += getMonotonicUs() - start;
+    }
 
     /* Send the clients to io thread without pending size check, since main thread
      * may process clients from other io threads, so we need to send them to the

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -557,6 +557,8 @@ int processClientsFromIOThread(IOThread *t) {
     size_t processed = listLength(mainThreadProcessingClients[t->id]);
     if (processed == 0) return 0;
 
+    monotime start = getMonotonicUs();
+
     int prefetch_clients = 0;
     /* We may call processClientsFromIOThread reentrantly, so we need to
      * reset the prefetching batch, besides, users may change the config
@@ -650,6 +652,11 @@ int processClientsFromIOThread(IOThread *t) {
         sendPendingClientsToIOThreadIfNeeded(t, 1);
     }
     if (node) zfree(node);
+
+    /* Accumulate time spent by main thread for clients from IO threads.
+     * Because this metric increases linearly with the number of requests, 
+     * it is well-suited for determining whether the main thread has become a bottleneck. */
+    server.io_threaded_client_processed_time += getMonotonicUs() - start;
 
     /* Send the clients to io thread without pending size check, since main thread
      * may process clients from other io threads, so we need to send them to the

--- a/src/server.c
+++ b/src/server.c
@@ -2850,6 +2850,7 @@ void resetServerStats(void) {
     server.stat_reply_buffer_expands = 0;
     server.stat_cluster_incompatible_ops = 0;
     server.stat_total_prefetch_batches = 0;
+    server.io_threaded_client_processed_time = 0;
     server.stat_total_prefetch_entries = 0;
     memset(server.duration_stats, 0, sizeof(durationStats) * EL_DURATION_TYPE_NUM);
     server.el_cmd_cnt_max = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -6549,6 +6549,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "io_threaded_writes_processed:%lld\r\n", stat_io_writes_processed,
             "io_threaded_total_prefetch_batches:%lld\r\n", server.stat_total_prefetch_batches,
             "io_threaded_total_prefetch_entries:%lld\r\n", server.stat_total_prefetch_entries,
+            "io_threaded_client_processed_time:%llu\r\n", (unsigned long long) server.io_threaded_client_processed_time / 1000,
             "client_query_buffer_limit_disconnections:%lld\r\n", stat_client_qbuf_limit_disconnections,
             "client_output_buffer_limit_disconnections:%lld\r\n", server.stat_client_outbuf_limit_disconnections,
             "reply_buffer_shrinks:%lld\r\n", server.stat_reply_buffer_shrinks,

--- a/src/server.h
+++ b/src/server.h
@@ -2091,6 +2091,7 @@ struct redisServer {
     long long stat_dump_payload_sanitizations; /* Number deep dump payloads integrity validations. */
     redisAtomic long long stat_io_reads_processed[IO_THREADS_MAX_NUM]; /* Number of read events processed by IO / Main threads */
     redisAtomic long long stat_io_writes_processed[IO_THREADS_MAX_NUM]; /* Number of write events processed by IO / Main threads */
+    monotime io_threaded_client_processed_time; /* Time spent by the main thread processing clients from IO threads */
     redisAtomic long long stat_client_qbuf_limit_disconnections;  /* Total number of clients reached query buf length limit */
     long long stat_client_outbuf_limit_disconnections;  /* Total number of clients reached output buf length limit */
     long long stat_cluster_incompatible_ops; /* Number of operations that are incompatible with cluster mode */


### PR DESCRIPTION
During stress testing of Redis 8.6 in a multi-threaded scenario, a peculiar phenomenon was observed: 

1. The main thread's CPU usage and QPS exhibited a non-linear relationship (see the table below for the corresponding stress test data);

2. Specifically, at both 700,000 QPS and 1.25 million QPS, the main thread's CPU usage remained at 95%+. Consequently, it is difficult to determine whether the server has reached a bottleneck based solely on main thread CPU usage.

| QPS | 100K | 300K | 500K |  700K |  900K |  1100K | 1230K (Peak QPS) |
|--------|------|------|------|------|------|------|------|
| CPU utilization ≈ |  55%| 90%| 95% | 95+% | 95+% | 95+% |95+% | 

In a multi-threaded scenario, aside from periodic tasks (such as defragmentation, expire cycle, etc.), the main thread primarily handles two types of work:

1. First part: Communication with I/O threads.

2. Second part: Processing clients dispatched from I/O threads, including key prefetching, command execution, and client-related periodic tasks. **Currently, no metric tracks the time spent on this part.** 

The time consumed by the first part actually decreases as QPS increases, thanks to a batching mechanism—each notification can include more requests. In contrast, the time consumed by the second part grows linearly with QPS. This combined effect explains why the main thread CPU usage remains around 95+% at both 700,000 QPS and 1.25 million QPS, making it difficult to infer server saturation from main thread CPU usage alone.

To better assess whether the server is approaching a bottleneck, this PR introduces a metric  `io_threaded_client_processed_time`, which represents the cumulative time spent by the main thread on processing clients dispatched from IO threads (i.e., the second part). The per-second increase of this metric `io_threaded_client_processed_time` relative to QPS can be seen in the stress test data below.

| QPS | 100K | 300K | 500K |  700K |  900K |  1100K | 1230K (Peak QPS) |
|--------|------|------|------|------|------|------|------|
| Per-second increase ≈ |  103 ms| 287ms | 492ms | 687ms | 872ms | 974ms | 987ms | 

Benchmark Environment

 - Redis server configuration: 10 I/O threads, AOF disabled, RDB disabled
 - Workload: Reading a 32‑byte key
 - CPU: Intel(R) Xeon(R) CPU E5‑2680 v4 @ 2.40GHz


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new stats counter and lightweight timing around `processClientsFromIOThread` without changing request handling logic. Main risk is minor performance impact or metric inaccuracies around nested execution paths.
> 
> **Overview**
> Adds a new cumulative metric, `io_threaded_client_processed_time`, to track time spent by the main thread processing clients dispatched from I/O threads.
> 
> `processClientsFromIOThread` now measures elapsed monotonic time for top-level (non-nested) executions and accumulates it into `server.io_threaded_client_processed_time`; the counter is reset with other stats and is exposed via `INFO` as `io_threaded_client_processed_time` (reported in milliseconds).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc6a6eb53eed57e3224c970d118b2d953357c841. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->