### PR TITLE
fix: vector sets docs typo

### DIFF
--- a/modules/vector-sets/README.md
+++ b/modules/vector-sets/README.md
@@ -168,7 +168,7 @@ Because vector sets perform insertion time normalization and optional
 quantization, the returned vector could be approximated. `VEMB` will take
 care to de-quantized and de-normalize the vector before returning it.
 
-It is possible to ask VEMB to return raw data, that is, the internal representation used by the vector: fp32, int8, or a bitmap for binary quantization. This behavior is triggered by the `RAW` option of of VEMB:
+It is possible to ask VEMB to return raw data, that is, the internal representation used by the vector: fp32, int8, or a bitmap for binary quantization. This behavior is triggered by the `RAW` option of VEMB:
 
     VEMB word_embedding apple RAW
 


### PR DESCRIPTION
fixes typo in vector sets docs `of of` -> `of`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that fixes a minor typo; no runtime behavior is affected.
> 
> **Overview**
> Fixes a typo in the Vector Sets documentation by correcting the `VEMB` `RAW` option description (removes duplicated "of"), improving readability without changing any behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c55eb70088e815304deea4cdfc67a1b968ef75d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->