### PR TITLE
Fix listpack memory leak in zipmap-to-hash conversion on error path

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2839,6 +2839,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                             rdbReportCorruptRDB("Hash zipmap with dup elements, or big length (%u)", flen);
                             dictRelease(dupSearchDict);
                             sdsfree(field);
+                            lpFree(lp);
                             zfree(encoded);
                             o->ptr = NULL;
                             decrRefCount(o);

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -377,6 +377,30 @@ test {corrupt payload: hash empty zipmap} {
     }
 }
 
+test {corrupt payload: hash zipmap with duplicate keys} {
+    # Craft a structurally valid zipmap with duplicate key "a" to trigger the
+    # dictAdd failure path in rdbLoadObject (RDB_TYPE_HASH_ZIPMAP).
+    # This exercises the error-handling branch that must free the listpack
+    # allocated for the zipmap-to-listpack conversion.
+    #
+    # Zipmap layout (12 bytes):
+    #   \x02           zmlen=2
+    #   \x01 a         key "a" (len 1)
+    #   \x01 \x00 b    value "b" (len 1, free 0)
+    #   \x01 a         key "a" again (duplicate!)
+    #   \x01 \x00 d    value "d" (len 1, free 0)
+    #   \xFF           end
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        r config set sanitize-dump-payload yes
+        r debug set-skip-checksum-validation 1
+        catch {
+            r RESTORE _hash 0 "\x09\x0C\x02\x01\x61\x01\x00\x62\x01\x61\x01\x00\x64\xFF\x09\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        } err
+        assert_match "*Bad data format*" $err
+        verify_log_message 0 "*Hash zipmap with dup elements*" 0
+    }
+}
+
 test {corrupt payload: fuzzer findings - NPD in streamIteratorGetID} {
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
         r config set sanitize-dump-payload no


### PR DESCRIPTION
When loading RDB_TYPE_HASH_ZIPMAP objects, a listpack is allocated for the zipmap-to-listpack conversion. If the conversion loop encounters a duplicate key, allocation failure, or oversized listpack, the error handler frees the dict, field, encoded buffer, and object — but not the listpack. Add the missing lpFree(lp) call and a regression test that RESTOREs a zipmap with duplicate keys to exercise this path.

## Reproduce

Without the fix, running the added test `./runtest --single integration/corrupt-dump --only "corrupt payload: hash zipmap with duplicate keys"` with an ASan build will trigger leak sanitizer:

```
Execution time of different units:
  1 seconds - integration/corrupt-dump

!!! WARNING The following tests failed:

*** [err]: Sanitizer error: 
=================================================================
==3754459==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 13 byte(s) in 1 object(s) allocated from:
    #0 0x7ff942ab4c38 in __interceptor_realloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:164
    #1 0x5632bad606d0 in ztryrealloc_usable_internal .../redis/src/zmalloc.c:426
    #2 0x5632bad606d0 in ztryrealloc_usable .../redis/src/zmalloc.c:460
    #3 0x5632bad606d0 in zrealloc_usable .../redis/src/zmalloc.c:486
    #4 0x5632bb16e2ec in lpInsert .../redis/src/listpack.c:1051
    #5 0x5632bb16f368 in lpAppend .../redis/src/listpack.c:1296
    #6 0x5632bae5a978 in rdbLoadObject .../redis/src/rdb.c:2850
    #7 0x5632baf621f8 in restoreCommand .../redis/src/cluster.c:267
    #8 0x5632bad36922 in call .../redis/src/server.c:3926
    #9 0x5632bad3f45c in processCommand .../redis/src/server.c:4703
    #10 0x5632badb3125 in processCommandAndResetClient .../redis/src/networking.c:3383
    #11 0x5632badb3125 in processInputBuffer .../redis/src/networking.c:3675
    #12 0x5632badba3df in readQueryFromClient .../redis/src/networking.c:3859
    #13 0x5632bb19741c in callHandler .../redis/src/connhelpers.h:59
    #14 0x5632bb19741c in connSocketEventHandler .../redis/src/socket.c:288
    #15 0x5632bacd3961 in aeProcessEvents .../redis/src/ae.c:435
    #16 0x5632bacd3961 in aeMain .../redis/src/ae.c:495
    #17 0x5632bacc4fe7 in main .../redis/src/server.c:8136
    #18 0x7ff942229d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
```

With the fix, the test won't trigger leak sanitizer anymore.

Please let me know if I can provide any more information, thanks!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only touches an RDB-load error path and adds an integration regression test; behavior changes only when rejecting corrupt/duplicate zipmap payloads.
> 
> **Overview**
> Fixes a memory leak when loading `RDB_TYPE_HASH_ZIPMAP` by freeing the temporary listpack (`lpFree(lp)`) on the duplicate-key/oversize/OOM failure path during zipmap-to-listpack conversion.
> 
> Adds an integration test that `RESTORE`s a crafted zipmap containing duplicate keys and asserts the expected `Bad data format` response and `Hash zipmap with dup elements` log message, exercising the corrected cleanup path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4f004a31a4495c2ebcf1a096786b220ba9ccb9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->