### PR TITLE
Allow RM_FreeString() to accept NULL pointer

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -2767,9 +2767,13 @@ RedisModuleString *RM_CreateStringFromStreamID(RedisModuleCtx *ctx, const RedisM
  * the context, so if you want to free a string out of context later, make sure
  * to create it using a NULL context.
  *
+ * It is safe to pass a NULL pointer to 'str', in which case no operation is
+ * performed, aligning with the behavior of free() and RedisModule_Free().
+ *
  * This API is not thread safe, access to these retained strings (if they originated
  * from a client command arguments) must be done with GIL locked. */
 void RM_FreeString(RedisModuleCtx *ctx, RedisModuleString *str) {
+    if (str == NULL) return;
     decrRefCount(str);
     if (ctx != NULL) autoMemoryFreed(ctx,REDISMODULE_AM_STRING,str);
 }


### PR DESCRIPTION
Fixes #10887 - Add NULL check at beginning of RM_FreeString() so passing NULL str is a safe no-op, aligning with free() and RM_Free(). Updated doc comment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a defensive NULL guard and updates documentation, with minimal impact limited to freeing behavior for invalid callers.
> 
> **Overview**
> `RM_FreeString()` now safely accepts a NULL `str` by returning early, preventing potential crashes when callers attempt to free a missing string.
> 
> The API comment is updated to document the NULL-safe, no-op behavior (matching `free()`/`RedisModule_Free()`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b26531ab4dbf7728d48df40719fa94970cc7e47d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->