### PR TITLE
zmscore optimization for Listpack 

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4096,6 +4096,102 @@ void zscoreCommand(client *c) {
         updateSlotAllocSize(c->db, getKeySlot(key->ptr), zobj, oldsize, kvobjAllocSize(zobj));
 }
 
+/* ZMSCORE fast path for OBJ_ENCODING_LISTPACK.
+ *
+ * Instead of calling zzlFind() per requested member — each a full O(L)
+ * traversal involving varint decoding, bounds checking, and skip logic
+ * per entry — walk the listpack once and match each member entry against
+ * all N requested members using memcmp comparisons.
+ *
+ * The zset listpack has layout [member₁][score₁][member₂][score₂]…
+ * (skip=1).  The baseline zzlFind() calls lpFind(lp, eptr, ele, len, 1)
+ * which must decode every entry (both members and scores) but only
+ * compares member entries.  Score entries are decoded via lpGetWithSize()
+ * just to advance the pointer — wasted work.
+ *
+ * This reduces the expensive listpack traversal overhead from O(N × L)
+ * to O(L), replacing it with O(N) cheap memcmp calls per member entry.
+ *
+ * Score pointers are stored during the single pass and used to emit
+ * replies after traversal completes. */
+static void zmscoreListpackSinglePass(client *c, robj *zobj) {
+    serverAssert(zobj->encoding == OBJ_ENCODING_LISTPACK);
+
+    int num_members = c->argc - 2;
+    unsigned char *lp = zobj->ptr;
+
+    /* Result array: stores a pointer to the score entry in the listpack
+     * for each requested member.  NULL means not found.
+     * Using zcalloc so all entries start as NULL. */
+    unsigned char **results = zcalloc(sizeof(unsigned char *) * num_members);
+
+    /* Track how many unique members remain to be found.  Once all are
+     * found, we can stop traversing the listpack early. */
+    int remaining = num_members;
+
+    /* --- Single pass over the listpack --- */
+
+    unsigned char *eptr = lpFirst(lp);
+
+    while (eptr != NULL && remaining > 0) {
+        /* Decode the member entry */
+        int64_t elen;
+        unsigned char *estr = lpGet(eptr, &elen, NULL);
+
+        /* Advance to the score entry */
+        unsigned char *sptr = lpNext(lp, eptr);
+        serverAssert(sptr != NULL);
+
+        /* Compare this LP member against each unfound requested member */
+        for (int i = 0; i < num_members; i++) {
+            if (results[i] != NULL)
+                continue;   /* already found this argv slot */
+
+            sds reqMember = c->argv[i + 2]->ptr;
+            size_t reqLen = sdslen(reqMember);
+
+            int match;
+            if (estr != NULL) {
+                /* LP member is a string: compare raw bytes */
+                match = (reqLen == (size_t)elen &&
+                         memcmp(reqMember, estr, elen) == 0);
+            } else {
+                /* LP member is integer-encoded.
+                 * Parse the argv string as integer and compare. */
+                long long reqll;
+                match = (string2ll(reqMember, reqLen, &reqll) &&
+                         reqll == (long long)elen);
+            }
+
+            if (match) {
+                results[i] = sptr;
+                remaining--;
+                /* Don't break: duplicate members in argv should all
+                 * get a result.  Each LP member is unique in a zset,
+                 * so no further LP entries will match this value —
+                 * but other argv slots may have the same member. */
+            }
+        }
+
+        /* Advance to the next member entry (skip past this score) */
+        eptr = lpNext(lp, sptr);
+    }
+
+    /* --- Emit replies in request order --- */
+
+    addReplyArrayLen(c, num_members);
+
+    for (int i = 0; i < num_members; i++) {
+        if (results[i] != NULL) {
+            addReplyDouble(c, zzlGetScore(results[i]));
+        } else {
+            addReplyNull(c);
+        }
+    }
+
+    zfree(results);
+}
+
 void zmscoreCommand(client *c) {
     robj *key = c->argv[1];
     double score;
@@ -4105,6 +4201,16 @@ void zmscoreCommand(client *c) {
 
     if (server.memory_tracking_enabled && zobj != NULL)
         oldsize = kvobjAllocSize(zobj);
+
+    /* Fast path: single-pass listpack scan for LISTPACK encoding.
+     * Not applicable to SKIPLIST (already O(1) per lookup via dict). */
+    if (zobj != NULL && zobj->encoding == OBJ_ENCODING_LISTPACK) {
+        zmscoreListpackSinglePass(c, zobj);
+        if (server.memory_tracking_enabled)
+            updateSlotAllocSize(c->db, getKeySlot(key->ptr), zobj, oldsize, kvobjAllocSize(zobj));
+        return;
+    }
+
     addReplyArrayLen(c,c->argc - 2);
     for (int j = 2; j < c->argc; j++) {
         /* Treat a missing set the same way as an empty set */

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4098,8 +4098,8 @@ void zscoreCommand(client *c) {
 
 /* ZMSCORE fast path for OBJ_ENCODING_LISTPACK.
  *
- * Instead of calling zzlFind() per requested member — each a full O(L)
- * traversal involving varint decoding, bounds checking, and skip logic
+ * Instead of calling zzlFind() per requested member — each traversal 
+ * involving varint decoding, bounds checking, and skip logic
  * per entry — walk the listpack once and match each member entry against
  * all N requested members using memcmp comparisons.
  *
@@ -4109,8 +4109,8 @@ void zscoreCommand(client *c) {
  * compares member entries.  Score entries are decoded via lpGetWithSize()
  * just to advance the pointer — wasted work.
  *
- * This reduces the expensive listpack traversal overhead from O(N × L)
- * to O(L), replacing it with O(N) cheap memcmp calls per member entry.
+ * This reduces the expensive listpack traversal overhead replacing it with 
+ * cheap memcmp calls per member entry.
  *
  * Score pointers are stored during the single pass and used to emit
  * replies after traversal completes. */

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1625,6 +1625,24 @@ start_server {tags {"zset"}} {
         assert_match {*ERR*wrong*number*arg*} $e
     }
 
+    test {ZMSCORE with duplicate members in request} {
+        r del zmscoretest
+        r zadd zmscoretest 10 x
+        r zadd zmscoretest 20 y
+
+        # Same member requested multiple times should return its score each time
+        r zmscore zmscoretest x x y x
+    } {10 10 20 10}
+
+    test {ZMSCORE all members missing} {
+        r del zmscoretest
+        r zadd zmscoretest 10 x
+        r zadd zmscoretest 20 y
+
+        # None of the requested members exist in the zset
+        r zmscore zmscoretest a b c
+    } {{} {} {}}
+
     test "ZSET commands don't accept the empty strings as valid score" {
         assert_error "*not*float*" {r zadd myzset "" abc}
     }
@@ -1678,16 +1696,21 @@ start_server {tags {"zset"}} {
         test "ZMSCORE - $encoding" {
             r del zscoretest
             set aux {}
+            set members {}
             for {set i 0} {$i < $elements} {incr i} {
                 set score [expr rand()]
                 lappend aux $score
+                lappend members $i
                 r zadd zscoretest $score $i
             }
 
             assert_encoding $encoding zscoretest
+
+            # Retrieve all scores in a single ZMSCORE call and verify each one.
+            # See ZSCORE test above for IEEE 754 double-precision notes.
+            set results [r zmscore zscoretest {*}$members]
             for {set i 0} {$i < $elements} {incr i} {
-                # Check above notes on IEEE 754 double-precision comparison
-                assert_equal [expr [lindex $aux $i]] [expr [r zscore zscoretest $i]]
+                assert_equal [expr [lindex $aux $i]] [expr [lindex $results $i]]
             }
         }
 


### PR DESCRIPTION
Walk the zset listpack, reading member entries (skipping score entries).  For each member, compare against all N argv members.  When matched, store the score pointer.  After traversal, emit scores in request order. 

This is an improvement because the baseline calls zzlFind() → lpFind() per requested member. Each call traverses the entire listpack from the start, decoding every entry — both member entries (for comparison) and score entries (just to skip past them). With N requested members and L member-score pairs, that's N full traversals × 2L entry decodes.

The optimization walks the listpack once. For each member entry, it does a cheap memcmp against all N requested members. Score entries are hopped over with lpNext() but never decoded during the search. Total entry decodes drop from N×2L to 2L. The comparison count stays roughly the same, but comparisons (memcmp on short strings) are much cheaper than the per-entry listpack decode overhead (lpGetWithSize + bounds checks + backlen decode + EOF check) that they replace.

This is using the same optimization pattern as: https://github.com/redis/redis/pull/14903

Performance improvement measured on an icelake server is: 

Baseline Ops/sec: 38588
Optimized Ops/sec: 51196 (about 32% improvement) 

The benchmark used for evaluating the performance is as follows. A separate pull request with this benchmark will be made in redis-benchmarks-specification. 

#start redis server (4 cores on socket 1) 
numactl -m 1 taskset -c 40,41,42,43 ./src/redis-server redis.conf

#benchmark started on 4 cores on socket 0
#populate 1M keys with 128 members
taskset -c 0,1,2,3 memtier_benchmark --json-out-file oss-standalone-2026-04-14-18-44-29-e1d35aca-preload__memtier_benchmark-1Mkeys-zset-128-members-zmscore-50-members.json --port 6379 --server localhost --command "ZADD __key__ 1 mem001 2 mem002 3 mem003 4 mem004 5 mem005 6 mem006 7 mem007 8 mem008 9 mem009 10 mem010 11 mem011 12 mem012 13 mem013 14 mem014 15 mem015 16 mem016 17 mem017 18 mem018 19 mem019 20 mem020 21 mem021 22 mem022 23 mem023 24 mem024 25 mem025 26 mem026 27 mem027 28 mem028 29 mem029 30 mem030 31 mem031 32 mem032 33 mem033 34 mem034 35 mem035 36 mem036 37 mem037 38 mem038 39 mem039 40 mem040 41 mem041 42 mem042 43 mem043 44 mem044 45 mem045 46 mem046 47 mem047 48 mem048 49 mem049 50 mem050 51 mem051 52 mem052 53 mem053 54 mem054 55 mem055 56 mem056 57 mem057 58 mem058 59 mem059 60 mem060 61 mem061 62 mem062 63 mem063 64 mem064 65 mem065 66 mem066 67 mem067 68 mem068 69 mem069 70 mem070 71 mem071 72 mem072 73 mem073 74 mem074 75 mem075 76 mem076 77 mem077 78 mem078 79 mem079 80 mem080 81 mem081 82 mem082 83 mem083 84 mem084 85 mem085 86 mem086 87 mem087 88 mem088 89 mem089 90 mem090 91 mem091 92 mem092 93 mem093 94 mem094 95 mem095 96 mem096 97 mem097 98 mem098 99 mem099 100 mem100 101 mem101 102 mem102 103 mem103 104 mem104 105 mem105 106 mem106 107 mem107 108 mem108 109 mem109 110 mem110 111 mem111 112 mem112 113 mem113 114 mem114 115 mem115 116 mem116 117 mem117 118 mem118 119 mem119 120 mem120 121 mem121 122 mem122 123 mem123 124 mem124 125 mem125 126 mem126 127 mem127 128 mem128" --command-key-pattern="P" --key-minimum=1 --key-maximum=1000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline 50

#benchmark command
taskset -c 0,1,2,3 memtier_benchmark --json-out-file oss-standalone-2026-04-14-18-47-37-e1d35aca-memtier_benchmark-1Mkeys-zset-128-members-zmscore-50-members.json --port 6379 --server localhost --command "ZMSCORE __key__ mem001 mem002 mem003 mem004 mem005 mem006 mem007 mem008 mem009 mem010 mem011 mem012 mem013 mem014 mem015 mem016 mem017 mem018 mem019 mem020 mem021 mem022 mem023 mem024 mem025 miss001 miss002 miss003 miss004 miss005 miss006 miss007 miss008 miss009 miss010 miss011 miss012 miss013 miss014 miss015 miss016 miss017 miss018 miss019 miss020 miss021 miss022 miss023 miss024 miss025" --command-key-pattern="R" --key-minimum=1 --key-maximum=1000000 --hide-histogram --test-time 180






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `ZMSCORE` execution for listpack-encoded zsets; while behavior should be identical, the new single-pass scan and integer/string matching could introduce subtle edge-case regressions.
> 
> **Overview**
> Improves `ZMSCORE` performance for listpack-encoded zsets by adding a **single-pass listpack scan** that matches each stored member against all requested members, caches score entry pointers, and then emits replies in request order (including correct handling of *duplicate members in the request*).
> 
> Extends unit coverage around `ZMSCORE` by adding tests for duplicate requested members, the all-missing case, and by validating bulk `ZMSCORE` results across both `listpack` and `skiplist` encodings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4b5f6f73b3da5098cf5a8ed1a82fb12a199821a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->