### PR TITLE
[replaced] Fix ZSET keysizes histogram update on partial ZADD failure 

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -36,7 +36,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'ubuntu')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -79,7 +79,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'assert-keyspace')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -114,7 +114,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'fortify')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -153,7 +153,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'malloc')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -187,7 +187,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'malloc')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -221,7 +221,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, '32bit')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -261,7 +261,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -301,7 +301,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -341,7 +341,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'iothreads')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -373,7 +373,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'specific')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -451,7 +451,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'valgrind') && !contains(github.event.inputs.skiptests, 'redis')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -484,7 +484,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'valgrind') && !(contains(github.event.inputs.skiptests, 'modules') && contains(github.event.inputs.skiptests, 'unittest'))
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -516,7 +516,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'valgrind') && !contains(github.event.inputs.skiptests, 'redis')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -546,7 +546,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'valgrind') && !(contains(github.event.inputs.skiptests, 'modules') && contains(github.event.inputs.skiptests, 'unittest'))
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -578,7 +578,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'sanitizer')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     strategy:
       matrix:
         compiler: [ gcc, clang ]
@@ -622,7 +622,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'sanitizer')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     env:
       CC: clang # MSan works only with clang
     steps:
@@ -663,7 +663,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'sanitizer')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     strategy:
       matrix:
         compiler: [ gcc, clang ]
@@ -707,7 +707,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'sanitizer')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     strategy:
       fail-fast: false # let gcc and clang both run until the end even if one of them fails
       matrix:
@@ -752,7 +752,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'centos')
     container: quay.io/centos/centos:stream9
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -791,7 +791,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
     container: quay.io/centos/centos:stream9
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -834,7 +834,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
     container: quay.io/centos/centos:stream9
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -876,7 +876,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !(contains(github.event.inputs.skiptests, 'redis') && contains(github.event.inputs.skiptests, 'modules'))
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -902,7 +902,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !contains(github.event.inputs.skiptests, 'sentinel')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -928,7 +928,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !contains(github.event.inputs.skiptests, 'cluster')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -957,7 +957,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'macos')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -983,7 +983,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'freebsd')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     env:
       CC: clang
       CXX: clang++
@@ -1083,7 +1083,7 @@ jobs:
 
   reply-schemas-validator:
     runs-on: ubuntu-latest
-    timeout-minutes: 14400
+    timeout-minutes: 360
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'reply-schema')
@@ -1127,7 +1127,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'oldTC')
     container: ubuntu:20.04
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -1173,7 +1173,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls') && !contains(github.event.inputs.skipjobs, 'oldTC')
     container: ubuntu:20.04
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -1224,7 +1224,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls') && !contains(github.event.inputs.skipjobs, 'oldTC')
     container: ubuntu:20.04
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -1274,7 +1274,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'defrag')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -1302,7 +1302,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'vectorset')
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,7 +11,7 @@ on:
     inputs:
       skipjobs:
         description: 'jobs to skip (delete the ones you wanna keep, do not leave empty)'
-        default: 'valgrind,sanitizer,tls,freebsd,macos,alpine,32bit,iothreads,ubuntu,centos,malloc,specific,fortify,reply-schema,oldTC,defrag,vectorset'
+        default: 'valgrind,sanitizer,tls,freebsd,macos,alpine,32bit,iothreads,ubuntu,centos,malloc,specific,fortify,reply-schema,oldTC,defrag,vectorset,assert-keyspace'
       skiptests:
         description: 'tests to skip (delete the ones you wanna keep, do not leave empty)'
         default: 'redis,modules,sentinel,cluster,unittest'
@@ -67,6 +67,47 @@ jobs:
     - name: unittest
       if: true && !contains(github.event.inputs.skiptests, 'unittest')
       run: ./src/redis-server test all --accurate
+
+  # Test with DEBUG_ASSERT_KEYSPACE enabled to verify keyspace consistency.
+  # This enables additional runtime checks after each command for:
+  # - Info keysizes histogram
+  # - Cluster slot stats
+  # Skips slow and defrag tests to avoid timeouts while maintaining good coverage.
+  # TODO: Fix ASM (atomic slot migration) compatibility with keysizes histogram tracking
+  test-debug-assert-keyspace:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
+      !contains(github.event.inputs.skipjobs, 'assert-keyspace')
+    timeout-minutes: 14400
+    steps:
+    - name: prep
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "GITHUB_REPOSITORY=${{github.event.inputs.use_repo}}" >> $GITHUB_ENV
+        echo "GITHUB_HEAD_REF=${{github.event.inputs.use_git_ref}}" >> $GITHUB_ENV
+        echo "skipjobs: ${{github.event.inputs.skipjobs}}"
+        echo "skiptests: ${{github.event.inputs.skiptests}}"
+        echo "test_args: ${{github.event.inputs.test_args}}"
+        echo "cluster_test_args: ${{github.event.inputs.cluster_test_args}}"
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ env.GITHUB_REPOSITORY }}
+        ref: ${{ env.GITHUB_HEAD_REF }}
+    - name: make
+      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST -DDEBUG_ASSERT_KEYSPACE'
+    - name: testprep
+      run: sudo apt-get install tcl8.6 tclx
+    - name: test
+      if: true && !contains(github.event.inputs.skiptests, 'redis')
+      run: |
+        ./runtest --verbose --tags "-slow -defrag" \
+          --skipunit unit/cluster/slot-stats \
+          --skipunit unit/cluster/atomic-slot-migration \
+          --dump-logs ${{github.event.inputs.test_args}}
+    - name: cluster tests
+      if: true && !contains(github.event.inputs.skiptests, 'cluster')
+      run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
   test-ubuntu-jemalloc-fortify:
     runs-on: ubuntu-latest

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -10,7 +10,7 @@ jobs:
   test-external-standalone:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.repository == 'redis/redis'
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - uses: actions/checkout@v4
     - name: Build
@@ -35,7 +35,7 @@ jobs:
   test-external-cluster:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.repository == 'redis/redis'
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
     - uses: actions/checkout@v4
     - name: Build
@@ -63,7 +63,7 @@ jobs:
   test-external-nodebug:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.repository == 'redis/redis'
-    timeout-minutes: 14400
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v4
       - name: Build

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -793,6 +793,30 @@ void linenoiseEditMoveRight(struct linenoiseState *l) {
     }
 }
 
