### PR TITLE
hmget optimization for listpack

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2639,6 +2639,99 @@ void hgetCommand(client *c) {
     addHashFieldToReply(c, o, c->argv[2]->ptr, HFE_LAZY_EXPIRE);
 }
 
+/* HMGET fast path for OBJ_ENCODING_LISTPACK.
+ *
+ * Instead of calling lpFind() per requested field (each a full O(L)
+ * traversal), walk the listpack once and match each entry against
+ * the requested fields.
+ *
+ * Not applicable to LISTPACK_EX: that encoding requires per-field
+ * lazy expiry handling which may mutate the listpack. */
+static void hmgetListpackSinglePass(client *c, robj *o) {
+    serverAssert(o->encoding == OBJ_ENCODING_LISTPACK);
+
+    int num_fields = c->argc - 2;
+    unsigned char *lp = o->ptr;
+
+    /* Result array: stores a pointer to the value entry in the listpack
+     * for each requested field.  NULL means not found.
+     * Using zcalloc so all entries start as NULL. */
+    unsigned char **results = zcalloc(sizeof(unsigned char *) * num_fields);
+
+    /* Track how many unique fields remain to be found.  Once all are
+     * found, we can stop traversing the listpack early. */
+    int remaining = num_fields;
+
+    /* --- Single pass over the listpack --- */
+
+    unsigned char *fptr = lpFirst(lp);
+
+    while (fptr != NULL && remaining > 0) {
+        /* Decode the field entry */
+        int64_t flen;
+        unsigned char *fstr = lpGet(fptr, &flen, NULL);
+
+        /* Advance to the value entry (fptr points to field, vptr to value) */
+        unsigned char *vptr = lpNext(lp, fptr);
+        serverAssert(vptr != NULL);
+
+        /* Compare this LP field against each unfound requested field */
+        for (int i = 0; i < num_fields; i++) {
+            if (results[i] != NULL)
+                continue;   /* already found this argv slot */
+
+            sds reqField = c->argv[i + 2]->ptr;
+            size_t reqLen = sdslen(reqField);
+
+            int match;
+            if (fstr != NULL) {
+                /* LP field is a string: compare raw bytes */
+                match = (reqLen == (size_t)flen &&
+                         memcmp(reqField, fstr, flen) == 0);
+            } else {
+                /* LP field is integer-encoded (unusual for field names).
+                 * Parse the argv string as integer and compare. */
+                long long reqll;
+                match = (string2ll(reqField, reqLen, &reqll) &&
+                         reqll == (long long)flen);
+            }
+
+            if (match) {
+                results[i] = vptr;
+                remaining--;
+                /* Don't break: duplicate field names in argv should
+                 * all get a result.  But each LP field is unique, so
+                 * no further LP entries will match — only other argv
+                 * slots with the same field name. */
+            }
+        }
+
+        /* Advance to the next field entry (skip past this value) */
+        fptr = lpNext(lp, vptr);
+    }
+
+    /* --- Emit replies in request order --- */
+
+    addReplyArrayLen(c, num_fields);
+
+    for (int i = 0; i < num_fields; i++) {
+        if (results[i] != NULL) {
+            unsigned char *vstr;
+            unsigned int vlen;
+            long long vll;
+            vstr = lpGetValue(results[i], &vlen, &vll);
+            if (vstr)
+                addReplyBulkCBuffer(c, vstr, vlen);
+            else
+                addReplyBulkLongLong(c, vll);
+        } else {
+            addReplyNull(c);
+        }
+    }
+
+    zfree(results);
+}
+
 void hmgetCommand(client *c) {
     GetFieldRes res = GETF_OK;
     int i;
@@ -2648,6 +2741,14 @@ void hmgetCommand(client *c) {
      * hashes, where HMGET should respond with a series of null bulks. */
     kvobj *o = lookupKeyRead(c->db, c->argv[1]);
     if (checkType(c,o,OBJ_HASH)) return;
+
+    /* Fast path: single-pass listpack scan for plain LISTPACK encoding.
+     * Not applicable to LISTPACK_EX (requires per-field lazy expiry)
+     * or HT (already O(1) per lookup). */
+    if (o != NULL && o->encoding == OBJ_ENCODING_LISTPACK) {
+        hmgetListpackSinglePass(c, o);
+        return;
+    }
 
     addReplyArrayLen(c, c->argc-2);
     for (i = 2; i < c->argc ; i++) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2641,9 +2641,14 @@ void hgetCommand(client *c) {
 
 /* HMGET fast path for OBJ_ENCODING_LISTPACK.
  *
- * Instead of calling lpFind() per requested field (each a full O(L)
- * traversal), walk the listpack once and match each entry against
- * the requested fields.
+ * Instead of calling lpFind() per requested field — each a full O(L)
+ * traversal involving varint decoding, bounds checking (lpAssertValidEntry),
+ * and skip logic per entry — walk the listpack once and match each entry
+ * against the requested fields using simple memcmp comparisons.
+ *
+ * This reduces the expensive listpack traversal overhead (varint decode,
+ * bounds validation, EOF checks) from O(N * L) to O(L), replacing it
+ * with O(N) cheap memcmp calls per listpack entry.
  *
  * Not applicable to LISTPACK_EX: that encoding requires per-field
  * lazy expiry handling which may mutate the listpack. */

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -406,6 +406,42 @@ start_server {tags {"hash"}} {
         set _ $err
     } {}
 
+    test {HMGET with duplicate fields in argv - listpack} {
+        r del myhash
+        r hset myhash f1 v1 f2 v2 f3 v3
+        assert_encoding listpack myhash
+        assert_equal {v1 v1} [r hmget myhash f1 f1]
+        assert_equal {{} {}} [r hmget myhash missing missing]
+        assert_equal {v2 {} v2} [r hmget myhash f2 missing f2]
+    }
+
+    test {HMGET with duplicate fields in argv - hashtable} {
+        r del myhash
+        for {set i 0} {$i < 520} {incr i} {r hset myhash "field$i" "val$i"}
+        assert_encoding hashtable myhash
+        assert_equal {val0 val0} [r hmget myhash field0 field0]
+        assert_equal {{} {}} [r hmget myhash missing missing]
+        assert_equal {val5 {} val5} [r hmget myhash field5 missing field5]
+    }
+
+    test {HMGET with integer-encoded field names - listpack} {
+        r del myhash
+        r hset myhash 100 val100 200 val200 300 val300 hello world
+        assert_encoding listpack myhash
+        assert_equal {val100 val300 {}} [r hmget myhash 100 300 999]
+        assert_equal {{} val200} [r hmget myhash 999 200]
+        assert_equal {world val100} [r hmget myhash hello 100]
+    }
+
+    test {HMGET with mix of found and not-found fields - listpack} {
+        r del myhash
+        r hset myhash a 1 b 2 c 3 d 4 e 5
+        assert_encoding listpack myhash
+        assert_equal {1 {} 3 {} 5} [r hmget myhash a missing1 c missing2 e]
+        assert_equal {{} 2 {} 4 {}} [r hmget myhash x b y d z]
+        assert_equal {{} {} {} {}} [r hmget myhash w x y z]
+    }
+
     test {HKEYS - small hash} {
         lsort [r hkeys smallhash]
     } [lsort [array names smallhash *]]


### PR DESCRIPTION
Add a fast-path optimization for hmget (listpack encoding). 
Instead of calling lpFind on each requested field, we walk the listpack only once and match each entry against the requested fields. This helps, because it reduces listpack traversal overhead ( variant decode, bounds validations, etc) and replaces it with cheaper memcmp calls per listpack entry. 

Performance Testing on IceLake server
Baseline ops/sec: 61045
Optimized ops/sec: 67780  (about 11% benefit) 

Test case: 

Data Loading
taskset -c 0,1,2,3 memtier_benchmark --json-out-file oss-standalone-2026-03-19-18-02-50-4ecc07fc-preload__memtier_benchmark-1Mkeys-hash-hmget-100of100-fields-with-32B-values-pipeline-1.json --port 6379 --server localhost "--data-size" "32" --command "HSET __key__ field1 __data__ field2 __data__ field3 __data__ field4 __data__ field5 __data__ field6 __data__ field7 __data__ field8 __data__ field9 __data__ field10 __data__ field11 __data__ field12 __data__ field13 __data__ field14 __data__ field15 __data__ field16 __data__ field17 __data__ field18 __data__ field19 __data__ field20 __data__ field21 __data__ field22 __data__ field23 __data__ field24 __data__ field25 __data__ field26 __data__ field27 __data__ field28 __data__ field29 __data__ field30 __data__ field31 __data__ field32 __data__ field33 __data__ field34 __data__ field35 __data__ field36 __data__ field37 __data__ field38 __data__ field39 __data__ field40 __data__ field41 __data__ field42 __data__ field43 __data__ field44 __data__ field45 __data__ field46 __data__ field47 __data__ field48 __data__ field49 __data__ field50 __data__ field51 __data__ field52 __data__ field53 __data__ field54 __data__ field55 __data__ field56 __data__ field57 __data__ field58 __data__ field59 __data__ field60 __data__ field61 __data__ field62 __data__ field63 __data__ field64 __data__ field65 __data__ field66 __data__ field67 __data__ field68 __data__ field69 __data__ field70 __data__ field71 __data__ field72 __data__ field73 __data__ field74 __data__ field75 __data__ field76 __data__ field77 __data__ field78 __data__ field79 __data__ field80 __data__ field81 __data__ field82 __data__ field83 __data__ field84 __data__ field85 __data__ field86 __data__ field87 __data__ field88 __data__ field89 __data__ field90 __data__ field91 __data__ field92 __data__ field93 __data__ field94 __data__ field95 __data__ field96 __data__ field97 __data__ field98 __data__ field99 __data__ field100 __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 10000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline 50

Benchmarking
taskset -c 0,1,2,3 memtier_benchmark --json-out-file oss-standalone-2026-03-19-18-03-51-4ecc07fc-memtier_benchmark-1Mkeys-hash-hmget-100of100-fields-with-32B-values-pipeline-1.json --port 6379 --server localhost --pipeline 1 --command "HMGET __key__ field1 field2 field3 field4 field5 field6 field7 field8 field9 field10 field11 field12 field13 field14 field15 field16 field17 field18 field19 field20 field21 field22 field23 field24 field25 field26 field27 field28 field29 field30 field31 field32 field33 field34 field35 field36 field37 field38 field39 field40 field41 field42 field43 field44 field45 field46 field47 field48 field49 field50 field51 field52 field53 field54 field55 field56 field57 field58 field59 field60 field61 field62 field63 field64 field65 field66 field67 field68 field69 field70 field71 field72 field73 field74 field75 field76 field77 field78 field79 field80 field81 field82 field83 field84 field85 field86 field87 field88 field89 field90 field91 field92 field93 field94 field95 field96 field97 field98 field99 field100" --command-key-pattern="R" --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram

Currently working to add this test case to the benchmark-specification: https://github.com/redis/redis-benchmarks-specification/pull/358

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `HMGET` read-path logic for listpack-encoded hashes; while intended to be behavior-preserving, pointer-based listpack iteration and integer-encoded field handling could introduce subtle correctness issues in edge cases.
> 
> **Overview**
> **Optimizes `HMGET` for listpack-encoded hashes** by adding a single-pass scan (`hmgetListpackSinglePass`) that walks the listpack once and matches requested fields via `memcmp`, instead of calling `lpFind()` per field.
> 
> `hmgetCommand` now routes plain `OBJ_ENCODING_LISTPACK` hashes through this fast path (leaving `OBJ_ENCODING_LISTPACK_EX` and hashtable lookups unchanged). Unit tests extend coverage for duplicate requested fields, integer-like field names, and mixed hit/miss patterns to validate reply ordering and correctness across encodings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a481cbc3a915f01baccd2bddac77ff60160ed60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->