### PR TITLE
Disable memory tracking in child processes

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -7377,6 +7377,8 @@ int redisFork(int purpose) {
         updateDictResizePolicy();
         dismissMemoryInChild();
         closeChildUnusedResourceAfterFork();
+        /* Memory tracking for slots is unnecessary in child processes. */
+        server.memory_tracking_enabled = 0;
         /* Close the reading part, so that if the parent crashes, the child will
          * get a write error and exit. */
         if (server.child_info_pipe[0] != -1)


### PR DESCRIPTION
Disable memory tracking in child processes (forked for RDB operations) to reduce unnecessary overhead.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single change to child-process initialization that only disables slot memory tracking in forked background children, reducing overhead without affecting parent behavior.
> 
> **Overview**
> Disables `server.memory_tracking_enabled` inside `redisFork()` child processes, so background forked children (e.g., for persistence) stop performing slot memory tracking work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbf21d2758ca23bf4a269d5e1d67852f3d499d51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->