### PR TITLE
rax: use memchr() for child-edge lookup in non-compressed nodes

### DIFF
--- a/src/rax.c
+++ b/src/rax.c
@@ -496,13 +496,15 @@ static inline size_t raxLowWalk(rax *rax, unsigned char *s, size_t len, raxNode 
                 j = h->size;
                 break;
             } else {
-                /* Even when h->size is large, linear scan provides good
-                 * performances compared to other approaches that are in theory
-                 * more sounding, like performing a binary search. */
-                for (j = 0; j < h->size; j++) {
-                    if (v[j] == s[i]) break;
-                }
-                if (j == h->size) break;
+                /* Lookup the matching child edge. memchr() is used instead
+                 * of an open-coded scalar loop because libc implementations
+                 * on most platforms are SIMD-optimized (SSE2/AVX2 on x86,
+                 * NEON on arm64), which is significantly faster than a
+                 * byte-by-byte scan at the small fan-out sizes (<= 256)
+                 * that rax nodes can have. */
+                unsigned char *p = memchr(v, s[i], h->size);
+                if (p == NULL) break;
+                j = (size_t)(p - v);
             }
             i++;
         }


### PR DESCRIPTION
Replace the open-coded byte-by-byte loop in raxLowWalk() with memchr(). libc implementations of memchr() on common platforms are SIMD-optimized (SSE2/AVX2 on x86_64, NEON on arm64), which significantly outperforms a scalar loop while remaining faster than a binary search at the small fan-out sizes (<= 256) that rax nodes can have.

## Redis `feature/enhance_rax` Benchmark Results (macOS arm64, 5-run average)
  ### Lookup (Mops/s)

  | nkeys | keylen | redis unstable | memchr | speedup |
  |-------|--------|----------------|--------|---------|
  | 10K   | 8      | 13.62          | 26.06  | 1.91x   |
  | 100K  | 4      | 8.28           | 19.24  | 2.32x   |
  | 200K  | 16     | 4.80           | 11.71  | 2.44x   |
  | 500K  | 20     | 3.54           | 7.34   | 2.07x   |
  | 1M    | 16     | 2.81           | 5.89   | 2.10x   |
  | 200K  | 64     | 3.36           | 4.51   | 1.34x   |

  ### Insert (Mops/s)

  | nkeys | keylen | redis unstable | memchr | speedup |
  |-------|--------|----------------|--------|---------|
  | 10K   | 8      | 5.18           | 5.61   | 1.08x   |
  | 100K  | 4      | 4.86           | 6.53   | 1.34x   |
  | 200K  | 16     | 4.16           | 5.35   | 1.29x   |
  | 500K  | 20     | 3.97           | 5.25   | 1.32x   |
  | 1M    | 16     | 3.93           | 4.98   | 1.27x   |
  | 200K  | 64     | 4.01           | 4.77   | 1.19x   |

## Redis `feature/enhance_rax` Benchmark Results (Linux x86_64 (Ryzen 7 8845HS, GCC 13.3, 5-run average)
### Lookup (Mops/s)
  | nkeys | keylen | redis unstable | feature/enhance_rax | speedup |
  |-------|--------|----------------|---------------------|---------|
  | 10K   | 8      | 16.06          | 32.69               | 2.04x   |
  | 100K  | 4      | 7.18           | 20.41               | 2.84x   |
  | 200K  | 16     | 4.08           | 8.32                | 2.04x   |
  | 500K  | 20     | 3.26           | 5.27                | 1.61x   |
  | 1M    | 16     | 3.15           | 4.89                | 1.55x   |
  | 200K  | 64     | 3.01           | 4.51                | 1.50x   |

### Insert (Mops/s)
  | nkeys | keylen | redis unstable | feature/enhance_rax | speedup |
  |-------|--------|----------------|---------------------|---------|
  | 10K   | 8      | 5.53           | 6.18                | 1.12x   |
  | 100K  | 4      | 4.49           | 5.61                | 1.25x   |
  | 200K  | 16     | 3.85           | 5.02                | 1.30x   |
  | 500K  | 20     | 3.56           | 4.76                | 1.34x   |
  | 1M    | 16     | 3.29           | 4.35                | 1.32x   |
  | 200K  | 64     | 3.44           | 4.32                | 1.26x   |


Actually I tested binary search method if h->size is greater than T(8, 16, 32) and SIMD implementation. SIMD(especially NEON in arm is a little bit faster than this PR). but memchr is stable and robust and it is more readable.

Thanks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance refactor confined to `raxLowWalk()` child-edge lookup; main risk is subtle behavior differences on edge cases (e.g., type/size conversions), but logic remains equivalent.
> 
> **Overview**
> Improves radix-tree lookup performance by replacing the open-coded byte-by-byte scan for matching child edges in non-compressed nodes with a `memchr()`-based search.
> 
> Adds rationale in-code for using libc’s SIMD-optimized `memchr()` and keeps the existing fast-path checks for the last child and out-of-range bytes before falling back to the scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38a7551aa227d23f3e22c60d6960ecf0e6e05c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->