### PR TITLE
Change log level for unknown extension types from LL_WARNING to LL_VERBOSE

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2648,7 +2648,7 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
             ext_shardid = shardid_ext->shard_id;
         } else {
             /* Unknown type, we will ignore it but log what happened. */
-            serverLog(LL_WARNING, "Received unknown extension type %d", type);
+            serverLog(LL_VERBOSE, "Received unknown extension type %d", type);
         }
 
         /* We know this will be valid since we validated it ahead of time */


### PR DESCRIPTION
In mixed-version clusters (7.2.x/7.4.x + 8.0+), unknown extension types are expected and safely skipped. This aligns with the change already made in 8.0+ (PR #13763).

Fixes #15014

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes a `serverLog` level from `LL_WARNING` to `LL_VERBOSE` without affecting cluster message parsing or behavior.
> 
> **Overview**
> Downgrades the log message for unknown cluster ping extension types in `src/cluster_legacy.c` from `LL_WARNING` to `LL_VERBOSE`, keeping the behavior of ignoring unknown extensions but reducing noise in mixed-version clusters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50f2d8340bb9a39f4bc043f0e6763052cdd3d7dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->