### PR TITLE
Fix decrRefCount on NULL robj on corrupt KEY_META payload

### DIFF
--- a/src/keymeta.c
+++ b/src/keymeta.c
@@ -416,7 +416,7 @@ int rdbLoadSkipMetaIfAllowed(rio *rdb, char *cname, int flags) {
          *
          * Note: rdbLoadCheckModuleValue() reads opcodes until it finds RDB_MODULE_OPCODE_EOF,
          * so it consumes the EOF marker as well. We don't need to read it separately. */
-        robj *dummy = rdbLoadCheckModuleValue(rdb, cname);
+        robj *dummy = rdbLoadCheckModuleValue(rdb, cname, 1);
         if (dummy == NULL) {
             serverLog(LL_WARNING, "Corrupted metadata value for class '%s'", cname);
             return -1;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2001,7 +2001,7 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename, int null_on_error) {
             if (rdbLoadLenByRef(rdb,NULL,&len) == -1) {
                 rdbReportCorruptRDB(
                     "Error reading integer from module %s value", modulename);
-                goto fail;
+                goto error;
             }
         } else if (opcode == RDB_MODULE_OPCODE_STRING) {
             robj *o = rdbGenericLoadStringObject(rdb,RDB_LOAD_NONE,NULL);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3563,7 +3563,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
         if (rdbCheckMode) {
             char name[10];
             moduleTypeNameByID(name,moduleid);
-            return rdbLoadCheckModuleValue(rdb,name,0);
+            return rdbLoadCheckModuleValue(rdb, name, 0);
         }
 
         if (mt == NULL) {
@@ -4015,7 +4015,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                 continue;
             } else {
                 /* RDB check mode. */
-                robj *aux = rdbLoadCheckModuleValue(rdb,name,0);
+                robj *aux = rdbLoadCheckModuleValue(rdb, name, 0);
                 decrRefCount(aux);
                 continue; /* Read next opcode. */
             }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1986,11 +1986,14 @@ void rdbRemoveTempFile(pid_t childpid, int from_signal) {
 
 /* This function is called by rdbLoadObject() when the code is in RDB-check
  * mode and we find a module value of type 2 that can be parsed without
- * the need of the actual module. The value is parsed for errors, finally
- * a dummy redis object is returned just to conform to the API. */
-robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename) {
+ * the need of the actual module. The value is parsed for errors.
+ * If null_on_fail is true, NULL is returned when data corruption is detected;
+ * otherwise a dummy redis object is always returned regardless of success or
+ * failure. */
+robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename, int null_on_error) {
     uint64_t opcode;
-    while((opcode = rdbLoadLen(rdb,NULL)) != RDB_LENERR) {
+    while((opcode = rdbLoadLen(rdb,NULL)) != RDB_MODULE_OPCODE_EOF) {
+        if (opcode == RDB_LENERR) goto fail;
         if (opcode == RDB_MODULE_OPCODE_SINT ||
             opcode == RDB_MODULE_OPCODE_UINT)
         {
@@ -1998,32 +2001,41 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename) {
             if (rdbLoadLenByRef(rdb,NULL,&len) == -1) {
                 rdbReportCorruptRDB(
                     "Error reading integer from module %s value", modulename);
+                goto fail;
             }
         } else if (opcode == RDB_MODULE_OPCODE_STRING) {
             robj *o = rdbGenericLoadStringObject(rdb,RDB_LOAD_NONE,NULL);
             if (o == NULL) {
                 rdbReportCorruptRDB(
                     "Error reading string from module %s value", modulename);
+                goto fail;
             }
-            if (o) decrRefCount(o);
+            decrRefCount(o);
         } else if (opcode == RDB_MODULE_OPCODE_FLOAT) {
             float val;
             if (rdbLoadBinaryFloatValue(rdb,&val) == -1) {
                 rdbReportCorruptRDB(
                     "Error reading float from module %s value", modulename);
+                goto fail;
             }
         } else if (opcode == RDB_MODULE_OPCODE_DOUBLE) {
             double val;
             if (rdbLoadBinaryDoubleValue(rdb,&val) == -1) {
                 rdbReportCorruptRDB(
                     "Error reading double from module %s value", modulename);
+                goto fail;
             }
-        } else if (opcode == RDB_MODULE_OPCODE_EOF) {
-            /* End of value */
-            break;
+        } else {
+            rdbReportCorruptRDB(
+                "Unknown module opcode %llu reading module %s value",
+                (unsigned long long)opcode, modulename);
+            goto fail;
         }
     }
+
     return createStringObject("module-dummy-value",18);
+fail:
+    return null_on_error ? NULL : createStringObject("module-dummy-value",18);
 }
 
 /* Load object type and optional key metadata (into `keymeta`) from RDB stream.
@@ -3548,7 +3560,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
         if (rdbCheckMode) {
             char name[10];
             moduleTypeNameByID(name,moduleid);
-            return rdbLoadCheckModuleValue(rdb,name);
+            return rdbLoadCheckModuleValue(rdb,name,0);
         }
 
         if (mt == NULL) {
@@ -4000,8 +4012,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                 continue;
             } else {
                 /* RDB check mode. */
-                robj *aux = rdbLoadCheckModuleValue(rdb,name);
-                if (aux) decrRefCount(aux);
+                rdbLoadCheckModuleValue(rdb,name,1);
                 continue; /* Read next opcode. */
             }
         } else if (type == RDB_OPCODE_FUNCTION_PRE_GA) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2035,7 +2035,6 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename, int null_on_error) {
             goto error;
         }
     }
