### PR TITLE
aof: write directly to server.aof_buf in feedAppendOnlyFile

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1407,15 +1407,19 @@ sds genAofTimestampAnnotationIfNeeded(int force) {
  * argc   - Number of values in argv
  */
 void feedAppendOnlyFile(int dictid, robj **argv, int argc) {
-    sds buf = sdsempty();
-
     serverAssert(dictid == -1 || (dictid >= 0 && dictid < server.dbnum));
+
+    if (!(server.aof_state == AOF_ON ||
+          (server.aof_state == AOF_WAIT_REWRITE && server.child_type == CHILD_TYPE_AOF)))
+    {
+        return;
+    }
 
     /* Feed timestamp if needed */
     if (server.aof_timestamp_enabled) {
         sds ts = genAofTimestampAnnotationIfNeeded(0);
         if (ts != NULL) {
-            buf = sdscatsds(buf, ts);
+            server.aof_buf = sdscatsds(server.aof_buf, ts);
             sdsfree(ts);
         }
     }
@@ -1426,25 +1430,15 @@ void feedAppendOnlyFile(int dictid, robj **argv, int argc) {
         char seldb[64];
 
         snprintf(seldb,sizeof(seldb),"%d",dictid);
-        buf = sdscatprintf(buf,"*2\r\n$6\r\nSELECT\r\n$%lu\r\n%s\r\n",
+        server.aof_buf = sdscatprintf(server.aof_buf,
+            "*2\r\n$6\r\nSELECT\r\n$%lu\r\n%s\r\n",
             (unsigned long)strlen(seldb),seldb);
         server.aof_selected_db = dictid;
     }
 
     /* All commands should be propagated the same way in AOF as in replication.
      * No need for AOF-specific translation. */
-    buf = catAppendOnlyGenericCommand(buf,argc,argv);
-
-    /* Append to the AOF buffer. This will be flushed on disk just before
-     * of re-entering the event loop, so before the client will get a
-     * positive reply about the operation performed. */
-    if (server.aof_state == AOF_ON ||
-        (server.aof_state == AOF_WAIT_REWRITE && server.child_type == CHILD_TYPE_AOF))
-    {
-        server.aof_buf = sdscatlen(server.aof_buf, buf, sdslen(buf));
-    }
-
-    sdsfree(buf);
+    server.aof_buf = catAppendOnlyGenericCommand(server.aof_buf,argc,argv);
 }
 
 /* ----------------------------------------------------------------------------


### PR DESCRIPTION
  Replace the "build-then-copy" pattern in `feedAppendOnlyFile()`: instead
  of building the serialized command in a temporary sds and then memcpy'ing
  it into `server.aof_buf`, write the timestamp annotation, `SELECT`, and
  command body directly into `aof_buf`. This removes one alloc + memcpy +
  free per propagated command. Also early-returns when AOF isn't actively
  writing.

  This brings the AOF path closer to the replication path
  (`replicationFeedReplicas`), which already streams directly into its
  buffer.

  Output bytes are identical. As a side effect of the early return,
  `server.aof_selected_db` is no longer updated in the transient
  `AOF_WAIT_REWRITE` + no-child state. This is actually more correct: the
  old code could advance `aof_selected_db` to a `dictid` that was never
  actually written to `aof_buf`, suppressing a needed `SELECT` once the
  rewrite child started. `stopAppendOnly()` and the post-rewrite path
  both reset `aof_selected_db` to `-1`, so legitimate transitions still
  re-emit `SELECT` correctly.

  ## Benchmark

  Measured by adding a temporary local-only `DEBUG aof-feed-bench
  <iterations>` subcommand that loops `feedAppendOnlyFile()` in a tight
  IO-free loop (single-threaded handler — no flush/cron interference),
  clearing `server.aof_buf` each iteration to prevent unbounded growth.
  The subcommand is **not** part of this PR; it was a measurement aid only.

  Workload: 10M iterations of a 3-arg `SET`. Called 5 times per side,
  median reported:

  | version | ns/op  | ops/sec |
  |---------|-------:|--------:|
  | before  | 157.76 | ~6.34M  |
  | after   |  73.75 | ~13.56M |

  ~2.14× faster on this hot path. Larger commands amplify the win since
  the eliminated copy scaled with payload size.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the AOF persistence hot path by changing how commands are buffered and when the function returns, so any subtle state mismatch could impact AOF correctness during rewrite transitions.
> 
> **Overview**
> `feedAppendOnlyFile()` now early-returns unless AOF is actively writing (either `AOF_ON` or `AOF_WAIT_REWRITE` with an AOF rewrite child), avoiding work when nothing will be appended.
> 
> It also removes the temporary `sds` build-and-copy buffer and instead appends the timestamp annotation, optional `SELECT`, and command serialization directly into `server.aof_buf`, reducing per-command allocations/copies and aligning behavior with streaming-style propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c80f6f438e5b99908ffa44a46edae798c3d9d171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->