### PR TITLE
DataTypes update  8.8 milestone 1

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.6.0
+MODULE_VERSION = v8.7.80
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 

--- a/modules/redisjson/Makefile
+++ b/modules/redisjson/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.6.0
+MODULE_VERSION = v8.7.80
 MODULE_REPO = https://github.com/redisjson/redisjson
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/rejson.so
 

--- a/modules/redistimeseries/Makefile
+++ b/modules/redistimeseries/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.6.0
+MODULE_VERSION = v8.7.80
 MODULE_REPO = https://github.com/redistimeseries/redistimeseries
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redistimeseries.so
 


### PR DESCRIPTION
update data type modules to 8.7.80 part of 8.8 milestone 1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump in build Makefiles only; main risk is downstream build/runtime behavior changes from the newer module releases.
> 
> **Overview**
> Updates the `MODULE_VERSION` in the Redis module Makefiles for **RedisBloom**, **RedisJSON**, and **RedisTimeSeries** from `v8.6.0` to `v8.7.80`, so builds pull and package the newer upstream module releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38b43f4126531471a51a9932e78144a066c15466. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->