### PR TITLE
Add error on enabling memory tracking in non-clustered mode

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2411,6 +2411,10 @@ static int isValidShutdownOnSigFlags(int val, const char **err) {
 }
 
 static int updateMemoryTrackingEnabled(const char **err) {
+    if (!server.cluster_enabled) {
+        *err = "memory tracking can be modified only in cluster mode";
+        return 0;
+    }
     int memory_tracking_enabled = server.key_memory_histograms || clusterSlotStatsEnabled(CLUSTER_SLOT_STATS_MEM);
     if (!server.memory_tracking_enabled && memory_tracking_enabled) {
         *err = "memory tracking cannot be enabled at runtime";

--- a/src/config.c
+++ b/src/config.c
@@ -2411,11 +2411,7 @@ static int isValidShutdownOnSigFlags(int val, const char **err) {
 }
 
 static int updateMemoryTrackingEnabled(const char **err) {
-    if (!server.cluster_enabled) {
-        *err = "memory tracking can be modified only in cluster mode";
-        return 0;
-    }
-    int memory_tracking_enabled = server.key_memory_histograms || clusterSlotStatsEnabled(CLUSTER_SLOT_STATS_MEM);
+    int memory_tracking_enabled = server.key_memory_histograms || (server.cluster_slot_stats_enabled & CLUSTER_SLOT_STATS_MEM);
     if (!server.memory_tracking_enabled && memory_tracking_enabled) {
         *err = "memory tracking cannot be enabled at runtime";
         return 0;

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -158,7 +158,7 @@ proc wait_for_replica_key_exists {key key_count} {
 # Test cases for CLUSTER SLOT-STATS cpu-usec metric correctness.
 # -----------------------------------------------------------------------------
 
-start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+start_cluster 1 0 {tags {external:skip cluster}} {
 
     # Define shared variables.
     set key "FOO"
@@ -361,7 +361,7 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
 # Test cases for CLUSTER SLOT-STATS network-bytes-in.
 # -----------------------------------------------------------------------------
 
-start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+start_cluster 1 0 {tags {external:skip cluster}} {
 
     # Define shared variables.
     set key "key"
@@ -471,7 +471,7 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
     R 0 FLUSHALL
 }
 
-start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+start_cluster 1 1 {tags {external:skip cluster}} {
     set channel "channel"
     set key_slot [R 0 cluster keyslot $channel]
     set metrics_to_assert [list network-bytes-in]
@@ -525,7 +525,6 @@ start_cluster 1 0 {tags {external:skip cluster}} {
     set key_slot [R 0 cluster keyslot $key]
     set expected_slots_to_key_count [dict create $key_slot 1]
     set metrics_to_assert [list network-bytes-out]
-    R 0 CONFIG SET cluster-slot-stats-enabled yes
 
     test "CLUSTER SLOT-STATS network-bytes-out, for non-slot specific commands." {
         R 0 INFO
@@ -583,7 +582,6 @@ start_cluster 1 1 {tags {external:skip cluster}} {
     set key "FOO"
     set key_slot [R 0 CLUSTER KEYSLOT $key]
     set metrics_to_assert [list network-bytes-out]
-    R 0 CONFIG SET cluster-slot-stats-enabled yes
 
     # Setup replication.
     assert {[s -1 role] eq {slave}}
@@ -616,7 +614,6 @@ start_cluster 1 1 {tags {external:skip cluster}} {
     set channel_secondary "channel2"
     set key_slot_secondary [R 0 cluster keyslot $channel_secondary]
     set metrics_to_assert [list network-bytes-out]
-    R 0 CONFIG SET cluster-slot-stats-enabled yes
 
     test "CLUSTER SLOT-STATS network-bytes-out, sharded pub/sub, single channel." {
         set slot [R 0 cluster keyslot $channel]
@@ -700,7 +697,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
 # Test cases for CLUSTER SLOT-STATS key-count metric correctness.
 # -----------------------------------------------------------------------------
 
-start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+start_cluster 1 0 {tags {external:skip cluster}} {
 
     # Define shared variables.
     set key "FOO"
@@ -785,7 +782,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
 # Test cases for CLUSTER SLOT-STATS ORDERBY sub-argument.
 # -----------------------------------------------------------------------------
 
-start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+start_cluster 1 0 {tags {external:skip cluster}} {
 
     set metrics [list "key-count" "memory-bytes" "cpu-usec" "network-bytes-in" "network-bytes-out"]
 
@@ -891,7 +888,7 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
 # Test cases for CLUSTER SLOT-STATS replication.
 # -----------------------------------------------------------------------------
 
-start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+start_cluster 1 1 {tags {external:skip cluster}} {
 
     # Define shared variables.
     set key "key"
@@ -994,7 +991,7 @@ start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-en
     R 1 CONFIG RESETSTAT
 }
 
-start_cluster 2 2 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+start_cluster 2 2 {tags {external:skip cluster}} {
     test "CLUSTER SLOT-STATS reset upon atomic slot migration" {
         # key on slot-0
         set key0 "{06S}mykey0"
@@ -1044,7 +1041,7 @@ start_cluster 2 2 {tags {external:skip cluster} overrides {cluster-slot-stats-en
 # Test cases for CLUSTER SLOT-STATS memory-bytes field presence.
 # -----------------------------------------------------------------------------
 
-start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+start_cluster 1 0 {tags {external:skip cluster}} {
     # Define shared variables.
     set key "FOO"
     set key_slot [R 0 cluster keyslot $key]
@@ -1174,7 +1171,7 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
 # may change object encoding (e.g., listTypeTryConversion).
 # -----------------------------------------------------------------------------
 
-start_cluster 1 0 {tags {external:skip cluster needs:debug} overrides {cluster-slot-stats-enabled yes}} {
+start_cluster 1 0 {tags {external:skip cluster needs:debug}} {
     # Enable debug assertion that validates memory tracking after each command.
     # This will cause a panic if tracked memory doesn't match actual memory.
     R 0 DEBUG ALLOCSIZE-SLOTS-ASSERT 1

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -1231,3 +1231,14 @@ start_cluster 1 0 {tags {external:skip cluster needs:debug}} {
         R 0 CONFIG SET list-max-listpack-size [lindex $origin_conf 1]
     }
 }
+
+start_server {} {
+    test "CLUSTER SLOT-STATS memory tracking cannot be re-enabled after being disabled (non-clustered mode)" {
+        # Once memory tracking is disabled, it cannot be re-enabled at runtime
+        assert_error "ERR*memory tracking cannot be enabled at runtime*" {r CONFIG SET cluster-slot-stats-enabled yes}
+        assert_error "ERR*memory tracking cannot be enabled at runtime*" {r CONFIG SET cluster-slot-stats-enabled mem}
+
+        # But cpu and net can still be enabled
+        assert_match "OK" [r CONFIG SET cluster-slot-stats-enabled "cpu net"]
+    }
+}


### PR DESCRIPTION
Enabling memory tracking is forbidden during runtime if it is already disabled. In non-clustered mode though the checks were incorrect so this PR enforces the correct behavior in non-clustered environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small boolean condition change in `updateMemoryTrackingEnabled()` plus test adjustments; main behavioral impact is stricter runtime validation of `cluster-slot-stats-enabled mem/yes` when memory tracking was previously disabled.
> 
> **Overview**
> Fixes runtime validation for memory tracking enablement by basing `updateMemoryTrackingEnabled()` on the `cluster-slot-stats-enabled` bitflags directly, ensuring *non-clustered mode* correctly rejects attempts to re-enable memory tracking once disabled.
> 
> Updates `slot-stats.tcl` to stop force-enabling slot stats at cluster startup, removes redundant `CONFIG SET cluster-slot-stats-enabled yes` calls, and adds a new non-clustered regression test asserting `mem/yes` re-enable fails while `cpu net` still succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efed3bf8053225bc6354a70f6dab80a9fd39712a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->