### PR TITLE
Fix memory leak in ZDIFF algorithm 2 on early exit

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2793,7 +2793,10 @@ static void zdiffAlgorithm2(zsetopsrc *src, long setnum, zset *dstzset, size_t *
 
             /* Exit if result set is empty as any additional removal
                 * of elements will have no effect. */
-            if (cardinality == 0) break;
+            if (cardinality == 0) {
+                zuiDiscardDirtyValue(&zval);
+                break;
+            }
         }
         zuiClearIterator(&src[j]);
 

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1114,6 +1114,18 @@ start_server {tags {"zset"}} {
             assert_equal {a 1 e 5} [r zrange zsete{t} 0 -1 withscores]
         }
 
+        test "ZDIFF algorithm 2 empty result early exit - $encoding" {
+            # Force algorithm 2 by inflating setnum with non-existing keys.
+            # algo_one_work = len(src[0]) * setnum / 2 = 2 * 10 / 2 = 10
+            # algo_two_work = 2 + 2 + 0*8 = 4
+            # algo_one (10) > algo_two (4) -> algorithm 2 is selected
+            r del zseta{t} zsetb{t} zsetc{t}
+            r zadd zseta{t} 1 a 2 b
+            r zadd zsetb{t} 1 a 2 b
+            assert_equal 0 [r zdiffstore zsetc{t} 10 zseta{t} zsetb{t} nx1{t} nx2{t} nx3{t} nx4{t} nx5{t} nx6{t} nx7{t} nx8{t}]
+            assert_equal {} [r zrange zsetc{t} 0 -1 withscores]
+        }
+
         test "ZDIFF fuzzing - $encoding" {
             for {set j 0} {$j < 100} {incr j} {
                 unset -nocomplain s


### PR DESCRIPTION
## Problem

`zdiffAlgorithm2()` can break out early once the destination cardinality reaches zero. In that path, a temporary SDS created by `zuiSdsFromValue()` is left dirty and never released, because the cleanup normally happens on the next `zuiNext()` call which is skipped due to the early `break`.

`zuiClearIterator()` called after the loop does **not** clean up dirty values — only `zuiNext()` or explicit `zuiDiscardDirtyValue()` does.

## Root Cause

In `zdiffAlgorithm2()` (src/t_zset.c), the flow is:

1. `zuiSdsFromValue(&zval)` allocates an SDS string and sets `OPVAL_DIRTY_SDS` flag
2. If `cardinality == 0`, the code breaks out of the while loop
3. `zuiClearIterator()` is called but does not free the dirty SDS value
4. The allocated SDS is leaked

## Fix

Add `zuiDiscardDirtyValue(&zval)` before the early `break` to ensure the temporary SDS is freed on all exit paths.

## Tests Added

- **ZDIFF algorithm 2 empty result early exit**: Forces algorithm 2 selection by inflating `setnum` with non-existing keys, creates two identical sorted sets, runs `ZDIFFSTORE` which triggers algorithm 2's early exit when cardinality reaches 0, and verifies the result is empty. This test would expose the leak under Valgrind.

## Impact

Minimal scope change — one conditional block expanded. No behavioral change; only prevents a memory leak on a specific code path. The leak is triggered when ZDIFF(STORE) uses algorithm 2 and all elements of the first set are found in subsequent sets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized memory-management fix in ZDIFF algorithm 2 plus a targeted regression test; no intended behavior change beyond preventing an SDS leak.
> 
> **Overview**
> Prevents a memory leak in `zdiffAlgorithm2()` by explicitly calling `zuiDiscardDirtyValue(&zval)` before breaking out of the removal loop when the destination cardinality hits zero.
> 
> Adds a unit test (`ZDIFF algorithm 2 empty result early exit`) that forces algorithm 2 selection with extra non-existent keys and verifies `ZDIFFSTORE` returns an empty result in the early-exit scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceec2065529bfa4da6a2d470f3f51db62cced788. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->