### PR TITLE
Test fix potential TCP deadlock in Active defrag IDMP streams test

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -606,15 +606,27 @@ run_solo {defrag} {
             # Populate memory with interleaving IDMP stream-key pattern of same size
             set dummy_iid "[string repeat x 400]"
             set rd [redis_deferring_client]
+
+            # Use batching to avoid TCP deadlock
+            set batch_size 1000
             for {set j 0} {$j < $n} {incr j} {
                 set producer_id "producer[expr {$j % 10}]"
                 set iid "$dummy_iid[format "%06d" $j]"
                 $rd xadd idmpstream IDMP $producer_id $iid * field value
                 $rd set k$j $iid
+
+                if {($j + 1) % $batch_size == 0} {
+                    for {set i 0} {$i < [expr {$batch_size * 2}]} {incr i} {
+                        $rd read
+                    }
+                }
             }
-            for {set j 0} {$j < [expr {$n * 2}]} {incr j} {
-                $rd read ; # Discard replies
+            # Read remaining responses
+            set remaining [expr {($n % $batch_size) * 2}]
+            for {set j 0} {$j < $remaining} {incr j} {
+                $rd read
             }
+
             after 120 ;# serverCron only updates the info once in 100ms
             if {$::verbose} {
                 puts "used [s allocator_allocated]"
@@ -624,7 +636,7 @@ run_solo {defrag} {
             }
             assert_lessthan [s allocator_frag_ratio] 1.05
 
-                # Verify IDMP structures were created
+            # Verify IDMP structures were created
             set idmp_info [r xinfo stream idmpstream full]
             set num_producers [dict get $idmp_info pids-tracked]
             set num_entries [dict get $idmp_info iids-tracked]

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -52,19 +52,15 @@ start_server {tags {"memefficiency external:skip"}} {
 
 run_solo {defrag} {
     proc wait_for_defrag_stop {maxtries delay {expect_frag 0}} {
-        set last_frag 0
-        set last_running 0
-
         wait_for_condition $maxtries $delay {
-            [set last_running [s active_defrag_running]] == 0 && \
-            ($expect_frag == 0 || [set last_frag [s allocator_frag_ratio]] <= $expect_frag)
+            [s active_defrag_running] eq 0 && ($expect_frag == 0 || [s allocator_frag_ratio] <= $expect_frag)
         } else {
             after 120 ;# serverCron only updates the info once in 100ms
             puts [r info memory]
             puts [r info stats]
             puts [r memory malloc-stats]
             if {$expect_frag != 0} {
-                fail "defrag didn't stop or failed to achieve expected frag ratio ($last_frag > $expect_frag) and final_frag=[s allocator_frag_ratio]"
+                fail "defrag didn't stop or failed to achieve expected frag ratio ([s allocator_frag_ratio] > $expect_frag)"
             } else {
                 fail "defrag didn't stop."
             }
@@ -675,7 +671,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 1000 100 1.1
+                wait_for_defrag_stop 500 100 1.1
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -52,15 +52,19 @@ start_server {tags {"memefficiency external:skip"}} {
 
 run_solo {defrag} {
     proc wait_for_defrag_stop {maxtries delay {expect_frag 0}} {
+        set last_frag 0
+        set last_running 0
+
         wait_for_condition $maxtries $delay {
-            [s active_defrag_running] eq 0 && ($expect_frag == 0 || [s allocator_frag_ratio] <= $expect_frag)
+            [set last_running [s active_defrag_running]] == 0 && \
+            ($expect_frag == 0 || [set last_frag [s allocator_frag_ratio]] <= $expect_frag)
         } else {
             after 120 ;# serverCron only updates the info once in 100ms
             puts [r info memory]
             puts [r info stats]
             puts [r memory malloc-stats]
             if {$expect_frag != 0} {
-                fail "defrag didn't stop or failed to achieve expected frag ratio ([s allocator_frag_ratio] > $expect_frag)"
+                fail "defrag didn't stop or failed to achieve expected frag ratio ($last_frag > $expect_frag) and final_frag=[s allocator_frag_ratio]"
             } else {
                 fail "defrag didn't stop."
             }
@@ -659,7 +663,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 500 100 1.1
+                wait_for_defrag_stop 1000 100 1.1
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms


### PR DESCRIPTION
Failed daily CI: https://github.com/redis/redis/actions/runs/22980491707/job/66718992772


The IDMP streams defrag test sends all commands (100k) before reading any replies, which can cause TCP deadlock when buffers fill up.

Fix by batching writes and reads (1000 iterations per batch), consistent with the approach already used in the script defrag test above.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to a unit test and only adjust how replies are drained from a deferring client to avoid hangs in slow/TLS CI runs.
> 
> **Overview**
> Improves the `Active defrag IDMP streams` test in `tests/unit/memefficiency.tcl` by **batching reads while enqueueing `XADD`/`SET` commands**, preventing TCP/congestion deadlocks when many deferred replies accumulate.
> 
> Replaces the single large reply-drain loop with periodic drains plus a final “remaining replies” drain, keeping test assertions and behavior the same while making CI runs less flaky.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a12be9daf35c7fa5c8be64ac557e84cf30c9d8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->