### PR TITLE
fix trivial double-free issue in rdbLoadObject

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2878,11 +2878,13 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
 
                         /* search for duplicate records */
                         sds field = sdstrynewlen(fstr, flen);
-                        if (!field || dictAdd(dupSearchDict, field, NULL) != DICT_OK ||
-                            !lpSafeToAdd(lp, (size_t)flen + vlen)) {
+                        int field_added = (field != NULL && dictAdd(dupSearchDict, field, NULL) == DICT_OK);
+                        if (!field_added || !lpSafeToAdd(lp, (size_t)flen + vlen)) {
                             rdbReportCorruptRDB("Hash zipmap with dup elements, or big length (%u)", flen);
+                            /* If field was not added to dict, we still own it.
+                             * If it was added, dict owns it and dictRelease will free it. */
+                            if (!field_added) sdsfree(field);
                             dictRelease(dupSearchDict);
-                            sdsfree(field);
                             lpFree(lp);
                             zfree(encoded);
                             o->ptr = NULL;


### PR DESCRIPTION
Actually it rarely can happen.

in rdbLoadObject.

when sdstrynewlen is OK and hashtableAdd is OK. but lpSafeToAdd is FAIL.

field will be double-freed.

but lpSafeToAdd will fail len + add > LISTPACK_MAX_SAFETY_SIZE(1GB)

so it can rarely happened and trivial. I think.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RDB load error-handling in `rdbLoadObject`, a critical startup/replication path; although the change is small, mistakes could cause crashes or leaks during RDB parsing.
> 
> **Overview**
> Fixes an error path in `rdbLoadObject` when converting `RDB_TYPE_HASH_ZIPMAP` to listpack: if the field was successfully added to the duplicate-detection dict but `lpSafeToAdd` fails, the field is no longer freed twice.
> 
> This refactors the duplicate-check insert to track whether the dict took ownership of `field`, and conditionally frees it only when insertion failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3aa2d6ddd6f589c2306114b2ab23b2c0e99bb0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->