### PR TITLE
Fix memory leak in clusterManagerFixSlotsCoverage

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6152,6 +6152,8 @@ static int clusterManagerFixSlotsCoverage(char *all_slots) {
                     fixed = -1;
                     if (reply) freeReplyObject(reply);
                     if (slot_nodes) listRelease(slot_nodes);
+                    sdsfree(slot_nodes_str);
+                    sdsfree(slot);
                     goto cleanup;
                 }
                 assert(reply->type == REDIS_REPLY_ARRAY);


### PR DESCRIPTION

https://github.com/redis/redis/blob/5aa6440cbc044f65c9bef8a69526b095333e8ccd/src/redis-cli.c#L6138-L6157

`slot` and `slot_nodes_str` are allocated at line 6139, if an error occurs, they should be freed before `go cleanup`; 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds missing `sdsfree` calls in an error path to prevent a memory leak, without changing cluster logic or command behavior.
> 
> **Overview**
> Fixes a memory leak in `clusterManagerFixSlotsCoverage` by freeing the per-slot `sds` strings (`slot` and `slot_nodes_str`) before jumping to `cleanup` when `CLUSTER GETKEYSINSLOT` replies fail.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1224f911774936258aee4b28d6b26fd4d17431c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->