### PR TITLE
keymeta: add DEBUG flag for runtime keymeta class registration

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -927,6 +927,11 @@ NULL
     {
         server.skip_checksum_validation = atoi(c->argv[2]->ptr);
         addReply(c,shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr,"enable-keymeta-runtime-registration") &&
+               c->argc == 3)
+    {
+        server.allow_keymeta_registration = atoi(c->argv[2]->ptr);
+        addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"aof-flush-sleep") &&
                c->argc == 3)
     {

--- a/src/debug.c
+++ b/src/debug.c
@@ -436,6 +436,8 @@ void debugCommand(client *c) {
 "    Show low level info about `key` and associated value.",
 "DROP-CLUSTER-PACKET-FILTER <packet-type>",
 "    Drop all packets that match the filtered type. Set to -1 allow all packets.",
+"ENABLE-KEYMETA-RUNTIME-REGISTRATION <0|1>",
+"    Allow keymeta class registration outside server startup (for testing).",
 "OOM",
 "    Crash the server simulating an out-of-memory error.",
 "PANIC",

--- a/src/module.c
+++ b/src/module.c
@@ -4503,8 +4503,10 @@ RedisModuleKeyMetaClassId RM_CreateKeyMetaClass(RedisModuleCtx *ctx,
 {
     RedisModuleKeyMetaClassId id;
     
-    /* Allow registration only OnLoad (and when debug commands disabled) */
-    if ((!ctx->module->onload) && (server.enable_debug_cmd == PROTECTED_ACTION_ALLOWED_NO))
+    /* Allow registration only during server startup (or when debug flag is set) */
+    int ctx_flags = RM_GetContextFlags(ctx);
+    if (!(ctx_flags & REDISMODULE_CTX_FLAGS_SERVER_STARTUP) &&
+        !server.allow_keymeta_registration)
         return -1;
 
     if (!confPtr)

--- a/src/module.c
+++ b/src/module.c
@@ -4480,9 +4480,10 @@ int RM_SetAbsExpire(RedisModuleKey *key, mstime_t expire) {
  *
  * Note: the metadata class name "AAAAAAAAA" is reserved and produces an error.
  *
- * If RM_CreateKeyMetaClass() is called outside of RedisModule_OnLoad() function,
- * there is already a metadata class registered with the same name,
- * or if the metadata class name or metaver is invalid, a negative value is returned.
+ * If RM_CreateKeyMetaClass() is called outside of RedisModule_OnLoad() function
+ * and outside of server startup, there is already a metadata class registered
+ * with the same name, or if the metadata class name or metaver is invalid,
+ * a negative value is returned.
  * Otherwise the new metadata class is registered into Redis, and a reference of
  * type RedisModuleKeyMetaClassId is returned: the caller of the function should store
  * this reference into a global variable to make future use of it in the
@@ -4503,9 +4504,10 @@ RedisModuleKeyMetaClassId RM_CreateKeyMetaClass(RedisModuleCtx *ctx,
 {
     RedisModuleKeyMetaClassId id;
     
-    /* Allow registration only during server startup (or when debug flag is set) */
+    /* Allow registration during OnLoad, server startup, or when debug flag is set */
     int ctx_flags = RM_GetContextFlags(ctx);
-    if (!(ctx_flags & REDISMODULE_CTX_FLAGS_SERVER_STARTUP) &&
+    if (!ctx->module->onload &&
+        !(ctx_flags & REDISMODULE_CTX_FLAGS_SERVER_STARTUP) &&
         !server.allow_keymeta_registration)
         return -1;
 

--- a/src/server.c
+++ b/src/server.c
@@ -2342,6 +2342,7 @@ void initServerConfig(void) {
     server.allow_access_expired = 0;
     server.allow_access_trimmed = 0;
     server.skip_checksum_validation = 0;
+    server.allow_keymeta_registration = 0;
     server.loading = 0;
     server.async_loading = 0;
     server.loading_rdb_used_mem = 0;

--- a/src/server.h
+++ b/src/server.h
@@ -2158,6 +2158,7 @@ struct redisServer {
     int active_defrag_enabled;
     int sanitize_dump_payload;      /* Enables deep sanitization for ziplist and listpack in RDB and RESTORE. */
     int skip_checksum_validation;   /* Disable checksum validation for RDB and RESTORE payload. */
+    int allow_keymeta_registration; /* Allow keymeta class registration outside server startup (for testing). */
     int jemalloc_bg_thread;         /* Enable jemalloc background thread */
     int active_defrag_configuration_changed; /* defrag configuration has been changed and need to reconsider
                                               * active_defrag_running in computeDefragCycles. */

--- a/tests/unit/moduleapi/keymeta.tcl
+++ b/tests/unit/moduleapi/keymeta.tcl
@@ -99,6 +99,7 @@ proc flushallAndVerifyCleanup {} {
 
 start_server {tags {"modules" "external:skip" "cluster:skip"} overrides {enable-debug-command yes}} {
     r module load $testmodule
+    r debug enable-keymeta-runtime-registration 1
 
     array set classesSpec {}
     set classesSpec(1) "KEEPONCOPY:KEEPONRENAME:KEEPONMOVE:ALLOWIGNORE:RDBLOAD:RDBSAVE"
@@ -763,6 +764,7 @@ test "RDB: Load with different module registration order preserves metadata corr
     # metadata values should still be correctly associated with their classes.
     start_server {tags {"modules" "external:skip" "cluster:skip"} overrides {enable-debug-command yes}} {
         r module load $testmodule
+        r debug enable-keymeta-runtime-registration 1
 
         # Helper function to generate class names (needed in inner scope)
         proc cname {id} { return "CLS$id" }
@@ -805,6 +807,7 @@ test "RDB: Load with different module registration order preserves metadata corr
         # INNER SERVER: Start new server, register classes in DIFFERENT order, then load RDB
         start_server [list overrides [list dir $rdb_dir enable-debug-command yes]] {
             r module load $testmodule
+            r debug enable-keymeta-runtime-registration 1
 
             # Helper function to generate class names (needed in inner scope)
             proc cname {id} { return "CLS$id" }
@@ -866,6 +869,7 @@ test "RDB: File size same with/without metadata when no rdb_save callback" {
 
     start_server {tags {"modules" "external:skip" "cluster:skip"} overrides {enable-debug-command yes}} {
         r module load $testmodule
+        r debug enable-keymeta-runtime-registration 1
 
         # Get RDB directory
         set rdb_dir [lindex [r config get dir] 1]
@@ -900,11 +904,11 @@ test "RDB: File size same with/without metadata when no rdb_save callback" {
 } {} {external:skip needs:save}
 
 test "Creating key metadata not during OnLoad should fail" {
-    # This time start_server without "enable-debug-command yes"
+    # Start server without enabling keymeta runtime registration debug flag
     start_server {tags {"modules" "external:skip" "cluster:skip"} overrides {enable-debug-command no}} {
         r module load $testmodule
-        # Creating a class not during OnLoad should fail
+        # Creating a class not during server startup should fail
         catch {r keymeta.register [cname 1] 1 "ALLOWIGNORE"} err
-        assert_match {*failed to create metadata class*} $err        
+        assert_match {*failed to create metadata class*} $err
     }
 } {} {external:skip needs:save}

--- a/tests/unit/moduleapi/ksn_notify_side_effect.tcl
+++ b/tests/unit/moduleapi/ksn_notify_side_effect.tcl
@@ -15,7 +15,8 @@
 
 set testmodule [file normalize tests/modules/keymeta_notify.so]
 
-start_server {tags {"modules" "external:skip"}} {
+start_server {tags {"modules" "external:skip"} overrides {enable-debug-command yes}} {
+    r debug enable-keymeta-runtime-registration 1
     r module load $testmodule
 
     # --- HASH notification tests ---


### PR DESCRIPTION
M_CreateKeyMetaClass() allows registration only on:
- 'DEBUG enable-module-keymeta-runtime-registration 1' (replaces server.enable_debug_cmd)
- REDISMODULE_CTX_FLAGS_SERVER_STARTUP, in addition to module->onload
