### PR TITLE
Fix HEXPIRE numfields overflow

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3589,14 +3589,16 @@ static int parseHashCommandArgs(client *c, HashCommandArgs *args,
                                               &numFields, "Parameter `numFields` should be greater than 0") != C_OK)
                 return C_ERR;
 
-            args->fieldCount = (int)numFields;
             args->firstFieldPos = i + 2;
 
-            /* Check bounds - we must have exactly the right number of fields */
-            if (args->firstFieldPos + args->fieldCount > c->argc) {
+            /* Validate that the FIELDS block fits in argv without overflowing. Extra
+             * option tokens may still appear after the field list. */
+            if (numFields > c->argc - args->firstFieldPos) {
                 addReplyError(c, "wrong number of arguments");
                 return C_ERR;
             }
+
+            args->fieldCount = (int)numFields;
 
             /* Skip over the field arguments */
             i = args->firstFieldPos + args->fieldCount - 1;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3591,8 +3591,7 @@ static int parseHashCommandArgs(client *c, HashCommandArgs *args,
 
             args->firstFieldPos = i + 2;
 
-            /* Validate that the FIELDS block fits in argv without overflowing. Extra
-             * option tokens may still appear after the field list. */
+            /* Check bounds - we must have exactly the right number of fields */
             if (numFields > c->argc - args->firstFieldPos) {
                 addReplyError(c, "wrong number of arguments");
                 return C_ERR;

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -2359,6 +2359,11 @@ start_server {tags {"hash"}} {
             assert_error {*Parameter*numFields*should be greater than 0*} {r HEXPIRE myhash 60 FIELDS -1 f1}
             assert_error {*invalid number of fields*} {r HSETEX myhash FIELDS 0 f1 v1 EX 60}
             assert_error {*invalid number of fields*} {r HGETEX myhash FIELDS 0 f1 EX 60}
+            set future_sec [expr {[clock seconds] + 60}]
+            set future_ms [expr {[clock milliseconds] + 60000}]
+            foreach {cmd expire} [list HEXPIRE 60 HPEXPIRE 60000 HEXPIREAT $future_sec HPEXPIREAT $future_ms] {
+                assert_error {*wrong number of arguments*} [list r $cmd myhash $expire FIELDS 2147483647 f1]
+            }
 
             # Test missing FIELDS keyword
             assert_error {*unknown argument*} {r HEXPIRE myhash 60 2 f1 f2}


### PR DESCRIPTION
## Summary
- validate HEXPIRE-family FIELDS counts without overflowing parser arithmetic
- preserve flexible option ordering by only requiring the field list to fit in argv
- add regression coverage for INT_MAX numfields across HEXPIRE/HPEXPIRE/HEXPIREAT/HPEXPIREAT
