### PR TITLE
Rename active clients stats fields

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -251,8 +251,8 @@ client *createClient(connection *conn) {
     c->commands_processed = 0;
     c->last_ts_when_counted_as_active = 0;
     c->stat_total_read_events = 0;
-    c->stat_avg_pipeline_length_sum = 0;
-    c->stat_avg_pipeline_length_cnt = 0;
+    c->stat_commands_per_parse_batch_sum = 0;
+    c->stat_commands_per_parse_batch_cnt = 0;
     c->task = NULL;
     c->node_id = NULL;
     atomicSet(c->pending_read, 0);
@@ -3612,11 +3612,11 @@ int processInputBuffer(client *c) {
 
         if (c->pending_cmds.ready_len != pending_cmd_before_reading) {
             int newly_parsed_cmds = c->pending_cmds.ready_len - pending_cmd_before_reading;
-            atomicIncr(server.stat_avg_pipeline_length_sum, newly_parsed_cmds);
-            atomicIncr(server.stat_avg_pipeline_length_cnt, 1);
+            atomicIncr(server.stat_commands_per_parse_batch_sum, newly_parsed_cmds);
+            atomicIncr(server.stat_commands_per_parse_batch_cnt, 1);
 
-            c->stat_avg_pipeline_length_sum += newly_parsed_cmds;
-            c->stat_avg_pipeline_length_cnt++;
+            c->stat_commands_per_parse_batch_sum += newly_parsed_cmds;
+            c->stat_commands_per_parse_batch_cnt++;
         }
 
         /* Try to consume the next ready command from the pending command list. */
@@ -4032,8 +4032,8 @@ sds catClientInfoString(sds s, client *client) {
         " tot-net-out=%U", client->net_output_bytes,
         " tot-cmds=%U", client->commands_processed,
         " read-events=%U", (unsigned long long)client->stat_total_read_events,
-        " avg-pipeline-len-sum=%U", (unsigned long long)client->stat_avg_pipeline_length_sum,
-        " avg-pipeline-len-cnt=%U", (unsigned long long)client->stat_avg_pipeline_length_cnt));
+        " parse-batch-cmd-sum=%U", (unsigned long long)client->stat_commands_per_parse_batch_sum,
+        " parse-batch-cnt=%U", (unsigned long long)client->stat_commands_per_parse_batch_cnt));
 
     if (paused) resumeIOThread(client->running_tid);
     return ret;

--- a/src/server.c
+++ b/src/server.c
@@ -2874,8 +2874,8 @@ void resetServerStats(void) {
     server.stat_cluster_incompatible_ops = 0;
     server.stat_total_prefetch_batches = 0;
     server.stat_total_prefetch_entries = 0;
-    atomicSet(server.stat_avg_pipeline_length_sum, 0);
-    atomicSet(server.stat_avg_pipeline_length_cnt, 0);
+    atomicSet(server.stat_commands_per_parse_batch_sum, 0);
+    atomicSet(server.stat_commands_per_parse_batch_cnt, 0);
     atomicSet(server.stat_total_client_process_input_buff_events, 0);
     server.stat_eventloop_cycles_with_clients_input_buff_processing = 0;
     stat_prev_total_client_process_input_buff_events = 0;
@@ -6588,8 +6588,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         long long stat_net_input_bytes, stat_net_output_bytes;
         long long stat_net_repl_input_bytes, stat_net_repl_output_bytes;
         long long stat_total_client_process_input_buff_events;
-        long long stat_avg_pipeline_length_sum;
-        long long stat_avg_pipeline_length_cnt;
+        long long stat_commands_per_parse_batch_sum;
+        long long stat_commands_per_parse_batch_cnt;
         long long current_eviction_exceeded_time = server.stat_last_eviction_exceeded_time ?
             (long long) elapsedUs(server.stat_last_eviction_exceeded_time): 0;
         long long current_active_defrag_time = server.stat_last_active_defrag_time ?
@@ -6601,8 +6601,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         atomicGet(server.stat_net_repl_output_bytes, stat_net_repl_output_bytes);
         atomicGet(server.stat_client_qbuf_limit_disconnections, stat_client_qbuf_limit_disconnections);
         atomicGet(server.stat_total_client_process_input_buff_events, stat_total_client_process_input_buff_events);
-        atomicGet(server.stat_avg_pipeline_length_sum, stat_avg_pipeline_length_sum);
-        atomicGet(server.stat_avg_pipeline_length_cnt, stat_avg_pipeline_length_cnt);
+        atomicGet(server.stat_commands_per_parse_batch_sum, stat_commands_per_parse_batch_sum);
+        atomicGet(server.stat_commands_per_parse_batch_cnt, stat_commands_per_parse_batch_cnt);
 
         /* If we calculated the total reads and writes in the threads section,
          * we don't need to do it again, and also keep the values consistent. */
@@ -6685,9 +6685,9 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION),
             "eventloop_cycles_with_clients_processing:%zu\r\n", server.stat_eventloop_cycles_with_clients_input_buff_processing,
             "total_client_processing_events:%lld\r\n", stat_total_client_process_input_buff_events,
