### PR TITLE
fixes around recent keyModified changes

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2247,7 +2247,7 @@ void renameGenericCommand(client *c, int nx) {
     }
 
     keyModified(c,c->db,c->argv[1],NULL,1);
-    keyModified(c,c->db,c->argv[2],NULL,1); /* LRM already updated by dbAddInternal */
+    keyModified(c,c->db,c->argv[2],o,1);
     notifyKeyspaceEvent(NOTIFY_GENERIC,"rename_from",
         c->argv[1],c->db->id);
     notifyKeyspaceEvent(NOTIFY_GENERIC,"rename_to",
@@ -2347,7 +2347,7 @@ void moveCommand(client *c) {
     }
 
     keyModified(c,src,c->argv[1],NULL,1);
-    keyModified(c,dst,c->argv[1],NULL,1); /* LRM already updated by dbAddInternal */
+    keyModified(c,dst,c->argv[1],kv,1);
     notifyKeyspaceEvent(NOTIFY_GENERIC,
                 "move_from",c->argv[1],src->id);
     notifyKeyspaceEvent(NOTIFY_GENERIC,
@@ -2475,8 +2475,8 @@ void copyCommand(client *c) {
         }
     }
 
-    /* OK! key copied. Signal modification (LRM already updated by dbAddInternal) */
-    keyModified(c,dst,c->argv[2],NULL,1);
+    /* OK! key copied. Signal modification */
+    keyModified(c,dst,c->argv[2],kvCopy,1);
     notifyKeyspaceEvent(NOTIFY_GENERIC,"copy_to",c->argv[2],dst->id);
 
     /* `delete` implies the destination key was overwritten */

--- a/src/debug.c
+++ b/src/debug.c
@@ -793,7 +793,7 @@ NULL
                 memcpy(val->ptr, buf, valsize<=buflen? valsize: buflen);
             }
             dbAdd(c->db, key, &val);
-            keyModified(c,c->db,key,NULL,1);
+            keyModified(c,c->db,key,val,1);
             decrRefCount(key);
         }
         addReply(c,shared.ok);

--- a/src/module.c
+++ b/src/module.c
@@ -2528,7 +2528,7 @@ void RM_SetModuleOptions(RedisModuleCtx *ctx, int options) {
  * RM_SetModuleOptions().
 */
 int RM_SignalModifiedKey(RedisModuleCtx *ctx, RedisModuleString *keyname) {
-    kvobj *kv = lookupKeyReadWithFlags(ctx->client->db, keyname, LOOKUP_NOTOUCH);
+    kvobj *kv = lookupKeyReadWithFlags(ctx->client->db, keyname, LOOKUP_NOEFFECTS);
     keyModified(ctx->client,ctx->client->db,keyname,kv,1);
     return REDISMODULE_OK;
 }


### PR DESCRIPTION
These areas were modified as part of the recent LRM eviction policy, and
i think they're wrong;
1. DEBUG POPULATE and a few others, have the value at hand, so they can pass it to
keyModified. It's harmless sine the key was just created and LRM is set, but its better for consistency to pass it anyway.
2. RM_SignalModifiedKey now calls lookupKey, but it should use NOEFFECTS
to avoid incrementing stats, key miss notification, and others.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core keyspace mutation paths (`RENAME`, `MOVE`, `COPY`, `DEBUG POPULATE`) and module APIs, which can affect eviction/LRM timestamps, client tracking invalidation, and keyspace stats if incorrect.
> 
> **Overview**
> Fixes several call sites to pass the actual value object into `keyModified()` after key creation/move/rename/copy, ensuring the LRM timestamp is updated for the destination key (instead of skipping LRM updates with `NULL`).
> 
> Updates `RM_SignalModifiedKey()` to use `lookupKeyReadWithFlags(..., LOOKUP_NOEFFECTS)` so signaling a modification doesn’t trigger read side effects like stats updates or key-miss notifications.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d6e139e364ce96046a00e4d0e6c2f1ce2ba9890. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->