### PR TITLE
Fix use-after-free in hash field expiration commands

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -3863,8 +3863,7 @@ int isSubkeyNotifyEnabled(int type);
  * RediSearch does it in some specific flows and modifies key metadata which in
  * turn might invalidates the local kvobj pointer. Those specific flows are
  * protected by the following macro which invalidates the local kvobj pointer
- * after the notification to prevent further access to it (Currently it is only 
- * using it with hash type keys, without hash field expiration) */
+ * after the notification to prevent further access to it. */
 #define KSN_INVALIDATE_KVOBJ(o) do { (o) = NULL; } while (0)
 
 /* Configuration */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2965,6 +2965,10 @@ void hgetexCommand(client *c) {
     server.dirty += vecSize(vdeleted) + vecSize(vupdated);
     keyModified(c, c->db, c->argv[1], o, 1);
 
+    /* Compute newlen before notifications – a module's KSN callback may call
+     * RM_SetKeyMeta() which reallocates kvobj, invalidating 'o'. */
+    newlen = hashTypeLength(o, 0);
+
     /* This command will never be propagated as it is. It will be propagated as
      * HDELs when fields are lazily expired or deleted, if the new timestamp is
      * in the past. HDEL's will be emitted as part of addHashFieldToReply()
@@ -3027,9 +3031,7 @@ void hgetexCommand(client *c) {
     vecRelease(vdeleted);
     vecRelease(vupdated);
 
-    /* Key may become empty due to lazy expiry in addHashFieldToReply()
-     * or the new expiration time is in the past.*/
-    newlen = hashTypeLength(o, 0);
+    KSN_INVALIDATE_KVOBJ(o);
 
     updateKeysizesHist(c->db, OBJ_HASH, oldlen, newlen);
     if (newlen == 0) {
@@ -4077,6 +4079,10 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
     if (server.memory_tracking_enabled)
         updateSlotAllocSize(c->db, getKeySlot(keyArg->ptr), hashObj, oldsize, kvobjAllocSize(hashObj));
 
+    /* Compute newlen before notifications – a module's KSN callback may call
+     * RM_SetKeyMeta() which reallocates kvobj, invalidating 'hashObj'. */
+    newlen = (int64_t) hashTypeLength(hashObj, 0);
+
     if (vecSize(vdeleted) + vecSize(vupdated) > 0) {
         server.dirty += vecSize(vdeleted) + vecSize(vupdated);
         keyModified(c, c->db, keyArg, hashObj, 1);
@@ -4084,9 +4090,8 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
                                 keyArg, c->db->id, (robj**)vecData(vdeleted), vecSize(vdeleted));
         if (vecSize(vupdated)) notifyKeyspaceEventWithSubkeys(NOTIFY_HASH, "hexpire",
                                 keyArg, c->db->id, (robj**)vecData(vupdated), vecSize(vupdated));
+        KSN_INVALIDATE_KVOBJ(hashObj);
     }
-
-    newlen = (int64_t) hashTypeLength(hashObj, 0);
     if (newlen == 0) {
         newlen = -1;
         /* Del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
@@ -4315,9 +4320,10 @@ void hpersistCommand(client *c) {
     /* Generates a hpersist event if the expiry time associated with any field
      * has been successfully deleted. */
     if (vecSize(vpersisted)) {
+        keyModified(c, c->db, c->argv[1], hashObj, 1);
         notifyKeyspaceEventWithSubkeys(NOTIFY_HASH, "hpersist", c->argv[1],
                                        c->db->id, (robj**)vecData(vpersisted), vecSize(vpersisted));
-        keyModified(c, c->db, c->argv[1], hashObj, 1);
+        KSN_INVALIDATE_KVOBJ(hashObj);
         server.dirty++;
     }
     vecRelease(vpersisted);

--- a/tests/unit/moduleapi/ksn_notify_side_effect.tcl
+++ b/tests/unit/moduleapi/ksn_notify_side_effect.tcl
@@ -1,12 +1,12 @@
 # Test for SetKeyMeta during keyspace notification (KSN) callbacks.
 #
-# On key space notification, the module shouldn't modify the key. This focused 
+# On key space notification, the module shouldn't modify the key. This focused
 # regression tests makes an exception for RediSearch which uses SetKeyMeta
-# as part of its KSN callback (Currently only for hash keys without hash field 
-# expiration). The test module mutates key metadata during selected notifications,
-# which may reallocate the underlying kvobj and invalidates any local pointer to 
-# it. Each test uses fresh keys when possible so the first metadata write forces
-# the reallocation-sensitive path, then verifies the command still completes.
+# as part of its KSN callback. The test module mutates key metadata during
+# selected notifications, which may reallocate the underlying kvobj and
+# invalidates any local pointer to it. Each test uses fresh keys when possible
+# so the first metadata write forces the reallocation-sensitive path, then
+# verifies the command still completes.
 
 set testmodule [file normalize tests/modules/keymeta_notify.so]
 
@@ -134,6 +134,52 @@ start_server {tags {"modules" "external:skip"} overrides {enable-debug-command y
         # HDEL multiple fields (in-place metadata update)
         r HDEL hdel_key f2 f3
         assert_equal [r HLEN hdel_key] 0
+    }
+
+    # --- HASH field expiration notification tests ---
+    # Each test creates a key without the module loaded, then loads the module
+    # so the first SetKeyMeta call during the HFE command triggers kvobj
+    # reallocation.
+
+    test {HGETEX with SetKeyMeta in notification does not crash} {
+        r module unload keymetanotify
+        r HSET hgetex_key f1 v1 f2 v2 f3 v3
+        r module load $testmodule
+
+        set before [r keymetanotify.setcount]
+        set result [r HGETEX hgetex_key EX 1000 FIELDS 2 f1 f2]
+        assert_equal [lindex $result 0] "v1"
+        assert_equal [lindex $result 1] "v2"
+        assert {[r keymetanotify.setcount] > $before}
+        assert_equal [r keymetanotify.get hgetex_key] "notified"
+        assert_equal [r HLEN hgetex_key] 3
+    }
+
+    test {HEXPIRE with SetKeyMeta in notification does not crash} {
+        r module unload keymetanotify
+        r HSET hexpire_key f1 v1 f2 v2
+        r module load $testmodule
+
+        set before [r keymetanotify.setcount]
+        r HEXPIRE hexpire_key 1000 FIELDS 1 f1
+        assert {[r keymetanotify.setcount] > $before}
+        assert_equal [r keymetanotify.get hexpire_key] "notified"
+        assert {[r HTTL hexpire_key FIELDS 1 f1] > 0}
+        assert_equal [r HLEN hexpire_key] 2
+    }
+
+    test {HPERSIST with SetKeyMeta in notification does not crash} {
+        r module unload keymetanotify
+        r HSET hpersist_key f1 v1 f2 v2
+        r HEXPIRE hpersist_key 1000 FIELDS 1 f1
+        r module load $testmodule
+
+        set before [r keymetanotify.setcount]
+        r HPERSIST hpersist_key FIELDS 1 f1
+        assert {[r keymetanotify.setcount] > $before}
+        assert_equal [r keymetanotify.get hpersist_key] "notified"
+        assert_equal [r HTTL hpersist_key FIELDS 1 f1] -1
+        assert_equal [r HLEN hpersist_key] 2
     }
 
     # --- GENERIC notification tests ---


### PR DESCRIPTION
PR #15004 introduced `KSN_INVALIDATE_KVOBJ()` to protect against
use-after-free when a module's KSN callback calls `RM_SetKeyMeta()`,
but explicitly scoped itself to "hash type keys, without hash field
expiration". Three HFE command handlers still access kvobj pointers
after `notifyKeyspaceEvent()`:

- `hgetexCommand`: `hashTypeLength(o)` called after notifications
- `hexpireGenericCommand`: `hashTypeLength(hashObj)` called after notification
- `hpersistCommand`: `keyModified(hashObj)` called after notification

Fix by computing `hashTypeLength()` before notifications, reordering
`keyModified()` before `notifyKeyspaceEvent()`, and adding
`KSN_INVALIDATE_KVOBJ()` after each notification block.

Fixes #15050

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core hash field-expiration command paths and keyspace notification ordering; while the change is small, mistakes could impact hash deletion/keysizes accounting or notification/replication behavior.
> 
> **Overview**
> Fixes potential use-after-free in hash field-expiration flows when a module mutates key metadata during keyspace notification callbacks.
> 
> The hash HFE command handlers now compute `hashTypeLength()` before emitting notifications, reorder `keyModified()` ahead of `notifyKeyspaceEvent*()` for `HPERSIST`, and explicitly `KSN_INVALIDATE_KVOBJ()` after notification blocks to prevent further access to possibly reallocated `kvobj` pointers. Regression tests are expanded to cover `HGETEX`, `HEXPIRE`, and `HPERSIST` under this module side-effect scenario, and the `KSN_INVALIDATE_KVOBJ` comment is generalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dc99d73c241730f94b3429ceb914b2e288a489c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->