### PR TITLE
[BUG] potential file descriptor leak in clusterLoadConfig() on fstat failure in src/cluster_legacy.c

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -330,6 +330,7 @@ int clusterLoadConfig(char *filename) {
         serverLog(LL_WARNING,
             "Unable to obtain the cluster node config file stat %s: %s",
             filename, strerror(errno));
+        fclose(fp);
         exit(1);
     }
     /* Check if the file is zero-length: if so return C_ERR to signal


### PR DESCRIPTION


### Problem

In `clusterLoadConfig()` under `src/cluster_legacy.c` on fstat failure the process is exited without closing the file descriptor fp which may lead to a file descriptor leak.

```c
if (redis_fstat(fileno(fp),&sb) == -1) {
        serverLog(LL_WARNING,
            "Unable to obtain the cluster node config file stat %s: %s",
            filename, strerror(errno));
        exit(1);
    }
```
### Fix

Close file descriptor fp before exiting on fstat failure to prevent potential file descriptor leak.

This patch ensures `fclose(fp)` is called before exiting.
No functional change otherwise.

```c
if (redis_fstat(fileno(fp),&sb) == -1) {
        serverLog(LL_WARNING,
            "Unable to obtain the cluster node config file stat %s: %s",
            filename, strerror(errno));
        fclose(fp);
        exit(1);
    }
```

### Testing & Verification

Verified by code inspection. The added `fclose(fp)` ensures the file descriptor is properly released on the fstate failure path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a missing `fclose(fp)` on an error path before `exit(1)`, reducing a potential file descriptor leak without changing normal execution flow.
> 
> **Overview**
> Fixes an error-path resource leak in `clusterLoadConfig()` by closing the opened config file (`fclose(fp)`) when `redis_fstat()` fails, before exiting the process.
> 
> No behavior changes on successful loads; this only affects the `fstat` failure path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c5370db5123106cb1adf6fa6a22d807ceb07ab9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->