### PR TITLE
DataTypes update 8.8 RC1

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.7.80
+MODULE_VERSION = v8.7.90
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 

--- a/modules/redisjson/Makefile
+++ b/modules/redisjson/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.7.80
+MODULE_VERSION = v8.7.90
 MODULE_REPO = https://github.com/redisjson/redisjson
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/rejson.so
 

--- a/modules/redistimeseries/Makefile
+++ b/modules/redistimeseries/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.7.80
+MODULE_VERSION = v8.7.90
 MODULE_REPO = https://github.com/redistimeseries/redistimeseries
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redistimeseries.so
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Bumps third-party Redis module versions, which can introduce behavior or compatibility changes at runtime despite a small diff.
> 
> **Overview**
> Updates the pinned `MODULE_VERSION` for RedisBloom, RedisJSON, and RedisTimeSeries from `v8.7.80` to `v8.7.90`, causing builds to pull and compile the newer upstream module releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5cd262999beafa26176ce8b56d85b527e9bc837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->