### PR TITLE
Eliminate buffer copy in zzlStrtod for sorted set score parsing

### DIFF
--- a/deps/fast_float/fast_float_strtod.cpp
+++ b/deps/fast_float/fast_float_strtod.cpp
@@ -30,3 +30,17 @@ extern "C" double fast_float_strtod(const char *nptr, char **endptr) {
   }
   return result;
 }
+
+/* Length-aware variant that avoids the need for null-terminated input.
+ * Parses at most 'len' bytes starting from 'nptr'. */
+extern "C" double fast_float_strtod_n(const char *nptr, size_t len, char **endptr) {
+  double result = 0.0;
+  auto answer = fast_float::from_chars(nptr, nptr + len, result);
+  if (answer.ec != std::errc()) {
+    errno = EINVAL;
+  }
+  if (endptr != NULL) {
+    *endptr = (char *)answer.ptr;
+  }
+  return result;
+}

--- a/deps/fast_float/fast_float_strtod.h
+++ b/deps/fast_float/fast_float_strtod.h
@@ -2,11 +2,14 @@
 #ifndef __FAST_FLOAT_STRTOD_H__
 #define __FAST_FLOAT_STRTOD_H__
 
+#include <stddef.h>
+
 #if defined(__cplusplus)
 extern "C"
 {
 #endif
     double fast_float_strtod(const char *in, char **out);
+    double fast_float_strtod_n(const char *in, size_t len, char **out);
 
 #if defined(__cplusplus)
 }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -945,13 +945,8 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n, un
  *----------------------------------------------------------------------------*/
 
 static double zzlStrtod(unsigned char *vstr, unsigned int vlen) {
-    char buf[128];
-    if (vlen > sizeof(buf) - 1)
-        vlen = sizeof(buf) - 1;
-    memcpy(buf,vstr,vlen);
-    buf[vlen] = '\0';
-    return fast_float_strtod(buf,NULL);
- }
+    return fast_float_strtod_n((const char *)vstr, vlen, NULL);
+}
 
 double zzlGetScore(unsigned char *sptr) {
     unsigned char *vstr;


### PR DESCRIPTION
## Summary

`zzlStrtod()` is called on every sorted-set listpack operation that reads
a score (ZADD, ZRANGE, ZRANGEBYSCORE, ZSCAN, etc.). It currently copies
the score bytes into a 128-byte stack buffer, null-terminates it, then
calls `fast_float_strtod()` — which internally calls `strlen()` to find
the end before parsing.

This memcpy + null-terminate + strlen chain is unnecessary because
`fast_float::from_chars()` natively accepts `(begin, end)` pointer pairs.

**This change:**
1. Adds `fast_float_strtod_n(const char *nptr, size_t len, char **endptr)` —
   a length-aware variant that passes `(nptr, nptr+len)` directly to
   `fast_float::from_chars()`
2. Replaces `zzlStrtod()` to call this directly, eliminating the stack
   buffer, memcpy, null-termination, and strlen

Note: Valkey addressed float parsing differently in valkey-io/valkey#3329
by replacing the fast_float C++ library with a pure C port (ffc). This PR
takes a different approach — keeping the existing fast_float library but
eliminating the unnecessary buffer copy by exposing the length-aware API
that `from_chars` already supports natively.

## Profiling

`zzlStrtod` consumes **11.4% flat CPU** in sorted-set listpack workloads
(ZADD 100 elements, listpack encoding). The buffer copy + null-termination
is the overhead — the underlying parser already supports bounded input.

## Benchmark Results

| Platform | Workload | Improvement |
|----------|----------|-------------|
| x86-AWS (m7i.metal-24xl) | ZADD listpack load | **+56.1%** |
| x86-AWS | zrangebyscore | +15.7% |
| x86-AWS | zrange | +15.4% |
| x86-GCP (c4-standard-48) | ZADD listpack load | **+55.2%** |
| x86-GCP | zrangebyscore | +18.5% |
| x86-GCP | zrange | +14.1% |
| ARM-GCP (c4a-standard-48) | ZADD listpack load | **+30.7%** |
| ARM-GCP | zrange/zrangebyscore | +5.7–5.8% |

Zero consistent regressions across 3 platforms. Gains are largest on
listpack-encoded sorted sets where score parsing is a significant fraction
of the work.