### PR TITLE
Log node address when ASM starts

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1058,15 +1058,15 @@ void clusterMigrationCommand(client *c) {
 }
 
 /* Returns the address of the node in the format "ip:port". */
-static const char *getNodeAddressStr(const char *node_id) {
+static const char *getNodeAddressStr(const char *node_id, int len) {
     serverAssert(node_id != NULL);
     static char buf[NET_HOST_PORT_STR_LEN];
 
-    clusterNode *n = clusterLookupNode(node_id, CLUSTER_NAMELEN);
-    const char *ip = n ? clusterNodeIp(n) : "?";
+    clusterNode *n = clusterLookupNode(node_id, len);
+    char *ip = n ? clusterNodeIp(n) : "?";
     int port = n ? (server.tls_replication ? clusterNodeTlsPort(n) :
                                              clusterNodeTcpPort(n)) : 0;
-    snprintf(buf, sizeof(buf), "%s:%d", ip, port);
+    formatAddr(buf, sizeof(buf), ip, port);
     return buf;
 }
 
@@ -1077,7 +1077,7 @@ void asmLogTaskEvent(asmTask *task, int event) {
     switch (event) {
         case ASM_EVENT_IMPORT_STARTED:
             serverLog(LL_NOTICE, "Import task %s started for slots: %s, source address: %s",
-                      task->id, str, getNodeAddressStr(task->source));
+                      task->id, str, getNodeAddressStr(task->source, CLUSTER_NAMELEN));
             break;
         case ASM_EVENT_IMPORT_FAILED:
             serverLog(LL_NOTICE, "Import task %s failed for slots: %s", task->id, str);
@@ -1091,7 +1091,7 @@ void asmLogTaskEvent(asmTask *task, int event) {
             break;
         case ASM_EVENT_MIGRATE_STARTED:
             serverLog(LL_NOTICE, "Migrate task %s started for slots: %s, destination address: %s, (number of keys at start: %llu)",
-                      task->id, str, getNodeAddressStr(task->dest), getKeyCountInSlotRangeArray(task->slots));
+                      task->id, str, getNodeAddressStr(task->dest, CLUSTER_NAMELEN), getKeyCountInSlotRangeArray(task->slots));
             break;
         case ASM_EVENT_MIGRATE_FAILED:
             serverLog(LL_NOTICE, "Migrate task %s failed for slots: %s", task->id, str);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1057,13 +1057,27 @@ void clusterMigrationCommand(client *c) {
     }
 }
 
+/* Returns the address of the node in the format "ip:port". */
+static const char *getNodeAddressStr(const char *node_id) {
+    serverAssert(node_id != NULL);
+    static char buf[NET_HOST_PORT_STR_LEN];
+
+    clusterNode *n = clusterLookupNode(node_id, CLUSTER_NAMELEN);
+    const char *ip = n ? clusterNodeIp(n) : "?";
+    int port = n ? (server.tls_replication ? clusterNodeTlsPort(n) :
+                                             clusterNodeTcpPort(n)) : 0;
+    snprintf(buf, sizeof(buf), "%s:%d", ip, port);
+    return buf;
+}
+
 /* Log a human-readable message for ASM task lifecycle events. */
 void asmLogTaskEvent(asmTask *task, int event) {
     sds str = slotRangeArrayToString(task->slots);
 
     switch (event) {
         case ASM_EVENT_IMPORT_STARTED:
-            serverLog(LL_NOTICE, "Import task %s started for slots: %s", task->id, str);
+            serverLog(LL_NOTICE, "Import task %s started for slots: %s, source address: %s",
+                      task->id, str, getNodeAddressStr(task->source));
             break;
         case ASM_EVENT_IMPORT_FAILED:
             serverLog(LL_NOTICE, "Import task %s failed for slots: %s", task->id, str);
@@ -1076,8 +1090,8 @@ void asmLogTaskEvent(asmTask *task, int event) {
                       task->id, str, getKeyCountInSlotRangeArray(task->slots));
             break;
         case ASM_EVENT_MIGRATE_STARTED:
-            serverLog(LL_NOTICE, "Migrate task %s started for slots: %s (number of keys at start: %llu)",
-                      task->id, str, getKeyCountInSlotRangeArray(task->slots));
+            serverLog(LL_NOTICE, "Migrate task %s started for slots: %s, destination address: %s, (number of keys at start: %llu)",
+                      task->id, str, getNodeAddressStr(task->dest), getKeyCountInSlotRangeArray(task->slots));
             break;
         case ASM_EVENT_MIGRATE_FAILED:
             serverLog(LL_NOTICE, "Migrate task %s failed for slots: %s", task->id, str);


### PR DESCRIPTION
Log source/destination address on import/migrate start events for easier debugging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change; no behavior changes to migration flow, with minimal risk beyond potential confusion if node lookup fails and logs `?:0`.
> 
> **Overview**
> Improves ASM observability by logging the resolved `ip:port` of the peer node when an atomic slot migration `IMPORT` or `MIGRATE` task starts.
> 
> Adds a small helper (`getNodeAddressStr`) that looks up the node by ID and formats the address (respecting `tls_replication`) for inclusion in the existing `asmLogTaskEvent` start-event messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a961966acd35c54c6b28894df39d273be050cc34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->