### PR TITLE
Fix VSIM FILTER memory leaks on duplicate option and error paths

### DIFF
--- a/modules/vector-sets/tests/vsim_duplicate_filter.py
+++ b/modules/vector-sets/tests/vsim_duplicate_filter.py
@@ -1,0 +1,19 @@
+from test import TestCase
+
+class VSIMDuplicateFilterLeak(TestCase):
+    def getname(self):
+        return "[regression] VSIM duplicate FILTER should not leak memory"
+
+    def test(self):
+        self.redis.execute_command('VADD', self.test_key, 'VALUES', 3, 0.5774, 0.5774, 0.5774, 'elem1')
+        self.redis.execute_command('VADD', self.test_key, 'VALUES', 3, 0.7071, 0.7071, 0.0, 'elem2')
+        self.redis.execute_command('VSETATTR', self.test_key, 'elem1', '{"a": 1, "b": 2}')
+        self.redis.execute_command('VSETATTR', self.test_key, 'elem2', '{"a": 2, "b": 3}')
+
+        # Duplicate FILTER: before the fix the first exprstate was
+        # overwritten without exprFree(), leaking ~760 bytes per call.
+        # Under ASAN/valgrind this shows up as a leak at server exit.
+        for _ in range(100):
+            self.redis.execute_command(
+                'VSIM', self.test_key, 'VALUES', 3, 0.5774, 0.5774, 0.5774,
+                'FILTER', '.a == 1', 'FILTER', '.b >= 1')

--- a/modules/vector-sets/tests/vsim_filter_error_leak.py
+++ b/modules/vector-sets/tests/vsim_filter_error_leak.py
@@ -1,0 +1,32 @@
+from test import TestCase
+import redis as redis_module
+
+class VSIMFilterLeakOnOptionError(TestCase):
+    def getname(self):
+        return "[regression] VSIM FILTER expr freed on option parse error"
+
+    def test(self):
+        self.redis.execute_command('VADD', self.test_key, 'VALUES', 3, 1, 0, 0, 'elem1')
+
+        # Valid FILTER followed by invalid option values. Before the fix,
+        # error paths freed vec but not filter_expr, leaking the compiled
+        # exprstate. Under ASAN/valgrind this shows up at server exit.
+        error_cmds = [
+            # invalid COUNT (0)
+            ['VSIM', self.test_key, 'VALUES', 3, 0, 0, 0, 'FILTER', '.a > 0', 'COUNT', 0],
+            # invalid EF (0)
+            ['VSIM', self.test_key, 'VALUES', 3, 0, 0, 0, 'FILTER', '.a > 0', 'EF', 0],
+            # invalid EPSILON (0)
+            ['VSIM', self.test_key, 'VALUES', 3, 0, 0, 0, 'FILTER', '.a > 0', 'EPSILON', 0],
+            # invalid FILTER-EF (0)
+            ['VSIM', self.test_key, 'VALUES', 3, 0, 0, 0, 'FILTER', '.a > 0', 'FILTER-EF', 0],
+            # unknown option
+            ['VSIM', self.test_key, 'VALUES', 3, 0, 0, 0, 'FILTER', '.a > 0', 'BADOPT', 1],
+        ]
+
+        for cmd in error_cmds:
+            for _ in range(20):
+                try:
+                    self.redis.execute_command(*cmd)
+                except redis_module.exceptions.ResponseError:
+                    pass

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -1064,6 +1064,7 @@ int VSIM_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                 != REDISMODULE_OK || count <= 0)
             {
                 RedisModule_Free(vec);
+                if (filter_expr) exprFree(filter_expr);
                 return RedisModule_ReplyWithError(ctx, "ERR invalid COUNT");
             }
             j += 2;
@@ -1072,6 +1073,7 @@ int VSIM_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                 REDISMODULE_OK || epsilon <= 0)
             {
                 RedisModule_Free(vec);
+                if (filter_expr) exprFree(filter_expr);
                 return RedisModule_ReplyWithError(ctx, "ERR invalid EPSILON");
             }
             j += 2;
