### PR TITLE
Remove unnecessary `-ERR` and `\r\n` for addReplyErrorFormat in extractLongLatOrReply()

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -108,7 +108,7 @@ int extractLongLatOrReply(client *c, robj **argv, double *xy) {
     if (xy[0] < GEO_LONG_MIN || xy[0] > GEO_LONG_MAX ||
         xy[1] < GEO_LAT_MIN  || xy[1] > GEO_LAT_MAX) {
         addReplyErrorFormat(c,
-            "-ERR invalid longitude,latitude pair %f,%f\r\n",xy[0],xy[1]);
+            "invalid longitude,latitude pair %f,%f",xy[0],xy[1]);
         return C_ERR;
     }
     return C_OK;

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -228,10 +228,7 @@ start_server {tags {"geo"}} {
         set reply [r geoadd nyc 200 40 "bad lon"]
         r readraw 0
         # RESP simple error: single line starting with '-', no duplicated "-ERR" prefix.
-        assert_equal "-" [string index $reply 0]
-        set body [string range $reply 1 end]
-        assert_match {ERR invalid longitude,latitude pair*} $body
-        assert_equal -1 [string first "-ERR" $body]
+        assert_match {-ERR invalid longitude,latitude pair*} $reply
     }
 
     test {GEOADD multi add} {

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -223,7 +223,7 @@ start_server {tags {"geo"}} {
         set err
     } {*valid*}
 
-    test {GEOADD out-of-range longitude/latitude error reply is well-formed on the wire} {
+    test {GEOADD out-of-range longitude/latitude error reply is well-formed} {
         r readraw 1
         set reply [r geoadd nyc 200 40 "bad lon"]
         r readraw 0

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -224,29 +224,14 @@ start_server {tags {"geo"}} {
     } {*valid*}
 
     test {GEOADD out-of-range longitude/latitude error reply is well-formed on the wire} {
-        if {$::tls} {
-            set fd [::tls::socket [srv host] [srv port]]
-        } else {
-            set fd [socket [srv host] [srv port]]
-        }
-        fconfigure $fd -translation binary
-        puts -nonewline $fd "*5\r\n\$6\r\nGEOADD\r\n\$3\r\nnyc\r\n\$3\r\n200\r\n\$2\r\n40\r\n\$7\r\nbad lon\r\n"
-        flush $fd
-        # Read until we have a full line ending with \r\n.
-        set raw ""
-        while {[string first "\r\n" $raw] == -1} {
-            append raw [read $fd 1]
-        }
-        close $fd
-        # Wire-level RESP error: must start with '-' and end with \r\n,
-        # and body must not contain a duplicated "-ERR" prefix or an
-        # embedded \r\n.
-        assert_equal "-" [string index $raw 0]
-        assert_equal "\r\n" [string range $raw end-1 end]
-        set body [string range $raw 1 end-2]
+        r readraw 1
+        set reply [r geoadd nyc 200 40 "bad lon"]
+        r readraw 0
+        # RESP simple error: single line starting with '-', no duplicated "-ERR" prefix.
+        assert_equal "-" [string index $reply 0]
+        set body [string range $reply 1 end]
         assert_match {ERR invalid longitude,latitude pair*} $body
         assert_equal -1 [string first "-ERR" $body]
-        assert_equal -1 [string first "\r\n" $body]
     }
 
     test {GEOADD multi add} {

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -223,6 +223,32 @@ start_server {tags {"geo"}} {
         set err
     } {*valid*}
 
+    test {GEOADD out-of-range longitude/latitude error reply is well-formed on the wire} {
+        if {$::tls} {
+            set fd [::tls::socket [srv host] [srv port]]
+        } else {
+            set fd [socket [srv host] [srv port]]
+        }
+        fconfigure $fd -translation binary
+        puts -nonewline $fd "*5\r\n\$6\r\nGEOADD\r\n\$3\r\nnyc\r\n\$3\r\n200\r\n\$2\r\n40\r\n\$7\r\nbad lon\r\n"
+        flush $fd
+        # Read until we have a full line ending with \r\n.
+        set raw ""
+        while {[string first "\r\n" $raw] == -1} {
+            append raw [read $fd 1]
+        }
+        close $fd
+        # Wire-level RESP error: must start with '-' and end with \r\n,
+        # and body must not contain a duplicated "-ERR" prefix or an
+        # embedded \r\n.
+        assert_equal "-" [string index $raw 0]
+        assert_equal "\r\n" [string range $raw end-1 end]
+        set body [string range $raw 1 end-2]
+        assert_match {ERR invalid longitude,latitude pair*} $body
+        assert_equal -1 [string first "-ERR" $body]
+        assert_equal -1 [string first "\r\n" $body]
+    }
+
     test {GEOADD multi add} {
         r geoadd nyc -73.9733487 40.7648057 "central park n/q/r" -73.9903085 40.7362513 "union square" -74.0131604 40.7126674 "wtc one" -73.7858139 40.6428986 "jfk" -73.9375699 40.7498929 "q4" -73.9564142 40.7480973 4545
     } {6}


### PR DESCRIPTION
In addReplyErrorLength and addReplyErrorFormatInternal, `-ERR` is automatically prepended if the message doesn’t start with `-`, so the initial `-ERR` is unnecessary. Also, trailing `\r\n` will be trimmed, so it doesn’t need to be included.

This is purely for consistency and does not change the code’s behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the formatting of an error reply string and adds a unit test; no command semantics or data handling logic is modified.
> 
> **Overview**
> Adjusts `extractLongLatOrReply()` (`src/geo.c`) to emit the out-of-range longitude/latitude error message without a hardcoded `-ERR` prefix or trailing `\r\n`, letting `addReplyErrorFormat()` produce the correct RESP error line.
> 
> Adds a unit test in `tests/unit/geo.tcl` that uses `readraw` to assert the `GEOADD` out-of-range error reply is a single well-formed RESP simple error (no duplicated `-ERR`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c7b056fa831dcee7f61ed8007b492de2a643aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->