-            "avg_pipeline_length_sum:%lld\r\n", stat_avg_pipeline_length_sum,
-            "avg_pipeline_length_cnt:%lld\r\n", stat_avg_pipeline_length_cnt,
-            "avg_pipeline_length:%.2f\r\n", stat_avg_pipeline_length_cnt ? (double)stat_avg_pipeline_length_sum / stat_avg_pipeline_length_cnt : 0,
+            "commands_per_parse_batch_sum:%lld\r\n", stat_commands_per_parse_batch_sum,
+            "commands_per_parse_batch_cnt:%lld\r\n", stat_commands_per_parse_batch_cnt,
+            "commands_per_parse_batch_avg:%.2f\r\n", stat_commands_per_parse_batch_cnt ? (double)stat_commands_per_parse_batch_sum / stat_commands_per_parse_batch_cnt : 0,
             "slowlog_commands_count:%lld\r\n", server.stat_slowlog_count,
             "slowlog_commands_time_ms_max:%.2f\r\n", (double)server.stat_slowlog_time_us_max / 1000,
             "slowlog_commands_time_ms_sum:%.2f\r\n", (double)server.stat_slowlog_time_us_sum / 1000));

--- a/src/server.h
+++ b/src/server.h
@@ -1619,8 +1619,8 @@ typedef struct client {
 
     mstime_t last_ts_when_counted_as_active; /* Timestamp of last time this client was counted as active */
     size_t stat_total_read_events; /* Number of times readQueryFromClient() was called */
-    size_t stat_avg_pipeline_length_sum; /* Sum of pipeline lengths for computing average */
-    size_t stat_avg_pipeline_length_cnt; /* Count of pipeline length samples */
+    size_t stat_commands_per_parse_batch_sum; /* Cumulative commands parsed across all parsing batches. */
+    size_t stat_commands_per_parse_batch_cnt; /* Number of parsing batches (each finding >= 1 command). */
 } client;
 
 typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) {
@@ -2119,8 +2119,8 @@ struct redisServer {
     long long stat_cluster_incompatible_ops; /* Number of operations that are incompatible with cluster mode */
     long long stat_total_prefetch_entries;  /* Total number of prefetched dict entries */
     long long stat_total_prefetch_batches;  /* Total number of prefetched batches */
-    redisAtomic long long stat_avg_pipeline_length_sum; /* Sum of pipeline lengths for computing average */
-    redisAtomic long long stat_avg_pipeline_length_cnt; /* Count of pipeline length samples */
+    redisAtomic long long stat_commands_per_parse_batch_sum; /* Cumulative commands parsed across all parsing batches for all clients. */
+    redisAtomic long long stat_commands_per_parse_batch_cnt; /* Total number of parsing batches across all clients. */
     redisAtomic long long stat_total_client_process_input_buff_events; /* Number of times processInputBuffer() was called */
     size_t stat_eventloop_cycles_with_clients_input_buff_processing; /* Event loop cycles with client input buffer processing */
     /* The following two are used to track instantaneous metrics, like

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -542,8 +542,8 @@ start_server {tags {"info" "external:skip"}} {
             set info1 [r info stats]
             set proc_events1 [getInfoProperty $info1 total_client_processing_events]
             set cycles1 [getInfoProperty $info1 eventloop_cycles_with_clients_processing]
-            set plsum1 [getInfoProperty $info1 avg_pipeline_length_sum]
-            set plcnt1 [getInfoProperty $info1 avg_pipeline_length_cnt]
+            set plsum1 [getInfoProperty $info1 commands_per_parse_batch_sum]
+            set plcnt1 [getInfoProperty $info1 commands_per_parse_batch_cnt]
 
             # Issue several commands
             r ping
@@ -553,9 +553,9 @@ start_server {tags {"info" "external:skip"}} {
             set info2 [r info stats]
             set proc_events2 [getInfoProperty $info2 total_client_processing_events]
             set cycles2 [getInfoProperty $info2 eventloop_cycles_with_clients_processing]
-            set plsum2 [getInfoProperty $info2 avg_pipeline_length_sum]
-            set plcnt2 [getInfoProperty $info2 avg_pipeline_length_cnt]
-            set plavg2 [getInfoProperty $info2 avg_pipeline_length]
+            set plsum2 [getInfoProperty $info2 commands_per_parse_batch_sum]
+            set plcnt2 [getInfoProperty $info2 commands_per_parse_batch_cnt]
+            set plavg2 [getInfoProperty $info2 commands_per_parse_batch_avg]
 
             # processInputBuffer was called for 3 PINGs + the INFO call = at least 4
             assert_morethan_equal [expr {$proc_events2 - $proc_events1}] 4
@@ -581,8 +581,8 @@ start_server {tags {"info" "external:skip"}} {
             set info_before [r info stats]
             set proc_before [getInfoProperty $info_before total_client_processing_events]
             set cycles_before [getInfoProperty $info_before eventloop_cycles_with_clients_processing]
-            set plsum_before [getInfoProperty $info_before avg_pipeline_length_sum]
-            set plcnt_before [getInfoProperty $info_before avg_pipeline_length_cnt]
+            set plsum_before [getInfoProperty $info_before commands_per_parse_batch_sum]
+            set plcnt_before [getInfoProperty $info_before commands_per_parse_batch_cnt]
 
             # Verify counters are meaningfully large before resetting
             assert_morethan $proc_before 10
@@ -595,8 +595,8 @@ start_server {tags {"info" "external:skip"}} {
             set info_after [r info stats]
             set proc_after [getInfoProperty $info_after total_client_processing_events]
             set cycles_after [getInfoProperty $info_after eventloop_cycles_with_clients_processing]
-            set plsum_after [getInfoProperty $info_after avg_pipeline_length_sum]
-            set plcnt_after [getInfoProperty $info_after avg_pipeline_length_cnt]
+            set plsum_after [getInfoProperty $info_after commands_per_parse_batch_sum]
+            set plcnt_after [getInfoProperty $info_after commands_per_parse_batch_cnt]
 
             # Counters should be near zero (only RESETSTAT + INFO ran after reset)
             assert_lessthan_equal $proc_after 3

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -21,9 +21,9 @@ start_server {tags {"introspection"}} {
     test {CLIENT LIST} {
         set client_list [r client list]
         if {[lindex [r config get io-threads] 1] == 1} {
-            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=* read-events=* avg-pipeline-len-sum=* avg-pipeline-len-cnt=*} $client_list
+            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=* read-events=* parse-batch-cmd-sum=* parse-batch-cnt=*} $client_list
         } else {
-            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=* read-events=* avg-pipeline-len-sum=* avg-pipeline-len-cnt=*} $client_list
+            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=* read-events=* parse-batch-cmd-sum=* parse-batch-cnt=*} $client_list
         }
     }
 
@@ -36,9 +36,9 @@ start_server {tags {"introspection"}} {
     test {CLIENT INFO} {
         set client [r client info]
         if {[lindex [r config get io-threads] 1] == 1} {
-            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=* read-events=* avg-pipeline-len-sum=* avg-pipeline-len-cnt=*} $client
+            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=* read-events=* parse-batch-cmd-sum=* parse-batch-cnt=*} $client
         } else {
-            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=* read-events=* avg-pipeline-len-sum=* avg-pipeline-len-cnt=*} $client
+            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=* read-events=* parse-batch-cmd-sum=* parse-batch-cnt=*} $client
         }
     } 
 
@@ -149,8 +149,8 @@ start_server {tags {"introspection"}} {
         # so capture the current state rather than assuming zeros.
         set info1 [$r2 client info]
         set re1 [get_field_in_client_info $info1 "read-events"]
-        set plsum1 [get_field_in_client_info $info1 "avg-pipeline-len-sum"]
-        set plcnt1 [get_field_in_client_info $info1 "avg-pipeline-len-cnt"]
+        set plsum1 [get_field_in_client_info $info1 "parse-batch-cmd-sum"]
+        set plcnt1 [get_field_in_client_info $info1 "parse-batch-cnt"]
 
         # Send 3 sequential (non-pipelined) commands
         $r2 ping
@@ -159,8 +159,8 @@ start_server {tags {"introspection"}} {
 
         set info2 [$r2 client info]
         set re2 [get_field_in_client_info $info2 "read-events"]
-        set plsum2 [get_field_in_client_info $info2 "avg-pipeline-len-sum"]
-        set plcnt2 [get_field_in_client_info $info2 "avg-pipeline-len-cnt"]
+        set plsum2 [get_field_in_client_info $info2 "parse-batch-cmd-sum"]
+        set plcnt2 [get_field_in_client_info $info2 "parse-batch-cnt"]
 
         # read-events should have increased (3 PINGs + the CLIENT INFO itself)
         assert_morethan_equal $re2 [expr {$re1 + 4}]
@@ -182,8 +182,8 @@ start_server {tags {"introspection"}} {
 
         # Capture baseline from CLIENT LIST
         set info_list [r client list]
-        set plsum1 [get_field_in_client_list $rd_id $info_list "avg-pipeline-len-sum"]
-        set plcnt1 [get_field_in_client_list $rd_id $info_list "avg-pipeline-len-cnt"]
+        set plsum1 [get_field_in_client_list $rd_id $info_list "parse-batch-cmd-sum"]
+        set plcnt1 [get_field_in_client_list $rd_id $info_list "parse-batch-cnt"]
 
         # Send 5 pipelined commands without reading replies
         for {set i 0} {$i < 5} {incr i} {
@@ -196,8 +196,8 @@ start_server {tags {"introspection"}} {
         }
 
         set info_list [r client list]
-        set plsum2 [get_field_in_client_list $rd_id $info_list "avg-pipeline-len-sum"]
-        set plcnt2 [get_field_in_client_list $rd_id $info_list "avg-pipeline-len-cnt"]
+        set plsum2 [get_field_in_client_list $rd_id $info_list "parse-batch-cmd-sum"]
+        set plcnt2 [get_field_in_client_list $rd_id $info_list "parse-batch-cnt"]
 
         # All 5 commands must have been counted in the sum
         set delta_sum [expr {$plsum2 - $plsum1}]


### PR DESCRIPTION
This PR follows #14841

Optimize the active client statistics fields with unclear names.

## Fields changes

**`INFO stats`**:
- `avg_pipeline_length_sum` -> `commands_per_parse_batch_sum`
- `avg_pipeline_length_cnt` -> `commands_per_parse_batch_cnt`
- `avg_pipeline_length`     -> `commands_per_parse_batch_avg`

**`CLIENT LIST` / `CLIENT INFO`**:
- `avg-pipeline-len-sum` -> `parse-batch-cmd-sum`
- `avg-pipeline-len-cnt` -> `parse-batch-cnt`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a metric/field rename affecting observability outputs and tests; risk is limited to compatibility for users parsing the old stat names.
> 
> **Overview**
> Renames the client/server “avg pipeline length” statistics to better reflect what’s actually being measured: commands parsed per input parsing batch.
> 
> This updates internal counters (client + global), the `INFO stats` fields (including the derived average), and the `CLIENT LIST`/`CLIENT INFO` output keys to the new `commands_per_parse_batch*` / `parse-batch-*` names, along with corresponding test expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0646087be17b9d8ffe3c047a2d13a14bcddd66d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->