### PR TITLE
keymeta: rename void *value to void *reserved in rdb_save/aof_rewrite callbacks

### DIFF
--- a/src/keymeta.c
+++ b/src/keymeta.c
@@ -593,7 +593,7 @@ int rdbSaveKeyMetadata(rio *rdb, robj *key, kvobj *kv, int dbid) {
                 /* Call module's rdb_save callback */
                 RedisModuleIO io;
                 moduleInitIOContext(&io, &pClass->entity, &payload_rio, key, dbid);
-                pClass->conf.rdb_save(&io, kv, pMeta);
+                pClass->conf.rdb_save(&io, NULL, pMeta);
 
                 if (io.ctx) {
                     moduleFreeContext(io.ctx);
@@ -668,7 +668,7 @@ int keyMetaOnAof(rio *r, robj *key, kvobj *kv, int dbid) {
             {
                 RedisModuleIO io;
                 moduleInitIOContext(&io, &keyMetaClass[keyMetaId].entity, r, key, dbid);
-                keyMetaClass[keyMetaId].conf.aof_rewrite(&io, kv, meta);
+                keyMetaClass[keyMetaId].conf.aof_rewrite(&io, NULL, meta);
                 if (io.ctx) {
                     moduleFreeContext(io.ctx);
                     zfree(io.ctx);

--- a/src/keymeta.h
+++ b/src/keymeta.h
@@ -60,8 +60,8 @@ typedef int KeyMetaClassId; /* Index into redisServer.keyMetaClass[] */
 
 /* RDB load callback: Return 1 to attach, 0 to skip, -1 on error */
 typedef int (*KeyMetaLoadFunc)(RedisModuleIO *rdb, uint64_t *meta, int encver);
-typedef void (*KeyMetaSaveFunc)(RedisModuleIO *rdb, void *value, uint64_t *meta);
-typedef void (*KeyMetaAOFRewriteFunc)(RedisModuleIO *aof, void *value, uint64_t meta);
+typedef void (*KeyMetaSaveFunc)(RedisModuleIO *rdb, void *reserved, uint64_t *meta);
+typedef void (*KeyMetaAOFRewriteFunc)(RedisModuleIO *aof, void *reserved, uint64_t meta);
 typedef void (*KeyMetaFreeFunc)(const char *keyname, uint64_t meta);
 typedef int (*KeyMetaCopyFunc)(struct RedisModuleKeyOptCtx *ctx, uint64_t *meta);
 typedef int (*KeyMetaRenameFunc)(struct RedisModuleKeyOptCtx *ctx, uint64_t *meta);
@@ -90,8 +90,8 @@ typedef struct KeyMetaClassConf {
     void (*unlink)(struct RedisModuleKeyOptCtx *ctx, uint64_t *meta);
     void (*free)(const char *keyname, uint64_t meta);
     int (*rdb_load)(struct RedisModuleIO *rdb, uint64_t *meta, int metaver);
-    void (*rdb_save)(struct RedisModuleIO *rdb, void *value, uint64_t *meta);
-    void (*aof_rewrite)(struct RedisModuleIO *aof, void *value, uint64_t meta);
+    void (*rdb_save)(struct RedisModuleIO *rdb, void *reserved, uint64_t *meta);
+    void (*aof_rewrite)(struct RedisModuleIO *aof, void *reserved, uint64_t meta);
     
     /****************************** TBD: ******************************/
     int (*defrag) (struct RedisModuleDefragCtx *ctx, struct redisObject *key, uint64_t meta);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1011,8 +1011,8 @@ typedef void (*RedisModuleOnUnblocked)(RedisModuleCtx *ctx, RedisModuleCallReply
 typedef int (*RedisModuleAuthCallback)(RedisModuleCtx *ctx, RedisModuleString *username, RedisModuleString *password, RedisModuleString **err);
 
 typedef int (*RedisModuleKeyMetaLoadFunc)(RedisModuleIO *rdb, uint64_t *meta, int encver);
-typedef void (*RedisModuleKeyMetaSaveFunc)(RedisModuleIO *rdb, void *value, uint64_t *meta);
-typedef void (*RedisModuleKeyMetaAOFRewriteFunc)(RedisModuleIO *aof, void *value, uint64_t meta);
+typedef void (*RedisModuleKeyMetaSaveFunc)(RedisModuleIO *rdb, void *reserved, uint64_t *meta);
+typedef void (*RedisModuleKeyMetaAOFRewriteFunc)(RedisModuleIO *aof, void *reserved, uint64_t meta);
 typedef void (*RedisModuleKeyMetaFreeFunc)(const char *keyname, uint64_t meta);
 typedef int (*RedisModuleKeyMetaCopyFunc)(RedisModuleKeyOptCtx *ctx, uint64_t *meta);
 typedef int (*RedisModuleKeyMetaRenameFunc)(RedisModuleKeyOptCtx *ctx, uint64_t *meta);

--- a/tests/modules/test_keymeta.c
+++ b/tests/modules/test_keymeta.c
@@ -173,11 +173,11 @@ static int KeyMetaMoveDiscardCallback(RedisModuleKeyOptCtx *ctx, uint64_t *meta)
  *
  * Parameters:
  *   - rdb: RedisModuleIO context for writing to RDB
- *   - value: The kvobj (key-value object) - not used in this implementation
+ *   - reserved: Reserved for future use
  *   - meta: Pointer to the 8-byte metadata value (pointer to our string)
  */
-static void KeyMetaRDBSaveCallback(RedisModuleIO *rdb, void *value, uint64_t *meta) {
-    REDISMODULE_NOT_USED(value);
+static void KeyMetaRDBSaveCallback(RedisModuleIO *rdb, void *reserved, uint64_t *meta) {
+    REDISMODULE_NOT_USED(reserved);
 
     /* If metadata is NULL (reset_value), don't save anything */
     if (*meta == 0) return;
@@ -252,12 +252,12 @@ static int KeyMetaRDBLoadCallback(RedisModuleIO *rdb, uint64_t *meta, int encver
  *
  * Parameters:
  *   - aof: RedisModuleIO context for writing to AOF
- *   - value: The kvobj (key-value object) - not used in this implementation
+ *   - reserved: Reserved for future use
  *   - meta: The 8-byte metadata value (pointer to our string)
  *   - class_id: The class ID for this metadata
  */
-static void KeyMetaAOFRewriteCallback_Class(RedisModuleIO *aof, void *value, uint64_t meta, RedisModuleKeyMetaClassId class_id) {
-    REDISMODULE_NOT_USED(value);
+static void KeyMetaAOFRewriteCallback_Class(RedisModuleIO *aof, void *reserved, uint64_t meta, RedisModuleKeyMetaClassId class_id) {
+    REDISMODULE_NOT_USED(reserved);
 
     /* If metadata is NULL (reset_value), don't emit anything */
     if (meta == 0) return;
@@ -289,32 +289,32 @@ static void KeyMetaAOFRewriteCallback_Class(RedisModuleIO *aof, void *value, uin
 
 /* Individual AOF rewrite callbacks for each class (1-7)
  * Each callback wraps the common implementation with its specific class ID */
-static void KeyMetaAOFRewriteCb1(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 1);
+static void KeyMetaAOFRewriteCb1(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 1);
 }
 
-static void KeyMetaAOFRewriteCb2(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 2);
+static void KeyMetaAOFRewriteCb2(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 2);
 }
 
-static void KeyMetaAOFRewriteCb3(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 3);
+static void KeyMetaAOFRewriteCb3(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 3);
 }
 
-static void KeyMetaAOFRewriteCb4(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 4);
+static void KeyMetaAOFRewriteCb4(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 4);
 }
 
-static void KeyMetaAOFRewriteCb5(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 5);
+static void KeyMetaAOFRewriteCb5(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 5);
 }
 
-static void KeyMetaAOFRewriteCb6(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 6);
+static void KeyMetaAOFRewriteCb6(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 6);
 }
 
-static void KeyMetaAOFRewriteCb7(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 7);
+static void KeyMetaAOFRewriteCb7(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 7);
 }
 
 /* KEYMETA.REGISTER <4-char-id> <version> [KEEPONCOPY:KEEPONRENAME:UNLINKFREE:ALLOWIGNORE:NORDBLOAD:NORDBSAVE] */


### PR DESCRIPTION
Rename the `void *value` parameter to `void *reserved` in keymeta `rdb_save` and `aof_rewrite` module callbacks, and pass `NULL` at call sites.

Originally the `value` parameter was planned to pass the internal kvobj for core use of key metadata, but since modules cannot use it in any meaningful way, it should not be exposed. The parameter is kept as a reserved slot for potential future use.