### PR TITLE
perf: stack-buffer stream ID formatting in reply path

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1696,12 +1696,21 @@ sds createStreamIDString(streamID *id) {
  * Returns the number of characters written (excluding null terminator).
  * The buffer must be at least STREAM_ID_STR_LEN bytes; two uint64 decimals
  * plus the separator fit comfortably, and the contract is enforced via an
- * assert on the caller-supplied buflen. */
+ * assert on the caller-supplied buflen.
+ *
+ * ull2string() returns 0 when the destination is too small; with the buflen
+ * assertion above a zero return is impossible on a well-formed uint64, but
+ * we assert the postcondition so future callers that shrink buflen or pass
+ * a non-uint64 value fail loudly here instead of silently producing
+ * malformed output like "-<seq>" when ull2string(ms) returns 0. */
 static inline int streamFormatID(char *buf, size_t buflen, streamID *id) {
     serverAssert(buflen >= STREAM_ID_STR_LEN);
     int n = ull2string(buf, buflen, id->ms);
+    serverAssert(n > 0);
     buf[n++] = '-';
-    n += ull2string(buf + n, buflen - n, id->seq);
+    int seq_n = ull2string(buf + n, buflen - n, id->seq);
+    serverAssert(seq_n > 0);
+    n += seq_n;
     return n;
 }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1692,11 +1692,27 @@ sds createStreamIDString(streamID *id) {
     return sdscatfmt(str,"%U-%U", id->ms,id->seq);
 }
 
+/* Format a stream ID into the supplied buffer as "<ms>-<seq>".
+ * Returns the number of characters written (excluding null terminator).
+ * The buffer must be at least STREAM_ID_STR_LEN bytes; two uint64 decimals
+ * plus the separator fit comfortably, and the contract is enforced via an
+ * assert on the caller-supplied buflen. */
+static inline int streamFormatID(char *buf, size_t buflen, streamID *id) {
+    serverAssert(buflen >= STREAM_ID_STR_LEN);
+    int n = ull2string(buf, buflen, id->ms);
+    buf[n++] = '-';
+    n += ull2string(buf + n, buflen - n, id->seq);
+    return n;
+}
+
 /* Emit a reply in the client output buffer by formatting a Stream ID
- * in the standard <ms>-<seq> format, using the simple string protocol
- * of REPL. */
+ * in the standard <ms>-<seq> format, using the bulk string protocol.
+ * Uses a stack buffer to avoid heap allocation — this replaces an
+ * SDS allocation+free round-trip for every stream ID reply. */
 void addReplyStreamID(client *c, streamID *id) {
-    addReplyBulkSds(c,createStreamIDString(id));
+    char buf[STREAM_ID_STR_LEN];
+    int len = streamFormatID(buf, sizeof(buf), id);
+    addReplyBulkCBuffer(c, buf, len);
 }
 
 void setDeferredReplyStreamID(client *c, void *dr, streamID *id) {


### PR DESCRIPTION
## Summary

Replace heap-allocated SDS with stack-buffer formatting for stream ID replies,
eliminating unnecessary `zmalloc`/`zfree` cycles (2 `LOCK XADD` per stream ID)
in the hot reply path.

### Changes

- Add `streamFormatID()` — formats `<ms>-<seq>` into a caller-supplied buffer
  using `ull2string()`, returning the length written
- `addReplyStreamID()` now uses a stack `char buf[45]` + `addReplyBulkCBuffer()`
  instead of `addReplyBulkSds(createStreamIDString())`
- `xaddCommand()` formats the reply ID on the stack; only allocates via
  `createObjectFromStreamID()` when replication propagation needs the `robj`
- `setDeferredReplyStreamID()` formats to stack buffer, copies into a minimal SDS
  for the deferred reply envelope

### Why

`addReplyStreamID` has 17 call sites across XREADGROUP, XRANGE, XINFO, XCLAIM,
XAUTOCLAIM etc. Every call previously allocated an SDS via `createStreamIDString`
(zmalloc → LOCK XADD) and freed it (zfree → LOCK XADD). For a single
`XREADGROUP COUNT 100`, that is 100+ unnecessary heap round-trips.

### Benchmark data

Tested on x86 (Intel Sapphire Rapids, m7i.metal-24xl) and ARM (Graviton4,
m8g.metal-24xl). Throughput is within noise (< 1% delta on all stream benchmarks).

### TMA (Top-Down Microarchitecture Analysis)

Test: `stream-concurrent-xadd-xreadgroup-70-30` on Intel Sapphire Rapids.

| TMA Metric | Unstable | PR | Delta |
|------------|----------|-----|-------|
| **Backend_Bound** | 49.1% | 41.7% | **-7.4pp** |
| Core_Bound | 17.3% | 7.8% | **-9.5pp** |
| Contested_Accesses | 17.7% | 8.0% | **-9.7pp** |
| L1_Latency_Dependency | 18.1% | 14.5% | -3.7pp |
| **Retiring** | 27.6% | 31.0% | **+3.5pp** |

The pipeline slot analysis confirms reduced cache-line contention and
dependency chains from eliminating the allocation/free cycles. The
`createStreamIDString` function is no longer visible in continuous profiling
(was ~52M flat samples on unstable, now zero).

### Tests

- `unit/type/stream` — pass
- `unit/type/stream-cgroups` — pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance refactor in the stream reply path; main risk is incorrect ID formatting/length handling affecting client replies if the new stack-buffer formatting is wrong.
> 
> **Overview**
> Stream ID replies are now formatted into a fixed-size stack buffer via new `streamFormatID()` (using `ull2string` + assertions) and sent with `addReplyBulkCBuffer()`, avoiding per-reply SDS allocation/free.
> 
> `createStreamIDString()` remains for object/deferred-reply use, but `addReplyStreamID()` no longer allocates when emitting `<ms>-<seq>` IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de803f67b017a5a0b75964616a97d55b04fa967f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->