### PR TITLE
Fix thread leaks in helloblock module by detaching unjoined threads example module

### DIFF
--- a/src/modules/helloblock.c
+++ b/src/modules/helloblock.c
@@ -14,6 +14,8 @@
 #include "../redismodule.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <time.h>
 #include <pthread.h>
 #include <unistd.h>
 
@@ -47,8 +49,9 @@ void *HelloBlock_ThreadMain(void *arg) {
     RedisModule_Free(targ);
 
     sleep(delay);
+    unsigned int seed = (unsigned int)time(NULL) ^ (unsigned int)(uintptr_t)pthread_self();
     int *r = RedisModule_Alloc(sizeof(int));
-    *r = rand();
+    *r = rand_r(&seed);
     RedisModule_UnblockClient(bc,r);
     return NULL;
 }
@@ -105,6 +108,7 @@ int HelloBlock_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int a
         RedisModule_AbortBlock(bc);
         return RedisModule_ReplyWithError(ctx,"-ERR Can't start thread");
     }
+    pthread_detach(tid);
     return REDISMODULE_OK;
 }
 
@@ -175,6 +179,7 @@ int HelloKeys_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
         RedisModule_AbortBlock(bc);
         return RedisModule_ReplyWithError(ctx,"-ERR Can't start thread");
     }
+    pthread_detach(tid);
     return REDISMODULE_OK;
 }
 


### PR DESCRIPTION
**Problem**
 The helloblock.c module created threads for blocking command execution using pthread_create(), but failed to join them upon completion (pthread_join()) or specify them as detached. Since standard POSIX threads are joinable by default, this meant the system retained the thread ID and minor state memory indefinitely after the background tasks finished, leading to a zombie thread resource leak on every invocation.

**Fix** 
Added pthread_detach(tid) immediately following successful thread creation for both HELLO.BLOCK and HELLO.KEYS commands. This safely separates the threads from the parent execution context, signaling the OS to automatically clean up all associated memory and resources the moment those threads exit.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to the `helloblock` example module and primarily adjusts thread lifecycle management; behavior change is confined to how the random reply value is generated per thread.
> 
> **Overview**
> Prevents background thread resource leaks in `src/modules/helloblock.c` by detaching the worker threads spawned by `hello.block` and `hello.keys` after successful `pthread_create()`.
> 
> Also switches `hello.block`’s random reply generation from global `rand()` to per-thread `rand_r()` with a time/thread-derived seed (adding required headers) to avoid shared RNG state across threads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6db268f40e7f3a18037560bca1724f2a2eb3441e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->