### PR TITLE
Fix ASM debug failpoints not aborting migration in error-handling tests

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1704,6 +1704,11 @@ void asmSlotSnapshotSucceed(struct asmTask *task) {
 
     task->state = ASM_SEND_STREAM;
     task->rdb_channel_state = ASM_COMPLETED;
+
+    if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state))) {
+        asmTaskSetFailed(task, "Main channel - Fail point triggered at %s",
+                         asmTaskStateToString(task->state));
+    }
 }
 
 /* Called when the RDB channel fails to send the snapshot. */
@@ -2135,6 +2140,14 @@ void clusterSyncSlotsCommand(client *c) {
             if (task->state == ASM_SEND_BULK_AND_STREAM || task->state == ASM_SEND_STREAM) {
                 /* Pause writes on the main channel if the lag is less than the threshold. */
                 if (task->dest_offset + server.asm_handoff_max_lag_bytes >= task->source_offset) {
+                    if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state))) {
+                        asmTaskSetFailed(task, "Main channel - Fail point triggered at %s",
+                                         asmTaskStateToString(task->state));
+                        return;
+                    }
+                    if (task->state == ASM_SEND_BULK_AND_STREAM &&
+                        unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, ASM_SEND_STREAM)))
+                        return; /* Wait for RDB to complete and enter send-stream first. */
                     if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, ASM_HANDOFF_PREP)))
                         return; /* Do not enter handoff prep state for testing buffer drain timeout. */
 
@@ -2522,6 +2535,12 @@ void asmSyncBufferStreamToDb(asmTask *task) {
     int ret = replDataBufStreamToDb(&task->sync_buffer, &ctx);
 
     if (ret == C_OK) {
+        if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state))) {
+            asmTaskSetFailed(task, "Main channel - Fail point triggered at %s",
+                             asmTaskStateToString(task->state));
+            return;
+        }
+
         if (task->stream_eof_during_streaming) {
             /* STREAM-EOF received during streaming, we can take over now. */
             asmImportTakeover(task);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1704,11 +1704,6 @@ void asmSlotSnapshotSucceed(struct asmTask *task) {
 
     task->state = ASM_SEND_STREAM;
     task->rdb_channel_state = ASM_COMPLETED;
-
-    if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state))) {
-        asmTaskSetFailed(task, "Main channel - Fail point triggered at %s",
-                         asmTaskStateToString(task->state));
-    }
 }
 
 /* Called when the RDB channel fails to send the snapshot. */


### PR DESCRIPTION
The atomic-slot-migration test was failing consistently on Ubuntu 24.04
(but not on CI) with:

    [exception]: Executing test client: ERR this node is already the
    owner of the slot range.

Two failpoints were ineffective, causing "Destination node main channel
basic error-handling tests" and "Source node main channel basic
error-handling tests" to fail:

1. Import side `streaming-buffer` (destination main channel): the
   `STREAM-EOF` command already accumulated in the sync buffer gets
   processed before the connection shutdown is detected, completing the
   migration. Add a failpoint check in `asmSyncBufferStreamToDb` after
   streaming succeeds, before calling `asmImportTakeover`.

2. Migrate side `send-stream` (source main channel): under light write
   load the ACK handler transitions the task from
   `ASM_SEND_BULK_AND_STREAM` directly to `ASM_HANDOFF_PREP`, skipping
   `ASM_SEND_STREAM`. Add a failpoint check against the current state in
   the ACK handler, and delay handoff while in
   `ASM_SEND_BULK_AND_STREAM` when the `send-stream` failpoint is
   pending so the task reaches `ASM_SEND_STREAM` first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches atomic slot migration state transitions on both import and migrate paths; while primarily affecting debug failpoint behavior, it runs in core `ACK`/buffer-streaming flows and could impact handoff timing if mis-triggered.
> 
> **Overview**
> Fixes ASM debug failpoints so error-handling tests reliably abort migrations instead of accidentally completing them.
> 
> On the **migrate (source) main channel**, the `ACK` handler now (1) fails the task immediately when a failpoint matches the *current* state, and (2) prevents transitioning from `ASM_SEND_BULK_AND_STREAM` directly into `ASM_HANDOFF_PREP` when the `send-stream` failpoint is armed, forcing the task to reach `ASM_SEND_STREAM` first.
> 
> On the **import (destination) main channel**, `asmSyncBufferStreamToDb` now checks the `ASM_STREAMING_BUF` failpoint *after* successful buffer application (and before `asmImportTakeover`) and marks the task failed, preventing `STREAM-EOF` already in the buffer from completing the migration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94c5050bc9bbbb06c9ad639c2a2884d0e8929651. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->