### PR TITLE
Fix command-docs and corrupt-dump-fuzzer of OBJ_GCRA type

### DIFF
--- a/src/commands/command-docs.json
+++ b/src/commands/command-docs.json
@@ -91,6 +91,9 @@
                                 },
                                 {
                                     "const": "transactions"
+                                },
+                                {
+                                    "const": "rate_limit"
                                 }
                             ]
                         },

--- a/src/server.h
+++ b/src/server.h
@@ -871,7 +871,15 @@ typedef enum {
  * - debug.c - xorObjectDigest, serverLogObjectDebugInfo
  * - defrag.c - defragKey
  * - module.c - RM_KeyType (and add the new keytype to redismodule.h)
- * - object.c - object(create/free/dismiss/allocSize/Length) */
+ * - object.c - object(create/free/dismiss/allocSize/Length)
+ * - tests/support/util.tcl:generate_fuzzy_traffic_on_key - add command(s) for the new object type to the `commands` dict.
+ *
+ * If the new object type requires new command group make sure to update the following:
+ * - src/commands/command-docs.json - update the group:oneOf map with the new group
+ * - utils/generate-command-code.py - add the new group to GROUPS and COMMAND_GROUP_STR arrays
+ * - src/acl.c - add the new group to ACLDefaultCommandCategories array
+ * - src/server.h - add the new group to redisCommandGroup enum
+ * - if needed add new KSN type related to the group - search for NOTIFY_* and REDISMODULE_NOTIFY_* defines. */
 
 /* Extract encver / signature from a module type ID. */
 #define REDISMODULE_TYPE_ENCVER_BITS 10

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -59,6 +59,7 @@ proc generate_types {} {
     # create other non-collection types
     r incr int
     r set string str
+    r gcra gcra 10 5 60000
 
     # create bigger objects with 10 items (more than a single ziplist / listpack)
     generate_collections big 10

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -59,7 +59,6 @@ proc generate_types {} {
     # create other non-collection types
     r incr int
     r set string str
-    r gcra gcra 10 5 60000
 
     # create bigger objects with 10 items (more than a single ziplist / listpack)
     generate_collections big 10

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -800,7 +800,8 @@ proc generate_fuzzy_traffic_on_key {key type duration} {
     set set_commands {SADD SCARD SDIFF SDIFFSTORE SINTER SINTERSTORE SISMEMBER SMEMBERS SMOVE SPOP SRANDMEMBER SREM SSCAN SUNION SUNIONSTORE}
     set stream_commands {XACK XADD XCLAIM XDEL XGROUP XINFO XLEN XPENDING XRANGE XREAD XREADGROUP XREVRANGE XTRIM XDELEX XACKDEL XNACK}
     set vset_commands {VADD VREM}
-    set commands [dict create string $string_commands hash $hash_commands zset $zset_commands list $list_commands set $set_commands stream $stream_commands vectorset $vset_commands]
+    set gcra_commands {GCRA}
+    set commands [dict create string $string_commands hash $hash_commands zset $zset_commands list $list_commands set $set_commands stream $stream_commands vectorset $vset_commands gcra $gcra_commands]
 
     set cmds [dict get $commands $type]
     set start_time [clock seconds]

--- a/tests/unit/gcra.tcl
+++ b/tests/unit/gcra.tcl
@@ -227,6 +227,14 @@ start_server {tags {"gcra" "external:skip"}} {
         catch {r gcra mykey 1 1 2147483647 TOKENS 2147483647} err
         assert_match "*would cause an overflow*" $err
     }
+
+    test {GCRASETVALUE - basic functionality} {
+        r del mykey
+        set tat_us [expr {[clock microseconds] + 60000000}]
+        assert_equal {OK} [r gcrasetvalue mykey $tat_us]
+        assert_equal {gcra} [r type mykey]
+        assert {[r pttl mykey] > 0}
+    }
 }
 
 start_server {tags {"gcra" "external:skip"}} {

--- a/utils/req-res-log-validator.py
+++ b/utils/req-res-log-validator.py
@@ -55,6 +55,7 @@ IGNORED_COMMANDS = {
     "sunsubscribe",
     "psubscribe",
     "punsubscribe",
+    "gcrasetvalue",  # internal replication command, only sent via replication stream (CLIENT_TYPE_MASTER)
     # Commands to which we decided not write a reply schema
     "pfdebug",
     "lolwut",

--- a/utils/req-res-log-validator.py
+++ b/utils/req-res-log-validator.py
@@ -55,7 +55,6 @@ IGNORED_COMMANDS = {
     "sunsubscribe",
     "psubscribe",
     "punsubscribe",
-    "gcrasetvalue",  # internal replication command, only sent via replication stream (CLIENT_TYPE_MASTER)
     # Commands to which we decided not write a reply schema
     "pfdebug",
     "lolwut",


### PR DESCRIPTION
### Problem 

While the new type `OBJ_GCRA` was added, several related code paths were not updated accordingly, leading to failures in the `reply-schemas-validator` CI job and `corrupt-dump-fuzzer.tcl`

##### reply-schemas-validator

Failed CI: https://github.com/redis/redis/actions/runs/24485248057/job/71558533290#step:10:903
```shell
Traceback (most recent call last):
  File "/home/runner/work/redis/redis/./utils/req-res-log-validator.py", line 238, in process_file
    jsonschema.validate(instance=res.json, schema=req.schema, cls=schema_validator)
  File "/home/runner/.local/lib/python3.12/site-packages/jsonschema/validators.py", line 1121, in validate
    raise error
jsonschema.exceptions.ValidationError: 'rate_limit' is not valid under any of the given schemas

Failed validating 'oneOf' in schema['patternProperties']['^.*$']['properties']['group']:
    {'description': 'the functional group to which the command belongs',
     'oneOf': [{'const': 'bitmap'},
               {'const': 'cluster'},
               {'const': 'connection'},
               {'const': 'generic'},
               {'const': 'geo'},
               {'const': 'hash'},
               {'const': 'hyperloglog'},
               {'const': 'list'},
               {'const': 'module'},
               {'const': 'pubsub'},
               {'const': 'scripting'},
               {'const': 'sentinel'},
               {'const': 'server'},
               {'const': 'set'},
               {'const': 'sorted-set'},
               {'const': 'stream'},
               {'const': 'string'},
               {'const': 'transactions'}]}

On instance['gcrasetvalue']['group']:
    'rate_limit'
```


##### `corrupt-dump-fuzzer.tcl`

Also fixed `: Fuzzer corrupt restore payloads - sanitize_dump: yes in tests/integration/corrupt-dump-fuzzer.tcl`

Failed daily test : https://github.com/redis/redis/actions/runs/24485248057/job/71558533312#step:6:8652
```shell
Server crashed (by signal: 0, err: key "gcra" not known in dictionary), with payload: "\x1C\x0A\x02\x5F\x37\xC0\x06\xC0\x00\x02\x5F\x39\xC0\x08\x02\x5F\x33\x02\x5F\x35\x02\x5F\x31\xC0\x02\xC0\x04\x0E\x00\xA9\x71\xBF\xEE\x6F\x46\xEF\xA6"
violating commands:
Done 1434 cycles in 600 seconds.
RESTORE: successful: 601, rejected: 833
Total commands sent in traffic: 1194776, crashes during traffic: 1 (0 by signal).
[: Fuzzer corrupt restore payloads - sanitize_dump: yes in tests/integration/corrupt-dump-fuzzer.tcl
Expected '1' to be equal to '0' (context: type eval line 155 cmd {assert_equal $stat_terminated_in_traffic 0} proc ::test)
[147/147 done]: integration/corrupt-dump-fuzzer (1201 seconds)
```

### Changed

This change completes the necessary updates across all relevant components to ensure consistent handling of the rate_limit group and restores CI stability.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation schema, comments, and test coverage; no production command behavior is modified.
> 
> **Overview**
> Fixes CI schema validation by allowing the `rate_limit` command `group` in `command-docs.json`, unblocking commands like `gcrasetvalue` that document under that category.
> 
> Extends GCRA coverage in tests by adding GCRA key creation to the corrupt dump fuzzer, including GCRA in fuzzy-traffic generation, and adding a basic `GCRASETVALUE` unit test (type + TTL assertions). Also updates `server.h` developer notes with a checklist for adding new object types/command groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b12e7eea5c841d1a95bd794f80e437ff8e0e04c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->