### PR TITLE
[Fix] free targ on pthread_create error path in helloblock.c and blockonbackground.c

### DIFF
--- a/src/modules/helloblock.c
+++ b/src/modules/helloblock.c
@@ -103,6 +103,7 @@ int HelloBlock_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
     if (pthread_create(&tid,NULL,HelloBlock_ThreadMain,targ) != 0) {
         RedisModule_AbortBlock(bc);
+        RedisModule_Free(targ);
         return RedisModule_ReplyWithError(ctx,"-ERR Can't start thread");
     }
     return REDISMODULE_OK;

--- a/tests/modules/blockonbackground.c
+++ b/tests/modules/blockonbackground.c
@@ -157,6 +157,7 @@ int HelloBlock_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
     if (pthread_create(&tid,NULL,BlockDebug_ThreadMain,targ) != 0) {
         RedisModule_AbortBlock(bc);
+        RedisModule_Free(targ);
         return RedisModule_ReplyWithError(ctx,"-ERR Can't start thread");
     }
     pthread_detach(tid);
@@ -200,6 +201,7 @@ int HelloBlockNoTracking_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **a
 
     if (pthread_create(&tid,NULL,BlockDebug_ThreadMain,targ) != 0) {
         RedisModule_AbortBlock(bc);
+        RedisModule_Free(targ);
         return RedisModule_ReplyWithError(ctx,"-ERR Can't start thread");
     }
     pthread_detach(tid);
@@ -231,6 +233,7 @@ int HelloDoubleBlock_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 
     if (pthread_create(&tid,NULL,DoubleBlock_ThreadMain,targ) != 0) {
         RedisModule_AbortBlock(bc);
+        RedisModule_Free(targ);
         return RedisModule_ReplyWithError(ctx,"-ERR Can't start thread");
     }
     pthread_detach(tid);


### PR DESCRIPTION
Fixes #15023
-
### Describe the bug

- In `src/modules/helloblock.c`, there is a missing free on an error path.
- In `HelloBlock_RedisCommand`, `targ` is allocated, but if `pthread_create` fails, the function returns without freeing `targ`.
- 
- Also in `tests/modules/blockonbackground.c` there is a missing free `targ` in multiple error paths.
- In `HelloBlock_RedisCommand()`, `targ` is allocated, but if `pthread_create` fails, the function returns without freeing `targ`.
- In `HelloBlockNoTracking_RedisCommand()`, `targ` is allocated, but if `pthread_create` fails, the function returns without freeing `targ`.
- In `HelloDoubleBlock_RedisCommand()`, `targ` is allocated, but if `pthread_create` fails, the function returns without freeing `targ`.

-----

### Location:

- `src/modules/helloblock.c` (`HelloBlock_RedisCommand()`, around the pthread_create failure branch)
- In `tests/modules/blockonbackground.c` 
(`HelloBlock_RedisCommand()`, `HelloBlockNoTracking_RedisCommand()`, `HelloDoubleBlock_RedisCommand()`)

------

### Expected behavior

On the `pthread_create` failure path, all temporary allocations made in the above functions should be released before returning.

--------

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk memory-management fix limited to module/test code paths when thread creation fails; only affects error handling.
> 
> **Overview**
> Fixes small memory leaks in blocking module commands by freeing the heap-allocated thread argument array (`targ`) when `pthread_create` fails in `helloblock` and `blockonbackground` modules.
> 
> This tightens cleanup in these error paths while keeping normal success-path behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a889bfb514f4650d30ec8f47e2daefb73d7cd4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->