### PR TITLE
Fix IDMP tracking not cleared when resetting stream IDMP config

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -5227,9 +5227,9 @@ void xcfgsetCommand(client *c) {
         changed = 1;
     }
 
-    /* Clean up and propagate if we changed something. */
+    /* Clean up and propagate if we changed something */
     if (changed) {
-        dictDelete(c->db->stream_idmp_keys, key); /* Untrack cleared IDMP key. */
+        dictDelete(c->db->stream_idmp_keys, key); /* Untrack cleared IDMP key */
         keyModified(c,c->db,key,kv,0);
         server.dirty++;
         if (server.memory_tracking_enabled)
@@ -5896,7 +5896,7 @@ cleanup:
     return C_ERR;
 }
 
-/* Clear all IDMP entries from a stream - free all producers and their entries. */
+/* Clear all IDMP entries from a stream - free all producers and their entries */
 static void streamClearIdmpEntries(stream *s) {
     if (s->idmp_producers == NULL) return;
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -48,7 +48,7 @@ void trackStreamClaimTimeouts(client *c, robj **keys, int numkeys, uint64_t expi
 
 /* Forward declarations for IDMP functions (defined at end of file) */
 static void trackStreamIdmpEntries(client *c, robj *key);
-static void streamClearIdmpEntries(stream *s, redisDb *db, robj *key);
+static void streamClearIdmpEntries(stream *s, client *c, robj *key);
 static void idmpInsertEntry(stream *s, idmpProducer *producer, idmpEntry *entry, const streamID *id);
 static int idmpLookupAndReply(stream *s, idmpProducer *producer, idmpEntry *entry, client *c);
 static int idmpLookup(idmpProducer *producer, idmpEntry *entry, streamID *id);
@@ -5218,12 +5218,12 @@ void xcfgsetCommand(client *c) {
      * to call this before starting to publish without clearing each time. */
     if (duration != -1 && s->idmp_duration != (uint64_t)duration) {
         s->idmp_duration = duration;
-        streamClearIdmpEntries(s, c->db, key);
+        streamClearIdmpEntries(s, c, key);
         changed = 1;
     }
     if (maxsize != -1 && s->idmp_max_entries != (uint64_t)maxsize) {
         s->idmp_max_entries = maxsize;
-        streamClearIdmpEntries(s, c->db, key);
+        streamClearIdmpEntries(s, c, key);
         changed = 1;
     }
 
@@ -5897,7 +5897,7 @@ cleanup:
 
 /* Clear all IDMP entries from a stream - free all producers and their entries,
  * and unregister the key from db->stream_idmp_keys. */
-static void streamClearIdmpEntries(stream *s, redisDb *db, robj *key) {
+static void streamClearIdmpEntries(stream *s, client *c, robj *key) {
     if (s->idmp_producers == NULL) return;
 
     /* Iterate through all producers and free them */
@@ -5912,7 +5912,7 @@ static void streamClearIdmpEntries(stream *s, redisDb *db, robj *key) {
     /* Free the producers rax tree and reset */
     raxFree(s->idmp_producers);
     s->idmp_producers = NULL;
-    dictDelete(db->stream_idmp_keys, key);
+    dictDelete(c->db->stream_idmp_keys, key);
 }
 
 /* Evict the oldest entry from the IDMP producer when max entries is exceeded.

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -48,7 +48,7 @@ void trackStreamClaimTimeouts(client *c, robj **keys, int numkeys, uint64_t expi
 
 /* Forward declarations for IDMP functions (defined at end of file) */
 static void trackStreamIdmpEntries(client *c, robj *key);
-static void streamClearIdmpEntries(stream *s);
+static void streamClearIdmpEntries(stream *s, redisDb *db, robj *key);
 static void idmpInsertEntry(stream *s, idmpProducer *producer, idmpEntry *entry, const streamID *id);
 static int idmpLookupAndReply(stream *s, idmpProducer *producer, idmpEntry *entry, client *c);
 static int idmpLookup(idmpProducer *producer, idmpEntry *entry, streamID *id);
@@ -5218,12 +5218,12 @@ void xcfgsetCommand(client *c) {
      * to call this before starting to publish without clearing each time. */
     if (duration != -1 && s->idmp_duration != (uint64_t)duration) {
         s->idmp_duration = duration;
-        streamClearIdmpEntries(s);
+        streamClearIdmpEntries(s, c->db, key);
         changed = 1;
     }
     if (maxsize != -1 && s->idmp_max_entries != (uint64_t)maxsize) {
         s->idmp_max_entries = maxsize;
-        streamClearIdmpEntries(s);
+        streamClearIdmpEntries(s, c->db, key);
         changed = 1;
     }
 
@@ -5895,8 +5895,9 @@ cleanup:
     return C_ERR;
 }
 
-/* Clear all IDMP entries from a stream - free all producers and their entries */
-static void streamClearIdmpEntries(stream *s) {
+/* Clear all IDMP entries from a stream - free all producers and their entries,
+ * and unregister the key from db->stream_idmp_keys. */
+static void streamClearIdmpEntries(stream *s, redisDb *db, robj *key) {
     if (s->idmp_producers == NULL) return;
 
     /* Iterate through all producers and free them */
@@ -5911,6 +5912,7 @@ static void streamClearIdmpEntries(stream *s) {
     /* Free the producers rax tree and reset */
     raxFree(s->idmp_producers);
     s->idmp_producers = NULL;
+    dictDelete(db->stream_idmp_keys, key);
 }
 
 /* Evict the oldest entry from the IDMP producer when max entries is exceeded.

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -48,7 +48,7 @@ void trackStreamClaimTimeouts(client *c, robj **keys, int numkeys, uint64_t expi
 
 /* Forward declarations for IDMP functions (defined at end of file) */
 static void trackStreamIdmpEntries(client *c, robj *key);
-static void streamClearIdmpEntries(stream *s, client *c, robj *key);
+static void streamClearIdmpEntries(stream *s);
 static void idmpInsertEntry(stream *s, idmpProducer *producer, idmpEntry *entry, const streamID *id);
 static int idmpLookupAndReply(stream *s, idmpProducer *producer, idmpEntry *entry, client *c);
 static int idmpLookup(idmpProducer *producer, idmpEntry *entry, streamID *id);
@@ -5218,17 +5218,18 @@ void xcfgsetCommand(client *c) {
      * to call this before starting to publish without clearing each time. */
     if (duration != -1 && s->idmp_duration != (uint64_t)duration) {
         s->idmp_duration = duration;
-        streamClearIdmpEntries(s, c, key);
+        streamClearIdmpEntries(s);
         changed = 1;
     }
     if (maxsize != -1 && s->idmp_max_entries != (uint64_t)maxsize) {
         s->idmp_max_entries = maxsize;
-        streamClearIdmpEntries(s, c, key);
+        streamClearIdmpEntries(s);
         changed = 1;
     }
 
-    /* Mark the key as dirty for replication only if we changed something */
+    /* Clean up and propagate if we changed something. */
     if (changed) {
+        dictDelete(c->db->stream_idmp_keys, key); /* Untrack cleared IDMP key. */
         keyModified(c,c->db,key,kv,0);
         server.dirty++;
         if (server.memory_tracking_enabled)
@@ -5895,9 +5896,8 @@ cleanup:
     return C_ERR;
 }
 
-/* Clear all IDMP entries from a stream - free all producers and their entries,
- * and unregister the key from db->stream_idmp_keys. */
-static void streamClearIdmpEntries(stream *s, client *c, robj *key) {
+/* Clear all IDMP entries from a stream - free all producers and their entries. */
+static void streamClearIdmpEntries(stream *s) {
     if (s->idmp_producers == NULL) return;
 
     /* Iterate through all producers and free them */
@@ -5912,7 +5912,6 @@ static void streamClearIdmpEntries(stream *s, client *c, robj *key) {
     /* Free the producers rax tree and reset */
     raxFree(s->idmp_producers);
     s->idmp_producers = NULL;
-    dictDelete(c->db->stream_idmp_keys, key);
 }
 
 /* Evict the oldest entry from the IDMP producer when max entries is exceeded.


### PR DESCRIPTION
## Summary

Unregisters stream keys from `db->stream_idmp_keys` when IDMP configuration is changed via `XCFGSET`. Previously, changing `IDMP-DURATION` or `IDMP-MAXSIZE` would clear all IDMP producers but leave the key registered in the tracking dictionary, causing the cron job `handleExpiredIdmpEntries()` to needlessly iterate over streams with no IDMP data.

## Changes

- **`xcfgsetCommand` (src/t_stream.c):** Added `dictDelete(c->db->stream_idmp_keys, key)` in the `if (changed)` block to immediately untrack the key when IDMP configuration changes clear all producers.

## Benefits

- **Immediate cleanup of tracking state:** The stream key is removed from `stream_idmp_keys` when configuration changes, rather than relying on the cron to detect and clean up the stale entry on a subsequent pass.
- **Reduced unnecessary cron work:** The cron no longer wastes cycles inspecting streams that have no IDMP producers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change confined to stream IDMP bookkeeping; it only adjusts in-memory tracking when `XCFGSET` clears IDMP state, but could affect expiration/cron behavior if the untracking is incorrect.
> 
> **Overview**
> When `XCFGSET` changes a stream’s `IDMP-DURATION` or `IDMP-MAXSIZE` (which clears IDMP producer maps), the key is now also removed from `db->stream_idmp_keys` so it is no longer tracked for IDMP cleanup.
> 
> This prevents stale entries from remaining in the IDMP tracking dictionary after IDMP data has been cleared, while keeping the existing propagation/dirtying behavior when a change occurs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 462401245373cee55732446a7f34dbbc6bb02b00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->