### PR TITLE
feat(module): add ClusterGetSlotRangesByNodeId API

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2103,6 +2103,14 @@ int clusterCanAccessKeysInSlot(int slot) {
 
 /* Return the slot ranges that belong to the current node or its master. */
 slotRangeArray *clusterGetLocalSlotRanges(void) {
+    return clusterGetSlotRangesByNode(getMyClusterNode());
+}
+
+/* Returns the slot ranges owned by the given node.
+ * If the node is a replica, the master's slot ranges are returned.
+ * Returns an empty array if the node has no slots. */
+slotRangeArray *clusterGetSlotRangesByNode(clusterNode *node) {
+    serverAssert(node != NULL);
     slotRangeArray *slots = NULL;
 
     if (!server.cluster_enabled) {
@@ -2111,7 +2119,7 @@ slotRangeArray *clusterGetLocalSlotRanges(void) {
         return slots;
     }
 
-    clusterNode *master = clusterNodeGetMaster(getMyClusterNode());
+    clusterNode *master = clusterNodeGetMaster(node);
     if (master) {
         for (int i = 0; i < CLUSTER_SLOTS; i++) {
             if (clusterNodeCoversSlot(master, i))

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -154,6 +154,7 @@ int getSlotOrReply(client *c, robj *o);
 int clusterIsMySlot(int slot);
 int clusterCanAccessKeysInSlot(int slot);
 struct slotRangeArray *clusterGetLocalSlotRanges(void);
+struct slotRangeArray *clusterGetSlotRangesByNode(clusterNode *node);
 
 /* functions with shared implementations */
 clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, int argc, int *hashslot,

--- a/src/module.c
+++ b/src/module.c
@@ -9816,6 +9816,22 @@ RedisModuleSlotRangeArray *RM_ClusterGetLocalSlotRanges(RedisModuleCtx *ctx) {
     return (RedisModuleSlotRangeArray *)slots;
 }
 
+/* Returns the slot ranges for a cluster node identified by nodeid.
+ *
+ * An optional `ctx` can be provided to enable auto-memory management.
+ * If cluster mode is disabled, the array will include all slots (0-16383).
+ * If the node is not found, an empty array is returned (num_ranges == 0).
+ * If the node is a replica, the slot ranges of its master are returned.
+ *
+ * The returned array must be freed with RM_ClusterFreeSlotRanges(). */
+RedisModuleSlotRangeArray *RM_ClusterGetSlotRangesByNodeId(RedisModuleCtx *ctx, const char *nodeid) {
+    clusterNode *node = clusterLookupNode(nodeid, CLUSTER_NAMELEN);
+    slotRangeArray *slots =
+        node ? clusterGetSlotRangesByNode(node) : slotRangeArrayCreate(0);
+    if (ctx) autoMemoryAdd(ctx, REDISMODULE_AM_SLOTRANGEARRAY, slots);
+    return (RedisModuleSlotRangeArray *)slots;
+}
+
 /* Frees a slot range array returned by RM_ClusterGetLocalSlotRanges().
  * Pass the `ctx` pointer only if the array was created with a context. */
 void RM_ClusterFreeSlotRanges(RedisModuleCtx *ctx, RedisModuleSlotRangeArray *slots) {
@@ -15436,6 +15452,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ClusterCanAccessKeysInSlot);
     REGISTER_API(ClusterPropagateForSlotMigration);
     REGISTER_API(ClusterGetLocalSlotRanges);
+    REGISTER_API(ClusterGetSlotRangesByNodeId);
     REGISTER_API(ClusterFreeSlotRanges);
     REGISTER_API(CreateDict);
     REGISTER_API(FreeDict);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1386,6 +1386,7 @@ REDISMODULE_API const char *(*RedisModule_ClusterCanonicalKeyNameInSlot)(unsigne
 REDISMODULE_API int (*RedisModule_ClusterCanAccessKeysInSlot)(int slot) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ClusterPropagateForSlotMigration)(RedisModuleCtx *ctx, const char *cmdname, const char *fmt, ...) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_ClusterGetLocalSlotRanges)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_ClusterGetSlotRangesByNodeId)(RedisModuleCtx *ctx, const char *nodeid) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ClusterFreeSlotRanges)(RedisModuleCtx *ctx, RedisModuleSlotRangeArray *slots) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExportSharedAPI)(RedisModuleCtx *ctx, const char *apiname, void *func) REDISMODULE_ATTR;
 REDISMODULE_API void * (*RedisModule_GetSharedAPI)(RedisModuleCtx *ctx, const char *apiname) REDISMODULE_ATTR;
@@ -1787,6 +1788,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ClusterCanAccessKeysInSlot);
     REDISMODULE_GET_API(ClusterPropagateForSlotMigration);
     REDISMODULE_GET_API(ClusterGetLocalSlotRanges);
+    REDISMODULE_GET_API(ClusterGetSlotRangesByNodeId);
     REDISMODULE_GET_API(ClusterFreeSlotRanges);
     REDISMODULE_GET_API(ExportSharedAPI);
     REDISMODULE_GET_API(GetSharedAPI);

--- a/tests/modules/atomicslotmigration.c
+++ b/tests/modules/atomicslotmigration.c
@@ -1,5 +1,6 @@
 #include "redismodule.h"
 
+#include <cstddef>
 #include <stdlib.h>
 #include <memory.h>
 #include <errno.h>
