### PR TITLE
Fix cache line false sharing on per-IO-thread stat counters

### DIFF
--- a/src/iothread.c
+++ b/src/iothread.c
@@ -11,7 +11,7 @@
 #include "server.h"
 
 /* IO threads. */
-static IOThread IOThreads[IO_THREADS_MAX_NUM];
+IOThread IOThreads[IO_THREADS_MAX_NUM];
 
 /* For main thread */
 static list *mainThreadPendingClientsToIOThreads[IO_THREADS_MAX_NUM]; /* Clients to IO threads */
@@ -172,7 +172,7 @@ void keepClientInMainThread(client *c) {
     if (c->tid == IOTHREAD_MAIN_THREAD_ID) return;
     serverAssert(c->running_tid == IOTHREAD_MAIN_THREAD_ID);
     /* IO thread no longer manage it. */
-    io_thread_stats[c->tid].clients_num--;
+    server.io_threads_clients_num[c->tid]--;
     /* Unbind connection of client from io thread event loop. */
     unbindClientFromIOThreadEventLoop(c);
     /* Update the client's data in case it was just fetched from IO thread */
@@ -186,7 +186,7 @@ void keepClientInMainThread(client *c) {
     freeClientIODeferredObjects(c, 1); /* Free IO deferred objects. */
     tryUnlinkClientFromPendingRefReply(c, 0);
     /* Main thread starts to manage it. */
-    io_thread_stats[c->tid].clients_num++;
+    server.io_threads_clients_num[c->tid]++;
 }
 
 /* If the client is managed by IO thread, we should fetch it from IO thread
@@ -286,16 +286,16 @@ void assignClientToIOThread(client *c) {
     int min_id = 0;
     int min = INT_MAX;
     for (int i = 1; i < server.io_threads_num; i++) {
-        if (io_thread_stats[i].clients_num < min) {
-            min = io_thread_stats[i].clients_num;
+        if (server.io_threads_clients_num[i] < min) {
+            min = server.io_threads_clients_num[i];
             min_id = i;
         }
     }
 
     /* Assign the client to the IO thread. */
-    io_thread_stats[c->tid].clients_num--;
+    server.io_threads_clients_num[c->tid]--;
     c->tid = min_id;
-    io_thread_stats[min_id].clients_num++;
+    server.io_threads_clients_num[min_id]++;
 
     /* The client running in IO thread needs to have deferred objects array. */
     c->deferred_objects = zmalloc(sizeof(deferredObject) * CLIENT_MAX_DEFERRED_OBJECTS);

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -172,7 +172,7 @@ void keepClientInMainThread(client *c) {
     if (c->tid == IOTHREAD_MAIN_THREAD_ID) return;
     serverAssert(c->running_tid == IOTHREAD_MAIN_THREAD_ID);
     /* IO thread no longer manage it. */
-    server.io_threads_clients_num[c->tid]--;
+    io_thread_stats[c->tid].clients_num--;
     /* Unbind connection of client from io thread event loop. */
     unbindClientFromIOThreadEventLoop(c);
     /* Update the client's data in case it was just fetched from IO thread */
@@ -186,7 +186,7 @@ void keepClientInMainThread(client *c) {
     freeClientIODeferredObjects(c, 1); /* Free IO deferred objects. */
     tryUnlinkClientFromPendingRefReply(c, 0);
     /* Main thread starts to manage it. */
-    server.io_threads_clients_num[c->tid]++;
+    io_thread_stats[c->tid].clients_num++;
 }
 
 /* If the client is managed by IO thread, we should fetch it from IO thread
@@ -286,16 +286,16 @@ void assignClientToIOThread(client *c) {
     int min_id = 0;
     int min = INT_MAX;
     for (int i = 1; i < server.io_threads_num; i++) {
-        if (server.io_threads_clients_num[i] < min) {
-            min = server.io_threads_clients_num[i];
+        if (io_thread_stats[i].clients_num < min) {
+            min = io_thread_stats[i].clients_num;
             min_id = i;
         }
     }
 
     /* Assign the client to the IO thread. */
-    server.io_threads_clients_num[c->tid]--;
+    io_thread_stats[c->tid].clients_num--;
     c->tid = min_id;
-    server.io_threads_clients_num[min_id]++;
+    io_thread_stats[min_id].clients_num++;
 
     /* The client running in IO thread needs to have deferred objects array. */
     c->deferred_objects = zmalloc(sizeof(deferredObject) * CLIENT_MAX_DEFERRED_OBJECTS);

--- a/src/networking.c
+++ b/src/networking.c
@@ -140,7 +140,7 @@ client *createClient(connection *conn) {
     c->id = client_id;
     c->tid = IOTHREAD_MAIN_THREAD_ID;
     c->running_tid = IOTHREAD_MAIN_THREAD_ID;
-    if (conn) server.io_threads_clients_num[c->tid]++;
+    if (conn) io_thread_stats[c->tid].clients_num++;
 #ifdef LOG_REQ_RES
     reqresReset(c, 0);
     c->resp = server.client_default_resp;
@@ -2172,7 +2172,7 @@ void freeClient(client *c) {
     }
 
     /* Update the number of clients in the IO thread. */
-    if (c->conn) server.io_threads_clients_num[c->tid]--;
+    if (c->conn) io_thread_stats[c->tid].clients_num--;
 
     /* For connected clients, call the disconnection event of modules hooks. */
     if (c->conn) {
@@ -2777,7 +2777,7 @@ static inline int _writeToClientSlave(client *c, ssize_t *nwritten) {
 int writeToClient(client *c, int handler_installed) {
     if (!(c->io_flags & CLIENT_IO_WRITE_ENABLED)) return C_OK;
     /* Update the number of writes of io threads on server */
-    atomicIncr(server.stat_io_writes_processed[c->running_tid], 1);
+    atomicIncr(io_thread_stats[c->running_tid].io_writes_processed, 1);
 
     ssize_t nwritten = 0, totwritten = 0;
     const int is_slave = clientTypeIsSlave(c);
@@ -3833,7 +3833,7 @@ void readQueryFromClient(connection *conn) {
     c->stat_total_read_events++;
 
     /* Update the number of reads of io threads on server */
-    atomicIncr(server.stat_io_reads_processed[c->running_tid], 1);
+    atomicIncr(io_thread_stats[c->running_tid].io_reads_processed, 1);
 
     readlen = PROTO_IOBUF_LEN;
     /* If this is a multi bulk request, and we are processing a bulk reply

--- a/src/networking.c
+++ b/src/networking.c
@@ -140,7 +140,7 @@ client *createClient(connection *conn) {
     c->id = client_id;
     c->tid = IOTHREAD_MAIN_THREAD_ID;
     c->running_tid = IOTHREAD_MAIN_THREAD_ID;
-    if (conn) io_thread_stats[c->tid].clients_num++;
+    if (conn) server.io_threads_clients_num[c->tid]++;
 #ifdef LOG_REQ_RES
     reqresReset(c, 0);
     c->resp = server.client_default_resp;
@@ -2172,7 +2172,7 @@ void freeClient(client *c) {
     }
 
     /* Update the number of clients in the IO thread. */
-    if (c->conn) io_thread_stats[c->tid].clients_num--;
+    if (c->conn) server.io_threads_clients_num[c->tid]--;
 
     /* For connected clients, call the disconnection event of modules hooks. */
     if (c->conn) {
@@ -2777,7 +2777,7 @@ static inline int _writeToClientSlave(client *c, ssize_t *nwritten) {
 int writeToClient(client *c, int handler_installed) {
     if (!(c->io_flags & CLIENT_IO_WRITE_ENABLED)) return C_OK;
     /* Update the number of writes of io threads on server */
-    atomicIncr(io_thread_stats[c->running_tid].io_writes_processed, 1);
+    atomicIncr(IOThreads[c->running_tid].io_writes_processed, 1);
 
     ssize_t nwritten = 0, totwritten = 0;
     const int is_slave = clientTypeIsSlave(c);
@@ -3833,7 +3833,7 @@ void readQueryFromClient(connection *conn) {
     c->stat_total_read_events++;
 
     /* Update the number of reads of io threads on server */
-    atomicIncr(io_thread_stats[c->running_tid].io_reads_processed, 1);
+    atomicIncr(IOThreads[c->running_tid].io_reads_processed, 1);
 
     readlen = PROTO_IOBUF_LEN;
     /* If this is a multi bulk request, and we are processing a bulk reply

--- a/src/replication.c
+++ b/src/replication.c
@@ -4010,7 +4010,7 @@ static void rdbChannelReplDataBufClear(void) {
 static int replDataBufReadIntoLastBlock(connection *conn, replDataBuf *buf,
                                     void (*error_handler)(connection *conn))
 {
-    atomicIncr(io_thread_stats[IOTHREAD_MAIN_THREAD_ID].io_reads_processed, 1);
+    atomicIncr(IOThreads[IOTHREAD_MAIN_THREAD_ID].io_reads_processed, 1);
 
     replDataBufBlock *block = listNodeValue(listLast(buf->blocks));
     serverAssert(block && block->size > block->used);

--- a/src/replication.c
+++ b/src/replication.c
@@ -4010,7 +4010,7 @@ static void rdbChannelReplDataBufClear(void) {
 static int replDataBufReadIntoLastBlock(connection *conn, replDataBuf *buf,
                                     void (*error_handler)(connection *conn))
 {
-    atomicIncr(server.stat_io_reads_processed[IOTHREAD_MAIN_THREAD_ID], 1);
+    atomicIncr(io_thread_stats[IOTHREAD_MAIN_THREAD_ID].io_reads_processed, 1);
 
     replDataBufBlock *block = listNodeValue(listLast(buf->blocks));
     serverAssert(block && block->size > block->used);

--- a/src/server.c
+++ b/src/server.c
@@ -83,6 +83,7 @@ double R_Zero, R_PosInf, R_NegInf, R_Nan;
 
 /* Global vars */
 struct redisServer server; /* Server global state */
+IOThreadStats io_thread_stats[IO_THREADS_MAX_NUM]; /* Per-IO-thread stats, cache-line padded */
 
 /* Snapshot of server.stat_total_client_process_input_buff_events used in
  * beforeSleep() to detect event loop cycles where client input buffers
@@ -2895,8 +2896,8 @@ void resetServerStats(void) {
     server.stat_sync_partial_ok = 0;
     server.stat_sync_partial_err = 0;
     for (j = 0; j < IO_THREADS_MAX_NUM; j++) {
-        atomicSet(server.stat_io_reads_processed[j], 0);
-        atomicSet(server.stat_io_writes_processed[j], 0);
+        atomicSet(io_thread_stats[j].io_reads_processed, 0);
+        atomicSet(io_thread_stats[j].io_writes_processed, 0);
     }
     atomicSet(server.stat_client_qbuf_limit_disconnections, 0);
     server.stat_client_outbuf_limit_disconnections = 0;
@@ -3116,7 +3117,7 @@ void initServer(void) {
     server.aof_last_write_errno = 0;
     server.repl_good_slaves_count = 0;
     server.last_sig_received = 0;
-    memset(server.io_threads_clients_num, 0, sizeof(server.io_threads_clients_num));
+    memset(io_thread_stats, 0, sizeof(io_thread_stats));
     atomicSetWithSync(server.running, 0);
     server.accum_call_count_since_ustime = 0;
     server.monotonic_us_when_ustime = 0;
@@ -6623,10 +6624,10 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         info = sdscatprintf(info, "# Threads\r\n");
         long long reads, writes;
         for (j = 0; j < server.io_threads_num; j++) {
-            atomicGet(server.stat_io_reads_processed[j], reads);
-            atomicGet(server.stat_io_writes_processed[j], writes);
+            atomicGet(io_thread_stats[j].io_reads_processed, reads);
+            atomicGet(io_thread_stats[j].io_writes_processed, writes);
             info = sdscatprintf(info, "io_thread_%d:clients=%d,reads=%lld,writes=%lld\r\n",
-                                       j, server.io_threads_clients_num[j], reads, writes);
+                                       j, io_thread_stats[j].clients_num, reads, writes);
             stat_total_reads_processed += reads;
             if (j != 0) stat_io_reads_processed += reads; /* Skip the main thread */
             stat_total_writes_processed += writes;
@@ -6661,10 +6662,10 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         if (!stat_io_ops_processed_calculated) {
             long long reads, writes;
             for (j = 0; j < server.io_threads_num; j++) {
-                atomicGet(server.stat_io_reads_processed[j], reads);
+                atomicGet(io_thread_stats[j].io_reads_processed, reads);
                 stat_total_reads_processed += reads;
                 if (j != 0) stat_io_reads_processed += reads; /* Skip the main thread */
-                atomicGet(server.stat_io_writes_processed[j], writes);
+                atomicGet(io_thread_stats[j].io_writes_processed, writes);
                 stat_total_writes_processed += writes;
                 if (j != 0) stat_io_writes_processed += writes; /* Skip the main thread */
             }

--- a/src/server.c
+++ b/src/server.c
@@ -83,7 +83,6 @@ double R_Zero, R_PosInf, R_NegInf, R_Nan;
 
 /* Global vars */
 struct redisServer server; /* Server global state */
-IOThreadStats io_thread_stats[IO_THREADS_MAX_NUM]; /* Per-IO-thread stats, cache-line padded */
 
 /* Snapshot of server.stat_total_client_process_input_buff_events used in
  * beforeSleep() to detect event loop cycles where client input buffers
@@ -2896,8 +2895,8 @@ void resetServerStats(void) {
     server.stat_sync_partial_ok = 0;
     server.stat_sync_partial_err = 0;
     for (j = 0; j < IO_THREADS_MAX_NUM; j++) {
-        atomicSet(io_thread_stats[j].io_reads_processed, 0);
-        atomicSet(io_thread_stats[j].io_writes_processed, 0);
+        atomicSet(IOThreads[j].io_reads_processed, 0);
+        atomicSet(IOThreads[j].io_writes_processed, 0);
     }
     atomicSet(server.stat_client_qbuf_limit_disconnections, 0);
     server.stat_client_outbuf_limit_disconnections = 0;
@@ -3118,7 +3117,7 @@ void initServer(void) {
     server.repl_good_slaves_count = 0;
     server.last_sig_received = 0;
     for (j = 0; j < IO_THREADS_MAX_NUM; j++) {
-        io_thread_stats[j].clients_num = 0;
+        server.io_threads_clients_num[j] = 0;
     }
     atomicSetWithSync(server.running, 0);
     server.accum_call_count_since_ustime = 0;
@@ -6626,10 +6625,10 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         info = sdscatprintf(info, "# Threads\r\n");
         long long reads, writes;
         for (j = 0; j < server.io_threads_num; j++) {
-            atomicGet(io_thread_stats[j].io_reads_processed, reads);
-            atomicGet(io_thread_stats[j].io_writes_processed, writes);
+            atomicGet(IOThreads[j].io_reads_processed, reads);
+            atomicGet(IOThreads[j].io_writes_processed, writes);
             info = sdscatprintf(info, "io_thread_%d:clients=%d,reads=%lld,writes=%lld\r\n",
-                                       j, io_thread_stats[j].clients_num, reads, writes);
+                                       j, server.io_threads_clients_num[j], reads, writes);
             stat_total_reads_processed += reads;
             if (j != 0) stat_io_reads_processed += reads; /* Skip the main thread */
             stat_total_writes_processed += writes;
@@ -6664,10 +6663,10 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         if (!stat_io_ops_processed_calculated) {
             long long reads, writes;
             for (j = 0; j < server.io_threads_num; j++) {
-                atomicGet(io_thread_stats[j].io_reads_processed, reads);
+                atomicGet(IOThreads[j].io_reads_processed, reads);
                 stat_total_reads_processed += reads;
                 if (j != 0) stat_io_reads_processed += reads; /* Skip the main thread */
-                atomicGet(io_thread_stats[j].io_writes_processed, writes);
+                atomicGet(IOThreads[j].io_writes_processed, writes);
                 stat_total_writes_processed += writes;
                 if (j != 0) stat_io_writes_processed += writes; /* Skip the main thread */
             }

--- a/src/server.c
+++ b/src/server.c
@@ -3116,9 +3116,7 @@ void initServer(void) {
     server.aof_last_write_errno = 0;
     server.repl_good_slaves_count = 0;
     server.last_sig_received = 0;
-    for (j = 0; j < IO_THREADS_MAX_NUM; j++) {
-        server.io_threads_clients_num[j] = 0;
-    }
+    memset(server.io_threads_clients_num, 0, sizeof(server.io_threads_clients_num));
     atomicSetWithSync(server.running, 0);
     server.accum_call_count_since_ustime = 0;
     server.monotonic_us_when_ustime = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -3117,10 +3117,8 @@ void initServer(void) {
     server.aof_last_write_errno = 0;
     server.repl_good_slaves_count = 0;
     server.last_sig_received = 0;
-    for (int i = 0; i < IO_THREADS_MAX_NUM; i++) {
-        atomicSet(io_thread_stats[i].io_reads_processed, 0);
-        atomicSet(io_thread_stats[i].io_writes_processed, 0);
-        io_thread_stats[i].clients_num = 0;
+    for (j = 0; j < IO_THREADS_MAX_NUM; j++) {
+        io_thread_stats[j].clients_num = 0;
     }
     atomicSetWithSync(server.running, 0);
     server.accum_call_count_since_ustime = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -3117,7 +3117,11 @@ void initServer(void) {
     server.aof_last_write_errno = 0;
     server.repl_good_slaves_count = 0;
     server.last_sig_received = 0;
-    memset(io_thread_stats, 0, sizeof(io_thread_stats));
+    for (int i = 0; i < IO_THREADS_MAX_NUM; i++) {
+        atomicSet(io_thread_stats[i].io_reads_processed, 0);
+        atomicSet(io_thread_stats[i].io_writes_processed, 0);
+        io_thread_stats[i].clients_num = 0;
+    }
     atomicSetWithSync(server.running, 0);
     server.accum_call_count_since_ustime = 0;
     server.monotonic_us_when_ustime = 0;

--- a/src/server.h
+++ b/src/server.h
@@ -225,7 +225,8 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define IO_THREADS_MAX_NUM 128
 
 /* Per-IO-thread stats, cache-line padded to prevent false sharing.
- * Each thread updates its own entry; aggregation happens only for INFO output. */
+ * Stat counters are updated by their respective IO thread;
+ * clients_num is updated by the main thread but infrequently. */
 typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) {
     redisAtomic long long io_reads_processed;  /* Number of read events processed */
     redisAtomic long long io_writes_processed; /* Number of write events processed */

--- a/src/server.h
+++ b/src/server.h
@@ -80,7 +80,7 @@ struct RedisModuleKeyOptCtx {
     int from_dbid, to_dbid;                /* The dbid of the key being processed, -1 when unknown.
                                               In most cases, only 'from_dbid' is valid, but in callbacks such
                                               as `copy2`, 'from_dbid' and 'to_dbid' are both valid. */
-}; 
+};
 
 #define REDISMODULE_CORE 1
 
@@ -223,17 +223,6 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 
 /* Max number of IO threads */
 #define IO_THREADS_MAX_NUM 128
-
-/* Per-IO-thread stats, cache-line padded to prevent false sharing.
- * Stat counters are updated by their respective IO thread;
- * clients_num is updated by the main thread but infrequently. */
-typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) {
-    redisAtomic long long io_reads_processed;  /* Number of read events processed */
-    redisAtomic long long io_writes_processed; /* Number of write events processed */
-    int clients_num;                           /* Number of clients assigned */
-} IOThreadStats;
-
-extern IOThreadStats io_thread_stats[IO_THREADS_MAX_NUM];
 
 /* To make IO threads and main thread run in parallel, we will transfer clients
  * between them if the number of clients in the pending list reaches this value. */
@@ -1076,7 +1065,7 @@ struct RedisModuleIO {
 /* Initialize an IO context. Note that the 'ver' field is populated
  * inside rdb.c according to the version of the value to load. */
 static inline void moduleInitIOContext(RedisModuleIO *io, ModuleEntityId *entity,
-                                       rio *rioptr, struct redisObject *keyptr, int db) 
+                                       rio *rioptr, struct redisObject *keyptr, int db)
 {
     io->rio = rioptr;
     io->entity = entity;
@@ -1276,7 +1265,7 @@ typedef struct rdbLoadingCtx {
 typedef struct pendingCommand pendingCommand;
 typedef struct multiState {
     pendingCommand **commands;     /* Array of pointers to MULTI commands */
-    int executing_cmd;      /* The index of the currently executed transaction 
+    int executing_cmd;      /* The index of the currently executed transaction
                                command (index in commands field) */
     int count;              /* Total number of MULTI commands */
     int cmd_flags;          /* The accumulated command flags OR-ed together.
@@ -1451,7 +1440,7 @@ typedef struct {
  * IO threads to avoid blocking the main event loop. */
 typedef struct deferredObject {
     int type;    /* Pointer to the object to be freed */
-    void *ptr;   /* Type of object: DEFERRED_OBJECT_TYPE_* */ 
+    void *ptr;   /* Type of object: DEFERRED_OBJECT_TYPE_* */
 } deferredObject;
 
 #define SHOULD_CLUSTER_COMPATIBILITY_SAMPLE() \
@@ -1688,7 +1677,11 @@ typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) {
     pthread_mutex_t pending_clients_mutex;      /* Mutex for pending write list */
     list *pending_clients_to_main_thread;       /* Clients that are waiting to be executed by the main thread. */
     list *clients;                              /* IO thread managed clients. */
+    redisAtomic long long io_reads_processed;   /* Number of read events processed */
+    redisAtomic long long io_writes_processed;  /* Number of write events processed */
 } IOThread;
+
+extern IOThread IOThreads[IO_THREADS_MAX_NUM];
 
 /* Context for streaming replDataBuf to database */
 typedef struct replDataBufToDbCtx {
@@ -2082,6 +2075,7 @@ struct redisServer {
     redisAtomic uint64_t next_client_id; /* Next client unique ID. Incremental. */
     int protected_mode;         /* Don't accept external connections. */
     int io_threads_num;         /* Number of IO threads to use. */
+    int io_threads_clients_num[IO_THREADS_MAX_NUM]; /* Number of clients assigned to each IO thread. */
     int io_threads_do_reads;    /* Read and parse from IO threads? */
     int io_threads_active;      /* Is IO threads currently active? */
     pendingCommandPool cmd_pool; /* Shared pool for reusing pendingCommand,

--- a/src/server.h
+++ b/src/server.h
@@ -224,6 +224,16 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 /* Max number of IO threads */
 #define IO_THREADS_MAX_NUM 128
 
+/* Per-IO-thread stats, cache-line padded to prevent false sharing.
+ * Each thread updates its own entry; aggregation happens only for INFO output. */
+typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) {
+    redisAtomic long long io_reads_processed;  /* Number of read events processed */
+    redisAtomic long long io_writes_processed; /* Number of write events processed */
+    int clients_num;                           /* Number of clients assigned */
+} IOThreadStats;
+
+extern IOThreadStats io_thread_stats[IO_THREADS_MAX_NUM];
+
 /* To make IO threads and main thread run in parallel, we will transfer clients
  * between them if the number of clients in the pending list reaches this value. */
 #define IO_THREAD_MAX_PENDING_CLIENTS 16
@@ -2071,7 +2081,6 @@ struct redisServer {
     redisAtomic uint64_t next_client_id; /* Next client unique ID. Incremental. */
     int protected_mode;         /* Don't accept external connections. */
     int io_threads_num;         /* Number of IO threads to use. */
-    int io_threads_clients_num[IO_THREADS_MAX_NUM]; /* Number of clients assigned to each IO thread. */
     int io_threads_do_reads;    /* Read and parse from IO threads? */
     int io_threads_active;      /* Is IO threads currently active? */
     pendingCommandPool cmd_pool; /* Shared pool for reusing pendingCommand,
@@ -2157,8 +2166,6 @@ struct redisServer {
     long long stat_unexpected_error_replies; /* Number of unexpected (aof-loading, replica to master, etc.) error replies */
     long long stat_total_error_replies; /* Total number of issued error replies ( command + rejected errors ) */
     long long stat_dump_payload_sanitizations; /* Number deep dump payloads integrity validations. */
-    redisAtomic long long stat_io_reads_processed[IO_THREADS_MAX_NUM]; /* Number of read events processed by IO / Main threads */
-    redisAtomic long long stat_io_writes_processed[IO_THREADS_MAX_NUM]; /* Number of write events processed by IO / Main threads */
     redisAtomic long long stat_client_qbuf_limit_disconnections;  /* Total number of clients reached query buf length limit */
     long long stat_client_outbuf_limit_disconnections;  /* Total number of clients reached output buf length limit */
     long long stat_cluster_incompatible_ops; /* Number of operations that are incompatible with cluster mode */

--- a/src/server.h
+++ b/src/server.h
@@ -80,7 +80,7 @@ struct RedisModuleKeyOptCtx {
     int from_dbid, to_dbid;                /* The dbid of the key being processed, -1 when unknown.
                                               In most cases, only 'from_dbid' is valid, but in callbacks such
                                               as `copy2`, 'from_dbid' and 'to_dbid' are both valid. */
-};
+}; 
 
 #define REDISMODULE_CORE 1
 
@@ -1065,7 +1065,7 @@ struct RedisModuleIO {
 /* Initialize an IO context. Note that the 'ver' field is populated
  * inside rdb.c according to the version of the value to load. */
 static inline void moduleInitIOContext(RedisModuleIO *io, ModuleEntityId *entity,
-                                       rio *rioptr, struct redisObject *keyptr, int db)
+                                       rio *rioptr, struct redisObject *keyptr, int db) 
 {
     io->rio = rioptr;
     io->entity = entity;
@@ -1265,7 +1265,7 @@ typedef struct rdbLoadingCtx {
 typedef struct pendingCommand pendingCommand;
 typedef struct multiState {
     pendingCommand **commands;     /* Array of pointers to MULTI commands */
-    int executing_cmd;      /* The index of the currently executed transaction
+    int executing_cmd;      /* The index of the currently executed transaction 
                                command (index in commands field) */
     int count;              /* Total number of MULTI commands */
     int cmd_flags;          /* The accumulated command flags OR-ed together.
@@ -1440,7 +1440,7 @@ typedef struct {
  * IO threads to avoid blocking the main event loop. */
 typedef struct deferredObject {
     int type;    /* Pointer to the object to be freed */
-    void *ptr;   /* Type of object: DEFERRED_OBJECT_TYPE_* */
+    void *ptr;   /* Type of object: DEFERRED_OBJECT_TYPE_* */ 
 } deferredObject;
 
 #define SHOULD_CLUSTER_COMPATIBILITY_SAMPLE() \


### PR DESCRIPTION
`stat_io_reads_processed[]` and `stat_io_writes_processed[]` were per-IO-thread arrays inside `struct redisServer` that suffer from false sharing. This PR moves the two stat counters into the IOThread struct, which is already `__attribute__((aligned(CACHE_LINE_SIZE)))`. Each IO thread's counters now sit on a separate cache line, eliminating the cross-thread contention.
- Added io_reads_processed and io_writes_processed fields to IOThread struct
- Removed stat_io_reads_processed[] and stat_io_writes_processed[] from struct redisServer
- Made IOThreads[] non-static with extern declaration in server.h
- Updated callers across `server.c`, `networking.c`, `replication.c`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-threaded I/O statistics accounting and makes `IOThreads` globally visible, which could introduce subtle concurrency or linkage issues if any thread ID/indexing assumptions are wrong.
> 
> **Overview**
> Moves per-IO-thread read/write processed counters out of `struct redisServer` and into the cache-line-aligned `IOThread` struct (`io_reads_processed`, `io_writes_processed`) to reduce false sharing under threaded I/O.
> 
> Updates all call sites to increment/read/reset these counters via `IOThreads[tid]` (including main-thread replication reads) and exposes `IOThreads[]` as a non-`static` global with an `extern` declaration in `server.h`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4db925b2cdc1097ad29c5db5337cd0a6c87f484e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->