### PR TITLE
Pass context to RM_GetUserUsername() to support auto memory management

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -10329,11 +10329,11 @@ int RM_FreeModuleUser(RedisModuleUser *user) {
  * Returns NULL if user is NULL or the user has no name.
  * The returned string must be freed by the caller with RedisModule_FreeString()
  * or by enabling automatic memory management on a context. */
- RedisModuleString *RM_GetUserUsername(const RedisModuleUser *user) {
+ RedisModuleString *RM_GetUserUsername(RedisModuleCtx *ctx, const RedisModuleUser *user) {
     if(user == NULL || user->user == NULL || user->user->name == NULL) 
         return NULL;
     
-    return RM_CreateString(NULL, user->user->name, sdslen(user->user->name));
+    return RM_CreateString(ctx, user->user->name, sdslen(user->user->name));
 }
 
 /* Sets the permissions of a user created through the redis module

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1410,7 +1410,7 @@ REDISMODULE_API RedisModuleUser * (*RedisModule_CreateModuleUser)(const char *na
 REDISMODULE_API void (*RedisModule_FreeModuleUser)(RedisModuleUser *user) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetContextUser)(RedisModuleCtx *ctx, const RedisModuleUser *user) REDISMODULE_ATTR;
 REDISMODULE_API const RedisModuleUser *(*RedisModule_GetContextUser)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_GetUserUsername)(const RedisModuleUser *user) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_GetUserUsername)(RedisModuleCtx *ctx, const RedisModuleUser *user) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetModuleUserACL)(RedisModuleUser *user, const char* acl) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetModuleUserACLString)(RedisModuleCtx * ctx, RedisModuleUser *user, const char* acl, RedisModuleString **error) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_GetModuleUserACLString)(RedisModuleUser *user) REDISMODULE_ATTR;

--- a/tests/modules/usercall.c
+++ b/tests/modules/usercall.c
@@ -125,7 +125,7 @@ int get_user_username(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_OK;
     }
     RedisModule_ReplyWithString(ctx, name);
-    RedisModule_FreeString(NULL, name);
+    RedisModule_FreeString(ctx, name);
     return REDISMODULE_OK;
 }
 

--- a/tests/modules/usercall.c
+++ b/tests/modules/usercall.c
@@ -119,7 +119,7 @@ int get_user_username(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         RedisModule_ReplyWithSimpleString(ctx, "none");
         return REDISMODULE_OK;
     }
-    RedisModuleString *name = RedisModule_GetUserUsername(user);
+    RedisModuleString *name = RedisModule_GetUserUsername(ctx, user);
     if (name == NULL) {
         RedisModule_ReplyWithSimpleString(ctx, "none");
         return REDISMODULE_OK;


### PR DESCRIPTION
Following #14890

## Problem
RM_GetUserUsername() documents that the returned RedisModuleString can be freed via automatic memory management, but it always creates the string with ctx=NULL so it cannot be tracked by RedisModule_AutoMemory. Modules following the documentation may leak memory.

```c
/* Return the username of the given RedisModuleUser as a RedisModuleString.
 * Returns NULL if user is NULL or the user has no name.
 * The returned string must be freed by the caller with RedisModule_FreeString()
 * or by enabling automatic memory management on a context. */
 RedisModuleString *RM_GetUserUsername(const RedisModuleUser *user) {
    if(user == NULL || user->user == NULL || user->user->name == NULL) 
        return NULL;
    
    return RM_CreateString(NULL, user->user->name, sdslen(user->user->name));
}
```

Suggested Fix
 - Fix API to accept ctx
 ```c
 RedisModuleString *RM_GetUserUsername(RedisModuleCtx *ctx, const RedisModuleUser *user) {
    if(user == NULL || user->user == NULL || user->user->name == NULL) 
        return NULL;
    
    return RM_CreateString(ctx, user->user->name, sdslen(user->user->name));
}

```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `RedisModule_GetUserUsername` API signature, requiring module code updates/recompilation and potentially affecting ABI compatibility. Behavioral change is small but touches the public modules API and memory-management semantics.
> 
> **Overview**
> Fixes `RedisModule_GetUserUsername` to accept a `RedisModuleCtx *` and create the returned `RedisModuleString` with that context, allowing RedisModule auto-memory management to track/free it as documented.
> 
> Updates the exported API declaration in `redismodule.h` and adjusts the `usercall` test module to pass `ctx` and free the returned string with `RedisModule_FreeString(ctx, ...)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 802876ee51b43b3d66cbfbcea868f7187bfd68bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->