### PR TITLE
Increase threshold for HPEXPIRETIME persists after RDB reload test

### DIFF
--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -296,17 +296,26 @@ start_server {tags {"external:skip needs:debug"}} {
         test "HPEXPIRETIME persists after RDB reload ($type)" {
             r del myhash
             r hset myhash field1 value1 field2 value2
-            r hpexpire myhash 300 NX FIELDS 1 field1
+
+            # Use a long expiry to accommodate slow debug reloads
+            r hpexpire myhash 5000 NX FIELDS 1 field1
             set before [r HPEXPIRETIME myhash FIELDS 1 field1]
             r debug reload
             set after [r HPEXPIRETIME myhash FIELDS 1 field1]
             assert_equal $before $after
+
             # field2 should not have expiration
             assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY
             assert_equal [get_stat_subexpiry r] 1
+
+            # shorten expiry to speed up expiration verification
+            r hpexpire myhash 50 XX FIELDS 1 field1
+            
             # Wait for field1 to expire robustly
-            wait_for_condition 50 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" } 
+            wait_for_condition 50 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
             assert_equal [r hget myhash field1] ""
+            assert_equal [r HPEXPIRETIME myhash FIELDS 1 field1] $T_NO_FIELD
+
             # field2 remains without expiration
             assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY
         }

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -298,7 +298,7 @@ start_server {tags {"external:skip needs:debug"}} {
             r hset myhash field1 value1 field2 value2
 
             # Use a long expiry to accommodate slow debug reloads
-            r hpexpire myhash 5000 NX FIELDS 1 field1
+            r hpexpire myhash 1500 NX FIELDS 1 field1
             set before [r HPEXPIRETIME myhash FIELDS 1 field1]
             r debug reload
             set after [r HPEXPIRETIME myhash FIELDS 1 field1]

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -296,25 +296,17 @@ start_server {tags {"external:skip needs:debug"}} {
         test "HPEXPIRETIME persists after RDB reload ($type)" {
             r del myhash
             r hset myhash field1 value1 field2 value2
-
-            # Use a long expiry to accommodate slow debug reloads
-            r hpexpire myhash 5000 NX FIELDS 1 field1
+            r hpexpire myhash 500 NX FIELDS 1 field1
             set before [r HPEXPIRETIME myhash FIELDS 1 field1]
             r debug reload
             set after [r HPEXPIRETIME myhash FIELDS 1 field1]
             assert_equal $before $after
-
             # field2 should not have expiration
             assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY
             assert_equal [get_stat_subexpiry r] 1
-
-            # shorten expiry to speed up expiration verification
-            r hpexpire myhash 50 XX FIELDS 1 field1
             # Wait for field1 to expire robustly
-            wait_for_condition 50 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
+            wait_for_condition 50 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" } 
             assert_equal [r hget myhash field1] ""
-            assert_equal [r HPEXPIRETIME myhash FIELDS 1 field1] $T_NO_FIELD
-
             # field2 remains without expiration
             assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY
         }

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -310,7 +310,6 @@ start_server {tags {"external:skip needs:debug"}} {
 
             # shorten expiry to speed up expiration verification
             r hpexpire myhash 50 XX FIELDS 1 field1
-            
             # Wait for field1 to expire robustly
             wait_for_condition 50 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
             assert_equal [r hget myhash field1] ""

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -298,7 +298,7 @@ start_server {tags {"external:skip needs:debug"}} {
             r hset myhash field1 value1 field2 value2
 
             # Use a long expiry to accommodate slow debug reloads
-            r hpexpire myhash 1500 NX FIELDS 1 field1
+            r hpexpire myhash 5000 NX FIELDS 1 field1
             set before [r HPEXPIRETIME myhash FIELDS 1 field1]
             r debug reload
             set after [r HPEXPIRETIME myhash FIELDS 1 field1]


### PR DESCRIPTION
### Problem

The test `HPEXPIRETIME persists after RDB reload` was flaky because the original 300ms field expiry was shorter than `DEBUG RELOAD` duration on CI.

Failed daily CI: https://github.com/redis/redis/actions/runs/24429732432/job/71371316961#step:7:1652
```shell
===== Start of server log (pid 10814) =====

[err]: HPEXPIRETIME persists after RDB reload (listpackex) in tests/unit/type/hash-field-expire.tcl
Expected '1776212706174' to be equal to '-2' (context: type eval line 8 cmd {assert_equal $before $after} proc ::test)
### Starting server for test 
10814:C 15 Apr 2026 00:25:04.741 # WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
10814:C 15 Apr 2026 00:25:04.741 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
10814:C 15 Apr 2026 00:25:04.741 * Redis version=255.255.255, bits=64, commit=00000000, modified=0, pid=10814, just started
10814:C 15 Apr 2026 00:25:04.741 * Configuration loaded
...
### Starting test HEXPIRETIME - returns TTL in Unix timestamp (listpackex) in tests/unit/type/hash-field-expire.tcl
###  in tests/unit/type/hash-field-expire.tcl
10814:M 15 Apr 2026 00:25:05.875 * BGSAVE done, 1 keys saved, 0 keys skipped, 163 bytes written.
10814:M 15 Apr 2026 00:25:06.295 * DB saved on disk
10814:M 15 Apr 2026 00:25:06.296 * Loading RDB produced by version 255.255.255
10814:M 15 Apr 2026 00:25:06.296 * RDB age 1 seconds
10814:M 15 Apr 2026 00:25:06.296 * RDB memory usage when created 1.17 Mb
10814:M 15 Apr 2026 00:25:06.296 - DB 9 resized: 4 key buckets, 0 expire buckets
10814:M 15 Apr 2026 00:25:06.296 * Done loading RDB, keys loaded: 1, keys expired: 0.
10814:M 15 Apr 2026 00:25:06.296 * DB reloaded by DEBUG RELOAD
===== End of server log (pid 10814) =====
```


Logs show ~421ms between `BGSAVE done` and `DB reloaded`, so the field may already be expired when the test reads `HPEXPIRETIME` after reload, returning `-2 (T_NO_FIELD)` instead of the original timestamp.


### Changed 

Just increase the TTL to avoid flaky test in slow CI env

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing tweak with no production code changes; main risk is slightly increased test runtime or masking a genuine timing regression.
> 
> **Overview**
> Fixes a flaky unit test in `tests/unit/type/hash-field-expire.tcl` by increasing the field expiry used in `HPEXPIRETIME persists after RDB reload` from 300ms to 500ms so the field is less likely to expire during `DEBUG RELOAD`, keeping the before/after `HPEXPIRETIME` assertion stable on slower CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87a4f1ec79c9564a9c9eb606694e35d6fd84d949. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->