### PR TITLE
Fix memory leak in helloacl module 

### DIFF
--- a/src/modules/helloacl.c
+++ b/src/modules/helloacl.c
@@ -147,6 +147,8 @@ int AuthAsyncCommand_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     targs[1] = RedisModule_CreateStringFromString(NULL, argv[1]);
 
     if (pthread_create(&tid, NULL, HelloACL_ThreadMain, targs) != 0) {
+        RedisModule_FreeString(NULL, targs[1]);
+        RedisModule_Free(targs);
         RedisModule_AbortBlock(bc);
         return RedisModule_ReplyWithError(ctx, "-ERR Can't start thread");
     }


### PR DESCRIPTION
**Problem**
In the AuthAsyncCommand_RedisCommand function, the module prepares arguments to be passed to a background thread. These include:

A duplicated RedisModuleString (targs[1]).
An allocated void array (targs) to hold the thread's arguments.
Critical Bug: If pthread_create calls failed (e.g., due to system resource limits), the code would immediately return an error message to Redis. However, it never freed the allocated targs array or the RedisModuleString. Over time, if many thread creations failed, this would lead to a significant memory leak.

**Fix**
I implemented the missing cleanup logic on the error-handling path. Now, if pthread_create fails, the following steps are performed before the error is returned to the user:

RedisModule_FreeString(NULL, targs[1]): Explicitly frees the duplicated string.
RedisModule_Free(targs): Frees the memory allocated for the arguments array.
This ensures that all resources allocated for the background task are correctly released regardless of whether the thread starts successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds missing cleanup on a rare error path without changing the successful auth flow.
> 
> **Overview**
> Prevents a memory leak in `helloacl.authasync` by freeing the duplicated `RedisModuleString` and the `targs` argument array when `pthread_create` fails, before aborting the blocked client and returning an error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7476f92c35aa8a7e927ef0fff10c09ba0d3e7c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->