### PR TITLE
Test tcp deadlock fixes

### DIFF
--- a/tests/cluster/tests/17-diskless-load-swapdb.tcl
+++ b/tests/cluster/tests/17-diskless-load-swapdb.tcl
@@ -54,9 +54,12 @@ test "Main db not affected when fail to diskless load" {
     set rd [redis_deferring_client redis $master_id]
     for {set j 0} {$j < $num} {incr j} {
         $rd set $j $value
-    }
-    for {set j 0} {$j < $num} {incr j} {
-        $rd read
+
+        if {($j + 1) % 500 == 0} {
+            for {set i 0} {$i < 500} {incr i} {
+                $rd read
+            }
+        }
     }
 
     # Start the replica again

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -59,6 +59,13 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
             after $sleep
         }
     }
+    
+    # Discard remaining replies
+    if {$count != 0} {
+        for {set i 0} {$i < $count} {incr i} {
+            $r read
+        }
+    }
 }
 
 gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6]

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -59,13 +59,6 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
             after $sleep
         }
     }
-    
-    # Discard remaining replies
-    if {$count != 0} {
-        for {set i 0} {$i < $count} {incr i} {
-            $r read
-        }
-    }
 }
 
 gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6]

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -22,13 +22,18 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
     set start_time [clock seconds]
     set r [redis $host $port 1 $tls]
     $r client setname LOAD_HANDLER
-    catch {$r select 9} ;# select 9 will fail in cluster mode
+    $r read
+    catch {
+        $r select 9
+        $r read
+    } ;# select 9 will fail in cluster mode
 
     # fixed size value
     if {$size != 0} {
         set value [string repeat "x" $size]
     }
 
+    set count 0
     while 1 {
         if {$size == 0} {
             set value [expr rand()]
@@ -39,6 +44,14 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
         } else {
             $r set $key $value
         }
+        
+        incr count
+        if {$count % 500 == 0} {
+            for {set i 0} {$i < 500} {incr i} {
+                $r read
+            }
+        }
+
         if {[clock seconds]-$start_time > $seconds} {
             exit 0
         }

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -53,12 +53,18 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
         }
 
         if {[clock seconds]-$start_time > $seconds} {
-            exit 0
+            break
         }
         if {$sleep ne 0} {
             after $sleep
         }
     }
+    
+    # Read remaining replies
+    for {set i 0} {$i < $count} {incr i} {
+        $r read
+    }
+    exit 0
 }
 
 gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6]

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -24,9 +24,12 @@ proc test_memory_efficiency {range} {
         incr written [string length $key]
         incr written [string length $val]
         incr written 2 ;# A separator is the minimum to store key-value data.
-    }
-    for {set j 0} {$j < 10000} {incr j} {
-        $rd read ; # Discard replies
+        
+        if {($j + 1) % 500 == 0} {
+            for {set i 0} {$i < 500} {incr i} {
+                $rd read ; # Discard replies
+            }
+        }
     }
 
     set current_mem [s used_memory]
@@ -352,7 +355,7 @@ run_solo {defrag} {
             # create big keys with 10k items
             # Use batching to avoid TCP deadlock
             set rd [redis_deferring_client]
-            set batch_size 1000
+            set batch_size 100
             for {set j 0} {$j < 10000} {incr j} {
                 $rd hset bighash $j [concat "asdfasdfasdf" $j]
                 $rd lpush biglist [concat "asdfasdfasdf" $j]
@@ -937,7 +940,7 @@ run_solo {defrag} {
                 $rd lpush biglist2 $val
 
                 incr count
-                discard_replies_every $rd $count 10000 20000
+                discard_replies_every $rd $count 1000 2000
             }
 
             # create some fragmentation

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1027,10 +1027,18 @@ foreach type {single multiple single_multiple} {
             }
         }
         r deferred 1
+        set count 0
         foreach m $members {
             r srem $myset $m
+            incr count
+            if {$count == 500} {
+                for {set i 0} {$i < 500} {incr i} {
+                    r read
+                }
+                set count 0
+            }
         }
-        foreach m $members {
+        for {set i 0} {$i < $count} {incr i} {
             r read
         }
         r deferred 0


### PR DESCRIPTION
This fix follows #14667 and #14886

Several tests pipelined large numbers of commands on deferring clients without draining replies. That can fill buffers and stall progress.

Fix by draining replies every 500 pipelined requests to avoid TCP stalls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test/helpers scripts, adjusting pipelining/read patterns to avoid socket buffer stalls without affecting production code paths.
> 
> **Overview**
> Prevents test hangs caused by pipelining large numbers of commands on deferring clients without draining replies.
> 
> Updates several Tcl tests/helpers to **periodically read/discard replies (generally every 500 requests)**, adds final reply-draining in `gen_write_load`, and tweaks batching parameters in `memefficiency.tcl` to reduce buffer pressure during large write bursts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0192dbf14f8827641ef38118b6b1f0ce6b88c648. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->