### PR TITLE
Make CONFIG REWRITE respect source files

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1718,6 +1718,22 @@ void rewriteConfigBindOption(standardConfig *config, const char *name, struct re
     rewriteConfigRewriteLine(state,name,line,force);
 }
 
+static void rewriteConfigStateDictValDestructor(dict *d, void *val) {
+    UNUSED(d);
+    rewriteConfigReleaseState(val);
+}
+
+/* Dict type for the include_states map (include path -> rewriteConfigState*). */
+static dictType includeStatesDictType = {
+    dictSdsCaseHash,                        /* hash function */
+    NULL,                                   /* key dup */
+    NULL,                                   /* val dup */
+    dictSdsKeyCaseCompare,                  /* key compare */
+    dictSdsDestructor,                      /* key destructor */
+    rewriteConfigStateDictValDestructor,    /* val destructor */
+    NULL                                    /* allow to expand */
+};
+
 /* Return the rewrite state for an include file, creating it on first access. */
 static struct rewriteConfigState *rewriteConfigGetIncludeState(dict *include_states,
                                                                 const char *filename) {
@@ -1961,7 +1977,7 @@ int rewriteConfig(char *path, int force_write) {
 
     /* Lazy-initialised map of include-file path -> rewriteConfigState for
      * configs that originated in a file other than the main config file. */
-    dict *include_states = dictCreate(&sdsHashDictType);
+    dict *include_states = dictCreate(&includeStatesDictType);
 
     /* Step 2: rewrite every single option, replacing or appending it inside
      * the appropriate rewrite state (main config or an include file). */
@@ -2016,7 +2032,6 @@ int rewriteConfig(char *path, int force_write) {
         sds inc_content = rewriteConfigGetContentFromState(inc_state);
         if (rewriteConfigOverwriteFile(inc_path, inc_content) == -1) retval = -1;
         sdsfree(inc_content);
-        rewriteConfigReleaseState(inc_state);
     }
     dictResetIterator(&di);
     dictRelease(include_states);

--- a/src/config.c
+++ b/src/config.c
@@ -288,6 +288,114 @@ struct standardConfig {
 
 dict *configs = NULL; /* Runtime config values */
 
+/*-----------------------------------------------------------------------------
+ * Config source tracking
+ *----------------------------------------------------------------------------*/
+
+/* Metadata describing where a config value was set from. */
+struct configSourceInfo {
+    configSource source;
+    sds filename;       /* Non-NULL for FILE/INCLUDE sources */
+};
+
+/* Global dictionary mapping config key -> configSourceInfo*. */
+static dict *config_sources = NULL;
+
+/* One entry in the active include chain: the file currently being parsed. */
+#define CONFIG_INCLUDE_MAX_DEPTH 16
+
+typedef struct configIncludeFrame {
+    configSource source;
+    sds filename;
+} configIncludeFrame;
+
+/* The full chain of nested includes active during a parse pass.
+ * frames[0] is the root (main config file / stdin / cmdline),
+ * frames[depth] is the innermost file currently being parsed. */
+typedef struct configIncludeChain {
+    configIncludeFrame frames[CONFIG_INCLUDE_MAX_DEPTH];
+    int depth;
+} configIncludeChain;
+
+/* Return the frame for the file currently being parsed. */
+static configIncludeFrame *configIncludeChainTop(configIncludeChain *chain) {
+    return &chain->frames[chain->depth];
+}
+
+/* Push a new frame for an included file.
+ * Returns 1 on success, 0 on failure (sets *err to a static error string). */
+static int configIncludeChainPush(configIncludeChain *chain,
+                                   configSource source, const char *filename,
+                                   const char **err) {
+    if (chain->depth + 1 >= CONFIG_INCLUDE_MAX_DEPTH) {
+        *err = "include nesting depth limit exceeded";
+        return 0;
+    }
+    if (filename) {
+        for (int i = 0; i <= chain->depth; i++) {
+            if (chain->frames[i].filename &&
+                !strcmp(chain->frames[i].filename, filename)) {
+                *err = "circular include detected";
+                return 0;
+            }
+        }
+    }
+    chain->frames[++chain->depth].source   = source;
+    chain->frames[chain->depth].filename   = filename ? sdsnew(filename) : NULL;
+    return 1;
+}
+
+/* Pop the current frame after an included file has been fully parsed. */
+static void configIncludeChainPop(configIncludeChain *chain) {
+    if (chain->depth > 0) {
+        sdsfree(chain->frames[chain->depth].filename);
+        chain->frames[chain->depth].filename = NULL;
+        chain->depth--;
+    }
+}
+
+void initConfigSourceTracking(void) {
+    config_sources = dictCreate(&sdsHashDictType);
+}
+
+void freeConfigSourceInfo(configSourceInfo *info) {
+    if (!info) return;
+    sdsfree(info->filename);
+    zfree(info);
+}
+
+/* Record (or overwrite) the source for a named config directive. */
+void recordConfigSource(const char *name, configSource source,
+                        const char *filename) {
+    if (!config_sources) return;
+
+    configSourceInfo *info = zmalloc(sizeof(configSourceInfo));
+    info->source   = source;
+    info->filename = filename ? sdsnew(filename) : NULL;
+
+    sds key = sdsnew(name);
+    dictEntry *existing = dictFind(config_sources, key);
+    if (existing) {
+        freeConfigSourceInfo(dictGetVal(existing));
+        dictSetVal(config_sources, existing, info);
+        sdsfree(key);
+    } else {
+        dictAdd(config_sources, key, info);
+    }
+}
+
+/* Look up source information for config parameter `name`. Returns NULL if not
+ * tracked.
+ */
+configSourceInfo *getConfigSource(const char *name) {
+    if (!config_sources) return NULL;
+    sds key = sdsnew(name);
+    dictEntry *de = dictFind(config_sources, key);
+    sdsfree(key);
+    return de ? dictGetVal(de) : NULL;
+}
+
+
 /* Lookup a config by the provided sds string name, or return NULL
  * if the config does not exist */
 static standardConfig *lookupConfig(const sds name) {
@@ -372,7 +480,8 @@ void resetServerSaveParams(void) {
     server.saveparamslen = 0;
 }
 
-void queueLoadModule(sds path, sds *argv, int argc) {
+void queueLoadModule(sds path, sds *argv, int argc,
+                     configSource source, const char *source_filename) {
     int i;
     struct moduleLoadQueueEntry *loadmod;
 
@@ -384,6 +493,12 @@ void queueLoadModule(sds path, sds *argv, int argc) {
         loadmod->argv[i] = createRawStringObject(argv[i],sdslen(argv[i]));
     }
     listAddNodeTail(server.loadmodule_queue,loadmod);
+
+    /* Record the source immediately so the info is available for CONFIG REWRITE
+     * even before the module is actually loaded. Key is "loadmodule:<path>". */
+    sds tracking_key = sdscatfmt(sdsempty(), "loadmodule:%s", path);
+    recordConfigSource(tracking_key, source, source_filename);
+    sdsfree(tracking_key);
 }
 
 /* Parse an array of `arg_len` sds strings, validate and populate
@@ -447,7 +562,7 @@ static int updateClientOutputBufferLimit(sds *args, int arg_len, const char **er
  * abnormal aggregate `save T C` functionality. Remove in the future. */
 static int reading_config_file;
 
-void loadServerConfigFromString(char *config) {
+void loadServerConfigFromString(char *config, configIncludeChain *chain) {
     deprecatedConfig deprecated_configs[] = {
         {"list-max-ziplist-entries", 2, 2},
         {"list-max-ziplist-value", 2, 2},
@@ -487,6 +602,11 @@ void loadServerConfigFromString(char *config) {
         }
         sdstolower(argv[0]);
 
+        /* Determine the effective source for this line.
+         * frame->filename is already NULL for non-file sources (cmdline/stdin). */
+        configIncludeFrame *frame = configIncludeChainTop(chain);
+        const char *line_filename = frame->filename;
+
         /* Iterate the configs that are standard */
         standardConfig *config = lookupConfig(argv[0]);
         if (config) {
@@ -516,15 +636,16 @@ void loadServerConfigFromString(char *config) {
                 }
             }
 
+            recordConfigSource(config->name, frame->source, line_filename);
             sdsfreesplitres(argv,argc);
             argv = NULL;
             continue;
         } else {
             int match = 0;
             for (deprecatedConfig *config = deprecated_configs; config->name != NULL; config++) {
-                if (!strcasecmp(argv[0], config->name) && 
-                    config->argc_min <= argc && 
-                    argc <= config->argc_max) 
+                if (!strcasecmp(argv[0], config->name) &&
+                    config->argc_min <= argc &&
+                    argc <= config->argc_max)
                 {
                     match = 1;
                     break;
@@ -539,7 +660,7 @@ void loadServerConfigFromString(char *config) {
 
         /* Execute config directives */
         if (!strcasecmp(argv[0],"include") && argc == 2) {
-            loadServerConfig(argv[1], 0, NULL);
+            loadServerConfig(argv[1], 0, NULL, chain);
         } else if (!strcasecmp(argv[0],"rename-command") && argc == 3) {
             struct redisCommand *cmd = lookupCommandBySds(argv[1]);
             int retval;
@@ -574,7 +695,7 @@ void loadServerConfigFromString(char *config) {
                 goto loaderr;
             }
         } else if (!strcasecmp(argv[0],"loadmodule") && argc >= 2) {
-            queueLoadModule(argv[1],&argv[2],argc-2);
+            queueLoadModule(argv[1],&argv[2],argc-2,frame->source,line_filename);
         } else if (!strcasecmp(argv[0],"sentinel")) {
             /* argc == 1 is handled by main() as we need to enter the sentinel
              * mode ASAP. */
@@ -583,14 +704,14 @@ void loadServerConfigFromString(char *config) {
                     err = "sentinel directive while not in sentinel mode";
                     goto loaderr;
                 }
-                queueSentinelConfig(argv+1,argc-1,linenum,lines[i]);
+                queueSentinelConfig(argv+1,argc-1,linenum,lines[i],
+                                    frame->source,line_filename);
             }
         } else {
             /* Collect all unknown configurations into `module_configs_queue`.
              * These may include valid module configurations or invalid ones.
              * They will be validated later by loadModuleConfigs() against the
              * configurations declared by the loaded module(s). */
-            
             if (argc < 2) {
                 err = "Bad directive or wrong number of arguments";
                 goto loaderr;
@@ -600,6 +721,7 @@ void loadServerConfigFromString(char *config) {
             for (int i = 2; i < argc; i++)
                 val = sdscatfmt(val, " %S", argv[i]);
             if (!dictReplace(server.module_configs_queue, name, val)) sdsfree(name);
+            recordConfigSource(argv[0], frame->source, line_filename);
         }
         sdsfreesplitres(argv,argc);
         argv = NULL;
@@ -651,85 +773,103 @@ loaderr:
     exit(1);
 }
 
+/* Read and parse a single concrete (non-wildcard) config file. */
+#define CONFIG_READ_LEN 1024
+static void loadOneConfigFile(const char *filename, configIncludeChain *chain) {
+    const char *push_err = NULL;
+    if (!configIncludeChainPush(chain, CONFIG_SOURCE_FILE, filename, &push_err)) {
+        serverLog(LL_WARNING, "Fatal error, can't process config file '%s': %s",
+                  filename, push_err);
+        exit(1);
+    }
+    char buf[CONFIG_READ_LEN+1];
+    FILE *fp = fopen(filename, "r");
+    if (fp == NULL) {
+        serverLog(LL_WARNING, "Fatal error, can't open config file '%s': %s",
+                  filename, strerror(errno));
+        exit(1);
+    }
+    sds config = sdsempty();
+    while (fgets(buf, CONFIG_READ_LEN+1, fp) != NULL)
+        config = sdscat(config, buf);
+    fclose(fp);
+    loadServerConfigFromString(config, chain);
+    sdsfree(config);
+    configIncludeChainPop(chain);
+}
+
 /* Load the server configuration from the specified filename.
- * The function appends the additional configuration directives stored
- * in the 'options' string to the config file before loading.
+ * stdin and options are only processed on the root call (chain == NULL).
  *
  * Both filename and options can be NULL, in such a case are considered
  * empty. This way loadServerConfig can be used to just load a file or
  * just load a string. */
-#define CONFIG_READ_LEN 1024
-void loadServerConfig(char *filename, char config_from_stdin, char *options) {
-    sds config = sdsempty();
-    char buf[CONFIG_READ_LEN+1];
-    FILE *fp;
+void loadServerConfig(char *filename, char config_from_stdin, char *options,
+                      configIncludeChain *chain) {
+    int is_root = (chain == NULL);
+    configIncludeChain root_chain;
     glob_t globbuf;
 
-    /* Load the file content */
-    if (filename) {
+    if (is_root) {
+        memset(&root_chain, 0, sizeof(root_chain));
+        chain = &root_chain;
+    }
 
-        /* The logic for handling wildcards has slightly different behavior in cases where
-         * there is a failure to locate the included file.
-         * Whether or not a wildcard is specified, we should ALWAYS log errors when attempting
-         * to open included config files.
-         *
-         * However, we desire a behavioral difference between instances where a wildcard was
-         * specified and those where it hasn't:
-         *      no wildcards   : attempt to open the specified file and fail with a logged error
-         *                       if the file cannot be found and opened.
-         *      with wildcards : attempt to glob the specified pattern; if no files match the
-         *                       pattern, then gracefully continue on to the next entry in the
-         *                       config file, as if the current entry was never encountered.
-         *                       This will allow for empty conf.d directories to be included. */
+    if (filename &&
+        (strchr(filename,'*') || strchr(filename,'?') || strchr(filename,'[')))
+    {
+        /* Wildcard filename: expand the glob and process each matched file
+         * individually so source tracking records the actual filename.
+         * Silently skip if nothing matches (allows empty conf.d/). */
+        int has_matches = (glob(filename, 0, NULL, &globbuf) == 0) &&
+                          globbuf.gl_pathc > 0;
 
-        if (strchr(filename, '*') || strchr(filename, '?') || strchr(filename, '[')) {
-            /* A wildcard character detected in filename, so let us use glob */
-            if (glob(filename, 0, NULL, &globbuf) == 0) {
-
-                for (size_t i = 0; i < globbuf.gl_pathc; i++) {
-                    if ((fp = fopen(globbuf.gl_pathv[i], "r")) == NULL) {
-                        serverLog(LL_WARNING,
-                                  "Fatal error, can't open config file '%s': %s",
-                                  globbuf.gl_pathv[i], strerror(errno));
-                        exit(1);
-                    }
-                    while(fgets(buf,CONFIG_READ_LEN+1,fp) != NULL)
-                        config = sdscat(config,buf);
-                    fclose(fp);
-                }
-
-                globfree(&globbuf);
-            }
-        } else {
-            /* No wildcard in filename means we can use the original logic to read and
-             * potentially fail traditionally */
-            if ((fp = fopen(filename, "r")) == NULL) {
-                serverLog(LL_WARNING,
-                          "Fatal error, can't open config file '%s': %s",
-                          filename, strerror(errno));
-                exit(1);
-            }
-            while(fgets(buf,CONFIG_READ_LEN+1,fp) != NULL)
-                config = sdscat(config,buf);
-            fclose(fp);
+        if (is_root && has_matches) {
+            /* Resolve server.configfile to the first matched path so that
+             * CONFIG REWRITE always has a concrete target. */
+            sdsfree(server.configfile);
+            server.configfile = sdsnew(globbuf.gl_pathv[0]);
         }
+
+        if (has_matches) {
+            for (size_t i = 0; i < globbuf.gl_pathc; i++)
+                loadOneConfigFile(globbuf.gl_pathv[i], chain);
+            globfree(&globbuf);
+        }
+    } else if (filename) {
+        loadOneConfigFile(filename, chain);
     }
 
-    /* Append content from stdin */
+    if (!is_root) return;
+
+    /* stdin and options are only processed at the root call level. */
+    char buf[CONFIG_READ_LEN+1];
+
     if (config_from_stdin) {
-        serverLog(LL_NOTICE,"Reading config from stdin");
-        fp = stdin;
-        while(fgets(buf,CONFIG_READ_LEN+1,fp) != NULL)
-            config = sdscat(config,buf);
+        serverLog(LL_NOTICE, "Reading config from stdin");
+        sds stdin_config = sdsempty();
+        while (fgets(buf, CONFIG_READ_LEN+1, stdin) != NULL)
+            stdin_config = sdscat(stdin_config, buf);
+        const char *push_err = NULL;
+        if (!configIncludeChainPush(chain, CONFIG_SOURCE_STDIN, NULL, &push_err)) {
+            serverLog(LL_WARNING, "Fatal error processing stdin config: %s", push_err);
+            sdsfree(stdin_config);
+            exit(1);
+        }
+        loadServerConfigFromString(stdin_config, chain);
+        configIncludeChainPop(chain);
+        sdsfree(stdin_config);
     }
 
-    /* Append the additional options */
     if (options) {
-        config = sdscat(config,"\n");
-        config = sdscat(config,options);
+        const char *push_err = NULL;
+        if (!configIncludeChainPush(chain, CONFIG_SOURCE_CMDLINE, NULL, &push_err)) {
+            serverLog(LL_WARNING, "Fatal error processing cmdline options: %s", push_err);
+            exit(1);
+        }
+        loadServerConfigFromString(options, chain);
+        configIncludeChainPop(chain);
     }
-    loadServerConfigFromString(config);
-    sdsfree(config);
 }
 
 static int performInterfaceSet(standardConfig *config, sds value, const char **errstr) {
@@ -1578,15 +1718,35 @@ void rewriteConfigBindOption(standardConfig *config, const char *name, struct re
     rewriteConfigRewriteLine(state,name,line,force);
 }
 
-/* Rewrite the loadmodule option. */
-void rewriteConfigLoadmoduleOption(struct rewriteConfigState *state) {
+/* Return the rewrite state for an include file, creating it on first access. */
+static struct rewriteConfigState *rewriteConfigGetIncludeState(dict *include_states,
+                                                                const char *filename) {
+    dictEntry *de = dictFind(include_states, filename);
+    if (de) return dictGetVal(de);
+
+    struct rewriteConfigState *inc_state = rewriteConfigReadOldFile((char *)filename);
+    if (!inc_state) inc_state = rewriteConfigCreateState();
+    /* Include files must not get the Redis rewrite signature. */
+    inc_state->needs_signature = 0;
+    dictAdd(include_states, sdsnew(filename), inc_state);
+    return inc_state;
+}
+
+/* Rewrite the loadmodule option.
+ * Routes each module to the state for the file it was originally loaded from,
+ * using the same include-file routing logic as the standard config loop.
+ * include_states and path may be NULL when there is no includes or no main
+ * config file. */
+void rewriteConfigLoadmoduleOption(struct rewriteConfigState *state,
+                                   dict *include_states, const char *path,
+                                   int force_write) {
     sds line;
     dictIterator di;
     dictEntry *de;
     dictInitIterator(&di, modules);
     while ((de = dictNext(&di)) != NULL) {
         struct RedisModule *module = dictGetVal(de);
-        /* Internal modules doesn't have path and are not part of the configuration file */
+        /* Internal modules don't have a path and are not part of the config file. */
         if (sdslen(module->loadmod->path) == 0) continue;
 
         line = sdsnew("loadmodule ");
@@ -1595,11 +1755,34 @@ void rewriteConfigLoadmoduleOption(struct rewriteConfigState *state) {
             line = sdscatlen(line, " ", 1);
             line = sdscatsds(line, module->loadmod->argv[i]->ptr);
         }
-        rewriteConfigRewriteLine(state,"loadmodule",line,1);
+
+        /* Route to the include-file state when the module was loaded from a
+         * file other than the main config.  force_write overrides routing.
+         * loadmodule directives from the command line or stdin are never persisted. */
+        struct rewriteConfigState *target = state;
+        if (!force_write && include_states) {
+            sds tracking_key = sdscatfmt(sdsempty(), "loadmodule:%s",
+                                         module->loadmod->path);
+            configSourceInfo *src = getConfigSource(tracking_key);
+            sdsfree(tracking_key);
+            if (src && (src->source == CONFIG_SOURCE_CMDLINE ||
+                        src->source == CONFIG_SOURCE_STDIN)) {
+                sdsfree(line);
+                continue;
+            } else if (src && src->filename &&
+                       (!path || strcmp(src->filename, path) != 0)) {
+                target = rewriteConfigGetIncludeState(include_states,
+                                                      src->filename);
+            }
+        }
+        if (target) rewriteConfigRewriteLine(target, "loadmodule", line, 1);
+        else sdsfree(line);
     }
     dictResetIterator(&di);
-    /* Mark "loadmodule" as processed in case modules is empty. */
-    rewriteConfigMarkAsProcessed(state,"loadmodule");
+    /* Always mark "loadmodule" as processed in the main state so that
+     * orphan removal can blank any stale loadmodule lines that have moved
+     * to an include file (or that belong to unloaded modules). */
+    if (state) rewriteConfigMarkAsProcessed(state, "loadmodule");
 }
 
 /* Glue together the configuration lines in the current configuration
@@ -1745,27 +1928,43 @@ cleanup:
     return retval;
 }
 
-/* Rewrite the configuration file at "path".
+/**
+ * Return the rewriteConfigState for an include file, creating it on first use.
+ * `include_states` maps include path (sds) -> rewriteConfigState*.
+ */
+/* Rewrite actual configuration parameters into their original locations.
  * If the configuration file already exists, we try at best to retain comments
  * and overall structure.
+ * If path is NULL, try to rewrite all configs to their original source files
+ * (includes)
  *
  * Configuration parameters that are at their default value, unless already
  * explicitly included in the old configuration file, are not rewritten.
  * The force_write flag overrides this behavior and forces everything to be
- * written. This is currently only used for testing purposes.
+ * written into main config. This is currently only used for testing purposes.
  *
  * On error -1 is returned and errno is set accordingly, otherwise 0. */
 int rewriteConfig(char *path, int force_write) {
-    struct rewriteConfigState *state;
+    struct rewriteConfigState *state = NULL;
     sds newcontent;
-    int retval;
+    int retval = 0;
 
-    /* Step 1: read the old config into our rewrite state. */
-    if ((state = rewriteConfigReadOldFile(path)) == NULL) return -1;
-    if (force_write) state->force_write = 1;
+    /* force_write consolidates everything into the main config; a path is
+     * required for that to make sense. */
+    if (!path && force_write) return -1;
+
+    /* Step 1: read the main config into our rewrite state if there is one. */
+    if (path) {
+        if ((state = rewriteConfigReadOldFile(path)) == NULL) return -1;
+        if (force_write) state->force_write = 1;
+    }
+
+    /* Lazy-initialised map of include-file path -> rewriteConfigState for
+     * configs that originated in a file other than the main config file. */
+    dict *include_states = dictCreate(&sdsHashDictType);
 
     /* Step 2: rewrite every single option, replacing or appending it inside
-     * the rewrite state. */
+     * the appropriate rewrite state (main config or an include file). */
 
     /* Iterate the configs that are standard */
     dictIterator di;
@@ -1775,28 +1974,61 @@ int rewriteConfig(char *path, int force_write) {
         standardConfig *config = dictGetVal(de);
         /* Only rewrite the primary names */
         if (config->flags & ALIAS_CONFIG) continue;
-        if (config->interface.rewrite) config->interface.rewrite(config, dictGetKey(de), state);
+        if (!config->interface.rewrite) continue;
+
+        /* Route to include-file state when the value originated in a file
+         * other than the main config file.  When force_write is set, skip
+         * routing so that everything lands in the main config.
+         * When there is no main config (state == NULL), any config without
+         * an include-file source has nowhere to go and is skipped.
+         * Configs from the command line or stdin are never persisted to any file. */
+        struct rewriteConfigState *target = state;
+        if (!force_write) {
+            configSourceInfo *src = getConfigSource(config->name);
+            if (src && (src->source == CONFIG_SOURCE_CMDLINE ||
+                        src->source == CONFIG_SOURCE_STDIN)) {
+                continue;
+            } else if (src && src->filename &&
+                       (!path || sdscmp(src->filename, path) != 0)) {
+                target = rewriteConfigGetIncludeState(include_states, src->filename);
+            }
+        }
+        if (!target) continue;
+        config->interface.rewrite(config, dictGetKey(de), target);
     }
     dictResetIterator(&di);
 
-    rewriteConfigUserOption(state);
-    rewriteConfigLoadmoduleOption(state);
+    rewriteConfigLoadmoduleOption(state, include_states, path, force_write);
 
-    /* Rewrite Sentinel config if in Sentinel mode. */
-    if (server.sentinel_mode) rewriteConfigSentinelOption(state);
+    if (state) {
+        rewriteConfigUserOption(state);
 
-    /* Step 3: remove all the orphaned lines in the old file, that is, lines
-     * that were used by a config option and are no longer used, like in case
-     * of multiple "save" options or duplicated options. */
-    rewriteConfigRemoveOrphaned(state);
+        /* Rewrite Sentinel config if in Sentinel mode. */
+        if (server.sentinel_mode) rewriteConfigSentinelOption(state);
+    }
 
-    /* Step 4: generate a new configuration file from the modified state
-     * and write it into the original file. */
-    newcontent = rewriteConfigGetContentFromState(state);
-    retval = rewriteConfigOverwriteFile(server.configfile,newcontent);
+    /* Step 3: remove orphaned lines and write every include file. */
+    dictInitIterator(&di, include_states);
+    while ((de = dictNext(&di)) != NULL) {
+        sds inc_path = dictGetKey(de);
+        struct rewriteConfigState *inc_state = dictGetVal(de);
+        rewriteConfigRemoveOrphaned(inc_state);
+        sds inc_content = rewriteConfigGetContentFromState(inc_state);
+        if (rewriteConfigOverwriteFile(inc_path, inc_content) == -1) retval = -1;
+        sdsfree(inc_content);
+        rewriteConfigReleaseState(inc_state);
+    }
+    dictResetIterator(&di);
+    dictRelease(include_states);
 
-    sdsfree(newcontent);
-    rewriteConfigReleaseState(state);
+    /* Step 4: remove orphaned lines and write the main config file. */
+    if (state) {
+        rewriteConfigRemoveOrphaned(state);
+        newcontent = rewriteConfigGetContentFromState(state);
+        if (rewriteConfigOverwriteFile(path, newcontent) == -1) retval = -1;
+        sdsfree(newcontent);
+        rewriteConfigReleaseState(state);
+    }
     return retval;
 }
 
@@ -3355,6 +3587,7 @@ int registerConfigValue(const char *name, const standardConfig *config, int alia
  * runtime configuration dictionary. */
 void initConfigValues(void) {
     configs = dictCreate(&sdsHashDictType);
+    initConfigSourceTracking();
     dictExpand(configs, sizeof(static_configs) / sizeof(standardConfig));
     for (standardConfig *config = static_configs; config->name != NULL; config++) {
         if (config->interface.init) config->interface.init(config);
@@ -3774,3 +4007,5 @@ void configRewriteCommand(client *c) {
 int configExists(const sds name) {
     return lookupConfig(name) != NULL;
 }
+
+

--- a/src/module.c
+++ b/src/module.c
@@ -13001,6 +13001,7 @@ void moduleLoadFromQueue(void) {
                 loadmod->path);
             exit(1);
         }
+
         moduleLoadQueueEntryFree(loadmod);
         listDelNode(server.loadmodule_queue, ln);
     }

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1757,13 +1757,15 @@ void freeSentinelLoadQueueEntry(void *item) {
     struct sentinelLoadQueueEntry *entry = item;
     sdsfreesplitres(entry->argv,entry->argc);
     sdsfree(entry->line);
+    if (entry->source_filename) sdsfree(entry->source_filename);
     zfree(entry);
 }
 
 /* This function is used for queuing sentinel configuration, the main
  * purpose of this function is to delay parsing the sentinel config option
  * in order to avoid the order dependent issue from the config. */
-void queueSentinelConfig(sds *argv, int argc, int linenum, sds line) {
+void queueSentinelConfig(sds *argv, int argc, int linenum, sds line,
+                         configSource source, const char *source_filename) {
     int i;
     struct sentinelLoadQueueEntry *entry;
 
@@ -1775,6 +1777,8 @@ void queueSentinelConfig(sds *argv, int argc, int linenum, sds line) {
     entry->argc = argc;
     entry->linenum = linenum;
     entry->line = sdsdup(line);
+    entry->source = source;
+    entry->source_filename = source_filename ? sdsnew(source_filename) : NULL;
     for (i = 0; i < argc; i++) {
         entry->argv[i] = sdsdup(argv[i]);
     }
@@ -1821,6 +1825,11 @@ void loadSentinelConfigFromQueue(void) {
                 line = entry->line;
                 goto loaderr;
             }
+            /* Record source under "sentinel:<subcommand>" (e.g. "sentinel:monitor"). */
+            sds tracking_key = sdscatfmt(sdsempty(), "sentinel:%s", entry->argv[0]);
+            recordConfigSource(tracking_key, entry->source,
+                               entry->source_filename);
+            sdsfree(tracking_key);
         }
     }
 
@@ -2265,6 +2274,11 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
 int sentinelFlushConfig(void) {
     int saved_hz = server.hz;
     int rewrite_status;
+
+    if (!server.configfile) {
+        serverLog(LL_WARNING,"WARNING: Sentinel was not able to save the new configuration on disk!!!: no config file");
+        return C_ERR;
+    }
 
     server.hz = CONFIG_DEFAULT_HZ;
     rewrite_status = rewriteConfig(server.configfile, 0);

--- a/src/server.c
+++ b/src/server.c
@@ -8052,7 +8052,7 @@ int main(int argc, char **argv) {
             j++;
         }
 
-        loadServerConfig(server.configfile, config_from_stdin, options);
+        loadServerConfig(server.configfile, config_from_stdin, options, NULL);
         if (server.sentinel_mode) loadSentinelConfigFromQueue();
         sdsfree(options);
     }

--- a/src/server.h
+++ b/src/server.h
@@ -1661,6 +1661,15 @@ struct saveparam {
     int changes;
 };
 
+/* Source of a configuration value. */
+typedef enum {
+    CONFIG_SOURCE_DEFAULT,   /* Default value (never explicitly set) */
+    CONFIG_SOURCE_FILE,      /* From a config file (main or included) */
+    CONFIG_SOURCE_STDIN,     /* From stdin */
+    CONFIG_SOURCE_CMDLINE,   /* From command-line argument */
+    CONFIG_SOURCE_RUNTIME,   /* From CONFIG SET at runtime */
+} configSource;
+
 struct moduleLoadQueueEntry {
     sds path;
     int argc;
@@ -1672,6 +1681,9 @@ struct sentinelLoadQueueEntry {
     sds *argv;
     int linenum;
     sds line;
+    /* Source tracking */
+    configSource source;
+    sds source_filename;    /* Non-NULL for FILE sources */
 };
 
 struct sentinelConfig {
@@ -3873,7 +3885,9 @@ typedef enum {
     SPECIAL_CONFIG,
 } configType;
 
-void loadServerConfig(char *filename, char config_from_stdin, char *options);
+struct configIncludeChain; /* defined in config.c */
+void loadServerConfig(char *filename, char config_from_stdin, char *options,
+                      struct configIncludeChain *chain);
 void appendServerSaveParams(time_t seconds, int changes);
 void resetServerSaveParams(void);
 struct rewriteConfigState; /* Forward declaration to export API. */
@@ -3884,6 +3898,13 @@ void initConfigValues(void);
 void removeConfig(sds name);
 sds getConfigDebugInfo(void);
 int allowProtectedAction(int config, client *c);
+/* Config source tracking API */
+typedef struct configSourceInfo configSourceInfo;
+void initConfigSourceTracking(void);
+void recordConfigSource(const char *name, configSource source,
+                        const char *filename);
+configSourceInfo *getConfigSource(const char *name);
+void freeConfigSourceInfo(configSourceInfo *info);
 void initServerClientMemUsageBuckets(void);
 void freeServerClientMemUsageBuckets(void);
 static inline int clusterSlotStatsEnabled(int stat) { return server.cluster_enabled && (server.cluster_slot_stats_enabled & stat); }
@@ -4055,7 +4076,8 @@ void initSentinelConfig(void);
 void initSentinel(void);
 void sentinelTimer(void);
 const char *sentinelHandleConfiguration(char **argv, int argc);
-void queueSentinelConfig(sds *argv, int argc, int linenum, sds line);
+void queueSentinelConfig(sds *argv, int argc, int linenum, sds line,
+                         configSource source, const char *source_filename);
 void loadSentinelConfigFromQueue(void);
 void sentinelIsRunning(void);
 void sentinelCheckConfigFile(void);

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1103,6 +1103,65 @@ test {CONFIG REWRITE handles alias config properly} {
     }
 } {} {external:skip}
 
+test {CONFIG REWRITE writes changed value back to the include file} {
+    set include_file [file normalize [tmpfile include.conf]]
+
+    set fd [open $include_file w]
+    puts $fd "tcp-keepalive 301"
+    close $fd
+
+    start_server [list tags {introspection} config_lines [list include $include_file]] {
+        assert_equal 301 [lindex [r config get tcp-keepalive] 1]
+
+        r config set tcp-keepalive 500
+        r config rewrite
+
+        # The updated value must appear in the include file, not only the main config
+        set include_content [exec cat $include_file]
+        assert_match "*tcp-keepalive 500*" $include_content
+
+        # Survives a restart, confirming the rewritten file is valid
+        restart_server 0 true false
+        assert_equal 500 [lindex [r config get tcp-keepalive] 1]
+    }
+} {} {external:skip}
+
+test {Circular include is detected and causes a fatal error} {
+    set conf_a [file normalize [tmpfile circular_a.conf]]
+    set conf_b [file normalize [tmpfile circular_b.conf]]
+
+    # a.conf includes b.conf and b.conf includes a.conf
+    set fd [open $conf_a w]
+    puts $fd "include $conf_b"
+    close $fd
+
+    set fd [open $conf_b w]
+    puts $fd "include $conf_a"
+    close $fd
+
+    catch {exec src/redis-server $conf_a} err
+    assert_match "*circular include detected*" $err
+} {} {external:skip}
+
+test {CONFIG REWRITE routes value from --include file back to that file} {
+    set include_file [file normalize [tmpfile cmdline_include.conf]]
+
+    set fd [open $include_file w]
+    puts $fd "timeout 30"
+    close $fd
+
+    start_server [list tags {introspection} args [list --include $include_file]] {
+        assert_equal 30 [lindex [r config get timeout] 1]
+
+        r config set timeout 60
+        r config rewrite
+
+        # The updated value must appear in the include file, not the main config
+        set include_content [exec cat $include_file]
+        assert_match "*timeout 60*" $include_content
+    }
+} {} {external:skip}
+
 test {IO threads client number} {
     start_server {overrides {io-threads 2} tags {external:skip}} {
         set iothread_clients [get_io_thread_clients 1]

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -382,5 +382,35 @@ start_server {tags {"modules external:skip"}} {
         assert_equal [r config get moduleconfigs.string] "moduleconfigs.string modified_value"
         r module unload moduleconfigs
     }
+
+    test {CONFIG REWRITE routes loadmodule and module config back to include file} {
+        # Both loadmodule and the module-specific config live in an include
+        # file, not the main redis.conf.  After changing the enum value and
+        # rewriting, everything must stay in the include file and nothing must
+        # spill into the main config.
+        set module_conf [file normalize [tmpfile moduleconfigs_inc.conf]]
+
+        set fd [open $module_conf w]
+        puts $fd "loadmodule $testmodule"
+        puts $fd "moduleconfigs.enum one"
+        close $fd
+
+        start_server [list tags {modules external:skip} config_lines [list include $module_conf]] {
+            assert_equal [r config get moduleconfigs.enum] "moduleconfigs.enum one"
+
+            r config set moduleconfigs.enum five
+            r config rewrite
+
+            set main_content [exec cat [srv 0 config_file]]
+            set inc_content  [exec cat $module_conf]
+
+            # loadmodule must not migrate into the main config
+            assert {![string match "*loadmodule*" $main_content]}
+
+            # Both directives must be rewritten into the include file
+            assert_match "*loadmodule*"               $inc_content
+            assert_match "*moduleconfigs.enum five*"  $inc_content
+        }
+    }
 }
 


### PR DESCRIPTION
This basically implements the [idea](https://github.com/redis/redis/issues/14404#issuecomment-3482911704) described by @YaacovHazan . While it is fully functional, there are some aspects (for example module unload, config aliases handling, more tests) that may need more attention. The goal was to see how this approach works and to drive discussion around the problem, because we need to resolve it somehow.

If this approach is considered good, it can be improved further. If not, I hope we can choose another, possibly simpler, way.

## Reminder: problems we are trying to solve

* Using includes to organize configuration is currently hindered by `CONFIG REWRITE`, because it duplicates entries in the main config and may even prevent the server from starting (for example with duplicated `loadmodule`). Organizing configuration in multiple files is currently standard across most distributions.
* The official Docker image behaves badly when combined with `CONFIG REWRITE`, which makes it hard to use in cluster/replica setups and surprises users.
* This also prevents organizing Docker configuration in a more convenient way, as discussed in https://github.com/redis/docker-library-redis/pull/432

See also:
https://github.com/redis/docker-library-redis/pull/504
https://github.com/redis/docker-library-redis/issues/468

## Important note about command line and stdin arguments

The main conceptual difference from the original idea is that parameters coming from non-writable sources (command line, stdin) are not written to the config file. I believe this is the right approach, because in practice if a server starts with specific arguments, it is usually restarted with the same arguments. This is true for cases like systemd unit files and Docker.

We can extend this idea to environment variables (not currently supported): if a process starts with a set of env vars, a restart will likely use the same env vars, and they should not be migrated from env to config.

This would solve the `loadmodule` duplication problem in Docker images.

Additional note about stdin: according to [git history](https://github.com/redis/redis/commit/dab5ec9b8d5c6f7a99a557d65cc95816b981835b), stdin config was introduced to be used together with config files so secret parameters could be provided via stdin. If `CONFIG REWRITE` writes those values back to `redis.conf`, that is clearly not the expected behavior.

While there are many real-world examples of why command-line/stdin parameters should not be written back to the main config, I could not find a realistic scenario where not writing them back would break an existing setup. The only case is `force_write`, but it is used only in tests, and in that mode I made it write everything to one file anyway.

## Things to highlight

* CONFIG REWRITE continues writing all include files even if one fails (for example, read-only file), but if at least one write fails, the overall operation is considered a failure.
* Include files are written even if no main config file exists, for example: `redis-server --include /path/to/file.conf`.
* When Redis is started with a wildcard main config file, the first glob match is treated as the main config, for example: `redis-server /etc/redis/*.conf`.
* When `force_write` is used, everything goes to the main config file regardless of source (file, command line, stdin, or include).
* Maximum include nesting depth is limited to 16.
* If a config parameter is specified more than once, the last source wins.

### One scenario that may break

There is a scenario [described](https://github.com/redis/redis/issues/14404#issuecomment-4180227635) by @douglyuckling that relies on the current REWRITE behavior: using a read-only include file as a base and overriding values via duplicate options. With this implementation, there is no way to override configuration while keeping part of it read-only.

A possible solution is to split configuration into parts and keep the mutable part (replication/cluster-related parameters) in a separate include file, then avoid updating that file with Ansible once it already exists.


## Fixed bugs

During this work I found the following minor bugs, which are fixed by this PR:

* Redis would crash on circular includes. Now circular includes are detected and the server fails to start with a clear error message.
* `CONFIG REWRITE` was broken when using a wildcard main config, for example: `redis-server /etc/redis/*.conf`. Now the first glob match is used as the main config (`server.configfile`) instead of keeping the glob pattern as `configfile`.


## PS

After working on this, I started to think that the CONFIG REWRITE concept itself introduces too much complexity for too little value. As long as it exists, there will always be edge cases and contradictions. A better approach might be to opt out of CONFIG REWRITE entirely. I believe the main use case is cluster/replication, which could be solved with a clear, explicit state file containing dynamic configuration overrides needed to manage cluster and replication behavior, without magic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core config parsing and `CONFIG REWRITE` behavior, including multi-file include handling and glob resolution; regressions could break startup or persist incorrect configs across restarts.
> 
> **Overview**
> **`CONFIG REWRITE` now preserves where config values came from.** The server tracks the source of each directive (main file vs included file vs stdin vs command line) during config parsing, including nested includes with depth limits and circular-include detection.
> 
> Rewrite logic is updated to **route rewritten options and `loadmodule` lines back to the file they originated from**, writing include files separately and skipping persistence for values sourced from stdin/command line (unless `force_write` consolidates into the main file). Wildcard config paths are expanded and the first match becomes the concrete main `server.configfile` for rewrites.
> 
> Sentinel config queueing records directive sources for rewrite purposes, and tests add coverage for include-file rewrites, `--include` behavior, circular include failures, and keeping module load + module configs in the include file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 476487bd076dbcfbdae2e11e527a10b38e08d2d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->