### PR TITLE
Fix gen_write_load error on MOVED/ASK during atomic-slot-migration tests

### DIFF
--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -48,8 +48,16 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
         incr count
         if {$count % 500 == 0} {
             for {set i 0} {$i < 500} {incr i} {
-                $r read
+                if {[catch {$r read} err]} {
+                    # MOVED/ASK means the slot migrated to another node,
+                    # continuing to write is pointless, exit gracefully.
+                    if {[string match {MOVED*} $err] || [string match {ASK*} $err]} {
+                        exit 0
+                    }
+                    error $err
+                }
             }
+            set count 0
         }
 
         if {[clock seconds]-$start_time > $seconds} {
@@ -60,9 +68,10 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
         }
     }
     
-    # Read remaining replies
+    # Read remaining replies, catch errors since the process is about to exit
+    # and the connection may already be broken or redirected.
     for {set i 0} {$i < $count} {incr i} {
-        $r read
+        catch {$r read}
     }
     exit 0
 }

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -70,15 +70,11 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {ignore_e
 
     # Read remaining replies
     for {set i 0} {$i < $count} {incr i} {
-        if {$ignore_error_reply} {
-            if {[catch {$r read} err]} {
-                if {[string match {MOVED*} $err] || [string match {ASK*} $err]} {
-                    continue
-                }
-                error $err
+        if {[catch {$r read} err]} {
+            if {$ignore_error_reply && ([string match {MOVED*} $err] || [string match {ASK*} $err])} {
+                continue
             }
-        } else {
-            $r read
+            error $err
         }
     }
     exit 0

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -84,8 +84,4 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {ignore_e
     exit 0
 }
 
-set ignore_error_reply 0
-if {[llength $argv] > 7} {
-    set ignore_error_reply [lindex $argv 7]
-}
-gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6] $ignore_error_reply
+gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6] [lindex $argv 7]

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -18,9 +18,8 @@ set ::tlsdir "tests/tls"
 
 # Continuously sends SET commands to the server. If key is omitted, a random key
 # is used for every SET command. The value is always random.
-#
-# cluster_load (default 0): when 1, exit 0 on MOVED or ASK while draining pipelined
-# SET replies; the final drain uses catch so read errors there do not fail shutdown.
+# cluster_load (default 0): when 1, MOVED/ASK replies are tolerated while
+# draining pipelined responses.
 proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {cluster_load 0}} {
     set start_time [clock seconds]
     set r [redis $host $port 1 $tls]
@@ -54,7 +53,7 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {cluster_
                 if {$cluster_load == 1} {
                     if {[catch {$r read} err]} {
                         if {[string match {MOVED*} $err] || [string match {ASK*} $err]} {
-                            exit 0
+                            continue
                         }
                         error $err
                     }
@@ -76,7 +75,12 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {cluster_
     # Read remaining replies
     for {set i 0} {$i < $count} {incr i} {
         if {$cluster_load == 1} {
-            catch {$r read}
+            if {[catch {$r read} err]} {
+                if {[string match {MOVED*} $err] || [string match {ASK*} $err]} {
+                    continue
+                }
+                error $err
+            }
         } else {
             $r read
         }
@@ -84,4 +88,8 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {cluster_
     exit 0
 }
 
-gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6] [lindex $argv 7]
+set cluster_load 0
+if {[llength $argv] > 7} {
+    set cluster_load [lindex $argv 7]
+}
+gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6] $cluster_load

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -46,18 +46,10 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
         }
         
         incr count
-        if {$count >= 500} {
-            for {set i 0} {$i < $count} {incr i} {
-                if {[catch {$r read} err]} {
-                    # MOVED/ASK means the slot migrated to another node,
-                    # continuing to write is pointless, exit gracefully.
-                    if {[string match {MOVED*} $err] || [string match {ASK*} $err]} {
-                        exit 0
-                    }
-                    error $err
-                }
+        if {$count % 500 == 0} {
+            for {set i 0} {$i < 500} {incr i} {
+                $r read
             }
-            set count 0
         }
 
         if {[clock seconds]-$start_time > $seconds} {
@@ -68,10 +60,9 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
         }
     }
     
-    # Read remaining replies, catch errors since the process is about to exit
-    # and the connection may already be broken or redirected.
+    # Read remaining replies
     for {set i 0} {$i < $count} {incr i} {
-        catch {$r read}
+        $r read
     }
     exit 0
 }

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -18,8 +18,8 @@ set ::tlsdir "tests/tls"
 
 # Continuously sends SET commands to the server. If key is omitted, a random key
 # is used for every SET command. The value is always random.
-# cluster_load (default 0): when 1, MOVED/ASK replies are tolerated while
-# draining pipelined responses.
+# ignore_error_reply (default 0): when non-zero, MOVED/ASK replies are tolerated
+# while draining pipelined responses (periodic 500-reply batches and final drain).
 proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {ignore_error_reply 0}} {
     set start_time [clock seconds]
     set r [redis $host $port 1 $tls]
@@ -51,7 +51,7 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {ignore_e
         if {$count % 500 == 0} {
             for {set i 0} {$i < 500} {incr i} {
                 [catch {$r read} err]
-                if {ignore_error_reply && [string match {MOVED*} $err] || [string match {ASK*} $err]} {
+                if {$ignore_error_reply && ([string match {MOVED*} $err] || [string match {ASK*} $err])} {
                     continue
                 }
                 error $err
@@ -69,7 +69,7 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {ignore_e
 
     # Read remaining replies
     for {set i 0} {$i < $count} {incr i} {
-        if {$cluster_load == 1} {
+        if {$ignore_error_reply} {
             if {[catch {$r read} err]} {
                 if {[string match {MOVED*} $err] || [string match {ASK*} $err]} {
                     continue
@@ -83,8 +83,8 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {ignore_e
     exit 0
 }
 
-set cluster_load 0
+set ignore_error_reply 0
 if {[llength $argv] > 7} {
-    set cluster_load [lindex $argv 7]
+    set ignore_error_reply [lindex $argv 7]
 }
-gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6] $cluster_load
+gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6] $ignore_error_reply

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -50,11 +50,12 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {ignore_e
         incr count
         if {$count % 500 == 0} {
             for {set i 0} {$i < 500} {incr i} {
-                [catch {$r read} err]
-                if {$ignore_error_reply && ([string match {MOVED*} $err] || [string match {ASK*} $err])} {
-                    continue
+                if {[catch {$r read} err]} {
+                    if {$ignore_error_reply && ([string match {MOVED*} $err] || [string match {ASK*} $err])} {
+                        continue
+                    }
+                    error $err
                 }
-                error $err
             }
             set count 0
         }

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -46,10 +46,18 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
         }
         
         incr count
-        if {$count % 500 == 0} {
-            for {set i 0} {$i < 500} {incr i} {
-                $r read
+        if {$count >= 500} {
+            for {set i 0} {$i < $count} {incr i} {
+                if {[catch {$r read} err]} {
+                    # MOVED/ASK means the slot migrated to another node,
+                    # continuing to write is pointless, exit gracefully.
+                    if {[string match {MOVED*} $err] || [string match {ASK*} $err]} {
+                        exit 0
+                    }
+                    error $err
+                }
             }
+            set count 0
         }
 
         if {[clock seconds]-$start_time > $seconds} {
@@ -60,9 +68,10 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
         }
     }
     
-    # Read remaining replies
+    # Read remaining replies, catch errors since the process is about to exit
+    # and the connection may already be broken or redirected.
     for {set i 0} {$i < $count} {incr i} {
-        $r read
+        catch {$r read}
     }
     exit 0
 }

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -50,16 +50,11 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {ignore_e
         incr count
         if {$count % 500 == 0} {
             for {set i 0} {$i < 500} {incr i} {
-                if {$cluster_load == 1} {
-                    if {[catch {$r read} err]} {
-                        if {[string match {MOVED*} $err] || [string match {ASK*} $err]} {
-                            continue
-                        }
-                        error $err
-                    }
-                } else {
-                    $r read
+                [catch {$r read} err]
+                if {ignore_error_reply && [string match {MOVED*} $err] || [string match {ASK*} $err]} {
+                    continue
                 }
+                error $err
             }
             set count 0
         }

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -50,6 +50,7 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
             for {set i 0} {$i < 500} {incr i} {
                 $r read
             }
+            set count 0
         }
 
         if {[clock seconds]-$start_time > $seconds} {

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -50,11 +50,12 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {ignore_e
         incr count
         if {$count % 500 == 0} {
             for {set i 0} {$i < 500} {incr i} {
-                if {[catch {$r read} err]} {
+                # Capture opts to preserve original errorInfo/errorCode on re-raise.
+                if {[catch {$r read} err opts]} {
                     if {$ignore_error_reply && ([string match {MOVED*} $err] || [string match {ASK*} $err])} {
                         continue
                     }
-                    error $err
+                    return -options $opts $err
                 }
             }
             set count 0
@@ -70,11 +71,11 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {ignore_e
 
     # Read remaining replies
     for {set i 0} {$i < $count} {incr i} {
-        if {[catch {$r read} err]} {
+        if {[catch {$r read} err opts]} {
             if {$ignore_error_reply && ([string match {MOVED*} $err] || [string match {ASK*} $err])} {
                 continue
             }
-            error $err
+            return -options $opts $err
         }
     }
     exit 0

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -48,16 +48,8 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
         incr count
         if {$count % 500 == 0} {
             for {set i 0} {$i < 500} {incr i} {
-                if {[catch {$r read} err]} {
-                    # MOVED/ASK means the slot migrated to another node,
-                    # continuing to write is pointless, exit gracefully.
-                    if {[string match {MOVED*} $err] || [string match {ASK*} $err]} {
-                        exit 0
-                    }
-                    error $err
-                }
+                $r read
             }
-            set count 0
         }
 
         if {[clock seconds]-$start_time > $seconds} {
@@ -68,10 +60,9 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
         }
     }
     
-    # Read remaining replies, catch errors since the process is about to exit
-    # and the connection may already be broken or redirected.
+    # Read remaining replies
     for {set i 0} {$i < $count} {incr i} {
-        catch {$r read}
+        $r read
     }
     exit 0
 }

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -20,7 +20,7 @@ set ::tlsdir "tests/tls"
 # is used for every SET command. The value is always random.
 # cluster_load (default 0): when 1, MOVED/ASK replies are tolerated while
 # draining pipelined responses.
-proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {cluster_load 0}} {
+proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {ignore_error_reply 0}} {
     set start_time [clock seconds]
     set r [redis $host $port 1 $tls]
     $r client setname LOAD_HANDLER

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -18,7 +18,10 @@ set ::tlsdir "tests/tls"
 
 # Continuously sends SET commands to the server. If key is omitted, a random key
 # is used for every SET command. The value is always random.
-proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
+#
+# cluster_load (default 0): when 1, exit 0 on MOVED or ASK while draining pipelined
+# SET replies; the final drain uses catch so read errors there do not fail shutdown.
+proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0} {cluster_load 0}} {
     set start_time [clock seconds]
     set r [redis $host $port 1 $tls]
     $r client setname LOAD_HANDLER
@@ -44,11 +47,20 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
         } else {
             $r set $key $value
         }
-        
+
         incr count
         if {$count % 500 == 0} {
             for {set i 0} {$i < 500} {incr i} {
-                $r read
+                if {$cluster_load == 1} {
+                    if {[catch {$r read} err]} {
+                        if {[string match {MOVED*} $err] || [string match {ASK*} $err]} {
+                            exit 0
+                        }
+                        error $err
+                    }
+                } else {
+                    $r read
+                }
             }
             set count 0
         }
@@ -60,12 +72,16 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
             after $sleep
         }
     }
-    
+
     # Read remaining replies
     for {set i 0} {$i < $count} {incr i} {
-        $r read
+        if {$cluster_load == 1} {
+            catch {$r read}
+        } else {
+            $r read
+        }
     }
     exit 0
 }
 
-gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6]
+gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6] [lindex $argv 7]

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -604,9 +604,8 @@ proc find_valgrind_errors {stderr on_termination} {
 # Execute a background process writing random data for the specified number
 # of seconds to the specified Redis instance. If key is omitted, a random key
 # is used for every SET command.
-#
-# cluster_load (default 0): set 1 when cluster slot migration may hit the load
-# connection with MOVED/ASK; passed as the last argv to tests/helpers/gen_write_load.tcl.
+# cluster_load (default 0): set 1 in cluster slot-migration tests to tolerate
+# MOVED/ASK replies while draining pipelined writes in the load helper.
 proc start_write_load {host port seconds {key ""} {size 0} {sleep 0} {cluster_load 0}} {
     set tclsh [info nameofexecutable]
     exec $tclsh tests/helpers/gen_write_load.tcl $host $port $seconds $::tls $key $size $sleep $cluster_load &

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -604,11 +604,11 @@ proc find_valgrind_errors {stderr on_termination} {
 # Execute a background process writing random data for the specified number
 # of seconds to the specified Redis instance. If key is omitted, a random key
 # is used for every SET command.
-# cluster_load (default 0): set 1 in cluster slot-migration tests to tolerate
+# ignore_error_reply (default 0): set non-zero in cluster slot-migration tests to tolerate
 # MOVED/ASK replies while draining pipelined writes in the load helper.
-proc start_write_load {host port seconds {key ""} {size 0} {sleep 0} {cluster_load 0}} {
+proc start_write_load {host port seconds {key ""} {size 0} {sleep 0} {ignore_error_reply 0}} {
     set tclsh [info nameofexecutable]
-    exec $tclsh tests/helpers/gen_write_load.tcl $host $port $seconds $::tls $key $size $sleep $cluster_load &
+    exec $tclsh tests/helpers/gen_write_load.tcl $host $port $seconds $::tls $key $size $sleep $ignore_error_reply &
 }
 
 # Stop a process generating write load executed with start_write_load.

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -604,9 +604,12 @@ proc find_valgrind_errors {stderr on_termination} {
 # Execute a background process writing random data for the specified number
 # of seconds to the specified Redis instance. If key is omitted, a random key
 # is used for every SET command.
-proc start_write_load {host port seconds {key ""} {size 0} {sleep 0}} {
+#
+# cluster_load (default 0): set 1 when cluster slot migration may hit the load
+# connection with MOVED/ASK; passed as the last argv to tests/helpers/gen_write_load.tcl.
+proc start_write_load {host port seconds {key ""} {size 0} {sleep 0} {cluster_load 0}} {
     set tclsh [info nameofexecutable]
-    exec $tclsh tests/helpers/gen_write_load.tcl $host $port $seconds $::tls $key $size $sleep &
+    exec $tclsh tests/helpers/gen_write_load.tcl $host $port $seconds $::tls $key $size $sleep $cluster_load &
 }
 
 # Stop a process generating write load executed with start_write_load.

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -791,15 +791,6 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     }
 
     test "Migration will be successful after fail points are cleared" {
-        # Ensure slot 0-100 is owned by R1 so R0 can import them.
-        # When running standalone (--only), R0 owns them initially.
-        if {[catch {R 1 set [slot_key 0 __probe__] __probe__}]} {
-            R 0 debug asm-failpoint "" ""
-            R 1 debug asm-failpoint "" ""
-            R 1 CLUSTER MIGRATION IMPORT 0 100
-            wait_for_asm_done
-        }
-
         R 0 flushall
         R 1 flushall
         set slot0_key [slot_key 0 mykey]

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -810,8 +810,8 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # we set a delay to write incremental data
         R 1 config set rdb-key-save-delay 1000000
 
-        # Start the slot 0 write load on R1. cluster_load 1: R0 imports slot 0 while
-        # load runs; pipelined reads on this fixed connection may see MOVED/ASK.
+        # Start slot 0 write load on R1. cluster_load=1 tolerates MOVED/ASK
+        # replies that can appear while slot 0 is being migrated.
         set load_handle [start_write_load "127.0.0.1" [get_port 1] 100 $slot0_key 0 0 1]
 
         # Clear all fail points

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -810,8 +810,9 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # we set a delay to write incremental data
         R 1 config set rdb-key-save-delay 1000000
 
-        # Start the slot 0 write load on the R 1
-        set load_handle [start_write_load "127.0.0.1" [get_port 1] 100 $slot0_key]
+        # Start the slot 0 write load on R1. cluster_load 1: R0 imports slot 0 while
+        # load runs; pipelined reads on this fixed connection may see MOVED/ASK.
+        set load_handle [start_write_load "127.0.0.1" [get_port 1] 100 $slot0_key 0 0 0]
 
         # Clear all fail points
         assert_equal {OK} [R 0 debug asm-failpoint "" ""]

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -803,7 +803,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # Start the slot 0 write load on R1. cluster_load 1: R0 imports slot 0 while
         # load runs; pipelined reads on this fixed connection may see MOVED/ASK.
-        set load_handle [start_write_load "127.0.0.1" [get_port 1] 100 $slot0_key 0 0 0]
+        set load_handle [start_write_load "127.0.0.1" [get_port 1] 100 $slot0_key 0 0 1]
 
         # Clear all fail points
         assert_equal {OK} [R 0 debug asm-failpoint "" ""]

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -577,13 +577,13 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 debug asm-trim-method none
         populate_slot 10000 -idx 1 -slot 6000
 
-        # Start write traffic on node-0 (cluster_load=1 tolerates MOVED/ASK
+        # Start write traffic on node-0 (ignore_error_reply=1 tolerates MOVED/ASK
         # replies while slots are being migrated).
         set port [get_port 0]
         set key [slot_key 0 mykey]
         set load_handle0 [start_write_load "127.0.0.1" $port 100 $key 0 5 1]
 
-        # Start write traffic on node-1 (cluster_load=1 for migration redirects).
+        # Start write traffic on node-1 (ignore_error_reply=1 for migration redirects).
         set port [get_port 1]
         set key [slot_key 6000 mykey]
         set load_handle1 [start_write_load "127.0.0.1" $port 100 $key 0 5 1]
@@ -794,7 +794,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # we set a delay to write incremental data
         R 1 config set rdb-key-save-delay 1000000
 
-        # Start slot 0 write load on R1. cluster_load=1 tolerates MOVED/ASK
+        # Start slot 0 write load on R1. ignore_error_reply=1 tolerates MOVED/ASK
         # replies that can appear while slot 0 is being migrated.
         set load_handle [start_write_load "127.0.0.1" [get_port 1] 100 $slot0_key 0 0 1]
 

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -577,23 +577,16 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 debug asm-trim-method none
         populate_slot 10000 -idx 1 -slot 6000
 
-        # Start write traffic on node-0
-        # Throws -MOVED error once asm is completed, catch block will ignore it.
-        catch {
-            # Start the slot 0 write load on the R 0
-            set port [get_port 0]
-            set key [slot_key 0 mykey]
-            set load_handle0 [start_write_load "127.0.0.1" $port 100 $key 0 5]
-        }
+        # Start write traffic on node-0 (cluster_load=1 tolerates MOVED/ASK
+        # replies while slots are being migrated).
+        set port [get_port 0]
+        set key [slot_key 0 mykey]
+        set load_handle0 [start_write_load "127.0.0.1" $port 100 $key 0 5 1]
 
-        # Start write traffic on node-1
-        # Throws -MOVED error once asm is completed, catch block will ignore it.
-        catch {
-            # Start the slot 6000 write load on the R 1
-            set port [get_port 1]
-            set key [slot_key 6000 mykey]
-            set load_handle1 [start_write_load "127.0.0.1" $port 100 $key 0 5]
-        }
+        # Start write traffic on node-1 (cluster_load=1 for migration redirects).
+        set port [get_port 1]
+        set key [slot_key 6000 mykey]
+        set load_handle1 [start_write_load "127.0.0.1" $port 100 $key 0 5 1]
 
         # Migrate keys
         R 1 CLUSTER MIGRATION IMPORT 0 100

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -791,6 +791,15 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     }
 
     test "Migration will be successful after fail points are cleared" {
+        # Ensure slot 0-100 is owned by R1 so R0 can import them.
+        # When running standalone (--only), R0 owns them initially.
+        if {[catch {R 1 set [slot_key 0 __probe__] __probe__}]} {
+            R 0 debug asm-failpoint "" ""
+            R 1 debug asm-failpoint "" ""
+            R 1 CLUSTER MIGRATION IMPORT 0 100
+            wait_for_asm_done
+        }
+
         R 0 flushall
         R 1 flushall
         set slot0_key [slot_key 0 mykey]


### PR DESCRIPTION


### Problem 

The `gen_write_load` helper can exit with an unhandled `MOVED` reply during `atomic-slot-migration`, specifically in `Migration will be successful after fail points are cleared`, which leaks Tcl stack traces into test output even though the test itself passes.

<img width="2252" height="562" alt="CleanShot 2026-04-08 at 23 20 35@2x" src="https://github.com/user-attachments/assets/94effcbc-5565-4e6d-9a95-f1a4b798fb25" />



### Changes

1. Handle MOVED/ASK responses gracefully during pipeline reply reading — exit cleanly instead of crashing to stderr. 
2. Also fix the reply count tracking so the final drain loop only reads the actual number of pending replies.

### Test

After commit :
<img width="1962" height="846" alt="CleanShot 2026-04-08 at 23 24 04@2x" src="https://github.com/user-attachments/assets/6e2bd130-afff-4856-a0e8-feccc454eb58" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Tcl test helpers and a few cluster tests; the main risk is altering load-generator behavior and masking unexpected redirect errors outside migration scenarios.
> 
> **Overview**
> Prevents the `tests/helpers/gen_write_load.tcl` load generator from crashing when a cluster slot migration triggers `MOVED`/`ASK` replies while draining pipelined `SET` responses.
> 
> Adds an `ignore_error_reply` flag plumbed through `start_write_load` and updates `atomic-slot-migration.tcl` to enable it for migration scenarios; also fixes reply-drain accounting by resetting the 500-reply batch counter so the final drain reads only outstanding replies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b6f6ded5d495f3a536a15072e9a8ab71e2bf17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->