### PR TITLE
Fix wrong argv index in xinfoReplyWithStreamInfo for slot alloc size tracking

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -52,7 +52,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
+      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST -DDEBUG_ASSERTIONS'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -5038,7 +5038,7 @@ void xtrimCommand(client *c) {
 
 /* Helper function for xinfoCommand.
  * Handles the variants of XINFO STREAM */
-void xinfoReplyWithStreamInfo(client *c, kvobj *kv) {
+void xinfoReplyWithStreamInfo(client *c, robj *key, kvobj *kv) {
     stream *s = kv->ptr;
     int full = 1;
     long long count = 10; /* Default COUNT is 10 so we don't block the server */
@@ -5275,7 +5275,7 @@ void xinfoReplyWithStreamInfo(client *c, kvobj *kv) {
         }
     }
     if (server.memory_tracking_enabled)
-        updateSlotAllocSize(c->db,getKeySlot(c->argv[1]->ptr),kv,old_alloc,kvobjAllocSize(kv));
+        updateSlotAllocSize(c->db,getKeySlot(key->ptr),kv,old_alloc,kvobjAllocSize(kv));
 }
 
 /* XINFO CONSUMERS <key> <group>
@@ -5379,7 +5379,7 @@ NULL
         raxStop(&ri);
     } else if (!strcasecmp(opt,"STREAM")) {
         /* XINFO STREAM <key> [FULL [COUNT <count>]]. */
-        xinfoReplyWithStreamInfo(c,kv);
+        xinfoReplyWithStreamInfo(c,key,kv);
     } else {
         addReplySubcommandSyntaxError(c);
     }


### PR DESCRIPTION
`xinfoReplyWithStreamInfo` passed the wrong key(c->argv[1]) instead of `c->argv[2]`  to `updateSlotAllocSize` when updating per-slot memory tracking.

Fix by passing the key explicitly to `xinfoReplyWithStreamInfo` instead of relying on a hardcoded argv index.
Also, add the `-DDEBUG_ASSERTIONS` flag to the test-ubuntu-jemalloc CI to cover this debug assertion.

The `xinfo` command argv layout is:
- argv[0] = "xinfo"
- argv[1] = subcommand ("stream", "groups", "consumers")
- argv[2] = key

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches per-slot memory tracking for `XINFO STREAM`, which can affect cluster slot memory accounting/metrics if incorrect, but the change is small and localized. CI build flags are expanded to run additional debug assertions that may surface new failures.
> 
> **Overview**
> Fixes `XINFO STREAM` per-slot memory tracking by passing the actual stream `key` into `xinfoReplyWithStreamInfo` and using it (instead of a hardcoded `argv` index) when calling `updateSlotAllocSize`.
> 
> Updates the `test-ubuntu-jemalloc` Daily CI job to compile with `-DDEBUG_ASSERTIONS` to exercise related debug checks during tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dde5f89ab68387861269932c566e2eb1c6503146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->