### PR TITLE
Fix test failures under Valgrind caused by unexpected slowlog fields in cmdstat output

### DIFF
--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -157,7 +157,7 @@ start_server {tags {"info" "external:skip"}} {
             catch {r eval {redis.pcall('XGROUP', 'CREATECONSUMER', 's1', 'mygroup', 'consumer') return } 0} e
             assert_match {*count=1*} [errorstat ERR]
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat xgroup\\|createconsumer]
-            assert_match {*calls=1,*,rejected_calls=0,failed_calls=0} [cmdstat eval]
+            assert_match {*calls=1,*,rejected_calls=0,failed_calls=0*} [cmdstat eval]
 
             # EVAL command errors should still be pinpointed to him
             catch {r eval a} e

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -156,7 +156,7 @@ start_server {tags {"info" "external:skip"}} {
             assert_equal [s total_error_replies] 0
             catch {r eval {redis.pcall('XGROUP', 'CREATECONSUMER', 's1', 'mygroup', 'consumer') return } 0} e
             assert_match {*count=1*} [errorstat ERR]
-            assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat xgroup\\|createconsumer]
+            assert_match {*calls=1,*,rejected_calls=0,failed_calls=1*} [cmdstat xgroup\\|createconsumer]
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=0*} [cmdstat eval]
 
             # EVAL command errors should still be pinpointed to him

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -162,7 +162,7 @@ start_server {tags {"info" "external:skip"}} {
             # EVAL command errors should still be pinpointed to him
             catch {r eval a} e
             assert_match {ERR wrong*} $e
-            assert_match {*calls=1,*,rejected_calls=1,failed_calls=0} [cmdstat eval]
+            assert_match {*calls=1,*,rejected_calls=1,failed_calls=0*} [cmdstat eval]
             assert_match {*count=2*} [errorstat ERR]
             assert_equal [s total_error_replies] 2
         }

--- a/tests/unit/moduleapi/moduleauth.tcl
+++ b/tests/unit/moduleapi/moduleauth.tcl
@@ -27,7 +27,7 @@ start_server {tags {"modules external:skip"}} {
         # Validate that an error is thrown for disabled users.
         r acl setuser foo >pwd off ~* &* +@all
         assert_error {*WRONGPASS*} {r AUTH foo pwd}
-        assert_match {*calls=2,*,rejected_calls=0,failed_calls=2} [cmdstat auth]
+        assert_match {*calls=2,*,rejected_calls=0,failed_calls=2*} [cmdstat auth]
     }
 
     test {test non blocking module AUTH} {

--- a/tests/unit/moduleapi/moduleauth.tcl
+++ b/tests/unit/moduleapi/moduleauth.tcl
@@ -23,7 +23,7 @@ start_server {tags {"modules external:skip"}} {
         r config resetstat
         # Validate that an error is thrown for non existing users.
         assert_error {*WRONGPASS*} {r AUTH foo pwd}
-        assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat auth]
+        assert_match {*calls=1,*,rejected_calls=0,failed_calls=1*} [cmdstat auth]
         # Validate that an error is thrown for disabled users.
         r acl setuser foo >pwd off ~* &* +@all
         assert_error {*WRONGPASS*} {r AUTH foo pwd}

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -747,7 +747,7 @@ tags "modules aof external:skip" {
             r EVAL {return redis.call('test.rm_call_replicate',ARGV[1],KEYS[1],ARGV[2])} 1 foo set bar8
             r exec
 
-            assert_match {*calls=8,*,rejected_calls=0,failed_calls=0} [cmdrstat set r]
+            assert_match {*calls=8,*,rejected_calls=0,failed_calls=0*} [cmdrstat set r]
             
             
             # Load the AOF


### PR DESCRIPTION


The recent PR https://github.com/redis/redis/pull/14896 introduced new slowlog statistics in `INFO` commandstats. This causes `assert_match` to fail in CI (especially under Valgrind) when commands trigger the slowlog, adding extra fields after failed_calls.
Failed daily CI: https://github.com/redis/redis/actions/runs/23466572596/job/68279867734


This PR updates the test patterns to append a trailing `*` to tolerate these optional fields.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test glob patterns and only broaden matching to avoid CI flakiness under environments like Valgrind.
> 
> **Overview**
> Makes `cmdstat`/`cmdrstat` assertions in unit tests more tolerant of optional trailing fields by appending a trailing `*` after `failed_calls=...` in the expected patterns.
> 
> This prevents failures when additional stats fields (e.g., slowlog-related) appear in command stats output during runs such as Valgrind.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 183d466ff8d41632c97e9df897c18e26e0eecbf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->