### PR TITLE
Increment the expiredkeys counter if RESTORE with a past expiration time

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -283,6 +283,9 @@ void restoreCommand(client *c) {
             notifyKeyspaceEvent(NOTIFY_GENERIC,"del",key,c->db->id);
             server.dirty++;
         }
+        /* If the expiration time is already elapsed, we skip adding
+         * it to the DB, but we still increment the stats. */
+        server.stat_expiredkeys++;
         keyMetaSpecCleanup(&keymeta);
         decrRefCount(obj);
         addReply(c, shared.ok);

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -42,9 +42,13 @@ start_server {tags {"dump"}} {
         set encoded [r dump foo]
         set now [clock milliseconds]
         r debug set-active-expire 0
+        set expiredkeys [s expired_keys]
         r restore foo [expr $now-3000] $encoded absttl REPLACE
         catch {r debug object foo} e
         r debug set-active-expire 1
+        # Verify that expired_keys was incremented, even though
+        # the key was not added to the DB actually.
+        assert_equal [expr $expiredkeys + 1] [s expired_keys]
         set e
     } {ERR no such key} {needs:debug}
 


### PR DESCRIPTION
a part of https://github.com/redis/redis/pull/14784, but only handle RESTORE command to back port to 8.6.