### PR TITLE
Add new OBJ_GCRA type

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -2039,8 +2039,9 @@ latency-monitor-threshold 0
 #        (Note: not included in the 'A' class)
 #  c     Type-changed events generated every time a key's type changes
 #        (Note: not included in the 'A' class)
+#  r     rate limit event
 #  A     Alias for g$lshzxetd, so that the "AKE" string means all the events
-#        except key-miss, new key, overwritten and type-changed.
+#        except key-miss, new key, overwritten, type-changed and rate-limit.
 #
 #  The "notify-keyspace-events" takes as argument a string that is composed
 #  of zero or multiple characters. The empty string means that notifications

--- a/src/acl.c
+++ b/src/acl.c
@@ -70,6 +70,7 @@ struct ACLCategoryItem {
     {"connection", ACL_CATEGORY_CONNECTION},
     {"transaction", ACL_CATEGORY_TRANSACTION},
     {"scripting", ACL_CATEGORY_SCRIPTING},
+    {"ratelimit", ACL_CATEGORY_RATE_LIMIT},
     {NULL,0} /* Terminator. */
 };
 

--- a/src/aof.c
+++ b/src/aof.c
@@ -2469,7 +2469,7 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
 
 int rewriteGCRAObject(rio *r, robj *key, robj *o) {
     long long val;
-    if (getLongLongFromGCRAObject(o, &val) == C_ERR) return 0;
+    getLongLongFromGCRAObject(o, &val);
 
     /* GCRASETVALUE <key> <tat> */
     if (rioWriteBulkCount(r,'*',3) == 0) return 0;

--- a/src/aof.c
+++ b/src/aof.c
@@ -2471,9 +2471,9 @@ int rewriteGCRAObject(rio *r, robj *key, robj *o) {
     long long val;
     if (getLongLongFromGCRAObject(o, &val) == C_ERR) return 0;
 
-    /* GCRASETTAT <key> <tat> */
+    /* GCRASETVALUE <key> <tat> */
     if (rioWriteBulkCount(r,'*',3) == 0) return 0;
-    if (rioWriteBulkString(r,"GCRASETTAT",10) == 0) return 0;
+    if (rioWriteBulkString(r,"GCRASETVALUE",12) == 0) return 0;
     if (rioWriteBulkObject(r,key) == 0) return 0;
     if (rioWriteBulkLongLong(r,val) == 0) return 0;
     return 1;

--- a/src/aof.c
+++ b/src/aof.c
@@ -2467,6 +2467,18 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
     return 1;
 }
 
+int rewriteGCRAObject(rio *r, robj *key, robj *o) {
+    long long val;
+    if (getLongLongFromGCRAObject(o, &val) == C_ERR) return 0;
+
+    /* GCRARECORD <key> <tat> */
+    if (rioWriteBulkCount(r,'*',3) == 0) return 0;
+    if (rioWriteBulkString(r,"GCRARECORD",10) == 0) return 0;
+    if (rioWriteBulkObject(r,key) == 0) return 0;
+    if (rioWriteBulkLongLong(r,val) == 0) return 0;
+    return 1;
+}
+
 /* Call the module type callback in order to rewrite a data type
  * that is exported by a module and is not handled by Redis itself.
  * The function returns 0 on error, 1 on success. */
@@ -2522,6 +2534,8 @@ int rewriteObject(rio *r, robj *key, robj *o, int dbid, long long expiretime) {
         if (rewriteHashObject(r,key,o) == 0) return C_ERR;
     } else if (o->type == OBJ_STREAM) {
         if (rewriteStreamObject(r,key,o) == 0) return C_ERR;
+    } else if (o->type == OBJ_GCRA) {
+        if (rewriteGCRAObject(r,key,o) == 0) return C_ERR;
     } else if (o->type == OBJ_MODULE) {
         if (rewriteModuleObject(r,key,o,dbid) == 0) return C_ERR;
     } else {

--- a/src/aof.c
+++ b/src/aof.c
@@ -2471,9 +2471,9 @@ int rewriteGCRAObject(rio *r, robj *key, robj *o) {
     long long val;
     if (getLongLongFromGCRAObject(o, &val) == C_ERR) return 0;
 
-    /* GCRARECORD <key> <tat> */
+    /* GCRASETTAT <key> <tat> */
     if (rioWriteBulkCount(r,'*',3) == 0) return 0;
-    if (rioWriteBulkString(r,"GCRARECORD",10) == 0) return 0;
+    if (rioWriteBulkString(r,"GCRASETTAT",10) == 0) return 0;
     if (rioWriteBulkObject(r,key) == 0) return 0;
     if (rioWriteBulkLongLong(r,val) == 0) return 0;
     return 1;

--- a/src/commands.def
+++ b/src/commands.def
@@ -11110,6 +11110,31 @@ struct COMMAND_ARG GCRA_Args[] = {
 {MAKE_ARG("count",ARG_TYPE_INTEGER,-1,"TOKENS",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
 };
 
+/********** GCRARECORD ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* GCRARECORD history */
+#define GCRARECORD_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* GCRARECORD tips */
+#define GCRARECORD_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* GCRARECORD key specs */
+keySpec GCRARECORD_Keyspecs[1] = {
+{NULL,CMD_KEY_OW|CMD_KEY_UPDATE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+};
+#endif
+
+/* GCRARECORD argument table */
+struct COMMAND_ARG GCRARECORD_Args[] = {
+{MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("tat",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
 /********** GET ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -12042,6 +12067,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("delex","Conditionally removes the specified key based on value or digest comparison.","O(1) for IFEQ/IFNE, O(N) for IFDEQ/IFDNE where N is the length of the string value.","8.4.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,DELEX_History,0,DELEX_Tips,0,delexCommand,-2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STRING,DELEX_Keyspecs,1,delexGetKeys,2),.args=DELEX_Args},
 {MAKE_CMD("digest","Returns the XXH3 hash of a string value.","O(N) where N is the length of the string value.","8.4.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,DIGEST_History,0,DIGEST_Tips,0,digestCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_STRING,DIGEST_Keyspecs,1,NULL,1),.args=DIGEST_Args},
 {MAKE_CMD("gcra","Rate limit via GCRA (Generic Cell Rate Algorithm).","O(1)","8.8.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GCRA_History,0,GCRA_Tips,0,gcraCommand,-5,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STRING,GCRA_Keyspecs,1,NULL,5),.args=GCRA_Args},
+{MAKE_CMD("gcrarecord","An internal command for recording a GCRA TAT value during AOF rewrite.","O(1)","8.8.0",CMD_DOC_SYSCMD,NULL,NULL,"string",COMMAND_GROUP_STRING,GCRARECORD_History,0,GCRARECORD_Tips,0,gcraRecordCommand,3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STRING,GCRARECORD_Keyspecs,1,NULL,2),.args=GCRARECORD_Args},
 {MAKE_CMD("get","Returns the string value of a key.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GET_History,0,GET_Tips,0,getCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_STRING,GET_Keyspecs,1,NULL,1),.args=GET_Args},
 {MAKE_CMD("getdel","Returns the string value of a key after deleting the key.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GETDEL_History,0,GETDEL_Tips,0,getdelCommand,2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STRING,GETDEL_Keyspecs,1,NULL,1),.args=GETDEL_Args},
 {MAKE_CMD("getex","Returns the string value of a key after setting its expiration time.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GETEX_History,0,GETEX_Tips,0,getexCommand,-2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STRING,GETEX_Keyspecs,1,NULL,2),.args=GETEX_Args},

--- a/src/commands.def
+++ b/src/commands.def
@@ -5408,27 +5408,27 @@ struct COMMAND_ARG GCRA_Args[] = {
 {MAKE_ARG("count",ARG_TYPE_INTEGER,-1,"TOKENS",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
 };
 
-/********** GCRASETTAT ********************/
+/********** GCRASETVALUE ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
-/* GCRASETTAT history */
-#define GCRASETTAT_History NULL
+/* GCRASETVALUE history */
+#define GCRASETVALUE_History NULL
 #endif
 
 #ifndef SKIP_CMD_TIPS_TABLE
-/* GCRASETTAT tips */
-#define GCRASETTAT_Tips NULL
+/* GCRASETVALUE tips */
+#define GCRASETVALUE_Tips NULL
 #endif
 
 #ifndef SKIP_CMD_KEY_SPECS_TABLE
-/* GCRASETTAT key specs */
-keySpec GCRASETTAT_Keyspecs[1] = {
+/* GCRASETVALUE key specs */
+keySpec GCRASETVALUE_Keyspecs[1] = {
 {NULL,CMD_KEY_OW|CMD_KEY_UPDATE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
 };
 #endif
 
-/* GCRASETTAT argument table */
-struct COMMAND_ARG GCRASETTAT_Args[] = {
+/* GCRASETVALUE argument table */
+struct COMMAND_ARG GCRASETVALUE_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("tat",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
@@ -11945,7 +11945,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("unsubscribe","Stops listening to messages posted to channels.","O(N) where N is the number of channels to unsubscribe.","2.0.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,UNSUBSCRIBE_History,0,UNSUBSCRIBE_Tips,0,unsubscribeCommand,-1,CMD_PUBSUB|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,0,UNSUBSCRIBE_Keyspecs,0,NULL,1),.args=UNSUBSCRIBE_Args},
 /* rate_limit */
 {MAKE_CMD("gcra","Rate limit via GCRA (Generic Cell Rate Algorithm).","O(1)","8.8.0",CMD_DOC_NONE,NULL,NULL,"rate_limit",COMMAND_GROUP_RATE_LIMIT,GCRA_History,0,GCRA_Tips,0,gcraCommand,-5,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_RATE_LIMIT,GCRA_Keyspecs,1,NULL,5),.args=GCRA_Args},
-{MAKE_CMD("gcrasettat","An internal command for recording a GCRA TAT value during AOF rewrite.","O(1)","8.8.0",CMD_DOC_NONE,NULL,NULL,"rate_limit",COMMAND_GROUP_RATE_LIMIT,GCRASETTAT_History,0,GCRASETTAT_Tips,0,gcraSetTATCommand,3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_RATE_LIMIT,GCRASETTAT_Keyspecs,1,NULL,2),.args=GCRASETTAT_Args},
+{MAKE_CMD("gcrasetvalue","An internal command for recording a GCRA TAT value during AOF rewrite and replication.","O(1)","8.8.0",CMD_DOC_NONE,NULL,NULL,"rate_limit",COMMAND_GROUP_RATE_LIMIT,GCRASETVALUE_History,0,GCRASETVALUE_Tips,0,gcraSetValueCommand,3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_RATE_LIMIT,GCRASETVALUE_Keyspecs,1,NULL,2),.args=GCRASETVALUE_Args},
 /* scripting */
 {MAKE_CMD("eval","Executes a server-side Lua script.","Depends on the script that is executed.","2.6.0",CMD_DOC_NONE,NULL,NULL,"scripting",COMMAND_GROUP_SCRIPTING,EVAL_History,0,EVAL_Tips,0,evalCommand,-3,CMD_NOSCRIPT|CMD_SKIP_MONITOR|CMD_MAY_REPLICATE|CMD_NO_MANDATORY_KEYS|CMD_STALE,ACL_CATEGORY_SCRIPTING,EVAL_Keyspecs,1,evalGetKeys,4),.args=EVAL_Args},
 {MAKE_CMD("evalsha","Executes a server-side Lua script by SHA1 digest.","Depends on the script that is executed.","2.6.0",CMD_DOC_NONE,NULL,NULL,"scripting",COMMAND_GROUP_SCRIPTING,EVALSHA_History,0,EVALSHA_Tips,0,evalShaCommand,-3,CMD_NOSCRIPT|CMD_SKIP_MONITOR|CMD_MAY_REPLICATE|CMD_NO_MANDATORY_KEYS|CMD_STALE,ACL_CATEGORY_SCRIPTING,EVALSHA_Keyspecs,1,evalGetKeys,4),.args=EVALSHA_Args},

--- a/src/commands.def
+++ b/src/commands.def
@@ -11110,27 +11110,27 @@ struct COMMAND_ARG GCRA_Args[] = {
 {MAKE_ARG("count",ARG_TYPE_INTEGER,-1,"TOKENS",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
 };
 
-/********** GCRARECORD ********************/
+/********** GCRASETTAT ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
-/* GCRARECORD history */
-#define GCRARECORD_History NULL
+/* GCRASETTAT history */
+#define GCRASETTAT_History NULL
 #endif
 
 #ifndef SKIP_CMD_TIPS_TABLE
-/* GCRARECORD tips */
-#define GCRARECORD_Tips NULL
+/* GCRASETTAT tips */
+#define GCRASETTAT_Tips NULL
 #endif
 
 #ifndef SKIP_CMD_KEY_SPECS_TABLE
-/* GCRARECORD key specs */
-keySpec GCRARECORD_Keyspecs[1] = {
+/* GCRASETTAT key specs */
+keySpec GCRASETTAT_Keyspecs[1] = {
 {NULL,CMD_KEY_OW|CMD_KEY_UPDATE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
 };
 #endif
 
-/* GCRARECORD argument table */
-struct COMMAND_ARG GCRARECORD_Args[] = {
+/* GCRASETTAT argument table */
+struct COMMAND_ARG GCRASETTAT_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("tat",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
@@ -12066,8 +12066,8 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("decrby","Decrements a number from the integer value of a key. Uses 0 as initial value if the key doesn't exist.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,DECRBY_History,0,DECRBY_Tips,0,decrbyCommand,3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STRING,DECRBY_Keyspecs,1,NULL,2),.args=DECRBY_Args},
 {MAKE_CMD("delex","Conditionally removes the specified key based on value or digest comparison.","O(1) for IFEQ/IFNE, O(N) for IFDEQ/IFDNE where N is the length of the string value.","8.4.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,DELEX_History,0,DELEX_Tips,0,delexCommand,-2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STRING,DELEX_Keyspecs,1,delexGetKeys,2),.args=DELEX_Args},
 {MAKE_CMD("digest","Returns the XXH3 hash of a string value.","O(N) where N is the length of the string value.","8.4.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,DIGEST_History,0,DIGEST_Tips,0,digestCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_STRING,DIGEST_Keyspecs,1,NULL,1),.args=DIGEST_Args},
-{MAKE_CMD("gcra","Rate limit via GCRA (Generic Cell Rate Algorithm).","O(1)","8.8.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GCRA_History,0,GCRA_Tips,0,gcraCommand,-5,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STRING,GCRA_Keyspecs,1,NULL,5),.args=GCRA_Args},
-{MAKE_CMD("gcrarecord","An internal command for recording a GCRA TAT value during AOF rewrite.","O(1)","8.8.0",CMD_DOC_SYSCMD,NULL,NULL,"string",COMMAND_GROUP_STRING,GCRARECORD_History,0,GCRARECORD_Tips,0,gcraRecordCommand,3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STRING,GCRARECORD_Keyspecs,1,NULL,2),.args=GCRARECORD_Args},
+{MAKE_CMD("gcra","Rate limit via GCRA (Generic Cell Rate Algorithm).","O(1)","8.8.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GCRA_History,0,GCRA_Tips,0,gcraCommand,-5,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_RATE_LIMIT,GCRA_Keyspecs,1,NULL,5),.args=GCRA_Args},
+{MAKE_CMD("gcrasettat","An internal command for recording a GCRA TAT value during AOF rewrite.","O(1)","8.8.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GCRASETTAT_History,0,GCRASETTAT_Tips,0,gcraSetTATCommand,3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_RATE_LIMIT,GCRASETTAT_Keyspecs,1,NULL,2),.args=GCRASETTAT_Args},
 {MAKE_CMD("get","Returns the string value of a key.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GET_History,0,GET_Tips,0,getCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_STRING,GET_Keyspecs,1,NULL,1),.args=GET_Args},
 {MAKE_CMD("getdel","Returns the string value of a key after deleting the key.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GETDEL_History,0,GETDEL_Tips,0,getdelCommand,2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STRING,GETDEL_Keyspecs,1,NULL,1),.args=GETDEL_Args},
 {MAKE_CMD("getex","Returns the string value of a key after setting its expiration time.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GETEX_History,0,GETEX_Tips,0,getexCommand,-2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STRING,GETEX_Keyspecs,1,NULL,2),.args=GETEX_Args},

--- a/src/commands.def
+++ b/src/commands.def
@@ -24,7 +24,8 @@ const char *COMMAND_GROUP_STR[] = {
     "geo",
     "stream",
     "bitmap",
-    "module"
+    "module",
+    "rate_limit"
 };
 
 const char *commandGroupStr(int index) {

--- a/src/commands.def
+++ b/src/commands.def
@@ -5379,6 +5379,59 @@ struct COMMAND_ARG UNSUBSCRIBE_Args[] = {
 {MAKE_ARG("channel",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,0,NULL)},
 };
 
+/********** GCRA ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* GCRA history */
+#define GCRA_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* GCRA tips */
+#define GCRA_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* GCRA key specs */
+keySpec GCRA_Keyspecs[1] = {
+{NULL,CMD_KEY_RW|CMD_KEY_ACCESS|CMD_KEY_UPDATE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+};
+#endif
+
+/* GCRA argument table */
+struct COMMAND_ARG GCRA_Args[] = {
+{MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("max-burst",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("tokens-per-period",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("period",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("count",ARG_TYPE_INTEGER,-1,"TOKENS",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
+};
+
+/********** GCRASETTAT ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* GCRASETTAT history */
+#define GCRASETTAT_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* GCRASETTAT tips */
+#define GCRASETTAT_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* GCRASETTAT key specs */
+keySpec GCRASETTAT_Keyspecs[1] = {
+{NULL,CMD_KEY_OW|CMD_KEY_UPDATE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+};
+#endif
+
+/* GCRASETTAT argument table */
+struct COMMAND_ARG GCRASETTAT_Args[] = {
+{MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("tat",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
 /********** EVAL ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -11082,59 +11135,6 @@ struct COMMAND_ARG DIGEST_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
-/********** GCRA ********************/
-
-#ifndef SKIP_CMD_HISTORY_TABLE
-/* GCRA history */
-#define GCRA_History NULL
-#endif
-
-#ifndef SKIP_CMD_TIPS_TABLE
-/* GCRA tips */
-#define GCRA_Tips NULL
-#endif
-
-#ifndef SKIP_CMD_KEY_SPECS_TABLE
-/* GCRA key specs */
-keySpec GCRA_Keyspecs[1] = {
-{NULL,CMD_KEY_RW|CMD_KEY_ACCESS|CMD_KEY_UPDATE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
-};
-#endif
-
-/* GCRA argument table */
-struct COMMAND_ARG GCRA_Args[] = {
-{MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("max-burst",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("tokens-per-period",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("period",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("count",ARG_TYPE_INTEGER,-1,"TOKENS",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
-};
-
-/********** GCRASETTAT ********************/
-
-#ifndef SKIP_CMD_HISTORY_TABLE
-/* GCRASETTAT history */
-#define GCRASETTAT_History NULL
-#endif
-
-#ifndef SKIP_CMD_TIPS_TABLE
-/* GCRASETTAT tips */
-#define GCRASETTAT_Tips NULL
-#endif
-
-#ifndef SKIP_CMD_KEY_SPECS_TABLE
-/* GCRASETTAT key specs */
-keySpec GCRASETTAT_Keyspecs[1] = {
-{NULL,CMD_KEY_OW|CMD_KEY_UPDATE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
-};
-#endif
-
-/* GCRASETTAT argument table */
-struct COMMAND_ARG GCRASETTAT_Args[] = {
-{MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("tat",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-};
-
 /********** GET ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -11942,6 +11942,9 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("subscribe","Listens for messages published to channels.","O(N) where N is the number of channels to subscribe to.","2.0.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,SUBSCRIBE_History,0,SUBSCRIBE_Tips,0,subscribeCommand,-2,CMD_PUBSUB|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,0,SUBSCRIBE_Keyspecs,0,NULL,1),.args=SUBSCRIBE_Args},
 {MAKE_CMD("sunsubscribe","Stops listening to messages posted to shard channels.","O(N) where N is the number of shard channels to unsubscribe.","7.0.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,SUNSUBSCRIBE_History,0,SUNSUBSCRIBE_Tips,0,sunsubscribeCommand,-1,CMD_PUBSUB|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,0,SUNSUBSCRIBE_Keyspecs,1,NULL,1),.args=SUNSUBSCRIBE_Args},
 {MAKE_CMD("unsubscribe","Stops listening to messages posted to channels.","O(N) where N is the number of channels to unsubscribe.","2.0.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,UNSUBSCRIBE_History,0,UNSUBSCRIBE_Tips,0,unsubscribeCommand,-1,CMD_PUBSUB|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,0,UNSUBSCRIBE_Keyspecs,0,NULL,1),.args=UNSUBSCRIBE_Args},
+/* rate_limit */
+{MAKE_CMD("gcra","Rate limit via GCRA (Generic Cell Rate Algorithm).","O(1)","8.8.0",CMD_DOC_NONE,NULL,NULL,"rate_limit",COMMAND_GROUP_RATE_LIMIT,GCRA_History,0,GCRA_Tips,0,gcraCommand,-5,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_RATE_LIMIT,GCRA_Keyspecs,1,NULL,5),.args=GCRA_Args},
+{MAKE_CMD("gcrasettat","An internal command for recording a GCRA TAT value during AOF rewrite.","O(1)","8.8.0",CMD_DOC_NONE,NULL,NULL,"rate_limit",COMMAND_GROUP_RATE_LIMIT,GCRASETTAT_History,0,GCRASETTAT_Tips,0,gcraSetTATCommand,3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_RATE_LIMIT,GCRASETTAT_Keyspecs,1,NULL,2),.args=GCRASETTAT_Args},
 /* scripting */
 {MAKE_CMD("eval","Executes a server-side Lua script.","Depends on the script that is executed.","2.6.0",CMD_DOC_NONE,NULL,NULL,"scripting",COMMAND_GROUP_SCRIPTING,EVAL_History,0,EVAL_Tips,0,evalCommand,-3,CMD_NOSCRIPT|CMD_SKIP_MONITOR|CMD_MAY_REPLICATE|CMD_NO_MANDATORY_KEYS|CMD_STALE,ACL_CATEGORY_SCRIPTING,EVAL_Keyspecs,1,evalGetKeys,4),.args=EVAL_Args},
 {MAKE_CMD("evalsha","Executes a server-side Lua script by SHA1 digest.","Depends on the script that is executed.","2.6.0",CMD_DOC_NONE,NULL,NULL,"scripting",COMMAND_GROUP_SCRIPTING,EVALSHA_History,0,EVALSHA_Tips,0,evalShaCommand,-3,CMD_NOSCRIPT|CMD_SKIP_MONITOR|CMD_MAY_REPLICATE|CMD_NO_MANDATORY_KEYS|CMD_STALE,ACL_CATEGORY_SCRIPTING,EVALSHA_Keyspecs,1,evalGetKeys,4),.args=EVALSHA_Args},
@@ -12066,8 +12069,6 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("decrby","Decrements a number from the integer value of a key. Uses 0 as initial value if the key doesn't exist.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,DECRBY_History,0,DECRBY_Tips,0,decrbyCommand,3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STRING,DECRBY_Keyspecs,1,NULL,2),.args=DECRBY_Args},
 {MAKE_CMD("delex","Conditionally removes the specified key based on value or digest comparison.","O(1) for IFEQ/IFNE, O(N) for IFDEQ/IFDNE where N is the length of the string value.","8.4.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,DELEX_History,0,DELEX_Tips,0,delexCommand,-2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STRING,DELEX_Keyspecs,1,delexGetKeys,2),.args=DELEX_Args},
 {MAKE_CMD("digest","Returns the XXH3 hash of a string value.","O(N) where N is the length of the string value.","8.4.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,DIGEST_History,0,DIGEST_Tips,0,digestCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_STRING,DIGEST_Keyspecs,1,NULL,1),.args=DIGEST_Args},
-{MAKE_CMD("gcra","Rate limit via GCRA (Generic Cell Rate Algorithm).","O(1)","8.8.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GCRA_History,0,GCRA_Tips,0,gcraCommand,-5,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_RATE_LIMIT,GCRA_Keyspecs,1,NULL,5),.args=GCRA_Args},
-{MAKE_CMD("gcrasettat","An internal command for recording a GCRA TAT value during AOF rewrite.","O(1)","8.8.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GCRASETTAT_History,0,GCRASETTAT_Tips,0,gcraSetTATCommand,3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_RATE_LIMIT,GCRASETTAT_Keyspecs,1,NULL,2),.args=GCRASETTAT_Args},
 {MAKE_CMD("get","Returns the string value of a key.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GET_History,0,GET_Tips,0,getCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_STRING,GET_Keyspecs,1,NULL,1),.args=GET_Args},
 {MAKE_CMD("getdel","Returns the string value of a key after deleting the key.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GETDEL_History,0,GETDEL_Tips,0,getdelCommand,2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STRING,GETDEL_Keyspecs,1,NULL,1),.args=GETDEL_Args},
 {MAKE_CMD("getex","Returns the string value of a key after setting its expiration time.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GETEX_History,0,GETEX_Tips,0,getexCommand,-2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STRING,GETEX_Keyspecs,1,NULL,2),.args=GETEX_Args},

--- a/src/commands/gcra.json
+++ b/src/commands/gcra.json
@@ -2,7 +2,7 @@
     "GCRA": {
         "summary": "Rate limit via GCRA (Generic Cell Rate Algorithm).",
         "complexity": "O(1)",
-        "group": "string",
+        "group": "rate_limit",
         "since": "8.8.0",
         "arity": -5,
         "function": "gcraCommand",

--- a/src/commands/gcra.json
+++ b/src/commands/gcra.json
@@ -12,7 +12,7 @@
             "FAST"
         ],
         "acl_categories": [
-            "STRING"
+            "RATE_LIMIT"
         ],
         "key_specs": [
             {

--- a/src/commands/gcrarecord.json
+++ b/src/commands/gcrarecord.json
@@ -1,0 +1,55 @@
+{
+    "GCRARECORD": {
+        "summary": "An internal command for recording a GCRA TAT value during AOF rewrite.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "8.8.0",
+        "arity": 3,
+        "function": "gcraRecordCommand",
+        "doc_flags": [
+            "SYSCMD"
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "tat",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/src/commands/gcrasettat.json
+++ b/src/commands/gcrasettat.json
@@ -2,7 +2,7 @@
     "GCRASETTAT": {
         "summary": "An internal command for recording a GCRA TAT value during AOF rewrite.",
         "complexity": "O(1)",
-        "group": "string",
+        "group": "rate_limit",
         "since": "8.8.0",
         "arity": 3,
         "function": "gcraSetTATCommand",

--- a/src/commands/gcrasettat.json
+++ b/src/commands/gcrasettat.json
@@ -1,21 +1,18 @@
 {
-    "GCRARECORD": {
+    "GCRASETTAT": {
         "summary": "An internal command for recording a GCRA TAT value during AOF rewrite.",
         "complexity": "O(1)",
         "group": "string",
         "since": "8.8.0",
         "arity": 3,
-        "function": "gcraRecordCommand",
-        "doc_flags": [
-            "SYSCMD"
-        ],
+        "function": "gcraSetTATCommand",
         "command_flags": [
             "WRITE",
             "DENYOOM",
             "FAST"
         ],
         "acl_categories": [
-            "STRING"
+            "RATE_LIMIT"
         ],
         "key_specs": [
             {

--- a/src/commands/gcrasetvalue.json
+++ b/src/commands/gcrasetvalue.json
@@ -1,11 +1,11 @@
 {
-    "GCRASETTAT": {
-        "summary": "An internal command for recording a GCRA TAT value during AOF rewrite.",
+    "GCRASETVALUE": {
+        "summary": "An internal command for recording a GCRA TAT value during AOF rewrite and replication.",
         "complexity": "O(1)",
         "group": "rate_limit",
         "since": "8.8.0",
         "arity": 3,
-        "function": "gcraSetTATCommand",
+        "function": "gcraSetValueCommand",
         "command_flags": [
             "WRITE",
             "DENYOOM",

--- a/src/config.c
+++ b/src/config.c
@@ -2917,7 +2917,7 @@ static int setConfigNotifyKeyspaceEventsOption(standardConfig *config, sds *argv
     }
     int flags = keyspaceEventsStringToFlags(argv[0]);
     if (flags == -1) {
-        *err = "Invalid event class character. Use 'Ag$lshzxeKEtmdn'.";
+        *err = "Invalid event class character. Use 'Ag$lshzxeKEtmdnocr'.";
         return 0;
     }
     server.notify_keyspace_events = flags;

--- a/src/db.c
+++ b/src/db.c
@@ -1756,7 +1756,8 @@ char *obj_type_name[OBJ_TYPE_MAX] = {
     "zset", 
     "hash", 
     NULL, /* module type is special */
-    "stream"
+    "stream",
+    "gcra"
 };
 
 /* Helper function to get type from a string in scan commands */
@@ -2438,6 +2439,7 @@ void copyCommand(client *c) {
         case OBJ_ZSET: newobj = zsetDup(o); break;
         case OBJ_HASH: newobj = hashTypeDup(o, &minHashExpire); break;
         case OBJ_STREAM: newobj = streamDup(o); break;
+        case OBJ_GCRA: newobj = gcraDup(o); break;
         case OBJ_MODULE:
             newobj = moduleTypeDupOrReply(c, key, newkey, dst->id, o);
             if (!newobj) return;

--- a/src/debug.c
+++ b/src/debug.c
@@ -124,12 +124,12 @@ void mixStringObjectDigest(unsigned char *digest, robj *o) {
 }
 
 void mixGCRAObjectDigest(unsigned char *digest, robj *o) {
-    char buf[32];
+    char buf[LONG_STR_SIZE];
     long long val;
     if (getLongLongFromGCRAObject(o, &val) == C_ERR) {
         serverPanic("invalid gcra object");
     }
-    int len = ll2string(buf, 32, val);
+    int len = ll2string(buf, sizeof(buf), val);
     mixDigest(digest,buf,len);
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -126,9 +126,7 @@ void mixStringObjectDigest(unsigned char *digest, robj *o) {
 void mixGCRAObjectDigest(unsigned char *digest, robj *o) {
     char buf[LONG_STR_SIZE];
     long long val;
-    if (getLongLongFromGCRAObject(o, &val) == C_ERR) {
-        serverPanic("invalid gcra object");
-    }
+    getLongLongFromGCRAObject(o, &val);
     int len = ll2string(buf, sizeof(buf), val);
     mixDigest(digest,buf,len);
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -130,9 +130,7 @@ void mixGCRAObjectDigest(unsigned char *digest, robj *o) {
         serverPanic("invalid gcra object");
     }
     int len = ll2string(buf, 32, val);
-    o = createStringObject(buf, len);
-    mixDigest(digest,o->ptr,sdslen(o->ptr));
-    decrRefCount(o);
+    mixDigest(digest,buf,len);
 }
 
 /* This function computes the digest of a data structure stored in the

--- a/src/debug.c
+++ b/src/debug.c
@@ -1317,8 +1317,9 @@ void serverLogObjectDebugInfo(const robj *o) {
     } else if (o->type == OBJ_STREAM) {
         serverLog(LL_WARNING,"Stream size: %d", (int) streamLength(o));
     } else if (o->type == OBJ_GCRA) {
-        if (o->encoding == OBJ_ENCODING_INT)
-            serverLog(LL_WARNING,"GCRA object: %lld", (long long)o->ptr);
+#if UINTPTR_MAX == 0xffffffff
+            serverLog(LL_WARNING, "GCRA object: %lld", (long long)o->ptr);
+#endif
     }
 #endif
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -123,6 +123,18 @@ void mixStringObjectDigest(unsigned char *digest, robj *o) {
     decrRefCount(o);
 }
 
+void mixGCRAObjectDigest(unsigned char *digest, robj *o) {
+    char buf[32];
+    long long val;
+    if (getLongLongFromGCRAObject(o, &val) == C_ERR) {
+        serverPanic("invalid gcra object");
+    }
+    int len = ll2string(buf, 32, val);
+    o = createStringObject(buf, len);
+    mixDigest(digest,o->ptr,sdslen(o->ptr));
+    decrRefCount(o);
+}
+
 /* This function computes the digest of a data structure stored in the
  * object 'o'. It is the core of the DEBUG DIGEST command: when taking the
  * digest of a whole dataset, we take the digest of the key and the value
@@ -255,6 +267,8 @@ void xorObjectDigest(redisDb *db, robj *keyobj, unsigned char *digest, robj *o) 
             }
         }
         streamIteratorStop(&si);
+    } else if (o->type == OBJ_GCRA) {
+        mixGCRAObjectDigest(digest, o);
     } else if (o->type == OBJ_MODULE) {
         RedisModuleDigest md = {{0},{0},keyobj,db->id};
         moduleValue *mv = o->ptr;
@@ -1302,6 +1316,8 @@ void serverLogObjectDebugInfo(const robj *o) {
             serverLog(LL_WARNING,"Skiplist level: %d", (int) ((const zset*)o->ptr)->zsl->level);
     } else if (o->type == OBJ_STREAM) {
         serverLog(LL_WARNING,"Stream size: %d", (int) streamLength(o));
+    } else if (o->type == OBJ_GCRA) {
+        serverLog(LL_WARNING,"GCRA object: %lld", *((long long*)o->ptr));
     }
 #endif
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -1313,7 +1313,7 @@ void serverLogObjectDebugInfo(const robj *o) {
     } else if (o->type == OBJ_STREAM) {
         serverLog(LL_WARNING,"Stream size: %d", (int) streamLength(o));
     } else if (o->type == OBJ_GCRA) {
-#if UINTPTR_MAX == 0xffffffff
+#if UINTPTR_MAX == 0xffffffffffffffff
         serverLog(LL_WARNING, "GCRA object: %lld", (long long)o->ptr);
 #endif
     }

--- a/src/debug.c
+++ b/src/debug.c
@@ -1316,7 +1316,7 @@ void serverLogObjectDebugInfo(const robj *o) {
         serverLog(LL_WARNING,"Stream size: %d", (int) streamLength(o));
     } else if (o->type == OBJ_GCRA) {
 #if UINTPTR_MAX == 0xffffffff
-            serverLog(LL_WARNING, "GCRA object: %lld", (long long)o->ptr);
+        serverLog(LL_WARNING, "GCRA object: %lld", (long long)o->ptr);
 #endif
     }
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -1317,7 +1317,8 @@ void serverLogObjectDebugInfo(const robj *o) {
     } else if (o->type == OBJ_STREAM) {
         serverLog(LL_WARNING,"Stream size: %d", (int) streamLength(o));
     } else if (o->type == OBJ_GCRA) {
-        serverLog(LL_WARNING,"GCRA object: %lld", *((long long*)o->ptr));
+        if (o->encoding == OBJ_ENCODING_INT)
+            serverLog(LL_WARNING,"GCRA object: %lld", (long long)o->ptr);
     }
 #endif
 }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1165,9 +1165,11 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
         defragStream(ctx, ob);
     } else if (ob->type == OBJ_GCRA) {
         /* GCRA object is just an allocation to a long long value */
-        void *newptr, *ptr = ob->ptr;
-        if ((newptr = activeDefragAlloc(ptr)))
-            ob->ptr = newptr;
+        if (ob->encoding == OBJOBJ_ENCODING_RAW) {
+            void *newptr, *ptr = ob->ptr;
+            if ((newptr = activeDefragAlloc(ptr)))
+                ob->ptr = newptr;
+        }
     } else if (ob->type == OBJ_MODULE) {
         defragModule(ctx,db, ob);
     } else {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1165,7 +1165,7 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
         defragStream(ctx, ob);
     } else if (ob->type == OBJ_GCRA) {
         /* GCRA object is just an allocation to a long long value */
-        if (ob->encoding == OBJOBJ_ENCODING_RAW) {
+        if (ob->encoding == OBJ_ENCODING_RAW) {
             void *newptr, *ptr = ob->ptr;
             if ((newptr = activeDefragAlloc(ptr)))
                 ob->ptr = newptr;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1166,9 +1166,9 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
     } else if (ob->type == OBJ_GCRA) {
         /* GCRA object is just an allocation to a long long value */
 #if UINTPTR_MAX == 0xffffffff
-            void *newptr, *ptr = ob->ptr;
-            if ((newptr = activeDefragAlloc(ptr)))
-                ob->ptr = newptr;
+        void *newptr, *ptr = ob->ptr;
+        if ((newptr = activeDefragAlloc(ptr)))
+            ob->ptr = newptr;
 #endif
     } else if (ob->type == OBJ_MODULE) {
         defragModule(ctx,db, ob);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1165,11 +1165,11 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
         defragStream(ctx, ob);
     } else if (ob->type == OBJ_GCRA) {
         /* GCRA object is just an allocation to a long long value */
-        if (ob->encoding == OBJ_ENCODING_PTRINT) {
+#if UINTPTR_MAX == 0xffffffff
             void *newptr, *ptr = ob->ptr;
             if ((newptr = activeDefragAlloc(ptr)))
                 ob->ptr = newptr;
-        }
+#endif
     } else if (ob->type == OBJ_MODULE) {
         defragModule(ctx,db, ob);
     } else {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1165,7 +1165,7 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
         defragStream(ctx, ob);
     } else if (ob->type == OBJ_GCRA) {
         /* GCRA object is just an allocation to a long long value */
-        if (ob->encoding == OBJ_ENCODING_RAW) {
+        if (ob->encoding == OBJ_ENCODING_PTRINT) {
             void *newptr, *ptr = ob->ptr;
             if ((newptr = activeDefragAlloc(ptr)))
                 ob->ptr = newptr;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1163,6 +1163,11 @@ void defragKey(defragKeysCtx *ctx, dictEntry *de, dictEntryLink link) {
         }
     } else if (ob->type == OBJ_STREAM) {
         defragStream(ctx, ob);
+    } else if (ob->type == OBJ_GCRA) {
+        /* GCRA object is just an allocation to a long long value */
+        void *newptr, *ptr = ob->ptr;
+        if ((newptr = activeDefragAlloc(ptr)))
+            ob->ptr = newptr;
     } else if (ob->type == OBJ_MODULE) {
         defragModule(ctx,db, ob);
     } else {

--- a/src/gcra.c
+++ b/src/gcra.c
@@ -210,10 +210,10 @@ void gcraCommand(client *c) {
         /* Replicating the command directly would mess up TaT as we use
          * commandTimeSnapshot. We instead rewrite the command as SET with the
          * appropriate expire time. */
-        robj *gcrarecord = createStringObject("GCRARECORD", 10);
+        robj *gcrasettat= createStringObject("GCRASETTAT", 10);
         robj *newtatstr = createStringObjectFromLongLong(new_tat_us);
-        rewriteClientCommandVector(c, 3, gcrarecord, key, newtatstr);
-        decrRefCount(gcrarecord);
+        rewriteClientCommandVector(c, 3, gcrasettat, key, newtatstr);
+        decrRefCount(gcrasettat);
         decrRefCount(newtatstr);
 
         server.dirty++;
@@ -233,10 +233,10 @@ void gcraCommand(client *c) {
     addReplyLongLong(c, reset_after_s);
 }
 
-/* GCRARECORD key tat
+/* GCRASETTAT key tat
  *
  * Internal command used during AOF rewrite to record a GCRA TAT value. */
-void gcraRecordCommand(client *c) {
+void gcraSetTATCommand(client *c) {
     robj *key = c->argv[1];
     robj *tat = c->argv[2];
     long long when;

--- a/src/gcra.c
+++ b/src/gcra.c
@@ -210,10 +210,10 @@ void gcraCommand(client *c) {
         /* Replicating the command directly would mess up TaT as we use
          * commandTimeSnapshot. We instead rewrite the command as SET with the
          * appropriate expire time. */
-        robj *gcrasettat= createStringObject("GCRASETTAT", 10);
+        robj *gcrasetvalue = createStringObject("GCRASETVALUE", 12);
         robj *newtatstr = createStringObjectFromLongLong(new_tat_us);
-        rewriteClientCommandVector(c, 3, gcrasettat, key, newtatstr);
-        decrRefCount(gcrasettat);
+        rewriteClientCommandVector(c, 3, gcrasetvalue, key, newtatstr);
+        decrRefCount(gcrasetvalue);
         decrRefCount(newtatstr);
 
         server.dirty++;
@@ -233,10 +233,12 @@ void gcraCommand(client *c) {
     addReplyLongLong(c, reset_after_s);
 }
 
-/* GCRASETTAT key tat
+/* GCRASETVALUE key tat
  *
- * Internal command used during AOF rewrite to record a GCRA TAT value. */
-void gcraSetTATCommand(client *c) {
+ * Internal command used during AOF rewrite to record a GCRA TAT value. The GCRA
+ * command is also rewritten as GCRASETVALUE for replication since GCRA uses
+ * commandTimeSnapshot. */
+void gcraSetValueCommand(client *c) {
     robj *key = c->argv[1];
     robj *tat = c->argv[2];
     long long when;
@@ -251,6 +253,8 @@ void gcraSetTATCommand(client *c) {
 
     robj *tatobj = createGCRAObject(when);
     setKeyByLink(c, c->db, key, &tatobj, kv ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST, &link);
+    notifyKeyspaceEvent(NOTIFY_RATE_LIMIT,"gcra",key,c->db->id);
+
     long long when_ms = when / 1000;
     kv = setExpireByLink(c, c->db, key->ptr, when_ms, link);
     notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);

--- a/src/gcra.c
+++ b/src/gcra.c
@@ -252,7 +252,11 @@ void gcraSetValueCommand(client *c) {
     kvobj *kv = lookupKeyWriteWithLink(c->db, key, &link);
     if (checkType(c, kv, OBJ_GCRA)) return;
 
-    if (getLongLongFromObjectOrReply(c, tat, &when, "Invalid tat value") == C_ERR) {
+    if (getLongLongFromObjectOrReply(c, tat, &when, "Invalid TaT value") == C_ERR) {
+        return;
+    }
+    if (when < 0) {
+        addReplyError(c, "Invalid negative TaT value");
         return;
     }
 

--- a/src/gcra.c
+++ b/src/gcra.c
@@ -129,21 +129,12 @@ void gcraCommand(client *c) {
     long long tat_us, new_tat_us;
     dictEntryLink link;
     kvobj *kv = lookupKeyWriteWithLink(c->db, key, &link);
-    if (checkType(c, kv, OBJ_STRING)) {
+    if (checkType(c, kv, OBJ_GCRA)) {
         return;
     }
     if (kv != NULL) {
-        /* Note the value of the key may have been overwritten outside of the
-         * GCRA command (f.e by calling SET). We don't try to catch such errors
-         * as this would be possible only with a dedicated structures for GCRA,
-         * while using STRING gives us all the benefits of a redis key -
-         * replication, setting expiration, etc. */
-        if (getLongLongFromObject(kv, &tat_us) != C_OK) {
-            addReplyError(c, "Invalid GCRA key");
-            return;
-        }
-        if (tat_us <= 0) {
-            addReplyError(c, "Negative time is invalid value for GCRA");
+        if (getLongLongFromGCRAObject(kv, &tat_us) != C_OK) {
+            addReplyError(c, "invalid value for GCRA");
             return;
         }
     } else {
@@ -208,9 +199,9 @@ void gcraCommand(client *c) {
     } else {
         limited = 0;
         ttl_us = new_tat_us - now;
-        robj *tatobj = createStringObjectFromLongLong(new_tat_us);
+        robj *tatobj = createGCRAObject(new_tat_us);
         setKeyByLink(c, c->db, key, &tatobj, kv ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST, &link);
-        notifyKeyspaceEvent(NOTIFY_STRING,"set",key,c->db->id);
+        notifyKeyspaceEvent(NOTIFY_GENERIC,"gcra",key,c->db->id);
 
         long long when = new_tat_us / 1000;
         kv = setExpireByLink(c, c->db, key->ptr, when, link);
@@ -219,9 +210,11 @@ void gcraCommand(client *c) {
         /* Replicating the command directly would mess up TaT as we use
          * commandTimeSnapshot. We instead rewrite the command as SET with the
          * appropriate expire time. */
-        robj *pexat_obj = createStringObjectFromLongLong(when);
-        rewriteClientCommandVector(c, 5, shared.set, key, kv, shared.pxat, pexat_obj);
-        decrRefCount(pexat_obj);
+        robj *gcrarecord = createStringObject("GCRARECORD", 10);
+        robj *newtatstr = createStringObjectFromLongLong(new_tat_us);
+        rewriteClientCommandVector(c, 3, gcrarecord, key, newtatstr);
+        decrRefCount(gcrarecord);
+        decrRefCount(newtatstr);
 
         server.dirty++;
     }
@@ -238,4 +231,36 @@ void gcraCommand(client *c) {
     addReplyLongLong(c, remaining);
     addReplyLongLong(c, retry_after_s);
     addReplyLongLong(c, reset_after_s);
+}
+
+/* GCRARECORD key tat
+ *
+ * Internal command used during AOF rewrite to record a GCRA TAT value. */
+void gcraRecordCommand(client *c) {
+    robj *key = c->argv[1];
+    robj *tat = c->argv[2];
+    long long when;
+
+    dictEntryLink link;
+    kvobj *kv = lookupKeyWriteWithLink(c->db, key, &link);
+    if (checkType(c, kv, OBJ_GCRA)) return;
+
+    if (getLongLongFromObjectOrReply(c, tat, &when, "Invalid tat value") == C_ERR) {
+        return;
+    }
+
+    robj *tatobj = createGCRAObject(when);
+    setKeyByLink(c, c->db, key, &tatobj, kv ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST, &link);
+    long long when_ms = when / 1000;
+    kv = setExpireByLink(c, c->db, key->ptr, when_ms, link);
+    notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);
+    server.dirty++;
+
+    addReply(c, shared.ok);
+}
+
+robj *gcraDup(robj *o) {
+    long long val;
+    serverAssert(getLongLongFromGCRAObject(o, &val) == C_OK);
+    return createGCRAObject(val);
 }

--- a/src/gcra.c
+++ b/src/gcra.c
@@ -133,10 +133,7 @@ void gcraCommand(client *c) {
         return;
     }
     if (kv != NULL) {
-        if (getLongLongFromGCRAObject(kv, &tat_us) != C_OK) {
-            addReplyError(c, "invalid value for GCRA");
-            return;
-        }
+        getLongLongFromGCRAObject(kv, &tat_us);
     } else {
         tat_us = now;
     }
@@ -274,6 +271,6 @@ void gcraSetValueCommand(client *c) {
 
 robj *gcraDup(robj *o) {
     long long val;
-    serverAssert(getLongLongFromGCRAObject(o, &val) == C_OK);
+    getLongLongFromGCRAObject(o, &val);
     return createGCRAObject(val);
 }

--- a/src/gcra.c
+++ b/src/gcra.c
@@ -201,7 +201,7 @@ void gcraCommand(client *c) {
         ttl_us = new_tat_us - now;
         robj *tatobj = createGCRAObject(new_tat_us);
         setKeyByLink(c, c->db, key, &tatobj, kv ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST, &link);
-        notifyKeyspaceEvent(NOTIFY_GENERIC,"gcra",key,c->db->id);
+        notifyKeyspaceEvent(NOTIFY_RATE_LIMIT,"gcra",key,c->db->id);
 
         long long when = new_tat_us / 1000;
         kv = setExpireByLink(c, c->db, key->ptr, when, link);

--- a/src/gcra.c
+++ b/src/gcra.c
@@ -203,6 +203,14 @@ void gcraCommand(client *c) {
         setKeyByLink(c, c->db, key, &tatobj, kv ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST, &link);
         notifyKeyspaceEvent(NOTIFY_RATE_LIMIT,"gcra",key,c->db->id);
 
+        /* The key implicitly sets its own expiry time (which is basically the
+         * TaT after which time the value is no longer of any use). That way even
+         * if only one GCRA command is called on a key it will automatically
+         * expire after reaching its TaT without user needing to explicitly call
+         * DEL on it.
+         * These keys are expected to be numerous and short lived thus the
+         * decision to keep the implicit expiraty.
+         * NOTE: idea is same as in redis-cell. */
         long long when = new_tat_us / 1000;
         kv = setExpireByLink(c, c->db, key->ptr, when, link);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);
@@ -255,6 +263,7 @@ void gcraSetValueCommand(client *c) {
     setKeyByLink(c, c->db, key, &tatobj, kv ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST, &link);
     notifyKeyspaceEvent(NOTIFY_RATE_LIMIT,"gcra",key,c->db->id);
 
+    /* Just like the base GCRA command we set the expire time of the key implicitly. */
     long long when_ms = when / 1000;
     kv = setExpireByLink(c, c->db, key->ptr, when_ms, link);
     notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);

--- a/src/module.c
+++ b/src/module.c
@@ -9205,8 +9205,8 @@ void moduleReleaseGIL(void) {
  *  - REDISMODULE_NOTIFY_KEY_TRIMMED: Key trimmed events after a slot migration operation
  *  - REDISMODULE_NOTIFY_ALL: All events (Excluding REDISMODULE_NOTIFY_KEYMISS,
  *                            REDISMODULE_NOTIFY_NEW, REDISMODULE_NOTIFY_OVERWRITTEN,
- *                            REDISMODULE_NOTIFY_TYPE_CHANGED
- *                            and REDISMODULE_NOTIFY_KEY_TRIMMED)
+ *                            REDISMODULE_NOTIFY_TYPE_CHANGED, REDISMODULE_NOTIFY_KEY_TRIMMED
+ *                            and REDISMODULE_NOTIFY_RATE_LIMIT)
  *  - REDISMODULE_NOTIFY_LOADED: A special notification available only for modules,
  *                               indicates that the key was loaded from persistence.
  *                               Notice, when this event fires, the given key

--- a/src/module.c
+++ b/src/module.c
@@ -9203,6 +9203,7 @@ void moduleReleaseGIL(void) {
  *  - REDISMODULE_NOTIFY_OVERWRITTEN: Overwritten events
  *  - REDISMODULE_NOTIFY_TYPE_CHANGED: Type-changed events
  *  - REDISMODULE_NOTIFY_KEY_TRIMMED: Key trimmed events after a slot migration operation
+ *  - REDISMODULE_NOTIFY_RATE_LIMIT: Rate limit event
  *  - REDISMODULE_NOTIFY_ALL: All events (Excluding REDISMODULE_NOTIFY_KEYMISS,
  *                            REDISMODULE_NOTIFY_NEW, REDISMODULE_NOTIFY_OVERWRITTEN,
  *                            REDISMODULE_NOTIFY_TYPE_CHANGED, REDISMODULE_NOTIFY_KEY_TRIMMED

--- a/src/module.c
+++ b/src/module.c
@@ -4225,6 +4225,7 @@ int RM_KeyType(RedisModuleKey *key) {
     case OBJ_HASH: return REDISMODULE_KEYTYPE_HASH;
     case OBJ_MODULE: return REDISMODULE_KEYTYPE_MODULE;
     case OBJ_STREAM: return REDISMODULE_KEYTYPE_STREAM;
+    case OBJ_GCRA: return REDISMODULE_KEYTYPE_GCRA;
     default: return REDISMODULE_KEYTYPE_EMPTY;
     }
 }

--- a/src/notify.c
+++ b/src/notify.c
@@ -40,6 +40,7 @@ int keyspaceEventsStringToFlags(char *classes) {
         case 'n': flags |= NOTIFY_NEW; break;
         case 'o': flags |= NOTIFY_OVERWRITTEN; break;
         case 'c': flags |= NOTIFY_TYPE_CHANGED; break;
+        case 'r': flags |= NOTIFY_RATE_LIMIT; break;
         default: return -1;
         }
     }
@@ -70,6 +71,7 @@ sds keyspaceEventsFlagsToString(int flags) {
         if (flags & NOTIFY_NEW) res = sdscatlen(res,"n",1);
         if (flags & NOTIFY_OVERWRITTEN) res = sdscatlen(res,"o",1);
         if (flags & NOTIFY_TYPE_CHANGED) res = sdscatlen(res,"c",1);
+        if (flags & NOTIFY_RATE_LIMIT) res = sdscatlen(res,"r",1);
     }
     if (flags & NOTIFY_KEYSPACE) res = sdscatlen(res,"K",1);
     if (flags & NOTIFY_KEYEVENT) res = sdscatlen(res,"E",1);

--- a/src/object.c
+++ b/src/object.c
@@ -1319,12 +1319,14 @@ size_t kvobjAllocSize(kvobj *o) {
 }
 
 size_t gcraTypeAllocSize(robj *o) {
+    (void)o;
+#if UINTPTR_MAX == 0xffffffff
+    return sizeof(long long);
+#else
     /* Same as string with int encoding there is no allocation as the value is
      * cast to void* and stored in o->ptr */
-    if (o->encoding == OBJ_ENCODING_INT) return 0;
-
-    /* Else the value is heap allocated */
-    return sizeof(long long);
+    return 0;
+#endif
 }
 
 /* The gcra object is a single long long value */

--- a/src/object.c
+++ b/src/object.c
@@ -605,7 +605,7 @@ void freeStreamObject(robj *o) {
 
 void freeGCRAObject(robj *o) {
 #if UINTPTR_MAX == 0xffffffff
-        zfree(o->ptr);
+    zfree(o->ptr);
 #else
     (void)o;
 #endif

--- a/src/object.c
+++ b/src/object.c
@@ -522,13 +522,12 @@ robj *createGCRAObject(long long value) {
     long long *v = zmalloc(sizeof(long long));
     *v = value;
     robj *o = createObject(OBJ_GCRA,v);
-    o->encoding = OBJ_ENCODING_PTRINT;
 #else
     robj *o = createObject(OBJ_GCRA,NULL);
-    o->encoding = OBJ_ENCODING_INT;
     o->ptr = (void*)value;
 #endif
 
+    o->encoding = OBJ_ENCODING_INT;
     return o;
 }
 
@@ -605,8 +604,11 @@ void freeStreamObject(robj *o) {
 }
 
 void freeGCRAObject(robj *o) {
-    if (o->encoding == OBJ_ENCODING_PTRINT)
+#if UINTPTR_MAX == 0xffffffff
         zfree(o->ptr);
+#else
+    (void)o;
+#endif
 }
 
 void incrRefCount(robj *o) {
@@ -1176,11 +1178,10 @@ int getLongLongFromGCRAObject(robj *o, long long *target) {
         res = 0;
     } else {
         serverAssertWithInfo(NULL, o, o->type == OBJ_GCRA);
+        serverAssert(o->encoding == OBJ_ENCODING_INT);
 #if UINTPTR_MAX == 0xffffffff
-        serverAssert(o->encoding == OBJ_ENCODING_PTRINT);
         res = *((long long*)o->ptr);
 #else
-        serverAssert(o->encoding == OBJ_ENCODING_INT);
         res = (long long)o->ptr;
 #endif
 
@@ -1265,7 +1266,6 @@ char *strEncoding(int encoding) {
     case OBJ_ENCODING_SKIPLIST: return "skiplist";
     case OBJ_ENCODING_EMBSTR: return "embstr";
     case OBJ_ENCODING_STREAM: return "stream";
-    case OBJ_ENCODING_PTRINT: return "ptrint";
     default: return "unknown";
     }
 }

--- a/src/object.c
+++ b/src/object.c
@@ -522,12 +522,12 @@ robj *createGCRAObject(long long value) {
         long long *v = zmalloc(sizeof(long long));
         *v = value;
         return createObject(OBJ_GCRA,v);
-#endif
-
+#else
     robj *o = createObject(OBJ_GCRA,NULL);
     o->encoding = OBJ_ENCODING_INT;
     o->ptr = (void*)value;
     return o;
+#endif
 }
 
 robj *createModuleObject(moduleType *mt, void *value) {

--- a/src/object.c
+++ b/src/object.c
@@ -1182,7 +1182,7 @@ int getLongLongFromGCRAObject(robj *o, long long *target) {
     res = (long long)o->ptr;
 #endif
     if (unlikely(res < 0)) {
-        return C_ERR;
+        serverPanic("Invalid negative GCRA value");
     }
     *target = res;
     return C_OK;

--- a/src/object.c
+++ b/src/object.c
@@ -1265,6 +1265,7 @@ char *strEncoding(int encoding) {
     case OBJ_ENCODING_SKIPLIST: return "skiplist";
     case OBJ_ENCODING_EMBSTR: return "embstr";
     case OBJ_ENCODING_STREAM: return "stream";
+    case OBJ_ENCODING_PTRINT: return "ptrint";
     default: return "unknown";
     }
 }

--- a/src/object.c
+++ b/src/object.c
@@ -1174,20 +1174,15 @@ int getLongLongFromObject(robj *o, long long *target) {
 
 int getLongLongFromGCRAObject(robj *o, long long *target) {
     long long res;
-    if (o == NULL) {
-        res = 0;
-    } else {
-        serverAssertWithInfo(NULL, o, o->type == OBJ_GCRA);
-        serverAssert(o->encoding == OBJ_ENCODING_INT);
+    serverAssertWithInfo(NULL, o, o->type == OBJ_GCRA);
+    serverAssert(o->encoding == OBJ_ENCODING_INT);
 #if UINTPTR_MAX == 0xffffffff
-        res = *((long long*)o->ptr);
+    res = *((long long*)o->ptr);
 #else
-        res = (long long)o->ptr;
+    res = (long long)o->ptr;
 #endif
-
-        if (unlikely(res < 0)) {
-            return C_ERR;
-        }
+    if (unlikely(res < 0)) {
+        return C_ERR;
     }
     *target = res;
     return C_OK;

--- a/src/object.c
+++ b/src/object.c
@@ -515,14 +515,18 @@ robj *createStreamObject(void) {
 }
 
 robj *createGCRAObject(long long value) {
-    /* NOTE: we can't use integer encoding here (as OBJ_STRING does) as the
-     * GCRA object is a unixtime value in microseconds. As of the time of writing
-     * of this function the unixtime in microseconds is already much more than
-     * LONG_MAX. We also can't really use the pointer assuming it's 8 bytes as
-     * we want to support 32-bit systems. */
-    long long *v = zmalloc(sizeof(long long));
-    *v = value;
-    robj *o = createObject(OBJ_GCRA,v);
+    /* NOTE: for 32-bit systems we can't use integer encoding (as OBJ_STRING does)
+     * as the GCRA object is a unixtime value in microseconds, which as of the
+     * time of writing is already much more than LONG_MAX. */
+#if UINTPTR_MAX == 0xffffffff
+        long long *v = zmalloc(sizeof(long long));
+        *v = value;
+        return createObject(OBJ_GCRA,v);
+#endif
+
+    robj *o = createObject(OBJ_GCRA,NULL);
+    o->encoding = OBJ_ENCODING_INT;
+    o->ptr = (void*)value;
     return o;
 }
 
@@ -599,7 +603,8 @@ void freeStreamObject(robj *o) {
 }
 
 void freeGCRAObject(robj *o) {
-    zfree(o->ptr);
+    if (o->encoding == OBJ_ENCODING_RAW)
+        zfree(o->ptr);
 }
 
 void incrRefCount(robj *o) {
@@ -1169,9 +1174,15 @@ int getLongLongFromGCRAObject(robj *o, long long *target) {
         res = 0;
     } else {
         serverAssertWithInfo(NULL, o, o->type == OBJ_GCRA);
-        res = *((long long*)o->ptr);
+        if (o->encoding == OBJ_ENCODING_RAW) {
+            res = *((long long*)o->ptr);
+        } else if (o->encoding == OBJ_ENCODING_INT) {
+            res = (long long)o->ptr;
+        } else {
+            serverPanic("Unknown GCRA encoding");
+        }
 
-        if (res < 0) {
+        if (unlikely(res < 0)) {
             return C_ERR;
         }
     }
@@ -1297,14 +1308,17 @@ size_t kvobjAllocSize(kvobj *o) {
         stream *s = o->ptr;
         asize += s->alloc_size;
     } else if (o->type == OBJ_GCRA) {
-        asize += gcraTypeAllocSize();
+        asize += gcraTypeAllocSize(o);
     } else if (o->type == OBJ_MODULE) {
         /* TODO: Provide moduleGetAllocSize() module API for O(1) allocation size retrieval */
     }
     return asize;
 }
 
-size_t gcraTypeAllocSize(void) {
+size_t gcraTypeAllocSize(robj *o) {
+    /* Same as string with int encoding there is no allocation as the value is
+     * stored as void* in o->ptr */
+    if (o->encoding == OBJ_ENCODING_INT) return 0;
     return sizeof(long long);
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -517,11 +517,12 @@ robj *createStreamObject(void) {
 robj *createGCRAObject(long long value) {
     /* NOTE: for 32-bit systems we can't use integer encoding (as OBJ_STRING does)
      * as the GCRA object is a unixtime value in microseconds, which as of the
-     * time of writing is already much more than LONG_MAX. */
+     * time of writing is already much more than 32-bit's LONG_MAX. */
 #if UINTPTR_MAX == 0xffffffff
         long long *v = zmalloc(sizeof(long long));
         *v = value;
-        return createObject(OBJ_GCRA,v);
+        robj *o = createObject(OBJ_GCRA,v);
+        o->encoding = OBJ_ENCODING_PTRINT;
 #else
     robj *o = createObject(OBJ_GCRA,NULL);
     o->encoding = OBJ_ENCODING_INT;
@@ -603,7 +604,7 @@ void freeStreamObject(robj *o) {
 }
 
 void freeGCRAObject(robj *o) {
-    if (o->encoding == OBJ_ENCODING_RAW)
+    if (o->encoding == OBJ_ENCODING_PTRINT)
         zfree(o->ptr);
 }
 
@@ -1175,7 +1176,7 @@ int getLongLongFromGCRAObject(robj *o, long long *target) {
     } else {
         serverAssertWithInfo(NULL, o, o->type == OBJ_GCRA);
 #if UINTPTR_MAX == 0xffffffff
-        serverAssert(o->encoding == OBJ_ENCODING_RAW);
+        serverAssert(o->encoding == OBJ_ENCODING_PTRINT);
         res = *((long long*)o->ptr);
 #else
         serverAssert(o->encoding == OBJ_ENCODING_INT);

--- a/src/object.c
+++ b/src/object.c
@@ -1174,13 +1174,13 @@ int getLongLongFromGCRAObject(robj *o, long long *target) {
         res = 0;
     } else {
         serverAssertWithInfo(NULL, o, o->type == OBJ_GCRA);
-        if (o->encoding == OBJ_ENCODING_RAW) {
-            res = *((long long*)o->ptr);
-        } else if (o->encoding == OBJ_ENCODING_INT) {
-            res = (long long)o->ptr;
-        } else {
-            serverPanic("Unknown GCRA encoding");
-        }
+#if UINTPTR_MAX == 0xffffffff
+        serverAssert(o->encoding == OBJ_ENCODING_RAW);
+        res = *((long long*)o->ptr);
+#else
+        serverAssert(o->encoding == OBJ_ENCODING_INT);
+        res = (long long)o->ptr;
+#endif
 
         if (unlikely(res < 0)) {
             return C_ERR;

--- a/src/object.c
+++ b/src/object.c
@@ -519,16 +519,17 @@ robj *createGCRAObject(long long value) {
      * as the GCRA object is a unixtime value in microseconds, which as of the
      * time of writing is already much more than 32-bit's LONG_MAX. */
 #if UINTPTR_MAX == 0xffffffff
-        long long *v = zmalloc(sizeof(long long));
-        *v = value;
-        robj *o = createObject(OBJ_GCRA,v);
-        o->encoding = OBJ_ENCODING_PTRINT;
+    long long *v = zmalloc(sizeof(long long));
+    *v = value;
+    robj *o = createObject(OBJ_GCRA,v);
+    o->encoding = OBJ_ENCODING_PTRINT;
 #else
     robj *o = createObject(OBJ_GCRA,NULL);
     o->encoding = OBJ_ENCODING_INT;
     o->ptr = (void*)value;
-    return o;
 #endif
+
+    return o;
 }
 
 robj *createModuleObject(moduleType *mt, void *value) {

--- a/src/object.c
+++ b/src/object.c
@@ -514,6 +514,18 @@ robj *createStreamObject(void) {
     return o;
 }
 
+robj *createGCRAObject(long long value) {
+    /* NOTE: we can't use integer encoding here (as OBJ_STRING does) as the
+     * GCRA object is a unixtime value in microseconds. As of the time of writing
+     * of this function the unixtime in microseconds is already much more than
+     * LONG_MAX. We also can't really use the pointer assuming it's 8 bytes as
+     * we want to support 32-bit systems. */
+    long long *v = zmalloc(sizeof(long long));
+    *v = value;
+    robj *o = createObject(OBJ_GCRA,v);
+    return o;
+}
+
 robj *createModuleObject(moduleType *mt, void *value) {
     moduleValue *mv = zmalloc(sizeof(*mv));
     mv->type = mt;
@@ -586,6 +598,10 @@ void freeStreamObject(robj *o) {
     freeStream(o->ptr);
 }
 
+void freeGCRAObject(robj *o) {
+    zfree(o->ptr);
+}
+
 void incrRefCount(robj *o) {
     if (o->refcount < OBJ_FIRST_SPECIAL_REFCOUNT - 1) {
         o->refcount++;
@@ -629,6 +645,7 @@ void decrRefCount(robj *o) {
             case OBJ_HASH: freeHashObject(o); break;
             case OBJ_MODULE: freeModuleObject(o); break;
             case OBJ_STREAM: freeStreamObject(o); break;
+            case OBJ_GCRA: freeGCRAObject(o); break;
             default: serverPanic("Unknown object type"); break;
             }
         }
@@ -780,6 +797,13 @@ void dismissStreamObject(robj *o, size_t size_hint) {
     }
 }
 
+void dismissGCRAObject(robj *o, size_t size_hint) {
+    /* GCRA is a single allocation of a long long thus way smaller than a
+     * page-size. The dismiss mechanism is not needed for it - hence NOOP.*/
+    (void)o;
+    (void)size_hint;
+}
+
 /* When creating a snapshot in a fork child process, the main process and child
  * process share the same physical memory pages, and if / when the parent
  * modifies any keys due to write traffic, it'll cause CoW which consume
@@ -808,6 +832,7 @@ void dismissObject(robj *o, size_t size_hint) {
         case OBJ_ZSET: dismissZsetObject(o, size_hint); break;
         case OBJ_HASH: dismissHashObject(o, size_hint); break;
         case OBJ_STREAM: dismissStreamObject(o, size_hint); break;
+        case OBJ_GCRA: dismissGCRAObject(o, size_hint); break;
         default: break;
     }
 #else
@@ -929,6 +954,7 @@ size_t getObjectLength(robj *o) {
         case OBJ_ZSET: return zsetLength(o);
         case OBJ_HASH: return hashTypeLength(o, 0);
         case OBJ_STREAM: return streamLength(o);
+        case OBJ_GCRA: return gcraObjectLength(o);
         default: return 0;
     }
 }
@@ -1137,6 +1163,22 @@ int getLongLongFromObject(robj *o, long long *target) {
     return C_OK;
 }
 
+int getLongLongFromGCRAObject(robj *o, long long *target) {
+    long long res;
+    if (o == NULL) {
+        res = 0;
+    } else {
+        serverAssertWithInfo(NULL, o, o->type == OBJ_GCRA);
+        res = *((long long*)o->ptr);
+
+        if (res < 0) {
+            return C_ERR;
+        }
+    }
+    *target = res;
+    return C_OK;
+}
+
 int getLongLongFromObjectOrReply(client *c, robj *o, long long *target, const char *msg) {
     long long value;
     if (getLongLongFromObject(o, &value) != C_OK) {
@@ -1227,7 +1269,8 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
         o->type == OBJ_SET ||
         o->type == OBJ_ZSET ||
         o->type == OBJ_HASH ||
-        o->type == OBJ_STREAM)
+        o->type == OBJ_STREAM ||
+        o->type == OBJ_GCRA)
     {
         return kvobjAllocSize(o);
     } else if (o->type == OBJ_MODULE) {
@@ -1253,10 +1296,22 @@ size_t kvobjAllocSize(kvobj *o) {
     } else if (o->type == OBJ_STREAM) {
         stream *s = o->ptr;
         asize += s->alloc_size;
+    } else if (o->type == OBJ_GCRA) {
+        asize += gcraTypeAllocSize();
     } else if (o->type == OBJ_MODULE) {
         /* TODO: Provide moduleGetAllocSize() module API for O(1) allocation size retrieval */
     }
     return asize;
+}
+
+size_t gcraTypeAllocSize(void) {
+    return sizeof(long long);
+}
+
+/* The gcra object is a single long long value */
+size_t gcraObjectLength(robj *o) {
+    (void)o;
+    return 1;
 }
 
 /* Release data obtained with getMemoryOverheadData(). */

--- a/src/object.c
+++ b/src/object.c
@@ -1318,8 +1318,10 @@ size_t kvobjAllocSize(kvobj *o) {
 
 size_t gcraTypeAllocSize(robj *o) {
     /* Same as string with int encoding there is no allocation as the value is
-     * stored as void* in o->ptr */
+     * cast to void* and stored in o->ptr */
     if (o->encoding == OBJ_ENCODING_INT) return 0;
+
+    /* Else the value is heap allocated */
     return sizeof(long long);
 }
 

--- a/src/object.h
+++ b/src/object.h
@@ -85,7 +85,6 @@ struct RedisModuleType;
 #define OBJ_ENCODING_STREAM 10 /* Encoded as a radix tree of listpacks */
 #define OBJ_ENCODING_LISTPACK 11 /* Encoded as a listpack */
 #define OBJ_ENCODING_LISTPACK_EX 12 /* Encoded as listpack, extended with metadata */
-#define OBJ_ENCODING_PTRINT 13 /* Encoded as pointer to integral(int, long, long long, etc.) value */
 
 #define LRU_BITS 24
 #define LRU_CLOCK_MAX ((1<<LRU_BITS)-1) /* Max value of obj->lru */

--- a/src/object.h
+++ b/src/object.h
@@ -85,6 +85,7 @@ struct RedisModuleType;
 #define OBJ_ENCODING_STREAM 10 /* Encoded as a radix tree of listpacks */
 #define OBJ_ENCODING_LISTPACK 11 /* Encoded as a listpack */
 #define OBJ_ENCODING_LISTPACK_EX 12 /* Encoded as listpack, extended with metadata */
+#define OBJ_ENCODING_PTRINT 13 /* Encoded as pointer to integral(int, long, long long, etc.) value */
 
 #define LRU_BITS 24
 #define LRU_CLOCK_MAX ((1<<LRU_BITS)-1) /* Max value of obj->lru */

--- a/src/object.h
+++ b/src/object.h
@@ -181,7 +181,7 @@ int collateStringObjects(const robj *a, const robj *b);
 int equalStringObjects(robj *a, robj *b);
 void trimStringObjectIfNeeded(robj *o, int trim_small_values);
 size_t kvobjAllocSize(kvobj *o);
-size_t gcraTypeAllocSize(void);
+size_t gcraTypeAllocSize(robj *o);
 size_t gcraObjectLength(robj *o);
 
 int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle,

--- a/src/object.h
+++ b/src/object.h
@@ -5,7 +5,7 @@
  * values of different logical types (strings, lists, sets, hashes, sorted sets,
  * streams, modules, ...). It contains:
  *   - type: one of OBJ_STRING, OBJ_LIST, OBJ_SET, OBJ_ZSET, OBJ_HASH, OBJ_STREAM,
- *           OBJ_MODULE, ...
+ *           OBJ_GCRA, OBJ_MODULE, ...
  *   - encoding: an implementation detail of how the value is represented in
  *           memory for the given type (see OBJ_ENCODING_* below). For example,
  *           strings may be RAW/EMBSTR/INT, sets may be INTSET or HT, etc.
@@ -161,6 +161,7 @@ robj *createHashObject(void);
 robj *createZsetObject(void);
 robj *createZsetListpackObject(void);
 robj *createStreamObject(void);
+robj *createGCRAObject(long long value);
 robj *createModuleObject(struct RedisModuleType *mt, void *value);
 int getLongFromObjectOrReply(struct client *c, robj *o, long *target, const char *msg);
 int getPositiveLongFromObjectOrReply(struct client *c, robj *o, long *target, const char *msg);
@@ -170,6 +171,7 @@ int getLongLongFromObjectOrReply(struct client *c, robj *o, long long *target, c
 int getDoubleFromObjectOrReply(struct client *c, robj *o, double *target, const char *msg);
 int getDoubleFromObject(const robj *o, double *target);
 int getLongLongFromObject(robj *o, long long *target);
+int getLongLongFromGCRAObject(robj *o, long long *target);
 int getLongDoubleFromObject(robj *o, long double *target);
 int getLongDoubleFromObjectOrReply(struct client *c, robj *o, long double *target, const char *msg);
 int getIntFromObjectOrReply(struct client *c, robj *o, int *target, const char *msg);
@@ -179,6 +181,8 @@ int collateStringObjects(const robj *a, const robj *b);
 int equalStringObjects(robj *a, robj *b);
 void trimStringObjectIfNeeded(robj *o, int trim_small_values);
 size_t kvobjAllocSize(kvobj *o);
+size_t gcraTypeAllocSize(void);
+size_t gcraObjectLength(robj *o);
 
 int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle,
                       long long lru_clock, int lru_multiplier);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -153,17 +153,6 @@ long long rdbLoadMillisecondTime(rio *rdb, int rdbver) {
     return (long long)t64;
 }
 
-/* GCRA functions are the same as milliseconds ones, present only for semantic
- * differentiation. For sake of completeness the stored value is actually
- * microseconds. */
-static inline ssize_t rdbSaveGCRATime(rio *rdb, long long t) {
-    return rdbSaveMillisecondTime(rdb, t);
-}
-
-static inline long long rdbLoadGCRATime(rio *rdb, int rdbver) {
-    return rdbLoadMillisecondTime(rdb, rdbver);
-}
-
 /* Saves an encoded length. The first two bits in the first byte are used to
  * hold the encoding type. See the RDB_* definitions for more information
  * on the types of encoding. */
@@ -1415,7 +1404,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
     } else if (o->type == OBJ_GCRA) {
         long long t;
         getLongLongFromGCRAObject(o, &t);
-        if ((n = rdbSaveGCRATime(rdb,t)) == -1) return -1;
+        if ((n = rdbSaveLen(rdb,t)) == -1) return -1;
         nwritten += n;
     } else if (o->type == OBJ_MODULE) {
         /* Save a module-specific value. */
@@ -3609,12 +3598,12 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
         }
         o = createModuleObject(mt, ptr);
     } else if (rdbtype == RDB_TYPE_GCRA) {
-        long long time = rdbLoadGCRATime(rdb, RDB_VERSION);
-        if (rioGetReadError(rdb)) {
+        uint64_t time = rdbLoadLen(rdb, NULL);
+        if (time == RDB_LENERR) {
             rdbReportReadError("Failed loading GCRA TaT value");
             return NULL;
         }
-        o = createGCRAObject(time);
+        o = createGCRAObject((long long)time);
     } else {
         rdbReportReadError("Unknown RDB encoding type %d",rdbtype);
         return NULL;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1413,8 +1413,9 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
         if ((n = rdbSaveLen(rdb,s->iids_duplicates)) == -1) return -1;
         nwritten += n;
     } else if (o->type == OBJ_GCRA) {
-        long long *t = o->ptr;
-        if ((n = rdbSaveGCRATime(rdb,*t)) == -1) return -1;
+        long long t;
+        getLongLongFromGCRAObject(o, &t);
+        if ((n = rdbSaveGCRATime(rdb,t)) == -1) return -1;
         nwritten += n;
     } else if (o->type == OBJ_MODULE) {
         /* Save a module-specific value. */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -153,6 +153,17 @@ long long rdbLoadMillisecondTime(rio *rdb, int rdbver) {
     return (long long)t64;
 }
 
+/* GCRA functions are the same as milliseconds ones, present only for semantic
+ * differentiation. For sake of completeness the stored value is actually
+ * microseconds. */
+static inline ssize_t rdbSaveGCRATime(rio *rdb, long long t) {
+    return rdbSaveMillisecondTime(rdb, t);
+}
+
+static inline long long rdbLoadGCRATime(rio *rdb, int rdbver) {
+    return rdbLoadMillisecondTime(rdb, rdbver);
+}
+
 /* Saves an encoded length. The first two bits in the first byte are used to
  * hold the encoding type. See the RDB_* definitions for more information
  * on the types of encoding. */
@@ -713,6 +724,8 @@ int rdbSaveObjectType(rio *rdb, robj *o) {
             serverPanic("Unknown hash encoding");
     case OBJ_STREAM:
         return rdbSaveType(rdb,RDB_TYPE_STREAM_LISTPACKS_5);
+    case OBJ_GCRA:
+        return rdbSaveType(rdb,RDB_TYPE_GCRA);
     case OBJ_MODULE:
         return rdbSaveType(rdb,RDB_TYPE_MODULE_2);
     default:
@@ -1398,6 +1411,10 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
 
         /* Save the all-time count of duplicate IIDs detected. */
         if ((n = rdbSaveLen(rdb,s->iids_duplicates)) == -1) return -1;
+        nwritten += n;
+    } else if (o->type == OBJ_GCRA) {
+        long long *t = o->ptr;
+        if ((n = rdbSaveGCRATime(rdb,*t)) == -1) return -1;
         nwritten += n;
     } else if (o->type == OBJ_MODULE) {
         /* Save a module-specific value. */
@@ -3590,6 +3607,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             return NULL;
         }
         o = createModuleObject(mt, ptr);
+    } else if (rdbtype == RDB_TYPE_GCRA) {
+        long long time = rdbLoadGCRATime(rdb, RDB_VERSION);
+        o = createGCRAObject(time);
     } else {
         rdbReportReadError("Unknown RDB encoding type %d",rdbtype);
         return NULL;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3610,6 +3610,10 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
         o = createModuleObject(mt, ptr);
     } else if (rdbtype == RDB_TYPE_GCRA) {
         long long time = rdbLoadGCRATime(rdb, RDB_VERSION);
+        if (rioGetReadError(rdb)) {
+            rdbReportReadError("Failed loading GCRA TaT value");
+            return NULL;
+        }
         o = createGCRAObject(time);
     } else {
         rdbReportReadError("Unknown RDB encoding type %d",rdbtype);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3599,7 +3599,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
         o = createModuleObject(mt, ptr);
     } else if (rdbtype == RDB_TYPE_GCRA) {
         uint64_t time = rdbLoadLen(rdb, NULL);
-        if (time == RDB_LENERR) {
+        if (time == RDB_LENERR || time > LLONG_MAX) {
             rdbReportReadError("Failed loading GCRA TaT value");
             return NULL;
         }

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -80,10 +80,11 @@
 #define RDB_TYPE_HASH_LISTPACK_EX 25          /* Hash LP with HFEs. Attach min TTL at start */
 #define RDB_TYPE_STREAM_LISTPACKS_4 26        /* Stream with IDMP support */
 #define RDB_TYPE_STREAM_LISTPACKS_5 27        /* Stream with XNACK support (NACKed entries) */
+#define RDB_TYPE_GCRA 28                      /* GCRA object */
 /* NOTE: WHEN ADDING NEW RDB TYPE, UPDATE rdbIsObjectType(), and rdb_type_string[] */
 
 /* Test if a type is an object type. */
-#define rdbIsObjectType(t) (((t) >= 0 && (t) <= 7) || ((t) >= 9 && (t) <= 27))
+#define rdbIsObjectType(t) (((t) >= 0 && (t) <= 7) || ((t) >= 9 && (t) <= 28))
 
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
 #define RDB_OPCODE_KEY_META   243   /* Key metadata (module metadata classes). */

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -88,6 +88,7 @@ char *rdb_type_string[] = {
     "hash-listpack-md",
     "stream-v4",
     "stream-v5",
+    "gcra",
 };
 
 /* Show a few stats collected into 'rdbstate' */

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -248,6 +248,7 @@ This flag should not be used directly by the module.
 #define REDISMODULE_NOTIFY_OVERWRITTEN (1<<15)   /* o, key overwrite notification */
 #define REDISMODULE_NOTIFY_TYPE_CHANGED (1<<16) /* c, key type changed notification */
 #define REDISMODULE_NOTIFY_KEY_TRIMMED (1<<17) /* module only key space notification, indicates a key trimmed during slot migration */
+#define REDISMODULE_NOTIFY_RATE_LIMIT (1<<18) /* r, rate limit event */
 
 /* Next notification flag, must be updated when adding new flags above!
 This flag should not be used directly by the module.

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -253,7 +253,7 @@ This flag should not be used directly by the module.
 /* Next notification flag, must be updated when adding new flags above!
 This flag should not be used directly by the module.
  * Use RedisModule_GetKeyspaceNotificationFlagsAll instead. */
-#define _REDISMODULE_NOTIFY_NEXT (1<<18)
+#define _REDISMODULE_NOTIFY_NEXT (1<<19)
 
 #define REDISMODULE_NOTIFY_ALL (REDISMODULE_NOTIFY_GENERIC | REDISMODULE_NOTIFY_STRING | REDISMODULE_NOTIFY_LIST | REDISMODULE_NOTIFY_SET | REDISMODULE_NOTIFY_HASH | REDISMODULE_NOTIFY_ZSET | REDISMODULE_NOTIFY_EXPIRED | REDISMODULE_NOTIFY_EVICTED | REDISMODULE_NOTIFY_STREAM | REDISMODULE_NOTIFY_MODULE)      /* A */
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -89,6 +89,7 @@ typedef long long ustime_t;
 #define REDISMODULE_KEYTYPE_ZSET 5
 #define REDISMODULE_KEYTYPE_MODULE 6
 #define REDISMODULE_KEYTYPE_STREAM 7
+#define REDISMODULE_KEYTYPE_GCRA 8
 
 /* Reply types. */
 #define REDISMODULE_REPLY_UNKNOWN -1

--- a/src/server.h
+++ b/src/server.h
@@ -859,7 +859,8 @@ typedef enum {
  * encoding version. */
 #define OBJ_MODULE 5    /* Module object. */
 #define OBJ_STREAM 6    /* Stream object. */
-#define OBJ_TYPE_MAX 7  /* Maximum number of object types */
+#define OBJ_GCRA 7    /* GCRA object. */
+#define OBJ_TYPE_MAX 8  /* Maximum number of object types */
 
 /* Extract encver / signature from a module type ID. */
 #define REDISMODULE_TYPE_ENCVER_BITS 10
@@ -3597,6 +3598,9 @@ int zzlLexValueLteMax(unsigned char *p, zlexrangespec *spec);
 int zslLexValueGteMin(sds value, zlexrangespec *spec);
 int zslLexValueLteMax(sds value, zlexrangespec *spec);
 
+/* gcra related */
+robj *gcraDup(robj *o);
+
 /* Core functions */
 int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *level);
 void updatePeakMemory(void);
@@ -4467,6 +4471,7 @@ void resetCommand(client *c);
 void failoverCommand(client *c);
 void digestCommand(client *c);
 void gcraCommand(client *c);
+void gcraRecordCommand(client *c);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));

--- a/src/server.h
+++ b/src/server.h
@@ -863,6 +863,15 @@ typedef enum {
 #define OBJ_GCRA 7    /* GCRA object. */
 #define OBJ_TYPE_MAX 8  /* Maximum number of object types */
 
+/* NOTE: adding a new object requires changes in the following places:
+ * - rdb.c - save/load (also bump RDB_VERSION if needed)
+ * - aof.c - rewrite
+ * - db.c - obj_type_name, copyCommand
+ * - debug.c - xorObjectDigest, serverLogObjectDebugInfo
+ * - defrag.c - defragKey
+ * - module.c - RM_KeyType (and add the new keytype to redismodule.h)
+ * - object.c - object(create/free/dismiss/allocSize/Length) */
+
 /* Extract encver / signature from a module type ID. */
 #define REDISMODULE_TYPE_ENCVER_BITS 10
 #define REDISMODULE_TYPE_ENCVER_MASK ((1<<REDISMODULE_TYPE_ENCVER_BITS)-1)

--- a/src/server.h
+++ b/src/server.h
@@ -4483,7 +4483,7 @@ void resetCommand(client *c);
 void failoverCommand(client *c);
 void digestCommand(client *c);
 void gcraCommand(client *c);
-void gcraSetTATCommand(client *c);
+void gcraSetValueCommand(client *c);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));

--- a/src/server.h
+++ b/src/server.h
@@ -796,6 +796,7 @@ typedef enum {
 #define NOTIFY_OVERWRITTEN (1<<15)   /* o, key overwrite notification (Note: excluded from NOTIFY_ALL) */
 #define NOTIFY_TYPE_CHANGED (1<<16) /* c, key type changed notification (Note: excluded from NOTIFY_ALL) */
 #define NOTIFY_KEY_TRIMMED (1<<17)     /* module only key space notification, indicates a key trimmed during slot migration */
+#define NOTIFY_RATE_LIMIT (1<<18) /* r, notify rate limit event (Note: excluded from NOTIFY_ALL)*/
 #define NOTIFY_ALL (NOTIFY_GENERIC | NOTIFY_STRING | NOTIFY_LIST | NOTIFY_SET | NOTIFY_HASH | NOTIFY_ZSET | NOTIFY_EXPIRED | NOTIFY_EVICTED | NOTIFY_STREAM | NOTIFY_MODULE) /* A flag */
 
 /* Using the following macro you can run code inside serverCron() with the
@@ -2782,6 +2783,7 @@ typedef enum {
     COMMAND_GROUP_STREAM,
     COMMAND_GROUP_BITMAP,
     COMMAND_GROUP_MODULE,
+    COMMAND_GROUP_RATE_LIMIT,
 } redisCommandGroup;
 
 typedef void redisCommandProc(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -287,6 +287,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define ACL_CATEGORY_CONNECTION (1ULL<<18)
 #define ACL_CATEGORY_TRANSACTION (1ULL<<19)
 #define ACL_CATEGORY_SCRIPTING (1ULL<<20)
+#define ACL_CATEGORY_RATE_LIMIT (1ULL<<21)
 
 /* Key-spec flags *
  * -------------- */
@@ -4471,7 +4472,7 @@ void resetCommand(client *c);
 void failoverCommand(client *c);
 void digestCommand(client *c);
 void gcraCommand(client *c);
-void gcraRecordCommand(client *c);
+void gcraSetTATCommand(client *c);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));

--- a/tests/unit/gcra.tcl
+++ b/tests/unit/gcra.tcl
@@ -229,6 +229,103 @@ start_server {tags {"gcra" "external:skip"}} {
     }
 }
 
+start_server {tags {"gcra" "external:skip"}} {
+    test {GCRA - RDB save and reload preserves value} {
+        r del mykey
+        r gcra mykey 5 1 60
+        r gcra mykey 5 1 60
+
+        set dump_before [r dump mykey]
+
+        r debug reload
+
+        assert_equal [r type mykey] "gcra"
+        set dump_after [r dump mykey]
+        assert_equal $dump_before $dump_after
+    } {} {needs:debug}
+
+    test {GCRA - RDB save and reload preserves TTL} {
+        r del mykey
+        r gcra mykey 5 1 60
+        set ttl_before [r pexpiretime mykey]
+        assert_morethan $ttl_before 0
+
+        r debug reload
+
+        set ttl_after [r pexpiretime mykey]
+        assert_morethan $ttl_after 0
+        assert_equal $ttl_after $ttl_before
+    } {} {needs:debug}
+
+    test {GCRA - DUMP and RESTORE roundtrip} {
+        r del mykey mykey2
+        r gcra mykey 5 1 60
+        r gcra mykey 5 1 60
+
+        set dump [r dump mykey]
+        set ttl [r pttl mykey]
+        r restore mykey2 $ttl $dump
+
+        assert_equal [r type mykey2] "gcra"
+
+        set result_orig [r gcra mykey 5 1 60]
+        set result_restored [r gcra mykey2 5 1 60]
+        assert_equal [lindex $result_orig 2] [lindex $result_restored 2]
+    }
+
+    test {GCRA - AOF rewrite preserves value} {
+        r del mykey
+        r config set appendonly yes
+        waitForBgrewriteaof r
+
+        r gcra mykey 5 1 60
+        r gcra mykey 5 1 60
+
+        set dump_before [r dump mykey]
+
+        r BGREWRITEAOF
+        waitForBgrewriteaof r
+        r debug reload
+
+        assert_equal [r type mykey] "gcra"
+        set dump_after [r dump mykey]
+        assert_equal $dump_before $dump_after
+    } {} {external:skip needs:debug}
+
+    test {GCRA - AOF rewrite preserves TTL} {
+        r del mykey
+        r config set appendonly yes
+        waitForBgrewriteaof r
+
+        r gcra mykey 5 1 60
+
+        r BGREWRITEAOF
+        waitForBgrewriteaof r
+
+        set ttl_before [r pttl mykey]
+        assert {$ttl_before > 0}
+
+        r debug reload
+
+        set ttl_after [r pttl mykey]
+        assert {$ttl_after > 0}
+        assert {$ttl_after <= $ttl_before}
+    } {} {external:skip needs:debug}
+
+    test {GCRA - DEBUG DIGEST consistent after RDB reload} {
+        r del mykey
+        r gcra mykey 5 1 60
+        r gcra mykey 5 1 60
+
+        set digest_before [r debug digest]
+
+        r debug reload
+
+        set digest_after [r debug digest]
+        assert_equal $digest_before $digest_after
+    } {} {needs:debug}
+}
+
 start_server {tags {"gcra repl" "external:skip"}} {
     set replica [srv 0 client]
     set replica_host [srv 0 host]
@@ -240,27 +337,26 @@ start_server {tags {"gcra repl" "external:skip"}} {
         set master_host [srv 0 host]
         set master_port [srv 0 port]
 
-        $master flushdb
-        $replica flushdb
+        test {GCRA - Replication works} {
+            $master flushdb
+            $replica flushdb
 
-        $replica replicaof $master_host $master_port
-        wait_for_condition 100 100 {
-            [s -1 master_link_status] eq "up"
-        } else {
-            fail "Master <-> Replica didn't finish sync"
-        }
+            $replica replicaof $master_host $master_port
+            wait_for_condition 100 100 {
+                [s -1 master_link_status] eq "up"
+            } else {
+                fail "Master <-> Replica didn't finish sync"
+            }
 
-        set cmdinfo [$replica info commandstats]
-        assert_equal [lsearch -glob $cmdinfo "cmdstat_gcra:*"] -1
-        assert_equal [lsearch -glob $cmdinfo "cmdstat_set:*"] -1
+            set cmdinfo [$replica info commandstats]
+            assert_equal [lsearch -glob $cmdinfo "cmdstat_gcrarecord:*"] -1
 
-        $master del mykey
-        $master gcra mykey 2 1 1000 TOKENS 2
+            $master del mykey
+            $master gcra mykey 2 1 1000 TOKENS 2
+            wait_for_ofs_sync $master $replica
 
-        wait_for_ofs_sync $master $replica
-
-        set cmdinfo [$replica info commandstats]
-        assert_equal [lsearch -glob $cmdinfo "cmdstat_gcra:*"] -1
-        assert_morethan_equal [lsearch -glob $cmdinfo "cmdstat_set:*"] 0
+            set cmdinfo [$replica info commandstats]
+            assert_morethan_equal [lsearch -glob $cmdinfo "cmdstat_gcrarecord:*"] 0
+        } {} {external:skip}
     }
 }

--- a/tests/unit/gcra.tcl
+++ b/tests/unit/gcra.tcl
@@ -349,14 +349,14 @@ start_server {tags {"gcra repl" "external:skip"}} {
             }
 
             set cmdinfo [$replica info commandstats]
-            assert_equal [lsearch -glob $cmdinfo "cmdstat_gcrasettat:*"] -1
+            assert_equal [lsearch -glob $cmdinfo "cmdstat_gcrasetvalue:*"] -1
 
             $master del mykey
             $master gcra mykey 2 1 1000 TOKENS 2
             wait_for_ofs_sync $master $replica
 
             set cmdinfo [$replica info commandstats]
-            assert_morethan_equal [lsearch -glob $cmdinfo "cmdstat_gcrasettat:*"] 0
+            assert_morethan_equal [lsearch -glob $cmdinfo "cmdstat_gcrasetvalue:*"] 0
         } {} {external:skip}
     }
 }

--- a/tests/unit/gcra.tcl
+++ b/tests/unit/gcra.tcl
@@ -349,14 +349,14 @@ start_server {tags {"gcra repl" "external:skip"}} {
             }
 
             set cmdinfo [$replica info commandstats]
-            assert_equal [lsearch -glob $cmdinfo "cmdstat_gcrarecord:*"] -1
+            assert_equal [lsearch -glob $cmdinfo "cmdstat_gcrasettat:*"] -1
 
             $master del mykey
             $master gcra mykey 2 1 1000 TOKENS 2
             wait_for_ofs_sync $master $replica
 
             set cmdinfo [$replica info commandstats]
-            assert_morethan_equal [lsearch -glob $cmdinfo "cmdstat_gcrarecord:*"] 0
+            assert_morethan_equal [lsearch -glob $cmdinfo "cmdstat_gcrasettat:*"] 0
         } {} {external:skip}
     }
 }

--- a/utils/generate-command-code.py
+++ b/utils/generate-command-code.py
@@ -34,6 +34,7 @@ GROUPS = {
     "geo": "COMMAND_GROUP_GEO",
     "stream": "COMMAND_GROUP_STREAM",
     "bitmap": "COMMAND_GROUP_BITMAP",
+    "rate_limit": "COMMAND_GROUP_RATE_LIMIT",
 }
 
 

--- a/utils/generate-command-code.py
+++ b/utils/generate-command-code.py
@@ -603,7 +603,8 @@ const char *COMMAND_GROUP_STR[] = {
     "geo",
     "stream",
     "bitmap",
-    "module"
+    "module",
+    "rate_limit"
 };
 
 const char *commandGroupStr(int index) {


### PR DESCRIPTION
[PR ](https://github.com/redis/redis/pull/14826) introduced a new rate limiting command which stores its internal implementation-detail data into a string key.

Since this will prevent a client from detecting type errors or accidental overwrites or value invalidations, f.e via SET or INCR this PR introduces a new data type - OBJ_GCRA specifically created for that new command.

OBJ_GCRA name subject to change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new core object type with new RDB encoding and AOF/replication rewrite behavior, which can impact persistence compatibility and data consistency if mishandled. Touches multiple critical subsystems (object lifecycle, copy/defrag, modules, keyspace notifications, command table).
> 
> **Overview**
> Introduces a dedicated `OBJ_GCRA` value type for the `GCRA` rate-limiting command, replacing the previous string-backed storage so type errors/overwrites are detectable and handled consistently.
> 
> Adds full core support for the new type across persistence and runtime internals: **RDB save/load** via new `RDB_TYPE_GCRA`, **AOF rewrite** support, dataset copy/dup, memory sizing, defrag, and `DEBUG DIGEST` handling. Replication/AOF propagation for `GCRA` is changed to rewrite into a new internal command `GCRASETVALUE`, which also gets command-table/JSON docs, its own ACL category/group (`rate_limit`), and new keyspace notification class `r` (`NOTIFY_RATE_LIMIT`).
> 
> Updates tests to cover RDB reload, DUMP/RESTORE, AOF rewrite, digest stability, and replication behavior for `GCRA` keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b1f705607012a60033d7675876c7a53cb35c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->