-
     return createStringObject("module-dummy-value",18);
 error:
     return null_on_error ? NULL : createStringObject("module-dummy-value",18);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4012,7 +4012,8 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                 continue;
             } else {
                 /* RDB check mode. */
-                rdbLoadCheckModuleValue(rdb,name,1);
+                robj *aux = rdbLoadCheckModuleValue(rdb,name,0);
+                decrRefCount(aux);
                 continue; /* Read next opcode. */
             }
         } else if (type == RDB_OPCODE_FUNCTION_PRE_GA) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1987,13 +1987,13 @@ void rdbRemoveTempFile(pid_t childpid, int from_signal) {
 /* This function is called by rdbLoadObject() when the code is in RDB-check
  * mode and we find a module value of type 2 that can be parsed without
  * the need of the actual module. The value is parsed for errors.
- * If null_on_fail is true, NULL is returned when data corruption is detected;
+ * If null_on_error is true, NULL is returned when data corruption is detected;
  * otherwise a dummy redis object is always returned regardless of success or
  * failure. */
 robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename, int null_on_error) {
     uint64_t opcode;
     while((opcode = rdbLoadLen(rdb,NULL)) != RDB_MODULE_OPCODE_EOF) {
-        if (opcode == RDB_LENERR) goto fail;
+        if (opcode == RDB_LENERR) goto error;
         if (opcode == RDB_MODULE_OPCODE_SINT ||
             opcode == RDB_MODULE_OPCODE_UINT)
         {
@@ -2008,7 +2008,7 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename, int null_on_error) {
             if (o == NULL) {
                 rdbReportCorruptRDB(
                     "Error reading string from module %s value", modulename);
-                goto fail;
+                goto error;
             }
             decrRefCount(o);
         } else if (opcode == RDB_MODULE_OPCODE_FLOAT) {
@@ -2016,25 +2016,25 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename, int null_on_error) {
             if (rdbLoadBinaryFloatValue(rdb,&val) == -1) {
                 rdbReportCorruptRDB(
                     "Error reading float from module %s value", modulename);
-                goto fail;
+                goto error;
             }
         } else if (opcode == RDB_MODULE_OPCODE_DOUBLE) {
             double val;
             if (rdbLoadBinaryDoubleValue(rdb,&val) == -1) {
                 rdbReportCorruptRDB(
                     "Error reading double from module %s value", modulename);
-                goto fail;
+                goto error;
             }
         } else {
             rdbReportCorruptRDB(
                 "Unknown module opcode %llu reading module %s value",
                 (unsigned long long)opcode, modulename);
-            goto fail;
+            goto error;
         }
     }
 
     return createStringObject("module-dummy-value",18);
-fail:
+error:
     return null_on_error ? NULL : createStringObject("module-dummy-value",18);
 }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1990,7 +1990,7 @@ void rdbRemoveTempFile(pid_t childpid, int from_signal) {
  * a dummy redis object is returned just to conform to the API. */
 robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename) {
     uint64_t opcode;
-    while((opcode = rdbLoadLen(rdb,NULL)) != RDB_MODULE_OPCODE_EOF) {
+    while((opcode = rdbLoadLen(rdb,NULL)) != RDB_LENERR) {
         if (opcode == RDB_MODULE_OPCODE_SINT ||
             opcode == RDB_MODULE_OPCODE_UINT)
         {
@@ -2005,7 +2005,7 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename) {
                 rdbReportCorruptRDB(
                     "Error reading string from module %s value", modulename);
             }
-            decrRefCount(o);
+            if (o) decrRefCount(o);
         } else if (opcode == RDB_MODULE_OPCODE_FLOAT) {
             float val;
             if (rdbLoadBinaryFloatValue(rdb,&val) == -1) {
@@ -2018,6 +2018,9 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename) {
                 rdbReportCorruptRDB(
                     "Error reading double from module %s value", modulename);
             }
+        } else if (opcode == RDB_MODULE_OPCODE_EOF) {
+            /* End of value */
+            break;
         }
     }
     return createStringObject("module-dummy-value",18);
@@ -3998,7 +4001,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             } else {
                 /* RDB check mode. */
                 robj *aux = rdbLoadCheckModuleValue(rdb,name);
-                decrRefCount(aux);
+                if (aux) decrRefCount(aux);
                 continue; /* Read next opcode. */
             }
         } else if (type == RDB_OPCODE_FUNCTION_PRE_GA) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1993,7 +1993,11 @@ void rdbRemoveTempFile(pid_t childpid, int from_signal) {
 robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename, int null_on_error) {
     uint64_t opcode;
     while((opcode = rdbLoadLen(rdb,NULL)) != RDB_MODULE_OPCODE_EOF) {
-        if (opcode == RDB_LENERR) goto error;
+        if (opcode == RDB_LENERR) {
+            rdbReportCorruptRDB("Error reading module opcode length from module %s value", modulename);
+            goto error;
+        }
+
         if (opcode == RDB_MODULE_OPCODE_SINT ||
             opcode == RDB_MODULE_OPCODE_UINT)
         {
@@ -2027,8 +2031,7 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename, int null_on_error) {
             }
         } else {
             rdbReportCorruptRDB(
-                "Unknown module opcode %llu reading module %s value",
-                (unsigned long long)opcode, modulename);
+                "Unknown module opcode %llu reading module %s value", (unsigned long long)opcode, modulename);
             goto error;
         }
     }

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -151,7 +151,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error);
 void backgroundSaveDoneHandler(int exitcode, int bysignal);
 int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime,int dbid);
 ssize_t rdbSaveSingleModuleAux(rio *rdb, int when, moduleType *mt);
-robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename);
+robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename, int null_on_error);
 int rdbResolveKeyType(rio *rdb, int *type, int dbid, KeyMetaSpec *keymeta);
 robj *rdbLoadStringObject(rio *rdb);
 ssize_t rdbSaveStringObject(rio *rdb, robj *obj);

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -325,7 +325,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             moduleTypeNameByID(name,moduleid);
             rdbCheckInfo("MODULE AUX for: %s", name);
 
-            robj *o = rdbLoadCheckModuleValue(&rdb,name,0);
+            robj *o = rdbLoadCheckModuleValue(&rdb, name, 0);
             decrRefCount(o);
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_FUNCTION_PRE_GA) {

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -255,7 +255,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
                 uint32_t classSpec;
                 if (rioRead(&rdb, &classSpec, 4) == 0) goto eoferr;
                 /* Skip module value using rdbLoadCheckModuleValue */
-                robj *o = rdbLoadCheckModuleValue(&rdb, "metadata");
+                robj *o = rdbLoadCheckModuleValue(&rdb, "metadata", 1);
                 if (o == NULL) goto eoferr;
                 decrRefCount(o);
             }
@@ -325,7 +325,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             moduleTypeNameByID(name,moduleid);
             rdbCheckInfo("MODULE AUX for: %s", name);
 
-            robj *o = rdbLoadCheckModuleValue(&rdb,name);
+            robj *o = rdbLoadCheckModuleValue(&rdb,name,0);
             decrRefCount(o);
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_FUNCTION_PRE_GA) {

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -989,6 +989,15 @@ test {corrupt payload: fuzzer findings - vector sets with wrong encoding} {
     }
 }
 
+test {corrupt payload: fuzzer findings - decrRefCount on NULL robj on corrupt KEY_META payload} {
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        r config set sanitize-dump-payload no
+        r debug set-skip-checksum-validation 1
+        catch {r restore key 0 "\xF3\x02\x01\x0D\x00\x54\x23\x3F\xC9\x82\x32\x05\x8D" replace} err
+        assert_match "*Bad data format*" $err
+        r ping
+    }
+}
 
 } ;# tags
 


### PR DESCRIPTION
## Summary

This PR fixes two issues when processing corrupt data in rdbLoadCheckModuleValue():

1. When handling `RDB_MODULE_OPCODE_STRING` opcode, rdbGenericLoadStringObject() can return NULL on a corrupt payload. The code called decrRefCount(o) unconditionally without a NULL check, resulting in a NULL pointer dereference crash.

2. The while loop condition was `!= RDB_MODULE_OPCODE_EOF`, which means a truncated payload (causing rdbLoadLen to return RDB_LENERR) would never exit the loop, since `RDB_LENERR != RDB_MODULE_OPCODE_EOF` is always true, potentially causing an infinite hang.

Note that the new test in corrupt-dump covers both of these issues.
To ensure that this test could be reproduced on version 8.6, manually modified the payload.

Failed CI: https://github.com/redis/redis/actions/runs/24219825926/job/70708582753

```
Server crashed in RESTORE with payload: "\xF3\x02\x01\x0E\x00\x54\x23\x3F\xC9\x82\x32\x05\x8D"
valgrind or asan found an issue for payload: "\xF3\x02\x01\x0E\x00\x54\x23\x3F\xC9\x82\x32\x05\x8D"
violating commands:
[err]: Sanitizer error: object.c:604:21: runtime error: member access within null pointer of type 'struct robj'
```



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to RDB-check/corruption paths and add stricter validation/early exits, with minimal impact on normal RDB load/save behavior.
> 
> **Overview**
> Improves corruption handling in `rdbLoadCheckModuleValue()` by detecting `RDB_LENERR`, rejecting unknown module opcodes, and avoiding `decrRefCount()` on a NULL string object read; it now supports an option to return `NULL` on corruption instead of always returning a dummy object.
> 
> Updates RDB/key-metadata and `redis-check-rdb` callers to pass the new `null_on_error` flag (returning `NULL` for KEY_META skipping paths, keeping dummy objects for regular check-mode parsing), and adds an integration test covering the corrupt `KEY_META` RESTORE regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10c03a400b2ad91e1a677ee6329afcdb26bbb567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->