### PR TITLE
Protect some keys

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1355,11 +1355,24 @@ void flushdbCommand(client *c) {
 
 }
 
+const char protected[11] = "PROTECTED_";
+
+
 /* This command implements DEL and UNLINK. */
 void delGenericCommand(client *c, int lazy) {
     int numdel = 0, j;
 
     for (j = 1; j < c->argc; j++) {
+
+        robj *object = c->argv[j];
+        if (object->type == OBJ_STRING) {
+            char *s = object->ptr;
+            if (sdslen(s) >= (sizeof(protected) - 1) && memcmp(s, protected, sizeof(protected) - 1) == 0) {
+                addReplyError(c, "don't try to mess with protected stuff");
+                return;
+            }
+        }
+
         if (expireIfNeeded(c->db, c->argv[j], NULL, 0) == KEY_DELETED)
             continue;
         int deleted  = lazy ? dbAsyncDelete(c->db,c->argv[j]) :


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core key-deletion behavior by rejecting `DEL`/`UNLINK` on keys with a reserved prefix, which could break existing clients or scripts that legitimately delete such keys.
> 
> **Overview**
> Adds a hard guard in `delGenericCommand` to **reject `DEL` and `UNLINK`** when any provided key name starts with the `PROTECTED_` prefix, returning an error and aborting the command.
> 
> Introduces a global `protected` prefix constant used for the prefix check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 852e2897f1b27ca7836ebe179a4f13ced2b82861. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->