### PR TITLE
MOD-14124 - Add RM_GetContextUser and RM_GetUserUserName module APIs

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -6577,6 +6577,13 @@ void RM_SetContextUser(RedisModuleCtx *ctx, const RedisModuleUser *user) {
     ctx->user = user;
 }
 
+/* Returns the user associated with the context via RM_SetContextUser.
+ * Returns NULL if no user was set on the context.
+ * The returned pointer is borrowed from the context — do NOT free it. */
+const RedisModuleUser *RM_GetContextUser(RedisModuleCtx *ctx) {
+    return ctx->user;
+}
+
 /* Returns an array of robj pointers, by parsing the format specifier "fmt" as described for
  * the RM_Call(), RM_Replicate() and other module APIs. Populates *argcp with the number of
  * items (which equals to the length of the allocated argv).
@@ -10312,6 +10319,17 @@ int RM_FreeModuleUser(RedisModuleUser *user) {
         ACLFreeUserAndKillClients(user->user);
     zfree(user);
     return REDISMODULE_OK;
+}
+
+/* Return the username of the given RedisModuleUser as a RedisModuleString.
+ * Returns NULL if user is NULL or the user has no name.
+ * The returned string must be freed by the caller with RedisModule_FreeString()
+ * or by enabling automatic memory management on a context. */
+ RedisModuleString *RM_GetUserUsername(const RedisModuleUser *user) {
+    if(user == NULL || user->user == NULL || user->user->name == NULL) 
+        return NULL;
+    
+    return RM_CreateString(NULL, user->user->name, sdslen(user->user->name));
 }
 
 /* Sets the permissions of a user created through the redis module
@@ -15491,6 +15509,8 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ScanKey);
     REGISTER_API(CreateModuleUser);
     REGISTER_API(SetContextUser);
+    REGISTER_API(GetContextUser);
+    REGISTER_API(GetUserUsername);
     REGISTER_API(SetModuleUserACL);
     REGISTER_API(SetModuleUserACLString);
     REGISTER_API(GetModuleUserACLString);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1409,6 +1409,8 @@ REDISMODULE_API size_t (*RedisModule_MallocSizeDict)(RedisModuleDict* dict) REDI
 REDISMODULE_API RedisModuleUser * (*RedisModule_CreateModuleUser)(const char *name) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_FreeModuleUser)(RedisModuleUser *user) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetContextUser)(RedisModuleCtx *ctx, const RedisModuleUser *user) REDISMODULE_ATTR;
+REDISMODULE_API const RedisModuleUser *(*RedisModule_GetContextUser)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_GetUserUsername)(const RedisModuleUser *user) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetModuleUserACL)(RedisModuleUser *user, const char* acl) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetModuleUserACLString)(RedisModuleCtx * ctx, RedisModuleUser *user, const char* acl, RedisModuleString **error) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_GetModuleUserACLString)(RedisModuleUser *user) REDISMODULE_ATTR;
@@ -1808,6 +1810,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(CreateModuleUser);
     REDISMODULE_GET_API(FreeModuleUser);
     REDISMODULE_GET_API(SetContextUser);
+    REDISMODULE_GET_API(GetContextUser);
+    REDISMODULE_GET_API(GetUserUsername);
     REDISMODULE_GET_API(SetModuleUserACL);
     REDISMODULE_GET_API(SetModuleUserACLString);
     REDISMODULE_GET_API(GetModuleUserACLString);

--- a/tests/modules/usercall.c
+++ b/tests/modules/usercall.c
@@ -89,6 +89,46 @@ int get_acl(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return REDISMODULE_OK;
 }
 
+/* Sets the context user via SetContextUser, retrieves it via GetContextUser,
+ * then returns the ACL string of that user. Tests SetContextUser + GetContextUser. */
+int get_context_acl(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+
+    if (argc != 1) {
+        return RedisModule_WrongArity(ctx);
+    }
+
+    RedisModule_Assert(user != NULL);
+    RedisModule_SetContextUser(ctx, user);
+    const RedisModuleUser *ctx_user = RedisModule_GetContextUser(ctx);
+    RedisModuleString *acl = RedisModule_GetModuleUserACLString((RedisModuleUser *)ctx_user);
+    RedisModule_ReplyWithString(ctx, acl);
+    RedisModule_FreeString(NULL, acl);
+    return REDISMODULE_OK;
+}
+
+/* Returns the username of the module user via RedisModule_GetUserUsername. Tests GetUserUsername API. */
+int get_user_username(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+
+    if (argc != 1) {
+        return RedisModule_WrongArity(ctx);
+    }
+
+    if (user == NULL) {
+        RedisModule_ReplyWithSimpleString(ctx, "none");
+        return REDISMODULE_OK;
+    }
+    RedisModuleString *name = RedisModule_GetUserUsername(user);
+    if (name == NULL) {
+        RedisModule_ReplyWithSimpleString(ctx, "none");
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithString(ctx, name);
+    RedisModule_FreeString(NULL, name);
+    return REDISMODULE_OK;
+}
+
 int reset_user(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
 
@@ -224,6 +264,12 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx,"usercall.get_acl", get_acl,"write",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"usercall.get_context_acl", get_context_acl,"write",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"usercall.get_user_username", get_user_username,"readonly",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     return REDISMODULE_OK;

--- a/tests/unit/moduleapi/usercall.tcl
+++ b/tests/unit/moduleapi/usercall.tcl
@@ -11,6 +11,19 @@ return 1"
 start_server {tags {"modules usercall external:skip"}} {
     r module load $testmodule
 
+    # Test RedisModule_GetContextUser API: set context user, get it back, return its ACL string
+    test {test GetContextUser API - set context user and get ACL via GetContextUser} {
+        assert_equal [r usercall.reset_user] OK
+        assert_equal [r usercall.add_to_acl "~* &* +@all -set"] OK
+        assert_equal [r usercall.get_context_acl] "off sanitize-payload ~* &* +@all -set"
+    }
+
+    # Test RedisModule_GetUserUsername API: get username of the module user
+    test {test GetUserUsername API - returns module user name} {
+        assert_equal [r usercall.reset_user] OK
+        assert_equal [r usercall.get_user_username] module_user
+    }
+
     # baseline test that module isn't doing anything weird
     test {test module check regular redis command without user/acl} {
         assert_equal [r usercall.reset_user] OK


### PR DESCRIPTION
Add RM_GetContextUser to retrieve the RedisModuleUser set via
RM_SetContextUser, allowing modules to access the user associated
with RM_Call ACL checks.
in addition , add new api to get the user name from RedisModuleUser


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new module APIs in the ACL/user surface area; while behavior is simple, it touches authentication-related context and module ABI/API registration, so regressions would impact third-party modules.
> 
> **Overview**
> Adds two new Redis Module APIs: `RM_GetContextUser()` to read back the user previously set via `RM_SetContextUser()` (used by `RM_Call` for ACL checks), and `RM_GetUserUsername()` to fetch a module user’s username as a `RedisModuleString`.
> 
> Wires both APIs into `module.c` API registration and `redismodule.h` function-pointer exports, and extends the `usercall` test module + `moduleapi/usercall.tcl` to validate round-tripping the context user and returning the module user name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a05daeb5b234e177a63c39dfcd4312597dceea5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->