+/* Consider letters/digits/underscore as “word”; others as delimiters. */
+static int isWordChar(char c) {
+    return (c == '_' || (c >= '0' && c <= '9') ||
+            (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'));
+}
+
+static void linenoiseEditMoveWordLeft(struct linenoiseState *l) {
+    if (l->pos == 0) return;
+    /* Skip any delimiters, then move left over the previous word */
+    while (l->pos > 0 && !isWordChar(l->buf[l->pos - 1])) l->pos--;
+    /* Then move to the start of that word */
+    while (l->pos > 0 && isWordChar(l->buf[l->pos - 1])) l->pos--;
+    refreshLine(l);
+}
+
+static void linenoiseEditMoveWordRight(struct linenoiseState *l) {
+    if (l->pos == l->len) return;
+    /* Skip the current word to the right */
+    while (l->pos < l->len && isWordChar(l->buf[l->pos])) l->pos++;
+    /* Then skip any delimiters to reach the next word */
+    while (l->pos < l->len && !isWordChar(l->buf[l->pos])) l->pos++;
+    refreshLine(l);
+}
+
 /* Move cursor to the start of the line. */
 void linenoiseEditMoveHome(struct linenoiseState *l) {
     if (l->pos != 0) {
@@ -1012,6 +1036,18 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
              * Use two calls to handle slow terminals returning the two
              * chars at different times. */
             if (read(l.ifd,seq,1) == -1) break;
+
+            /* Handle Meta-b / Meta-f directly because it's a 2-byte sequence */
+            if (seq[0] == 'b' || seq[0] == 'f') {
+                if (reverse_search_mode_enabled) {
+                    disableReverseSearchMode(&l, buf, buflen, 1);
+                    break;
+                }
+                if (seq[0] == 'b') linenoiseEditMoveWordLeft(&l);   /* ESC b → word left */
+                else linenoiseEditMoveWordRight(&l);                /* ESC f → word right */
+                break;
+            }
+
             if (read(l.ifd,seq+1,1) == -1) break;
 
             if (reverse_search_mode_enabled) {
@@ -1022,14 +1058,51 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
             /* ESC [ sequences. */
             if (seq[0] == '[') {
                 if (seq[1] >= '0' && seq[1] <= '9') {
-                    /* Extended escape, read additional byte. */
-                    if (read(l.ifd,seq+2,1) == -1) break;
-                    if (seq[2] == '~') {
-                        switch(seq[1]) {
-                        case '3': /* Delete key. */
-                            linenoiseEditDelete(&l);
-                            break;
-                        }
+                    /* Extended escape, read additional bytes.
+                     * Examples: ESC [1;5C  ESC [3~ */
+                    const int seq_buffer_max_length = 8;
+                    char seq_buffer[seq_buffer_max_length];
+                    int i = 0;
+                    seq_buffer[i++] = seq[1];
+
+                    /* Read more bytes until we see a CSI final byte (range @..~).
+                     * Use seq_buffer_max_length-1 to reserve one position for '\0'. */
+                    char seq_char;
+                    while (i < seq_buffer_max_length-1 && read(l.ifd, &seq_char, 1) == 1) {
+                        seq_buffer[i++] = seq_char;
+                        if (seq_char >= '@' && seq_char <= '~') break; /* CSI final byte */
+                    }
+                    seq_buffer[i] = '\0';
+
+                    /* The exact key mapping behavior depends on your keyboard/terminal setup.
+                     * For example, in MacOS terminal you can go to the profile keyboard setting
+                     * to see or configure the current mapping.
+                     *
+                     * Take action `[1;5C` (Ctrl + →) or `[1;3D` (Alt + ←) as examples:
+                     * [ indicates a CSI (Control Sequence Introducer), telling the terminal
+                     *    "What follows is a control command, not text"
+                     * 1 is how many units to move (default is 1 if omitted)
+                     * ; is the separator between parameters
+                     * 5 is the modifier mask for Ctrl. Other possible values include 1 (no modifier),
+                     *     2 (Shift), 3 (Alt), 4 (Shift + Alt), 6 (Shift + Ctrl), 7 (Alt + Ctrl), etc.
+                     * C is the cursor right command. Other commands include A (cursor up), B (cursor
+                     *     down), D (cursor left).
+                     */
+
+                    /* Word left: Ctrl + ← (modifier 5) or Alt + ← (modifier 3) */
+                    if (strcmp(seq_buffer, "1;5D") == 0 || strcmp(seq_buffer, "1;3D") == 0) {
+                        linenoiseEditMoveWordLeft(&l);
+                        break;
+                    }
+                    /* Word right: Ctrl + → (modifier 5) or Alt + → (modifier 3) */
+                    if (strcmp(seq_buffer, "1;5C") == 0 || strcmp(seq_buffer, "1;3C") == 0) {
+                        linenoiseEditMoveWordRight(&l);
+                        break;
+                    }
+                    /* Delete key */
+                    if (strcmp(seq_buffer, "3~") == 0) {
+                        linenoiseEditDelete(&l);
+                        break;
                     }
                 } else {
                     switch(seq[1]) {

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -120,6 +120,7 @@
 #include <assert.h>
 #include "linenoise.h"
 
+#define SEQ_BUFFER_MAX_LENGTH 8
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
 #define LINENOISE_MAX_LINE 4096
 static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
@@ -1060,15 +1061,14 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                 if (seq[1] >= '0' && seq[1] <= '9') {
                     /* Extended escape, read additional bytes.
                      * Examples: ESC [1;5C  ESC [3~ */
-                    const int seq_buffer_max_length = 8;
-                    char seq_buffer[seq_buffer_max_length];
+                    char seq_buffer[SEQ_BUFFER_MAX_LENGTH];
                     int i = 0;
                     seq_buffer[i++] = seq[1];
 
                     /* Read more bytes until we see a CSI final byte (range @..~).
-                     * Use seq_buffer_max_length-1 to reserve one position for '\0'. */
+                     * Use SEQ_BUFFER_MAX_LENGTH-1 to reserve one position for '\0'. */
                     char seq_char;
-                    while (i < seq_buffer_max_length-1 && read(l.ifd, &seq_char, 1) == 1) {
+                    while (i < SEQ_BUFFER_MAX_LENGTH - 1 && read(l.ifd, &seq_char, 1) == 1) {
                         seq_buffer[i++] = seq_char;
                         if (seq_char >= '@' && seq_char <= '~') break; /* CSI final byte */
                     }

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -40,24 +40,24 @@ ifeq ($(INSTALL_RUST_TOOLCHAIN),yes)
 		'x86_64') \
 			if [ "$${LIBC_TYPE}" = "musl" ]; then \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-x86_64-unknown-linux-musl"; \
-				RUST_SHA256="5a6c766ce05ad7229aadbb365bad2c9c809c9e378706f123c156821fe6ab2711"; \
+				RUST_SHA256="6a57ddfffa77bfa97ab325586b08fc1e96c3acb82ecc9f554cdb2ef748466ef2"; \
 			else \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-x86_64-unknown-linux-gnu"; \
-				RUST_SHA256="fa99eb4e823fdeb8ee25e486c7973b4803013ac68c64e8f74880da788db9739c"; \
+				RUST_SHA256="518872275a3648f735471d7add854d39171c5a6b17f423c4d7f931f52120c2af"; \
 			fi ;; \
 		'aarch64') \
 			if [ "$${LIBC_TYPE}" = "musl" ]; then \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-aarch64-unknown-linux-musl"; \
-				RUST_SHA256="859d2e973ba1b0106aaeb5df7db72673cb82b9de417339e28ae9b5074756db5b"; \
+				RUST_SHA256="34f0ffb0cd3e334aeae344daae09984f951eeb842386406d4bdf11cd0b4c2b36"; \
 			else \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-aarch64-unknown-linux-gnu"; \
-				RUST_SHA256="bbe822f0aae2c1d31fa950a78446d4749e07ed67e974f87bf0c69146df2a9d9c"; \
+				RUST_SHA256="701d55b62286bed013ceb2393ff7687d0953205605afaa15c62e2cd18024c32c"; \
 			fi ;; \
 		*) echo >&2 "Unsupported architecture: '$${ARCH}'"; exit 1 ;; \
 	esac; \
 	echo "Downloading and installing Rust standalone installer: $${RUST_INSTALLER}"; \
 	wget --quiet -O $${RUST_INSTALLER}.tar.xz https://static.rust-lang.org/dist/$${RUST_INSTALLER}.tar.xz; \
-	echo "$${RUST_SHA256} $${RUST_INSTALLER}.tar.xz" | sha256sum -c --quiet || { echo "Rust standalone installer checksum failed!"; exit 1; }; \
+	echo "$${RUST_SHA256} $${RUST_INSTALLER}.tar.xz" | sha256sum -c --status || { echo "Rust standalone installer checksum failed!"; exit 1; }; \
 	tar -xf $${RUST_INSTALLER}.tar.xz; \
 	(cd $${RUST_INSTALLER} && ./install.sh); \
 	rm -rf $${RUST_INSTALLER}

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -32,7 +32,7 @@ clean_environment: uninstall-rust
 # Keep all of the Rust stuff in one place
 install-rust:
 ifeq ($(INSTALL_RUST_TOOLCHAIN),yes)
-	@RUST_VERSION=1.92.0; \
+	@RUST_VERSION=1.93.1; \
 	ARCH="$$(uname -m)"; \
 	if ldd --version 2>&1 | grep -q musl; then LIBC_TYPE="musl"; else LIBC_TYPE="gnu"; fi; \
 	echo "Detected architecture: $${ARCH} and libc: $${LIBC_TYPE}"; \
@@ -40,18 +40,18 @@ ifeq ($(INSTALL_RUST_TOOLCHAIN),yes)
 		'x86_64') \
 			if [ "$${LIBC_TYPE}" = "musl" ]; then \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-x86_64-unknown-linux-musl"; \
-				RUST_SHA256="e9b977ef480504d3beef0a095b470945af79e8496bcbb0e4a9d4601d6d72dd91"; \
+				RUST_SHA256="5a6c766ce05ad7229aadbb365bad2c9c809c9e378706f123c156821fe6ab2711"; \
 			else \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-x86_64-unknown-linux-gnu"; \
-				RUST_SHA256="d2ccef59dd9f7439f2c694948069f789a044dc1addcc0803613232af8f88ee0c"; \
+				RUST_SHA256="fa99eb4e823fdeb8ee25e486c7973b4803013ac68c64e8f74880da788db9739c"; \
 			fi ;; \
 		'aarch64') \
 			if [ "$${LIBC_TYPE}" = "musl" ]; then \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-aarch64-unknown-linux-musl"; \
-				RUST_SHA256="0c35fca319d01c3d55345d44dbe66c987858c45e262a77c4db679e9869b0af73"; \
+				RUST_SHA256="859d2e973ba1b0106aaeb5df7db72673cb82b9de417339e28ae9b5074756db5b"; \
 			else \
 				RUST_INSTALLER="rust-$${RUST_VERSION}-aarch64-unknown-linux-gnu"; \
-				RUST_SHA256="3e383f8b4fca710d0600d0c1de97b78281672be2cda6575ecbe1c183a12e3822"; \
+				RUST_SHA256="bbe822f0aae2c1d31fa950a78446d4749e07ed67e974f87bf0c69146df2a9d9c"; \
 			fi ;; \
 		*) echo >&2 "Unsupported architecture: '$${ARCH}'"; exit 1 ;; \
 	esac; \

--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.5.90
+MODULE_VERSION = v8.6.0
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 

--- a/modules/redisjson/Makefile
+++ b/modules/redisjson/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.5.90
+MODULE_VERSION = v8.6.0
 MODULE_REPO = https://github.com/redisjson/redisjson
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/rejson.so
 

--- a/modules/redistimeseries/Makefile
+++ b/modules/redistimeseries/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.5.90
+MODULE_VERSION = v8.6.0
 MODULE_REPO = https://github.com/redistimeseries/redistimeseries
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redistimeseries.so
 

--- a/runtest
+++ b/runtest
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6 8.7"
+TCL_VERSIONS="8.5 8.6 8.7 9.0"
 TCLSH=""
 
 for VERSION in $TCL_VERSIONS; do

--- a/src/acl.c
+++ b/src/acl.c
@@ -2277,15 +2277,15 @@ int ACLLoadConfiguredUsers(void) {
 }
 
 /* This function loads the ACL from the specified filename: every line
- * is validated and should be either empty or in the format used to specify
- * users in the redis.conf configuration or in the ACL file, that is:
+ * is validated and should be either empty, a comment, or in the format
+ * used to specify users in the redis.conf configuration or in the ACL file,
+ * that is:
  *
  *  user <username> ... rules ...
  *
- * Note that this function considers comments starting with '#' as errors
- * because the ACL file is meant to be rewritten, and comments would be
- * lost after the rewrite. Yet empty lines are allowed to avoid being too
- * strict.
+ * Lines starting with '#' are treated as comments and ignored. Note that
+ * comments will be lost after ACL SAVE rewrites the file. Empty lines are
+ * also allowed.
  *
  * One important part of implementing ACL LOAD, that uses this function, is
  * to avoid ending with broken rules if the ACL file is invalid for some
@@ -2337,8 +2337,8 @@ sds ACLLoadFromFile(const char *filename) {
 
         lines[i] = sdstrim(lines[i]," \t\r\n");
 
-        /* Skip blank lines */
-        if (lines[i][0] == '\0') continue;
+        /* Skip blank lines and comments */
+        if (lines[i][0] == '\0' || lines[i][0] == '#') continue;
 
         /* Split into arguments */
         argv = sdssplitlen(lines[i],sdslen(lines[i])," ",1,&argc);

--- a/src/anet.c
+++ b/src/anet.c
@@ -715,7 +715,7 @@ error:
  * and one of the use cases is O_CLOEXEC|O_NONBLOCK. */
 int anetPipe(int fds[2], int read_flags, int write_flags) {
     int pipe_flags = 0;
-#if defined(__linux__) || defined(__FreeBSD__)
+#ifdef HAVE_PIPE2
     /* When possible, try to leverage pipe2() to apply flags that are common to both ends.
      * There is no harm to set O_CLOEXEC to prevent fd leaks. */
     pipe_flags = O_CLOEXEC | (read_flags & write_flags);

--- a/src/aof.c
+++ b/src/aof.c
@@ -2211,17 +2211,31 @@ int rioWriteStreamEmptyConsumer(rio *r, robj *key, const char *groupname, size_t
     return 1;
 }
 
+/* Helper for rewriteStreamObject(): emit the XIDMPRECORD needed to
+ * restore an IDMP entry for the given producer in the context of the
+ * specified key. */
+int rioWriteStreamIdmpEntry(rio *r, robj *key, const char *pid, size_t pid_len, idmpEntry *entry) {
+    /* XIDMPRECORD <key> <pid> <iid> <streamID> */
+    if (rioWriteBulkCount(r,'*',5) == 0) return 0;
+    if (rioWriteBulkString(r,"XIDMPRECORD",11) == 0) return 0;
+    if (rioWriteBulkObject(r,key) == 0) return 0;
+    if (rioWriteBulkString(r,pid,pid_len) == 0) return 0;
+    if (rioWriteBulkString(r,entry->iid,entry->iid_len) == 0) return 0;
+    if (rioWriteBulkStreamID(r,&entry->id) == 0) return 0;
+    return 1;
+}
+
 /* Emit the commands needed to rebuild a stream object.
  * The function returns 0 on error, 1 on success. */
 int rewriteStreamObject(rio *r, robj *key, robj *o) {
     stream *s = o->ptr;
-    streamIterator si;
-    streamIteratorStart(&si,s,NULL,NULL,0);
     streamID id;
-    int64_t numfields;
 
     if (s->length) {
         /* Reconstruct the stream data using XADD commands. */
+        streamIterator si;
+        int64_t numfields;
+        streamIteratorStart(&si,s,NULL,NULL,0);
         while(streamIteratorGetID(&si,&id,&numfields)) {
             /* Emit a two elements array for each item. The first is
              * the ID, the second is an array of field-value pairs. */
@@ -2247,6 +2261,7 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
                 }
             }
         }
+        streamIteratorStop(&si);
     } else {
         /* Use the XADD MAXLEN 0 trick to generate an empty stream if
          * the key we are serializing is an empty string, which is possible
@@ -2261,7 +2276,6 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
             !rioWriteBulkString(r,"x",1) ||
             !rioWriteBulkString(r,"y",1))
         {
-            streamIteratorStop(&si);
             return 0;     
         }
     }
@@ -2277,10 +2291,8 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
         !rioWriteBulkString(r,"MAXDELETEDID",12) ||
         !rioWriteBulkStreamID(r,&s->max_deleted_entry_id)) 
     {
-        streamIteratorStop(&si);
         return 0; 
     }
-
 
     /* Create all the stream consumer groups. */
     if (s->cgroups) {
@@ -2300,7 +2312,6 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
                 !rioWriteBulkLongLong(r,group->entries_read))
             {
                 raxStop(&ri);
-                streamIteratorStop(&si);
                 return 0;
             }
 
@@ -2319,7 +2330,6 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
                     {
                         raxStop(&ri_cons);
                         raxStop(&ri);
-                        streamIteratorStop(&si);
                         return 0;
                     }
                     continue;
@@ -2338,7 +2348,6 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
                         raxStop(&ri_pel);
                         raxStop(&ri_cons);
                         raxStop(&ri);
-                        streamIteratorStop(&si);
                         return 0;
                     }
                 }
@@ -2349,7 +2358,46 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
         raxStop(&ri);
     }
 
-    streamIteratorStop(&si);
+    /* Emit XCFGSET to restore per-stream IDMP configuration if it differs
+     * from the server defaults, so that AOF rewrite preserves custom settings. */
+    if (s->idmp_duration != (uint64_t)server.stream_idmp_duration ||
+        s->idmp_max_entries != (uint64_t)server.stream_idmp_maxsize)
+    {
+        if (!rioWriteBulkCount(r,'*',6) ||
+            !rioWriteBulkString(r,"XCFGSET",7) ||
+            !rioWriteBulkObject(r,key) ||
+            !rioWriteBulkString(r,"IDMP-DURATION",13) ||
+            !rioWriteBulkLongLong(r,s->idmp_duration) ||
+            !rioWriteBulkString(r,"IDMP-MAXSIZE",12) ||
+            !rioWriteBulkLongLong(r,s->idmp_max_entries))
+        {
+            return 0;
+        }
+    }
+
+    /* Emit XIDMPRECORD for each IDMP entry. Entries whose stream ID no
+     * longer exists (removed by XDEL/trim) are skipped, since
+     * xidmprecordCommand() rejects references to missing IDs and would
+     * cause AOF replay errors. */
+    if (s->idmp_producers) {
+        raxIterator ri_idmp;
+        raxStart(&ri_idmp,s->idmp_producers);
+        raxSeek(&ri_idmp,"^",NULL,0);
+        while(raxNext(&ri_idmp)) {
+            idmpProducer *producer = ri_idmp.data;
+            for (idmpEntry *entry = producer->idmp_head; entry != NULL; entry = entry->next) {
+                if (!streamEntryExists(s, &entry->id)) continue;
+                if (rioWriteStreamIdmpEntry(r,key,(char*)ri_idmp.key,
+                                            ri_idmp.key_len,entry) == 0)
+                {
+                    raxStop(&ri_idmp);
+                    return 0;
+                }
+            }
+        }
+        raxStop(&ri_idmp);
+    }
+
     return 1;
 }
 

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1722,7 +1722,7 @@ void bitfieldGeneric(client *c, int flags) {
     kvobj *o;
     uint64_t bitoffset;
     int j, numops = 0, changes = 0;
-    size_t strOldSize, strGrowSize = 0;
+    size_t strOldSize = 0, strGrowSize = 0;
     struct bitfieldOp *ops = NULL; /* Array of ops to execute at end. */
     int owtype = BFOVERFLOW_WRAP; /* Overflow type. */
     int readonly = 1;

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -237,7 +237,11 @@ int blockedClientMayTimeout(client *c) {
  * unblockClient() will be called with the same client as argument. */
 void replyToBlockedClientTimedOut(client *c) {
     if (c->bstate.btype == BLOCKED_LAZYFREE) {
-        addReply(c, shared.ok); /* No reason lazy-free to fail */
+        /* SFLUSH: reply with empty array, FLUSH*: reply with OK */
+        if (c->cmd && c->cmd->proc == sflushCommand)
+            addReplyArrayLen(c, 0);
+        else
+            addReply(c, shared.ok); /* No reason lazy-free to fail */
     } else if (c->bstate.btype == BLOCKED_LIST ||
         c->bstate.btype == BLOCKED_ZSET ||
         c->bstate.btype == BLOCKED_STREAM) {
@@ -297,7 +301,11 @@ void disconnectAllBlockedClients(void) {
                 continue;
 
             if (c->bstate.btype == BLOCKED_LAZYFREE) {
-                addReply(c, shared.ok); /* No reason lazy-free to fail */
+                /* SFLUSH: reply with empty array, FLUSH*: reply with OK */
+                if (c->cmd && c->cmd->proc == sflushCommand)
+                    addReplyArrayLen(c, 0);
+                else
+                    addReply(c, shared.ok);
                 updateStatsOnUnblock(c, 0, 0, 0);
                 c->flags &= ~CLIENT_PENDING_COMMAND;
                 unblockClient(c, 1);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1268,6 +1268,7 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
             /* The command has keys and was checked for cross-slot between its keys in preprocessCommand() */
             if (pcmd->read_error == CLIENT_READ_CROSS_SLOT) {
                 /* Error: multiple keys from different slots. */
+                if (!use_cache_keys_result) getKeysFreeResult(&result);
                 if (error_code)
                     *error_code = CLUSTER_REDIR_CROSS_SLOT;
                 return NULL;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2118,12 +2118,13 @@ slotRangeArray *clusterGetLocalSlotRanges(void) {
  *
  * Usage: SFLUSH <start-slot> <end slot> [<start-slot> <end slot>]* [SYNC|ASYNC]
  *
- * This is an initial implementation of SFLUSH (slots flush) which is limited to
- * flushing a single shard as a whole, but in the future the same command may be
- * used to partially flush a shard based on hash slots. Currently only if provided
- * slots cover entirely the slots of a node, the node will be flushed and the
- * return value will be pairs of slot ranges. Otherwise, a single empty set will 
- * be returned. If possible, SFLUSH SYNC will be run as blocking ASYNC as an 
+ * Redis will flush the slots that belong to this node and reply with the flushed 
+ * slot ranges. If no slot is flushed, an empty array will be returned.
+ * 
+ * e.g. Node owns slot 100-200, user issues SFLUSH 50 150
+ * Redis will flush slot 100-150 and reply with [100,150]
+ * 
+ * If possible, SFLUSH SYNC will be run as blocking ASYNC as an 
  * optimization.
  */
 void sflushCommand(client *c) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -284,6 +284,8 @@ void restoreCommand(client *c) {
             notifyKeyspaceEvent(NOTIFY_GENERIC,"del",key,c->db->id);
             server.dirty++;
         }
+        /* Update the stats, see setGenericCommand for details. */
+        server.stat_expiredkeys++;
         keyMetaSpecCleanup(&keymeta);
         decrRefCount(obj);
         addReply(c, shared.ok);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -24,6 +24,7 @@
 #include "cluster_slot_stats.h"
 
 #include <ctype.h>
+#include "bio.h"
 
 /* -----------------------------------------------------------------------------
  * Key space handling
@@ -1175,6 +1176,8 @@ int extractSlotFromKeysResult(robj **argv, getKeysResult *keys_result) {
  * already "down" but it is fragile to rely on the update of the global state,
  * so we also handle it here.
  *
+ * CLUSTER_REDIR_TRIMMING if the request addresses a slot that is being trimmed.
+ *
  * CLUSTER_REDIR_DOWN_STATE and CLUSTER_REDIR_DOWN_RO_STATE if the cluster is
  * down but the user attempts to execute a command that addresses one or more keys. */
 clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, int argc, int *hashslot,
@@ -1416,6 +1419,15 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
         return myself;
     }
 
+    /* If this node is responsible for the slot and is currently trimming it,
+     * SFLUSH may have triggered active trimming and it could still be in progress.
+     * Here we reject any write commands as no writes should be accepted for
+     * trimming slots while active trimming is in progress. */
+    if (n == myself && is_write_command && isSlotInTrimJob(slot)) {
+        if (error_code) *error_code = CLUSTER_REDIR_TRIMMING;
+        return NULL;
+    }
+
     /* Base case: just return the right node. However, if this node is not
      * myself, set error_code to MOVED since we need to issue a redirection. */
     if (n != myself && error_code) *error_code = CLUSTER_REDIR_MOVED;
@@ -1452,6 +1464,8 @@ void clusterRedirectClient(client *c, clusterNode *n, int hashslot, int error_co
                                         "-%s %d %s:%d",
                                         (error_code == CLUSTER_REDIR_ASK) ? "ASK" : "MOVED",
                                         hashslot, clusterNodePreferredEndpoint(n), port));
+    } else if (error_code == CLUSTER_REDIR_TRIMMING) {
+        addReplyError(c,"-TRYAGAIN Slot is being trimmed");
     } else {
         serverPanic("getNodeByQuery() unknown error.");
     }
@@ -1973,6 +1987,19 @@ void slotRangeArrayFreeGeneric(void *slots) {
     slotRangeArrayFree(slots);
 }
 
+/* Returns the number of keys in the given slot ranges. */
+unsigned long long getKeyCountInSlotRangeArray(slotRangeArray *slots) {
+    if (!slots) return 0;
+
+    unsigned long long key_count = 0;
+    for (int i = 0; i < slots->num_ranges; i++) {
+        for (int j = slots->ranges[i].start; j <= slots->ranges[i].end; j++) {
+            key_count += countKeysInSlot(j);
+        }
+    }
+    return key_count;
+}
+
 /* Slot range array iterator */
 slotRangeArrayIter *slotRangeArrayGetIterator(slotRangeArray *slots) {
     slotRangeArrayIter *it = zmalloc(sizeof(*it));
@@ -2100,6 +2127,7 @@ slotRangeArray *clusterGetLocalSlotRanges(void) {
  */
 void sflushCommand(client *c) {
     int flags = EMPTYDB_NO_FLAGS, argc = c->argc;
+    int trim_method = ASM_TRIM_METHOD_NONE;
 
     if (server.cluster_enabled == 0) {
         addReplyError(c,"This instance has cluster support disabled");
@@ -2127,40 +2155,73 @@ void sflushCommand(client *c) {
     slotRangeArray *slots = parseSlotRangesOrReply(c, argc, 1);
     if (!slots) return;
 
+    /* If client is AOF or master, we must obey the slot ranges.
+     * NOTE: we should exclude CLIENT_PSEUDO_MASTER when merging into fork. */
+    int must_obey = mustObeyClient(c);
+
     /* Iterate and find the slot ranges that belong to this node. Save them in
      * a new slotRangeArray. It is allocated on heap since there is a chance
      * that FLUSH SYNC will be running as blocking ASYNC and only later reply
      * with slot ranges */
-    unsigned char slots_to_flush[CLUSTER_SLOTS] = {0}; /* Requested slots to flush */
     slotRangeArray *myslots = NULL;
     for (int i = 0; i < slots->num_ranges; i++) {
         for (int j = slots->ranges[i].start; j <= slots->ranges[i].end; j++) {
-            if (clusterIsMySlot(j)) {
+            if (must_obey || clusterIsMySlot(j)) {
                 myslots = slotRangeArrayAppend(myslots, j);
-                slots_to_flush[j] = 1;
             }
         }
     }
 
-    /* Verify that all slots of mynode got covered. See sflushCommand() comment. */
-    int all_slots_covered = 1;
-    for (int i = 0; i < CLUSTER_SLOTS; i++) {
-        if (clusterIsMySlot(i) && !slots_to_flush[i]) {
-            all_slots_covered = 0;
-            break;
-        }
-    }
-    if (myslots == NULL || !all_slots_covered) {
+    /* If no slots belong to this node, return empty array. */
+    if (myslots == NULL) {
         addReplyArrayLen(c, 0);
         slotRangeArrayFree(slots);
-        slotRangeArrayFree(myslots);
         return;
     }
     slotRangeArrayFree(slots);
 
-    /* Flush selected slots. If not flush as blocking async, then reply immediately */
-    if (flushCommandCommon(c, FLUSH_TYPE_SLOTS, flags, myslots) == 0)
+    /* Cancel all ASM tasks that overlap with the given slot ranges. */
+    clusterAsmCancelBySlotRangeArray(myslots, c->argv[0]->ptr);
+
+    /* In case of SYNC, check if we can optimize and run it in bg as blocking ASYNC */
+    int blocking_async = 0;
+    if ((!(flags & EMPTYDB_ASYNC)) && (!(c->flags & CLIENT_AVOID_BLOCKING_ASYNC_FLUSH))) {
+        flags |= EMPTYDB_ASYNC; /* Run as ASYNC */
+        blocking_async = 1;
+    }
+
+    /* Trim the slots if running in async mode and not loading from AOF,
+     * otherwise delete the keys synchronously. */
+    if (flags & EMPTYDB_ASYNC && server.loading == 0) {
+        /* Update dirty stats before trimming. */
+        server.dirty += getKeyCountInSlotRangeArray(myslots);
+        /* Pass client id for active trim to unblock client when trim completes. */
+        trim_method = asmTrimSlots(myslots, blocking_async ? c->id : 0, 0);
+    } else {
+        clusterDelKeysInSlotRangeArray(myslots, 1);
+    }
+
+    /* Without the forceCommandPropagation, when DB was already empty,
+     * SFLUSH will not be replicated nor put into the AOF. */
+    forceCommandPropagation(c, PROPAGATE_REPL | PROPAGATE_AOF);
+
+    /* Handle waiting for trim job to complete in case of blocking async flush.
+     * Block the client and schedule completion callback based on trim method:
+     * - BG trim uses BIO lazyfree worker to trim the slots, so schedule a new
+     *   BIO lazyfree worker to wait for completion, then unblock client and reply.
+     * - Active trim works in cron job of the main thread, it will automatically
+     *   unblock client and reply in active trim completion. */
+    if (blocking_async && trim_method != ASM_TRIM_METHOD_NONE) {
+        blockClientForAsyncFlush(c);
+        if (trim_method == ASM_TRIM_METHOD_BG)
+            bioCreateCompRq(BIO_WORKER_LAZY_FREE, unblockClientForAsyncFlush, c->id, myslots);
+        else /* ASM_TRIM_METHOD_ACTIVE, just free the slot ranges */
+            slotRangeArrayFree(myslots);
+    } else {
+        /* Reply with slot ranges that were flushed. SYNC and ASYNC mode will be
+         * replied here immediately. */
         replySlotsFlushAndFree(c, myslots);
+    }
 }
 
 /* The READWRITE command just clears the READONLY command state. */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -37,6 +37,7 @@
 #define CLUSTER_REDIR_DOWN_STATE 5    /* -CLUSTERDOWN, global state. */
 #define CLUSTER_REDIR_DOWN_UNBOUND 6  /* -CLUSTERDOWN, unbound slot. */
 #define CLUSTER_REDIR_DOWN_RO_STATE 7 /* -CLUSTERDOWN, allow reads. */
+#define CLUSTER_REDIR_TRIMMING 8      /* -TRYAGAIN, slot is being trimmed. */
 
 typedef struct _clusterNode clusterNode;
 struct clusterState;
@@ -196,6 +197,7 @@ int slotRangeArrayGetCurrentSlot(slotRangeArrayIter *it);
 void slotRangeArrayIteratorFree(slotRangeArrayIter *it);
 int slotRangeArrayNormalizeAndValidate(slotRangeArray *slots, sds *err);
 slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos);
+unsigned long long getKeyCountInSlotRangeArray(slotRangeArray *slots);
 
 unsigned int clusterDelKeysInSlot(unsigned int hashslot, int by_command);
 unsigned int clusterDelKeysInSlotRangeArray(slotRangeArray *slots, int by_command);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1031,7 +1031,7 @@ void asmLogTaskEvent(asmTask *task, int event) {
                       task->id, str, getKeyCountInSlotRangeArray(task->slots));
             break;
         case ASM_EVENT_MIGRATE_STARTED:
-            serverLog(LL_NOTICE, "Migrate task %s started for slots: %s (keys at start: %llu)",
+            serverLog(LL_NOTICE, "Migrate task %s started for slots: %s (number of keys at start: %llu)",
                       task->id, str, getKeyCountInSlotRangeArray(task->slots));
             break;
         case ASM_EVENT_MIGRATE_FAILED:
@@ -1213,6 +1213,11 @@ static void asmTaskCancel(asmTask *task, const char *reason) {
 void asmImportTakeover(asmTask *task) {
     serverAssert(task->state == ASM_WAIT_STREAM_EOF ||
                  task->state == ASM_STREAMING_BUF);
+
+    if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, ASM_TAKEOVER))) {
+        /* Do not take over slots to test timeout scenario. */
+        return;
+    }
 
     /* Free the main channel connection since it is no longer needed. */
     serverAssert(task->main_channel_conn != NULL);
@@ -2069,6 +2074,7 @@ void clusterSyncSlotsCommand(client *c) {
                 return;
             }
             task->dest_offset = offset;
+            /* Detailed ACK progress log (for debugging handoff/drain issues). */
             serverLog(LL_DEBUG, "CLUSTER SYNCSLOTS ACK received, dest state: %s, "
                                 "updated dest offset to %lld, source offset: %lld",
                 asmTaskStateToString(dest_state), task->dest_offset, task->source_offset);
@@ -2559,28 +2565,9 @@ void asmBeforeSleep(void) {
             return;
         }
 
-        if (task->state == ASM_HANDOFF) {
-            /* To avoid long pause, we fail the task if the pause takes too long. */
-            if (server.mstime - task->paused_time >= server.asm_write_pause_timeout) {
-                asmTaskSetFailed(task, "Server paused timeout");
-                return;
-            }
+        /* Send STREAM-EOF if the destination drained the command stream. */
+        if (task->state == ASM_HANDOFF)
             asmSendStreamEofIfDrained(task);
-        } else if (task->state == ASM_STREAM_EOF) {
-            /* In state ASM_STREAM_EOF (server is still paused), we are waiting
-             * for the destination node to broadcast the slot ownership change.
-             * But maybe the destination node is failed or network is not available,
-             * the source node may be paused forever. So we fail the task if it
-             * takes too long.
-             *
-             * NOTE: There is a tricky case where the destination node may advertise
-             * ownership of the slot, causing a temporary configuration conflict.
-             * However, the configuration will eventually converge. In most cases,
-             * the destination node becomes the winner, since it bumps its config
-             * epoch before taking over slot ownership. */
-            if (server.mstime - task->paused_time >= server.asm_write_pause_timeout)
-                asmTaskSetFailed(task, "Server paused timeout");
-        }
     }
 }
 
@@ -2650,6 +2637,25 @@ void asmCron(void) {
                         (task->dest_accum_applied_time - task->dest_slots_snapshot_time) * 2))
             {
                 asmTaskSetFailed(task, "Sync buffer drain timeout");
+            }
+        } else if (task->state == ASM_HANDOFF || task->state == ASM_STREAM_EOF) {
+            /* In these states, writes are still paused while waiting for the 
+             * destination to broadcast the slot ownership change. If the 
+             * destination fails or becomes unreachable, the source could remain 
+             * paused indefinitely, so we enforce a timeout and fail the task.
+             * 
+             * NOTE: There is a tricky case where the destination node may 
+             * advertise ownership of the slot after the source node resumes 
+             * writes, causing a temporary configuration conflict. However, the
+             * configuration will eventually converge. In most cases, the
+             * destination node becomes the winner, since it bumps its config 
+             * epoch before taking over slot ownership. During this window, 
+             * writes accepted by the source will not be replicated to the
+             * destination and those writes will be lost.*/
+            if (server.mstime - task->paused_time >= server.asm_write_pause_timeout) {
+                asmTaskSetFailed(task, "Write pause timeout during slot handoff: destination did not take ownership within %lld ms.",
+                                 server.asm_write_pause_timeout);
+                return;
             }
         }
     }
@@ -2998,7 +3004,48 @@ void asmTriggerBackgroundTrim(slotRangeArray *slots, int migration_cleanup) {
     asmUnblockMasterAfterTrim();
 }
 
-/* Trim the slots, return the trim method used.
+/* Trimming of slots can be triggered in several cases: 
+ *  - After a successful ASM migrate operation: slots are migrated away from
+ *    this node and keys that are no longer owned must be removed.
+ *  - After a failed ASM import operation: partially imported slot data must
+ *    be cleaned up.
+ *  - Due to user initiated SFLUSH command.
+ * 
+ * Redis supports two trimming methods: background trim and active trim.
+ * 
+ * Background trim: In cluster mode, Redis maintains per-slot data structures 
+ * for keys, expires, and subexpires. This makes it possible to efficiently 
+ * detach all data associated with a given slot in a single step. During trimming, 
+ * these slot-specific data structures are handed off to a BIO thread for 
+ * asynchronous cleanup, similar to how FLUSHALL or FLUSHDB operate. This is the 
+ * default trimming method.
+ * 
+ * Active trim: Unlike Redis itself, some modules may not maintain per-slot data
+ * structures and therefore cannot drop related slots data in a single operation.
+ * To support these cases, Redis introduces active trim, where key deletion 
+ * occurs in the main thread instead. This is not a blocking operation, trimming
+ * runs concurrently in the main thread, periodically removing keys during the
+ * cron loop. Each deletion triggers a keyspace notification so that modules can
+ * react to individual key removals. While active trim is less efficient, it 
+ * ensures backward compatibility for modules during the transition period.
+
+ * Before starting the trim, Redis checks whether any module is subscribed to 
+ * REDISMODULE_NOTIFY_KEY_TRIMMED keyspace event. If such subscribers exist,
+ * active trim is used; otherwise, background trim is triggered. Going forward,
+ * modules are expected to adopt background trim and active trim will be phased 
+ * out once modules migrate to the new method.
+ *
+ * Active trim is also preferred if there is any client that is using client
+ * tracking feature (client-side caching). In the client tracking protocol, 
+ * there is currently no mechanism to signal that only specific slots have been
+ * flushed. So, iterating over all keys in the slots and sending invalidation 
+ * notifications would be a blocking operation. To avoid this, if there is any 
+ * client that is using client tracking feature, Redis triggers active trim. 
+ * During trimming, it sends invalidation notifications for each key being trimmed.
+ * In the future, the client tracking protocol can be extended to support slot-based
+ * invalidation, allowing background trim to be used in this case as well.
+ * 
+ * Trim the slots, return the trim method used.
  * If client_id is non-zero, the client will be unblocked when trim completes.
  * If migration_cleanup is true, this is a migration cleanup of slots no longer owned. */
 int asmTrimSlots(struct slotRangeArray *slots, uint64_t client_id, int migration_cleanup) {
@@ -3027,14 +3074,15 @@ int asmTrimSlots(struct slotRangeArray *slots, uint64_t client_id, int migration
 
 /* Schedule a trim job for the specified slot ranges. The job will be
  * deferred and handled later in asmBeforeSleep(). We delay the trim jobs to
- * asmBeforeSleep() to ensure it only runs when there is no write pause. */
+ * asmBeforeSleep() to ensure it only runs when there is no write pause. 
+ * For trim method details, see asmTrimSlots(). */
 void asmTrimJobSchedule(slotRangeArray *slots) {
     listAddNodeTail(asmManager->pending_trim_jobs, slotRangeArrayDup(slots));
 }
 
 /* Process any pending trim jobs. */
 void asmTrimJobProcessPending(void) {
-    /* Check if there is any pending trim job and we can propagate it. */
+    /* Check if there is any pending trim jobs. */
     if (listLength(asmManager->pending_trim_jobs) == 0 ||
         asmManager->debug_trim_method == ASM_DEBUG_TRIM_NONE)
     {
@@ -3051,7 +3099,7 @@ void asmTrimJobProcessPending(void) {
 
     /* Determine if we can start the trim job:
      * - require client writes not paused (so key deletions are allowed)
-     * - require replicas not paused (so TRIMSLOTS can be propagated).
+     * - require replica traffic is not paused (so TRIMSLOTS can be propagated).
      * - require trim is not disabled via RedisModule_ClusterDisableTrim().
      */
     static int logged = 0;

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -54,6 +54,12 @@ typedef struct asmTask {
     redisOpArray *pre_snapshot_module_cmds; /* Module commands to be propagated at the beginning of slot migration */
 } asmTask;
 
+typedef struct activeTrimJob {
+    slotRangeArray *slots;      /* Slots being trimmed */
+    uint64_t client_id;         /* Client ID waiting for active trim completion (0 if none) */
+    int migration_cleanup;      /* Whether this is a migration cleanup of slots no longer owned */
+} activeTrimJob;
+
 struct asmManager {
     list *tasks;                        /* List of asmTask to be processed */
     list *archived_tasks;               /* List of archived asmTask */
@@ -140,11 +146,12 @@ static void propagateTrimSlots(slotRangeArray *slots);
 void asmTrimJobSchedule(slotRangeArray *slots);
 void asmTrimJobProcessPending(void);
 void asmCancelPendingTrimJobs(void);
-void asmTriggerActiveTrim(slotRangeArray *slots);
+void asmTriggerActiveTrim(slotRangeArray *slots, uint64_t client_id, int migration_cleanup);
 void asmActiveTrimEnd(void);
 int asmIsAnyTrimJobOverlaps(slotRangeArray *slots);
 void asmTrimSlotsIfNotOwned(slotRangeArray *slots);
 void asmNotifyStateChange(asmTask *task, int event);
+void activeTrimJobFreeMethod(void *ptr);
 
 void asmInit(void) {
     asmManager = zcalloc(sizeof(*asmManager));
@@ -161,7 +168,7 @@ void asmInit(void) {
     asmManager->active_trim_started = 0;
     asmManager->active_trim_completed = 0;
     asmManager->active_trim_cancelled = 0;
-    listSetFreeMethod(asmManager->active_trim_jobs, slotRangeArrayFreeGeneric);
+    listSetFreeMethod(asmManager->active_trim_jobs, activeTrimJobFreeMethod);
 }
 
 char *asmTaskStateToString(int state) {
@@ -1005,19 +1012,6 @@ void clusterMigrationCommand(client *c) {
     }
 }
 
-/* Return the number of keys in the specified slot ranges. */
-unsigned long long asmCountKeysInSlots(slotRangeArray *slots) {
-    if (!slots) return 0;
-
-    unsigned long long key_count = 0;
-    for (int i = 0; i < slots->num_ranges; i++) {
-        for (int j = slots->ranges[i].start; j <= slots->ranges[i].end; j++) {
-            key_count += kvstoreDictSize(server.db[0].keys, j);
-        }
-    }
-    return key_count;
-}
-
 /* Log a human-readable message for ASM task lifecycle events. */
 void asmLogTaskEvent(asmTask *task, int event) {
     sds str = slotRangeArrayToString(task->slots);
@@ -1034,11 +1028,11 @@ void asmLogTaskEvent(asmTask *task, int event) {
             break;
         case ASM_EVENT_IMPORT_COMPLETED:
             serverLog(LL_NOTICE, "Import task %s completed for slots: %s (imported %llu keys)",
-                      task->id, str, asmCountKeysInSlots(task->slots));
+                      task->id, str, getKeyCountInSlotRangeArray(task->slots));
             break;
         case ASM_EVENT_MIGRATE_STARTED:
             serverLog(LL_NOTICE, "Migrate task %s started for slots: %s (keys at start: %llu)",
-                      task->id, str, asmCountKeysInSlots(task->slots));
+                      task->id, str, getKeyCountInSlotRangeArray(task->slots));
             break;
         case ASM_EVENT_MIGRATE_FAILED:
             serverLog(LL_NOTICE, "Migrate task %s failed for slots: %s", task->id, str);
@@ -1048,7 +1042,7 @@ void asmLogTaskEvent(asmTask *task, int event) {
             break;
         case ASM_EVENT_MIGRATE_COMPLETED:
             serverLog(LL_NOTICE, "Migrate task %s completed for slots: %s (migrated %llu keys)",
-                      task->id, str, asmCountKeysInSlots(task->slots));
+                      task->id, str, getKeyCountInSlotRangeArray(task->slots));
             break;
         default:
             break;
@@ -1886,6 +1880,14 @@ void clusterSyncSlotsCommand(client *c) {
                 slotRangeArrayFree(slots);
                 return;
             }
+        }
+
+        /* Check if there is any trim job in progress for the slot ranges.
+         * We can't start the migrate task since the trim job will modify the data.*/
+        if (asmIsAnyTrimJobOverlaps(slots)) {
+            addReplyError(c, "Trim job in progress for the slots");
+            slotRangeArrayFree(slots);
+            return;
         }
 
         sds task_id = c->argv[3]->ptr;
@@ -2779,8 +2781,8 @@ int isSlotInTrimJob(int slot) {
     /* Check if the slot is in any active trim job. */
     listRewind(asmManager->active_trim_jobs, &li);
     while ((ln = listNext(&li)) != NULL) {
-        slotRangeArray *slots = listNodeValue(ln);
-        if (slotRangeArrayOverlaps(slots, &req))
+        activeTrimJob *job = listNodeValue(ln);
+        if (slotRangeArrayOverlaps(job->slots, &req))
             return 1;
     }
     return 0;
@@ -2946,16 +2948,19 @@ void asmUnblockMasterAfterTrim(void) {
     }
 }
 
-/* Trim the slots asynchronously in the BIO thread. */
-void asmTriggerBackgroundTrim(slotRangeArray *slots) {
+/* Trim the slots asynchronously in the BIO thread. migration_cleanup is true if this
+ * is a migration cleanup of slots no longer owned. */
+void asmTriggerBackgroundTrim(slotRangeArray *slots, int migration_cleanup) {
     RedisModuleClusterSlotMigrationTrimInfoV1 fsi = {
             REDISMODULE_CLUSTER_SLOT_MIGRATION_TRIMINFO_VERSION,
             (RedisModuleSlotRangeArray *) slots
     };
 
-    moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM,
-                          REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_BACKGROUND,
-                          &fsi);
+    /* Fire the trim event to modules only if this is a migration cleanup. */
+    if (migration_cleanup)
+        moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM,
+                REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_BACKGROUND,
+                &fsi);
 
     signalFlushedDb(0, 1, slots);
 
@@ -2993,10 +2998,12 @@ void asmTriggerBackgroundTrim(slotRangeArray *slots) {
     asmUnblockMasterAfterTrim();
 }
 
-/* Trim the slots. */
-void asmTrimSlots(slotRangeArray *slots) {
+/* Trim the slots, return the trim method used.
+ * If client_id is non-zero, the client will be unblocked when trim completes.
+ * If migration_cleanup is true, this is a migration cleanup of slots no longer owned. */
+int asmTrimSlots(struct slotRangeArray *slots, uint64_t client_id, int migration_cleanup) {
     if (asmManager->debug_trim_method == ASM_DEBUG_TRIM_NONE)
-        return;
+        return ASM_TRIM_METHOD_NONE;
 
     /* Trigger active trim for the following cases:
      * 1. Debug override: trim method is set to 'active'.
@@ -3011,9 +3018,11 @@ void asmTrimSlots(slotRangeArray *slots) {
                      (asmManager->debug_trim_method == ASM_DEBUG_TRIM_DEFAULT &&
                       moduleHasSubscribersForKeyspaceEvent(NOTIFY_KEY_TRIMMED));
     if (activetrim)
-        asmTriggerActiveTrim(slots);
+        asmTriggerActiveTrim(slots, client_id, migration_cleanup);
     else
-        asmTriggerBackgroundTrim(slots);
+        asmTriggerBackgroundTrim(slots, migration_cleanup);
+
+    return activetrim ? ASM_TRIM_METHOD_ACTIVE : ASM_TRIM_METHOD_BG;
 }
 
 /* Schedule a trim job for the specified slot ranges. The job will be
@@ -3068,7 +3077,7 @@ void asmTrimJobProcessPending(void) {
     listRewind(asmManager->pending_trim_jobs, &li);
     while ((ln = listNext(&li)) != NULL) {
         slotRangeArray *slots = listNodeValue(ln);
-        asmTrimSlots(slots);
+        asmTrimSlots(slots, 0, 1);
         propagateTrimSlots(slots);
         listDelNode(asmManager->pending_trim_jobs, ln);
         slotRangeArrayFree(slots);
@@ -3234,6 +3243,19 @@ void asmCancelPendingTrimJobs(void) {
     }
 }
 
+/* Free an activeTrimJob and unblock pending client if needed. */
+void activeTrimJobFreeMethod(void *ptr) {
+    activeTrimJob *job = ptr;
+    if (job->client_id != 0) {
+        /* Reply with the slot ranges that requested to be trimmed. Generally we
+         * cancel trim jobs as the dataset is reset, no need to trim anymore. */
+        unblockClientForAsyncFlush(job->client_id, job->slots);
+        job->slots = NULL; /* slots were freed in unblockClientForAsyncFlush */
+    }
+    if (job->slots) slotRangeArrayFree(job->slots);
+    zfree(job);
+}
+
 /* Cancel all pending and active trim jobs. */
 void asmCancelTrimJobs(void) {
     if (!asmManager) return;
@@ -3308,7 +3330,7 @@ void trimslotsCommand(client *c) {
                 }
             }
         }
-        asmTrimSlots(slots);
+        asmTrimSlots(slots, 0, 1);
     }
 
     /* Command will not be propagated automatically since it does not modify
@@ -3321,7 +3343,8 @@ void trimslotsCommand(client *c) {
 
 /* Start the active trim job. */
 void asmActiveTrimStart(void) {
-    slotRangeArray *slots = listNodeValue(listFirst(asmManager->active_trim_jobs));
+    activeTrimJob *job = listNodeValue(listFirst(asmManager->active_trim_jobs));
+    slotRangeArray *slots = job->slots;
 
     serverAssert(asmManager->active_trim_it == NULL);
     asmManager->active_trim_it = slotRangeArrayGetIterator(slots);
@@ -3330,16 +3353,18 @@ void asmActiveTrimStart(void) {
     asmManager->active_trim_current_job_trimmed = 0;
 
     /* Count the number of keys to trim */
-    asmManager->active_trim_current_job_keys += asmCountKeysInSlots(slots);
+    asmManager->active_trim_current_job_keys += getKeyCountInSlotRangeArray(slots);
 
     RedisModuleClusterSlotMigrationTrimInfoV1 fsi = {
             REDISMODULE_CLUSTER_SLOT_MIGRATION_TRIMINFO_VERSION,
             (RedisModuleSlotRangeArray *) slots
     };
 
-    moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM,
-                          REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_STARTED,
-                          &fsi);
+    /* Fire the trim event to modules only if this is a migration cleanup. */
+    if (job->migration_cleanup)
+        moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM,
+                              REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_STARTED,
+                              &fsi);
 
     sds str = slotRangeArrayToString(slots);
     serverLog(LL_NOTICE, "Active trim initiated for slots: %s, to trim %llu keys.",
@@ -3347,9 +3372,14 @@ void asmActiveTrimStart(void) {
     sdsfree(str);
 }
 
-/* Schedule an active trim job. */
-void asmTriggerActiveTrim(slotRangeArray *slots) {
-    listAddNodeTail(asmManager->active_trim_jobs, slotRangeArrayDup(slots));
+/* Schedule an active trim job with optional client waiting for completion. */
+void asmTriggerActiveTrim(slotRangeArray *slots, uint64_t client_id, int migration_cleanup) {
+    activeTrimJob *job = zmalloc(sizeof(*job));
+    job->slots = slotRangeArrayDup(slots);
+    job->client_id = client_id;
+    job->migration_cleanup = migration_cleanup;
+
+    listAddNodeTail(asmManager->active_trim_jobs, job);
     sds str = slotRangeArrayToString(slots);
     serverLog(LL_NOTICE, "Active trim scheduled for slots: %s", str);
     sdsfree(str);
@@ -3363,7 +3393,8 @@ void asmTriggerActiveTrim(slotRangeArray *slots) {
 
 /* End the active trim job. */
 void asmActiveTrimEnd(void) {
-    slotRangeArray *slots = listNodeValue(listFirst(asmManager->active_trim_jobs));
+    activeTrimJob *job = listNodeValue(listFirst(asmManager->active_trim_jobs));
+    slotRangeArray *slots = job->slots;
 
     if (asmManager->active_trim_it) {
         slotRangeArrayIteratorFree(asmManager->active_trim_it);
@@ -3378,9 +3409,11 @@ void asmActiveTrimEnd(void) {
             (RedisModuleSlotRangeArray *) slots
     };
 
-    moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM,
-                          REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_COMPLETED,
-                          &fsi);
+    /* Fire the trim event to modules only if this is a migration cleanup. */
+    if (job->migration_cleanup)
+        moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM,
+                 REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_COMPLETED,
+                 &fsi);
 
     sds str = slotRangeArrayToString(slots);
     serverLog(LL_NOTICE, "Active trim completed for slots: %s, %llu keys trimmed.",
@@ -3434,7 +3467,7 @@ int asmGetTrimmingSlotForCommand(struct redisCommand *cmd, robj **argv, int argc
 }
 
 /* Delete the key and notify the modules. */
-void asmActiveTrimDeleteKey(redisDb *db, robj *keyobj) {
+void asmActiveTrimDeleteKey(redisDb *db, robj *keyobj, int migration_cleanup) {
     if (asmManager->debug_active_trim_delay > 0)
         debugDelay(asmManager->debug_active_trim_delay);
 
@@ -3444,11 +3477,17 @@ void asmActiveTrimDeleteKey(redisDb *db, robj *keyobj) {
 
     dbDelete(db, keyobj);
     keyModified(NULL, db, keyobj, NULL, 1);
-    /* The keys are not actually logically deleted from the database, just moved
-     * to another node. The modules need to know that these keys are no longer
-     * available locally, so just send the keyspace notification to the modules,
-     * but not to clients. */
-    moduleNotifyKeyspaceEvent(NOTIFY_KEY_TRIMMED, "key_trimmed", keyobj, db->id);
+    if (migration_cleanup) {
+        /* The keys are not actually logically deleted from the database, just moved
+        * to another node. The modules need to know that these keys are no longer
+        * available locally, so just send the keyspace notification to the modules,
+        * but not to clients. */
+        moduleNotifyKeyspaceEvent(NOTIFY_KEY_TRIMMED, "key_trimmed", keyobj, db->id);
+    } else {
+        /* Not a migration cleanup, the key is really deleted from the database,
+         * need to notify the clients. */
+        notifyKeyspaceEvent(NOTIFY_GENERIC, "del", keyobj, db->id);
+    }
     asmManager->active_trim_current_job_trimmed++;
 
     if (static_key) decrRefCount(keyobj);
@@ -3492,6 +3531,8 @@ void asmActiveTrimCycle(void) {
     timelimit = 1000000 * trim_cycle_time_perc / server.hz / 100;
     if (timelimit <= 0) timelimit = 1;
 
+    activeTrimJob *job = listNodeValue(listFirst(asmManager->active_trim_jobs));
+
     serverAssert(asmManager->active_trim_it);
     int slot = slotRangeArrayGetCurrentSlot(asmManager->active_trim_it);
 
@@ -3505,7 +3546,7 @@ void asmActiveTrimCycle(void) {
 
             enterExecutionUnit(1, 0);
             robj *keyobj = createStringObject(sdskey, sdslen(sdskey));
-            asmActiveTrimDeleteKey(&server.db[0], keyobj);
+            asmActiveTrimDeleteKey(&server.db[0], keyobj, job->migration_cleanup);
             decrRefCount(keyobj);
             exitExecutionUnit();
             postExecutionUnitOperations();

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -15,6 +15,10 @@ struct asmTask;
 struct slotRangeArray;
 struct slotRange;
 
+#define ASM_TRIM_METHOD_NONE 0
+#define ASM_TRIM_METHOD_BG 1
+#define ASM_TRIM_METHOD_ACTIVE 2
+
 void asmInit(void);
 void asmBeforeSleep(void);
 void asmCron(void);
@@ -53,5 +57,6 @@ int asmGetTrimmingSlotForCommand(struct redisCommand *cmd, robj **argv, int argc
 void asmActiveTrimCycle(void);
 int asmIsKeyInTrimJob(sds keyname);
 int asmModulePropagateBeforeSlotSnapshot(struct redisCommand *cmd, robj **argv, int argc);
+int asmTrimSlots(struct slotRangeArray *slots, uint64_t client_id, int migration_cleanup);
 #endif
 

--- a/src/commands.def
+++ b/src/commands.def
@@ -10058,23 +10058,16 @@ struct COMMAND_ARG XADD_condition_Subargs[] = {
 {MAKE_ARG("acked",ARG_TYPE_PURE_TOKEN,-1,"ACKED",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
-/* XADD idmp idmpauto_with_pid argument table */
-struct COMMAND_ARG XADD_idmp_idmpauto_with_pid_Subargs[] = {
-{MAKE_ARG("idmpauto-token",ARG_TYPE_PURE_TOKEN,-1,"IDMPAUTO",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("pid",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-};
-
-/* XADD idmp idmp_with_pid_iid argument table */
-struct COMMAND_ARG XADD_idmp_idmp_with_pid_iid_Subargs[] = {
-{MAKE_ARG("idmp-token",ARG_TYPE_PURE_TOKEN,-1,"IDMP",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+/* XADD idmp idmp argument table */
+struct COMMAND_ARG XADD_idmp_idmp_Subargs[] = {
 {MAKE_ARG("pid",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("iid",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
 /* XADD idmp argument table */
 struct COMMAND_ARG XADD_idmp_Subargs[] = {
-{MAKE_ARG("idmpauto-with-pid",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=XADD_idmp_idmpauto_with_pid_Subargs},
-{MAKE_ARG("idmp-with-pid-iid",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,3,NULL),.subargs=XADD_idmp_idmp_with_pid_iid_Subargs},
+{MAKE_ARG("pid",ARG_TYPE_STRING,-1,"IDMPAUTO",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("idmp",ARG_TYPE_BLOCK,-1,"IDMP",NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=XADD_idmp_idmp_Subargs},
 };
 
 /* XADD trim strategy argument table */
@@ -10114,7 +10107,7 @@ struct COMMAND_ARG XADD_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("nomkstream",ARG_TYPE_PURE_TOKEN,-1,"NOMKSTREAM",NULL,"6.2.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("condition",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,3,NULL),.subargs=XADD_condition_Subargs},
-{MAKE_ARG("idmp",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=XADD_idmp_Subargs},
+{MAKE_ARG("idmp",ARG_TYPE_ONEOF,-1,NULL,NULL,"8.6.0",CMD_ARG_OPTIONAL,2,NULL),.subargs=XADD_idmp_Subargs},
 {MAKE_ARG("trim",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,4,NULL),.subargs=XADD_trim_Subargs},
 {MAKE_ARG("id-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=XADD_id_selector_Subargs},
 {MAKE_ARG("data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=XADD_data_Subargs},
@@ -10173,23 +10166,11 @@ keySpec XCFGSET_Keyspecs[1] = {
 };
 #endif
 
-/* XCFGSET idmp_duration_block argument table */
-struct COMMAND_ARG XCFGSET_idmp_duration_block_Subargs[] = {
-{MAKE_ARG("idmp-duration-token",ARG_TYPE_PURE_TOKEN,-1,"IDMP-DURATION",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("duration",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-};
-
-/* XCFGSET idmp_maxsize_block argument table */
-struct COMMAND_ARG XCFGSET_idmp_maxsize_block_Subargs[] = {
-{MAKE_ARG("idmp-maxsize-token",ARG_TYPE_PURE_TOKEN,-1,"IDMP-MAXSIZE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("maxsize",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-};
-
 /* XCFGSET argument table */
 struct COMMAND_ARG XCFGSET_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("idmp-duration-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=XCFGSET_idmp_duration_block_Subargs},
-{MAKE_ARG("idmp-maxsize-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=XCFGSET_idmp_maxsize_block_Subargs},
+{MAKE_ARG("idmp-duration",ARG_TYPE_INTEGER,-1,"IDMP-DURATION",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("idmp-maxsize",ARG_TYPE_INTEGER,-1,"IDMP-MAXSIZE",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
 };
 
 /********** XCLAIM ********************/

--- a/src/commands.def
+++ b/src/commands.def
@@ -7332,6 +7332,23 @@ const char *HOTKEYS_GET_Tips[] = {
 #define HOTKEYS_GET_Keyspecs NULL
 #endif
 
+/********** HOTKEYS HELP ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* HOTKEYS HELP history */
+#define HOTKEYS_HELP_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* HOTKEYS HELP tips */
+#define HOTKEYS_HELP_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* HOTKEYS HELP key specs */
+#define HOTKEYS_HELP_Keyspecs NULL
+#endif
+
 /********** HOTKEYS RESET ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -7414,6 +7431,7 @@ const char *HOTKEYS_STOP_Tips[] = {
 /* HOTKEYS command table */
 struct COMMAND_STRUCT HOTKEYS_Subcommands[] = {
 {MAKE_CMD("get","Returns lists of top K hotkeys depending on metrics chosen in HOTKEYS START command.","O(K) where K is the number of hotkeys returned.","8.6.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,HOTKEYS_GET_History,0,HOTKEYS_GET_Tips,3,hotkeysCommand,2,CMD_ADMIN|CMD_NOSCRIPT,0,HOTKEYS_GET_Keyspecs,0,NULL,0)},
+{MAKE_CMD("help","Return helpful text about HOTKEYS command parameters.","O(1)","8.6.1",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,HOTKEYS_HELP_History,0,HOTKEYS_HELP_Tips,0,hotkeysCommand,2,CMD_LOADING|CMD_STALE,0,HOTKEYS_HELP_Keyspecs,0,NULL,0)},
 {MAKE_CMD("reset","Release the resources used for hotkey tracking.","O(1)","8.6.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,HOTKEYS_RESET_History,0,HOTKEYS_RESET_Tips,1,hotkeysCommand,2,CMD_ADMIN|CMD_NOSCRIPT,0,HOTKEYS_RESET_Keyspecs,0,NULL,0)},
 {MAKE_CMD("start","Starts hotkeys tracking.","O(1)","8.6.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,HOTKEYS_START_History,0,HOTKEYS_START_Tips,1,hotkeysCommand,-2,CMD_ADMIN|CMD_NOSCRIPT,0,HOTKEYS_START_Keyspecs,0,NULL,5),.args=HOTKEYS_START_Args},
 {MAKE_CMD("stop","Stops hotkeys tracking.","O(1)","8.6.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,HOTKEYS_STOP_History,0,HOTKEYS_STOP_Tips,1,hotkeysCommand,2,CMD_ADMIN|CMD_NOSCRIPT,0,HOTKEYS_STOP_Keyspecs,0,NULL,0)},

--- a/src/commands.def
+++ b/src/commands.def
@@ -10485,6 +10485,33 @@ struct COMMAND_STRUCT XGROUP_Subcommands[] = {
 #define XGROUP_Keyspecs NULL
 #endif
 
+/********** XIDMPRECORD ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* XIDMPRECORD history */
+#define XIDMPRECORD_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* XIDMPRECORD tips */
+#define XIDMPRECORD_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* XIDMPRECORD key specs */
+keySpec XIDMPRECORD_Keyspecs[1] = {
+{NULL,CMD_KEY_RW|CMD_KEY_UPDATE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+};
+#endif
+
+/* XIDMPRECORD argument table */
+struct COMMAND_ARG XIDMPRECORD_Args[] = {
+{MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("pid",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("iid",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("stream-id",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
 /********** XINFO CONSUMERS ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -11945,6 +11972,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("xdel","Returns the number of messages after removing them from a stream.","O(1) for each single item to delete in the stream, regardless of the stream size.","5.0.0",CMD_DOC_NONE,NULL,NULL,"stream",COMMAND_GROUP_STREAM,XDEL_History,0,XDEL_Tips,0,xdelCommand,-3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STREAM,XDEL_Keyspecs,1,NULL,2),.args=XDEL_Args},
 {MAKE_CMD("xdelex","Deletes one or multiple entries from the stream.","O(1) for each single item to delete in the stream, regardless of the stream size.","8.2.0",CMD_DOC_NONE,NULL,NULL,"stream",COMMAND_GROUP_STREAM,XDELEX_History,0,XDELEX_Tips,0,xdelexCommand,-5,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STREAM,XDELEX_Keyspecs,1,NULL,3),.args=XDELEX_Args},
 {MAKE_CMD("xgroup","A container for consumer groups commands.","Depends on subcommand.","5.0.0",CMD_DOC_NONE,NULL,NULL,"stream",COMMAND_GROUP_STREAM,XGROUP_History,0,XGROUP_Tips,0,NULL,-2,0,0,XGROUP_Keyspecs,0,NULL,0),.subcommands=XGROUP_Subcommands},
+{MAKE_CMD("xidmprecord","An internal command for setting IDMP metadata on an existing stream message.","O(1)","8.6.2",CMD_DOC_NONE,NULL,NULL,"stream",COMMAND_GROUP_STREAM,XIDMPRECORD_History,0,XIDMPRECORD_Tips,0,xidmprecordCommand,5,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STREAM,XIDMPRECORD_Keyspecs,1,NULL,4),.args=XIDMPRECORD_Args},
 {MAKE_CMD("xinfo","A container for stream introspection commands.","Depends on subcommand.","5.0.0",CMD_DOC_NONE,NULL,NULL,"stream",COMMAND_GROUP_STREAM,XINFO_History,0,XINFO_Tips,0,NULL,-2,0,0,XINFO_Keyspecs,0,NULL,0),.subcommands=XINFO_Subcommands},
 {MAKE_CMD("xlen","Return the number of messages in a stream.","O(1)","5.0.0",CMD_DOC_NONE,NULL,NULL,"stream",COMMAND_GROUP_STREAM,XLEN_History,0,XLEN_Tips,0,xlenCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_STREAM,XLEN_Keyspecs,1,NULL,1),.args=XLEN_Args},
 {MAKE_CMD("xpending","Returns the information and entries from a stream consumer group's pending entries list.","O(N) with N being the number of elements returned, so asking for a small fixed number of entries per call is O(1). O(M), where M is the total number of entries scanned when used with the IDLE filter. When the command returns just the summary and the list of consumers is small, it runs in O(1) time; otherwise, an additional O(N) time for iterating every consumer.","5.0.0",CMD_DOC_NONE,NULL,NULL,"stream",COMMAND_GROUP_STREAM,XPENDING_History,1,XPENDING_Tips,1,xpendingCommand,-3,CMD_READONLY,ACL_CATEGORY_STREAM,XPENDING_Keyspecs,1,NULL,3),.args=XPENDING_Args},

--- a/src/commands/hotkeys-get.json
+++ b/src/commands/hotkeys-get.json
@@ -44,7 +44,7 @@
                                 },
                                 "description": "Array of slot ranges. Each element is an array: single-element [slot] for individual slots, or two-element [start, end] for inclusive ranges."
                             },
-                            "sampled-command-selected-slots-us": {
+                            "sampled-commands-selected-slots-us": {
                                 "type": "integer",
                                 "description": "CPU time in microseconds for sampled commands in selected slots (only present when sampling and slots are configured)."
                             },

--- a/src/commands/hotkeys-help.json
+++ b/src/commands/hotkeys-help.json
@@ -1,0 +1,22 @@
+{
+    "HELP": {
+        "summary": "Return helpful text about HOTKEYS command parameters.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "8.6.1",
+        "arity": 2,
+        "container": "HOTKEYS",
+        "function": "hotkeysCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/src/commands/xadd.json
+++ b/src/commands/xadd.json
@@ -91,32 +91,19 @@
                 "name": "idmp",
                 "type": "oneof",
                 "optional": true,
+                "since": "8.6.0",
                 "arguments": [
                     {
-                        "name": "idmpauto-with-pid",
-                        "type": "block",
-                        "arguments": [
-                            {
-                                "token": "IDMPAUTO",
-                                "name": "idmpauto-token",
-                                "type": "pure-token"
-                            },
-                            {
-                                "name": "pid",
-                                "type": "string",
-                                "display_text": "producer-id"
-                            }
-                        ]
+                        "token": "IDMPAUTO",
+                        "type": "string",
+                        "name": "pid",
+                        "display_text": "producer-id"
                     },
                     {
-                        "name": "idmp-with-pid-iid",
+                        "token": "IDMP",
                         "type": "block",
+                        "name": "idmp",
                         "arguments": [
-                            {
-                                "token": "IDMP",
-                                "name": "idmp-token",
-                                "type": "pure-token"
-                            },
                             {
                                 "name": "pid",
                                 "type": "string",

--- a/src/commands/xcfgset.json
+++ b/src/commands/xcfgset.json
@@ -43,36 +43,16 @@
                 "key_spec_index": 0
             },
             {
-                "name": "idmp-duration-block",
-                "type": "block",
-                "optional": true,
-                "arguments": [
-                    {
-                        "name": "idmp-duration-token",
-                        "type": "pure-token",
-                        "token": "IDMP-DURATION"
-                    },
-                    {
-                        "name": "duration",
-                        "type": "integer"
-                    }
-                ]
+                "name": "idmp-duration",
+                "type": "integer",
+                "token": "IDMP-DURATION",
+                "optional": true
             },
             {
-                "name": "idmp-maxsize-block",
-                "type": "block",
-                "optional": true,
-                "arguments": [
-                    {
-                        "name": "idmp-maxsize-token",
-                        "type": "pure-token",
-                        "token": "IDMP-MAXSIZE"
-                    },
-                    {
-                        "name": "maxsize",
-                        "type": "integer"
-                    }
-                ]
+                "name": "idmp-maxsize",
+                "type": "integer",
+                "token": "IDMP-MAXSIZE",
+                "optional": true
             }
         ]
     }

--- a/src/commands/xidmprecord.json
+++ b/src/commands/xidmprecord.json
@@ -1,0 +1,60 @@
+{
+    "XIDMPRECORD": {
+        "summary": "An internal command for setting IDMP metadata on an existing stream message.",
+        "complexity": "O(1)",
+        "group": "stream",
+        "since": "8.6.2",
+        "arity": 5,
+        "function": "xidmprecordCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "pid",
+                "type": "string"
+            },
+            {
+                "name": "iid",
+                "type": "string"
+            },
+            {
+                "name": "stream-id",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/src/config.h
+++ b/src/config.h
@@ -94,6 +94,15 @@
 #define HAVE_ACCEPT4 1
 #endif
 
+/* Detect for pipe2() */
+#if defined(__linux__) || \
+    defined(__FreeBSD__) || \
+    (defined(__OpenBSD__) && OpenBSD >= 201505) || \
+    (defined(__DragonFly_version) && __DragonFly_version >= 400106) || \
+    (defined(__NetBSD_Version__) && __NetBSD_Version__ >= 600000000)
+#define HAVE_PIPE2 1
+#endif
+
 #if (defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__)
 #define HAVE_KQUEUE 1
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -103,7 +103,9 @@
 #define HAVE_PIPE2 1
 #endif
 
-#if (defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__)
+/* Detect for kqueue */
+#if (defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)) || defined(__FreeBSD__) || \
+    defined(__OpenBSD__) || defined (__NetBSD__) || defined(__DragonFly__)
 #define HAVE_KQUEUE 1
 #endif
 

--- a/src/db.c
+++ b/src/db.c
@@ -206,6 +206,12 @@ static void dbgAssertHist(kvstore *kvs, keysizesHist hist,
  * Triggered by DEBUG KEYSIZES-HIST-ASSERT 1 and tested after each command.
  */
 void dbgAssertKeysizesHist(redisDb *db) {
+    /* Don't assert during nested calls. Intermediate state may be inconsistent. */
+    if (server.execution_nesting) return;
+
+    /* Don't assert during RDB loading. Database may be in inconsistent state. */
+    if (server.loading || server.async_loading) return;
+
     kvstoreMetadata *meta = kvstoreGetMetadata(db->keys);
     dbgAssertHist(db->keys, meta->keysizes_hist, getObjectLength, "dbgAssertKeysizesHist");
     if (server.memory_tracking_enabled)
@@ -217,6 +223,12 @@ void dbgAssertKeysizesHist(redisDb *db) {
  * Triggered by DEBUG ALLOCSIZE-SLOTS-ASSERT 1 and tested after each command.
  */
 void dbgAssertAllocSizePerSlot(redisDb *db) {
+    /* Don't assert during nested calls. Intermediate state may be inconsistent. */
+    if (server.execution_nesting) return;
+
+    /* Don't assert during RDB loading. Database may be in inconsistent state. */
+    if (server.loading || server.async_loading) return;
+
     if (!server.memory_tracking_enabled) return;
     size_t slot_sizes[CLUSTER_SLOTS] = {0};
     dictEntry *de;

--- a/src/db.c
+++ b/src/db.c
@@ -1209,11 +1209,22 @@ void flushAllDataAndResetRDB(int flags) {
 #endif
 }
 
-/* CB function on blocking ASYNC FLUSH completion
- *
- * Utilized by commands SFLUSH, FLUSHALL and FLUSHDB.
- */
-void flushallSyncBgDone(uint64_t client_id, void *userdata) {
+/* Block client for blocking ASYNC FLUSH operation (FLUSH*, SFLUSH). */
+void blockClientForAsyncFlush(client *c) {
+    /* measure bg job till completion as elapsed time of flush command */
+    elapsedStart(&c->bstate.lazyfreeStartTime);
+
+    c->bstate.timeout = 0;
+    /* We still need to perform cleanup operations for the command, including
+     * updating the replication offset, so mark this command as pending to
+     * avoid command from being reset during unblock. */
+    c->flags |= CLIENT_PENDING_COMMAND;
+    blockClient(c, BLOCKED_LAZYFREE);
+}
+
+/* CB function on blocking ASYNC FLUSH completion.
+ * We will unblock the client and send the proper reply. */
+void unblockClientForAsyncFlush(uint64_t client_id, void *userdata) {
     slotRangeArray *slots = userdata;
     client *c = lookupClientByID(client_id);
 
@@ -1254,16 +1265,12 @@ void flushallSyncBgDone(uint64_t client_id, void *userdata) {
     server.current_client = old_client;
 }
 
-/* Common flush command implementation for FLUSHALL, FLUSHDB and SFLUSH.
+/* Common flush command implementation for FLUSHALL, FLUSHDB.
  *
  * Return 1 indicates that flush SYNC is actually running in bg as blocking ASYNC
  * Return 0 otherwise
- *
- * slots - provided only by SFLUSH command, otherwise NULL. Will be used on
- *         completion to reply with the slots flush result. Ownership is passed
- *         to the completion job in case of `blocking_async`.
  */
-int flushCommandCommon(client *c, int type, int flags, slotRangeArray *slots) {
+int flushCommandCommon(client *c, int type, int flags) {
     int blocking_async = 0; /* Flush SYNC option to run as blocking ASYNC */
 
     /* in case of SYNC, check if we can optimize and run it in bg as blocking ASYNC */
@@ -1273,8 +1280,8 @@ int flushCommandCommon(client *c, int type, int flags, slotRangeArray *slots) {
         blocking_async = 1;
     }
 
-    /* Cancel all ASM tasks that overlap with the given slot ranges. */
-    clusterAsmCancelBySlotRangeArray(slots, c->argv[0]->ptr);
+    /* Cancel all ASM tasks. */
+    clusterAsmCancelBySlotRangeArray(NULL, c->argv[0]->ptr);
 
     if (type == FLUSH_TYPE_ALL)
         flushAllDataAndResetRDB(flags | EMPTYDB_NOFUNCTIONS);
@@ -1289,16 +1296,8 @@ int flushCommandCommon(client *c, int type, int flags, slotRangeArray *slots) {
      * worker's queue. To be called and reply with OK only after all preceding pending
      * lazyfree jobs in queue were processed */
     if (blocking_async) {
-        /* measure bg job till completion as elapsed time of flush command */
-        elapsedStart(&c->bstate.lazyfreeStartTime);
-
-        c->bstate.timeout = 0;
-        /* We still need to perform cleanup operations for the command, including
-         * updating the replication offset, so mark this command as pending to
-         * avoid command from being reset during unblock. */
-        c->flags |= CLIENT_PENDING_COMMAND;
-        blockClient(c,BLOCKED_LAZYFREE);
-        bioCreateCompRq(BIO_WORKER_LAZY_FREE, flushallSyncBgDone, c->id, slots);
+        blockClientForAsyncFlush(c);
+        bioCreateCompRq(BIO_WORKER_LAZY_FREE, unblockClientForAsyncFlush, c->id, NULL);
     }
 
 #if defined(USE_JEMALLOC)
@@ -1327,7 +1326,7 @@ void flushallCommand(client *c) {
     if (getFlushCommandFlags(c,&flags) == C_ERR) return;
 
     /* If FLUSH SYNC isn't running as blocking async, then reply */
-    if (flushCommandCommon(c, FLUSH_TYPE_ALL, flags, NULL) == 0)
+    if (flushCommandCommon(c, FLUSH_TYPE_ALL, flags) == 0)
         addReply(c, shared.ok);
 }
 
@@ -1339,7 +1338,7 @@ void flushdbCommand(client *c) {
     if (getFlushCommandFlags(c,&flags) == C_ERR) return;
 
     /* If FLUSH SYNC isn't running as blocking async, then reply */
-    if (flushCommandCommon(c, FLUSH_TYPE_DB,flags, NULL) == 0)
+    if (flushCommandCommon(c, FLUSH_TYPE_DB,flags) == 0)
         addReply(c, shared.ok);
 
 }
@@ -2859,7 +2858,10 @@ keyStatus expireIfNeeded(redisDb *db, robj *key, kvobj *kv, int flags) {
         if (server.allow_access_trimmed || (flags & EXPIRE_ALLOW_ACCESS_TRIMMED))
             return KEY_VALID;
 
-        return KEY_TRIMMED;
+        /* If the slot is not served by this node, we should not allow access
+         * to the key, we consider it as trimmed. */
+        if (!clusterCanAccessKeysInSlot(getKeySlot(key_name)))
+            return KEY_TRIMMED;
     }
 
     if ((flags & EXPIRE_ALLOW_ACCESS_EXPIRED) ||

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -968,34 +968,15 @@ static void defragIdmpProducer(idmpProducer *producer) {
     }
 }
 
-/* Defrag all IDMP producers and their dict/linked list entries. */
-void defragStreamIdmpProducers(stream *s) {
-    if (s->idmp_producers == NULL) return;
-
-    /* Defrag the producers rax tree itself */
-    rax *newrax = activeDefragAlloc(s->idmp_producers);
-    if (newrax)
-        s->idmp_producers = newrax;
-
-    /* Defrag the rax head node */
-    defragRaxNode(&s->idmp_producers->head, NULL);
-
-    /* Iterate through all producers and defrag each one */
-    raxIterator ri;
-    raxStart(&ri, s->idmp_producers);
-    /* Set the node callback to defrag internal rax nodes */
-    ri.node_cb = defragRaxNode;
-    raxSeek(&ri, "^", NULL, 0);
-    while (raxNext(&ri)) {
-        idmpProducer *producer = ri.data;
-        idmpProducer *newproducer = activeDefragAlloc(producer);
-        if (newproducer) {
-            raxSetData(ri.node, ri.data=newproducer);
-            producer = newproducer;
-        }
-        defragIdmpProducer(producer);
+static void* defragIdmpProducerCallback(raxIterator *ri, void *privdata) {
+    UNUSED(privdata);
+    idmpProducer *producer = ri->data;
+    idmpProducer *newproducer = activeDefragAlloc(producer);
+    if (newproducer) {
+        producer = newproducer;
     }
-    raxStop(&ri);
+    defragIdmpProducer(producer);
+    return newproducer; /* returns NULL if producer was not defragged */
 }
 
 void defragStream(defragKeysCtx *ctx, kvobj *ob) {
@@ -1028,8 +1009,9 @@ void defragStream(defragKeysCtx *ctx, kvobj *ob) {
     }
 
     if (s->idmp_producers) {
-        /* Defrag the producers and all idmpEntry structures in their linked lists */
-        defragStreamIdmpProducers(s);
+        /* Update idmp_producers back-pointer to new stream */
+        s->idmp_producers->alloc_size = &s->alloc_size;
+        defragRadixTree(&s->idmp_producers, 0, defragIdmpProducerCallback, NULL);
     }
 }
 

--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -545,9 +545,9 @@ void hotkeysCommand(client *c) {
         addReplyBulkCString(c, "selected-slots");
         addReplySelectedSlots(c, server.hotkeys);
 
-        /* sampled-command-selected-slots-us (conditional) */
+        /* sampled-commands-selected-slots-us (conditional) */
         if (has_sampling && has_selected_slots) {
-            addReplyBulkCString(c, "sampled-command-selected-slots-us");
+            addReplyBulkCString(c, "sampled-commands-selected-slots-us");
             addReplyLongLong(c, server.hotkeys->time_sampled_commands_selected_slots);
 
             total_len++;

--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -266,7 +266,33 @@ void hotkeysCommand(client *c) {
 
     char *sub = c->argv[1]->ptr;
 
-    if (!strcasecmp(sub, "START")) {
+    if (!strcasecmp(sub, "HELP")) {
+        const char *help[] = {
+            "START <METRICS count [CPU] [NET]> [COUNT k] [DURATION duration] [SAMPLE ratio] [SLOTS count slot...]",
+            "    Starts hotkeys tracking with specified metrics.",
+            "    * METRICS count [CPU] [NET]",
+            "        Specify count of metrics and choose amongst:",
+            "        - CPU: Track hotkeys by CPU time percentage",
+            "        - NET: Track hotkeys by network bytes percentage",
+            "    * COUNT k",
+            "        Specifies the value of K for the top-K hotkeys tracking. Default: 10",
+            "    * DURATION duration",
+            "        Specifies tracking duration in seconds. 0 means tracking will continue until manually stopped. Default: 0",
+            "    * SAMPLE ratio",
+            "        Keys are tracked with probability 1/ratio. Default: 1 (tracks every key)",
+            "    * SLOTS count slot...",
+            "        Specify which slots to track keys from. Only available in cluster mode. Default: empty (track all slots)",
+            "STOP",
+            "    Stop hotkeys tracking. Results are still available via GET",
+            "GET",
+            "    Get results from hotkeys tracking.",
+            "RESET",
+            "    Reset memory used for hotkeys tracking. Tracking must have been stopped.",
+            "    Results will no longer be available after this command.",
+            NULL
+        };
+        addReplyHelp(c, help);
+    } else if (!strcasecmp(sub, "START")) {
         /* HOTKEYS START
          *         <METRICS count [CPU] [NET]>
          *         [COUNT k]

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -492,6 +492,7 @@ int prefetchIOThreadCommands(IOThread *t) {
         c[i] = listNodeValue(ln);
         redis_prefetch_read(c[i]);
         redis_prefetch_read(&c[i]->pending_cmds);
+        redis_prefetch_read(&c[i]->io_deferred_objects);
     }
     /* Phase 2: Access client data (now likely in cache) and add to batch.
      * Also prefetch additional fields (reply, mem_usage_bucket) that will be
@@ -500,6 +501,7 @@ int prefetchIOThreadCommands(IOThread *t) {
         if (addCommandToBatch(c[i]) == C_ERR) break;
         if (c[i]->reply) redis_prefetch_read(c[i]->reply);
         redis_prefetch_read(&c[i]->mem_usage_bucket);
+        if (c[i]->io_deferred_objects) redis_prefetch_read(c[i]->io_deferred_objects);
         clients++;
     }
     /* Prefetch the commands in the batch. */

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -385,9 +385,10 @@ unsigned long long kvstoreScan(kvstore *kvs, unsigned long long cursor,
  */
 int kvstoreExpand(kvstore *kvs, uint64_t newsize, int try_expand, kvstoreExpandShouldSkipDictIndex *skip_cb) {
     for (int i = 0; i < kvs->num_dicts; i++) {
-        dict *d = kvstoreGetDict(kvs, i);
-        if (!d || (skip_cb && skip_cb(i)))
-            continue;
+        if (skip_cb && skip_cb(i)) continue;
+        dict *d = createDictIfNeeded(kvs, i);
+        if (!d) continue;
+
         int result = try_expand ? dictTryExpand(d, newsize) : dictExpand(d, newsize);
         if (try_expand && result == DICT_ERR)
             return 0;

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -73,9 +73,11 @@ typedef struct PrefetchCommandsBatch {
     size_t cur_idx;                 /* Index of the current key being processed */
     size_t key_count;               /* Number of keys in the current batch */
     size_t client_count;            /* Number of clients in the current batch */
+    size_t pcmd_count;              /* Number of pending commands in the current batch */
     size_t max_prefetch_size;       /* Maximum number of keys to prefetch in a batch */
     void **keys;                    /* Array of keys to prefetch in the current batch */
     client **clients;               /* Array of clients in the current batch */
+    pendingCommand **pending_cmds;  /* Array of pending commands in the current batch */
     dict **keys_dicts;              /* Main dict for each key */
     dict **current_dicts;           /* Points to dict to prefetch from */
     KeyPrefetchInfo *prefetch_info; /* Prefetch info for each key */
@@ -90,6 +92,7 @@ void freePrefetchCommandsBatch(void) {
     }
 
     zfree(batch->clients);
+    zfree(batch->pending_cmds);
     zfree(batch->keys);
     zfree(batch->keys_dicts);
     zfree(batch->prefetch_info);
@@ -112,6 +115,7 @@ void prefetchCommandsBatchInit(void) {
     batch = zcalloc(sizeof(PrefetchCommandsBatch));
     batch->max_prefetch_size = max_prefetch_size;
     batch->clients = zcalloc(max_prefetch_size * sizeof(client *));
+    batch->pending_cmds = zcalloc(max_prefetch_size * sizeof(pendingCommand *));
     batch->keys = zcalloc(max_prefetch_size * sizeof(void *));
     batch->keys_dicts = zcalloc(max_prefetch_size * sizeof(dict *));
     batch->prefetch_info = zcalloc(max_prefetch_size * sizeof(KeyPrefetchInfo));
@@ -299,6 +303,7 @@ void resetCommandsBatch(void) {
     batch->cur_idx = 0;
     batch->key_count = 0;
     batch->client_count = 0;
+    batch->pcmd_count = 0;
 
     /* Handle the case where the max prefetch size has been changed. */
     if (batch->max_prefetch_size != (size_t)server.prefetch_batch_max_size * 2) {
@@ -325,31 +330,39 @@ int determinePrefetchCount(int len) {
 /* Prefetch command-related data:
  * 1. Prefetch the command arguments allocated by the I/O thread to bring them
  *    closer to the L1 cache.
- * 2. Prefetch the keys and values for all commands in the current batch from
+ * 2. Prefetch the io_deferred_objects for all clients.
+ * 3. Prefetch the keys and values for all commands in the current batch from
  *    the main dictionaries. */
 void prefetchCommands(void) {
     if (!batch) return;
 
-    /* Prefetch argv's for all clients */
-    for (size_t i = 0; i < batch->client_count; i++) {
-        client *c = batch->clients[i];
-        if (!c || c->argc <= 1) continue;
-        /* Skip prefetching first argv (cmd name) it was already looked up by
-         * the I/O thread, and the main thread will not touch argv[0]. */
-        for (int j = 1; j < c->argc; j++) {
-            redis_prefetch_read(c->argv[j]);
+    /* Prefetch argv's for all pending commands */
+    for (size_t i = 0; i < batch->pcmd_count; i++) {
+        pendingCommand *pcmd = batch->pending_cmds[i];
+        if (unlikely(pcmd->argc <= 0)) continue;
+        for (int j = 0; j < pcmd->argc; j++) {
+            redis_prefetch_read(pcmd->argv[j]);
         }
     }
 
     /* Prefetch the argv->ptr if required */
-    for (size_t i = 0; i < batch->client_count; i++) {
-        client *c = batch->clients[i];
-        if (!c || c->argc <= 1) continue;
-        for (int j = 1; j < c->argc; j++) {
-            if (c->argv[j]->encoding == OBJ_ENCODING_RAW) {
-                redis_prefetch_read(c->argv[j]->ptr);
+    for (size_t i = 0; i < batch->pcmd_count; i++) {
+        pendingCommand *pcmd = batch->pending_cmds[i];
+        if (unlikely(pcmd->argc <= 1)) continue;
+        /* Skip the first argument (command name), as it's typically short */
+        for (int j = 1; j < pcmd->argc; j++) {
+            if (pcmd->argv[j]->encoding == OBJ_ENCODING_RAW) {
+                redis_prefetch_read(pcmd->argv[j]->ptr);
             }
         }
+    }
+
+    /* Prefetch io_deferred_objects for all clients */
+    for (size_t i = 0; i < batch->client_count; i++) {
+        client *c = batch->clients[i];
+        if (!c->io_deferred_objects || c->io_deferred_objects_num == 0) continue;
+        for (int j = 0; j < c->io_deferred_objects_num; j++)
+            redis_prefetch_read(c->io_deferred_objects[j]);
     }
 
     /* Get the keys ptrs - we do it here after the key obj was prefetched. */
@@ -376,18 +389,20 @@ int addCommandToBatch(client *c) {
      * We also check the client count to handle cases where
      * no keys exist for the clients' commands. */
     if (batch->client_count == batch->max_prefetch_size ||
-        batch->key_count == batch->max_prefetch_size)
+        batch->key_count == batch->max_prefetch_size ||
+        batch->pcmd_count == batch->max_prefetch_size)
     {
         return C_ERR;
     }
 
-    /* Avoid partial prefetching: if the batch already has keys and adding this
+    /* Avoid partial prefetching: if the batch already has commands and adding this
      * client's ready commands would likely exceed the batch size limit, reject
      * the entire client. This is a conservative estimate using command count as
      * a proxy for key count to ensure all keys from a client are either fully
      * prefetched together or not prefetched at all. */
-    if (batch->key_count > 0 &&
-        c->pending_cmds.ready_len + batch->key_count > batch->max_prefetch_size)
+    if (batch->pcmd_count > 0 &&
+        (c->pending_cmds.ready_len + batch->key_count > batch->max_prefetch_size ||
+         c->pending_cmds.ready_len + batch->pcmd_count > batch->max_prefetch_size))
     {
         return C_ERR;
     }
@@ -395,9 +410,13 @@ int addCommandToBatch(client *c) {
     batch->clients[batch->client_count++] = c;
 
     pendingCommand *pcmd = c->pending_cmds.head;
-    while (pcmd != NULL) {
+    while (pcmd != NULL && batch->pcmd_count < batch->max_prefetch_size) {
+        if (pcmd->next) redis_prefetch_read(pcmd->next);
+
         /* Skip commands that have not been preprocessed, or have errors. */
         if ((pcmd->flags & PENDING_CMD_FLAG_INCOMPLETE) || !pcmd->cmd || pcmd->read_error) break;
+
+        batch->pending_cmds[batch->pcmd_count++] = pcmd;
 
         serverAssert(pcmd->flags & PENDING_CMD_KEYS_RESULT_VALID);
         for (int i = 0; i < pcmd->keys_result.numkeys && batch->key_count < batch->max_prefetch_size; i++) {

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -339,7 +339,7 @@ void prefetchCommands(void) {
     /* Prefetch argv's for all pending commands */
     for (size_t i = 0; i < batch->pcmd_count; i++) {
         pendingCommand *pcmd = batch->pending_cmds[i];
-        if (unlikely(pcmd->argc <= 0)) continue;
+        if (unlikely(pcmd->argc <= 0 || !pcmd->argv)) continue;
         for (int j = 0; j < pcmd->argc; j++) {
             redis_prefetch_read(pcmd->argv[j]);
         }
@@ -348,7 +348,7 @@ void prefetchCommands(void) {
     /* Prefetch the argv->ptr if required */
     for (size_t i = 0; i < batch->pcmd_count; i++) {
         pendingCommand *pcmd = batch->pending_cmds[i];
-        if (unlikely(pcmd->argc <= 1)) continue;
+        if (unlikely(pcmd->argc <= 1 || !pcmd->argv)) continue;
         /* Skip the first argument (command name), as it's typically short */
         for (int j = 1; j < pcmd->argc; j++) {
             if (pcmd->argv[j]->encoding == OBJ_ENCODING_RAW) {
@@ -367,6 +367,7 @@ void prefetchCommands(void) {
 
     /* Get the keys ptrs - we do it here after the key obj was prefetched. */
     for (size_t i = 0; i < batch->key_count; i++) {
+        if (unlikely(batch->keys[i] == NULL)) continue;
         batch->keys[i] = ((robj *)batch->keys[i])->ptr;
     }
 

--- a/src/module.c
+++ b/src/module.c
@@ -338,6 +338,7 @@ static list *modulePostExecUnitJobs;
 /* Data structures related to the exported dictionary data structure. */
 typedef struct RedisModuleDict {
     rax *rax;                       /* The radix tree. */
+    size_t alloc_size;              /* Total memory used (in bytes) by this dict. */
 } RedisModuleDict;
 
 typedef struct RedisModuleDictIter {
@@ -10728,8 +10729,10 @@ RedisModuleString *RM_GetClientCertificate(RedisModuleCtx *ctx, uint64_t client_
  *    Next / Prev dictionary iterator calls.
  */
 RedisModuleDict *RM_CreateDict(RedisModuleCtx *ctx) {
-    struct RedisModuleDict *d = zmalloc(sizeof(*d));
-    d->rax = raxNew();
+    size_t usable;
+    RedisModuleDict *d = zmalloc_usable(sizeof(*d), &usable);
+    d->alloc_size = usable;
+    d->rax = raxNewWithMetadata(0, &d->alloc_size);
     if (ctx != NULL) autoMemoryAdd(ctx,REDISMODULE_AM_DICT,d);
     return d;
 }
@@ -11682,11 +11685,7 @@ size_t RM_MallocSizeString(RedisModuleString* str) {
  * it does not include the allocation size of the keys and values.
  */
 size_t RM_MallocSizeDict(RedisModuleDict* dict) {
-    size_t size = sizeof(RedisModuleDict) + sizeof(rax);
-    size += dict->rax->numnodes * sizeof(raxNode);
-    /* For more info about this weird line, see streamRadixTreeMemoryUsage */
-    size += dict->rax->numnodes * sizeof(long)*30;
-    return size;
+    return dict->alloc_size;
 }
 
 /* Return the a number between 0 to 1 indicating the amount of memory
@@ -15002,6 +15001,8 @@ RedisModuleDict *RM_DefragRedisModuleDict(RedisModuleDefragCtx *ctx, RedisModule
         rax* newrax = NULL;
         if ((newdict = activeDefragAlloc(dict)))
             dict = newdict;
+        /* Update rax back-pointer to dict */
+        dict->rax->alloc_size = &dict->alloc_size;
         if ((newrax = activeDefragAlloc(dict->rax)))
             dict->rax = newrax;
     }

--- a/src/module.c
+++ b/src/module.c
@@ -3424,7 +3424,10 @@ int RM_ReplyWithCString(RedisModuleCtx *ctx, const char *buf) {
 int RM_ReplyWithString(RedisModuleCtx *ctx, RedisModuleString *str) {
     client *c = moduleGetReplyClient(ctx);
     if (c == NULL) return REDISMODULE_OK;
-    addReplyBulk(c,str);
+    /* Disable reply copy avoidance: the module string may belong to a datatype
+     * that could be lazy-freed by BIO thread, causing UAF if we hold a reference
+     * to it in the client reply list. */
+    addReplyBulkWithFlag(c,str,0);
     return REDISMODULE_OK;
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -13583,7 +13583,8 @@ int setModuleStringConfig(ModuleConfig *config, sds strval, const char **err) {
 
 int setModuleEnumConfig(ModuleConfig *config, int val, const char **err) {
     RedisModuleString *error = NULL;
-    int return_code = config->set_fn.set_enum(config->name, val, config->privdata, &error);
+    char *rname = getRegisteredConfigName(config);
+    int return_code = config->set_fn.set_enum(rname, val, config->privdata, &error);
     propagateErrorString(error, err);
     return return_code == REDISMODULE_OK ? 1 : 0;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -5971,7 +5971,7 @@ int RM_StreamAdd(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisM
         use_id_ptr = &use_id;
     }
 
-    size_t oldsize = kvobjAllocSize(key->kv);
+    size_t oldsize = server.memory_tracking_enabled ? kvobjAllocSize(key->kv) : 0;
     if (streamAppendItem(s,argv,numfields,&added_id,use_id_ptr,1) == C_ERR) {
         /* Either the ID not greater than all existing IDs in the stream, or
          * the elements are too large to be stored. either way, errno is already
@@ -6024,7 +6024,7 @@ int RM_StreamDelete(RedisModuleKey *key, RedisModuleStreamID *id) {
         return REDISMODULE_ERR;
     }
     stream *s = key->kv->ptr;
-    size_t oldsize = kvobjAllocSize(key->kv);
+    size_t oldsize = server.memory_tracking_enabled ? kvobjAllocSize(key->kv) : 0;
     streamID streamid = {id->ms, id->seq};
     if (streamDeleteItem(s, &streamid)) {
         if (server.memory_tracking_enabled)
@@ -6328,7 +6328,7 @@ long long RM_StreamTrimByLength(RedisModuleKey *key, int flags, long long length
     }
     int approx = flags & REDISMODULE_STREAM_TRIM_APPROX ? 1 : 0;
     stream *s = key->kv->ptr;
-    size_t oldsize = kvobjAllocSize(key->kv);
+    size_t oldsize = server.memory_tracking_enabled ? kvobjAllocSize(key->kv) : 0;
     long long retval = streamTrimByLength(s, length, approx);
     if (server.memory_tracking_enabled)
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), key->kv, oldsize, kvobjAllocSize(key->kv));
@@ -6364,7 +6364,7 @@ long long RM_StreamTrimByID(RedisModuleKey *key, int flags, RedisModuleStreamID 
     int approx = flags & REDISMODULE_STREAM_TRIM_APPROX ? 1 : 0;
     streamID minid = (streamID){id->ms, id->seq};
     stream *s = key->kv->ptr;
-    size_t oldsize = kvobjAllocSize(key->kv);
+    size_t oldsize = server.memory_tracking_enabled ? kvobjAllocSize(key->kv) : 0;
     long long retval = streamTrimByID(s, minid, approx);
     if (server.memory_tracking_enabled)
         updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), key->kv, oldsize, kvobjAllocSize(key->kv));

--- a/src/module.c
+++ b/src/module.c
@@ -4742,6 +4742,8 @@ int RM_StringTruncate(RedisModuleKey *key, size_t newlen) {
         }
         if (server.memory_tracking_enabled)
             updateSlotAllocSize(key->db, getKeySlot(key->key->ptr), key->kv, oldsize, kvobjAllocSize(key->kv));
+        if (curlen != newlen)
+            updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_STRING, curlen, newlen);
     }
     return REDISMODULE_OK;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -8684,9 +8684,9 @@ void RM_BlockClientSetPrivateData(RedisModuleBlockedClient *blocked_client, void
  * Note: Under normal circumstances RedisModule_UnblockClient should not be
  *       called for clients that are blocked on keys (Either the key will
  *       become ready or a timeout will occur). If for some reason you do want
- *       to call RedisModule_UnblockClient it is possible: Client will be
- *       handled as if it were timed-out (You must implement the timeout
- *       callback in that case).
+ *       to call RedisModule_UnblockClient it is possible, but it must NOT be
+ *       called from module threads and the client will be handled as if it
+ *       timed out (You must implement the timeout callback in that case).
  */
 RedisModuleBlockedClient *RM_BlockClientOnKeys(RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback,
                                                RedisModuleCmdFunc timeout_callback, void (*free_privdata)(RedisModuleCtx*,void*),
@@ -8756,7 +8756,8 @@ int moduleClientIsBlockedOnKeys(client *c) {
  * needs to be passed to the client, included but not limited some slow
  * to compute reply or some reply obtained via networking.
  *
- * Note 1: this function can be called from threads spawned by the module.
+ * Note 1: this function can be called from threads spawned by the module when
+ * the client was blocked using RedisModule_BlockClient().
  *
  * Note 2: when we unblock a client that is blocked for keys using the API
  * RedisModule_BlockClientOnKeys(), the privdata argument here is not used.

--- a/src/networking.c
+++ b/src/networking.c
@@ -1263,13 +1263,14 @@ static int tryAvoidBulkStrCopyToReply(client *c, robj *obj, size_t len) {
     return C_OK;
 }
 
-/* Add a Redis Object as a bulk reply */
-void addReplyBulk(client *c, robj *obj) {
+/* Add a Redis Object as a bulk reply.
+ * If avoid_copy is non-zero, attempt to use copy avoidance optimization. */
+void addReplyBulkWithFlag(client *c, robj *obj, int avoid_copy) {
     if (_prepareClientToWrite(c) != C_OK) return;
 
     if (sdsEncodedObject(obj)) {
         const size_t len = sdslen(obj->ptr);
-        if (tryAvoidBulkStrCopyToReply(c, obj, len) == C_OK)
+        if (avoid_copy && tryAvoidBulkStrCopyToReply(c, obj, len) == C_OK)
             return;
         _addReplyLongLongBulk(c, len);
         _addReplyToBufferOrList(c,obj->ptr,len);
@@ -1287,6 +1288,11 @@ void addReplyBulk(client *c, robj *obj) {
     } else {
         serverPanic("Wrong obj->encoding in addReply()");
     }
+}
+
+/* Add a Redis Object as a bulk reply */
+void addReplyBulk(client *c, robj *obj) {
+    addReplyBulkWithFlag(c, obj, 1);
 }
 
 /* Add a C buffer as bulk reply */

--- a/src/networking.c
+++ b/src/networking.c
@@ -1599,7 +1599,7 @@ void acceptCommonHandler(connection *conn, int flags, char *ip) {
         char addr[NET_ADDR_STR_LEN] = {0};
         char laddr[NET_ADDR_STR_LEN] = {0};
         connFormatAddr(conn, addr, sizeof(addr), 1);
-        connFormatAddr(conn, laddr, sizeof(addr), 0);
+        connFormatAddr(conn, laddr, sizeof(laddr), 0);
         serverLog(LL_VERBOSE,
                   "Accepted client connection in error state: %s (addr=%s laddr=%s)",
                   connGetLastError(conn), addr, laddr);
@@ -1638,7 +1638,7 @@ void acceptCommonHandler(connection *conn, int flags, char *ip) {
         char addr[NET_ADDR_STR_LEN] = {0};
         char laddr[NET_ADDR_STR_LEN] = {0};
         connFormatAddr(conn, addr, sizeof(addr), 1);
-        connFormatAddr(conn, laddr, sizeof(addr), 0);
+        connFormatAddr(conn, laddr, sizeof(laddr), 0);
         serverLog(LL_WARNING,
                   "Error registering fd event for the new client connection: %s (addr=%s laddr=%s)",
                   connGetLastError(conn), addr, laddr);

--- a/src/object.c
+++ b/src/object.c
@@ -1394,7 +1394,7 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
     mem_total += hotkeysGetMemoryUsage(server.hotkeys);
 
     mh->overhead_total = mem_total;
-    mh->dataset = zmalloc_used - mem_total;
+    mh->dataset = (zmalloc_used > mem_total) ? (zmalloc_used - mem_total) : 0;
     mh->peak_perc = (float)zmalloc_used*100/mh->peak_allocated;
 
     /* Metrics computed after subtracting the startup memory from

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -856,7 +856,7 @@ int rdbLoadStreamIdmpEntries(rio *rdb, stream *s) {
     if (num_producers == 0) return 0;
 
     /* Create the producers rax tree. */
-    s->idmp_producers = raxNew();
+    s->idmp_producers = raxNewWithMetadata(0, &s->alloc_size);
     if (s->idmp_producers == NULL) {
         return -1;
     }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3902,6 +3902,8 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             dbExpand(db, db_size, 0);
             dbExpandExpires(db, expires_size, 0);
             should_expand_db = 0;
+            serverLog(LL_VERBOSE, "DB %d resized: %lu key buckets, %lu expire buckets",
+                        db->id, kvstoreBuckets(db->keys), kvstoreBuckets(db->expires));
         }
 
         /* With metadata, type = RDB_OPCODE_KEY_META. Layout: [<META>,]<TYPE>,<KEY>,<VALUE> */

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -10498,22 +10498,16 @@ static int displayKeyStatsSizeDist(struct hdr_histogram *keysize_histogram) {
     line_count += cleanPrintfln("-------- ---------- -----------");
 
     while (hdr_iter_next(&iter)) {
-        /* Skip repeat in hdr_histogram cumulative_count, and set the last line
-         * to 100% when total_count is reached. For instance:
+        /* Skip repeat in hdr_histogram cumulative_count. For instance:
          * 140.68K    99.9969%        50013
          * 140.68K    99.9977%        50013
-         *   2.04G    99.9985%        50014
          *   2.04G   100.0000%        50014
          * Will display:
          * 140.68K    99.9969%        50013
          *   2.04G   100.0000%        50014                                   */
 
         if (iter.cumulative_count != last_displayed_cumulative_count) {
-            if (iter.cumulative_count == iter.h->total_count) {
-                percentile = 100;
-            } else {
-                percentile = iter.specifics.percentiles.percentile;
-            }
+            percentile = (100.0 * (double) iter.cumulative_count) / iter.h->total_count;
 
             line_count += cleanPrintfln("%8s %9.4f%% %11lld",
                 bytesToHuman(size, sizeof(size), iter.highest_equivalent_value),
@@ -10691,7 +10685,7 @@ static void updateKeyType(redisReply *element, unsigned long long size, typeinfo
         /* Keep track of biggest key name for this type */
         if (type->biggest_key)
             sdsfree(type->biggest_key);
-        type->biggest_key = sdsnewlen(element->str, element->len);
+        type->biggest_key = sdscatrepr(sdsempty(), element->str, element->len);
         if (!type->biggest_key) {
             fprintf(stderr, "Failed to allocate memory for key!\n");
             exit(1);

--- a/src/script.c
+++ b/src/script.c
@@ -523,6 +523,8 @@ static int scriptVerifyClusterState(scriptRunCtx *run_ctx, client *c, client *or
                              c->cmd->fullname); 
         } else if (error_code == CLUSTER_REDIR_DOWN_UNBOUND) {
             *err = sdsnew("Script attempted to access a slot not served"); 
+        } else if (error_code == CLUSTER_REDIR_TRIMMING) {
+            *err = sdsnew("Script attempted to access a slot being trimmed");
         } else {
             /* error_code == CLUSTER_REDIR_MOVED || error_code == CLUSTER_REDIR_ASK */
             *err = sdsnew("Script attempted to access a non local key in a "

--- a/src/server.c
+++ b/src/server.c
@@ -6726,16 +6726,18 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
     }
 
     /* Hotkeys */
-    if (server.hotkeys &&
-        (all_sections || (dictFind(section_dict,"hotkeys") != NULL)))
+    if (all_sections || (dictFind(section_dict,"hotkeys") != NULL))
     {
         if (sections++) info = sdscat(info,"\r\n"); 
 
-        info = sdscatprintf(info, "# Hotkeys\r\n"
-            "hotkeys-tracking-active:%d\r\n"
-            "hotkeys-cmd-cpu-time:%lld\r\n",
-            server.hotkeys->active ? 1 : 0,
-            server.hotkeys->cpu_time);
+        info = sdscatprintf(info, "# Hotkeys\r\n");
+        if (server.hotkeys) {
+            info = sdscatprintf(info,
+                "hotkeys-tracking-active:%d\r\n"
+                "hotkeys-cmd-cpu-time:%lld\r\n",
+                server.hotkeys->active ? 1 : 0,
+                server.hotkeys->cpu_time);
+        }
     }
 
     /* Modules */

--- a/src/server.c
+++ b/src/server.c
@@ -2304,8 +2304,13 @@ void initServerConfig(void) {
     server.configfile = NULL;
     server.executable = NULL;
     server.arch_bits = (sizeof(long) == 8) ? 64 : 32;
-    server.dbg_assert_keysizes = 0; /* Disabled by default */
-    server.dbg_assert_alloc_per_slot = 0; /* Disabled by default */
+#if DEBUG_ASSERT_KEYSPACE
+    server.dbg_assert_keysizes = 1;
+    server.dbg_assert_alloc_per_slot = 1;
+#else
+    server.dbg_assert_keysizes = 0;
+    server.dbg_assert_alloc_per_slot = 0;
+#endif
     server.bindaddr_count = CONFIG_DEFAULT_BINDADDR_COUNT;
     for (j = 0; j < CONFIG_DEFAULT_BINDADDR_COUNT; j++)
         server.bindaddr[j] = zstrdup(default_bindaddr[j]);

--- a/src/server.h
+++ b/src/server.h
@@ -3121,6 +3121,7 @@ void addReplyVerbatim(client *c, const char *s, size_t len, const char *ext);
 void addReplyProto(client *c, const char *s, size_t len);
 void AddReplyFromClient(client *c, client *src);
 void addReplyBulk(client *c, robj *obj);
+void addReplyBulkWithFlag(client *c, robj *obj, int avoid_copy);
 void addReplyBulkCString(client *c, const char *s);
 void addReplyBulkCBuffer(client *c, const void *p, size_t len);
 void addReplyBulkLongLong(client *c, long long ll);

--- a/src/server.h
+++ b/src/server.h
@@ -4401,6 +4401,7 @@ void xlenCommand(client *c);
 void xreadCommand(client *c);
 void xgroupCommand(client *c);
 void xsetidCommand(client *c);
+void xidmprecordCommand(client *c);
 void xackCommand(client *c);
 void xackdelCommand(client *c);
 void xpendingCommand(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -3943,7 +3943,9 @@ kvobj *dbUnshareStringValueByLink(redisDb *db, robj *key, kvobj *kv, dictEntryLi
 #define FLUSH_TYPE_DB    1
 #define FLUSH_TYPE_SLOTS 2
 void replySlotsFlushAndFree(client *c, struct slotRangeArray *slots);
-int flushCommandCommon(client *c, int type, int flags, struct slotRangeArray *ranges);
+int flushCommandCommon(client *c, int type, int flags);
+void unblockClientForAsyncFlush(uint64_t client_id, void *userdata);
+void blockClientForAsyncFlush(client *c);
 #define EMPTYDB_NO_FLAGS 0      /* No flags. */
 #define EMPTYDB_ASYNC (1<<0)    /* Reclaim memory in another thread. */
 #define EMPTYDB_NOFUNCTIONS (1<<1) /* Indicate not to flush the functions. */

--- a/src/stream.h
+++ b/src/stream.h
@@ -192,6 +192,7 @@ void streamGetEdgeID(stream *s, int first, int skip_tombstones, streamID *edge_i
 long long streamEstimateDistanceFromFirstEverEntry(stream *s, streamID *id);
 int64_t streamTrimByLength(stream *s, long long maxlen, int approx);
 int64_t streamTrimByID(stream *s, streamID minid, int approx);
+int streamEntryExists(stream *s, streamID *id);
 
 listNode *streamLinkCGroupToEntry(stream *s, streamCG *cg, unsigned char *key);
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1,6 +1,9 @@
 /*
  * Copyright (c) 2009-Present, Redis Ltd.
  * All rights reserved.
+ * 
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
  *
  * Licensed under your choice of (a) the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
@@ -2926,6 +2929,8 @@ void hdelCommand(client *c) {
      * field with expiration and removes it from global HFE DS. */
     int isHFE = hashTypeIsFieldsWithExpire(o);
 
+    if (o->encoding == OBJ_ENCODING_HT)
+        dictPauseAutoResize((dict*)o->ptr);
     for (j = 2; j < c->argc; j++) {
         if (hashTypeDelete(o,c->argv[j]->ptr)) {
             deleted++;
@@ -2938,6 +2943,10 @@ void hdelCommand(client *c) {
                 break;
             }
         }
+    }
+    if (!keyremoved && o->encoding == OBJ_ENCODING_HT) {
+        dictResumeAutoResize((dict*)o->ptr);
+        dictShrinkIfNeeded((dict*)o->ptr);
     }
     if (server.memory_tracking_enabled && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldsize, kvobjAllocSize(o));

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1235,7 +1235,8 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
         /* Update dst obj cardinality in KEYSIZES */
         updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_LIST, oldlen, newlen);
         /* Update src obj cardinality in KEYSIZES by listElementsRemoved() */
-        listElementsRemoved(c, skey, wherefrom, kvsrc, 1, kvobjAllocSize(kvsrc), 1, NULL);
+        size_t srcsize = server.memory_tracking_enabled ? kvobjAllocSize(kvsrc) : 0;
+        listElementsRemoved(c, skey, wherefrom, kvsrc, 1, srcsize, 1, NULL);
         /* listTypePop returns an object with its refcount incremented */
         decrRefCount(value);
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -657,6 +657,8 @@ void sremCommand(client *c) {
     if (server.memory_tracking_enabled)
         oldsize = kvobjAllocSize(set);
 
+    if (set->encoding == OBJ_ENCODING_HT)
+        dictPauseAutoResize((dict*)set->ptr);
     for (j = 2; j < c->argc; j++) {
         if (setTypeRemove(set,c->argv[j]->ptr)) {
             deleted++;
@@ -668,6 +670,10 @@ void sremCommand(client *c) {
                 break;
             }
         }
+    }
+    if (!keyremoved && set->encoding == OBJ_ENCODING_HT) {
+        dictResumeAutoResize((dict*)set->ptr);
+        dictShrinkIfNeeded((dict*)set->ptr);
     }
     if (server.memory_tracking_enabled && !keyremoved)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), set, oldsize, kvobjAllocSize(set));

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -5550,7 +5550,7 @@ static void idmpInsertEntry(stream *s, idmpProducer *producer, idmpEntry *entry,
 static idmpProducer *idmpGetOrCreateProducer(stream *s, const char *pid, size_t pid_len) {
     /* Create the producers rax tree if it doesn't exist */
     if (s->idmp_producers == NULL) {
-        s->idmp_producers = raxNew();
+        s->idmp_producers = raxNewWithMetadata(0, &s->alloc_size);
     }
 
     /* Look up the producer */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2435,7 +2435,7 @@ void xaddCommand(client *c) {
     stream *s;
     if ((kv = streamTypeLookupWriteOrCreate(c,c->argv[1],parsed_args.no_mkstream)) == NULL) return;
     s = kv->ptr;
-    size_t old_alloc = kvobjAllocSize(kv);
+    size_t old_alloc = server.memory_tracking_enabled ? kvobjAllocSize(kv) : 0;
 
     /* IDMP: Check if IID already exists, save IID for later insertion */
     XXH128_hash_t hash;
@@ -2564,7 +2564,7 @@ void xrangeGenericCommand(client *c, int rev) {
     robj *startarg = rev ? c->argv[3] : c->argv[2];
     robj *endarg = rev ? c->argv[2] : c->argv[3];
     int startex = 0, endex = 0;
-    size_t old_alloc;
+    size_t old_alloc = 0;
     
     /* Parse start and end IDs. */
     if (streamParseIntervalIDOrReply(c,startarg,&startid,&startex,0) != C_OK)
@@ -2606,7 +2606,8 @@ void xrangeGenericCommand(client *c, int rev) {
         addReplyNullArray(c);
     } else {
         if (count == -1) count = 0;
-        old_alloc = kvobjAllocSize(kv);
+        if (server.memory_tracking_enabled)
+            old_alloc = kvobjAllocSize(kv);
         streamReplyWithRange(c,s,&startid,&endid,count,rev,-1,NULL,NULL,0,NULL,NULL);
         if (server.memory_tracking_enabled)
             updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),kv,old_alloc,kvobjAllocSize(kv));
@@ -2653,7 +2654,7 @@ void xreadCommand(client *c) {
     int xreadgroup = sdslen(c->argv[0]->ptr) == 10; /* XREAD or XREADGROUP? */
     robj *groupname = NULL;
     robj *consumername = NULL;
-    size_t old_alloc;
+    size_t old_alloc = 0;
 
     /* Parse arguments. */
     for (int i = 1; i < c->argc; i++) {
@@ -2881,7 +2882,8 @@ void xreadCommand(client *c) {
             }
             consumer = streamLookupConsumer(groups[i],consumername->ptr);
             if (consumer == NULL) {
-                old_alloc = kvobjAllocSize(o);
+                if (server.memory_tracking_enabled)
+                    old_alloc = kvobjAllocSize(o);
                 consumer = streamCreateConsumer(s,groups[i],consumername->ptr,
                                                 c->argv[streams_arg+i],
                                                 c->db->id,SCC_DEFAULT);
@@ -2933,7 +2935,8 @@ void xreadCommand(client *c) {
             unsigned long propCount = 0;
             if (noack) flags |= STREAM_RWR_NOACK;
             if (serve_history) flags |= STREAM_RWR_HISTORY;
-            old_alloc = kvobjAllocSize(o);
+            if (server.memory_tracking_enabled)
+                old_alloc = kvobjAllocSize(o);
             streamReplyWithRange(c,s,&start,NULL,count,0, min_idle_time,
                                  groups ? groups[i] : NULL,
                                  consumer, flags, &spi, &propCount);
@@ -3356,7 +3359,7 @@ void xgroupCommand(client *c) {
     int mkstream = 0;
     long long entries_read = SCG_INVALID_ENTRIES_READ;
     robj *o;
-    size_t old_alloc;
+    size_t old_alloc = 0;
 
     /* Everything but the "HELP" option requires a key and group name. */
     if (c->argc >= 4) {
@@ -3460,7 +3463,8 @@ NULL
             entries_read = s->entries_added;
         }
 
-        old_alloc = kvobjAllocSize(o);
+        if (server.memory_tracking_enabled)
+            old_alloc = kvobjAllocSize(o);
         streamCG *cg = streamCreateCG(s,grpname,sdslen(grpname),&id,entries_read);
         if (cg) {
             if (server.memory_tracking_enabled)
@@ -3493,7 +3497,8 @@ NULL
         keyModified(c,c->db,c->argv[2],o,0);
     } else if (!strcasecmp(opt,"DESTROY") && c->argc == 4) {
         if (cg) {
-            old_alloc = kvobjAllocSize(o);
+            if (server.memory_tracking_enabled)
+                old_alloc = kvobjAllocSize(o);
             raxRemove(s->cgroups,(unsigned char*)grpname,sdslen(grpname),NULL);
             streamDestroyCG(s, cg);
             if (server.memory_tracking_enabled)
@@ -3509,7 +3514,8 @@ NULL
             addReply(c,shared.czero);
         }
     } else if (!strcasecmp(opt,"CREATECONSUMER") && c->argc == 5) {
-        old_alloc = kvobjAllocSize(o);
+        if (server.memory_tracking_enabled)
+            old_alloc = kvobjAllocSize(o);
         streamConsumer *created = streamCreateConsumer(s,cg,c->argv[4]->ptr,c->argv[2],
                                                        c->db->id,SCC_DEFAULT);
         keyModified(c,c->db,c->argv[2],o,0);
@@ -3522,7 +3528,8 @@ NULL
         if (consumer) {
             /* Delete the consumer and returns the number of pending messages
              * that were yet associated with such a consumer. */
-            old_alloc = kvobjAllocSize(o);
+            if (server.memory_tracking_enabled)
+                old_alloc = kvobjAllocSize(o);
             pending = raxSize(consumer->pel);
             streamDelConsumer(s,cg,consumer);
             if (server.memory_tracking_enabled)
@@ -3650,7 +3657,7 @@ void xackCommand(client *c) {
     }
 
     int acknowledged = 0;
-    size_t old_alloc = kvobjAllocSize(kv);
+    size_t old_alloc = server.memory_tracking_enabled ? kvobjAllocSize(kv) : 0;
     for (int j = 3; j < c->argc; j++) {
         unsigned char buf[sizeof(streamID)];
         streamEncodeID(buf,&ids[j-3]);
@@ -3721,7 +3728,7 @@ void xackdelCommand(client *c) {
     }
 
     s = kv->ptr;
-    size_t old_alloc = kvobjAllocSize(kv);
+    size_t old_alloc = server.memory_tracking_enabled ? kvobjAllocSize(kv) : 0;
     int first_entry = 0;
     int deleted = 0, dirty = server.dirty;
     addReplyArrayLen(c, args.numids);
@@ -4149,7 +4156,7 @@ void xclaimCommand(client *c) {
 
     /* Do the actual claiming. */
     stream *s = o->ptr;
-    size_t old_alloc = kvobjAllocSize(o);
+    size_t old_alloc = server.memory_tracking_enabled ? kvobjAllocSize(o) : 0;
     streamConsumer *consumer = streamLookupConsumer(group,c->argv[3]->ptr);
     if (consumer == NULL) {
         consumer = streamCreateConsumer(o->ptr,group,c->argv[3]->ptr,c->argv[1],c->db->id,SCC_DEFAULT);
@@ -4342,7 +4349,7 @@ void xautoclaimCommand(client *c) {
 
     /* Do the actual claiming. */
     stream *s = o->ptr;
-    size_t old_alloc = kvobjAllocSize(o);
+    size_t old_alloc = server.memory_tracking_enabled ? kvobjAllocSize(o) : 0;
     streamConsumer *consumer = streamLookupConsumer(group,c->argv[3]->ptr);
     if (consumer == NULL) {
         consumer = streamCreateConsumer(o->ptr,group,c->argv[3]->ptr,c->argv[1],c->db->id,SCC_DEFAULT);
@@ -4471,7 +4478,7 @@ void xdelCommand(client *c) {
     kvobj *kv = lookupKeyWriteOrReply(c, c->argv[1], shared.czero); 
     if (kv == NULL || checkType(c, kv, OBJ_STREAM)) return;
     stream *s = kv->ptr;
-    size_t old_alloc = kvobjAllocSize(kv);
+    size_t old_alloc = server.memory_tracking_enabled ? kvobjAllocSize(kv) : 0;
 
     /* We need to sanity check the IDs passed to start. Even if not
      * a big issue, it is not great that the command is only partially
@@ -4569,7 +4576,7 @@ void xdelexCommand(client *c) {
     }
 
     stream *s = kv->ptr;
-    size_t old_alloc = kvobjAllocSize(kv);
+    size_t old_alloc = server.memory_tracking_enabled ? kvobjAllocSize(kv) : 0;
     int first_entry = 0;
     int deleted = 0;
     addReplyArrayLen(c, args.numids);
@@ -4674,7 +4681,7 @@ void xtrimCommand(client *c) {
     stream *s = kv->ptr;
 
     /* Perform the trimming. */
-    size_t old_alloc = kvobjAllocSize(kv);
+    size_t old_alloc = server.memory_tracking_enabled ? kvobjAllocSize(kv) : 0;
     int64_t deleted = streamTrim(s, &parsed_args);
     if (server.memory_tracking_enabled)
         updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),kv,old_alloc,kvobjAllocSize(kv));
@@ -4774,7 +4781,7 @@ void xinfoReplyWithStreamInfo(client *c, kvobj *kv) {
     addReplyBulkCString(c,"iids-duplicates");
     addReplyLongLong(c,s->iids_duplicates);
 
-    size_t old_alloc = kvobjAllocSize(kv);
+    size_t old_alloc = server.memory_tracking_enabled ? kvobjAllocSize(kv) : 0;
     if (!full) {
         /* XINFO STREAM <key> */
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -51,6 +51,7 @@ static void trackStreamIdmpEntries(client *c, robj *key);
 static void streamClearIdmpEntries(stream *s);
 static void idmpInsertEntry(stream *s, idmpProducer *producer, idmpEntry *entry, const streamID *id);
 static int idmpLookupAndReply(stream *s, idmpProducer *producer, idmpEntry *entry, client *c);
+static int idmpLookup(idmpProducer *producer, idmpEntry *entry, streamID *id);
 static idmpProducer *idmpGetOrCreateProducer(stream *s, const char *pid, size_t pid_len);
 static int createIdempotencyHash(robj **argv, int64_t numfields, XXH128_hash_t *out_hash);
 static void idmpEvictOldestEntry(stream *s, idmpProducer *producer);
@@ -3621,6 +3622,64 @@ void xsetidCommand(client *c) {
     keyModified(c,c->db,c->argv[1],kv,0);
 }
 
+/* XIDMPRECORD <key> <pid> <iid> <streamID>
+ * Set IDMP metadata (producer id + idempotency id) on an existing stream message. */
+void xidmprecordCommand(client *c) {
+    streamID id;
+
+    if (streamParseStrictIDOrReply(c, c->argv[4], &id, 0, NULL) != C_OK)
+        return;
+
+    const char *pid_str = c->argv[2]->ptr;
+    size_t pid_len = sdslen((sds)pid_str);
+    const char *iid_str = c->argv[3]->ptr;
+    size_t iid_len = sdslen((sds)iid_str);
+
+    if (pid_len == 0) {
+        addReplyError(c,"producer ID must be non-empty");
+        return;
+    }
+    if (iid_len == 0) {
+        addReplyError(c,"idempotent ID must be non-empty");
+        return;
+    }
+
+    kvobj *kv = lookupKeyWriteOrReply(c, c->argv[1], shared.nokeyerr);
+    if (kv == NULL || checkType(c, kv, OBJ_STREAM)) return;
+    stream *s = kv->ptr;
+
+    if (!streamEntryExists(s, &id)) {
+        addReplyError(c, "No such message in stream");
+        return;
+    }
+
+    size_t old_alloc = server.memory_tracking_enabled ? kvobjAllocSize(kv) : 0;
+
+    idmpProducer *producer = idmpGetOrCreateProducer(s, pid_str, pid_len);
+    idmpEntry *entry = idmpEntryCreate(iid_str, iid_len, &s->alloc_size);
+    int found = idmpLookup(producer, entry, &id);
+    if (found) {
+        idmpEntryFree(entry, &s->alloc_size);
+        if (found == 1)
+            addReply(c, shared.ok);
+        else
+            addReplyError(c, "IID already exists for this producer with a different stream ID");
+        if (server.memory_tracking_enabled)
+            updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),kv,old_alloc,kvobjAllocSize(kv));
+        return;
+    }
+
+    idmpInsertEntry(s, producer, entry, &id);
+    trackStreamIdmpEntries(c, c->argv[1]);
+    addReply(c, shared.ok);
+    server.dirty++;
+
+    if (server.memory_tracking_enabled)
+        updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),kv,old_alloc,kvobjAllocSize(kv));
+
+    keyModified(c, c->db, c->argv[1], kv, 0);
+}
+
 /* XACK <key> <group> <id> <id> ... <id>
  * Acknowledge a message as processed. In practical terms we just check the
  * pending entries list (PEL) of the group, and delete the PEL entry both from
@@ -5527,6 +5586,16 @@ static int idmpLookupAndReply(stream *s, idmpProducer *producer, idmpEntry *entr
         return 1;
     }
     return 0;
+}
+
+/* Lookup IID in the producer's dict.
+ * Return: 0 = not found, 1 = found same ID, -1 = found different ID. */
+static int idmpLookup(idmpProducer *producer, idmpEntry *entry, streamID *id) {
+    dictEntry *de = dictFind(producer->idmp_dict, entry);
+    if (de == NULL)
+        return 0;
+    idmpEntry *existing = (idmpEntry *)dictGetKey(de);
+    return streamCompareID(&existing->id, id) == 0 ? 1 : -1;
 }
 
 /* Insert an idmpEntry into the producer's dict and linked list with the given stream ID. */

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -147,6 +147,30 @@ void setGenericCommand(client *c, int flags, robj *key, robj **valref, robj *exp
         }
     }
 
+    /* If the expire time is already elapsed, we don't need to add the key,
+     * but we still need to update the stats, and we also need to delete the
+     * key if it exists.
+     *
+     * From stats perspective, we behave as if we inserted a new key (possibly
+     * an overwrite) and later expired it, but from the per-key KSN observability,
+     * we reflect what we've actually done in the db (deletion of old key, and
+     * no insertion of new one), so we don't confuse modules. */
+    if (expire && checkAlreadyExpired(milliseconds)) {
+        if (found) {
+            dbDelete(c->db, key);
+            robj *aux = server.lazyfree_lazy_server_del ? shared.unlink : shared.del;
+            rewriteClientCommandVector(c, 2, aux, key);
+            keyModified(c, c->db, key, NULL, 1);
+            notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
+            server.dirty++;
+        }
+        server.stat_expiredkeys++;
+        if (!(flags & OBJ_SET_GET)) {
+            addReply(c, ok_reply ? ok_reply : shared.ok);
+        }
+        return;
+    }
+
     /* When expire is not NULL, we avoid deleting the TTL so it can be updated later instead of being deleted and then created again. */
     setkey_flags |= ((flags & OBJ_KEEPTTL) || expire) ? SETKEY_KEEPTTL : 0;
     setkey_flags |= found ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2118,6 +2118,8 @@ void zremCommand(client *c) {
     int64_t oldlen = (int64_t) zsetLength(zobj);
     if (server.memory_tracking_enabled)
         oldsize = kvobjAllocSize(zobj);
+    if (zobj->encoding == OBJ_ENCODING_SKIPLIST)
+        dictPauseAutoResize(((zset*)zobj->ptr)->dict);
     for (j = 2; j < c->argc; j++) {
         if (zsetDel(zobj, c->argv[j]->ptr)) deleted++;
         if (zsetLength(zobj) == 0) {
@@ -2128,6 +2130,10 @@ void zremCommand(client *c) {
             keyremoved = 1;
             break;
         }
+    }
+    if (!keyremoved && zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+        dictResumeAutoResize(((zset*)zobj->ptr)->dict);
+        dictShrinkIfNeeded(((zset*)zobj->ptr)->dict);
     }
 
     if (server.memory_tracking_enabled && !keyremoved)

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2068,6 +2068,7 @@ void zaddGenericCommand(client *c, int flags) {
             addReplyError(c,nanerr);
             if (server.memory_tracking_enabled)
                 updateSlotAllocSize(c->db, getKeySlot(key->ptr), zobj, oldsize, kvobjAllocSize(zobj));
+            updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, llen, llen+added);
             goto cleanup;
         }
         if (retflags & ZADD_OUT_ADDED) added++;

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -154,7 +154,7 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
             return C_ERR;
 
         ftval *= 1000.0;  /* seconds => millisec */
-        if (ftval > LLONG_MAX) {
+        if (ftval > (long double)LLONG_MAX) {
             addReplyError(c, "timeout is out of range");
             return C_ERR;
         }

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -200,6 +200,13 @@ void enableTracking(client *c, uint64_t redirect_to, uint64_t options, robj **pr
  * that should receive an invalidation message with certain groups of keys
  * are modified. */
 void trackingRememberKeys(client *tracking, client *executing) {
+    /* Shard channels are treated as special keys for client
+     * library to rely on `COMMAND` command to discover the node
+     * to connect to. These channels don't need to be tracked. */
+    if (executing->cmd->flags & CMD_PUBSUB) {
+        return;
+    }
+
     /* Return if we are in optin/out mode and the right CACHING command
      * was/wasn't given in order to modify the default behavior. */
     uint64_t optin = tracking->flags & CLIENT_TRACKING_OPTIN;
@@ -211,12 +218,6 @@ void trackingRememberKeys(client *tracking, client *executing) {
     int numkeys = getKeysFromCommand(executing->cmd,executing->argv,executing->argc,&result);
     if (!numkeys) {
         getKeysFreeResult(&result);
-        return;
-    }
-    /* Shard channels are treated as special keys for client
-     * library to rely on `COMMAND` command to discover the node
-     * to connect to. These channels doesn't need to be tracked. */
-    if (executing->cmd->flags & CMD_PUBSUB) {
         return;
     }
 

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -10,9 +10,9 @@
 # (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
 # GNU Affero General Public License v3 (AGPLv3).
 
-package require Tcl 8.5
+package require Tcl 8.5-10
 
-set tcl_precision 17
+if {$tcl_version < 9.0} { set tcl_precision 17 }
 source ../support/redis.tcl
 source ../support/util.tcl
 source ../support/aofmanifest.tcl

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -145,7 +145,13 @@ foreach sanitize_dump {no yes} {
                         }
                     }
                 } else {
-                    r ping ;# an attempt to check if the server didn't terminate (this will throw an error that will terminate the tests)
+                    # an attempt to check if the server didn't terminate (this will throw an error that will terminate the tests)
+                    if { [catch { r ping } err] } {
+                        set msg "Server crashed after RESTORE with payload: $printable_dump"
+                        write_log_line 0 $msg
+                        puts $msg
+                        error $err
+                    }
                 }
 
                 set print_commands false

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -80,6 +80,23 @@ start_server [list overrides [list "dir" $server_path] keep_persistence true] {
     r del stream
 }
 
+start_server {overrides {loglevel verbose}} {
+    test {RDB load applies RESIZEDB hint to expand hash tables} {
+        # Populate keys and save RDB
+        r flushall sync
+        regexp {db=(\d+)} [r client info] -> dbid
+        # 500 keys with 3600 second expiration, 500 without
+        populate 500 "key1:" 3 0 false 3600
+        populate 500 "key2:" 3 0 false 0
+        r save
+
+        restart_server 0 true false
+
+        # Verify DB resize log message
+        verify_log_message 0 "*DB $dbid resized*1024 key*512 expire*" 0
+    }
+}
+
 # Helper function to start a server and kill it, just to check the error
 # logged.
 set defaults {}

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1832,3 +1832,48 @@ start_server {tags {"repl external:skip"}} {
         }
     }
 }
+
+# Test for issue #14838: No crash when prefetchCommands handles NULL argv and keys during replication
+start_server {tags {"repl external:skip"}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+
+    start_server {} {
+        set slave [srv 0 client]
+
+        test {Prefetch handles NULL argv gracefully during RDB replication} {
+            # Configure master for diskless sync to trigger prefetch code path
+            $master config set repl-diskless-sync yes
+            $master config set repl-diskless-sync-delay 500
+
+            # Create data on the master  
+            $master set test_key "test_value"
+            $master set another_key "another_value"
+
+            # Start replication from the slave
+            $slave slaveof $master_host $master_port
+
+            # Use a longer timeout and wait for replication to complete
+            set retry 200
+            while {$retry > 0} {
+                set role [lindex [$slave role] 0]
+                set info [$slave info replication]
+                
+                if {$role eq {slave} && [string match {*master_link_status:up*} $info]} {
+                    break
+                }
+                incr retry -1
+                after 100
+            }
+
+            if {$retry == 0} {
+                fail "Replica did not complete synchronization"
+            }
+
+            # Verify the replicated data
+            assert_equal "test_value" [$slave get test_key]
+            assert_equal "another_value" [$slave get another_key]
+        }
+    }
+}

--- a/tests/modules/cmdintrospection.c
+++ b/tests/modules/cmdintrospection.c
@@ -87,33 +87,19 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
             {
                 .name = "idmp",
                 .type = REDISMODULE_ARG_TYPE_ONEOF,
+                .since = "8.6.0",
                 .flags = REDISMODULE_CMD_ARG_OPTIONAL,
                 .subargs = (RedisModuleCommandArg[]){
                     {
-                        .name = "idmpauto-with-pid",
-                        .type = REDISMODULE_ARG_TYPE_BLOCK,
-                        .subargs = (RedisModuleCommandArg[]){
-                            {
-                                .name = "idmpauto-token",
-                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                                .token = "IDMPAUTO"
-                            },
-                            {
-                                .name = "pid",
-                                .type = REDISMODULE_ARG_TYPE_STRING,
-                            },
-                            {0}
-                        }
+                        .name = "pid",
+                        .type = REDISMODULE_ARG_TYPE_STRING,
+                        .token = "IDMPAUTO"
                     },
                     {
-                        .name = "idmp-with-pid-iid",
+                        .name = "idmp",
                         .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .token = "IDMP",
                         .subargs = (RedisModuleCommandArg[]){
-                            {
-                                .name = "idmp-token",
-                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                                .token = "IDMP"
-                            },
                             {
                                 .name = "pid",
                                 .type = REDISMODULE_ARG_TYPE_STRING,

--- a/tests/modules/infotest.c
+++ b/tests/modules/infotest.c
@@ -3,9 +3,11 @@
 #include <string.h>
 
 void InfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
+    static int info_func_calls = 0;
     RedisModule_InfoAddSection(ctx, "");
     RedisModule_InfoAddFieldLongLong(ctx, "global", -2);
     RedisModule_InfoAddFieldULongLong(ctx, "uglobal", (unsigned long long)-2);
+    RedisModule_InfoAddFieldLongLong(ctx, "info_calls", ++info_func_calls);
 
     RedisModule_InfoAddSection(ctx, "Spanish");
     RedisModule_InfoAddFieldCString(ctx, "uno", "one");

--- a/tests/modules/moduleconfigs.c
+++ b/tests/modules/moduleconfigs.c
@@ -1,5 +1,7 @@
 #include "redismodule.h"
+#include <string.h>
 #include <strings.h>
+#include <assert.h>
 int mutable_bool_val, no_prefix_bool, no_prefix_bool2;
 int immutable_bool_val;
 long long longval, no_prefix_longval;
@@ -13,38 +15,37 @@ int flagsval;
  * to point to the config, and they register the configs as such. Note that one could also just
  * use names if they wanted, and store anything in privdata. */
 int getBoolConfigCommand(const char *name, void *privdata) {
-    REDISMODULE_NOT_USED(name);
+    assert(strcmp(name, "mutable_bool") == 0 || strcmp(name, "immutable_bool") == 0);
     return (*(int *)privdata);
 }
 
 int setBoolConfigCommand(const char *name, int new, void *privdata, RedisModuleString **err) {
-    REDISMODULE_NOT_USED(name);
     REDISMODULE_NOT_USED(err);
+    assert(strcmp(name, "mutable_bool") == 0 || strcmp(name, "immutable_bool") == 0);
     *(int *)privdata = new;
     return REDISMODULE_OK;
 }
 
 long long getNumericConfigCommand(const char *name, void *privdata) {
-    REDISMODULE_NOT_USED(name);
+    assert(strcmp(name, "numeric") == 0 || strcmp(name, "memory_numeric") == 0);
     return (*(long long *) privdata);
 }
 
 int setNumericConfigCommand(const char *name, long long new, void *privdata, RedisModuleString **err) {
-    REDISMODULE_NOT_USED(name);
     REDISMODULE_NOT_USED(err);
+    assert(strcmp(name, "numeric") == 0 || strcmp(name, "memory_numeric") == 0);
     *(long long *)privdata = new;
     return REDISMODULE_OK;
 }
 
 RedisModuleString *getStringConfigCommand(const char *name, void *privdata) {
-    REDISMODULE_NOT_USED(name);
     REDISMODULE_NOT_USED(privdata);
+    assert(strcmp(name, "string") == 0);
     return strval;
 }
 int setStringConfigCommand(const char *name, RedisModuleString *new, void *privdata, RedisModuleString **err) {
-    REDISMODULE_NOT_USED(name);
-    REDISMODULE_NOT_USED(err);
     REDISMODULE_NOT_USED(privdata);
+    assert(strcmp(name, "string") == 0);
     size_t len;
     if (!strcasecmp(RedisModule_StringPtrLen(new, &len), "rejectisfreed")) {
         *err = RedisModule_CreateString(NULL, "Cannot set string to 'rejectisfreed'", 36);
@@ -57,29 +58,29 @@ int setStringConfigCommand(const char *name, RedisModuleString *new, void *privd
 }
 
 int getEnumConfigCommand(const char *name, void *privdata) {
-    REDISMODULE_NOT_USED(name);
     REDISMODULE_NOT_USED(privdata);
+    assert(strcmp(name, "enum") == 0);
     return enumval;
 }
 
 int setEnumConfigCommand(const char *name, int val, void *privdata, RedisModuleString **err) {
-    REDISMODULE_NOT_USED(name);
-    REDISMODULE_NOT_USED(err);
     REDISMODULE_NOT_USED(privdata);
+    REDISMODULE_NOT_USED(err);
+    assert(strcmp(name, "enum") == 0);
     enumval = val;
     return REDISMODULE_OK;
 }
 
 int getFlagsConfigCommand(const char *name, void *privdata) {
-    REDISMODULE_NOT_USED(name);
     REDISMODULE_NOT_USED(privdata);
+    assert(strcmp(name, "flags") == 0);
     return flagsval;
 }
 
 int setFlagsConfigCommand(const char *name, int val, void *privdata, RedisModuleString **err) {
-    REDISMODULE_NOT_USED(name);
     REDISMODULE_NOT_USED(err);
     REDISMODULE_NOT_USED(privdata);
+    assert(strcmp(name, "flags") == 0);
     flagsval = val;
     return REDISMODULE_OK;
 }
@@ -102,34 +103,60 @@ int longlongApplyFunc(RedisModuleCtx *ctx, void *privdata, RedisModuleString **e
         return REDISMODULE_ERR;
     }
     return REDISMODULE_OK;
-}
+}    
 
 RedisModuleString *getStringConfigUnprefix(const char *name, void *privdata) {
-    REDISMODULE_NOT_USED(name);
     REDISMODULE_NOT_USED(privdata);
+    assert(strcmp(name, "unprefix-string") == 0 || strcmp(name, "unprefix.string-alias") == 0);
     return strval2;
 }
 
 int setStringConfigUnprefix(const char *name, RedisModuleString *new, void *privdata, RedisModuleString **err) {
-    REDISMODULE_NOT_USED(name);
-    REDISMODULE_NOT_USED(err);
     REDISMODULE_NOT_USED(privdata);
+    REDISMODULE_NOT_USED(err);
+    assert(strcmp(name, "unprefix-string") == 0 || strcmp(name, "unprefix.string-alias") == 0);
     if (strval2) RedisModule_FreeString(NULL, strval2);
     RedisModule_RetainString(NULL, new);
     strval2 = new;
     return REDISMODULE_OK;
 }
 
+int getBoolConfigUnprefix(const char *name, void *privdata) {
+    assert(strcmp(name, "unprefix-bool") == 0 || strcmp(name, "unprefix-bool-alias") == 0 ||
+           strcmp(name, "unprefix-noalias-bool") == 0);
+    return (*(int *)privdata);
+}
+
+int setBoolConfigUnprefix(const char *name, int new, void *privdata, RedisModuleString **err) {
+    REDISMODULE_NOT_USED(err);
+    assert(strcmp(name, "unprefix-bool") == 0 || strcmp(name, "unprefix-bool-alias") == 0 ||
+           strcmp(name, "unprefix-noalias-bool") == 0);
+    *(int *)privdata = new;
+    return REDISMODULE_OK;
+}
+
+long long getNumericConfigUnprefix(const char *name, void *privdata) {
+    assert(strcmp(name, "unprefix.numeric") == 0 || strcmp(name, "unprefix.numeric-alias") == 0);
+    return (*(long long *) privdata);
+}
+
+int setNumericConfigUnprefix(const char *name, long long new, void *privdata, RedisModuleString **err) {
+    REDISMODULE_NOT_USED(err);
+    assert(strcmp(name, "unprefix.numeric") == 0 || strcmp(name, "unprefix.numeric-alias") == 0);
+    *(long long *)privdata = new;
+    return REDISMODULE_OK;
+}
+
 int getEnumConfigUnprefix(const char *name, void *privdata) {
-    REDISMODULE_NOT_USED(name);
     REDISMODULE_NOT_USED(privdata);
+    assert(strcmp(name, "unprefix-enum") == 0 || strcmp(name, "unprefix-enum-alias") == 0);
     return no_prefix_enumval;
 }
 
 int setEnumConfigUnprefix(const char *name, int val, void *privdata, RedisModuleString **err) {
-    REDISMODULE_NOT_USED(name);
-    REDISMODULE_NOT_USED(err);
     REDISMODULE_NOT_USED(privdata);
+    REDISMODULE_NOT_USED(err);
+    assert(strcmp(name, "unprefix-enum") == 0 || strcmp(name, "unprefix-enum-alias") == 0);
     no_prefix_enumval = val;
     return REDISMODULE_OK;
 }
@@ -222,21 +249,21 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     }
 
     /*** unprefixed and aliased configuration ***/
-    if (RedisModule_RegisterBoolConfig(ctx, "unprefix-bool|unprefix-bool-alias", 1, REDISMODULE_CONFIG_DEFAULT|REDISMODULE_CONFIG_UNPREFIXED, 
-                                       getBoolConfigCommand, setBoolConfigCommand, NULL, &no_prefix_bool) == REDISMODULE_ERR) {
+    if (RedisModule_RegisterBoolConfig(ctx, "unprefix-bool|unprefix-bool-alias", 1, REDISMODULE_CONFIG_DEFAULT|REDISMODULE_CONFIG_UNPREFIXED,
+                                       getBoolConfigUnprefix, setBoolConfigUnprefix, NULL, &no_prefix_bool) == REDISMODULE_ERR) {
         RedisModule_Log(ctx, "warning", "Failed to register unprefix-bool");
         return REDISMODULE_ERR;
     }
     if (RedisModule_RegisterBoolConfig(ctx, "unprefix-noalias-bool", 1, REDISMODULE_CONFIG_DEFAULT|REDISMODULE_CONFIG_UNPREFIXED,
-                                       getBoolConfigCommand, setBoolConfigCommand, NULL, &no_prefix_bool2) == REDISMODULE_ERR) {
+                                       getBoolConfigUnprefix, setBoolConfigUnprefix, NULL, &no_prefix_bool2) == REDISMODULE_ERR) {
         RedisModule_Log(ctx, "warning", "Failed to register unprefix-noalias-bool");
         return REDISMODULE_ERR;
-    }    
-    if (RedisModule_RegisterNumericConfig(ctx, "unprefix.numeric|unprefix.numeric-alias", -1, REDISMODULE_CONFIG_DEFAULT|REDISMODULE_CONFIG_UNPREFIXED, 
-                                          -5, 2000, getNumericConfigCommand, setNumericConfigCommand, NULL, &no_prefix_longval) == REDISMODULE_ERR) {
+    }
+    if (RedisModule_RegisterNumericConfig(ctx, "unprefix.numeric|unprefix.numeric-alias", -1, REDISMODULE_CONFIG_DEFAULT|REDISMODULE_CONFIG_UNPREFIXED,
+                                          -5, 2000, getNumericConfigUnprefix, setNumericConfigUnprefix, NULL, &no_prefix_longval) == REDISMODULE_ERR) {
         RedisModule_Log(ctx, "warning", "Failed to register unprefix.numeric");
         return REDISMODULE_ERR;
-    }    
+    }
     if (RedisModule_RegisterStringConfig(ctx, "unprefix-string|unprefix.string-alias", "secret unprefix", REDISMODULE_CONFIG_DEFAULT|REDISMODULE_CONFIG_UNPREFIXED, 
                                          getStringConfigUnprefix, setStringConfigUnprefix, NULL, NULL) == REDISMODULE_ERR) {
         RedisModule_Log(ctx, "warning", "Failed to register unprefix-string");

--- a/tests/modules/test_keymeta.c
+++ b/tests/modules/test_keymeta.c
@@ -541,7 +541,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
 
-    if (RedisModule_Init(ctx, "test_metakey", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR) {
+    if (RedisModule_Init(ctx, "test_keymeta", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }
 

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -14,7 +14,7 @@
 # $c get foo
 # $c close
 
-package require Tcl 8.5
+package require Tcl 8.5-10
 package provide redis_cluster 0.1
 
 namespace eval redis_cluster {}

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -30,7 +30,7 @@
 #
 # vwait forever
 
-package require Tcl 8.5
+package require Tcl 8.5-10
 package provide redis 0.1
 
 source [file join [file dirname [info script]] "response_transformers.tcl"]
@@ -165,6 +165,11 @@ proc ::redis::__dispatch__raw__ {id method argv} {
         set cmd "*[expr {[llength $argv]+1}]\r\n"
         append cmd "$[string length $method]\r\n$method\r\n"
         foreach a $argv {
+            # In Tcl 9.0, only convert to UTF-8 if the string contains non-byte characters
+            # to preserve binary data while handling unicode correctly
+            if {$::tcl_version >= 9.0 && [string match "*\[^\u0000-\u00ff\]*" $a]} {
+                set a [encoding convertto utf-8 $a]
+            }
             append cmd "$[string length $a]\r\n$a\r\n"
         }
         ::redis::redis_write $fd $cmd

--- a/tests/support/response_transformers.tcl
+++ b/tests/support/response_transformers.tcl
@@ -19,7 +19,7 @@
 # changes in many files) we decided to transform the response to RESP2
 # when running with --force-resp3
 
-package require Tcl 8.5
+package require Tcl 8.5-10
 
 namespace eval response_transformers {}
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -13,9 +13,9 @@
 # Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
 #
 
-package require Tcl 8.5
+package require Tcl 8.5-10
 
-set tcl_precision 17
+if {$tcl_version < 9.0} { set tcl_precision 17 }
 source tests/support/redis.tcl
 source tests/support/aofmanifest.tcl
 source tests/support/server.tcl
@@ -333,7 +333,7 @@ proc test_server_cron {} {
 }
 
 proc accept_test_clients {fd addr port} {
-    fconfigure $fd -encoding binary
+    fconfigure $fd -translation binary
     fileevent $fd readable [list read_from_test_client $fd]
 }
 
@@ -524,7 +524,7 @@ proc the_end {} {
 # to read the command, execute, reply... all this in a loop.
 proc test_client_main server_port {
     set ::test_server_fd [socket localhost $server_port]
-    fconfigure $::test_server_fd -encoding binary
+    fconfigure $::test_server_fd -translation binary
     send_data_packet $::test_server_fd ready [pid]
     while 1 {
         set bytes [gets $::test_server_fd]

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1298,6 +1298,26 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
         catch {exec src/redis-server --user default --user default} err
         assert_match {*Duplicate user*} $err
     } {} {external:skip}
+
+    test {Test loading an ACL file with comments} {
+        exec cp -f tests/assets/user.acl $server_path
+
+        # Add comments to the ACL file
+        set acl_content "# This is a comment at the beginning\nuser alice on allcommands allkeys &* >alice\n# Comment between users\nuser bob on -@all +@set +acl ~set* &* >bob\n\n# Comment with blank line above\nuser doug on resetchannels &test +@all ~* >doug\nuser default on nopass ~* &* +@all\n# Comment at the end"
+        set fd [open $server_path/user.acl w]
+        puts $fd $acl_content
+        close $fd
+
+        # Load the ACL file with comments
+        assert_match {OK} [r ACL LOAD]
+
+        # Verify all users loaded correctly
+        assert {[r ACL GETUSER alice] != ""}
+        assert_equal [dict get [r ACL GETUSER alice] commands] "+@all"
+        assert {[r ACL GETUSER bob] != ""}
+        assert {[r ACL GETUSER doug] != ""}
+        assert {[r ACL GETUSER default] != ""}
+    }
 }
 
 start_server {overrides {user "default on nopass ~* +@all -flushdb"} tags {acl external:skip}} {

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1316,7 +1316,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         if {[string match {*stream-done*} [migration_status 0 $task_id state]]} {
             wait_for_condition 1000 20 {
                 [string match {*failed*} [migration_status 0 $task_id state]] &&
-                [string match {*Server paused*} [migration_status 0 $task_id last_error]]
+                [string match {*Write pause timeout*} [migration_status 0 $task_id last_error]]
             } else {
                 fail "ASM task did not fail"
             }
@@ -1433,9 +1433,10 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 flushall
     }
 
-    test "Source server paused timeout" {
+    test "Source write pause timeout" {
         # set timeout to 0, so the task will fail immediately when checking timeout
         R 0 config set cluster-slot-migration-write-pause-timeout 0
+        R 1 debug asm-failpoint "import-main-channel" "takeover"
 
         # start migration from node 0 to 1
         set task_id [setup_slot_migration_with_delay 0 1 0 100]
@@ -1444,10 +1445,10 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         set slot0_key [slot_key 0 mykey]
         set load_handle [start_write_load "127.0.0.1" [get_port 0] 100 $slot0_key]
 
-        # node 0 will fail since server paused timeout
+        # node 0 will fail due to write pause timeout
         wait_for_condition 2000 10 {
             [string match {*failed*} [migration_status 0 $task_id state]] &&
-            [string match {*Server paused timeout*} \
+            [string match {*Write pause timeout*} \
                 [migration_status 0 $task_id last_error]]
         } else {
             fail "ASM task did not fail"
@@ -1459,6 +1460,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 config set cluster-slot-migration-write-pause-timeout 10000
         R 0 cluster migration cancel id $task_id
         R 1 cluster migration cancel id $task_id
+        R 1 debug asm-failpoint "" ""
     }
 
     test "Sync buffer drain timeout" {

--- a/tests/unit/cluster/multi-slot-operations.tcl
+++ b/tests/unit/cluster/multi-slot-operations.tcl
@@ -133,20 +133,20 @@ test "SFLUSH - Errors and output validation" {
     assert_error {ERR wrong number of arguments*}           {$master1 SFLUSH 0 999 2001 8191 ASYNCX}
 
     # Test SFLUSH output validation
-    assert_match "" [$master1 SFLUSH 2 4]
-    assert_match "" [$master1 SFLUSH 0 4]
+    assert_match "{2 4}" [$master1 SFLUSH 2 4]
+    assert_match "{0 4}" [$master1 SFLUSH 0 4]
     assert_match "" [$master2 SFLUSH 0 4]
-    assert_match "" [$master1 SFLUSH 1 8191]
-    assert_match "" [$master1 SFLUSH 0 8190]
-    assert_match "" [$master1 SFLUSH 0 998 2001 8191]
-    assert_match "" [$master1 SFLUSH 1 999 2001 8191]
-    assert_match "" [$master1 SFLUSH 0 999 2001 8190]
-    assert_match "" [$master1 SFLUSH 0 999 2002 8191]
+    assert_match "{1 999} {2001 8191}" [$master1 SFLUSH 1 8191]
+    assert_match "{0 999} {2001 8190}" [$master1 SFLUSH 0 8190]
+    assert_match "{0 998} {2001 8191}" [$master1 SFLUSH 0 998 2001 8191]
+    assert_match "{1 999} {2001 8191}" [$master1 SFLUSH 1 999 2001 8191]
+    assert_match "{0 999} {2001 8190}" [$master1 SFLUSH 0 999 2001 8190]
+    assert_match "{0 999} {2002 8191}" [$master1 SFLUSH 0 999 2002 8191]
     assert_match "{0 999} {2001 8191}" [$master1 SFLUSH 0 999 2001 8191]
     assert_match "{0 999} {2001 8191}" [$master1 SFLUSH 0 8191]
     assert_match "{0 999} {2001 8191}" [$master1 SFLUSH 0 4000 4001 8191]
-    assert_match "" [$master2 SFLUSH 8193 16383]
-    assert_match "" [$master2 SFLUSH 8192 16382]
+    assert_match "{8193 16383}" [$master2 SFLUSH 8193 16383]
+    assert_match "{8192 16382}" [$master2 SFLUSH 8192 16382]
     assert_match "{8192 16383}" [$master2 SFLUSH 8192 16383]
     assert_match "{8192 16383}" [$master2 SFLUSH 8192 16383 SYNC]
     assert_match "{8192 16383}" [$master2 SFLUSH 8192 16383 ASYNC]
@@ -179,4 +179,110 @@ test "SFLUSH - Deletes the keys with argument <NONE>/SYNC/ASYNC" {
     }
 }
 
+}
+
+set testmodule [file normalize tests/modules/atomicslotmigration.so]
+start_cluster 2 2 [list tags {external:skip cluster experimental modules} config_lines [list loadmodule $testmodule]] {
+foreach sync_method {"SYNC" "BLOCKING-ASYNC" "ASYNC"} {
+foreach trim_method {"active" "bg"} {
+    test "sflush can propagate to replicas (sync method: $sync_method, trim method: $trim_method)" {
+        R 0 flushall
+        R 0 debug asm-trim-method $trim_method
+        R 2 debug asm-trim-method $trim_method
+
+        # Add keys in master
+        R 0 set "06S" "slot0"
+        wait_for_ofs_sync [Rn 0] [Rn 2]
+
+        set loglines [count_log_lines 0]
+
+        # since we have optimization, if the master is not running in blocking context,
+        # we will try to run in blocking ASYNC mode, so we need to use MULTI/EXEC to make it blocking
+        if {$sync_method eq "SYNC"} {
+            R 0 MULTI
+        }
+
+        # Execute SFLUSH on master, SYNC will be run as blocking ASYNC if not running in MULTI/EXEC
+        set sync_option "SYNC"
+        if {$sync_method eq "ASYNC"} {
+            set sync_option "ASYNC"
+        }
+        R 0 SFLUSH 0 8191 $sync_option
+
+        # Execute EXEC if using SYNC
+        if {$sync_method eq "SYNC"} {
+            R 0 EXEC
+        }
+
+        # Wait for SFLUSH to propagate to replica, and complete the trim
+        wait_for_condition 1000 10 {
+           [R 0 DBSIZE] == 0 && [R 2 DBSIZE] == 0
+        } else {
+            fail "SFLUSH did not propagate to replica"
+        }
+
+        if {$sync_method ne "SYNC"} {
+            if {$trim_method eq "active"} {
+                wait_for_log_messages 0 {"*Active trim completed for slots*0-8191*"} $loglines 1000 10
+            } else {
+                # background trim
+                wait_for_log_messages 0 {"*Background trim started for slots*0-8191*"} $loglines 1000 10
+            }
+        }
+    }
+}
+}
+    test "Canceling active trimming can unblock sflush" {
+        # Delay active trim to make sure it is not completed before FLUSHDB
+        R 0 debug asm-trim-method active 10000 ;# delay 10ms per key
+        # Add slot 0 keys in master
+        for {set i 0} {$i < 1000} {incr i} {
+            R 0 set "{06S}$i" "value$i"
+        }
+
+        set rd [redis_deferring_client 0]
+        $rd SFLUSH 0 8191 SYNC ;# running in blocking async method
+
+        # FLUSHDB will cancel all trim jobs
+        R 0 SELECT 0
+        R 0 FLUSHDB SYNC
+
+        # SFLUSH should be unblocked and return empty array
+        assert_equal [$rd read] "{0 8191}"
+        $rd close
+    }
+
+    test "Write is rejected and read is allowed in SFLUSH slots using active trim" {
+        R 0 debug asm-trim-method active 1000 ;# delay 1ms per key
+        R 0 asm.clear_event_log
+        R 2 asm.clear_event_log
+
+        # Add slot 0 keys
+        for {set i 0} {$i < 1000} {incr i} {
+            R 0 set "{06S}$i" "value$i"
+        }
+        # Add a slot 1 key, we should trim slot 0 first, then slot 1
+        set slot1_key "Qi"
+        R 0 set $slot1_key "slot1"
+        wait_for_ofs_sync [Rn 0] [Rn 2]
+
+        set rd [redis_deferring_client 0]
+        $rd SFLUSH 0 8191 SYNC ;# running in blocking async method
+
+        # we can read the slot 1 key
+        assert_equal [R 0 get $slot1_key] "slot1"
+        # Module with flag REDISMODULE_OPEN_KEY_ACCESS_TRIMMED also can read the key
+        assert_equal [R 0 asm.read_pending_trim_key $slot1_key] "slot1"
+
+        # we can not write to the slot 1 key
+        assert_error "*TRYAGAIN Slot is being trimmed*" {R 0 set $slot1_key "value1"}
+
+        # wait for SFLUSH to complete
+        assert_equal [$rd read] "{0 8191}"
+        $rd close
+
+        # there is no trim event since we sfluh the owned slots of this node
+        assert_equal [R 0 asm.get_cluster_event_log] {}
+        assert_equal [R 2 asm.get_cluster_event_log] {}
+    }
 }

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -42,9 +42,13 @@ start_server {tags {"dump"}} {
         set encoded [r dump foo]
         set now [clock milliseconds]
         r debug set-active-expire 0
+        set expiredkeys [s expired_keys]
         r restore foo [expr $now-3000] $encoded absttl REPLACE
         catch {r debug object foo} e
         r debug set-active-expire 1
+        # Verify that expired_keys was incremented, even though
+        # the key was not added to the DB actually.
+        assert_equal [expr $expiredkeys + 1] [s expired_keys]
         set e
     } {ERR no such key} {needs:debug}
 

--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -312,7 +312,7 @@ start_server {tags {external:skip "hotkeys"}} {
         }
 
         # Should NOT have selected-slots conditional fields
-        assert {![dict exists $result "sampled-command-selected-slots-us"]}
+        assert {![dict exists $result "sampled-commands-selected-slots-us"]}
         assert {![dict exists $result "all-commands-selected-slots-us"]}
         assert {![dict exists $result "net-bytes-sampled-commands-selected-slots"]}
         assert {![dict exists $result "net-bytes-all-commands-selected-slots"]}
@@ -571,7 +571,7 @@ start_cluster 1 0 {tags {external:skip cluster hotkeys}} {
         }
 
         # Should have conditional fields
-        assert [dict exists $result "sampled-command-selected-slots-us"]
+        assert [dict exists $result "sampled-commands-selected-slots-us"]
         assert [dict exists $result "all-commands-selected-slots-us"]
         assert [dict exists $result "net-bytes-sampled-commands-selected-slots"]
         assert [dict exists $result "net-bytes-all-commands-selected-slots"]
@@ -590,7 +590,7 @@ start_cluster 1 0 {tags {external:skip cluster hotkeys}} {
         }
 
         # Should NOT have sampled-commands fields (sample_ratio = 1)
-        assert {![dict exists $result "sampled-command-selected-slots-us"]}
+        assert {![dict exists $result "sampled-commands-selected-slots-us"]}
         assert {![dict exists $result "net-bytes-sampled-commands-selected-slots"]}
 
         # Should have all-commands-selected-slots fields

--- a/tests/unit/info-keysizes.tcl
+++ b/tests/unit/info-keysizes.tcl
@@ -417,6 +417,24 @@ proc test_all_keysizes { {replMode 0} } {
         run_cmd_verify_hist {$server ZADD z1 1 a 2 b 3 c} {db0_ZSET:2=1}
         run_cmd_verify_hist {$server ZMPOP 1 z1 MIN} {db0_ZSET:2=1}
         run_cmd_verify_hist {$server ZMPOP 1 z1 MAX COUNT 2} {}
+
+        # ROOT CAUSE TEST: ZADD INCR with NaN error + histogram update
+        # This reproduces the bug from issue #14767:
+        # When ZADD with INCR flag fails (score becomes NaN), the histogram
+        # is NOT updated, causing desync. Only happens with INCR flag since
+        # it's the only ZADD path that can return error (return 0).
+        run_cmd_verify_hist {$server FLUSHALL} {}
+
+        # Step 1: Create a ZSET with one element with +inf score
+        run_cmd_verify_hist {$server ZADD z1 +inf member} {db0_ZSET:1=1}
+
+        # Step 2: Try ZADD with INCR that produces NaN
+        # This tries to add -inf to +inf which produces NaN
+        # The histogram should still be updated correctly
+        catch {$server ZADD z1 INCR -inf member}
+
+        # The set should still have 1 element, histogram should be consistent
+        run_cmd_verify_hist {$server ZPOPMIN z1} {}
         
     } {} {cluster:skip}    
     

--- a/tests/unit/moduleapi/infotest.tcl
+++ b/tests/unit/moduleapi/infotest.tcl
@@ -10,6 +10,16 @@ proc field {info property} {
 start_server {tags {"modules external:skip"}} {
     r module load $testmodule log-key 0
 
+    test {module info not attempted in INFO ALL} {
+        # call INFO in a few different ways, check that regardless of the section filtering,
+        # the module isn't at all being called when unneeded.
+        r INFO
+        r INFO all
+        r INFO memory
+        set info [r info everything]
+        set calls [field $info infotest_info_calls]
+    } {1}
+
     test {module reading info} {
         # check string, integer and float fields
         assert_equal [r info.gets replication role] "master"

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -16,6 +16,7 @@ start_server {tags {"other"}} {
         assert_match "*CONFIG <subcommand> *" [r CONFIG HELP]
         assert_match "*FUNCTION <subcommand> *" [r FUNCTION HELP]
         assert_match "*MODULE <subcommand> *" [r MODULE HELP]
+        assert_match "*HOTKEYS <subcommand> *" [r HOTKEYS HELP]
     }
 
     test {Coverage: MEMORY MALLOC-STATS} {

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -227,7 +227,7 @@ start_server {tags {"other"}} {
             } else {
                 set fd2 [socket [srv host] [srv port]]
             }
-            fconfigure $fd2 -encoding binary -translation binary
+            fconfigure $fd2 -translation binary
             if {!$::singledb} {
                 puts -nonewline $fd2 "SELECT 9\r\n"
                 flush $fd2

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1026,7 +1026,14 @@ foreach type {single multiple single_multiple} {
                 break
             }
         }
-        r srem $myset {*}$members
+        r deferred 1
+        foreach m $members {
+            r srem $myset $m
+        }
+        foreach m $members {
+            r read
+        }
+        r deferred 0
     }
 
     proc verify_rehashing_completed_key {myset table_size keys} {

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -632,6 +632,155 @@ start_server {
         assert_equal $id1 $id1_dup2
     } {} {external:skip needs:debug}
 
+    # XIDMPRECORD tests
+    test {XIDMPRECORD parameter validation} {
+        # Wrong arity
+        assert_error {*wrong number of arguments for 'xidmprecord' command} {r XIDMPRECORD mystream p1 i1}
+        assert_error {*wrong number of arguments for 'xidmprecord' command} {r XIDMPRECORD mystream p1 i1 1-1 extra}
+
+        # Key does not exist
+        assert_error {*no such key*} {r XIDMPRECORD nosuchkey p1 i1 1-1}
+
+        # Key is not a stream
+        r SET notastream "value"
+        assert_error {*WRONGTYPE*} {r XIDMPRECORD notastream p1 i1 1-1}
+        r DEL notastream
+
+        # Invalid stream ID (need existing stream)
+        r DEL mystream
+        r XADD mystream 1-1 f v
+        assert_error {*Invalid stream ID specified as stream*} {r XIDMPRECORD mystream p1 i1 bad}
+        assert_error {*Invalid stream ID specified as stream*} {r XIDMPRECORD mystream p1 i1 1-}
+        assert_error {*Invalid stream ID specified as stream*} {r XIDMPRECORD mystream p1 i1 -1}
+
+        # Empty pid and empty iid
+        assert_error {*producer ID must be non-empty*} {r XIDMPRECORD mystream "" i1 1-1}
+        assert_error {*idempotent ID must be non-empty*} {r XIDMPRECORD mystream p1 "" 1-1}
+    }
+
+    test {XIDMPRECORD with binary-safe iid} {
+        r DEL mystream
+        set id [r XADD mystream * f v]
+        set binary_iid "\x00\x01\x02\xff"
+        assert_equal "OK" [r XIDMPRECORD mystream p1 $binary_iid $id]
+        set id_dup [r XADD mystream IDMP p1 $binary_iid * f v2]
+        assert_equal $id $id_dup
+    }
+
+    test {XIDMPRECORD with maximum length iid} {
+        r DEL mystream
+        set id [r XADD mystream * f v]
+        set long_iid [string repeat "x" 65536]
+        assert_equal "OK" [r XIDMPRECORD mystream p1 $long_iid $id]
+        set id_dup [r XADD mystream IDMP p1 $long_iid * f v2]
+        assert_equal $id $id_dup
+    }
+
+    test {XIDMPRECORD with unicode pid and iid} {
+        r DEL mystream
+        set id [r XADD mystream * f v]
+        assert_equal "OK" [r XIDMPRECORD mystream "producer-世界" "req-héllo" $id]
+        set id_dup [r XADD mystream IDMP "producer-世界" "req-héllo" * f v2]
+        assert_equal $id $id_dup
+    }
+
+    test {XIDMPRECORD with long producer ID} {
+        r DEL mystream
+        set id [r XADD mystream * f v]
+        set long_pid [string repeat "p" 1000]
+        assert_equal "OK" [r XIDMPRECORD mystream $long_pid i1 $id]
+        set id_dup [r XADD mystream IDMP $long_pid i1 * f v2]
+        assert_equal $id $id_dup
+    }
+
+    test {XIDMPRECORD with special characters in iid} {
+        r DEL mystream
+        set id [r XADD mystream * f v]
+        assert_equal "OK" [r XIDMPRECORD mystream p1 "key:value" $id]
+        set id_dup [r XADD mystream IDMP p1 "key:value" * f v2]
+        assert_equal $id $id_dup
+    }
+
+    test {XIDMPRECORD message must exist in stream} {
+        r DEL mystream
+        r XADD mystream 1-1 f v
+        assert_error {*No such message in stream*} {r XIDMPRECORD mystream p1 i1 999-999}
+    }
+
+    test {XIDMPRECORD then deduplication works} {
+        r DEL mystream
+        set id [r XADD mystream * f v]
+        assert_equal "OK" [r XIDMPRECORD mystream p1 req-1 $id]
+        set id_dup [r XADD mystream IDMP p1 req-1 * f v2]
+        assert_equal $id $id_dup
+        assert_equal 1 [r XLEN mystream]
+    }
+
+    test {XIDMPRECORD idempotent} {
+        r DEL mystream
+        set id [r XADD mystream * f v]
+        assert_equal "OK" [r XIDMPRECORD mystream p1 req-1 $id]
+        assert_equal "OK" [r XIDMPRECORD mystream p1 req-1 $id]
+        set id_dup [r XADD mystream IDMP p1 req-1 * f v2]
+        assert_equal $id $id_dup
+    }
+
+    test {XIDMPRECORD conflict same pid iid different stream ID} {
+        r DEL mystream
+        set id1 [r XADD mystream * f v1]
+        set id2 [r XADD mystream * f v2]
+        assert_equal "OK" [r XIDMPRECORD mystream p1 i1 $id1]
+        assert_error {*IID already exists for this producer with a different stream ID*} {r XIDMPRECORD mystream p1 i1 $id2}
+    }
+
+    test {XIDMPRECORD multiple producers} {
+        r DEL mystream
+        set id1 [r XADD mystream * f v1]
+        set id2 [r XADD mystream * f v2]
+        assert_equal "OK" [r XIDMPRECORD mystream p1 i1 $id1]
+        assert_equal "OK" [r XIDMPRECORD mystream p2 i2 $id2]
+        assert_equal $id1 [r XADD mystream IDMP p1 i1 * f dup1]
+        assert_equal $id2 [r XADD mystream IDMP p2 i2 * f dup2]
+    }
+
+    test {XIDMPRECORD AOF rewrite restores IDMP} {
+        r DEL mystream
+        r config set appendonly yes
+        waitForBgrewriteaof r
+
+        set id1 [r XADD mystream IDMP p1 "aof-xidmp-1" * field "value1"]
+        r XADD mystream IDMP p1 "aof-xidmp-2" * field "value2"
+        set id1_dup [r XADD mystream IDMP p1 "aof-xidmp-1" * field "dup"]
+        assert_equal $id1 $id1_dup
+
+        r BGREWRITEAOF
+        waitForBgrewriteaof r
+        r DEBUG RELOAD
+
+        assert_equal 2 [r XLEN mystream]
+        set id1_dup2 [r XADD mystream IDMP p1 "aof-xidmp-1" * field "new"]
+        assert_equal $id1 $id1_dup2
+    } {} {external:skip needs:debug}
+
+    test {XIDMPRECORD AOF rewrite emits XIDMPRECORD for stream with IDMP from XIDMPRECORD only} {
+        r DEL mystream
+        r config set appendonly yes
+        waitForBgrewriteaof r
+
+        set id [r XADD mystream * f v]
+        assert_equal "OK" [r XIDMPRECORD mystream p1 rec-1 $id]
+        set id_dup [r XADD mystream IDMP p1 rec-1 * f v2]
+        assert_equal $id $id_dup
+
+        r BGREWRITEAOF
+        waitForBgrewriteaof r
+        r DEBUG RELOAD
+
+        assert_equal 1 [r XLEN mystream]
+        set id_dup2 [r XADD mystream IDMP p1 rec-1 * f v3]
+        assert_equal $id $id_dup2
+    } {} {external:skip needs:debug}
+
     test {XADD IDMP multiple producers have isolated namespaces} {
         r DEL mystream
         

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -665,6 +665,21 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         list $old_value $new_value
     } {bar bar}
 
+    test {Extended SET GET option with a past expiration time and no previous value} {
+        r del foo
+        r debug set-active-expire 0
+        set now [clock milliseconds]
+        set expiredkeys [s expired_keys]
+        set old_value [r set foo baz GET PXAT [expr $now-3000]]
+        assert_equal $old_value {}
+        # Verify that expired_keys was incremented, even though
+        # the key was not added to the DB actually.
+        assert_equal [expr $expiredkeys + 1] [s expired_keys]
+        catch {r debug object foo} e
+        r debug set-active-expire 1
+        set e
+    } {ERR no such key} {needs:debug}
+
     test {Extended SET GET with incorrect type should result in wrong type error} {
       r del foo
       r rpush foo waffle
@@ -698,6 +713,43 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         r set foo bar pxat [expr [clock milliseconds] + 10000]
         assert_range [r ttl foo] 5 10
     }
+
+    test {Extended SET PXAT option with a past expiration time} {
+        r set foo bar
+        r debug set-active-expire 0
+        set now [clock milliseconds]
+        set expiredkeys [s expired_keys]
+        r set foo baz PXAT [expr $now-3000]
+        # Verify that expired_keys was incremented, even though
+        # the key was not added to the DB actually.
+        assert_equal [expr $expiredkeys + 1] [s expired_keys]
+        catch {r debug object foo} e
+        r debug set-active-expire 1
+        set e
+    } {ERR no such key} {needs:debug}
+
+    test {SET PXAT with a past expiration time will propagate it as DEL or UNLINK} {
+        r flushall
+        r set foo foo
+        r set bar bar
+        set repl [attach_to_replication_stream]
+
+        # Keys that have expired timestamp will be deleted immediately
+        set now [clock milliseconds]
+        r config set lazyfree-lazy-server-del no
+        assert_equal {OK} [r set foo foo PXAT [expr $now-3000]]
+        r config set lazyfree-lazy-server-del yes
+        assert_equal {OK} [r set bar bar PXAT [expr $now-3000]]
+
+        # Verify the propagate of DEL and UNLINK.
+        assert_replication_stream $repl {
+            {select *}
+            {del foo}
+            {unlink bar}
+        }
+        close_replication_stream $repl
+    } {} {needs:repl}
+
     test {Extended SET using multiple options at once} {
         r set foo val
         assert {[r set foo bar xx px 10000] eq {OK}}
@@ -1215,7 +1267,6 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
     test {Extended SET with IFDEQ - key exists and digest matches} {
         r set mykey "hello"
         set digest [r digest mykey]
-        puts $digest
         assert_equal "OK" [r set mykey "world" IFDEQ $digest]
         assert_equal "world" [r get mykey]
     }


### PR DESCRIPTION
## Summary

When ZADD with INCR flag fails (score becomes NaN), the histogram was NOT updated, causing desync between the actual key sizes and the histogram counts.

## Root Cause

In `zaddGenericCommand()`, when `zsetAdd()` returns 0 (indicating NaN error), the code jumps to cleanup without calling `updateKeysizesHist()`. This leaves the histogram in an inconsistent state.

## Fix

Add the missing `updateKeysizesHist()` call in the error path before returning the error.

## Test

Added a test case that:
1. Creates a ZSET with +inf score
2. Tries ZADD INCR -inf (produces NaN)
3. Verifies histogram remains consistent

This test verifies that issue #14767 is fixed and histogram returns elements correctly after the NaN error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk due to substantial changes in cluster `SFLUSH`/slot-trimming behavior, ASM migration timeouts, and AOF rewrite of stream IDMP metadata, which can affect data safety, write availability, and replication/AOF replay.
> 
> **Overview**
> Adds a new CI job for `DEBUG_ASSERT_KEYSPACE` and reduces many GitHub Actions job timeouts from 4h to 6m, while also extending `runtest` Tcl detection to include Tcl 9.0.
> 
> Improves cluster slot maintenance: `SFLUSH` now supports partial slot-range flushing, can run as *blocking async* with client unblocking on trim completion, cancels overlapping ASM work, and rejects writes to slots currently being actively trimmed (new `CLUSTER_REDIR_TRIMMING` / `-TRYAGAIN`). ASM trimming is refactored to distinguish background vs active trim, track active trim jobs (optionally unblocking a waiting client), gate module trim events to migration cleanup only, and add/adjust handoff timeout handling and overlap checks.
> 
> Extends persistence/stream support by emitting per-stream IDMP config (`XCFGSET`) and IDMP entries (`XIDMPRECORD`) during AOF rewrite (skipping entries for deleted IDs), adding command/docs JSON for `XIDMPRECORD`, and tightening stream IDMP memory/defrag handling. Separately, a set of correctness/safety updates land across the codebase: allow `#` comments in ACL files, fix keyspace histogram/memory tracking edge cases (e.g., ZADD NaN error path, module string resize, list move), adjust reply copy-avoidance for module strings to prevent UAF, improve kvstore expansion behavior, and add multiple small fixes/perf tweaks (linenoise word navigation, networking buffer sizes, hotkeys help/field rename, etc.).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1858039ae6793ab80a8fdea60a51e564701b2b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->