### PR TITLE
Fix flaky cluster pubsubshard test in 26-pubsubshard

### DIFF
--- a/tests/cluster/tests/26-pubsubshard.tcl
+++ b/tests/cluster/tests/26-pubsubshard.tcl
@@ -123,6 +123,7 @@ test "PUBSUB channels/shardchannels" {
     assert_equal {3} [llength [$publishclient pubsub shardchannels]]
 
     sunsubscribe $subscribeclient
+    $subscribeclient read
     set channel_list [$publishclient pubsub shardchannels]
     assert_equal {2} [llength $channel_list]
     assert {[lsearch -exact $channel_list "\{channel.0\}2"] >= 0}


### PR DESCRIPTION
In the "PUBSUB channels/shardchannels" test, we call sunsubscribe without channels, but the number of loops in consume_subscribe_messages() is determined by the size of channels.
When channels are empty, the loop will loop 0 times and will not read the sunsubscribe response message returned by the server.
This means that when verifying the channel length, the previous command might not have been complete yet, so this PR added a read after sunsubscribe.

Failed CI output:
```
00:39:14> PUBSUB channels/shardchannels: FAILED: Expected '2' to be equal to '3' (context: type eval line 17 cmd {assert_equal {2} [llength $channel_list]} proc ::test)
(Jumping to next unit after error)
FAILED: caught an error in the test 
assertion:Expected '2' to be equal to '3' (context: type eval line 17 cmd {assert_equal {2} [llength $channel_list]} proc ::test)
    while executing
"error "assertion:$expected_err $detail""
    (procedure "assert_failed" line 7)
    invoked from within
"assert_failed "Expected '$value' to be equal to '$expected'" $detail"
    (procedure "assert_equal" line 3)
    invoked from within
"assert_equal {2} [llength $channel_list]"
    ("uplevel" body line 17)
    invoked from within
"uplevel 1 $code"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds a missing read to ensure unsubscribe completion before asserting `PUBSUB SHARDCHANNELS` results.
> 
> **Overview**
> Stabilizes the `PUBSUB channels/shardchannels` cluster test by adding an explicit `$subscribeclient read` after calling `sunsubscribe` with no channels, ensuring the unsubscribe reply is consumed before checking the shard channel list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bc498097917ac121f57643d40a2ac939c5c13b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->