### PR TITLE
Add global and per-command stats for slowlog metrics

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2878,6 +2878,9 @@ void resetServerStats(void) {
     stat_prev_total_client_process_input_buff_events = 0;
     memset(server.duration_stats, 0, sizeof(durationStats) * EL_DURATION_TYPE_NUM);
     server.el_cmd_cnt_max = 0;
+    server.stat_slowlog_count = 0;
+    server.stat_slowlog_time_us_sum = 0;
+    server.stat_slowlog_time_us_max = 0;
     lazyfreeResetStats();
 }
 
@@ -3436,6 +3439,9 @@ void resetCommandTableStats(dict* commands) {
         c->calls = 0;
         c->rejected_calls = 0;
         c->failed_calls = 0;
+        c->slowlog_count = 0;
+        c->slowlog_time_us_sum = 0;
+        c->slowlog_time_us_max = 0;
         if(c->latency_histogram) {
             hdr_close(c->latency_histogram);
             c->latency_histogram = NULL;
@@ -3700,7 +3706,16 @@ void slowlogPushCurrentCommand(client *c, struct redisCommand *cmd, ustime_t dur
      * arguments. */
     robj **argv = c->original_argv ? c->original_argv : c->argv;
     int argc = c->original_argv ? c->original_argc : c->argc;
-    slowlogPushEntryIfNeeded(c,argv,argc,duration);
+    if (slowlogPushEntryIfNeeded(c,argv,argc,duration)) {
+        server.stat_slowlog_count++;
+        server.stat_slowlog_time_us_sum += duration;
+        if (duration > server.stat_slowlog_time_us_max)
+            server.stat_slowlog_time_us_max = duration;
+        cmd->slowlog_count++;
+        cmd->slowlog_time_us_sum += duration;
+        if (duration > cmd->slowlog_time_us_max)
+            cmd->slowlog_time_us_max = duration;
+    }
 }
 
 /* This function is called in order to update the total command histogram duration.
@@ -6070,12 +6085,24 @@ sds genRedisInfoStringCommandStats(sds info, dict *commands) {
         char *tmpsafe;
         c = (struct redisCommand *) dictGetVal(de);
         if (c->calls || c->failed_calls || c->rejected_calls) {
-            info = sdscatprintf(info,
-                "cmdstat_%s:calls=%lld,usec=%lld,usec_per_call=%.2f"
-                ",rejected_calls=%lld,failed_calls=%lld\r\n",
-                getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe), c->calls, c->microseconds,
-                (c->calls == 0) ? 0 : ((float)c->microseconds/c->calls),
-                c->rejected_calls, c->failed_calls);
+            if (c->slowlog_count > 0) {
+                info = sdscatprintf(info,
+                    "cmdstat_%s:calls=%lld,usec=%lld,usec_per_call=%.2f"
+                    ",rejected_calls=%lld,failed_calls=%lld"
+                    ",slowlog_count=%lld,slowlog_time_ms_sum=%.2f,slowlog_time_ms_max=%.2f\r\n",
+                    getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe), c->calls, c->microseconds,
+                    (c->calls == 0) ? 0 : ((float)c->microseconds/c->calls),
+                    c->rejected_calls, c->failed_calls,
+                    c->slowlog_count, (double)c->slowlog_time_us_sum / 1000,
+                    (double)c->slowlog_time_us_max / 1000);
+            } else {
+                info = sdscatprintf(info,
+                    "cmdstat_%s:calls=%lld,usec=%lld,usec_per_call=%.2f"
+                    ",rejected_calls=%lld,failed_calls=%lld\r\n",
+                    getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe), c->calls, c->microseconds,
+                    (c->calls == 0) ? 0 : ((float)c->microseconds/c->calls),
+                    c->rejected_calls, c->failed_calls);
+            }
             if (tmpsafe != NULL) zfree(tmpsafe);
         }
         if (c->subcommands_dict) {
@@ -6661,7 +6688,10 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "total_client_processing_events:%lld\r\n", stat_total_client_process_input_buff_events,
             "avg_pipeline_length_sum:%lld\r\n", stat_avg_pipeline_length_sum,
             "avg_pipeline_length_cnt:%lld\r\n", stat_avg_pipeline_length_cnt,
-            "avg_pipeline_length:%.2f\r\n", stat_avg_pipeline_length_cnt ? (double)stat_avg_pipeline_length_sum / stat_avg_pipeline_length_cnt : 0));
+            "avg_pipeline_length:%.2f\r\n", stat_avg_pipeline_length_cnt ? (double)stat_avg_pipeline_length_sum / stat_avg_pipeline_length_cnt : 0,
+            "slowlog_commands_count:%lld\r\n", server.stat_slowlog_count,
+            "slowlog_commands_time_ms_max:%.2f\r\n", (double)server.stat_slowlog_time_us_max / 1000,
+            "slowlog_commands_time_ms_sum:%.2f\r\n", (double)server.stat_slowlog_time_us_sum / 1000));
         info = genRedisInfoStringACLStats(info);
         if (!server.cluster_enabled && server.cluster_compatibility_sample_ratio) {
             info = sdscatprintf(info, "cluster_incompatible_ops:%lld\r\n", server.stat_cluster_incompatible_ops);

--- a/src/server.h
+++ b/src/server.h
@@ -2080,6 +2080,9 @@ struct redisServer {
     long long slowlog_entry_id;     /* SLOWLOG current entry ID */
     long long slowlog_log_slower_than; /* SLOWLOG time limit (to get logged) */
     unsigned long slowlog_max_len;     /* SLOWLOG max number of items logged */
+    long long stat_slowlog_count;          /* Total slowlog entries ever pushed */
+    long long stat_slowlog_time_us_sum;    /* Sum of all slowlog entry durations (usec) */
+    long long stat_slowlog_time_us_max;    /* Max slowlog entry duration (usec) */
     struct malloc_stats cron_malloc_stats; /* sampled in serverCron(). */
     redisAtomic long long stat_net_input_bytes; /* Bytes read from network. */
     redisAtomic long long stat_net_output_bytes; /* Bytes written to network. */
@@ -2891,6 +2894,7 @@ struct redisCommand {
 
     /* Runtime populated data */
     long long microseconds, calls, rejected_calls, failed_calls;
+    long long slowlog_count, slowlog_time_us_sum, slowlog_time_us_max;
     int id;     /* Command ID. This is a progressive ID starting from 0 that
                    is assigned at runtime, and is used in order to check
                    ACLs. A connection is able to execute a given command if

--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -99,16 +99,20 @@ void slowlogInit(void) {
 
 /* Push a new entry into the slow log.
  * This function will make sure to trim the slow log accordingly to the
- * configured max length. */
-void slowlogPushEntryIfNeeded(client *c, robj **argv, int argc, long long duration) {
-    if (server.slowlog_log_slower_than < 0 || server.slowlog_max_len == 0) return; /* Slowlog disabled */
-    if (duration >= server.slowlog_log_slower_than)
+ * configured max length.
+ * Returns 1 if an entry was added, 0 otherwise. */
+int slowlogPushEntryIfNeeded(client *c, robj **argv, int argc, long long duration) {
+    if (server.slowlog_log_slower_than < 0 || server.slowlog_max_len == 0) return 0;
+    if (duration >= server.slowlog_log_slower_than) {
         listAddNodeHead(server.slowlog,
                         slowlogCreateEntry(c,argv,argc,duration));
 
-    /* Remove old entries if needed. */
-    while (listLength(server.slowlog) > server.slowlog_max_len)
-        listDelNode(server.slowlog,listLast(server.slowlog));
+        /* Remove old entries if needed. */
+        while (listLength(server.slowlog) > server.slowlog_max_len)
+            listDelNode(server.slowlog,listLast(server.slowlog));
+        return 1;
+    }
+    return 0;
 }
 
 /* Remove all the entries from the current slow log. */

--- a/src/slowlog.h
+++ b/src/slowlog.h
@@ -26,6 +26,6 @@ typedef struct slowlogEntry {
 
 /* Exported API */
 void slowlogInit(void);
-void slowlogPushEntryIfNeeded(client *c, robj **argv, int argc, long long duration);
+int slowlogPushEntryIfNeeded(client *c, robj **argv, int argc, long long duration);
 
 #endif /* __SLOWLOG_H__ */

--- a/tests/unit/moduleapi/moduleauth.tcl
+++ b/tests/unit/moduleapi/moduleauth.tcl
@@ -267,7 +267,7 @@ start_server {tags {"modules external:skip"}} {
         assert_equal [$rd read] "OK"
         $rd_two flush
         assert_equal [$rd_two read] "OK"
-        assert_match {*calls=4,*,rejected_calls=0,failed_calls=0} [cmdstat auth]
+        assert_match {*calls=4,*,rejected_calls=0,failed_calls=0*} [cmdstat auth]
     }
 
     test {module auth inside MULTI EXEC} {
@@ -331,7 +331,7 @@ start_server {tags {"modules external:skip"}} {
         # blocks the client and uses the RM_AbortBlock API. This should result in module auth
         # failing and the client being unblocked with the default AUTH err message.
         assert_error {*WRONGPASS*} {r AUTH foo block_abort}
-        assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat auth]
+        assert_match {*calls=1,*,rejected_calls=0,failed_calls=1*} [cmdstat auth]
     }
 
     test {test RM_RegisterAuthCallback Module API during blocking module auth} {

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -273,16 +273,16 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         assert_equal 1 [getInfoProperty $info slowlog_commands_count]
         set sum1 [getInfoProperty $info slowlog_commands_time_ms_sum]
         set max1 [getInfoProperty $info slowlog_commands_time_ms_max]
-        assert_morethan $sum1 100
-        assert_morethan $max1 100
+        assert_morethan $sum1 190
+        assert_morethan $max1 190
 
         r debug sleep 0.3
         set info [r info stats]
         assert_equal 2 [getInfoProperty $info slowlog_commands_count]
         set sum2 [getInfoProperty $info slowlog_commands_time_ms_sum]
         set max2 [getInfoProperty $info slowlog_commands_time_ms_max]
-        assert_morethan $sum2 $sum1
-        assert_morethan $max2 $max1
+        assert_morethan $sum2 490
+        assert_morethan $max2 290
     } {} {needs:debug}
 
     test {SLOWLOG - INFO STATS slowlog metrics survive SLOWLOG RESET} {
@@ -336,8 +336,8 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         regexp {slowlog_time_ms_sum=([0-9.]+)} $cmdstat -> sl_sum
         regexp {slowlog_time_ms_max=([0-9.]+)} $cmdstat -> sl_max
         assert_equal 2 $sl_count
-        assert_morethan $sl_sum 400
-        assert_morethan $sl_max 200
+        assert_morethan $sl_sum 490
+        assert_morethan $sl_max 290
     } {} {needs:debug}
 
     test {SLOWLOG - INFO COMMANDSTATS slowlog metrics only on commands that are slow} {

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -248,4 +248,116 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         
         $rd close
     }
+
+    test {SLOWLOG - INFO STATS slowlog metrics with no slowlog entries} {
+        r config set slowlog-log-slower-than 1000000
+        r config resetstat
+        r slowlog reset
+
+        r ping
+        r get foo
+
+        set info [r info stats]
+        assert_equal 0 [getInfoProperty $info slowlog_commands_count]
+        assert_equal {0.00} [getInfoProperty $info slowlog_commands_time_ms_max]
+        assert_equal {0.00} [getInfoProperty $info slowlog_commands_time_ms_sum]
+    }
+
+    test {SLOWLOG - INFO STATS slowlog metrics accumulate with slow commands} {
+        r config set slowlog-log-slower-than 100000
+        r config resetstat
+        r slowlog reset
+
+        r debug sleep 0.2
+        set info [r info stats]
+        assert_equal 1 [getInfoProperty $info slowlog_commands_count]
+        set sum1 [getInfoProperty $info slowlog_commands_time_ms_sum]
+        set max1 [getInfoProperty $info slowlog_commands_time_ms_max]
+        assert_morethan $sum1 100
+        assert_morethan $max1 100
+
+        r debug sleep 0.3
+        set info [r info stats]
+        assert_equal 2 [getInfoProperty $info slowlog_commands_count]
+        set sum2 [getInfoProperty $info slowlog_commands_time_ms_sum]
+        set max2 [getInfoProperty $info slowlog_commands_time_ms_max]
+        assert_morethan $sum2 $sum1
+        assert_morethan $max2 $max1
+    } {} {needs:debug}
+
+    test {SLOWLOG - INFO STATS slowlog metrics survive SLOWLOG RESET} {
+        r config set slowlog-log-slower-than 100000
+        r config resetstat
+        r slowlog reset
+
+        r debug sleep 0.2
+        set info [r info stats]
+        set count_before [getInfoProperty $info slowlog_commands_count]
+        assert_equal 1 $count_before
+
+        r slowlog reset
+        assert_equal 0 [r slowlog len]
+
+        set info [r info stats]
+        assert_equal 1 [getInfoProperty $info slowlog_commands_count]
+        assert_morethan [getInfoProperty $info slowlog_commands_time_ms_sum] 0
+    } {} {needs:debug}
+
+    test {SLOWLOG - INFO STATS slowlog metrics reset with CONFIG RESETSTAT} {
+        r config set slowlog-log-slower-than 100000
+        r config resetstat
+        r slowlog reset
+
+        r debug sleep 0.2
+        set info [r info stats]
+        assert_equal 1 [getInfoProperty $info slowlog_commands_count]
+
+        r config resetstat
+        set info [r info stats]
+        assert_equal 0 [getInfoProperty $info slowlog_commands_count]
+        assert_equal {0.00} [getInfoProperty $info slowlog_commands_time_ms_max]
+        assert_equal {0.00} [getInfoProperty $info slowlog_commands_time_ms_sum]
+    } {} {needs:debug}
+
+    test {SLOWLOG - INFO COMMANDSTATS shows slowlog metrics for slow commands} {
+        r config set slowlog-log-slower-than 100000
+        r config resetstat
+        r slowlog reset
+
+        r debug sleep 0.2
+        r debug sleep 0.3
+
+        set cmdstat [cmdrstat debug r]
+        assert_match {*slowlog_count=2*} $cmdstat
+        assert_match {*slowlog_time_ms_sum=*} $cmdstat
+        assert_match {*slowlog_time_ms_max=*} $cmdstat
+
+        regexp {slowlog_count=(\d+)} $cmdstat -> sl_count
+        regexp {slowlog_time_ms_sum=([0-9.]+)} $cmdstat -> sl_sum
+        regexp {slowlog_time_ms_max=([0-9.]+)} $cmdstat -> sl_max
+        assert_equal 2 $sl_count
+        assert_morethan $sl_sum 400
+        assert_morethan $sl_max 200
+    } {} {needs:debug}
+
+    test {SLOWLOG - INFO COMMANDSTATS slowlog metrics only on commands that are slow} {
+        r config set slowlog-log-slower-than 100000
+        r config resetstat
+        r slowlog reset
+
+        r set mykey myvalue
+        r get mykey
+        r debug sleep 0.2
+
+        set cmdstat_set [cmdrstat set r]
+        assert_no_match {*slowlog_count*} $cmdstat_set
+
+        set cmdstat_get [cmdrstat get r]
+        assert_no_match {*slowlog_count*} $cmdstat_get
+
+        set cmdstat_debug [cmdrstat debug r]
+        assert_match {*slowlog_count=1*} $cmdstat_debug
+        assert_match {*slowlog_time_ms_sum=*} $cmdstat_debug
+        assert_match {*slowlog_time_ms_max=*} $cmdstat_debug
+    } {} {needs:debug}
 }


### PR DESCRIPTION
# What

Add global and per-command slowlog metrics.
`INFO STATS` now shows:
- slowlog_commands_count - total count of commands written to slowlog (including trimmed ones)
- slowlog_commands_time_ms_sum - sum of execution times of the commands from the slowlog.
- slowlog_commands_time_ms_max - maximum execution time of a command from the slowlog (useful for calculating averege values)

`INFO COMMANDSTATS` adds the equivalent 3 metrics, but per command. Only shown for a command if it was added at least once in the slowlog:
- slowlog_count - how many times the command was written in the slowlog
- slowlog_time_ms_sum - sum of execution time of the command (only from the slowlog)
- slowlog_time_ms_max - maximum execution time of the command (only from the slowlog)

# Why

More fine-grained slowlog metrics, easy of alert creation regarding slowlog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core command execution/slowlog plumbing and extends `INFO` output; while behavior is additive, it changes an internal API (`slowlogPushEntryIfNeeded`) and adds new counters that must stay consistent under load.
> 
> **Overview**
> Adds new **global** slowlog counters (count, sum, max duration) that are incremented when a command is actually written to the slowlog, reset by `CONFIG RESETSTAT`, and exposed in `INFO STATS` as `slowlog_commands_*`.
> 
> Adds **per-command** slowlog counters to `redisCommand` and conditionally appends `slowlog_*` fields to `INFO COMMANDSTATS` only for commands that have generated slowlog entries.
> 
> Updates `slowlogPushEntryIfNeeded` to return whether an entry was added, and expands unit tests to validate the new `INFO`/`COMMANDSTATS` metrics and adjust existing `cmdstat` assertions to tolerate extra fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cf302036b7d4caea8e077613df0fb2a843167c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->