### PR TITLE
zset: add in-place fast path for score updates in listpack encoding

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1647,8 +1647,56 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 
             /* Remove and re-insert when score changed. */
             if (score != curscore) {
-                zobj->ptr = zzlDelete(zobj->ptr,eptr);
-                zobj->ptr = zzlInsert(zobj->ptr,ele,score);
+                unsigned char *zl = zobj->ptr;
+                unsigned char *sptr = lpNext(zl, eptr);
+                serverAssert(sptr != NULL);
+
+                /* Fast path: if the new score keeps the element in its current
+                 * slot under (score, ele) ordering, replace the score entry in
+                 * place instead of delete + full re-scan.
+                 *
+                 * Only the neighbor in the direction of the score change needs
+                 * to be checked: if the score increases, the previous neighbor
+                 * satisfies (prev_score < score) strictly (since prev_score <=
+                 * curscore < score), so only the next neighbor can violate the
+                 * order. The score-decrease case is symmetric. */
+                int keep_position = 1;
+                if (score > curscore) {
+                    unsigned char *next_eptr = eptr, *next_sptr = sptr;
+                    zzlNext(zl, &next_eptr, &next_sptr);
+                    if (next_sptr != NULL) {
+                        double next_score = zzlGetScore(next_sptr);
+                        if (next_score < score ||
+                            (next_score == score &&
+                             zzlCompareElements(next_eptr, (unsigned char *)ele, sdslen(ele)) < 0))
+                            keep_position = 0;
+                    }
+                } else { /* score < curscore */
+                    unsigned char *prev_eptr = eptr, *prev_sptr = sptr;
+                    zzlPrev(zl, &prev_eptr, &prev_sptr);
+                    if (prev_sptr != NULL) {
+                        double prev_score = zzlGetScore(prev_sptr);
+                        if (prev_score > score ||
+                            (prev_score == score &&
+                             zzlCompareElements(prev_eptr, (unsigned char *)ele, sdslen(ele)) > 0))
+                            keep_position = 0;
+                    }
+                }
+
+                if (keep_position) {
+                    long long lscore;
+                    if (double2ll(score, &lscore)) {
+                        zl = lpReplaceInteger(zl, &sptr, lscore);
+                    } else {
+                        char scorebuf[MAX_D2STRING_CHARS];
+                        int scorelen = d2string(scorebuf, sizeof(scorebuf), score);
+                        zl = lpReplace(zl, &sptr, (unsigned char *)scorebuf, scorelen);
+                    }
+                    zobj->ptr = zl;
+                } else {
+                    zobj->ptr = zzlDelete(zl, eptr);
+                    zobj->ptr = zzlInsert(zobj->ptr, ele, score);
+                }
                 *out_flags |= ZADD_OUT_UPDATED;
             }
             return 1;


