### PR TITLE
Optimize infoCommand with SDS pre-allocation and getrusage caching

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1452,6 +1452,8 @@ void cronUpdateMemoryStats(void) {
                                    NULL,
                                    &server.cron_malloc_stats.allocator_muzzy,
                                    &server.cron_malloc_stats.allocator_frag_smallbins_bytes);
+        getrusage(RUSAGE_SELF, &server.cron_rusage_self);
+        getrusage(RUSAGE_CHILDREN, &server.cron_rusage_children);
         if (server.lua_arena != UINT_MAX) {
             zmalloc_get_allocator_info_by_arena(server.lua_arena,
                                                 0,
@@ -6274,6 +6276,7 @@ static sds sdscatHistograms(sds info, int dbnum, keysizesHist histogram, const c
  * on memory corruption problems. */
 sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
     sds info = sdsempty();
+    info = sdsMakeRoomFor(info, 4096);
     time_t uptime = server.unixtime-server.stat_starttime;
     int j;
     int sections = 0;
@@ -6834,19 +6837,18 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
     if (all_sections || (dictFind(section_dict,"cpu") != NULL)) {
         if (sections++) info = sdscat(info,"\r\n");
 
-        struct rusage self_ru, c_ru;
-        getrusage(RUSAGE_SELF, &self_ru);
-        getrusage(RUSAGE_CHILDREN, &c_ru);
+        struct rusage *self_ru = &server.cron_rusage_self;
+        struct rusage *c_ru = &server.cron_rusage_children;
         info = sdscatprintf(info,
         "# CPU\r\n"
         "used_cpu_sys:%ld.%06ld\r\n"
         "used_cpu_user:%ld.%06ld\r\n"
         "used_cpu_sys_children:%ld.%06ld\r\n"
         "used_cpu_user_children:%ld.%06ld\r\n",
-        (long)self_ru.ru_stime.tv_sec, (long)self_ru.ru_stime.tv_usec,
-        (long)self_ru.ru_utime.tv_sec, (long)self_ru.ru_utime.tv_usec,
-        (long)c_ru.ru_stime.tv_sec, (long)c_ru.ru_stime.tv_usec,
-        (long)c_ru.ru_utime.tv_sec, (long)c_ru.ru_utime.tv_usec);
+        (long)self_ru->ru_stime.tv_sec, (long)self_ru->ru_stime.tv_usec,
+        (long)self_ru->ru_utime.tv_sec, (long)self_ru->ru_utime.tv_usec,
+        (long)c_ru->ru_stime.tv_sec, (long)c_ru->ru_stime.tv_usec,
+        (long)c_ru->ru_utime.tv_sec, (long)c_ru->ru_utime.tv_usec);
 #ifdef RUSAGE_THREAD
         struct rusage m_ru;
         getrusage(RUSAGE_THREAD, &m_ru);

--- a/src/server.h
+++ b/src/server.h
@@ -38,6 +38,7 @@
 #include <sys/socket.h>
 #include <lua.h>
 #include <signal.h>
+#include <sys/resource.h>
 
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>
@@ -2094,6 +2095,8 @@ struct redisServer {
     long long stat_slowlog_time_us_sum;    /* Sum of all slowlog entry durations (usec) */
     long long stat_slowlog_time_us_max;    /* Max slowlog entry duration (usec) */
     struct malloc_stats cron_malloc_stats; /* sampled in serverCron(). */
+    struct rusage cron_rusage_self;       /* sampled in serverCron(). */
+    struct rusage cron_rusage_children;   /* sampled in serverCron(). */
     redisAtomic long long stat_net_input_bytes; /* Bytes read from network. */
     redisAtomic long long stat_net_output_bytes; /* Bytes written to network. */
     redisAtomic long long stat_net_repl_input_bytes; /* Bytes read during replication, added to stat_net_input_bytes in 'info'. */


### PR DESCRIPTION
I think info command is one of the important command in Redis. because it is necessary to monitor redis.
so its performance is very important. so small improvement is also important.

I optimized info command 2 ways. and increase "info all" performance around 5% in linux and Mac

pre allocation for result String as 4K. (Buffer sizes smaller than 4K or larger than 8K actually degrade performance. in my test)
caching rusage system call in cron. (we already use this way for stats)
INFO ALL (rps) with redis-benchmark

|Branch|1|2|3|
|unstable|61,538.46|61,957.87|60,295.45|
|PR|64,143.68(+4.23)|64,164.26(+3.56%)|64,536.95(+7.03%)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance optimization that changes how CPU usage stats are sourced (cached from `serverCron`) and how the INFO response string is allocated; functional output should remain the same aside from slightly less up-to-date CPU figures between cron samples.
> 
> **Overview**
> Improves `INFO` command performance by **pre-allocating** ~4KB in `genRedisInfoString()` to reduce repeated SDS growth.
> 
> Moves `getrusage(RUSAGE_SELF/CHILDREN)` out of the `INFO` CPU section and into periodic sampling in `serverCron()` (stored on `server.cron_rusage_self/children`), so INFO reads cached CPU usage instead of issuing syscalls each time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e8f60faa69c59a8668a6e81efda9562962a4d31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->