### PR TITLE
prevent string reference memory leak on existing keys in hellodict.c

### DIFF
--- a/src/modules/hellodict.c
+++ b/src/modules/hellodict.c
@@ -26,7 +26,14 @@ static RedisModuleDict *Keyspace;
  * Set the specified key to the specified value. */
 int cmd_SET(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 3) return RedisModule_WrongArity(ctx);
-    RedisModule_DictSet(Keyspace,argv[1],argv[2]);
+
+    /* If the key already exists, we must free its old value to avoid a memory leak. */
+    RedisModuleString *oldval = RedisModule_DictGet(Keyspace,argv[1],NULL);
+    if (oldval) {
+        RedisModule_FreeString(NULL, oldval);
+    }
+
+    RedisModule_DictReplace(Keyspace,argv[1],argv[2]);
     /* We need to keep a reference to the value stored at the key, otherwise
      * it would be freed when this callback returns. */
     RedisModule_RetainString(NULL,argv[2]);


### PR DESCRIPTION
**Problem**: Updating an existing key using HELLODICT.SET triggered a memory leak. RedisModule_DictSet failed to overwrite the key, but the command still manually retained the new string in memory (RedisModule_RetainString). Because the new string was never linked to the dictionary, its memory was orphaned and leaked.

**Fix**: We updated cmd_SET to properly handle existing keys:

Checked for an existing value using RedisModule_DictGet and released its memory via RedisModule_FreeString.
Swapped RedisModule_DictSet with RedisModule_DictReplace to successfully overwrite the key structure in the dictionary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches manual Redis module string lifecycle management in `hellodict.set`; mistakes here could cause leaks or use-after-free, though the change is small and localized.
> 
> **Overview**
> Fixes `hellodict.set` to correctly overwrite existing dictionary entries without leaking memory.
> 
> When setting a key that already exists, the command now fetches and frees the old stored `RedisModuleString`, then uses `RedisModule_DictReplace` (instead of `RedisModule_DictSet`) before retaining the new value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba974ec7b9e1933476a471946cad0b3c90493484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->