### PR TITLE
Fix missing ksn_notify_side_effect module test in runtest-moduleapi

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -60,4 +60,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/internalsecret \
 --single unit/moduleapi/configaccess \
 --single unit/moduleapi/keymeta \
+--single unit/moduleapi/ksn_notify_side_effect \
 "${@}"


### PR DESCRIPTION
Fix missing `unit/moduleapi/ksn_notify_side_effect` in `runtest-moduleapi` test suite.

### Question: How about removing runtest-moduleapi entirely?

I noticed that `runtest-moduleapi` is rarely used and often gets out of sync because `runtest` and `make test` already cover all tests in `unit/moduleapi`.

In our CI environment, we always use the general test suite like this, we do not have a separate configuration for `runtest-moduleapi`:
https://github.com/redis/redis/blob/ef741a95a2338c95cc9a9fc193a5142d57c04fe2/.github/workflows/daily.yml#L58-L69





After a global search for moduleapi, I found that these are the only two places where `runtest-moduleapi` is still being used:
https://github.com/redis/redis/blob/ef741a95a2338c95cc9a9fc193a5142d57c04fe2/utils/releasetools/03_test_release.sh#L25-L28

https://github.com/redis/redis/blob/ef741a95a2338c95cc9a9fc193a5142d57c04fe2/src/Makefile#L509-L519

- The command in `03_test_release.sh` appear to be redundant
- If we need to keep this functionality, maybe we can just add an argument to make test for specific modules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the `runtest-moduleapi` test runner to include one additional test, with no production code changes.
> 
> **Overview**
> Fixes the `runtest-moduleapi` script so it also runs the previously omitted Module API test `unit/moduleapi/ksn_notify_side_effect`, keeping the module API test subset in sync with the full `unit/moduleapi` suite.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 313bd3fab175ebe4e5ab0e4a336d7770c019eb88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->