### PR DESCRIPTION
  ## Summary

  - Before: Updating the score of an existing member in a listpack-encoded zset always performs `zzlDelete` followed by `zzlInsert`, which
  re-scans from the head to find the new position.
  - Change: If the new score keeps the member between its current neighbors under `(score, ele)` ordering, update the score entry in place via
  `lpReplaceInteger` or `lpReplace` — no delete, no scan.
  - Note: Mirrors the fast path already used by `zslUpdateScore` on the skiplist side.

  ## Motivation

  Small score adjustments are common (leaderboards, counters, weighted metrics). In these patterns, the member typically stays in place, yet the
  current path still pays for delete + O(N/2) re-scan. Avoiding that work makes the hot path much cheaper.

  ## Change

  When `score != curscore`, probe the neighbor in the direction of the score change and, if ordering holds, replace the score entry with
  `lpReplace*`; otherwise fall back to delete + re-insert.

  Only the neighbor in the direction of the score change can violate ordering:

  - If `score > curscore`, the previous neighbor is always safe (`prev_score <= curscore < score` strictly). Check only the next.
  - If `score < curscore`, the next is always safe. Check only the previous.

  No protocol, syntax, error, or semantic change. The slow path is unchanged.

  ## Benchmarks

  Linux, 20k ops per run, 5 runs per cell, mean ± σ (μs/op). `zset-max-listpack-entries` raised to keep listpack encoding. RESP and loopback cost
   included.

  ### small_delta (±0.5 nudge — fast path hits almost always)

  | N   | baseline        | feature         | speedup   |
  |---:|---:|---:|---:|
  |   8 | 1.340 ± 0.012   | 1.177 ± 0.018   | **1.14×** |
  |  16 | 1.438 ± 0.016   | 1.175 ± 0.010   | **1.22×** |
  |  32 | 1.692 ± 0.038   | 1.246 ± 0.034   | **1.36×** |
  |  64 | 2.267 ± 0.084   | 1.309 ± 0.025   | **1.73×** |
  | 128 | 3.577 ± 0.039   | 1.511 ± 0.075   | **2.37×** |
  | 256 | 5.724 ± 0.055   | 1.720 ± 0.021   | **3.33×** |
  | 512 | 9.268 ± 0.091   | 2.486 ± 0.111   | **3.73×** |

  ### monotonic (increasing scores — ZINCRBY-like)

  | N   | baseline        | feature         | speedup    |
  |---:|---:|---:|---:|
  |   8 | 1.414 ± 0.017   | 1.388 ± 0.024   | ~1.02×     |
  |  16 | 1.676 ± 0.038   | 1.629 ± 0.039   | ~1.03×     |
  |  32 | 2.198 ± 0.114   | 1.963 ± 0.082   | ~1.12×     |
  |  64 | 3.491 ± 0.076   | 3.036 ± 0.037   | ~1.15×     |
  | 128 | 5.187 ± 0.259   | 4.644 ± 0.090   | ~1.12×     |
  | 256 | 8.717 ± 0.168   | 7.857 ± 0.228   | ~1.11×     |
  | 512 | 15.606 ± 0.030  | 13.263 ± 0.028  | **~1.18×** |

  ### random (adversarial — fast path rarely hits)

  | N   | baseline        | feature         | Δ                |
  |---:|---:|---:|---:|
  |   8 | 1.383 ± 0.048   | 1.365 ± 0.019   | −1.3%            |
  |  16 | 1.472 ± 0.045   | 1.500 ± 0.096   | +1.9% (~σ)       |
  |  32 | 1.705 ± 0.098   | 1.685 ± 0.031   | −1.2%            |
  |  64 | 2.314 ± 0.048   | 2.287 ± 0.059   | −1.2%            |
  | 128 | 3.491 ± 0.238*  | 3.592 ± 0.028   | +2.9% (baseline outlier) |
  | 256 | 5.475 ± 0.406*  | 5.635 ± 0.060   | +2.9% (baseline outlier) |
  | 512 | 9.175 ± 0.420*  | 9.321 ± 0.101   | +1.6% (baseline outlier) |

  *baseline σ inflated by one low-side outlier; excluding it the two are a tie.

  ## Safety

  - Behaviorally identical: same replies, errors, and tie-break (score, then lex).
  - Reallocation-safe: `lpReplace*` may reallocate; the returned pointer is always written back to `zobj->ptr`.
  - Floating-point edge cases: `NaN` is rejected at `zsetAdd` entry; `+0.0`/`-0.0` compare equal so the fast path is not taken; `±Inf` follows
  the existing `d2string` / `double2ll` encoding paths.
  - Fallback remains: if ordering doesn't hold, we still do `zzlDelete` → `zzlInsert`.

  ## Tests

  Existing zset tests pass. Updates of existing scores (`ZADD` overwrite, `ZINCRBY`, `ZADD GT/LT`) naturally exercise the fast path; reordering
  cases exercise the slow path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core sorted-set update logic for listpack encoding; while behavior should be unchanged, incorrect neighbor/order checks or listpack reallocation handling could corrupt ordering or pointers under edge cases.
> 
> **Overview**
> Improves the hot path for updating an existing member’s score in listpack-encoded zsets: when `score != curscore`, it now checks only the adjacent neighbor in the direction of the change and, if ordering is still valid, updates the score *in place* via `lpReplaceInteger`/`lpReplace`.
> 
> If the new score would violate `(score, ele)` ordering relative to that neighbor, it preserves existing behavior by falling back to `zzlDelete` + `zzlInsert` (full re-scan).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f70533897bdd2d4ba150e41d694fc58c58156d5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->