### PR TITLE
Fix signed integer overflow in scan count parameter

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1910,7 +1910,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
          * COUNT, so if the hash table is in a pathological state (very
          * sparsely populated) we avoid to block too much time at the cost
          * of returning no or very few elements. */
-        long maxiterations = count*10;
+        long maxiterations = (count > LONG_MAX / 10) ? LONG_MAX : count * 10;
 
         /* We pass scanData which have three pointers to the callback:
          * 1. data.keys: the list to which it will add new elements;

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -498,6 +498,19 @@ proc test_scan {type} {
 
 start_server {tags {"scan network standalone"}} {
     test_scan "standalone"
+
+    test "scan count overflow" {
+        r flushdb
+        populate 10
+
+        # count = LONG_MAX/10 + 1 = 922337203685477581, within LONG_MAX so
+        # it parses fine, but count*10 overflows signed long which is
+        # undefined behavior.
+        set big_count 922337203685477581
+        set res [r scan 0 count $big_count]
+        assert {[llength $res] == 2}
+        assert {[string is integer [lindex $res 0]]}
+    }
 }
 
 start_cluster 1 0 {tags {"external:skip cluster scan"}} {

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -471,6 +471,19 @@ proc test_scan {type} {
         }
     }
 
+    test "{$type} SCAN COUNT overflow" {
+        r flushdb
+        populate 10
+
+        # count = LONG_MAX/10 + 1 = 922337203685477581, within LONG_MAX so
+        # it parses fine, but count*10 overflows signed long which is
+        # undefined behavior.
+        set big_count 922337203685477581
+        set res [r scan 0 count $big_count]
+        assert {[llength $res] == 2}
+        assert {[string is integer [lindex $res 0]]}
+    }
+
     test "{$type} SCAN MATCH pattern implies cluster slot" {
         # Tests the code path for an optimization for patterns like "{foo}-*"
         # which implies that all matching keys belong to one slot.
@@ -494,23 +507,12 @@ proc test_scan {type} {
         set keys [lsort -unique $keys]
         assert_equal 100 [llength $keys]
     }
+    
+    
 }
 
 start_server {tags {"scan network standalone"}} {
     test_scan "standalone"
-
-    test "scan count overflow" {
-        r flushdb
-        populate 10
-
-        # count = LONG_MAX/10 + 1 = 922337203685477581, within LONG_MAX so
-        # it parses fine, but count*10 overflows signed long which is
-        # undefined behavior.
-        set big_count 922337203685477581
-        set res [r scan 0 count $big_count]
-        assert {[llength $res] == 2}
-        assert {[string is integer [lindex $res 0]]}
-    }
 }
 
 start_cluster 1 0 {tags {"external:skip cluster scan"}} {

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -482,7 +482,8 @@ proc test_scan {type} {
         set big_count [expr {$long_max / 10 + 1}]
         set res [r scan 0 count $big_count]
         assert {[llength $res] == 2}
-        assert {[string is integer [lindex $res 0]]}
+        assert_equal 0 [lindex $res 0]
+        assert_equal 10 [llength [lindex $res 1]]
     }
 
     test "{$type} SCAN MATCH pattern implies cluster slot" {

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -507,8 +507,6 @@ proc test_scan {type} {
         set keys [lsort -unique $keys]
         assert_equal 100 [llength $keys]
     }
-    
-    
 }
 
 start_server {tags {"scan network standalone"}} {

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -475,10 +475,11 @@ proc test_scan {type} {
         r flushdb
         populate 10
 
-        # count = LONG_MAX/10 + 1 = 922337203685477581, within LONG_MAX so
-        # it parses fine, but count*10 overflows signed long which is
-        # undefined behavior.
-        set big_count 922337203685477581
+        # count = LONG_MAX/10 + 1, within LONG_MAX so it parses fine,
+        # but count*10 overflows signed long which is undefined behavior.
+        # Compute dynamically to support both 32-bit and 64-bit builds.
+        set long_max [expr {[s arch_bits] == 32 ? 2147483647 : 9223372036854775807}]
+        set big_count [expr {$long_max / 10 + 1}]
         set res [r scan 0 count $big_count]
         assert {[llength $res] == 2}
         assert {[string is integer [lindex $res 0]]}


### PR DESCRIPTION
### Problem 

In `scanGenericCommand`, `maxiterations = count * 10` overflows when `count > LONG_MAX / 10`, causing undefined behavior.


### Changed 

1. Use saturating arithmetic to prevent the overflow
2. Added a test triggers the overflow path, detectable by UBSan.

### Test

```shell
make SANITIZER=undefined REDIS_CFLAGS='-DREDIS_TEST -Werror' -j$(nproc)
./runtest --single unit/scan 
```

#### Pre-fix

Sanitizer report with new test:

<img width="2320" height="316" alt="CleanShot 2026-04-03 at 19 13 42@2x" src="https://github.com/user-attachments/assets/e9a251ff-749c-426a-85e7-e2e5f0a6e98d" />



#### After-fix

<img width="1346" height="748" alt="CleanShot 2026-04-03 at 19 15 30@2x" src="https://github.com/user-attachments/assets/9217b523-c1bd-46a4-9351-29b806560f9d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to SCAN iteration bounds plus a targeted regression test; low risk of behavior change outside extreme `COUNT` values.
> 
> **Overview**
> Fixes an integer overflow in `scanGenericCommand` when deriving `maxiterations` from the user-provided `COUNT` option by switching to saturating arithmetic (`LONG_MAX` cap) instead of blindly doing `count * 10`.
> 
> Adds a unit test in `tests/unit/scan.tcl` that passes a `COUNT` value just over `LONG_MAX/10` (computed per 32/64-bit build) to ensure the command completes correctly and to catch the prior undefined-behavior path under UBSan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f56e30ea80b13c3e5124bbed3a02bde94b9f1df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->