### PR TITLE
Add batched prefetch for HGETALL on hashtable encoding

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3074,7 +3074,7 @@ void genericHgetallCommand(client *c, int flags) {
      * value SDS data, then emit replies while the data is cache-warm.
      * This hides the latency of pointer chasing through scattered
      * heap allocations (dictEntry → Entry → value SDS). */
-    #define HGETALL_BATCH 16
+#define HGETALL_BATCH 16
     if (o->encoding == OBJ_ENCODING_HT) {
         int skip_expired = !server.allow_access_expired;
         dict *d = o->ptr;
@@ -3088,23 +3088,17 @@ void genericHgetallCommand(client *c, int flags) {
              * skipping expired fields (unless allow_access_expired),
              * and prefetching Entry structs. */
             batch_count = 0;
-            for (int i = 0; i < HGETALL_BATCH; i++) {
-                dictEntry *de;
-                Entry *e;
-                while ((de = dictNext(&di)) != NULL) {
-                    e = dictGetKey(de);
-                    if (skip_expired) {
-                        uint64_t expire_time = entryGetExpiry(e);
-                        if (expire_time != EB_EXPIRE_TIME_INVALID &&
-                            (mstime_t)expire_time < commandTimeSnapshot())
-                            continue;
-                    }
-                    break;
-                }
+            while (batch_count < HGETALL_BATCH) {
+                dictEntry *de = dictNext(&di);
                 if (!de) break;
-                batch_entry[batch_count] = e;
+                Entry *e = dictGetKey(de);
+                if (skip_expired) {
+                    uint64_t expire_time = entryGetExpiry(e);
+                    if (expire_time != EB_EXPIRE_TIME_INVALID && (mstime_t)expire_time < commandTimeSnapshot())
+                        continue;
+                }
+                batch_entry[batch_count++] = e;
                 redis_prefetch_read(e);
-                batch_count++;
             }
             if (batch_count == 0) break;
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3074,18 +3074,15 @@ void genericHgetallCommand(client *c, int flags) {
      * value SDS data, then emit replies while the data is cache-warm.
      * This hides the latency of pointer chasing through scattered
      * heap allocations (dictEntry → Entry → value SDS). */
+    #define HGETALL_BATCH 16
     if (o->encoding == OBJ_ENCODING_HT &&
-        (flags & OBJ_HASH_KEY) && (flags & OBJ_HASH_VALUE) &&
-        server.prefetch_batch_max_size > 0)
+        (flags & OBJ_HASH_KEY) && (flags & OBJ_HASH_VALUE))
     {
-        #define HGETALL_BATCH_MAX 16
-        int batch_size = server.prefetch_batch_max_size < HGETALL_BATCH_MAX
-                       ? server.prefetch_batch_max_size : HGETALL_BATCH_MAX;
         int skip_expired = !server.allow_access_expired;
         dict *d = o->ptr;
         dictIterator di;
         dictInitSafeIterator(&di, d);
-        Entry *batch_entry[HGETALL_BATCH_MAX];
+        Entry *batch_entry[HGETALL_BATCH];
 
         int batch_count;
         while (1) {
@@ -3093,7 +3090,7 @@ void genericHgetallCommand(client *c, int flags) {
              * skipping expired fields (unless allow_access_expired),
              * and prefetching Entry structs. */
             batch_count = 0;
-            for (int i = 0; i < batch_size; i++) {
+            for (int i = 0; i < HGETALL_BATCH; i++) {
                 dictEntry *de;
                 Entry *e;
                 while ((de = dictNext(&di)) != NULL) {
@@ -3133,24 +3130,26 @@ void genericHgetallCommand(client *c, int flags) {
                 count += 2;
             }
         }
-        #undef HGETALL_BATCH_MAX
         dictResetIterator(&di);
-    } else {
-        hashTypeInitIterator(&hi, o);
-
-        while (hashTypeNext(&hi, 1 /*skipExpiredFields*/) != C_ERR) {
-            if (flags & OBJ_HASH_KEY) {
-                addHashIteratorCursorToReply(c, &hi, OBJ_HASH_KEY);
-                count++;
-            }
-            if (flags & OBJ_HASH_VALUE) {
-                addHashIteratorCursorToReply(c, &hi, OBJ_HASH_VALUE);
-                count++;
-            }
-        }
-
-        hashTypeResetIterator(&hi);
+        goto done;
     }
+
+    hashTypeInitIterator(&hi, o);
+
+    while (hashTypeNext(&hi, 1 /*skipExpiredFields*/) != C_ERR) {
+        if (flags & OBJ_HASH_KEY) {
+            addHashIteratorCursorToReply(c, &hi, OBJ_HASH_KEY);
+            count++;
+        }
+        if (flags & OBJ_HASH_VALUE) {
+            addHashIteratorCursorToReply(c, &hi, OBJ_HASH_VALUE);
+            count++;
+        }
+    }
+
+    hashTypeResetIterator(&hi);
+
+done:
     if (server.memory_tracking_enabled)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldsize, kvobjAllocSize(o));
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3075,8 +3075,7 @@ void genericHgetallCommand(client *c, int flags) {
      * This hides the latency of pointer chasing through scattered
      * heap allocations (dictEntry → Entry → value SDS). */
     #define HGETALL_BATCH 16
-    if (o->encoding == OBJ_ENCODING_HT &&
-        (flags & OBJ_HASH_KEY) && (flags & OBJ_HASH_VALUE))
+    if (o->encoding == OBJ_ENCODING_HT)
     {
         int skip_expired = !server.allow_access_expired;
         dict *d = o->ptr;
@@ -3113,21 +3112,26 @@ void genericHgetallCommand(client *c, int flags) {
             /* Phase 2: Entry structs are now warm — prefetch value SDS.
              * For entries with pointer-based values (Type 3), this
              * dereferences the value pointer and prefetches the
-             * separately allocated value data. */
-            for (int i = 0; i < batch_count; i++) {
-                sds val = entryGetValue(batch_entry[i]);
-                redis_prefetch_read(val);
+             * separately allocated value data. Skip if only keys. */
+            if (flags & OBJ_HASH_VALUE) {
+                for (int i = 0; i < batch_count; i++) {
+                    sds val = entryGetValue(batch_entry[i]);
+                    redis_prefetch_read(val);
+                }
             }
 
             /* Phase 3: process batch — field + value data is cache-warm. */
             for (int i = 0; i < batch_count; i++) {
-                sds field = entryGetField(batch_entry[i]);
-                size_t flen = sdslen(field);
-                sds val = entryGetValue(batch_entry[i]);
-                size_t vlen = sdslen(val);
-                addReplyBulkCBuffer(c, field, flen);
-                addReplyBulkCBuffer(c, val, vlen);
-                count += 2;
+                if (flags & OBJ_HASH_KEY) {
+                    sds field = entryGetField(batch_entry[i]);
+                    addReplyBulkCBuffer(c, field, sdslen(field));
+                    count++;
+                }
+                if (flags & OBJ_HASH_VALUE) {
+                    sds val = entryGetValue(batch_entry[i]);
+                    addReplyBulkCBuffer(c, val, sdslen(val));
+                    count++;
+                }
             }
         }
         dictResetIterator(&di);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3078,32 +3078,35 @@ void genericHgetallCommand(client *c, int flags) {
         (flags & OBJ_HASH_KEY) && (flags & OBJ_HASH_VALUE) &&
         server.prefetch_batch_max_size > 0)
     {
-        #define HGETALL_BATCH 16
+        #define HGETALL_BATCH_MAX 16
+        int batch_size = server.prefetch_batch_max_size < HGETALL_BATCH_MAX
+                       ? server.prefetch_batch_max_size : HGETALL_BATCH_MAX;
+        int skip_expired = !server.allow_access_expired;
         dict *d = o->ptr;
         dictIterator di;
         dictInitSafeIterator(&di, d);
-        dictEntry *batch_de[HGETALL_BATCH];
-        Entry *batch_entry[HGETALL_BATCH];
+        Entry *batch_entry[HGETALL_BATCH_MAX];
 
         int batch_count;
         while (1) {
             /* Phase 1: collect batch of entries from dict iterator,
-             * skipping expired fields and prefetching Entry structs. */
+             * skipping expired fields (unless allow_access_expired),
+             * and prefetching Entry structs. */
             batch_count = 0;
-            for (int i = 0; i < HGETALL_BATCH; i++) {
+            for (int i = 0; i < batch_size; i++) {
                 dictEntry *de;
                 Entry *e;
-                /* Skip expired fields like hashTypeNext does. */
                 while ((de = dictNext(&di)) != NULL) {
                     e = dictGetKey(de);
-                    uint64_t expire_time = entryGetExpiry(e);
-                    if (expire_time != EB_EXPIRE_TIME_INVALID &&
-                        (mstime_t)expire_time < commandTimeSnapshot())
-                        continue;
+                    if (skip_expired) {
+                        uint64_t expire_time = entryGetExpiry(e);
+                        if (expire_time != EB_EXPIRE_TIME_INVALID &&
+                            (mstime_t)expire_time < commandTimeSnapshot())
+                            continue;
+                    }
                     break;
                 }
                 if (!de) break;
-                batch_de[batch_count] = de;
                 batch_entry[batch_count] = e;
                 redis_prefetch_read(e);
                 batch_count++;
@@ -3130,7 +3133,7 @@ void genericHgetallCommand(client *c, int flags) {
                 count += 2;
             }
         }
-        #undef HGETALL_BATCH
+        #undef HGETALL_BATCH_MAX
         dictResetIterator(&di);
     } else {
         hashTypeInitIterator(&hi, o);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3075,8 +3075,7 @@ void genericHgetallCommand(client *c, int flags) {
      * This hides the latency of pointer chasing through scattered
      * heap allocations (dictEntry → Entry → value SDS). */
     #define HGETALL_BATCH 16
-    if (o->encoding == OBJ_ENCODING_HT)
-    {
+    if (o->encoding == OBJ_ENCODING_HT) {
         int skip_expired = !server.allow_access_expired;
         dict *d = o->ptr;
         dictIterator di;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3068,20 +3068,86 @@ void genericHgetallCommand(client *c, int flags) {
 
     if (server.memory_tracking_enabled)
         oldsize = kvobjAllocSize(o);
-    hashTypeInitIterator(&hi, o);
 
-    while (hashTypeNext(&hi, 1 /*skipExpiredFields*/) != C_ERR) {
-        if (flags & OBJ_HASH_KEY) {
-            addHashIteratorCursorToReply(c, &hi, OBJ_HASH_KEY);
-            count++;
+    /* Fast path: batched prefetch for hashtable-encoded HGETALL.
+     * Collect a batch of dict entries, prefetch their Entry structs and
+     * value SDS data, then emit replies while the data is cache-warm.
+     * This hides the latency of pointer chasing through scattered
+     * heap allocations (dictEntry → Entry → value SDS). */
+    if (o->encoding == OBJ_ENCODING_HT &&
+        (flags & OBJ_HASH_KEY) && (flags & OBJ_HASH_VALUE) &&
+        server.prefetch_batch_max_size > 0)
+    {
+        #define HGETALL_BATCH 16
+        dict *d = o->ptr;
+        dictIterator di;
+        dictInitSafeIterator(&di, d);
+        dictEntry *batch_de[HGETALL_BATCH];
+        Entry *batch_entry[HGETALL_BATCH];
+
+        int batch_count;
+        while (1) {
+            /* Phase 1: collect batch of entries from dict iterator,
+             * skipping expired fields and prefetching Entry structs. */
+            batch_count = 0;
+            for (int i = 0; i < HGETALL_BATCH; i++) {
+                dictEntry *de;
+                Entry *e;
+                /* Skip expired fields like hashTypeNext does. */
+                while ((de = dictNext(&di)) != NULL) {
+                    e = dictGetKey(de);
+                    uint64_t expire_time = entryGetExpiry(e);
+                    if (expire_time != EB_EXPIRE_TIME_INVALID &&
+                        (mstime_t)expire_time < commandTimeSnapshot())
+                        continue;
+                    break;
+                }
+                if (!de) break;
+                batch_de[batch_count] = de;
+                batch_entry[batch_count] = e;
+                redis_prefetch_read(e);
+                batch_count++;
+            }
+            if (batch_count == 0) break;
+
+            /* Phase 2: Entry structs are now warm — prefetch value SDS.
+             * For entries with pointer-based values (Type 3), this
+             * dereferences the value pointer and prefetches the
+             * separately allocated value data. */
+            for (int i = 0; i < batch_count; i++) {
+                sds val = entryGetValue(batch_entry[i]);
+                redis_prefetch_read(val);
+            }
+
+            /* Phase 3: process batch — field + value data is cache-warm. */
+            for (int i = 0; i < batch_count; i++) {
+                sds field = entryGetField(batch_entry[i]);
+                size_t flen = sdslen(field);
+                sds val = entryGetValue(batch_entry[i]);
+                size_t vlen = sdslen(val);
+                addReplyBulkCBuffer(c, field, flen);
+                addReplyBulkCBuffer(c, val, vlen);
+                count += 2;
+            }
         }
-        if (flags & OBJ_HASH_VALUE) {
-            addHashIteratorCursorToReply(c, &hi, OBJ_HASH_VALUE);
-            count++;
+        #undef HGETALL_BATCH
+        dictResetIterator(&di);
+    } else {
+        hashTypeInitIterator(&hi, o);
+
+        while (hashTypeNext(&hi, 1 /*skipExpiredFields*/) != C_ERR) {
+            if (flags & OBJ_HASH_KEY) {
+                addHashIteratorCursorToReply(c, &hi, OBJ_HASH_KEY);
+                count++;
+            }
+            if (flags & OBJ_HASH_VALUE) {
+                addHashIteratorCursorToReply(c, &hi, OBJ_HASH_VALUE);
+                count++;
+            }
         }
+
+        hashTypeResetIterator(&hi);
     }
-
-    hashTypeResetIterator(&hi);
     if (server.memory_tracking_enabled)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldsize, kvobjAllocSize(o));
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3081,47 +3081,51 @@ void genericHgetallCommand(client *c, int flags) {
         dictIterator di;
         dictInitSafeIterator(&di, d);
         Entry *batch_entry[HGETALL_BATCH];
+        sds batch_val[HGETALL_BATCH];
 
-        int batch_count;
         while (1) {
-            /* Phase 1: collect batch of entries from dict iterator,
-             * skipping expired fields (unless allow_access_expired),
-             * and prefetching Entry structs. */
-            batch_count = 0;
+            /* Phase 1: pull a batch of entries from the dict iterator and
+             * prefetch their Entry structs. Pure pointer-fetch — we don't
+             * dereference Entry here so the prefetch is effective. */
+            int batch_count = 0;
             while (batch_count < HGETALL_BATCH) {
                 dictEntry *de = dictNext(&di);
                 if (!de) break;
                 Entry *e = dictGetKey(de);
-                if (skip_expired) {
-                    uint64_t expire_time = entryGetExpiry(e);
-                    if (expire_time != EB_EXPIRE_TIME_INVALID && (mstime_t)expire_time < commandTimeSnapshot())
-                        continue;
-                }
                 batch_entry[batch_count++] = e;
                 redis_prefetch_read(e);
             }
             if (batch_count == 0) break;
 
-            /* Phase 2: Entry structs are now warm — prefetch value SDS.
-             * For entries with pointer-based values (Type 3), this
-             * dereferences the value pointer and prefetches the
-             * separately allocated value data. Skip if only keys. */
-            if (flags & OBJ_HASH_VALUE) {
-                for (int i = 0; i < batch_count; i++) {
-                    sds val = entryGetValue(batch_entry[i]);
+            /* Phase 2: Entry structs are warm — check expiry, extract value,
+             * and prefetch the value SDS. Expired entries are dropped from
+             * the batch by compacting in place. */
+            int valid_count = 0;
+            for (int i = 0; i < batch_count; i++) {
+                Entry *e = batch_entry[i];
+                if (skip_expired) {
+                    uint64_t expire_time = entryGetExpiry(e);
+                    if (expire_time != EB_EXPIRE_TIME_INVALID && (mstime_t)expire_time < commandTimeSnapshot())
+                        continue;
+                }
+                batch_entry[valid_count] = e;
+                if (flags & OBJ_HASH_VALUE) {
+                    sds val = entryGetValue(e);
+                    batch_val[valid_count] = val;
                     redis_prefetch_read(val);
                 }
+                valid_count++;
             }
 
-            /* Phase 3: process batch — field + value data is cache-warm. */
-            for (int i = 0; i < batch_count; i++) {
+            /* Phase 3: emit replies — field + value data is cache-warm. */
+            for (int i = 0; i < valid_count; i++) {
                 if (flags & OBJ_HASH_KEY) {
                     sds field = entryGetField(batch_entry[i]);
                     addReplyBulkCBuffer(c, field, sdslen(field));
                     count++;
                 }
                 if (flags & OBJ_HASH_VALUE) {
-                    sds val = entryGetValue(batch_entry[i]);
+                    sds val = batch_val[i];
                     addReplyBulkCBuffer(c, val, sdslen(val));
                     count++;
                 }


### PR DESCRIPTION
## Summary

Add a batched prefetch fast path for `HGETALL`  on hashtable-encoded hashes. When iterating large hash tables, pointer chasing through scattered heap allocations (`dictEntry` → `Entry` → value SDS) causes cache misses that dominate CPU time (~10% flat in `dictNext`).

The new path collects dict entries in batches of configured batch size, issues software prefetches for the `Entry` structs and their value SDS data, then emits replies while the data is cache-warm. This hides memory latency by overlapping prefetch with reply generation.

**Conditions for the fast path:**
- Hashtable encoding (not listpack)
- Both key and value requested
- `prefetch-batch-max-size` > 0

Falls back to the existing generic iterator path otherwise.

## Benchmark Results

Tested on `x86-aws-m7i.metal-24xl` and `arm-aws-m8g.metal-24xl`, `oss-standalone` topology.

### x86 — 5 improvements, 0 regressions

| Test | Baseline (unstable) | PR | Change |
|------|---------------------|-----|--------|
| 10Kkeys-500f-100B | 14,387 ±3.1% | 17,229 ±1.8% | **+19.8%** |
| 10Kkeys-200f-100B | 35,701 ±0.2% | 42,024 ±0.9% | **+17.7%** |
| 1key-1Kf-hgetall-pipeline-10 | 15,409 ±0.8% | 18,116 ±0.3% | **+17.6%** |
| 1key-1Kf-hgetall | 16,539 ±0.7% | 18,866 ±0.2% | **+14.1%** |
| 10Kkeys-100f-100B | 65,592 ±0.1% | 72,793 ±1.3% | **+11.0%** |
| 100Kkeys-50f-100B | 163,447 ±1.4% | 163,626 ±2.0% | +0.1% |
| 1Mkeys-50f-10B (listpack) | 171,672 ±1.9% | 174,819 | +1.8% |
| 1Mkeys-mixed-hget/hgetall/hkeys/hvals | 173,737 ±2.0% | 173,966 | +0.1% |

### ARM — 5 improvements, 0 regressions

| Test | Baseline (unstable) | PR | Change |
|------|---------------------|-----|--------|
| 10Kkeys-200f-100B | 43,894 ±1.1% | 52,665 ±1.2% | **+20.0%** |
| 1key-1Kf-hgetall-pipeline-10 | 15,146 ±0.7% | 17,732 ±0.1% | **+17.1%** |
| 1key-1Kf-hgetall | 16,216 ±0.5% | 18,659 ±0.5% | **+15.1%** |
| 10Kkeys-100f-100B | 77,862 ±1.4% | 86,865 ±0.6% | **+11.6%** |
| 100Kkeys-50f-100B | 205,051 ±0.4% | 206,866 ±0.5% | +0.9% |
| 1Mkeys-50f-10B (listpack) | 212,915 ±0.6% | 211,842 | -0.5% |
| 1Mkeys-mixed-hget/hgetall/hkeys/hvals | 219,900 ±0.4% | 220,934 | +0.5% |

Improvement scales with field count — more fields means more cache misses hidden by prefetch. Zero regressions on listpack-encoded or small hashtable hashes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot reply/iteration path for `HGETALL` and adds new control flow (`goto done`) plus expiry filtering, so subtle count/order or iterator correctness issues could surface under edge cases despite being scoped to HT encoding.
> 
> **Overview**
> Adds a **batched prefetch fast path** to `genericHgetallCommand` for hashtable-encoded hashes (`OBJ_ENCODING_HT`), issuing `redis_prefetch_read` on `Entry` structs and their value SDS in small batches before writing replies.
> 
> The new path compacts out expired fields (when `allow_access_expired` is off), preserves existing reply shape/count assertions, and falls back to the existing `hashTypeIterator` loop for non-HT encodings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b475e1ccad89216bca6fdcf999149c77c08f1ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->