@@ -77,6 +78,36 @@ int testClusterGetLocalSlotRanges(RedisModuleCtx *ctx, RedisModuleString **argv,
         slots = RedisModule_ClusterGetLocalSlotRanges(ctx);
     } else {
         slots = RedisModule_ClusterGetLocalSlotRanges(NULL);
+    }
+
+    RedisModule_ReplyWithArray(ctx, slots->num_ranges);
+    for (int i = 0; i < slots->num_ranges; i++) {
+        RedisModule_ReplyWithArray(ctx, 2);
+        RedisModule_ReplyWithLongLong(ctx, slots->ranges[i].start);
+        RedisModule_ReplyWithLongLong(ctx, slots->ranges[i].end);
+    }
+    if (!use_auto_memory)
+        RedisModule_ClusterFreeSlotRanges(NULL, slots);
+    return REDISMODULE_OK;
+}
+
+/* Test command for RedisModule_ClusterGetSlotRangesByNodeId */
+int testClusterGetSlotRangesByNodeId(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 2) {
+        return RedisModule_WrongArity(ctx);
+    }
+
+    const char *nodeid = RedisModule_StringPtrLen(argv[1], NULL);
+
+    static int use_auto_memory = 0;
+    use_auto_memory = !use_auto_memory;
+
+    RedisModuleSlotRangeArray *slots;
+    if (use_auto_memory) {
+        RedisModule_AutoMemory(ctx);
+        slots = RedisModule_ClusterGetSlotRangesByNodeId(ctx, nodeid);
+    } else {
+        slots = RedisModule_ClusterGetSlotRangesByNodeId(NULL, nodeid);
     }
 
     RedisModule_ReplyWithArray(ctx, slots->num_ranges);
@@ -560,6 +591,9 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx, "asm.cluster_get_local_slot_ranges", testClusterGetLocalSlotRanges, "", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "asm.cluster_get_slot_ranges_by_nodeid", testClusterGetSlotRangesByNodeId, "", 0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx, "asm.get_last_deleted_key", getLastDeletedKey, "", 0, 0, 0) == REDISMODULE_ERR)

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -2949,6 +2949,32 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
        assert_equal [R 1 asm.cluster_get_local_slot_ranges] {}
        assert_equal [R 4 asm.cluster_get_local_slot_ranges] {}
     }
+
+    test "Test RM_ClusterGetSlotRangesByNodeId for local node" {
+        set local_id [R 0 cluster myid]
+        set ranges [R 0 asm.cluster_get_slot_ranges_by_nodeid $local_id]
+        set local_ranges [R 0 asm.cluster_get_local_slot_ranges]
+        assert_equal $ranges $local_ranges
+    }
+
+    test "Test RM_ClusterGetSlotRangesByNodeId for remote node" {
+        set node2_id [R 2 cluster myid]
+        set ranges [R 0 asm.cluster_get_slot_ranges_by_nodeid $node2_id]
+        set remote_ranges [R 2 asm.cluster_get_local_slot_ranges]
+        assert_equal $ranges $remote_ranges
+    }
+
+    test "Test RM_ClusterGetSlotRangesByNodeId for non-existent node" {
+        set ranges [R 0 asm.cluster_get_slot_ranges_by_nodeid "0000000000000000000000000000000000000000"]
+        assert_equal $ranges {}
+    }
+
+    test "Test RM_ClusterGetSlotRangesByNodeId for replica returns master slots" {
+        set replica3_id [R 3 cluster myid]
+        set ranges [R 0 asm.cluster_get_slot_ranges_by_nodeid $replica3_id]
+        set master_ranges [R 0 asm.cluster_get_local_slot_ranges]
+        assert_equal $ranges $master_ranges
+    }
 }
 
 set testmodule [file normalize tests/modules/atomicslotmigration.so]
@@ -3060,6 +3086,15 @@ start_server {tags "cluster external:skip"} {
     test "Test RM_ClusterGetLocalSlotRanges without cluster" {
         r module load $testmodule
         assert_equal [r asm.cluster_get_local_slot_ranges] {{0 16383}}
+    }
+}
+
+start_server {tags "cluster external:skip"} {
+    test "Test RM_ClusterGetSlotRangesByNodeId without cluster" {
+        r module load $testmodule
+        set local_id "nonexistent-node-id"
+        set ranges [r asm.cluster_get_slot_ranges_by_nodeid $local_id]
+        assert_equal $ranges {{0 16383}}
     }
 }
 }


### PR DESCRIPTION

## Changes
- Add new module API `RM_ClusterGetSlotRangesByNodeId` that allows modules to query slot ranges for any cluster node by its node ID, not just the local node.
- Refactor `clusterGetLocalSlotRanges()` to delegate to a new internal function `clusterGetSlotRangesByNode(clusterNode *node)`, eliminating code duplication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Redis modules Cluster API and refactors cluster slot-range lookup to accept an arbitrary node, which could affect module consumers and any edge cases around node lookup (missing IDs, replica/master resolution, and non-cluster mode). Changes are localized but touch cluster ownership calculations used by modules and tests.
> 
> **Overview**
> Adds a new modules API `RM_ClusterGetSlotRangesByNodeId` to query slot ranges for an arbitrary cluster node ID, with optional auto-memory support and integration into the exported module API table.
> 
> Refactors slot-range computation by extracting `clusterGetSlotRangesByNode(clusterNode *node)` and making `clusterGetLocalSlotRanges()` delegate to it, preserving replica->master behavior and returning an empty range set when the target owns no slots.
> 
> Extends the atomic slot migration test module and unit tests to exercise the new API for local nodes, remote nodes, replicas (returning master ranges), missing node IDs, and behavior when cluster mode is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6457cf17a040e8897e851093bdcc5a7ccecc0a7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->