### PR TITLE
Expose READONLY and REPLICATED flags in module client info

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3734,6 +3734,10 @@ int modulePopulateClientInfoStructure(void *ci, client *client, int structver) {
         ci1->flags |= REDISMODULE_CLIENTINFO_FLAG_BLOCKED;
     if (client->conn->type == connectionTypeTls())
         ci1->flags |= REDISMODULE_CLIENTINFO_FLAG_SSL;
+    if (client->flags & CLIENT_READONLY) 
+        ci1->flags |= REDISMODULE_CLIENTINFO_FLAG_READONLY;
+    if (client->flags & CLIENT_MASTER)
+        ci1->flags |= REDISMODULE_CLIENTINFO_FLAG_REPLICATED;
 
     int port;
     connAddrPeerName(client->conn,ci1->addr,sizeof(ci1->addr),&port);

--- a/src/module.c
+++ b/src/module.c
@@ -3797,6 +3797,8 @@ int modulePopulateReplicationInfoStructure(void *ri, int structver) {
  *     REDISMODULE_CLIENTINFO_FLAG_TRACKING     Client with keys tracking on.
  *     REDISMODULE_CLIENTINFO_FLAG_UNIXSOCKET   Client using unix domain socket.
  *     REDISMODULE_CLIENTINFO_FLAG_MULTI        Client in MULTI state.
+ *     REDISMODULE_CLIENTINFO_FLAG_READONLY     Client is in readonly mode.
+ *     REDISMODULE_CLIENTINFO_FLAG_REPLICATED   Client is a master connection (replica-to-master link).
  *
  * However passing NULL is a way to just check if the client exists in case
  * we are not interested in any additional information.

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -738,6 +738,8 @@ static const RedisModuleEvent
 #define REDISMODULE_CLIENTINFO_FLAG_TRACKING (1<<3)
 #define REDISMODULE_CLIENTINFO_FLAG_UNIXSOCKET (1<<4)
 #define REDISMODULE_CLIENTINFO_FLAG_MULTI (1<<5)
+#define REDISMODULE_CLIENTINFO_FLAG_READONLY (1<<6)
+#define REDISMODULE_CLIENTINFO_FLAG_REPLICATED (1<<7)
 
 /* Here we take all the structures that the module pass to the core
  * and the other way around. Notably the list here contains the structures


### PR DESCRIPTION
 Summary

  This PR exposes two additional client flags in the module API's RedisModuleClientInfo structure:

  - REDISMODULE_CLIENTINFO_FLAG_READONLY - indicates the client is in readonly mode
  - REDISMODULE_CLIENTINFO_FLAG_REPLICATED - indicates the client is a master (replication source)

  Motivation

  These flags enable modules to make more informed decisions in scenarios such as:

  Modules using RedisModule_RegisterCommandFilter can now:
  - Filter replication stream commands: Detect if a command originates from a master connection
  (CLIENT_MASTER) and decide whether to process or ignore it
 - A module may want to skip certain validation logic or apply different rules for
  commands coming from replication streams vs regular client connections.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small additive API change that only sets new bits in `RedisModule_GetClientInfoById` without altering existing behavior. Main risk is compatibility/expectations for modules that interpret the new `flags` values.
> 
> **Overview**
> Adds two new `RedisModuleClientInfo` flag constants, `REDISMODULE_CLIENTINFO_FLAG_READONLY` and `REDISMODULE_CLIENTINFO_FLAG_REPLICATED`, to the public module header.
> 
> Updates `modulePopulateClientInfoStructure()` (used by `RedisModule_GetClientInfoById`) to set these bits based on `CLIENT_READONLY` and `CLIENT_MASTER`, and documents the new flags in the API comment block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 117a7fc4a2b7139e3690a24e4fd573a95fdf1fd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->