### PR TITLE
feat(module): support command rejection in command filters

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -351,6 +351,7 @@ typedef struct RedisModuleCommandFilterCtx {
     int argv_len;
     int argc;
     client *c;
+    int aborted;
 } RedisModuleCommandFilterCtx;
 
 typedef void (*RedisModuleCommandFilterFunc) (RedisModuleCommandFilterCtx *filter);
@@ -6863,7 +6864,13 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
     }
 
     /* Call command filters */
-    moduleCallCommandFilters(c);
+    if (moduleCallCommandFilters(c) != REDISMODULE_OK) {
+        /* Command was aborted by a filter */
+        errno = ECANCELED;
+        sds msg = sdsnew("command is aborted on module command filter");
+        reply = callReplyCreateError(msg, ctx);
+        goto cleanup;
+    }
 
     /* Lookup command now, after filters had a chance to make modifications
      * if necessary.
@@ -11557,8 +11564,8 @@ int RM_UnregisterCommandFilter(RedisModuleCtx *ctx, RedisModuleCommandFilter *fi
     return REDISMODULE_OK;
 }
 
-void moduleCallCommandFilters(client *c) {
-    if (listLength(moduleCommandFilters) == 0) return;
+int moduleCallCommandFilters(client *c) {
+    if (listLength(moduleCommandFilters) == 0) return REDISMODULE_OK;
 
     listIter li;
     listNode *ln;
@@ -11568,7 +11575,8 @@ void moduleCallCommandFilters(client *c) {
         .argv = c->argv,
         .argv_len = c->argv_len,
         .argc = c->argc,
-        .c = c
+        .c = c,
+        .aborted = 0
     };
 
     while((ln = listNext(&li))) {
@@ -11593,7 +11601,7 @@ void moduleCallCommandFilters(client *c) {
 
     /* Update pending command if it exists. */
     pendingCommand *pcmd = c->current_pending_cmd;
