### PR TITLE
fix(cluster): add null check for server.cluster in clusterLookupNode()

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1590,6 +1590,7 @@ void clusterDelNode(clusterNode *delnode) {
 
 /* Node lookup by name */
 clusterNode *clusterLookupNode(const char *name, int length) {
+    if (server.cluster == NULL) return NULL;
     if (verifyClusterNodeId(name, length) != C_OK) return NULL;
     sds s = sdsnewlen(name, length);
     dictEntry *de = dictFind(server.cluster->nodes, s);


### PR DESCRIPTION
Fix crash in clusterLookupNode() when called on a non-cluster-enabled Redis instance.

clusterLookupNode() dereferences server.cluster without checking if it's NULL. This causes a segmentation fault when a module calls RM_GetClusterNodeInfo() on a node that is not running in cluster mode (server.cluster is NULL)


The fix adds a NULL guard before accessing server.cluster->nodes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line defensive check that only changes behavior when `server.cluster` is NULL, returning `NULL` instead of crashing.
> 
> **Overview**
> Prevents crashes when `clusterLookupNode()` is invoked on non-cluster instances by adding an early `server.cluster == NULL` check before accessing `server.cluster->nodes`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2cdf9a399131aae567f15d23a29054d20256d74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->