### PR TITLE
Add LCS LEN fast path using rolling two-row DP

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -973,6 +973,54 @@ void strlenCommand(client *c) {
     addReplyLongLong(c,stringObjectLen(kv));
 }
 
+/* Compute only the LCS length using two rolling rows, and reply to the client.
+ * Used when LCS is invoked with LEN (and without IDX), since recovering the
+ * actual subsequence or match indices is not required. Memory usage is
+ * O(min(|a|,|b|)) instead of O(|a|*|b|). On allocation/limit failures this
+ * sends an error reply; in all cases the client receives exactly one reply. */
+static void lcsReplyLength(client *c, sds a, sds b) {
+    uint32_t alen = sdslen(a);
+    uint32_t blen = sdslen(b);
+    /* Use the shorter string for the inner dimension to minimize memory. */
+    const char *astr = a;
+    const char *bstr = b;
+    if (blen > alen) {
+        uint32_t tmp_len = alen; alen = blen; blen = tmp_len;
+        const char *tmp_str = astr; astr = bstr; bstr = tmp_str;
+    }
+
+    size_t row_bytes = ((size_t)blen + 1) * sizeof(uint32_t);
+    if (row_bytes * 2 > (size_t)server.proto_max_bulk_len) {
+        addReplyError(c, "Insufficient memory, transient memory for LCS exceeds proto-max-bulk-len");
+        return;
+    }
+    uint32_t *prev = ztrycalloc(row_bytes);
+    uint32_t *curr = ztrycalloc(row_bytes);
+    if (!prev || !curr) {
+        if (prev) zfree(prev);
+        if (curr) zfree(curr);
+        addReplyError(c, "Insufficient memory, failed allocating transient memory for LCS");
+        return;
+    }
+
+    for (uint32_t ii = 1; ii <= alen; ii++) {
+        curr[0] = 0;
+        for (uint32_t jj = 1; jj <= blen; jj++) {
+            if (astr[ii - 1] == bstr[jj - 1]) {
+                curr[jj] = prev[jj - 1] + 1;
+            } else {
+                uint32_t v1 = prev[jj];
+                uint32_t v2 = curr[jj - 1];
+                curr[jj] = v1 > v2 ? v1 : v2;
+            }
+        }
+        uint32_t *tmp = prev; prev = curr; curr = tmp;
+    }
+    addReplyLongLong(c, prev[blen]);
+    zfree(prev);
+    zfree(curr);
+}
+
 /* LCS key1 key2 [LEN] [IDX] [MINMATCHLEN <len>] [WITHMATCHLEN] */
 void lcsCommand(client *c) {
     uint32_t i, j;
@@ -1029,6 +1077,13 @@ void lcsCommand(client *c) {
     /* Detect string truncation or later overflows. */
     if (sdslen(a) >= UINT32_MAX-1 || sdslen(b) >= UINT32_MAX-1) {
         addReplyError(c, "String too long for LCS");
+        goto cleanup;
+    }
+
+    /* Fast path: when only LEN is requested, compute with rolling DP
+     * to avoid allocating the full O(n*m) table. */
+    if (getlen && !getidx) {
+        lcsReplyLength(c, a, b);
         goto cleanup;
     }
 


### PR DESCRIPTION
LCS key1 key2 LEN currently allocates and fills the full (|a|+1) × (|b|+1) DP table even though only the final cell is read. This change
introduces a fast path for the LEN-only case (LEN without IDX) that computes the length using a rolling two-row DP, reducing transient memory
from O(|a|·|b|) to O(min(|a|, |b|)). The rolling computation is extracted into a small helper, lcsReplyLength(), so lcsCommand() stays focused
on argument parsing and dispatch.

  ## Redis (feature/enhance_lcs vs unstable)

  ```
  === redis-baseline ===
    size=64    avg=2.162 ms/op  (over 200 iters)
    size=256   avg=2.214 ms/op  (over 200 iters)
    size=1024  avg=2.908 ms/op  (over 200 iters)
    size=2048  avg=5.351 ms/op  (over 200 iters)
    size=4096  avg=13.880 ms/op (over 200 iters)
    size=8192  avg=57.454 ms/op (over 200 iters)
  === redis-feature ===
    size=64    avg=2.514 ms/op  (over 200 iters)
    size=256   avg=2.496 ms/op  (over 200 iters)
    size=1024  avg=3.024 ms/op  (over 200 iters)
    size=2048  avg=4.831 ms/op  (over 200 iters)
    size=4096  avg=10.811 ms/op (over 200 iters)
    size=8192  avg=34.130 ms/op (over 200 iters)
  ```

  | size   | baseline  | feature  | speedup |
  |---:|---:|---:|---:|
  |    64  |   2.16 ms |   2.51 ms | ~0.86× (RTT noise) |
  |   256  |   2.21 ms |   2.50 ms | ~0.89× (RTT noise) |
  |  1024  |   2.91 ms |   3.02 ms | ~0.96× |
  |  2048  |   5.35 ms |   4.83 ms | ~1.11× |
  |  4096  |  13.88 ms |  10.81 ms | ~1.28× |
  |  8192  |  57.45 ms |  34.13 ms | **~1.68×** |
  | 16384+ |    ERR    | works     | newly possible |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `LCS` command’s execution path for `LEN`-only requests, which could affect correctness and error behavior for large inputs if edge cases are missed. It also introduces new transient allocation/limit checks tied to `proto-max-bulk-len`.
> 
> **Overview**
> Adds a **LEN-only fast path** for `LCS` that computes just the LCS length via a two-row rolling dynamic-programming helper (`lcsReplyLength`) instead of allocating the full O(n*m) table.
> 
> The new helper minimizes transient memory to O(min(|a|,|b|)), includes `proto-max-bulk-len`/allocation failure handling, and `lcsCommand` now dispatches to it when `LEN` is specified without `IDX`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc0897bfc16d6fd39e411bb980d2813260e6f4cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->