### PR TITLE
[fix] replica-to-primary connection issues when the IPs change

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2193,6 +2193,40 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
                 }
             }
 
+            /* If we already know this node in NOADDR state but
+             * gossip from a trusted sender reports a healthy endpoint at a
+             * different address, adopt it so we can reconnect. Without this,
+             * failure detection skips NOADDR nodes, so the PFAIL-based gossip
+             * repair below never runs. */
+            if (sender &&
+                (node->flags & CLUSTER_NODE_NOADDR) &&
+                !(node->flags & CLUSTER_NODE_HANDSHAKE) &&
+                !(flags & CLUSTER_NODE_NOADDR) &&
+                !(flags & (CLUSTER_NODE_FAIL|CLUSTER_NODE_PFAIL)) &&
+                g->ip[0] != '\0' &&
+                strcmp(g->ip, myself->ip) != 0 &&
+                !clusterBlacklistExists(g->nodename, CLUSTER_NAMELEN) &&
+                (strcasecmp(node->ip,g->ip) ||
+                 node->tls_port != (server.tls_cluster ? ntohs(g->port) : ntohs(g->pport)) ||
+                 node->tcp_port != (server.tls_cluster ? ntohs(g->pport) : ntohs(g->port)) ||
+                 node->cport != ntohs(g->cport)))
+            {
+                if (node->link) freeClusterLink(node->link);
+                memcpy(node->ip,g->ip,NET_IP_STR_LEN);
+                node->tcp_port = msg_tcp_port;
+                node->tls_port = msg_tls_port;
+                node->cport = ntohs(g->cport);
+                node->flags &= ~CLUSTER_NODE_NOADDR;
+                serverLog(LL_NOTICE,
+                    "Gossip updated address for NOADDR node %.40s (%s), now %s:%d",
+                    node->name, node->human_nodename, node->ip,
+                    getNodeDefaultClientPort(node));
+                if (nodeIsSlave(myself) && myself->slaveof == node)
+                    replicationSetMaster(node->ip, getNodeDefaultReplicationPort(node));
+                clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG|
+                                     CLUSTER_TODO_UPDATE_STATE);
+            }
+
             /* If we already know this node, but it is not reachable, and
              * we see a different address in the gossip section of a node that
              * can talk with this other node, update the address, disconnect
@@ -5878,6 +5912,33 @@ int clusterNodeIsMaster(clusterNode *n) {
 }
 
 int handleDebugClusterCommand(client *c) {
+    /* DEBUG FORCE-NOADDR <node-id> -- testing: simulate stuck NOADDR peer. */
+    if (c->argc == 3 && !strcasecmp(c->argv[1]->ptr, "FORCE-NOADDR")) {
+        if (!server.cluster_enabled) {
+            addReplyError(c, "Debug option only available for cluster mode enabled setup!");
+            return 1;
+        }
+        clusterNode *n = clusterLookupNode(c->argv[2]->ptr, sdslen(c->argv[2]->ptr));
+        if (!n) {
+            addReplyErrorFormat(c, "Unknown node %s", (char *) c->argv[2]->ptr);
+            return 1;
+        }
+        if (n == myself) {
+            addReplyError(c, "Cannot set NOADDR on myself");
+            return 1;
+        }
+        if (n->link) freeClusterLink(n->link);
+        if (n->inbound_link) freeClusterLink(n->inbound_link);
+        n->flags |= CLUSTER_NODE_NOADDR;
+        n->ip[0] = '\0';
+        n->tcp_port = 0;
+        n->tls_port = 0;
+        n->cport = 0;
+        clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG|CLUSTER_TODO_UPDATE_STATE);
+        addReply(c, shared.ok);
+        return 1;
+    }
+
     if (c->argc != 5 ||
         strcasecmp(c->argv[1]->ptr, "CLUSTERLINK") ||
         strcasecmp(c->argv[2]->ptr, "KILL")) {
@@ -5953,6 +6014,8 @@ const char **clusterDebugCommandExtendedHelp(void) {
     static const char *help[] = {
         "CLUSTERLINK KILL <to|from|all> <node-id>",
         "    Kills the link based on the direction to/from (both) with the provided node.",
+        "FORCE-NOADDR <node-id>",
+        "    Testing only: mark a known peer as NOADDR and clear its address.",
         NULL
     };
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2204,7 +2204,6 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
                 !(flags & CLUSTER_NODE_NOADDR) &&
                 !(flags & (CLUSTER_NODE_FAIL|CLUSTER_NODE_PFAIL)) &&
                 g->ip[0] != '\0' &&
-                strcmp(g->ip, myself->ip) != 0 &&
                 !clusterBlacklistExists(g->nodename, CLUSTER_NAMELEN) &&
                 (strcasecmp(node->ip,g->ip) ||
                  node->tls_port != (server.tls_cluster ? ntohs(g->port) : ntohs(g->pport)) ||

--- a/tests/unit/cluster/noaddr-gossip-recovery.tcl
+++ b/tests/unit/cluster/noaddr-gossip-recovery.tcl
@@ -1,0 +1,83 @@
+#
+# Copyright (C) 2014-Present, Redis Ltd.
+# All Rights reserved.
+#
+# Licensed under your choice of (a) the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+
+# Gossip repair for peers stuck in NOADDR (e.g. after address confusion).
+
+proc cluster_unit_get_node_by_id {instance_id node_id} {
+    foreach n [get_cluster_nodes $instance_id] {
+        if {[dict get $n id] eq $node_id} {
+            return $n
+        }
+    }
+    return {}
+}
+
+# Return 1 when instance_id no longer marks peer_id as NOADDR and has a localhost addr for it.
+proc cluster_unit_noaddr_repaired {instance_id peer_id} {
+    set n2 [cluster_unit_get_node_by_id $instance_id $peer_id]
+    if {$n2 eq {}} {return 0}
+    if {[cluster_has_flag $n2 noaddr]} {return 0}
+    if {![string match {127.0.0.1:*} [dict get $n2 addr]]} {return 0}
+    return 1
+}
+
+proc cluster_unit_rep_info_field {rid name} {
+    foreach line [split [R $rid info replication] "\n\r"] {
+        if {[string match "${name}:*" $line]} {
+            set i [string first : $line]
+            return [string trim [string range $line [expr {$i + 1}] end]]
+        }
+    }
+    return {}
+}
+
+# Replica `rid`: peer master repaired, master_host matches `want_host`, link up.
+proc cluster_unit_replica_master_recovered {rid master_id want_host} {
+    if {![cluster_unit_noaddr_repaired $rid $master_id]} {return 0}
+    if {[cluster_unit_rep_info_field $rid master_host] ne $want_host} {return 0}
+    if {[cluster_unit_rep_info_field $rid master_link_status] ne {up}} {return 0}
+    return 1
+}
+
+start_cluster 3 0 {tags {external:skip cluster needs:debug}} {
+    test "NOADDR peer address is repaired from trusted gossip" {
+        set id2 [R 2 CLUSTER MYID]
+        set n2 [cluster_unit_get_node_by_id 0 $id2]
+        assert {$n2 ne {}}
+        assert_equal 0 [cluster_has_flag $n2 noaddr]
+        assert_match {127.0.0.1:*} [dict get $n2 addr]
+
+        R 0 DEBUG FORCE-NOADDR $id2
+
+        set n2 [cluster_unit_get_node_by_id 0 $id2]
+        assert_equal 1 [cluster_has_flag $n2 noaddr]
+
+        wait_for_condition 200 50 {[cluster_unit_noaddr_repaired 0 $id2]} else {
+            fail "NOADDR gossip repair did not restore peer address on node 0"
+        }
+    }
+}
+
+start_cluster 2 1 {tags {external:skip cluster needs:debug}} {
+    test "NOADDR gossip repair updates replica replication master address" {
+        wait_for_condition 50 100 {
+            [cluster_unit_rep_info_field 2 master_link_status] eq {up}
+        } else {
+            fail "replica did not sync to master"
+        }
+        set master_id [R 0 CLUSTER MYID]
+        set want_host [cluster_unit_rep_info_field 2 master_host]
+
+        R 2 DEBUG FORCE-NOADDR $master_id
+
+        wait_for_condition 200 50 \
+            [format {[cluster_unit_replica_master_recovered 2 %s %s]} $master_id $want_host] else {
+            fail "replica master_host or link not restored after gossip NOADDR repair"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #14633

### Core Issue

The core issue was that whenever a previously known node gets into `noaddr` state (say for some reason like dynamic ip change) it would never be put into failed or possibly failed state (`FAIL / PFAIL`) so its ip address would never be recovered/relearnt from cluster gossip signals from other trusted nodes (because currently only nodes that were marked `FAIL / PFAIL` only their ip address was getting recovered)

Because of the above reason master-slave replica nodes whose ip was swapped were putting each other in `noaddr` state and would remain that way forever...

### Suggested fix

The suggested fix builds a dedicated path which would now recover/relearn the ip address of nodes which were previously known but put into `noaddr` state for some reason if other trusted nodes communicate its address via gossip layer.
The way we recover ip address is mirroring the already existing logic of recovery in case the node had `FAIL / PFAIL` set. (Same idea as the existing `FAIL/PFAIL` gossip address update, extended to the `noaddr` case.)

If the recovered ip address is of a node who is master of the current node (slave) then the master's ip adress is set using `replicationSetMaster()`


### Tests

- Have added unit tests that verifies the fix
2 masters + 1 replica: force master `noaddr` on the replica’s view; assert master_host and master_link_status:up recover via gossip.
- To make the unit test possible have added a `debug force-noaddr` command to mark the node with `noaddr` for debugging purpose only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster gossip address-update logic and can change how nodes reconnect and how replicas retarget their master after IP/port changes; mistakes could cause incorrect peer addressing or replication flaps.
> 
> **Overview**
> Fixes cluster peers getting stuck in `NOADDR` by allowing *trusted gossip* from healthy nodes to overwrite the address/ports of an existing `NOADDR` node, clearing the flag, dropping stale links, and persisting the updated config.
> 
> When the repaired node is the current replica's master, the replica now updates its replication target via `replicationSetMaster()`.
> 
> Adds `DEBUG FORCE-NOADDR <node-id>` (testing only) and a new unit test `noaddr-gossip-recovery.tcl` to verify both address repair and replica master reconnection after forced `NOADDR`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f02f3429bfb34ba42d335523eded25766923f1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->