### PR TITLE
Partial support set keymeta on ksn

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -321,6 +321,7 @@ void restoreCommand(client *c) {
     objectSetLRUOrLFU(kv, lfu_freq, lru_idle, lru_clock, 1000);
     keyModified(c,c->db,key,NULL,1);
     notifyKeyspaceEvent(NOTIFY_GENERIC,"restore",key,c->db->id);
+    KSN_INVALIDATE_KVOBJ(kv);
 
     /* If we deleted a key that means REPLACE parameter was passed and the
      * destination key existed. */

--- a/src/db.c
+++ b/src/db.c
@@ -1522,6 +1522,7 @@ void delexCommand(client *c) {
         rewriteClientCommandVector(c, 2, shared.del, key);
         keyModified(c, c->db, key, NULL, 1);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
+        KSN_INVALIDATE_KVOBJ(o);
         server.dirty++;
     }
 
@@ -2248,10 +2249,9 @@ void renameGenericCommand(client *c, int nx) {
 
     keyModified(c,c->db,c->argv[1],NULL,1);
     keyModified(c,c->db,c->argv[2],NULL,1); /* LRM already updated by dbAddInternal */
-    notifyKeyspaceEvent(NOTIFY_GENERIC,"rename_from",
-        c->argv[1],c->db->id);
-    notifyKeyspaceEvent(NOTIFY_GENERIC,"rename_to",
-        c->argv[2],c->db->id);
+    notifyKeyspaceEvent(NOTIFY_GENERIC, "rename_from", c->argv[1],c->db->id);
+    notifyKeyspaceEvent(NOTIFY_GENERIC, "rename_to", c->argv[2],c->db->id);
+    KSN_INVALIDATE_KVOBJ(o);
     if (overwritten) {
         notifyKeyspaceEvent(NOTIFY_OVERWRITTEN, "overwritten", c->argv[2], c->db->id);
         if (desttype != srctype)
@@ -2346,10 +2346,9 @@ void moveCommand(client *c) {
 
     keyModified(c,src,c->argv[1],NULL,1);
     keyModified(c,dst,c->argv[1],NULL,1); /* LRM already updated by dbAddInternal */
-    notifyKeyspaceEvent(NOTIFY_GENERIC,
-                "move_from",c->argv[1],src->id);
-    notifyKeyspaceEvent(NOTIFY_GENERIC,
-                "move_to",c->argv[1],dst->id);
+    notifyKeyspaceEvent(NOTIFY_GENERIC, "move_from", c->argv[1],src->id);
+    notifyKeyspaceEvent(NOTIFY_GENERIC, "move_to", c->argv[1],dst->id);
+    KSN_INVALIDATE_KVOBJ(kv);
 
     server.dirty++;
     addReply(c,shared.cone);
@@ -2471,6 +2470,7 @@ void copyCommand(client *c) {
     /* OK! key copied. Signal modification (LRM already updated by dbAddInternal) */
     keyModified(c,dst,c->argv[2],NULL,1);
     notifyKeyspaceEvent(NOTIFY_GENERIC,"copy_to",c->argv[2],dst->id);
+    KSN_INVALIDATE_KVOBJ(kvCopy);
 
     /* `delete` implies the destination key was overwritten */
     if (delete) {

--- a/src/expire.c
+++ b/src/expire.c
@@ -836,6 +836,7 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
 
         keyModified(c,c->db,key,kv,1);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);
+        KSN_INVALIDATE_KVOBJ(kv);
         server.dirty++;
         return;
     }
@@ -913,6 +914,7 @@ void persistCommand(client *c) {
         if (removeExpire(c->db,c->argv[1])) {
             keyModified(c,c->db,c->argv[1],kv,1);
             notifyKeyspaceEvent(NOTIFY_GENERIC,"persist",c->argv[1],c->db->id);
+            KSN_INVALIDATE_KVOBJ(kv);
             addReply(c,shared.cone);
             server.dirty++;
         } else {

--- a/src/keymeta.c
+++ b/src/keymeta.c
@@ -743,25 +743,25 @@ KeyMetaClassId keyMetaClassCreate(RedisModule *context, const char *name,
 
     /* Check for name conflicts using 4-char name. Allow reuse of RELEASED; forbid if INUSE. */
     int alreayReleased;
-    int slot = keyMetaClassLookupByName(name, &alreayReleased);
+    int keyMetaId = keyMetaClassLookupByName(name, &alreayReleased);
 
     if (alreayReleased) {
-        /* If already released, then reuse the slot. */
+        /* If already released, then reuse the keyMetaId. */
     } else {
         /* Assert class is registered for first time */
-        serverAssert(slot == -1);
+        serverAssert(keyMetaId == -1);
 
-        /* Find free slot */
+        /* Find free keyMetaId */
         for (int i = KEY_META_ID_MODULE_FIRST; i <= KEY_META_ID_MODULE_LAST; i++) {
             if (keyMetaClass[i].state == CLASS_STATE_FREE) {
-                slot = i;
+                keyMetaId = i;
                 break;
             }
         }
-        if (slot == -1) return 0; /* no free slots */
+        if (keyMetaId == -1) return 0; /* no free keyMetaId */
     }
 
-    KeyMetaClass *pKeyMetaClass = &keyMetaClass[slot];
+    KeyMetaClass *pKeyMetaClass = &keyMetaClass[keyMetaId];
 
     /* Store 4-char short name */
     memcpy(pKeyMetaClass->name, name, KM_NAME_LEN);
@@ -774,7 +774,7 @@ KeyMetaClassId keyMetaClassCreate(RedisModule *context, const char *name,
     pKeyMetaClass->state = CLASS_STATE_INUSE;
     pKeyMetaClass->classSpecEncoded = classSpecEncoded;
     KM_SET_CONST_CONF(pKeyMetaClass->conf) = *conf; /* Copy config as is. */
-    return slot; /* Return handle (1..7). */
+    return keyMetaId; /* Return handle (1..7). */
 }
 
 /* Destroy (release) a class by its ID. Returns 1 on success, 0 on failure. */

--- a/src/server.h
+++ b/src/server.h
@@ -3825,6 +3825,14 @@ void notifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
 int keyspaceEventsStringToFlags(char *classes);
 sds keyspaceEventsFlagsToString(int flags);
 
+/* As part of KSN the module should not attempt to modify the key. Nevertheless,
+ * RediSearch does it in some specific flows and modifies key metadata which in
+ * turn might invalidates the local kvobj pointer. Those specific flows are
+ * protected by the following macro which invalidates the local kvobj pointer
+ * after the notification to prevent further access to it (Currently it is only 
+ * using it with hash type keys, without hash field expiration) */
+#define KSN_INVALIDATE_KVOBJ(o) do { (o) = NULL; } while (0)
+
 /* Configuration */
 /* Configuration Flags */
 #define MODIFIABLE_CONFIG 0 /* This is the implied default for a standard

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2965,22 +2965,23 @@ void hdelCommand(client *c) {
         int64_t newLen = (int64_t) hashTypeLength(o, 0);
         updateKeysizesHist(c->db, OBJ_HASH, oldLen, delete_key ? -1 : newLen);
         
-        /* is it last HFE */
-        if (!delete_key && isHFE && (hashTypeIsFieldsWithExpire(o) == 0))
-            estoreRemove(c->db->subexpires, getKeySlot(c->argv[1]->ptr), o);
+        if (delete_key) {
+            /* del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
+            dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
+        } else {
+            /* is it last HFE */
+            if (isHFE && (hashTypeIsFieldsWithExpire(o) == 0))
+                estoreRemove(c->db->subexpires, getKeySlot(c->argv[1]->ptr), o);
+        }
 
         /* Signal key modification */
-        keyModified(c, c->db, c->argv[1], o, 1);
+        keyModified(c, c->db, c->argv[1], delete_key ? NULL : o, 1);
         notifyKeyspaceEvent(NOTIFY_HASH,"hdel",c->argv[1],c->db->id);
         
         KSN_INVALIDATE_KVOBJ(o); /* Invalidate local kvobj pointer */
         
-        /* Delete key if empty */
-        if (delete_key) {
-            /* del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
-            dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
-            notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
-        }
+        /* Notify del event if key was deleted */
+        if (delete_key) notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
         server.dirty += deleted;
     }
     addReplyLongLong(c,deleted);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2484,6 +2484,8 @@ out:
         
         KSN_INVALIDATE_KVOBJ(o);
         
+        /* Key may become empty due to lazy expiry in hashTypeExists()
+         * or the new expiration time is in the past.*/
         if (newlen == 0) {
             newlen = -1;
             /* Del key but don't update KEYSIZES. else it will decr wrong bin in histogram */
@@ -2924,7 +2926,7 @@ void hgetexCommand(client *c) {
 
 void hdelCommand(client *c) {
     kvobj *o;
-    int j, deleted = 0, delete_key = 0;
+    int j, deleted = 0, keyremoved = 0;
     size_t oldsize = 0;
 
     if ((o = lookupKeyWriteOrReply(c,c->argv[1],shared.czero)) == NULL ||
@@ -2948,13 +2950,13 @@ void hdelCommand(client *c) {
         if (hashTypeDelete(o,c->argv[j]->ptr)) {
             deleted++;
             if (hashTypeLength(o, 0) == 0) {
-                delete_key = 1;
+                keyremoved = 1;
                 break;
             }
         }
     }
     
-    if (!delete_key && o->encoding == OBJ_ENCODING_HT) {
+    if (!keyremoved && o->encoding == OBJ_ENCODING_HT) {
         dictResumeAutoResize((dict*)o->ptr);
         dictShrinkIfNeeded((dict*)o->ptr);
     }
@@ -2963,9 +2965,9 @@ void hdelCommand(client *c) {
     if (deleted) {
         /* Update keysizes histogram */
         int64_t newLen = (int64_t) hashTypeLength(o, 0);
-        updateKeysizesHist(c->db, OBJ_HASH, oldLen, delete_key ? -1 : newLen);
+        updateKeysizesHist(c->db, OBJ_HASH, oldLen, keyremoved ? -1 : newLen);
         
-        if (delete_key) {
+        if (keyremoved) {
             /* del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
             dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
         } else {
@@ -2975,13 +2977,13 @@ void hdelCommand(client *c) {
         }
 
         /* Signal key modification */
-        keyModified(c, c->db, c->argv[1], delete_key ? NULL : o, 1);
+        keyModified(c, c->db, c->argv[1], keyremoved ? NULL : o, 1);
         notifyKeyspaceEvent(NOTIFY_HASH,"hdel",c->argv[1],c->db->id);
         
         KSN_INVALIDATE_KVOBJ(o); /* Invalidate local kvobj pointer */
         
         /* Notify del event if key was deleted */
-        if (delete_key) notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
+        if (keyremoved) notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
         server.dirty += deleted;
     }
     addReplyLongLong(c,deleted);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2105,6 +2105,7 @@ void hsetnxCommand(client *c) {
     if (server.memory_tracking_enabled)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), kv, oldsize, kvobjAllocSize(kv));
     notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
+    KSN_INVALIDATE_KVOBJ(kv);
     server.dirty++;
 }
 
@@ -2142,6 +2143,7 @@ void hsetCommand(client *c) {
     if (server.memory_tracking_enabled)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), kv, oldsize, kvobjAllocSize(kv));
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
+    KSN_INVALIDATE_KVOBJ(kv);
     server.dirty += (c->argc - 2)/2;
 }
 
@@ -2470,6 +2472,7 @@ out:
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldsize, kvobjAllocSize(o));
     /* Emit keyspace notifications based on field expiry, mutation, or key deletion */
     if (fields_set || expired) {
+        newlen = (int64_t) hashTypeLength(o, 0); 
         keyModified(c, c->db, c->argv[1], o, 1);
         if (expired)
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
@@ -2478,18 +2481,18 @@ out:
             if (deleted || updated)
                 notifyKeyspaceEvent(NOTIFY_HASH, deleted ? "hdel" : "hexpire", c->argv[1], c->db->id);
         }
+        
+        KSN_INVALIDATE_KVOBJ(o);
+        
+        if (newlen == 0) {
+            newlen = -1;
+            /* Del key but don't update KEYSIZES. else it will decr wrong bin in histogram */
+            dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
+            notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
+        }
+        if (oldlen != newlen)
+            updateKeysizesHist(c->db, OBJ_HASH, oldlen, newlen);
     }
-    /* Key may become empty due to lazy expiry in hashTypeExists()
-     * or the new expiration time is in the past.*/
-    newlen = (int64_t) hashTypeLength(o, 0);
-    if (newlen == 0) {
-        newlen = -1;
-        /* Del key but don't update KEYSIZES. else it will decr wrong bin in histogram */
-        dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
-        notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
-    }
-    if (oldlen != newlen)
-        updateKeysizesHist(c->db, OBJ_HASH, oldlen, newlen);
 }
 
 void hincrbyCommand(client *c) {
@@ -2540,6 +2543,7 @@ void hincrbyCommand(client *c) {
     addReplyLongLong(c,value);
     keyModified(c,c->db,c->argv[1], o, 1);
     notifyKeyspaceEvent(NOTIFY_HASH,"hincrby",c->argv[1],c->db->id);
+    KSN_INVALIDATE_KVOBJ(o);
     server.dirty++;
 }
 
@@ -2598,6 +2602,7 @@ void hincrbyfloatCommand(client *c) {
     addReplyBulkCBuffer(c,buf,len);
     keyModified(c,c->db,c->argv[1],o,1);
     notifyKeyspaceEvent(NOTIFY_HASH,"hincrbyfloat",c->argv[1],c->db->id);
+    KSN_INVALIDATE_KVOBJ(o);
     server.dirty++;
 
     /* Always replicate HINCRBYFLOAT as an HSETEX command with the final value
@@ -2737,8 +2742,20 @@ void hgetdelCommand(client *c) {
     if (expired == 0 && deleted == 0)
         return;
 
+    int64_t newlen = (int64_t) hashTypeLength(o, 0);
+    /* del key if become empty */
+    int delete_key = (newlen == 0);
+    /* update new len for keysizes histogram */
+    int64_t hist_newlen = delete_key ? -1 : newlen;
+    if (oldlen != hist_newlen)
+        updateKeysizesHist(c->db, OBJ_HASH, oldlen, hist_newlen);
+    /* update memory tracking */
     if (server.memory_tracking_enabled)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldsize, kvobjAllocSize(o));
+    /* is it last HFE */
+    if (!delete_key && hfe && (hashTypeIsFieldsWithExpire(o) == 0))
+        estoreRemove(c->db->subexpires, getKeySlot(c->argv[1]->ptr), o);
+    
     keyModified(c, c->db, c->argv[1], o, 1);
 
     if (expired)
@@ -2755,21 +2772,14 @@ void hgetdelCommand(client *c) {
         rewriteClientCommandArgument(c, 2, NULL);  /* Delete <numfields> arg */
     }
 
+    KSN_INVALIDATE_KVOBJ(o);
+
     /* Key may have become empty because of deleting fields or lazy expire. */
-    int64_t newlen = (int64_t) hashTypeLength(o, 0);
-    if (newlen == 0) {
-        newlen = -1;
+    if (delete_key) {
         /* Del key but don't update KEYSIZES. else it will decr wrong bin in histogram */
         dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
-    } else {
-        if (hfe && (hashTypeIsFieldsWithExpire(o) == 0)) { /*is it last HFE*/
-            estoreRemove(c->db->subexpires, getKeySlot(kvobjGetKey(o)), o);
-        }
     }
-
-    if (oldlen != newlen)
-        updateKeysizesHist(c->db, OBJ_HASH, oldlen, newlen);
 }
 
 /* Get the value of one or more fields of a given hash key and optionally set 
@@ -2914,7 +2924,7 @@ void hgetexCommand(client *c) {
 
 void hdelCommand(client *c) {
     kvobj *o;
-    int j, deleted = 0, keyremoved = 0;
+    int j, deleted = 0, delete_key = 0;
     size_t oldsize = 0;
 
     if ((o = lookupKeyWriteOrReply(c,c->argv[1],shared.czero)) == NULL ||
@@ -2938,33 +2948,39 @@ void hdelCommand(client *c) {
         if (hashTypeDelete(o,c->argv[j]->ptr)) {
             deleted++;
             if (hashTypeLength(o, 0) == 0) {
-                if (server.memory_tracking_enabled)
-                    updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldsize, kvobjAllocSize(o));
-                /* del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
-                dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
-                keyremoved = 1;
+                delete_key = 1;
                 break;
             }
         }
     }
-    if (!keyremoved && o->encoding == OBJ_ENCODING_HT) {
+    
+    if (!delete_key && o->encoding == OBJ_ENCODING_HT) {
         dictResumeAutoResize((dict*)o->ptr);
         dictShrinkIfNeeded((dict*)o->ptr);
     }
-    if (server.memory_tracking_enabled && !keyremoved)
+    if (server.memory_tracking_enabled)
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldsize, kvobjAllocSize(o));
     if (deleted) {
-        int64_t newLen = -1; /* The value -1 indicates that the key is deleted. */
-        keyModified(c, c->db, c->argv[1], keyremoved ? NULL : o, 1);
+        /* Update keysizes histogram */
+        int64_t newLen = (int64_t) hashTypeLength(o, 0);
+        updateKeysizesHist(c->db, OBJ_HASH, oldLen, delete_key ? -1 : newLen);
+        
+        /* is it last HFE */
+        if (!delete_key && isHFE && (hashTypeIsFieldsWithExpire(o) == 0))
+            estoreRemove(c->db->subexpires, getKeySlot(c->argv[1]->ptr), o);
+
+        /* Signal key modification */
+        keyModified(c, c->db, c->argv[1], o, 1);
         notifyKeyspaceEvent(NOTIFY_HASH,"hdel",c->argv[1],c->db->id);
-        if (keyremoved) {
+        
+        KSN_INVALIDATE_KVOBJ(o); /* Invalidate local kvobj pointer */
+        
+        /* Delete key if empty */
+        if (delete_key) {
+            /* del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
+            dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
             notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
-        } else {
-            if (isHFE && (hashTypeIsFieldsWithExpire(o) == 0)) /* is it last HFE */
-                estoreRemove(c->db->subexpires, getKeySlot(c->argv[1]->ptr), o);
-            newLen = oldLen - deleted;
         }
-        updateKeysizesHist(c->db, OBJ_HASH, oldLen, newLen);
         server.dirty += deleted;
     }
     addReplyLongLong(c,deleted);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2484,7 +2484,7 @@ out:
         
         KSN_INVALIDATE_KVOBJ(o);
         
-        /* Key may become empty due to lazy expiry in hashTypeExists()
+        /* Key may become empty due to lazy expiry in hashTypeGetValue()
          * or the new expiration time is in the past.*/
         if (newlen == 0) {
             newlen = -1;

--- a/tests/modules/keymeta_notify.c
+++ b/tests/modules/keymeta_notify.c
@@ -1,10 +1,10 @@
-/* Test module: SetKeyMeta during keyspace notification callback.
+/* Test module for KSN paths that must tolerate keymeta writes.
  *
- * This module registers keyspace notification callbacks for HASH, STRING,
- * GENERIC, EXPIRED, and EVICTED events that write to key metadata (via
- * RedisModule_SetKeyMeta). It is used to verify that commands remain safe
- * when a notification callback modifies key metadata, which may trigger
- * kvobj reallocation.
+ * In general, keyspace notification callbacks must not perform write
+ * operations. However, Search module modifies key metadata as part of KSN, so 
+ * this module exercises the subset of KSN flows that must remain resilient to
+ * such keymeta modifications, including cases that may trigger kvobj
+ * reallocation.
  *
  * Commands:
  *   KEYMETANOTIFY.GET <key>      - Get the metadata value attached to a key
@@ -143,6 +143,17 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_CreateCommand(ctx, "keymetanotify.setcount", SetCountCommand,
                                   "readonly", 0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
+
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnUnload(RedisModuleCtx *ctx) {
+    REDISMODULE_NOT_USED(ctx);
+
+    if (meta_class_id >= 0) {
+        RedisModule_ReleaseKeyMetaClass(meta_class_id);
+        meta_class_id = -1;
+    }
 
     return REDISMODULE_OK;
 }

--- a/tests/unit/moduleapi/ksn_notify_side_effect.tcl
+++ b/tests/unit/moduleapi/ksn_notify_side_effect.tcl
@@ -221,6 +221,85 @@ start_server {tags {"modules" "external:skip"}} {
         assert_equal [r HTTL hpersist_key FIELDS 1 f1] -1
     }
 
+    test {Hash field expiration (hexpired) with SetKeyMeta in notification does not crash} {
+        # Create hash with field that will expire quickly
+        set before [r keymetanotify.setcount]
+        r HSET hexpired_key f1 v1 f2 v2
+        assert_equal [r keymetanotify.get hexpired_key] "notified"
+        assert {[r keymetanotify.setcount] > $before}
+
+        # Set very short expiration (100ms)
+        r HPEXPIRE hexpired_key 100 FIELDS 1 f1
+
+        # Wait for field to expire
+        after 200
+
+        # Access the hash to trigger lazy expiration (hexpired notification)
+        # The main test here is that this doesn't crash when SetKeyMeta is called
+        # during the hexpired notification callback
+        set result [r HGET hexpired_key f1]
+        # Field should be expired
+        assert_equal $result {}
+
+        # f2 should still exist and accessible without crash
+        assert_equal [r HGET hexpired_key f2] "v2"
+
+        # Key should still have metadata set
+        assert_equal [r keymetanotify.get hexpired_key] "notified"
+    }
+
+    # --- GENERIC notification tests ---
+
+    test {PERSIST with SetKeyMeta in notification does not crash} {
+        # Create key with expiration
+        set before [r keymetanotify.setcount]
+        r SET persist_key "value"
+        r EXPIRE persist_key 1000
+        assert_equal [r keymetanotify.get persist_key] "notified"
+        assert {[r keymetanotify.setcount] > $before}
+
+        # Verify TTL is set
+        assert {[r TTL persist_key] > 0}
+
+        # PERSIST removes expiration
+        set before [r keymetanotify.setcount]
+        r PERSIST persist_key
+        # persist notification triggers SetKeyMeta
+        assert {[r keymetanotify.setcount] > $before}
+
+        # Verify TTL is removed
+        assert_equal [r TTL persist_key] -1
+        assert_equal [r GET persist_key] "value"
+    }
+
+    test {COPY with SetKeyMeta in notification does not crash} {
+        # Create source key
+        set before [r keymetanotify.setcount]
+        r HSET copy_src_key f1 v1 f2 v2
+        assert_equal [r keymetanotify.get copy_src_key] "notified"
+        assert {[r keymetanotify.setcount] > $before}
+
+        # COPY to new key
+        set before [r keymetanotify.setcount]
+        r COPY copy_src_key copy_dst_key
+        # copy_to notification triggers SetKeyMeta on destination
+        assert_equal [r keymetanotify.get copy_dst_key] "notified"
+        assert {[r keymetanotify.setcount] > $before}
+
+        # Verify both keys have same content
+        assert_equal [r HGET copy_src_key f1] "v1"
+        assert_equal [r HGET copy_dst_key f1] "v1"
+        assert_equal [r HGET copy_src_key f2] "v2"
+        assert_equal [r HGET copy_dst_key f2] "v2"
+
+        # COPY with REPLACE
+        r HSET copy_src_key f3 v3
+        set before [r keymetanotify.setcount]
+        r COPY copy_src_key copy_dst_key REPLACE
+        assert {[r keymetanotify.setcount] > $before}
+        assert_equal [r HGET copy_dst_key f3] "v3"
+    }
+
     # --- STRING notification tests ---
     # Each test uses a fresh key for actual kvobj reallocation.
 

--- a/tests/unit/moduleapi/ksn_notify_side_effect.tcl
+++ b/tests/unit/moduleapi/ksn_notify_side_effect.tcl
@@ -91,6 +91,136 @@ start_server {tags {"modules" "external:skip"}} {
         assert {[r keymetanotify.setcount] >= $before + 100}
     }
 
+    test {HSETEX with SetKeyMeta in notification does not crash} {
+        set before [r keymetanotify.setcount]
+        r HSETEX hsetex_key FIELDS 1 f1 v1
+        assert_equal [r HGET hsetex_key f1] "v1"
+        assert_equal [r keymetanotify.get hsetex_key] "notified"
+        assert {[r keymetanotify.setcount] > $before}
+
+        # HSETEX with expiration
+        r HSETEX hsetex_key EX 1000 FIELDS 1 f2 v2
+        assert_equal [r HGET hsetex_key f2] "v2"
+        assert_equal [r HLEN hsetex_key] 2
+
+        # HSETEX with FXX flag (only set if all fields exist)
+        r HSETEX hsetex_key FXX FIELDS 1 f1 v1_updated
+        assert_equal [r HGET hsetex_key f1] "v1_updated"
+
+        # HSETEX with FNX flag (only set if no fields exist)
+        set before [r keymetanotify.setcount]
+        r HSETEX hsetex_fnx_key FNX FIELDS 2 f1 v1 f2 v2
+        assert_equal [r HGET hsetex_fnx_key f1] "v1"
+        assert_equal [r HGET hsetex_fnx_key f2] "v2"
+        assert_equal [r keymetanotify.get hsetex_fnx_key] "notified"
+        assert {[r keymetanotify.setcount] > $before}
+    }
+
+    test {HGETDEL with SetKeyMeta in notification does not crash} {
+        # Create hash with fields
+        set before [r keymetanotify.setcount]
+        r HSET hgetdel_key f1 v1 f2 v2 f3 v3
+        assert_equal [r keymetanotify.get hgetdel_key] "notified"
+        assert {[r keymetanotify.setcount] > $before}
+
+        # HGETDEL returns the value and deletes the field
+        set before [r keymetanotify.setcount]
+        set result [r HGETDEL hgetdel_key FIELDS 1 f1]
+        assert_equal $result "v1"
+        assert_equal [r HEXISTS hgetdel_key f1] 0
+        assert_equal [r HLEN hgetdel_key] 2
+        # SetKeyMeta should be called during the hdel notification
+        assert {[r keymetanotify.setcount] > $before}
+
+        # HGETDEL multiple fields
+        set result [r HGETDEL hgetdel_key FIELDS 2 f2 f3]
+        assert_equal [lindex $result 0] "v2"
+        assert_equal [lindex $result 1] "v3"
+        assert_equal [r HLEN hgetdel_key] 0
+    }
+
+    test {HGETEX with SetKeyMeta in notification does not crash} {
+        # Create hash with fields
+        set before [r keymetanotify.setcount]
+        r HSET hgetex_key f1 v1 f2 v2
+        assert_equal [r keymetanotify.get hgetex_key] "notified"
+        assert {[r keymetanotify.setcount] > $before}
+
+        # HGETEX without expiration just returns values
+        set result [r HGETEX hgetex_key FIELDS 1 f1]
+        assert_equal [lindex $result 0] "v1"
+
+        # HGETEX with expiration
+        set before [r keymetanotify.setcount]
+        set result [r HGETEX hgetex_key EX 1000 FIELDS 1 f1]
+        assert_equal [lindex $result 0] "v1"
+        # hexpire notification triggers SetKeyMeta
+        assert {[r keymetanotify.setcount] > $before}
+
+        # HGETEX with PERSIST
+        r HGETEX hgetex_key PERSIST FIELDS 1 f1
+        assert_equal [r HTTL hgetex_key FIELDS 1 f1] -1
+    }
+
+    test {HDEL with SetKeyMeta in notification does not crash} {
+        # Create hash with fields
+        set before [r keymetanotify.setcount]
+        r HSET hdel_key f1 v1 f2 v2 f3 v3
+        assert_equal [r keymetanotify.get hdel_key] "notified"
+        assert {[r keymetanotify.setcount] > $before}
+
+        # HDEL single field
+        set before [r keymetanotify.setcount]
+        r HDEL hdel_key f1
+        assert_equal [r HEXISTS hdel_key f1] 0
+        assert_equal [r HLEN hdel_key] 2
+        # SetKeyMeta should be called during the hdel notification
+        assert {[r keymetanotify.setcount] > $before}
+
+        # HDEL multiple fields
+        r HDEL hdel_key f2 f3
+        assert_equal [r HLEN hdel_key] 0
+    }
+
+    test {HEXPIRE with SetKeyMeta in notification does not crash} {
+        # Create hash with fields
+        set before [r keymetanotify.setcount]
+        r HSET hexpire_key f1 v1 f2 v2
+        assert_equal [r keymetanotify.get hexpire_key] "notified"
+        assert {[r keymetanotify.setcount] > $before}
+
+        # HEXPIRE sets field expiration
+        set before [r keymetanotify.setcount]
+        r HEXPIRE hexpire_key 1000 FIELDS 1 f1
+        # hexpire notification triggers SetKeyMeta
+        assert {[r keymetanotify.setcount] > $before}
+
+        # Verify TTL is set
+        assert {[r HTTL hexpire_key FIELDS 1 f1] > 0}
+
+        # HPEXPIRE (milliseconds)
+        r HPEXPIRE hexpire_key 500000 FIELDS 1 f2
+        assert {[r HPTTL hexpire_key FIELDS 1 f2] > 0}
+    }
+
+    test {HPERSIST with SetKeyMeta in notification does not crash} {
+        # Create hash with field expiration
+        set before [r keymetanotify.setcount]
+        r HSET hpersist_key f1 v1
+        r HEXPIRE hpersist_key 1000 FIELDS 1 f1
+        assert_equal [r keymetanotify.get hpersist_key] "notified"
+        assert {[r keymetanotify.setcount] > $before}
+
+        # HPERSIST removes field expiration
+        set before [r keymetanotify.setcount]
+        r HPERSIST hpersist_key FIELDS 1 f1
+        # hpersist notification triggers SetKeyMeta
+        assert {[r keymetanotify.setcount] > $before}
+
+        # Verify TTL is removed
+        assert_equal [r HTTL hpersist_key FIELDS 1 f1] -1
+    }
+
     # --- STRING notification tests ---
     # Each test uses a fresh key for actual kvobj reallocation.
 

--- a/tests/unit/moduleapi/ksn_notify_side_effect.tcl
+++ b/tests/unit/moduleapi/ksn_notify_side_effect.tcl
@@ -163,9 +163,12 @@ start_server {tags {"modules" "external:skip"}} {
         set result [r HGETEX hgetex_key FIELDS 1 f1]
         assert_equal [lindex $result 0] "v1"
 
-        # HGETEX with PERSIST
+        # HGETEX with PERSIST - triggers hpersist notification
+        set before [r keymetanotify.setcount]
         r HGETEX hgetex_key PERSIST FIELDS 1 f1
         assert_equal [r HTTL hgetex_key FIELDS 1 f1] -1
+        # hpersist notification triggers SetKeyMeta
+        assert {[r keymetanotify.setcount] > $before}
     }
 
     test {HDEL with SetKeyMeta in notification does not crash} {

--- a/tests/unit/moduleapi/ksn_notify_side_effect.tcl
+++ b/tests/unit/moduleapi/ksn_notify_side_effect.tcl
@@ -1,17 +1,12 @@
 # Test for SetKeyMeta during keyspace notification (KSN) callbacks.
 #
-# This test loads a module that registers KSN callbacks for HASH, STRING,
-# GENERIC, EXPIRED, and EVICTED events. The callback writes to key metadata
-# (via RedisModule_SetKeyMeta), which may trigger kvobj reallocation.
-# It exercises various commands across these notification types to catch
-# regressions where the kvobj pointer becomes stale after a notification
-# callback reallocates it.
-#
-# Important: each test uses a fresh key so that SetKeyMeta triggers an actual
-# kvobj reallocation (the first metadata attachment grows the kvobj). We verify
-# this by checking that the setcount increases after each command.
-# Each test also validates that the metadata is properly accessible after the
-# operation by reading it back via RedisModule_GetKeyMeta.
+# On key space notification, the module shouldn't modify the key. This focused 
+# regression tests makes an exception for RediSearch which uses SetKeyMeta
+# as part of its KSN callback (Currently only for hash keys without hash field 
+# expiration). The test module mutates key metadata during selected notifications,
+# which may reallocate the underlying kvobj and invalidates any local pointer to 
+# it. Each test uses fresh keys when possible so the first metadata write forces
+# the reallocation-sensitive path, then verifies the command still completes.
 
 set testmodule [file normalize tests/modules/keymeta_notify.so]
 
@@ -91,31 +86,6 @@ start_server {tags {"modules" "external:skip"}} {
         assert {[r keymetanotify.setcount] >= $before + 100}
     }
 
-    test {HSETEX with SetKeyMeta in notification does not crash} {
-        set before [r keymetanotify.setcount]
-        r HSETEX hsetex_key FIELDS 1 f1 v1
-        assert_equal [r HGET hsetex_key f1] "v1"
-        assert_equal [r keymetanotify.get hsetex_key] "notified"
-        assert {[r keymetanotify.setcount] > $before}
-
-        # HSETEX with expiration
-        r HSETEX hsetex_key EX 1000 FIELDS 1 f2 v2
-        assert_equal [r HGET hsetex_key f2] "v2"
-        assert_equal [r HLEN hsetex_key] 2
-
-        # HSETEX with FXX flag (only set if all fields exist)
-        r HSETEX hsetex_key FXX FIELDS 1 f1 v1_updated
-        assert_equal [r HGET hsetex_key f1] "v1_updated"
-
-        # HSETEX with FNX flag (only set if no fields exist)
-        set before [r keymetanotify.setcount]
-        r HSETEX hsetex_fnx_key FNX FIELDS 2 f1 v1 f2 v2
-        assert_equal [r HGET hsetex_fnx_key f1] "v1"
-        assert_equal [r HGET hsetex_fnx_key f2] "v2"
-        assert_equal [r keymetanotify.get hsetex_fnx_key] "notified"
-        assert {[r keymetanotify.setcount] > $before}
-    }
-
     test {HGETDEL with SetKeyMeta in notification does not crash} {
         # To test the "first SetKeyMeta causes kvobj reallocation" scenario,
         # create the key BEFORE loading the module so the first metadata
@@ -142,35 +112,6 @@ start_server {tags {"modules" "external:skip"}} {
         assert_equal [r HLEN hgetdel_key] 0
     }
 
-    test {HGETEX with SetKeyMeta in notification does not crash} {
-        # To test the "first SetKeyMeta causes kvobj reallocation" scenario,
-        # create the key BEFORE loading the module so the first metadata
-        # attachment happens during HGETEX, not during HSET.
-        r module unload keymetanotify
-        r HSET hgetex_key f1 v1 f2 v2
-        r module load $testmodule
-
-        # HGETEX with expiration - this is the first SetKeyMeta call for this key,
-        # triggering kvobj reallocation during the hexpire notification
-        set before [r keymetanotify.setcount]
-        set result [r HGETEX hgetex_key EX 1000 FIELDS 1 f1]
-        assert_equal [lindex $result 0] "v1"
-        # hexpire notification triggers SetKeyMeta
-        assert {[r keymetanotify.setcount] > $before}
-        assert_equal [r keymetanotify.get hgetex_key] "notified"
-
-        # HGETEX without expiration just returns values (in-place metadata update)
-        set result [r HGETEX hgetex_key FIELDS 1 f1]
-        assert_equal [lindex $result 0] "v1"
-
-        # HGETEX with PERSIST - triggers hpersist notification
-        set before [r keymetanotify.setcount]
-        r HGETEX hgetex_key PERSIST FIELDS 1 f1
-        assert_equal [r HTTL hgetex_key FIELDS 1 f1] -1
-        # hpersist notification triggers SetKeyMeta
-        assert {[r keymetanotify.setcount] > $before}
-    }
-
     test {HDEL with SetKeyMeta in notification does not crash} {
         # To test the "first SetKeyMeta causes kvobj reallocation" scenario,
         # create the key BEFORE loading the module so the first metadata
@@ -192,78 +133,6 @@ start_server {tags {"modules" "external:skip"}} {
         # HDEL multiple fields (in-place metadata update)
         r HDEL hdel_key f2 f3
         assert_equal [r HLEN hdel_key] 0
-    }
-
-    test {HEXPIRE with SetKeyMeta in notification does not crash} {
-        # To test the "first SetKeyMeta causes kvobj reallocation" scenario,
-        # create the key BEFORE loading the module so the first metadata
-        # attachment happens during HEXPIRE, not during HSET.
-        r module unload keymetanotify
-        r HSET hexpire_key f1 v1 f2 v2
-        r module load $testmodule
-
-        # HEXPIRE sets field expiration - this is the first SetKeyMeta call
-        # for this key, triggering kvobj reallocation
-        set before [r keymetanotify.setcount]
-        r HEXPIRE hexpire_key 1000 FIELDS 1 f1
-        # hexpire notification triggers SetKeyMeta
-        assert {[r keymetanotify.setcount] > $before}
-        assert_equal [r keymetanotify.get hexpire_key] "notified"
-
-        # Verify TTL is set
-        assert {[r HTTL hexpire_key FIELDS 1 f1] > 0}
-
-        # HPEXPIRE (milliseconds) - in-place metadata update
-        r HPEXPIRE hexpire_key 500000 FIELDS 1 f2
-        assert {[r HPTTL hexpire_key FIELDS 1 f2] > 0}
-    }
-
-    test {HPERSIST with SetKeyMeta in notification does not crash} {
-        # To test the "first SetKeyMeta causes kvobj reallocation" scenario,
-        # create the key with field expiration BEFORE loading the module so
-        # the first metadata attachment happens during HPERSIST.
-        r module unload keymetanotify
-        r HSET hpersist_key f1 v1
-        r HEXPIRE hpersist_key 1000 FIELDS 1 f1
-        r module load $testmodule
-
-        # HPERSIST removes field expiration - this is the first SetKeyMeta call
-        # for this key, triggering kvobj reallocation
-        set before [r keymetanotify.setcount]
-        r HPERSIST hpersist_key FIELDS 1 f1
-        # hpersist notification triggers SetKeyMeta
-        assert {[r keymetanotify.setcount] > $before}
-        assert_equal [r keymetanotify.get hpersist_key] "notified"
-
-        # Verify TTL is removed
-        assert_equal [r HTTL hpersist_key FIELDS 1 f1] -1
-    }
-
-    test {Hash field expiration (hexpired) with SetKeyMeta in notification does not crash} {
-        # Create hash with field that will expire quickly
-        set before [r keymetanotify.setcount]
-        r HSET hexpired_key f1 v1 f2 v2
-        assert_equal [r keymetanotify.get hexpired_key] "notified"
-        assert {[r keymetanotify.setcount] > $before}
-
-        # Set very short expiration (100ms)
-        r HPEXPIRE hexpired_key 100 FIELDS 1 f1
-
-        # Wait for field to expire
-        after 200
-
-        # Access the hash to trigger lazy expiration (hexpired notification)
-        # The main test here is that this doesn't crash when SetKeyMeta is called
-        # during the hexpired notification callback
-        set result [r HGET hexpired_key f1]
-        # Field should be expired
-        assert_equal $result {}
-
-        # f2 should still exist and accessible without crash
-        assert_equal [r HGET hexpired_key f2] "v2"
-
-        # Key should still have metadata set
-        assert_equal [r keymetanotify.get hexpired_key] "notified"
     }
 
     # --- GENERIC notification tests ---
@@ -390,6 +259,37 @@ start_server {tags {"modules" "external:skip"}} {
         r DEL del_key
         assert_equal [r EXISTS del_key] 0
     }
+
+    test {DELEX with SetKeyMeta in notification does not crash} {
+        r SET delex_key "value"
+        assert_equal [r keymetanotify.get delex_key] "notified"
+        r DELEX delex_key IFEQ value
+        assert_equal [r EXISTS delex_key] 0
+    }
+
+    test {MOVE with SetKeyMeta in notification does not crash} {
+        r select 10
+        r DEL move_key
+        r select 9
+
+        # Create the key before loading the module so the first metadata
+        # attachment happens during MOVE, not during SET.
+        r module unload keymetanotify
+        r SET move_key "value"
+        r module load $testmodule
+
+        set before [r keymetanotify.setcount]
+        r MOVE move_key 10
+        assert_equal [r EXISTS move_key] 0
+
+        r select 10
+        assert_equal [r GET move_key] "value"
+        assert_equal [r keymetanotify.get move_key] "notified"
+        assert {[r keymetanotify.setcount] > $before}
+        r DEL move_key
+        r select 9
+        set _ {}
+    } {} {singledb:skip}
 
     test {RENAME with SetKeyMeta in notification does not crash} {
         r SET rename_src "value"

--- a/tests/unit/moduleapi/ksn_notify_side_effect.tcl
+++ b/tests/unit/moduleapi/ksn_notify_side_effect.tcl
@@ -117,13 +117,15 @@ start_server {tags {"modules" "external:skip"}} {
     }
 
     test {HGETDEL with SetKeyMeta in notification does not crash} {
-        # Create hash with fields
-        set before [r keymetanotify.setcount]
+        # To test the "first SetKeyMeta causes kvobj reallocation" scenario,
+        # create the key BEFORE loading the module so the first metadata
+        # attachment happens during HGETDEL, not during HSET.
+        r module unload keymetanotify
         r HSET hgetdel_key f1 v1 f2 v2 f3 v3
-        assert_equal [r keymetanotify.get hgetdel_key] "notified"
-        assert {[r keymetanotify.setcount] > $before}
+        r module load $testmodule
 
         # HGETDEL returns the value and deletes the field
+        # This is the first SetKeyMeta call for this key, triggering kvobj reallocation
         set before [r keymetanotify.setcount]
         set result [r HGETDEL hgetdel_key FIELDS 1 f1]
         assert_equal $result "v1"
@@ -131,6 +133,7 @@ start_server {tags {"modules" "external:skip"}} {
         assert_equal [r HLEN hgetdel_key] 2
         # SetKeyMeta should be called during the hdel notification
         assert {[r keymetanotify.setcount] > $before}
+        assert_equal [r keymetanotify.get hgetdel_key] "notified"
 
         # HGETDEL multiple fields
         set result [r HGETDEL hgetdel_key FIELDS 2 f2 f3]
@@ -140,22 +143,25 @@ start_server {tags {"modules" "external:skip"}} {
     }
 
     test {HGETEX with SetKeyMeta in notification does not crash} {
-        # Create hash with fields
-        set before [r keymetanotify.setcount]
+        # To test the "first SetKeyMeta causes kvobj reallocation" scenario,
+        # create the key BEFORE loading the module so the first metadata
+        # attachment happens during HGETEX, not during HSET.
+        r module unload keymetanotify
         r HSET hgetex_key f1 v1 f2 v2
-        assert_equal [r keymetanotify.get hgetex_key] "notified"
-        assert {[r keymetanotify.setcount] > $before}
+        r module load $testmodule
 
-        # HGETEX without expiration just returns values
-        set result [r HGETEX hgetex_key FIELDS 1 f1]
-        assert_equal [lindex $result 0] "v1"
-
-        # HGETEX with expiration
+        # HGETEX with expiration - this is the first SetKeyMeta call for this key,
+        # triggering kvobj reallocation during the hexpire notification
         set before [r keymetanotify.setcount]
         set result [r HGETEX hgetex_key EX 1000 FIELDS 1 f1]
         assert_equal [lindex $result 0] "v1"
         # hexpire notification triggers SetKeyMeta
         assert {[r keymetanotify.setcount] > $before}
+        assert_equal [r keymetanotify.get hgetex_key] "notified"
+
+        # HGETEX without expiration just returns values (in-place metadata update)
+        set result [r HGETEX hgetex_key FIELDS 1 f1]
+        assert_equal [lindex $result 0] "v1"
 
         # HGETEX with PERSIST
         r HGETEX hgetex_key PERSIST FIELDS 1 f1
@@ -163,59 +169,68 @@ start_server {tags {"modules" "external:skip"}} {
     }
 
     test {HDEL with SetKeyMeta in notification does not crash} {
-        # Create hash with fields
-        set before [r keymetanotify.setcount]
+        # To test the "first SetKeyMeta causes kvobj reallocation" scenario,
+        # create the key BEFORE loading the module so the first metadata
+        # attachment happens during HDEL, not during HSET.
+        r module unload keymetanotify
         r HSET hdel_key f1 v1 f2 v2 f3 v3
-        assert_equal [r keymetanotify.get hdel_key] "notified"
-        assert {[r keymetanotify.setcount] > $before}
+        r module load $testmodule
 
-        # HDEL single field
+        # HDEL single field - this is the first SetKeyMeta call for this key,
+        # triggering kvobj reallocation during the hdel notification
         set before [r keymetanotify.setcount]
         r HDEL hdel_key f1
         assert_equal [r HEXISTS hdel_key f1] 0
         assert_equal [r HLEN hdel_key] 2
         # SetKeyMeta should be called during the hdel notification
         assert {[r keymetanotify.setcount] > $before}
+        assert_equal [r keymetanotify.get hdel_key] "notified"
 
-        # HDEL multiple fields
+        # HDEL multiple fields (in-place metadata update)
         r HDEL hdel_key f2 f3
         assert_equal [r HLEN hdel_key] 0
     }
 
     test {HEXPIRE with SetKeyMeta in notification does not crash} {
-        # Create hash with fields
-        set before [r keymetanotify.setcount]
+        # To test the "first SetKeyMeta causes kvobj reallocation" scenario,
+        # create the key BEFORE loading the module so the first metadata
+        # attachment happens during HEXPIRE, not during HSET.
+        r module unload keymetanotify
         r HSET hexpire_key f1 v1 f2 v2
-        assert_equal [r keymetanotify.get hexpire_key] "notified"
-        assert {[r keymetanotify.setcount] > $before}
+        r module load $testmodule
 
-        # HEXPIRE sets field expiration
+        # HEXPIRE sets field expiration - this is the first SetKeyMeta call
+        # for this key, triggering kvobj reallocation
         set before [r keymetanotify.setcount]
         r HEXPIRE hexpire_key 1000 FIELDS 1 f1
         # hexpire notification triggers SetKeyMeta
         assert {[r keymetanotify.setcount] > $before}
+        assert_equal [r keymetanotify.get hexpire_key] "notified"
 
         # Verify TTL is set
         assert {[r HTTL hexpire_key FIELDS 1 f1] > 0}
 
-        # HPEXPIRE (milliseconds)
+        # HPEXPIRE (milliseconds) - in-place metadata update
         r HPEXPIRE hexpire_key 500000 FIELDS 1 f2
         assert {[r HPTTL hexpire_key FIELDS 1 f2] > 0}
     }
 
     test {HPERSIST with SetKeyMeta in notification does not crash} {
-        # Create hash with field expiration
-        set before [r keymetanotify.setcount]
+        # To test the "first SetKeyMeta causes kvobj reallocation" scenario,
+        # create the key with field expiration BEFORE loading the module so
+        # the first metadata attachment happens during HPERSIST.
+        r module unload keymetanotify
         r HSET hpersist_key f1 v1
         r HEXPIRE hpersist_key 1000 FIELDS 1 f1
-        assert_equal [r keymetanotify.get hpersist_key] "notified"
-        assert {[r keymetanotify.setcount] > $before}
+        r module load $testmodule
 
-        # HPERSIST removes field expiration
+        # HPERSIST removes field expiration - this is the first SetKeyMeta call
+        # for this key, triggering kvobj reallocation
         set before [r keymetanotify.setcount]
         r HPERSIST hpersist_key FIELDS 1 f1
         # hpersist notification triggers SetKeyMeta
         assert {[r keymetanotify.setcount] > $before}
+        assert_equal [r keymetanotify.get hpersist_key] "notified"
 
         # Verify TTL is removed
         assert_equal [r HTTL hpersist_key FIELDS 1 f1] -1


### PR DESCRIPTION
As part of KSN the module should not attempt to modify the key. Nevertheless,
RediSearch does it in some specific flows and modifies key metadata which in
turn might invalidates the local kvobj pointer. Those specific flows will be
protected by macro KSN_INVALIDATE_KVOBJ() which invalidates the local kvobj 
pointer after the notification to prevent further access to it by redis core (Currently it 
is only relevant to hash type keys, without hash field expiration).

Change Includes
- Pick up @JoanFM's additional tests: https://github.com/redis/redis/pull/14939
- Add KSN_INVALIDATE_KVOBJ() to mark and guard error-prone paths
- Apply it to generic command flows KSN beyond hashes
- Extend KSN side-effect coverage for DELEX and MOVE
- Rearranged some of the KSNs such that after notification, local kv won't get accessed


### Implications / behavior changes
No intended behavior change, and no intentional reordering of existing
notifications.

For example, in the `HDEL` last-field case, the observable order is preserved:

- delete the last field
- delete the key
- notify `hdel`
- notify `del`

The same goes for other related commands/notifications.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple write command paths (`RESTORE`, `DEL`/`DELEX`, `RENAME`/`MOVE`/`COPY`, `EXPIRE`/`PERSIST`, and several hash mutations) to avoid use-after-realloc when modules mutate key metadata during keyspace notifications. Risk is moderate because it changes ordering/structure around notifications and follow-up bookkeeping in core DB/hash logic, though intended behavior is unchanged.
> 
> **Overview**
> Prevents Redis core from using potentially stale `kvobj*` pointers after `notifyKeyspaceEvent()` when a module’s keyspace-notification callback mutates key metadata and may reallocate the underlying object.
> 
> This introduces `KSN_INVALIDATE_KVOBJ()` and applies it across several key-modifying flows (notably hash mutations and generic events like `del`, `restore`, `expire`/`persist`, `rename`/`move`, `copy`) and slightly rearranges some hash cleanup/bookkeeping to ensure no further access occurs after notifications.
> 
> Test coverage is expanded with a module-based regression suite that mutates key metadata during selected notifications (including new cases like `HGETDEL`, `HDEL`, `PERSIST`, `COPY`, `DELEX`, `MOVE`), and the test module now releases its key meta class on unload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637e2ff6eb6fe9bbd761f679542ee550ad01e916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->