### PR TITLE
Fix safety check in lpSafeToAdd size_t Addition Overflow Bypass

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -123,7 +123,7 @@ static inline void lpAssertValidEntry(unsigned char* lp, size_t lpbytes, unsigne
 #define LISTPACK_MAX_SAFETY_SIZE (1<<30)
 int lpSafeToAdd(unsigned char* lp, size_t add) {
     size_t len = lp? lpGetTotalBytes(lp): 0;
-    if (len + add > LISTPACK_MAX_SAFETY_SIZE)
+    if (add > LISTPACK_MAX_SAFETY_SIZE || len > LISTPACK_MAX_SAFETY_SIZE - add)
         return 0;
     return 1;
 }


### PR DESCRIPTION
File: listpack.c:124-129

```
int lpSafeToAdd(unsigned char* lp, size_t add) {
    size_t len = lp? lpGetTotalBytes(lp): 0;
    if (len + add > LISTPACK_MAX_SAFETY_SIZE)  // wraps if add ≈ SIZE_MAX
        return 0;
    return 1;
}
```

Fix: 

```
if (add > LISTPACK_MAX_SAFETY_SIZE || len > LISTPACK_MAX_SAFETY_SIZE - add) 
        return 0;
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a core bounds-check used before growing listpacks; while the change is small, mistakes here could impact memory safety or allow oversized allocations in multiple call sites.
> 
> **Overview**
> Fixes an integer-overflow bypass in `lpSafeToAdd` by replacing the `len + add` limit check with an overflow-safe comparison (`add > max` or `len > max - add`). This ensures listpack growth is consistently rejected when the requested addition would exceed the 1GB safety cap, even when `add` is near `SIZE_MAX`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a49b6467a1d9e595eb597c367f7f92a2fd0491c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->