### PR TITLE
Use SHUTDOWN instead of CLUSTER RESET SOFT in del-node

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -116,7 +116,7 @@
 #define CLUSTER_MANAGER_CMD_FLAG_FIX_WITH_UNREACHABLE_MASTERS 1 << 10
 #define CLUSTER_MANAGER_CMD_FLAG_MASTERS_ONLY   1 << 11
 #define CLUSTER_MANAGER_CMD_FLAG_SLAVES_ONLY    1 << 12
-#define CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN       1 << 13
+#define CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN_AFTER_DEL 1 << 13
 
 #define CLUSTER_MANAGER_OPT_GETFRIENDS  1 << 0
 #define CLUSTER_MANAGER_OPT_COLD        1 << 1
@@ -2997,9 +2997,9 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--cluster-fix-with-unreachable-masters")) {
             config.cluster_manager_command.flags |=
                 CLUSTER_MANAGER_CMD_FLAG_FIX_WITH_UNREACHABLE_MASTERS;
-        } else if (!strcmp(argv[i],"--cluster-shutdown")) {
+        } else if (!strcmp(argv[i],"--cluster-shutdown-after-del")) {
             config.cluster_manager_command.flags |=
-                CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN;
+                CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN_AFTER_DEL;
         } else if (!strcmp(argv[i],"--test_hint") && !lastarg) {
             config.test_hint = argv[++i];
         } else if (!strcmp(argv[i],"--test_hint_file") && !lastarg) {
@@ -3952,7 +3952,7 @@ clusterManagerCommandDef clusterManagerCommands[] = {
      "timeout <arg>,simulate,pipeline <arg>,threshold <arg>,replace"},
     {"add-node", clusterManagerCommandAddNode, 2,
      "new_host:new_port existing_host:existing_port", "slave,master-id <arg>"},
-    {"del-node", clusterManagerCommandDeleteNode, 2, "host:port node_id","shutdown"},
+    {"del-node", clusterManagerCommandDeleteNode, 2, "host:port node_id","shutdown-after-del"},
     {"call", clusterManagerCommandCall, -2,
         "host:port command arg arg .. arg", "only-masters,only-replicas"},
     {"set-timeout", clusterManagerCommandSetTimeout, 2,
@@ -7566,8 +7566,8 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
         if (!success) return 0;
     }
 
-    if (config.cluster_manager_command.flags & CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN) {
-        /* With --cluster-shutdown: send SHUTDOWN NOSAVE so that clients get a
+    if (config.cluster_manager_command.flags & CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN_AFTER_DEL) {
+        /* With --cluster-shutdown-after-del: send SHUTDOWN NOSAVE so that clients get a
          * clear connection failure instead of connecting to a stale standalone
          * node.  If SHUTDOWN fails, fall back to CLUSTER RESET SOFT. */
         clusterManagerLogInfo(">>> Sending SHUTDOWN NOSAVE to the deleted node.\n");

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2997,7 +2997,7 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--cluster-fix-with-unreachable-masters")) {
             config.cluster_manager_command.flags |=
                 CLUSTER_MANAGER_CMD_FLAG_FIX_WITH_UNREACHABLE_MASTERS;
-        } else if (!strcmp(argv[i],"--shutdown-nosave-on-del")) {
+        } else if (!strcmp(argv[i],"--cluster-shutdown-nosave-on-del")) {
             config.cluster_manager_command.flags |=
                 CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN_NOSAVE_ON_DEL;
         } else if (!strcmp(argv[i],"--test_hint") && !lastarg) {
@@ -7567,7 +7567,7 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
     }
 
     if (config.cluster_manager_command.flags & CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN_NOSAVE_ON_DEL) {
-        /* With --shutdown-nosave-on-del: send SHUTDOWN NOSAVE so that clients get a
+        /* With --cluster-shutdown-nosave-on-del: send SHUTDOWN NOSAVE so that clients get a
          * clear connection failure instead of connecting to a stale standalone
          * node.  If SHUTDOWN fails, fall back to CLUSTER RESET SOFT. */
         clusterManagerLogInfo(">>> Sending SHUTDOWN NOSAVE to the deleted node.\n");

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7562,10 +7562,21 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
         if (!success) return 0;
     }
 
-    /* Finally send CLUSTER RESET to the node. */
-    clusterManagerLogInfo(">>> Sending CLUSTER RESET SOFT to the "
-                          "deleted node.\n");
-    redisReply *r = redisCommand(node->context, "CLUSTER RESET %s", "SOFT");
+    /* Send SHUTDOWN to the node to ensure clients get a clear connection
+     * failure instead of connecting to a stale standalone node. If SHUTDOWN
+     * fails (disabled or no permission), fall back to CLUSTER RESET SOFT. */
+    clusterManagerLogInfo(">>> Sending SHUTDOWN NOSAVE to the deleted node.\n");
+    redisReply *r = redisCommand(node->context, "SHUTDOWN NOSAVE");
+    if (r == NULL && (node->context->err == REDIS_ERR_IO ||
+                       node->context->err == REDIS_ERR_EOF)) {
+        /* Connection closed - expected after successful SHUTDOWN */
+        clusterManagerLogOk("[OK] Node %s:%d shut down.\n", node->ip, node->port);
+        return 1;
+    }
+    /* SHUTDOWN failed - fall back to CLUSTER RESET SOFT */
+    if (r) freeReplyObject(r);
+    clusterManagerLogWarn(">>> SHUTDOWN failed, falling back to CLUSTER RESET SOFT.\n");
+    r = redisCommand(node->context, "CLUSTER RESET %s", "SOFT");
     success = clusterManagerCheckRedisReply(node, r, NULL);
     if (r) freeReplyObject(r);
     return success;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -116,6 +116,7 @@
 #define CLUSTER_MANAGER_CMD_FLAG_FIX_WITH_UNREACHABLE_MASTERS 1 << 10
 #define CLUSTER_MANAGER_CMD_FLAG_MASTERS_ONLY   1 << 11
 #define CLUSTER_MANAGER_CMD_FLAG_SLAVES_ONLY    1 << 12
+#define CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN       1 << 13
 
 #define CLUSTER_MANAGER_OPT_GETFRIENDS  1 << 0
 #define CLUSTER_MANAGER_OPT_COLD        1 << 1
@@ -2996,6 +2997,9 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--cluster-fix-with-unreachable-masters")) {
             config.cluster_manager_command.flags |=
                 CLUSTER_MANAGER_CMD_FLAG_FIX_WITH_UNREACHABLE_MASTERS;
+        } else if (!strcmp(argv[i],"--cluster-shutdown")) {
+            config.cluster_manager_command.flags |=
+                CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN;
         } else if (!strcmp(argv[i],"--test_hint") && !lastarg) {
             config.test_hint = argv[++i];
         } else if (!strcmp(argv[i],"--test_hint_file") && !lastarg) {
@@ -3948,7 +3952,7 @@ clusterManagerCommandDef clusterManagerCommands[] = {
      "timeout <arg>,simulate,pipeline <arg>,threshold <arg>,replace"},
     {"add-node", clusterManagerCommandAddNode, 2,
      "new_host:new_port existing_host:existing_port", "slave,master-id <arg>"},
-    {"del-node", clusterManagerCommandDeleteNode, 2, "host:port node_id",NULL},
+    {"del-node", clusterManagerCommandDeleteNode, 2, "host:port node_id","shutdown"},
     {"call", clusterManagerCommandCall, -2,
         "host:port command arg arg .. arg", "only-masters,only-replicas"},
     {"set-timeout", clusterManagerCommandSetTimeout, 2,
@@ -7562,21 +7566,27 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
         if (!success) return 0;
     }
 
-    /* Send SHUTDOWN to the node to ensure clients get a clear connection
-     * failure instead of connecting to a stale standalone node. If SHUTDOWN
-     * fails (disabled or no permission), fall back to CLUSTER RESET SOFT. */
-    clusterManagerLogInfo(">>> Sending SHUTDOWN NOSAVE to the deleted node.\n");
-    redisReply *r = redisCommand(node->context, "SHUTDOWN NOSAVE");
-    if (r == NULL && (node->context->err == REDIS_ERR_IO ||
-                       node->context->err == REDIS_ERR_EOF)) {
-        /* Connection closed - expected after successful SHUTDOWN */
-        clusterManagerLogOk("[OK] Node %s:%d shut down.\n", node->ip, node->port);
-        return 1;
+    if (config.cluster_manager_command.flags & CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN) {
+        /* With --cluster-shutdown: send SHUTDOWN NOSAVE so that clients get a
+         * clear connection failure instead of connecting to a stale standalone
+         * node.  If SHUTDOWN fails, fall back to CLUSTER RESET SOFT. */
+        clusterManagerLogInfo(">>> Sending SHUTDOWN NOSAVE to the deleted node.\n");
+        redisReply *r = redisCommand(node->context, "SHUTDOWN NOSAVE");
+        if (r == NULL && (node->context->err == REDIS_ERR_IO ||
+                           node->context->err == REDIS_ERR_EOF)) {
+            /* Connection closed - expected after successful SHUTDOWN */
+            clusterManagerLogOk("[OK] Node %s:%d shut down.\n", node->ip, node->port);
+            return 1;
+        }
+        /* SHUTDOWN failed - fall back to CLUSTER RESET SOFT */
+        if (r) freeReplyObject(r);
+        clusterManagerLogWarn(">>> SHUTDOWN failed, falling back to CLUSTER RESET SOFT.\n");
     }
-    /* SHUTDOWN failed - fall back to CLUSTER RESET SOFT */
-    if (r) freeReplyObject(r);
-    clusterManagerLogWarn(">>> SHUTDOWN failed, falling back to CLUSTER RESET SOFT.\n");
-    r = redisCommand(node->context, "CLUSTER RESET %s", "SOFT");
+
+    /* Finally send CLUSTER RESET to the node. */
+    clusterManagerLogInfo(">>> Sending CLUSTER RESET SOFT to the "
+                          "deleted node.\n");
+    redisReply *r = redisCommand(node->context, "CLUSTER RESET %s", "SOFT");
     success = clusterManagerCheckRedisReply(node, r, NULL);
     if (r) freeReplyObject(r);
     return success;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -116,7 +116,7 @@
 #define CLUSTER_MANAGER_CMD_FLAG_FIX_WITH_UNREACHABLE_MASTERS 1 << 10
 #define CLUSTER_MANAGER_CMD_FLAG_MASTERS_ONLY   1 << 11
 #define CLUSTER_MANAGER_CMD_FLAG_SLAVES_ONLY    1 << 12
-#define CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN_AFTER_DEL 1 << 13
+#define CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN_NOSAVE_ON_DEL 1 << 13
 
 #define CLUSTER_MANAGER_OPT_GETFRIENDS  1 << 0
 #define CLUSTER_MANAGER_OPT_COLD        1 << 1
@@ -2997,9 +2997,9 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--cluster-fix-with-unreachable-masters")) {
             config.cluster_manager_command.flags |=
                 CLUSTER_MANAGER_CMD_FLAG_FIX_WITH_UNREACHABLE_MASTERS;
-        } else if (!strcmp(argv[i],"--cluster-shutdown-after-del")) {
+        } else if (!strcmp(argv[i],"--shutdown-nosave-on-del")) {
             config.cluster_manager_command.flags |=
-                CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN_AFTER_DEL;
+                CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN_NOSAVE_ON_DEL;
         } else if (!strcmp(argv[i],"--test_hint") && !lastarg) {
             config.test_hint = argv[++i];
         } else if (!strcmp(argv[i],"--test_hint_file") && !lastarg) {
@@ -3952,7 +3952,7 @@ clusterManagerCommandDef clusterManagerCommands[] = {
      "timeout <arg>,simulate,pipeline <arg>,threshold <arg>,replace"},
     {"add-node", clusterManagerCommandAddNode, 2,
      "new_host:new_port existing_host:existing_port", "slave,master-id <arg>"},
-    {"del-node", clusterManagerCommandDeleteNode, 2, "host:port node_id","shutdown-after-del"},
+    {"del-node", clusterManagerCommandDeleteNode, 2, "host:port node_id","shutdown-nosave-on-del"},
     {"call", clusterManagerCommandCall, -2,
         "host:port command arg arg .. arg", "only-masters,only-replicas"},
     {"set-timeout", clusterManagerCommandSetTimeout, 2,
@@ -7566,8 +7566,8 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
         if (!success) return 0;
     }
 
-    if (config.cluster_manager_command.flags & CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN_AFTER_DEL) {
-        /* With --cluster-shutdown-after-del: send SHUTDOWN NOSAVE so that clients get a
+    if (config.cluster_manager_command.flags & CLUSTER_MANAGER_CMD_FLAG_SHUTDOWN_NOSAVE_ON_DEL) {
+        /* With --shutdown-nosave-on-del: send SHUTDOWN NOSAVE so that clients get a
          * clear connection failure instead of connecting to a stale standalone
          * node.  If SHUTDOWN fails, fall back to CLUSTER RESET SOFT. */
         clusterManagerLogInfo(">>> Sending SHUTDOWN NOSAVE to the deleted node.\n");

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -413,7 +413,7 @@ start_server [list overrides [list cluster-enabled yes cluster-node-timeout 1 cl
 # Test del-node default behavior: CLUSTER RESET SOFT (node stays alive).
 start_multiple_servers 4 [list overrides $base_conf] {
 
-    test {del-node without --cluster-shutdown-after-del resets the node but keeps it alive} {
+    test {del-node without --shutdown-nosave-on-del resets the node but keeps it alive} {
         # Create a 3-node cluster
         exec src/redis-cli --cluster-yes --cluster create \
                            127.0.0.1:[srv 0 port] \
@@ -478,12 +478,12 @@ start_multiple_servers 4 [list overrides $base_conf] {
     }
 } ;# stop servers
 
-# Test del-node with --cluster-shutdown-after-del: SHUTDOWN NOSAVE (node terminated).
+# Test del-node with --shutdown-nosave-on-del: SHUTDOWN NOSAVE (node terminated).
 # With this flag the deleted node is shut down so that clients get a clear
 # connection failure instead of hitting a stale standalone node. See #14965.
 start_multiple_servers 4 [list overrides $base_conf] {
 
-    test {del-node with --cluster-shutdown-after-del shuts down the removed node} {
+    test {del-node with --shutdown-nosave-on-del shuts down the removed node} {
         # Create a 3-node cluster
         exec src/redis-cli --cluster-yes --cluster create \
                            127.0.0.1:[srv 0 port] \
@@ -518,16 +518,16 @@ start_multiple_servers 4 [list overrides $base_conf] {
         set node4_r [redis_client -3]
         set node4_id [$node4_r cluster myid]
 
-        # Delete node4 from the cluster with --cluster-shutdown-after-del
+        # Delete node4 from the cluster with --shutdown-nosave-on-del
         exec src/redis-cli --cluster-yes --cluster del-node \
                        127.0.0.1:[srv 0 port] $node4_id \
-                       --cluster-shutdown-after-del
+                       --shutdown-nosave-on-del
 
         # Verify the deleted node's process is terminated
         wait_for_condition 50 100 {
             [is_alive $node4_pid] == 0
         } else {
-            fail "Deleted node process is still alive after del-node --cluster-shutdown-after-del"
+            fail "Deleted node process is still alive after del-node --shutdown-nosave-on-del"
         }
 
         # Verify remaining nodes no longer know about the deleted node

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -410,6 +410,74 @@ start_server [list overrides [list cluster-enabled yes cluster-node-timeout 1 cl
 
 } ;# foreach ip_or_localhost
 
+# Test redis-cli --cluster del-node shuts down the removed node.
+# This verifies that after del-node, the deleted node's process is terminated
+# (SHUTDOWN NOSAVE) rather than left running as a standalone instance that
+# could confuse clients with empty cluster info. See #14965.
+start_multiple_servers 4 [list overrides $base_conf] {
+
+    test {del-node should shut down the removed node} {
+        # Create a 3-node cluster
+        exec src/redis-cli --cluster-yes --cluster create \
+                           127.0.0.1:[srv 0 port] \
+                           127.0.0.1:[srv -1 port] \
+                           127.0.0.1:[srv -2 port]
+
+        wait_for_condition 1000 50 {
+            [CI 0 cluster_state] eq {ok} &&
+            [CI 1 cluster_state] eq {ok} &&
+            [CI 2 cluster_state] eq {ok}
+        } else {
+            fail "Cluster doesn't stabilize"
+        }
+
+        # Add node4 to the cluster (no slots assigned)
+        exec src/redis-cli --cluster-yes --cluster add-node \
+                       127.0.0.1:[srv -3 port] \
+                       127.0.0.1:[srv 0 port]
+
+        wait_for_cluster_size 4
+
+        wait_for_condition 1000 50 {
+            [CI 0 cluster_state] eq {ok} &&
+            [CI 1 cluster_state] eq {ok} &&
+            [CI 2 cluster_state] eq {ok} &&
+            [CI 3 cluster_state] eq {ok}
+        } else {
+            fail "Cluster doesn't stabilize after add-node"
+        }
+
+        set node4_pid [srv -3 pid]
+        set node4_r [redis_client -3]
+        set node4_id [$node4_r cluster myid]
+
+        # Delete node4 from the cluster
+        exec src/redis-cli --cluster-yes --cluster del-node \
+                       127.0.0.1:[srv 0 port] $node4_id
+
+        # Verify the deleted node's process is terminated
+        wait_for_condition 50 100 {
+            [is_alive $node4_pid] == 0
+        } else {
+            fail "Deleted node process is still alive after del-node"
+        }
+
+        # Verify remaining nodes no longer know about the deleted node
+        wait_for_condition 1000 50 {
+            [CI 0 cluster_known_nodes] == 3 &&
+            [CI 1 cluster_known_nodes] == 3 &&
+            [CI 2 cluster_known_nodes] == 3
+        } else {
+            fail "Deleted node was not forgotten by all nodes"
+        }
+
+        # Verify the cluster is still healthy
+        assert_equal [CI 0 cluster_state] {ok}
+        assert_equal [CI 1 cluster_state] {ok}
+        assert_equal [CI 2 cluster_state] {ok}
+    }
+} ;# stop servers
+
 } ;# tags
 
 set ::singledb $old_singledb

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -413,7 +413,7 @@ start_server [list overrides [list cluster-enabled yes cluster-node-timeout 1 cl
 # Test del-node default behavior: CLUSTER RESET SOFT (node stays alive).
 start_multiple_servers 4 [list overrides $base_conf] {
 
-    test {del-node without --cluster-shutdown resets the node but keeps it alive} {
+    test {del-node without --cluster-shutdown-after-del resets the node but keeps it alive} {
         # Create a 3-node cluster
         exec src/redis-cli --cluster-yes --cluster create \
                            127.0.0.1:[srv 0 port] \
@@ -478,12 +478,12 @@ start_multiple_servers 4 [list overrides $base_conf] {
     }
 } ;# stop servers
 
-# Test del-node with --cluster-shutdown: SHUTDOWN NOSAVE (node terminated).
+# Test del-node with --cluster-shutdown-after-del: SHUTDOWN NOSAVE (node terminated).
 # With this flag the deleted node is shut down so that clients get a clear
 # connection failure instead of hitting a stale standalone node. See #14965.
 start_multiple_servers 4 [list overrides $base_conf] {
 
-    test {del-node with --cluster-shutdown shuts down the removed node} {
+    test {del-node with --cluster-shutdown-after-del shuts down the removed node} {
         # Create a 3-node cluster
         exec src/redis-cli --cluster-yes --cluster create \
                            127.0.0.1:[srv 0 port] \
@@ -518,16 +518,16 @@ start_multiple_servers 4 [list overrides $base_conf] {
         set node4_r [redis_client -3]
         set node4_id [$node4_r cluster myid]
 
-        # Delete node4 from the cluster with --cluster-shutdown
+        # Delete node4 from the cluster with --cluster-shutdown-after-del
         exec src/redis-cli --cluster-yes --cluster del-node \
                        127.0.0.1:[srv 0 port] $node4_id \
-                       --cluster-shutdown
+                       --cluster-shutdown-after-del
 
         # Verify the deleted node's process is terminated
         wait_for_condition 50 100 {
             [is_alive $node4_pid] == 0
         } else {
-            fail "Deleted node process is still alive after del-node --cluster-shutdown"
+            fail "Deleted node process is still alive after del-node --cluster-shutdown-after-del"
         }
 
         # Verify remaining nodes no longer know about the deleted node

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -410,13 +410,10 @@ start_server [list overrides [list cluster-enabled yes cluster-node-timeout 1 cl
 
 } ;# foreach ip_or_localhost
 
-# Test redis-cli --cluster del-node shuts down the removed node.
-# This verifies that after del-node, the deleted node's process is terminated
-# (SHUTDOWN NOSAVE) rather than left running as a standalone instance that
-# could confuse clients with empty cluster info. See #14965.
+# Test del-node default behavior: CLUSTER RESET SOFT (node stays alive).
 start_multiple_servers 4 [list overrides $base_conf] {
 
-    test {del-node should shut down the removed node} {
+    test {del-node without --cluster-shutdown resets the node but keeps it alive} {
         # Create a 3-node cluster
         exec src/redis-cli --cluster-yes --cluster create \
                            127.0.0.1:[srv 0 port] \
@@ -451,15 +448,86 @@ start_multiple_servers 4 [list overrides $base_conf] {
         set node4_r [redis_client -3]
         set node4_id [$node4_r cluster myid]
 
-        # Delete node4 from the cluster
+        # Delete node4 from the cluster (default: CLUSTER RESET SOFT)
         exec src/redis-cli --cluster-yes --cluster del-node \
                        127.0.0.1:[srv 0 port] $node4_id
+
+        # Verify the deleted node's process is still alive
+        assert_equal [is_alive $node4_pid] 1
+
+        # Verify the deleted node was reset (no longer knows about others)
+        wait_for_condition 50 100 {
+            [getInfoProperty [$node4_r cluster info] cluster_known_nodes] == 1
+        } else {
+            fail "Deleted node was not reset"
+        }
+
+        # Verify remaining nodes no longer know about the deleted node
+        wait_for_condition 1000 50 {
+            [CI 0 cluster_known_nodes] == 3 &&
+            [CI 1 cluster_known_nodes] == 3 &&
+            [CI 2 cluster_known_nodes] == 3
+        } else {
+            fail "Deleted node was not forgotten by all nodes"
+        }
+
+        # Verify the cluster is still healthy
+        assert_equal [CI 0 cluster_state] {ok}
+        assert_equal [CI 1 cluster_state] {ok}
+        assert_equal [CI 2 cluster_state] {ok}
+    }
+} ;# stop servers
+
+# Test del-node with --cluster-shutdown: SHUTDOWN NOSAVE (node terminated).
+# With this flag the deleted node is shut down so that clients get a clear
+# connection failure instead of hitting a stale standalone node. See #14965.
+start_multiple_servers 4 [list overrides $base_conf] {
+
+    test {del-node with --cluster-shutdown shuts down the removed node} {
+        # Create a 3-node cluster
+        exec src/redis-cli --cluster-yes --cluster create \
+                           127.0.0.1:[srv 0 port] \
+                           127.0.0.1:[srv -1 port] \
+                           127.0.0.1:[srv -2 port]
+
+        wait_for_condition 1000 50 {
+            [CI 0 cluster_state] eq {ok} &&
+            [CI 1 cluster_state] eq {ok} &&
+            [CI 2 cluster_state] eq {ok}
+        } else {
+            fail "Cluster doesn't stabilize"
+        }
+
+        # Add node4 to the cluster (no slots assigned)
+        exec src/redis-cli --cluster-yes --cluster add-node \
+                       127.0.0.1:[srv -3 port] \
+                       127.0.0.1:[srv 0 port]
+
+        wait_for_cluster_size 4
+
+        wait_for_condition 1000 50 {
+            [CI 0 cluster_state] eq {ok} &&
+            [CI 1 cluster_state] eq {ok} &&
+            [CI 2 cluster_state] eq {ok} &&
+            [CI 3 cluster_state] eq {ok}
+        } else {
+            fail "Cluster doesn't stabilize after add-node"
+        }
+
+        set node4_pid [srv -3 pid]
+        set node4_r [redis_client -3]
+        set node4_id [$node4_r cluster myid]
+
+        # Delete node4 from the cluster with --cluster-shutdown
+        exec src/redis-cli --cluster-yes --cluster del-node \
+                       127.0.0.1:[srv 0 port] $node4_id \
+                       --cluster-shutdown
 
         # Verify the deleted node's process is terminated
         wait_for_condition 50 100 {
             [is_alive $node4_pid] == 0
         } else {
-            fail "Deleted node process is still alive after del-node"
+            fail "Deleted node process is still alive after del-node --cluster-shutdown"
         }
 
         # Verify remaining nodes no longer know about the deleted node

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -413,7 +413,7 @@ start_server [list overrides [list cluster-enabled yes cluster-node-timeout 1 cl
 # Test del-node default behavior: CLUSTER RESET SOFT (node stays alive).
 start_multiple_servers 4 [list overrides $base_conf] {
 
-    test {del-node without --shutdown-nosave-on-del resets the node but keeps it alive} {
+    test {del-node without --cluster-shutdown-nosave-on-del resets the node but keeps it alive} {
         # Create a 3-node cluster
         exec src/redis-cli --cluster-yes --cluster create \
                            127.0.0.1:[srv 0 port] \
@@ -478,12 +478,12 @@ start_multiple_servers 4 [list overrides $base_conf] {
     }
 } ;# stop servers
 
-# Test del-node with --shutdown-nosave-on-del: SHUTDOWN NOSAVE (node terminated).
+# Test del-node with --cluster-shutdown-nosave-on-del: SHUTDOWN NOSAVE (node terminated).
 # With this flag the deleted node is shut down so that clients get a clear
 # connection failure instead of hitting a stale standalone node. See #14965.
 start_multiple_servers 4 [list overrides $base_conf] {
 
-    test {del-node with --shutdown-nosave-on-del shuts down the removed node} {
+    test {del-node with --cluster-shutdown-nosave-on-del shuts down the removed node} {
         # Create a 3-node cluster
         exec src/redis-cli --cluster-yes --cluster create \
                            127.0.0.1:[srv 0 port] \
@@ -518,16 +518,16 @@ start_multiple_servers 4 [list overrides $base_conf] {
         set node4_r [redis_client -3]
         set node4_id [$node4_r cluster myid]
 
-        # Delete node4 from the cluster with --shutdown-nosave-on-del
+        # Delete node4 from the cluster with --cluster-shutdown-nosave-on-del
         exec src/redis-cli --cluster-yes --cluster del-node \
                        127.0.0.1:[srv 0 port] $node4_id \
-                       --shutdown-nosave-on-del
+                       --cluster-shutdown-nosave-on-del
 
         # Verify the deleted node's process is terminated
         wait_for_condition 50 100 {
             [is_alive $node4_pid] == 0
         } else {
-            fail "Deleted node process is still alive after del-node --shutdown-nosave-on-del"
+            fail "Deleted node process is still alive after del-node --cluster-shutdown-nosave-on-del"
         }
 
         # Verify remaining nodes no longer know about the deleted node


### PR DESCRIPTION
## Problem

`redis-cli --cluster del-node` sends `CLUSTER RESET SOFT` to the deleted node, leaving it running as a standalone instance. Clients may still connect to this node and receive empty cluster information, causing confusion about whether the cluster exists.

This differs from the original `redis-trib.rb` behavior which sent `SHUTDOWN`.

## Fix

Send `SHUTDOWN NOSAVE` instead of `CLUSTER RESET SOFT` after removing a node from the cluster. This ensures clients get a clear connection failure and retry with other cluster nodes.

Fixes #14965

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> While default behavior is unchanged, enabling the new flag changes node lifecycle by terminating the removed instance, which could surprise operators or expose edge cases if `SHUTDOWN` behaves differently across environments.
> 
> **Overview**
> `redis-cli --cluster del-node` now supports an opt-in `--cluster-shutdown-nosave-on-del` flag that attempts `SHUTDOWN NOSAVE` on the removed node (treating an EOF/IO disconnect as success) and falls back to the previous `CLUSTER RESET SOFT` behavior if shutdown fails.
> 
> Adds unit tests covering both paths: default deletion resets the node but leaves it running, while the new flag verifies the node process terminates and the remaining cluster stays healthy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 740273ac3bd3fa5a7226d224c5d116cd26a73020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->