### PR TITLE
Avoid redundant KEYSIZES histogram update after HGETEX deletes the last hash fields

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2921,7 +2921,7 @@ void hgetexCommand(client *c) {
 
     updateKeysizesHist(c->db, OBJ_HASH, oldlen, hist_newlen);
     if (newlen == 0) {
-        dbDelete(c->db, c->argv[1]);
+        dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
     }
 }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2914,10 +2914,12 @@ void hgetexCommand(client *c) {
     }
 
     /* Key may become empty due to lazy expiry in addHashFieldToReply()
-     * or the new expiration time is in the past.*/
+     * or the new expiration time is in the past. Keep the KEYSIZES
+     * histogram aligned with the fact that an empty hash key is removed. */
     newlen = hashTypeLength(o, 0);
+    int64_t hist_newlen = (newlen == 0) ? -1 : newlen;
 
-    updateKeysizesHist(c->db, OBJ_HASH, oldlen, newlen);
+    updateKeysizesHist(c->db, OBJ_HASH, oldlen, hist_newlen);
     if (newlen == 0) {
         dbDelete(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2917,11 +2917,13 @@ void hgetexCommand(client *c) {
      * or the new expiration time is in the past. */
     newlen = hashTypeLength(o, 0);
     if (newlen == 0) {
+        updateKeysizesHist(c->db, OBJ_HASH, oldlen, 0);
         dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
-        newlen = -1;
+        updateKeysizesHist(c->db, OBJ_HASH, 0, -1);
+    } else {
+        updateKeysizesHist(c->db, OBJ_HASH, oldlen, newlen);
     }
-    updateKeysizesHist(c->db, OBJ_HASH, oldlen, newlen);
 }
 
 void hdelCommand(client *c) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2914,16 +2914,14 @@ void hgetexCommand(client *c) {
     }
 
     /* Key may become empty due to lazy expiry in addHashFieldToReply()
-     * or the new expiration time is in the past. Keep the KEYSIZES
-     * histogram aligned with the fact that an empty hash key is removed. */
+     * or the new expiration time is in the past. */
     newlen = hashTypeLength(o, 0);
-    int64_t hist_newlen = (newlen == 0) ? -1 : newlen;
-
-    updateKeysizesHist(c->db, OBJ_HASH, oldlen, hist_newlen);
     if (newlen == 0) {
         dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
+        newlen = -1;
     }
+    updateKeysizesHist(c->db, OBJ_HASH, oldlen, newlen);
 }
 
 void hdelCommand(client *c) {

--- a/tests/unit/info-keysizes.tcl
+++ b/tests/unit/info-keysizes.tcl
@@ -753,6 +753,12 @@ proc test_all_keysizes { {replMode 0} } {
         run_cmd_verify_hist {$server DEBUG RELOAD} {db0_STR:8=1}
     } {} {cluster:skip needs:debug}
 
+    test "KEYSIZES - HGETEX deleting the last hash fields removes the histogram entry $suffixRepl" {
+        run_cmd_verify_hist {$server FLUSHALL} {}
+        run_cmd_verify_hist {$server HSET myhash f1 v1 f2 v2 f3 v3} {db0_HASH:2=1}
+        run_cmd_verify_hist {$server HGETEX myhash PXAT 1 FIELDS 3 f1 f2 f3} {}
+    } {} {cluster:skip}
+
     test "KEYSIZES - Test RDB $suffixRepl" {
         run_cmd_verify_hist {$server FLUSHALL} {}
         # Write list, set and zset to db0


### PR DESCRIPTION
`HGETEX` could delete the last remaining fields in a hash and remove the key, but still update the KEYSIZES histogram as if an empty hash still existed. That left `INFO KEYSIZES` with a stale hash entry even though the key had already been deleted.

This patch makes `hgetexCommand` treat a zero-length post-operation hash as a removed key when updating the KEYSIZES histogram. Concretely, it reports the new size as `-1` for histogram accounting before deleting the key. A regression test was also added to verify that when `HGETEX PXAT 1` expires all fields in a hash, the corresponding KEYSIZES hash bucket disappears.

Testing:
- Added a regression test in `tests/unit/info-keysizes.tcl` covering `HGETEX` deleting the last hash fields and verifying the histogram entry is removed
- Not tested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to KEYSIZES histogram bookkeeping and key deletion path for `HGETEX`; no changes to data semantics beyond stats/INFO output.
> 
> **Overview**
> Fixes `HGETEX` KEYSIZES histogram accounting when the operation deletes the final fields in a hash and removes the key.
> 
> `hgetexCommand` now treats a zero-length post-operation hash as a key deletion for histogram purposes (avoids `dbDelete`’s internal KEYSIZES update, and explicitly updates the histogram to remove the hash bucket). A regression test was added to ensure the hash histogram entry disappears after `HGETEX ... PXAT 1` expires all fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f33bf2aea1f9142af85cbda457d2e19f47ccdc0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->