### PR TITLE
Fix memory leak in helloblock.c on thread creation failure

### DIFF
--- a/src/modules/helloblock.c
+++ b/src/modules/helloblock.c
@@ -103,6 +103,7 @@ int HelloBlock_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
     if (pthread_create(&tid,NULL,HelloBlock_ThreadMain,targ) != 0) {
         RedisModule_AbortBlock(bc);
+        RedisModule_Free(targ);
         return RedisModule_ReplyWithError(ctx,"-ERR Can't start thread");
     }
     return REDISMODULE_OK;


### PR DESCRIPTION
In  **src/modules/helloblock.c** , the command **HELLO.BLOCK** allocates a small array (**targ**) to pass arguments (the blocked client handle and the delay) to a background thread.

However, if **pthread_create** fails, the function would call **RedisModule_AbortBlock(bc)** and return an error immediately without freeing the **targ** allocation. This resulted in a small memory leak on each failed thread creation attempt.

Changes
Added a call to **RedisModule_Free(targ)** within the **pthread_create** error handling block in **HelloBlock_RedisCommand**.

This ensures that all temporary allocations are cleaned up before returning an error to the client.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized cleanup in an error path to prevent a memory leak when thread creation fails.
> 
> **Overview**
> Prevents a memory leak in `src/modules/helloblock.c` by freeing the temporary `targ` allocation when `pthread_create` fails in `HelloBlock_RedisCommand` (after aborting the block and before returning an error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1b008285b80d1aa6bbfbdf3097da0455f45d7de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->