### PR TITLE
keymeta: add dedicated debug flag for runtime class registration

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -927,6 +927,11 @@ NULL
     {
         server.skip_checksum_validation = atoi(c->argv[2]->ptr);
         addReply(c,shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr,"enable-keymeta-runtime-registration") &&
+               c->argc == 3)
+    {
+        server.allow_keymeta_registration = atoi(c->argv[2]->ptr);
+        addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"aof-flush-sleep") &&
                c->argc == 3)
     {

--- a/src/keymeta.c
+++ b/src/keymeta.c
@@ -593,7 +593,7 @@ int rdbSaveKeyMetadata(rio *rdb, robj *key, kvobj *kv, int dbid) {
                 /* Call module's rdb_save callback */
                 RedisModuleIO io;
                 moduleInitIOContext(&io, &pClass->entity, &payload_rio, key, dbid);
-                pClass->conf.rdb_save(&io, kv, pMeta);
+                pClass->conf.rdb_save(&io, NULL, pMeta);
 
                 if (io.ctx) {
                     moduleFreeContext(io.ctx);
@@ -668,7 +668,7 @@ int keyMetaOnAof(rio *r, robj *key, kvobj *kv, int dbid) {
             {
                 RedisModuleIO io;
                 moduleInitIOContext(&io, &keyMetaClass[keyMetaId].entity, r, key, dbid);
-                keyMetaClass[keyMetaId].conf.aof_rewrite(&io, kv, meta);
+                keyMetaClass[keyMetaId].conf.aof_rewrite(&io, NULL, meta);
                 if (io.ctx) {
                     moduleFreeContext(io.ctx);
                     zfree(io.ctx);

--- a/src/keymeta.h
+++ b/src/keymeta.h
@@ -60,8 +60,8 @@ typedef int KeyMetaClassId; /* Index into redisServer.keyMetaClass[] */
 
 /* RDB load callback: Return 1 to attach, 0 to skip, -1 on error */
 typedef int (*KeyMetaLoadFunc)(RedisModuleIO *rdb, uint64_t *meta, int encver);
-typedef void (*KeyMetaSaveFunc)(RedisModuleIO *rdb, void *value, uint64_t *meta);
-typedef void (*KeyMetaAOFRewriteFunc)(RedisModuleIO *aof, void *value, uint64_t meta);
+typedef void (*KeyMetaSaveFunc)(RedisModuleIO *rdb, void *reserved, uint64_t *meta);
+typedef void (*KeyMetaAOFRewriteFunc)(RedisModuleIO *aof, void *reserved, uint64_t meta);
 typedef void (*KeyMetaFreeFunc)(const char *keyname, uint64_t meta);
 typedef int (*KeyMetaCopyFunc)(struct RedisModuleKeyOptCtx *ctx, uint64_t *meta);
 typedef int (*KeyMetaRenameFunc)(struct RedisModuleKeyOptCtx *ctx, uint64_t *meta);
@@ -90,8 +90,8 @@ typedef struct KeyMetaClassConf {
     void (*unlink)(struct RedisModuleKeyOptCtx *ctx, uint64_t *meta);
     void (*free)(const char *keyname, uint64_t meta);
     int (*rdb_load)(struct RedisModuleIO *rdb, uint64_t *meta, int metaver);
-    void (*rdb_save)(struct RedisModuleIO *rdb, void *value, uint64_t *meta);
-    void (*aof_rewrite)(struct RedisModuleIO *aof, void *value, uint64_t meta);
+    void (*rdb_save)(struct RedisModuleIO *rdb, void *reserved, uint64_t *meta);
+    void (*aof_rewrite)(struct RedisModuleIO *aof, void *reserved, uint64_t meta);
     
     /****************************** TBD: ******************************/
     int (*defrag) (struct RedisModuleDefragCtx *ctx, struct redisObject *key, uint64_t meta);

--- a/src/module.c
+++ b/src/module.c
@@ -4503,8 +4503,10 @@ RedisModuleKeyMetaClassId RM_CreateKeyMetaClass(RedisModuleCtx *ctx,
 {
     RedisModuleKeyMetaClassId id;
     
-    /* Allow registration only OnLoad (and when debug commands disabled) */
-    if ((!ctx->module->onload) && (server.enable_debug_cmd == PROTECTED_ACTION_ALLOWED_NO))
+    /* Allow registration only during server startup (or when debug flag is set) */
+    int ctx_flags = RM_GetContextFlags(ctx);
+    if (!(ctx_flags & REDISMODULE_CTX_FLAGS_SERVER_STARTUP) &&
+        !server.allow_keymeta_registration)
         return -1;
 
     if (!confPtr)

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1011,8 +1011,8 @@ typedef void (*RedisModuleOnUnblocked)(RedisModuleCtx *ctx, RedisModuleCallReply
 typedef int (*RedisModuleAuthCallback)(RedisModuleCtx *ctx, RedisModuleString *username, RedisModuleString *password, RedisModuleString **err);
 
 typedef int (*RedisModuleKeyMetaLoadFunc)(RedisModuleIO *rdb, uint64_t *meta, int encver);
-typedef void (*RedisModuleKeyMetaSaveFunc)(RedisModuleIO *rdb, void *value, uint64_t *meta);
-typedef void (*RedisModuleKeyMetaAOFRewriteFunc)(RedisModuleIO *aof, void *value, uint64_t meta);
+typedef void (*RedisModuleKeyMetaSaveFunc)(RedisModuleIO *rdb, void *reserved, uint64_t *meta);
+typedef void (*RedisModuleKeyMetaAOFRewriteFunc)(RedisModuleIO *aof, void *reserved, uint64_t meta);
 typedef void (*RedisModuleKeyMetaFreeFunc)(const char *keyname, uint64_t meta);
 typedef int (*RedisModuleKeyMetaCopyFunc)(RedisModuleKeyOptCtx *ctx, uint64_t *meta);
 typedef int (*RedisModuleKeyMetaRenameFunc)(RedisModuleKeyOptCtx *ctx, uint64_t *meta);

--- a/src/server.c
+++ b/src/server.c
@@ -2342,6 +2342,7 @@ void initServerConfig(void) {
     server.allow_access_expired = 0;
     server.allow_access_trimmed = 0;
     server.skip_checksum_validation = 0;
+    server.allow_keymeta_registration = 0;
     server.loading = 0;
     server.async_loading = 0;
     server.loading_rdb_used_mem = 0;

--- a/src/server.h
+++ b/src/server.h
@@ -2158,6 +2158,7 @@ struct redisServer {
     int active_defrag_enabled;
     int sanitize_dump_payload;      /* Enables deep sanitization for ziplist and listpack in RDB and RESTORE. */
     int skip_checksum_validation;   /* Disable checksum validation for RDB and RESTORE payload. */
+    int allow_keymeta_registration; /* Allow keymeta class registration outside server startup (for testing). */
     int jemalloc_bg_thread;         /* Enable jemalloc background thread */
     int active_defrag_configuration_changed; /* defrag configuration has been changed and need to reconsider
                                               * active_defrag_running in computeDefragCycles. */

--- a/tests/modules/test_keymeta.c
+++ b/tests/modules/test_keymeta.c
@@ -173,11 +173,11 @@ static int KeyMetaMoveDiscardCallback(RedisModuleKeyOptCtx *ctx, uint64_t *meta)
  *
  * Parameters:
  *   - rdb: RedisModuleIO context for writing to RDB
- *   - value: The kvobj (key-value object) - not used in this implementation
+ *   - reserved: Reserved for future use
  *   - meta: Pointer to the 8-byte metadata value (pointer to our string)
  */
-static void KeyMetaRDBSaveCallback(RedisModuleIO *rdb, void *value, uint64_t *meta) {
-    REDISMODULE_NOT_USED(value);
+static void KeyMetaRDBSaveCallback(RedisModuleIO *rdb, void *reserved, uint64_t *meta) {
+    REDISMODULE_NOT_USED(reserved);
 
     /* If metadata is NULL (reset_value), don't save anything */
     if (*meta == 0) return;
@@ -252,12 +252,12 @@ static int KeyMetaRDBLoadCallback(RedisModuleIO *rdb, uint64_t *meta, int encver
  *
  * Parameters:
  *   - aof: RedisModuleIO context for writing to AOF
- *   - value: The kvobj (key-value object) - not used in this implementation
+ *   - reserved: Reserved for future use
  *   - meta: The 8-byte metadata value (pointer to our string)
  *   - class_id: The class ID for this metadata
  */
-static void KeyMetaAOFRewriteCallback_Class(RedisModuleIO *aof, void *value, uint64_t meta, RedisModuleKeyMetaClassId class_id) {
-    REDISMODULE_NOT_USED(value);
+static void KeyMetaAOFRewriteCallback_Class(RedisModuleIO *aof, void *reserved, uint64_t meta, RedisModuleKeyMetaClassId class_id) {
+    REDISMODULE_NOT_USED(reserved);
 
     /* If metadata is NULL (reset_value), don't emit anything */
     if (meta == 0) return;
@@ -289,32 +289,32 @@ static void KeyMetaAOFRewriteCallback_Class(RedisModuleIO *aof, void *value, uin
 
 /* Individual AOF rewrite callbacks for each class (1-7)
  * Each callback wraps the common implementation with its specific class ID */
-static void KeyMetaAOFRewriteCb1(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 1);
+static void KeyMetaAOFRewriteCb1(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 1);
 }
 
-static void KeyMetaAOFRewriteCb2(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 2);
+static void KeyMetaAOFRewriteCb2(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 2);
 }
 
-static void KeyMetaAOFRewriteCb3(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 3);
+static void KeyMetaAOFRewriteCb3(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 3);
 }
 
-static void KeyMetaAOFRewriteCb4(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 4);
+static void KeyMetaAOFRewriteCb4(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 4);
 }
 
-static void KeyMetaAOFRewriteCb5(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 5);
+static void KeyMetaAOFRewriteCb5(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 5);
 }
 
-static void KeyMetaAOFRewriteCb6(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 6);
+static void KeyMetaAOFRewriteCb6(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 6);
 }
 
-static void KeyMetaAOFRewriteCb7(RedisModuleIO *aof, void *value, uint64_t meta) {
-    KeyMetaAOFRewriteCallback_Class(aof, value, meta, 7);
+static void KeyMetaAOFRewriteCb7(RedisModuleIO *aof, void *reserved, uint64_t meta) {
+    KeyMetaAOFRewriteCallback_Class(aof, reserved, meta, 7);
 }
 
 /* KEYMETA.REGISTER <4-char-id> <version> [KEEPONCOPY:KEEPONRENAME:UNLINKFREE:ALLOWIGNORE:NORDBLOAD:NORDBSAVE] */

--- a/tests/unit/moduleapi/keymeta.tcl
+++ b/tests/unit/moduleapi/keymeta.tcl
@@ -99,6 +99,7 @@ proc flushallAndVerifyCleanup {} {
 
 start_server {tags {"modules" "external:skip" "cluster:skip"} overrides {enable-debug-command yes}} {
     r module load $testmodule
+    r debug enable-keymeta-runtime-registration 1
 
     array set classesSpec {}
     set classesSpec(1) "KEEPONCOPY:KEEPONRENAME:KEEPONMOVE:ALLOWIGNORE:RDBLOAD:RDBSAVE"
@@ -763,6 +764,7 @@ test "RDB: Load with different module registration order preserves metadata corr
     # metadata values should still be correctly associated with their classes.
     start_server {tags {"modules" "external:skip" "cluster:skip"} overrides {enable-debug-command yes}} {
         r module load $testmodule
+        r debug enable-keymeta-runtime-registration 1
 
         # Helper function to generate class names (needed in inner scope)
         proc cname {id} { return "CLS$id" }
@@ -805,6 +807,7 @@ test "RDB: Load with different module registration order preserves metadata corr
         # INNER SERVER: Start new server, register classes in DIFFERENT order, then load RDB
         start_server [list overrides [list dir $rdb_dir enable-debug-command yes]] {
             r module load $testmodule
+            r debug enable-keymeta-runtime-registration 1
 
             # Helper function to generate class names (needed in inner scope)
             proc cname {id} { return "CLS$id" }
@@ -866,6 +869,7 @@ test "RDB: File size same with/without metadata when no rdb_save callback" {
 
     start_server {tags {"modules" "external:skip" "cluster:skip"} overrides {enable-debug-command yes}} {
         r module load $testmodule
+        r debug enable-keymeta-runtime-registration 1
 
         # Get RDB directory
         set rdb_dir [lindex [r config get dir] 1]
@@ -900,11 +904,11 @@ test "RDB: File size same with/without metadata when no rdb_save callback" {
 } {} {external:skip needs:save}
 
 test "Creating key metadata not during OnLoad should fail" {
-    # This time start_server without "enable-debug-command yes"
+    # Start server without enabling keymeta runtime registration debug flag
     start_server {tags {"modules" "external:skip" "cluster:skip"} overrides {enable-debug-command no}} {
         r module load $testmodule
-        # Creating a class not during OnLoad should fail
+        # Creating a class not during server startup should fail
         catch {r keymeta.register [cname 1] 1 "ALLOWIGNORE"} err
-        assert_match {*failed to create metadata class*} $err        
+        assert_match {*failed to create metadata class*} $err
     }
 } {} {external:skip needs:save}


### PR DESCRIPTION
Add `DEBUG enable-module-keymeta-runtime-registration <0|1>` to control keymeta class registration outside server startup.

Previously, `RM_CreateKeyMetaClass()` relied on `REDISMODULE_CTX_FLAGS_DEBUG_ENABLED` to bypass the startup-only restriction, which was too broad. Replace it with a dedicated `server.allow_keymeta_registration` flag and use `REDISMODULE_CTX_FLAGS_SERVER_STARTUP` for the production check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches module API surface and the gate that controls when modules can register key metadata classes, which can impact module compatibility and startup/runtime behavior, but the change is narrow and test-covered.
> 
> **Overview**
> Keymeta class registration is now restricted to *server startup* (`REDISMODULE_CTX_FLAGS_SERVER_STARTUP`) by default, with an explicit runtime override via new `DEBUG enable-keymeta-runtime-registration <0|1>` (backed by `server.allow_keymeta_registration`).
> 
> The module keymeta persistence callback signatures were adjusted to take a `reserved` pointer (passed as `NULL`) instead of a kv/value pointer, updating core call sites (`rdb_save`/`aof_rewrite`) and the keymeta test module and tests to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85a9b6264f69d08b4047930d8de364c37b1429b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->