### PR TITLE
RED-183357 tarball upload automation

### DIFF
--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -98,7 +98,6 @@ jobs:
   upload-tarball:
     runs-on: ubuntu-latest
     needs: [ extract-release-info, create-tarball] # todo: add approval-gate to needs
-    if: needs.extract-release-info.outputs.release_type == 'latest'
 
     steps:
       - name: Checkout repository
@@ -122,11 +121,15 @@ jobs:
 
       - name: Upload tarball
         run: |
-          echo "" | ./utils/releasetools/02_upload_tarball.sh ${{ needs.extract-release-info.outputs.tag_name }}
+          if [[ "${{ needs.extract-release-info.outputs.release_type }}" == "latest" ]]; then
+            ./utils/releasetools/02_upload_tarball.sh ${{ needs.extract-release-info.outputs.tag_name }} --stable
+          else
+            ./utils/releasetools/02_upload_tarball.sh ${{ needs.extract-release-info.outputs.tag_name }} --unstable
+          fi
 
       - name: Verify upload
         run: |
-          ssh ubuntu@host.redis.io "ls -lh /var/www/download/releases/redis-${{ needs.extract-release-info.tag_name }}.tar.gz"
+          ssh ubuntu@host.redis.io "ls -lh /var/www/download/releases/redis-${{ needs.extract-release-info.outputs.tag_name }}.tar.gz"
 
   # test-release-tarball:
   #   needs: upload-tarball

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -97,7 +97,7 @@ jobs:
 
   upload-tarball:
     runs-on: ubuntu-latest
-    needs: [ extract-release-info, create-tarball, approval-gate ]
+    needs: [ extract-release-info, create-tarball] # todo: add approval-gate to needs
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -95,17 +95,35 @@ jobs:
   #         # This could use GitHub Environments with required reviewers
   #         # or a manual approval step
 
