### PR TITLE
fix use after free in RESTORE command handling

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -294,16 +294,16 @@ void restoreCommand(client *c) {
 
     /* Create the key and set the TTL if any */
     kvobj *kv = dbAddInternal(c->db, key, &obj, NULL, &keymeta);
-
+    int newtype = kv->type;
     /* If minExpiredField was set, then the object is hash with expiration
      * on fields and need to register it in global HFE DS */
-    if (kv->type == OBJ_HASH) {
+    if (newtype == OBJ_HASH) {
         uint64_t minExpiredField = hashTypeGetMinExpire(kv, 1);
         if (minExpiredField != EB_EXPIRE_TIME_INVALID)
             estoreAdd(c->db->subexpires, getKeySlot(key->ptr), kv, minExpiredField);
     }
 
-    if (kv->type == OBJ_STREAM) {
+    if (newtype == OBJ_STREAM) {
         stream *s = kv->ptr;
         if (s->idmp_producers != NULL) {
             if (dictAdd(c->db->stream_idmp_keys, key, NULL) == DICT_OK)
@@ -328,7 +328,7 @@ void restoreCommand(client *c) {
      * destination key existed. */
     if (deleted) {
         notifyKeyspaceEvent(NOTIFY_OVERWRITTEN, "overwritten", key, c->db->id);
-        if (oldtype != kv->type) {
+        if (oldtype != newtype) {
             notifyKeyspaceEvent(NOTIFY_TYPE_CHANGED, "type_changed", key, c->db->id);
         }
     }


### PR DESCRIPTION
This PR aims to fix the sanitizer errors shown in https://github.com/redis/redis/actions/runs/23570878820/job/68632915653

The idea is not to access `kvobj` after the HashNotification callbacks because the KVObj may have been reallocated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `RESTORE` key creation/notification flow in `src/cluster.c`, which is a core data-loading path used by `RESTORE`/`MIGRATE`, but the change is small and only affects how the new key type is tracked after insertion.
> 
> **Overview**
> Avoids a potential use-after-free in `restoreCommand` by caching the newly created key’s type (`newtype`) immediately after `dbAddInternal()` and using it for subsequent type-specific handling (hash field-expiry registration, stream IDMP tracking) and overwrite type-change notifications, instead of re-reading `kv->type` after callbacks that may reallocate the `kvobj`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b89fa24875a2189646131f041d7e95adc1f8b3d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->