### PR TITLE
ACL: add user expireat support

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -431,6 +431,7 @@ user *ACLCreateUser(const char *name, size_t namelen) {
     listSetFreeMethod(u->passwords,ACLListFreeSds);
     listSetDupMethod(u->passwords,ACLListDupSds);
 
+    u->acl_expire = 0;
     u->selectors = listCreate();
     listSetFreeMethod(u->selectors,ACLListFreeSelector);
     listSetDupMethod(u->selectors,ACLListDuplicateSelector);
@@ -500,6 +501,25 @@ void ACLFreeUserAndKillClients(user *u) {
     ACLFreeUser(u);
 }
 
+/* Scan all users and kill active connections that belong to expired users.
+ * Called from serverCron once per second. The user struct is NOT removed —
+ * the admin can inspect or reactivate it. New AUTH attempts are already
+ * blocked by ACLCheckUserCredentials(). */
+void ACLExpiredUsersCycle(void) {
+    listIter li;
+    listNode *ln;
+    listRewind(server.clients,&li);
+    while ((ln = listNext(&li)) != NULL) {
+        client *c = listNodeValue(ln);
+        user *u = c->user;
+        if (u == NULL || u->acl_expire == 0 || server.mstime < u->acl_expire) continue;
+        addACLLogEntry(c,ACL_DENIED_AUTH,
+                       ACL_LOG_CTX_TOPLEVEL,0,
+                       u->name,sdsnew("User ACL expired"));
+        deauthenticateAndCloseClient(c);
+    }
+}
+
 /* Copy the user ACL rules from the source user 'src' to the destination
  * user 'dst' so that at the end of the process they'll have exactly the
  * same rules (but the names will continue to be the original ones). */
@@ -509,6 +529,7 @@ void ACLCopyUser(user *dst, user *src) {
     dst->passwords = listDup(src->passwords);
     dst->selectors = listDup(src->selectors);
     dst->flags = src->flags;
+    dst->acl_expire = src->acl_expire;
     if (dst->acl_string) {
         decrRefCount(dst->acl_string);
     }
@@ -869,6 +890,11 @@ robj *ACLDescribeUser(user *u) {
             res = sdscat(res,ACLUserFlags[j].name);
             res = sdscatlen(res," ",1);
         }
+    }
+
+    /* Expiry */
+    if (u->acl_expire != 0) {
+        res = sdscatfmt(res,"expireat %I ", (long long)(u->acl_expire / 1000));
     }
 
     /* Passwords. */
@@ -1370,6 +1396,23 @@ int ACLSetUser(user *u, const char *op, ssize_t oplen) {
         serverAssert(ACLSetUser(u,"sanitize-payload",-1) == C_OK);
         serverAssert(ACLSetUser(u,"clearselectors",-1) == C_OK);
         serverAssert(ACLSetUser(u,"-@all",-1) == C_OK);
+        serverAssert(ACLSetUser(u,"persist",-1) == C_OK);
+    } else if (!strncasecmp(op,"expireat ",9)) {
+        /* Syntax: expireat <unix-seconds-timestamp>.
+         * Setting a past timestamp is valid and takes effect immediately. */
+        long long ts_sec;
+        if (string2ll(op+9,strlen(op+9),&ts_sec) == 0 || ts_sec <= 0) {
+            errno = EINVAL;
+            return C_ERR;
+        }
+        /* Guard against signed overflow: ts_sec * 1000 must fit in mstime_t. */
+        if (ts_sec > LLONG_MAX / 1000) {
+            errno = EINVAL;
+            return C_ERR;
+        }
+        u->acl_expire = ts_sec * 1000LL;
+    } else if (!strcasecmp(op,"persist")) {
+        u->acl_expire = 0;
     } else {
         aclSelector *selector = ACLUserGetRootSelector(u);
         if (ACLSetSelector(selector, op, oplen) == C_ERR) {
@@ -1447,6 +1490,12 @@ int ACLCheckUserCredentials(robj *username, robj *password) {
 
     /* Disabled users can't login. */
     if (u->flags & USER_FLAG_DISABLED) {
+        errno = EINVAL;
+        return C_ERR;
+    }
+
+    /* Expired users can't login. */
+    if (u->acl_expire != 0 && server.mstime >= u->acl_expire) {
         errno = EINVAL;
         return C_ERR;
     }
@@ -2083,6 +2132,15 @@ sds *ACLMergeSelectorArguments(sds *argv, int argc, int *merged_argc, int *inval
                 acl_args[*merged_argc] = selector;                        
                 (*merged_argc)++;
             }
+            continue;
+        }
+
+        /* Join "expireat <timestamp>" into a single token, symmetric to
+         * the "(selector ...)" merging above. */
+        if (!strcasecmp(op, "expireat") && j + 1 < argc) {
+            acl_args[*merged_argc] = sdscatfmt(sdsdup(argv[j]), " %s", argv[j+1]);
+            (*merged_argc)++;
+            j++;
             continue;
         }
 
@@ -2962,6 +3020,15 @@ void aclCommand(client *c) {
             sds thispass = listNodeValue(ln);
             addReplyBulkCBuffer(c,thispass,sdslen(thispass));
         }
+        /* Expiry: millisecond timestamp, or nil if no expiry. */
+        addReplyBulkCString(c,"expire");
+        if (u->acl_expire != 0) {
+            addReplyLongLong(c,u->acl_expire);
+        } else {
+            addReplyNull(c);
+        }
+        fields++;
+
         /* Include the root selector at the top level for backwards compatibility */
         fields += aclAddReplySelectorDescription(c, ACLUserGetRootSelector(u));
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -2754,6 +2754,7 @@ void addACLLogEntry(client *c, int reason, int context, int argpos, sds username
     
     if (server.acllog_max_len == 0) {
         trimACLLogEntriesToMaxLen();
+        if (object) sdsfree(object); /* Honor ownership contract on early return. */
         return;
     }
     

--- a/src/server.c
+++ b/src/server.c
@@ -1723,6 +1723,11 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
         migrateCloseTimedoutSockets();
     }
 
+    /* Kill active connections from ACL-expired users. */
+    run_with_period(1000) {
+        ACLExpiredUsersCycle();
+    }
+
     /* Cleanup expired IDMP entries from tracked streams */
     run_with_period(1000) {
         handleExpiredIdmpEntries();

--- a/src/server.h
+++ b/src/server.h
@@ -1339,6 +1339,7 @@ typedef struct {
                         against. This list will always contain at least
                         one selector for backwards compatibility. */
     robj *acl_string; /* cached string represent of ACLs */
+    mstime_t acl_expire; /* Expiry unix time in milliseconds. 0 = no expiry. */
 } user;
 
 /* With multiplexing we need to take per-client state.
@@ -3521,6 +3522,7 @@ void ACLLoadUsersAtStartup(void);
 void addReplyCommandCategories(client *c, struct redisCommand *cmd);
 user *ACLCreateUnlinkedUser(void);
 void ACLFreeUserAndKillClients(user *u);
+void ACLExpiredUsersCycle(void);
 void addACLLogEntry(client *c, int reason, int context, int argpos, sds username, sds object);
 sds getAclErrorMessage(int acl_res, user *user, struct redisCommand *cmd, sds errored_val, int verbose);
 void ACLUpdateDefaultUserPassword(sds password);

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1329,3 +1329,84 @@ start_server {overrides {user "default on nopass ~* +@all -flushdb"} tags {acl e
     }
 }
 
+start_server {tags {acl external:skip}} {
+    test {ACL SETUSER expireat sets an expiry} {
+        r ACL SETUSER exptest on nopass +acl
+        set future [expr {[clock seconds] + 3600}]
+        r ACL SETUSER exptest expireat $future
+        set info [r ACL GETUSER exptest]
+        assert_equal [dict get $info expire] [expr {$future * 1000}]
+        r ACL DELUSER exptest
+    }
+
+    test {ACL GETUSER returns nil expire when no expiry set} {
+        r ACL SETUSER noexptest on nopass +acl
+        set info [r ACL GETUSER noexptest]
+        assert_equal [dict get $info expire] {}
+        r ACL DELUSER noexptest
+    }
+
+    test {ACL LIST includes expireat token for users with expiry} {
+        set future [expr {[clock seconds] + 3600}]
+        r ACL SETUSER listexptest on nopass expireat $future
+        set acllist [r ACL LIST]
+        set found 0
+        foreach entry $acllist {
+            if {[string match "*listexptest*" $entry]} {
+                assert_match "*expireat $future*" $entry
+                set found 1
+            }
+        }
+        assert_equal $found 1
+        r ACL DELUSER listexptest
+    }
+
+    test {Expired user cannot authenticate} {
+        set past [expr {[clock seconds] - 1}]
+        r ACL SETUSER expireduser on >password +acl expireat $past
+        catch {r AUTH expireduser password} err
+        assert_match {*WRONGPASS*} $err
+        r ACL DELUSER expireduser
+    }
+
+    test {persist removes expiry} {
+        set future [expr {[clock seconds] + 3600}]
+        r ACL SETUSER persisttest on nopass expireat $future
+        r ACL SETUSER persisttest persist
+        set info [r ACL GETUSER persisttest]
+        assert_equal [dict get $info expire] {}
+        r ACL DELUSER persisttest
+    }
+
+    test {reset clears expiry} {
+        set future [expr {[clock seconds] + 3600}]
+        r ACL SETUSER resettest on nopass expireat $future
+        r ACL SETUSER resettest reset
+        set info [r ACL GETUSER resettest]
+        assert_equal [dict get $info expire] {}
+        r ACL DELUSER resettest
+    }
+
+    test {expireat with invalid timestamp returns error} {
+        catch {r ACL SETUSER errtest expireat notanumber} err
+        assert_match {*ERR*} $err
+        catch {r ACL GETUSER errtest} _
+        r ACL DELUSER errtest
+    }
+
+    test {Active connections are killed when user expires} {
+        set future [expr {[clock seconds] + 1}]
+        r ACL SETUSER killtest on >pw allcommands allkeys expireat $future
+        set rd [redis_deferring_client]
+        assert_equal [$rd read] {} ;# consume the initial connect response if any
+        $rd AUTH killtest pw
+        assert_equal [$rd read] "OK"
+        # Wait for expiry and cron to fire
+        after 2100
+        catch {$rd PING} err
+        $rd close
+        assert_match {*err*} [string tolower $err]
+        r ACL DELUSER killtest
+    }
+}
+


### PR DESCRIPTION
https://github.com/redis/redis/issues/12393

## Summary

This PR adds ACL user expiration support via `expireat`, allowing users to become invalid at a
specific Unix timestamp.

## What changed

### 1) User model
- Added `acl_expire` to `user` (`mstime_t`, `0` means no expiration).
- Initialized on user creation.
- Copied in `ACLCopyUser`.
- Cleared by reset flow (via `persist` semantics).

### 2) `ACL SETUSER` additions
- Added `expireat <unix-seconds>`.
  - Accepts positive integer seconds.
  - Supports past timestamps (immediate expiration).
  - Includes overflow guard before converting seconds to milliseconds.
- Added `persist`.
  - Removes expiration (`acl_expire = 0`).

### 3) Auth and connection enforcement
- `ACLCheckUserCredentials` now rejects expired users.
- Added a periodic cron cycle (`ACLExpiredUsersCycle`, every 1s) to close active connections
owned by expired users.
- Expired users are not deleted automatically; they remain available for inspection/
reactivation.

### 4) ACL output
- `ACL GETUSER` now returns an `expire` field:
  - millisecond timestamp when set,
  - `nil` when not set.
- `ACL LIST` includes `expireat <seconds>` for users with expiration.

### 5) Argument merge path
- Updated ACL argument merging to treat `expireat <timestamp>` as a paired token, consistent
with existing merge behavior.

## Usage

```bash
# Set expiration
ACL SETUSER alice on >password +@all expireat 1767225600

# Remove expiration
ACL SETUSER alice persist

# Inspect expiration
ACL GETUSER alice
# includes:
# "expire" => <milliseconds> or nil

# List users
ACL LIST
# user entry includes:
# ... expireat 1767225600 ...
```

## Behavior

- After expiration, new authentication is denied.
- Existing authenticated connections are closed by cron (second-level granularity).
- User definitions are retained (not auto-deleted).

## Tests

Added/updated ACL unit tests covering:

- setting and reading expireat,
- nil expire when unset,
- ACL LIST output includes expireat,
- expired user auth rejection,
- persist / reset clearing expiration,
- invalid timestamp errors,
- active connection termination after expiration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes authentication/ACL enforcement and adds a new cron-driven path that forcibly deauthenticates clients, which could impact security and connection stability if edge cases are missed.
> 
> **Overview**
> Adds ACL user expiration by introducing `user.acl_expire` and new `ACL SETUSER` modifiers `expireat <unix-seconds>` and `persist` (plus `reset` now clears expiry).
> 
> Expired users are prevented from authenticating in `ACLCheckUserCredentials()`, and a new `ACLExpiredUsersCycle()` runs from `serverCron` every second to log and disconnect already-authenticated clients whose user has expired.
> 
> Updates ACL introspection/output (`ACL LIST` includes `expireat ...`; `ACL GETUSER` returns an `expire` field) and extends argument merging to treat `expireat <timestamp>` as a single token; also fixes an `addACLLogEntry()` early-return leak when it takes ownership of `object`. Tests cover the new expiry semantics and connection termination.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6758db7b64fbfe75e20f8ee6bd5f147df4eba2e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->