-  # upload-tarball:
-  #   needs: [extract-release-info, create-tarball, approval-gate]
-  #   if: always() && !cancelled() && needs.create-tarball.result == 'success' && (needs.approval-gate.result == 'success' || needs.approval-gate.result == 'skipped')
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Upload tarball
-  #       run: |
-  #         echo "TODO: Implement tarball upload"
-  #         # This will require:
-  #         # - SSH credentials/keys for upload to download.redis.io
-  #         # - Adaptation of utils/releasetools/02_upload_tarball.sh for CI environment
+  upload-tarball:
+    runs-on: ubuntu-latest
+    needs: [ extract-release-info, create-tarball, approval-gate ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.UBUNTU_REDIS_IO_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H host.redis.io >> ~/.ssh/known_hosts
+
+      - name: Test SSH connection
+        run: ssh -o BatchMode=yes ubuntu@host.redis.io "echo 'SSH connection successful'"
+
+      - name: Upload tarball
+        run: |
+          if [ "${{ needs.extract-release-info.release_type }}" = "latest" ]; then
+            ./utils/releasetools/02_upload_tarball.sh --stable ${{ needs.extract-release-info.tag_name }}
+          else
+            ./utils/releasetools/02_upload_tarball.sh --unstable ${{ needs.extract-release-info.tag_name }}
+          fi
+
+      - name: Verify upload
+        run: |
+          ssh ubuntu@host.redis.io "ls -lh /var/www/download/releases/redis-${{ needs.extract-release-info.tag_name }}.tar.gz"
 
   # test-release-tarball:
   #   needs: upload-tarball

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -98,6 +98,7 @@ jobs:
   upload-tarball:
     runs-on: ubuntu-latest
     needs: [ extract-release-info, create-tarball] # todo: add approval-gate to needs
+    if: needs.extract-release-info.outputs.release_type == 'latest'
 
     steps:
       - name: Checkout repository
@@ -121,7 +122,7 @@ jobs:
 
       - name: Upload tarball
         run: |
-          ./utils/releasetools/02_upload_tarball.sh ${{ needs.extract-release-info.tag_name }}
+          echo "" | ./utils/releasetools/02_upload_tarball.sh ${{ needs.extract-release-info.outputs.tag_name }}
 
       - name: Verify upload
         run: |

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -103,6 +103,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Download tarball artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: redis-${{ needs.extract-release-info.outputs.tag_name }}-tarball
+          path: /tmp
+
       - name: Setup SSH key
         run: |
           mkdir -p ~/.ssh
@@ -115,11 +121,7 @@ jobs:
 
       - name: Upload tarball
         run: |
-          if [ "${{ needs.extract-release-info.release_type }}" = "latest" ]; then
-            ./utils/releasetools/02_upload_tarball.sh --stable ${{ needs.extract-release-info.tag_name }}
-          else
-            ./utils/releasetools/02_upload_tarball.sh --unstable ${{ needs.extract-release-info.tag_name }}
-          fi
+          ./utils/releasetools/02_upload_tarball.sh ${{ needs.extract-release-info.tag_name }}
 
       - name: Verify upload
         run: |

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download tarball artifact
         uses: actions/download-artifact@v6

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -116,9 +116,6 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H host.redis.io >> ~/.ssh/known_hosts
 
-      - name: Test SSH connection
-        run: ssh -o BatchMode=yes ubuntu@host.redis.io "echo 'SSH connection successful'"
-
       - name: Upload tarball
         run: |
           if [[ "${{ needs.extract-release-info.outputs.release_type }}" == "latest" ]]; then

--- a/utils/releasetools/02_upload_tarball.sh
+++ b/utils/releasetools/02_upload_tarball.sh
@@ -19,21 +19,22 @@ fi
 echo "Uploading..."
 scp /tmp/redis-${VERSION_TAG}.tar.gz ubuntu@host.redis.io:/var/www/download/releases/
 
-# Only update the stable version if --stable flag is provided
-if [ "$VERSION_TYPE" == "--stable" ]
+# Exit if unstable release
+if [ "$VERSION_TYPE" == "--unstable" ]
 then
-    echo "Updating web site... "
-    echo "Please check the github action tests for the release."
-    ssh ubuntu@host.redis.io "cd /var/www/download;
-                              rm -rf redis-${VERSION_TAG}.tar.gz;
-                              wget http://download.redis.io/releases/redis-${VERSION_TAG}.tar.gz;
-                              tar xvzf redis-${VERSION_TAG}.tar.gz;
-                              rm -rf redis-stable;
-                              mv redis-${VERSION_TAG} redis-stable;
-                              tar cvzf redis-stable.tar.gz redis-stable;
-                              rm -rf redis-${VERSION_TAG}.tar.gz;
-                              shasum -a 256 redis-stable.tar.gz > redis-stable.tar.gz.SHA256SUM;
-                              "
-else
     echo "Unstable release - skipping stable version update"
+    exit 0
 fi
+
+echo "Updating web site... "
+echo "Please check the github action tests for the release."
+ssh ubuntu@host.redis.io "cd /var/www/download;
+                          rm -rf redis-${VERSION_TAG}.tar.gz;
+                          wget http://download.redis.io/releases/redis-${VERSION_TAG}.tar.gz;
+                          tar xvzf redis-${VERSION_TAG}.tar.gz;
+                          rm -rf redis-stable;
+                          mv redis-${VERSION_TAG} redis-stable;
+                          tar cvzf redis-stable.tar.gz redis-stable;
+                          rm -rf redis-${VERSION_TAG}.tar.gz;
+                          shasum -a 256 redis-stable.tar.gz > redis-stable.tar.gz.SHA256SUM;
+                          "

--- a/utils/releasetools/02_upload_tarball.sh
+++ b/utils/releasetools/02_upload_tarball.sh
@@ -1,23 +1,41 @@
 #!/bin/bash
-if [ $# != "1" ]
+if [ $# != "2" ]
 then
-    echo "Usage: ./utils/releasetools/02_upload_tarball.sh <version_tag>"
+    echo "Usage: ./utils/releasetools/02_upload_tarball.sh <version_tag> <--stable|--unstable>"
+    exit 1
+fi
+
+VERSION_TAG=$1
+VERSION_TYPE=$2
+
+# Validate the stability flag
+if [ "$VERSION_TYPE" != "--stable" ] && [ "$VERSION_TYPE" != "--unstable" ]
+then
+    echo "Error: Second parameter must be either --stable or --unstable"
+    echo "Usage: ./utils/releasetools/02_upload_tarball.sh <version_tag> <--stable|--unstable>"
     exit 1
 fi
 
 echo "Uploading..."
-scp /tmp/redis-${1}.tar.gz ubuntu@host.redis.io:/var/www/download/releases/
-echo "Updating web site... "
-echo "Please check the github action tests for the release."
-echo "Press any key if it is a stable release, or Ctrl+C to abort"
-read x
-ssh ubuntu@host.redis.io "cd /var/www/download;
-                          rm -rf redis-${1}.tar.gz;
-                          wget http://download.redis.io/releases/redis-${1}.tar.gz;
-                          tar xvzf redis-${1}.tar.gz;
-                          rm -rf redis-stable;
-                          mv redis-${1} redis-stable;
-                          tar cvzf redis-stable.tar.gz redis-stable;
-                          rm -rf redis-${1}.tar.gz;
-                          shasum -a 256 redis-stable.tar.gz > redis-stable.tar.gz.SHA256SUM;
-                          "
+scp /tmp/redis-${VERSION_TAG}.tar.gz ubuntu@host.redis.io:/var/www/download/releases/
+
+# Only update the stable version if --stable flag is provided
+if [ "$VERSION_TYPE" == "--stable" ]
+then
+    echo "Updating web site... "
+    echo "Please check the github action tests for the release."
+    echo "Press any key if it is a stable release, or Ctrl+C to abort"
+    read x
+    ssh ubuntu@host.redis.io "cd /var/www/download;
+                              rm -rf redis-${VERSION_TAG}.tar.gz;
+                              wget http://download.redis.io/releases/redis-${VERSION_TAG}.tar.gz;
+                              tar xvzf redis-${VERSION_TAG}.tar.gz;
+                              rm -rf redis-stable;
+                              mv redis-${VERSION_TAG} redis-stable;
+                              tar cvzf redis-stable.tar.gz redis-stable;
+                              rm -rf redis-${VERSION_TAG}.tar.gz;
+                              shasum -a 256 redis-stable.tar.gz > redis-stable.tar.gz.SHA256SUM;
+                              "
+else
+    echo "Unstable release - skipping stable version update"
+fi

--- a/utils/releasetools/02_upload_tarball.sh
+++ b/utils/releasetools/02_upload_tarball.sh
@@ -24,8 +24,6 @@ if [ "$VERSION_TYPE" == "--stable" ]
 then
     echo "Updating web site... "
     echo "Please check the github action tests for the release."
-    echo "Press any key if it is a stable release, or Ctrl+C to abort"
-    read x
     ssh ubuntu@host.redis.io "cd /var/www/download;
                               rm -rf redis-${VERSION_TAG}.tar.gz;
                               wget http://download.redis.io/releases/redis-${VERSION_TAG}.tar.gz;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds automated SSH/scp publishing to `host.redis.io` and updates the `redis-stable` tarball on stable releases, which is operationally sensitive and depends on correct secret/remote handling.
> 
> **Overview**
> The post-release GitHub Action now performs a real `upload-tarball` job: it downloads the tarball artifact, configures an SSH key from secrets, uploads the tarball to `host.redis.io`, and verifies the file exists on the server.
> 
> `02_upload_tarball.sh` is updated to be non-interactive and CI-friendly by requiring a `--stable|--unstable` flag; unstable releases only upload the tarball, while stable releases additionally refresh the server-side `redis-stable` bundle and checksum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ebe727d64f6edc247793721877f10c6aaa417b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->