-    if (pcmd) {
+    if (!filter.aborted && pcmd) {
         pcmd->argv = filter.argv;
         pcmd->argc = filter.argc;
         pcmd->argv_len = filter.argv_len;
@@ -11605,6 +11613,8 @@ void moduleCallCommandFilters(client *c) {
         getKeysFreeResult(&pcmd->keys_result);
         pcmd->keys_result = (getKeysResult)GETKEYS_RESULT_INIT;
     }
+
+    return filter.aborted ? REDISMODULE_ERR : REDISMODULE_OK;
 }
 
 /* Return the number of arguments a filtered command has.  The number of
@@ -11683,6 +11693,15 @@ int RM_CommandFilterArgDelete(RedisModuleCommandFilterCtx *fctx, int pos)
 /* Get Client ID for client that issued the command we are filtering */
 unsigned long long RM_CommandFilterGetClientId(RedisModuleCommandFilterCtx *fctx) {
     return fctx->c->id;
+}
+
+/* Set the abort status of the current command.
+ * This function can be called by a command filter to set whether
+ * the command should be aborted or allowed to continue.
+ */
+int RM_CommandFilterAbortCommand(RedisModuleCommandFilterCtx *fctx, int abort_flag) {
+    fctx->aborted = abort_flag;
+    return REDISMODULE_OK;
 }
 
 /* For a given pointer allocated via RedisModule_Alloc() or
@@ -15469,6 +15488,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(CommandFilterArgReplace);
     REGISTER_API(CommandFilterArgDelete);
     REGISTER_API(CommandFilterGetClientId);
+    REGISTER_API(CommandFilterAbortCommand);
     REGISTER_API(Fork);
     REGISTER_API(SendChildHeartbeat);
     REGISTER_API(ExitFromChild);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1397,6 +1397,7 @@ REDISMODULE_API int (*RedisModule_CommandFilterArgInsert)(RedisModuleCommandFilt
 REDISMODULE_API int (*RedisModule_CommandFilterArgReplace)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CommandFilterArgDelete)(RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_CommandFilterGetClientId)(RedisModuleCommandFilterCtx *fctx) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_CommandFilterAbortCommand)(RedisModuleCommandFilterCtx *fctx, int abort_flag) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_Fork)(RedisModuleForkDoneHandler cb, void *user_data) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SendChildHeartbeat)(double progress) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExitFromChild)(int retcode) REDISMODULE_ATTR;
@@ -1798,6 +1799,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(CommandFilterArgReplace);
     REDISMODULE_GET_API(CommandFilterArgDelete);
     REDISMODULE_GET_API(CommandFilterGetClientId);
+    REDISMODULE_GET_API(CommandFilterAbortCommand);
     REDISMODULE_GET_API(Fork);
     REDISMODULE_GET_API(SendChildHeartbeat);
     REDISMODULE_GET_API(ExitFromChild);

--- a/src/script.c
+++ b/src/script.c
@@ -637,7 +637,10 @@ void scriptCall(scriptRunCtx *run_ctx, sds *err) {
     c->user = run_ctx->original_client->user;
 
     /* Process module hooks */
-    moduleCallCommandFilters(c);
+    if (moduleCallCommandFilters(c) != REDISMODULE_OK) {
+        *err = sdsnew("command is aborted on module command filter");
+        goto error;
+    }
 
     struct redisCommand *cmd = lookupCommand(c->argv, c->argc);
     c->cmd = c->lastcmd = c->realcmd = cmd;

--- a/src/server.c
+++ b/src/server.c
@@ -4354,7 +4354,11 @@ int processCommand(client *c) {
 
     /* only run command filter if not reprocessing command */
     if (!client_reprocessing_command) {
-        moduleCallCommandFilters(c);
+        /* Command was aborted by a filter */
+        if (moduleCallCommandFilters(c) != REDISMODULE_OK) {
+            rejectCommandFormat(c, "command is aborted on module command filter");
+            return C_OK;
+        }
         reqresAppendRequest(c);
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -3065,7 +3065,7 @@ int moduleTryAcquireGIL(void);
 void moduleReleaseGIL(void);
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
 void firePostExecutionUnitJobs(void);
-void moduleCallCommandFilters(client *c);
+int moduleCallCommandFilters(client *c);
 void modulePostExecutionUnitOperations(void);
 void ModuleForkDoneHandler(int exitcode, int bysignal);
 int TerminateModuleForkChild(int child_pid, int wait);


### PR DESCRIPTION
## Motivation

Previously, command filters (`RM_RegisterCommandFilter`) could only inspect or modify command
arguments, but could not reject the command entirely. This required modules to implement complex
workarounds when they needed to block a command based on
custom criteria such as rate limiting, IP allowlisting, or business-specific access control.

With this change, a filter can simply call `RM_CommandFilterAbortCommand(fctx, 1)` to reject the
command. The client receives an error response:  `ERR command is aborted on module command filter`

## Changes

- Add `RM_CommandFilterAbortCommand(fctx, abort_flag)` API that allows module command filters to abort
the command being filtered
- Change `moduleCallCommandFilters()` return type from `void` to `int` to signal abort status
- Handle abort in all three call sites: `processCommand()`, `scriptCall()`, and `RM_Call()`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core command execution paths (`processCommand`, `scriptCall`, `RM_Call`) to support filter-driven rejection, which could alter behavior for modules and scripts and needs validation across all call sites.
> 
> **Overview**
> **Module command filters can now reject commands.** This adds `RedisModule_CommandFilterAbortCommand` (and backing `RM_CommandFilterAbortCommand`) plus an `aborted` flag in `RedisModuleCommandFilterCtx` so filters can stop execution instead of rewriting to a no-op.
> 
> `moduleCallCommandFilters()` now returns `REDISMODULE_OK/ERR`, and its callers (`processCommand()`, Lua `scriptCall()`, and `RM_Call()`) convert an aborted command into a consistent error (`"command is aborted on module command filter"`), with `RM_Call()` additionally setting `errno=ECANCELED` and returning an error reply. Pending-command updates are skipped when a filter aborts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 548b33929ff7c64f2a2b3338ddeeaf856ff3b9db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->