@@ -1080,6 +1082,7 @@ int VSIM_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                 REDISMODULE_OK || ef <= 0 || ef > 1000000)
             {
                 RedisModule_Free(vec);
+                if (filter_expr) exprFree(filter_expr);
                 return RedisModule_ReplyWithError(ctx, "ERR invalid EF");
             }
             j += 2;
@@ -1088,6 +1091,7 @@ int VSIM_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                 REDISMODULE_OK || filter_ef <= 0)
             {
                 RedisModule_Free(vec);
+                if (filter_expr) exprFree(filter_expr);
                 return RedisModule_ReplyWithError(ctx, "ERR invalid FILTER-EF");
             }
             j += 2;
@@ -1096,6 +1100,7 @@ int VSIM_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             size_t exprlen;
             char *exprstr = (char*)RedisModule_StringPtrLen(exprarg,&exprlen);
             int errpos;
+            if (filter_expr) exprFree(filter_expr);
             filter_expr = exprCompile(exprstr,&errpos);
             if (filter_expr == NULL) {
                 if ((size_t)errpos >= exprlen) errpos = 0;
@@ -1107,6 +1112,7 @@ int VSIM_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             j += 2;
         } else {
             RedisModule_Free(vec);
+            if (filter_expr) exprFree(filter_expr);
             return RedisModule_ReplyWithError(ctx,
                 "ERR syntax error in VSIM command");
         }


### PR DESCRIPTION
`VSIM_RedisCommand` in `vset.c` had two memory leak bugs related to the compiled FILTER expression (`exprstate` allocated by `exprCompile`):

1. Duplicate FILTER: When two FILTER options are provided in a single VSIM command, the second `exprCompile` overwrites `filter_expr` without freeing the first. Only the last one is freed in `VSIM_execute cleanup`. 
    Fix: call `exprFree` on the existing `filter_expr` before reassigning.

2. Error path leaks: When FILTER is parsed successfully but a later option fails validation (invalid COUNT/EF/EPSILON/FILTER-EF or unknown option), the error return frees `vec` but not `filter_expr`.
    Fix: add `exprFree(filter_expr)` to all five error return paths.

Added regression tests:
- tests/vsim_duplicate_filter.py
- tests/vsim_filter_error_leak.py


Without the fix, running the added tests with an ASan build will give lsan error for both tests:
```
==1416168==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 16000 byte(s) in 200 object(s) allocated from:
    #0 0x79b64aab4887 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x5fb7f064008e in ztrymalloc_usable_internal .../redis/src/zmalloc.c:176
    #2 0x5fb7f064008e in zmalloc_usable .../redis/src/zmalloc.c:224
    #3 0x5fb7f064008e in RM_Alloc .../redis/src/module.c:530
    #4 0x5fb7f07d2972 in exprCompile ../modules/vector-sets/expr.c:595
    #5 0x5fb7f07e1126 in VSIM_RedisCommand ../modules/vector-sets/vset.c:1099
    #6 0x5fb7f0652c7f in RedisModuleCommandDispatcher .../redis/src/module.c:935
    #7 0x5fb7f030e922 in call .../redis/src/server.c:3926
    ...
```

Please let me know if I can provide any more information, thanks!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches C-level command option parsing for `VSIM`; while behavior should be unchanged aside from memory cleanup, mistakes here could affect query handling or stability in the vector-sets module.
> 
> **Overview**
> Fixes memory leaks in `VSIM` when using the `FILTER` option by freeing any previously-compiled expression before compiling a new one, and by freeing the compiled expression on all option-parse/validation error returns (e.g., invalid `COUNT`/`EF`/`EPSILON`/`FILTER-EF` or unknown options).
> 
> Adds two regression tests that repeatedly issue `VSIM` with duplicate `FILTER` options and with a valid `FILTER` followed by invalid options, intended to catch these leaks under ASAN/valgrind.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c277d4c1ecef5ed03215ce818ee08fa16e422f20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->