### PR TITLE
Use no_value dict type for stream_idmp_keys to explicitly mark it as a key-only set

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -3033,7 +3033,7 @@ void asmTriggerBackgroundTrim(asmTrimCtx *trim_ctx, int migration_cleanup) {
                                      CLUSTER_SLOT_MASK_BITS,
                                      KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
     estore *subexpires = estoreCreate(&subexpiresBucketsType, CLUSTER_SLOT_MASK_BITS);
-    dict *stream_idmp_keys = dictCreate(&objectKeyPointerValueDictType);
+    dict *stream_idmp_keys = dictCreate(&streamIdmpKeysDictType);
 
     size_t total_keys = 0;
 

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -3033,7 +3033,7 @@ void asmTriggerBackgroundTrim(asmTrimCtx *trim_ctx, int migration_cleanup) {
                                      CLUSTER_SLOT_MASK_BITS,
                                      KVSTORE_ALLOCATE_DICTS_ON_DEMAND);
     estore *subexpires = estoreCreate(&subexpiresBucketsType, CLUSTER_SLOT_MASK_BITS);
-    dict *stream_idmp_keys = dictCreate(&streamIdmpKeysDictType);
+    dict *stream_idmp_keys = dictCreate(&objectKeyNoValueDictType);
 
     size_t total_keys = 0;
 

--- a/src/db.c
+++ b/src/db.c
@@ -1083,7 +1083,7 @@ redisDb *initTempDb(void) {
         tempDb[i].expires = kvstoreCreate(&kvstoreBaseType, &dbExpiresDictType,
                                           slot_count_bits, flags);
         tempDb[i].subexpires = estoreCreate(&subexpiresBucketsType, slot_count_bits);
-        tempDb[i].stream_idmp_keys = dictCreate(&objectKeyPointerValueDictType);
+        tempDb[i].stream_idmp_keys = dictCreate(&streamIdmpKeysDictType);
     }
 
     return tempDb;
@@ -1117,7 +1117,7 @@ void streamMoveIdmpKeys(dict *src, dict *dst, int slot) {
     while ((de = dictNext(di)) != NULL) {
         robj *key = dictGetKey(de);
         if (calculateKeySlot(key->ptr) == slot) {
-            if (dictAdd(dst, key, dictGetVal(de)) == DICT_OK) {
+            if (dictAdd(dst, key, NULL) == DICT_OK) {
                 incrRefCount(key);
             }
             dictDelete(src, key);

--- a/src/db.c
+++ b/src/db.c
@@ -1117,7 +1117,7 @@ void streamMoveIdmpKeys(dict *src, dict *dst, int slot) {
     while ((de = dictNext(di)) != NULL) {
         robj *key = dictGetKey(de);
         if (calculateKeySlot(key->ptr) == slot) {
-            if (dictAdd(dst, key, NULL) == DICT_OK) {
+            if (dictAddRaw(dst, key, NULL)) {
                 incrRefCount(key);
             }
             dictDelete(src, key);

--- a/src/db.c
+++ b/src/db.c
@@ -1083,7 +1083,7 @@ redisDb *initTempDb(void) {
         tempDb[i].expires = kvstoreCreate(&kvstoreBaseType, &dbExpiresDictType,
                                           slot_count_bits, flags);
         tempDb[i].subexpires = estoreCreate(&subexpiresBucketsType, slot_count_bits);
-        tempDb[i].stream_idmp_keys = dictCreate(&streamIdmpKeysDictType);
+        tempDb[i].stream_idmp_keys = dictCreate(&objectKeyNoValueDictType);
     }
 
     return tempDb;

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -332,7 +332,7 @@ void emptyDbAsync(redisDb *db) {
     db->keys = kvstoreCreate(&kvstoreExType, &dbDictType, slot_count_bits, flags);
     db->expires = kvstoreCreate(&kvstoreBaseType, &dbExpiresDictType, slot_count_bits, flags);
     db->subexpires = estoreCreate(&subexpiresBucketsType, slot_count_bits);
-    db->stream_idmp_keys = dictCreate(&objectKeyPointerValueDictType);
+    db->stream_idmp_keys = dictCreate(&streamIdmpKeysDictType);
     protectClientReplyObjects(); /* Protect client reply objects before async free. */
     emptyDbDataAsync(oldkeys, oldexpires, oldsubexpires, old_stream_idmp_keys, NULL);
 }

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -332,7 +332,7 @@ void emptyDbAsync(redisDb *db) {
     db->keys = kvstoreCreate(&kvstoreExType, &dbDictType, slot_count_bits, flags);
     db->expires = kvstoreCreate(&kvstoreBaseType, &dbExpiresDictType, slot_count_bits, flags);
     db->subexpires = estoreCreate(&subexpiresBucketsType, slot_count_bits);
-    db->stream_idmp_keys = dictCreate(&streamIdmpKeysDictType);
+    db->stream_idmp_keys = dictCreate(&objectKeyNoValueDictType);
     protectClientReplyObjects(); /* Protect client reply objects before async free. */
     emptyDbDataAsync(oldkeys, oldexpires, oldsubexpires, old_stream_idmp_keys, NULL);
 }

--- a/src/server.c
+++ b/src/server.c
@@ -581,7 +581,8 @@ dictType objectKeyPointerValueDictType = {
     NULL                       /* allow to expand */
 };
 
-/* Dict type for stream IDMP keys - keys are set of stream keys (robj pointers), values unused */
+/* Dict type for stream IDMP keys - keys are set of stream keys (robj pointers), 
+ * values unused */
 dictType streamIdmpKeysDictType = {
     dictEncObjHash,            /* hash function */
     NULL,                      /* key dup */
@@ -589,7 +590,7 @@ dictType streamIdmpKeysDictType = {
     dictEncObjKeyCompare,      /* key compare */
     dictObjectDestructor,      /* key destructor */
     NULL,                      /* val destructor */
-    NULL,                       /* allow to expand */
+    NULL,                      /* allow to expand */
     .no_value = 1,             /* no values in this dict */
 };
 

--- a/src/server.c
+++ b/src/server.c
@@ -581,8 +581,7 @@ dictType objectKeyPointerValueDictType = {
     NULL                       /* allow to expand */
 };
 
-/* Dict type for stream IDMP keys - keys are set of stream keys (robj pointers), 
- * values unused */
+/* Dict type with robj pointer keys and no values. */
 dictType objectKeyNoValueDictType = {
     dictEncObjHash,            /* hash function */
     NULL,                      /* key dup */
@@ -592,7 +591,7 @@ dictType objectKeyNoValueDictType = {
     NULL,                      /* val destructor */
     NULL,                      /* allow to expand */
     .no_value = 1,             /* no values in this dict */
-    .keys_are_odd = 0,         /* stream keys (robj pointers) are not odd */
+    .keys_are_odd = 0,         /* robj pointers are not odd */
 };
 
 /* Like objectKeyPointerValueDictType(), but values can be destroyed, if

--- a/src/server.c
+++ b/src/server.c
@@ -592,6 +592,7 @@ dictType objectKeyNoValueDictType = {
     NULL,                      /* val destructor */
     NULL,                      /* allow to expand */
     .no_value = 1,             /* no values in this dict */
+    .keys_are_odd = 0,         /* stream keys (robj pointers) are not odd */
 };
 
 /* Like objectKeyPointerValueDictType(), but values can be destroyed, if

--- a/src/server.c
+++ b/src/server.c
@@ -581,6 +581,18 @@ dictType objectKeyPointerValueDictType = {
     NULL                       /* allow to expand */
 };
 
+/* Dict type for stream IDMP keys - keys are set of stream keys (robj pointers), values unused */
+dictType streamIdmpKeysDictType = {
+    dictEncObjHash,            /* hash function */
+    NULL,                      /* key dup */
+    NULL,                      /* val dup */
+    dictEncObjKeyCompare,      /* key compare */
+    dictObjectDestructor,      /* key destructor */
+    NULL,                      /* val destructor */
+    NULL,                       /* allow to expand */
+    .no_value = 1,             /* no values in this dict */
+};
+
 /* Like objectKeyPointerValueDictType(), but values can be destroyed, if
  * not NULL, calling zfree(). */
 dictType objectKeyHeapPointerValueDictType = {
@@ -2994,7 +3006,7 @@ void initServer(void) {
         server.db[j].blocking_keys = dictCreate(&keylistDictType);
         server.db[j].blocking_keys_unblock_on_nokey = dictCreate(&objectKeyPointerValueDictType);
         server.db[j].stream_claim_pending_keys = dictCreate(&objectKeyPointerValueDictType);
-        server.db[j].stream_idmp_keys = dictCreate(&objectKeyPointerValueDictType);
+        server.db[j].stream_idmp_keys = dictCreate(&streamIdmpKeysDictType);
         server.db[j].ready_keys = dictCreate(&objectKeyPointerValueDictType);
         server.db[j].watched_keys = dictCreate(&keylistDictType);
         server.db[j].id = j;

--- a/src/server.c
+++ b/src/server.c
@@ -583,7 +583,7 @@ dictType objectKeyPointerValueDictType = {
 
 /* Dict type for stream IDMP keys - keys are set of stream keys (robj pointers), 
  * values unused */
-dictType streamIdmpKeysDictType = {
+dictType objectKeyNoValueDictType = {
     dictEncObjHash,            /* hash function */
     NULL,                      /* key dup */
     NULL,                      /* val dup */
@@ -3007,7 +3007,7 @@ void initServer(void) {
         server.db[j].blocking_keys = dictCreate(&keylistDictType);
         server.db[j].blocking_keys_unblock_on_nokey = dictCreate(&objectKeyPointerValueDictType);
         server.db[j].stream_claim_pending_keys = dictCreate(&objectKeyPointerValueDictType);
-        server.db[j].stream_idmp_keys = dictCreate(&streamIdmpKeysDictType);
+        server.db[j].stream_idmp_keys = dictCreate(&objectKeyNoValueDictType);
         server.db[j].ready_keys = dictCreate(&objectKeyPointerValueDictType);
         server.db[j].watched_keys = dictCreate(&keylistDictType);
         server.db[j].id = j;

--- a/src/server.h
+++ b/src/server.h
@@ -3003,7 +3003,7 @@ typedef struct {
 extern struct redisServer server;
 extern struct sharedObjectsStruct shared;
 extern dictType objectKeyPointerValueDictType;
-extern dictType streamIdmpKeysDictType;
+extern dictType objectKeyNoValueDictType;
 extern dictType objectKeyHeapPointerValueDictType;
 extern dictType setDictType;
 extern dictType BenchmarkDictType;

--- a/src/server.h
+++ b/src/server.h
@@ -3003,6 +3003,7 @@ typedef struct {
 extern struct redisServer server;
 extern struct sharedObjectsStruct shared;
 extern dictType objectKeyPointerValueDictType;
+extern dictType streamIdmpKeysDictType;
 extern dictType objectKeyHeapPointerValueDictType;
 extern dictType setDictType;
 extern dictType BenchmarkDictType;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -5712,7 +5712,7 @@ void streamKeyLoaded(redisDb *db, robj *key, robj *val) {
         robj *tracked_key = key;
         if (key->refcount == OBJ_STATIC_REFCOUNT)
             tracked_key = createStringObject(key->ptr, sdslen(key->ptr));
-        if (dictAddRaw(db->stream_idmp_keys, tracked_key, NULL)) {
+        if (dictAdd(db->stream_idmp_keys, tracked_key, NULL) == DICT_OK) {
             incrRefCount(tracked_key);
         }
         if (tracked_key != key)

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -5700,7 +5700,7 @@ static idmpProducer *idmpGetOrCreateProducer(stream *s, const char *pid, size_t 
  * by a previous XADD operation), this function does nothing, as the stream
  * is already registered for periodic cleanup. */
 static void trackStreamIdmpEntries(client *c, robj *key) {
-    if (dictAddRaw(c->db->stream_idmp_keys, key, NULL)) {
+    if (dictAdd(c->db->stream_idmp_keys, key, NULL) == DICT_OK) {
         incrRefCount(key);
     }
 }
@@ -5720,7 +5720,7 @@ void streamKeyLoaded(redisDb *db, robj *key, robj *val) {
     }
 }
 
-/* To be used when a steam key was removed from ram, un-redigster from stream_idmp_keys if needed */
+/* To be used when a stream key was removed from ram, un-register from stream_idmp_keys if needed */
 void streamKeyRemoved(redisDb *db, robj *key, robj *val) {
     UNUSED(val);
     dictDelete(db->stream_idmp_keys, key);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -5700,7 +5700,7 @@ static idmpProducer *idmpGetOrCreateProducer(stream *s, const char *pid, size_t 
  * by a previous XADD operation), this function does nothing, as the stream
  * is already registered for periodic cleanup. */
 static void trackStreamIdmpEntries(client *c, robj *key) {
-    if (dictAdd(c->db->stream_idmp_keys, key, NULL) == DICT_OK) {
+    if (dictAddRaw(c->db->stream_idmp_keys, key, NULL)) {
         incrRefCount(key);
     }
 }
@@ -5712,7 +5712,7 @@ void streamKeyLoaded(redisDb *db, robj *key, robj *val) {
         robj *tracked_key = key;
         if (key->refcount == OBJ_STATIC_REFCOUNT)
             tracked_key = createStringObject(key->ptr, sdslen(key->ptr));
-        if (dictAdd(db->stream_idmp_keys, tracked_key, NULL) == DICT_OK) {
+        if (dictAddRaw(db->stream_idmp_keys, tracked_key, NULL)) {
             incrRefCount(tracked_key);
         }
         if (tracked_key != key)


### PR DESCRIPTION
Fixes #14985

### Problem

dict stream_idmp_keys was using objectKeyPointerValueDictType, in this dict type dicts are expected to have RObj as keys and Pointers as values, but stream_idmp_keys was not using the value field at all.

### Solution
This PR fixes the above issue by implementing new dict type (objectKeyNoValueDictType) for stream_idmp_keys



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a contained data-structure change that mainly affects allocation/move paths for `stream_idmp_keys`; behavioral impact should be limited to stream idempotency key tracking and slot trim/migration helpers.
> 
> **Overview**
> **Makes `stream_idmp_keys` explicitly key-only.** Introduces `objectKeyNoValueDictType` (with `.no_value = 1`) and updates DB initialization, temp DB creation, lazyfree emptying, and cluster ASM background trim to create `stream_idmp_keys` using this type instead of `objectKeyPointerValueDictType`.
> 
> Adjusts `streamMoveIdmpKeys()` to add keys to the destination dict via `dictAddRaw(..., NULL)` (no value stored), and includes a small comment typo fix in `t_stream.c`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b09e2499b365f2325e8618d8fa499d799ad7471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->