### PR TITLE
Fix FIELDS argument validation in HSETEX/HGETEX

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3631,6 +3631,12 @@ static int parseHashCommandArgs(client *c, HashCommandArgs *args,
         return C_ERR;
     }
 
+    /* Ensure FIELDS is specified */
+    if (args->firstFieldPos == -1) {
+        addReplyError(c, "missing FIELDS argument");
+        return C_ERR;
+    }
+
     if (__builtin_popcount(args->expireCondition & (HFE_NX|HFE_XX|HFE_GT|HFE_LT)) > 1) {
         addReplyError(c, "Multiple condition flags specified");
         return C_ERR;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2317,6 +2317,12 @@ static int parseHashFieldExpireArgs(client *c, int *flags,
         }
     }
 
+    /* Ensure FIELDS is specified */
+    if (*first_field_pos == -1) {
+        addReplyError(c, "missing FIELDS argument");
+        return C_ERR;
+    }
+
     /* Validate command-specific argument compatibility */
     if ((command_type == HASH_CMD_HGETEX && (*flags & (HFE_KEEPTTL | HFE_FXX | HFE_FNX))) ||
         (command_type == HASH_CMD_HSETEX && (*flags & HFE_PERSIST))) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3632,7 +3632,7 @@ static int parseHashCommandArgs(client *c, HashCommandArgs *args,
     }
 
     /* Ensure FIELDS is specified */
-    if (args->firstFieldPos == -1) {
+    if (args->fieldsPos == -1) {
         addReplyError(c, "missing FIELDS argument");
         return C_ERR;
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2205,18 +2205,15 @@ static int parseHashFieldExpireArgs(client *c, int *flags,
     *first_field_pos = -1;
     *field_count = -1;
     *expire_time_pos = -1;
-    int fields_argv_count = 0;
 
     for (int i = 2; i < c->argc; i++) {
         if (!strcasecmp(c->argv[i]->ptr, "fields")) {
 
             /* Ensure only one FIELDS argument is provided */
-            if (fields_argv_count) {
+            if (*first_field_pos != -1) {
                 addReplyError(c, "wrong number of arguments");
                 return C_ERR;
             }
-
-            fields_argv_count = 1;
 
             int args_per_field = (command_type == HASH_CMD_HSETEX) ? 2 : 1;
             long val;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2208,10 +2208,9 @@ static int parseHashFieldExpireArgs(client *c, int *flags,
 
     for (int i = 2; i < c->argc; i++) {
         if (!strcasecmp(c->argv[i]->ptr, "fields")) {
-
             /* Ensure only one FIELDS argument is provided */
             if (*first_field_pos != -1) {
-                addReplyError(c, "wrong number of arguments");
+                addReplyError(c, "FIELDS keyword specified multiple times");
                 return C_ERR;
             }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2205,9 +2205,19 @@ static int parseHashFieldExpireArgs(client *c, int *flags,
     *first_field_pos = -1;
     *field_count = -1;
     *expire_time_pos = -1;
+    int fields_argv_count = 0;
 
     for (int i = 2; i < c->argc; i++) {
         if (!strcasecmp(c->argv[i]->ptr, "fields")) {
+
+            /* Ensure only one FIELDS argument is provided */
+            if (fields_argv_count) {
+                addReplyError(c, "wrong number of arguments");
+                return C_ERR;
+            }
+
+            fields_argv_count = 1;
+
             int args_per_field = (command_type == HASH_CMD_HSETEX) ? 2 : 1;
             long val;
             /* Ensure we have at least the numfields argument */

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -1324,6 +1324,12 @@ start_server {tags {"external:skip needs:debug"}} {
             assert_range [r httl myhash FIELDS 1 f3] 9000 10000
         }
 
+        test "HSETEX - Test multiple 'FIELDS' arguments raise error ($type)" {
+            r del myhash
+            assert_error {*wrong number of arguments*} {r hsetex myhash FIELDS 1 f1 v1 FIELDS 1 f2 v2}
+            assert_error {*wrong number of arguments*} {r hsetex myhash FIELDS 1 f1 v1 EX 100 FIELDS 1 f2 v2}
+        }
+
         test "HSETEX - Test no expiry flag discards TTL ($type)" {
             r del myhash
 

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -1326,8 +1326,8 @@ start_server {tags {"external:skip needs:debug"}} {
 
         test "HSETEX - Test multiple 'FIELDS' arguments raise error ($type)" {
             r del myhash
-            assert_error {*wrong number of arguments*} {r hsetex myhash FIELDS 1 f1 v1 FIELDS 1 f2 v2}
-            assert_error {*wrong number of arguments*} {r hsetex myhash FIELDS 1 f1 v1 EX 100 FIELDS 1 f2 v2}
+            assert_error {*FIELDS keyword specified multiple times*} {r hsetex myhash FIELDS 1 f1 v1 FIELDS 1 f2 v2}
+            assert_error {*FIELDS keyword specified multiple times*} {r hsetex myhash FIELDS 1 f1 v1 EX 100 FIELDS 1 f2 v2}
         }
 
         test "HSETEX - Test no expiry flag discards TTL ($type)" {


### PR DESCRIPTION
Fixes #14879 

Improve validation of the FIELDS argument in HSETEX and HGETEX to ensure exactly one field is provided, rejecting both missing and multiple fields with consistent and accurate error messages.

Align behavior across both commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens argument validation for `HSETEX`/`HGETEX` and the HEXPIRE-family parsers, which can change previously-accepted (but ambiguous) command forms into hard errors and may impact client compatibility.
> 
> **Overview**
> Prevents ambiguous hash field-expiration invocations by enforcing that `FIELDS` is **present exactly once**.
> 
> `parseHashFieldExpireArgs()` now errors if `FIELDS` is specified multiple times and rejects calls that omit `FIELDS` entirely; the flexible `parseHashCommandArgs()` used by the HEXPIRE family similarly rejects missing `FIELDS`. Unit tests add coverage that `HSETEX` with repeated `FIELDS` returns an error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 470e67697fb69758a42276b404c478d8f0cbdbd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->