### PR TITLE
Fix CI failures in old-chain jobs caused by EOL Ubuntu/package sources

### DIFF
--- a/.github/actions/install-gcc48/action.yml
+++ b/.github/actions/install-gcc48/action.yml
@@ -1,0 +1,22 @@
+name: 'Install gcc-4.8'
+description: 'Download and install gcc-4.8 (Ubuntu 18.04 bionic) from mirrors.kernel.org'
+
+runs:
+  using: composite
+  steps:
+    - name: Download and install gcc-4.8
+      shell: bash
+      run: |
+        BASE=https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
+        VER=4.8.5-4ubuntu8
+        wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
+                ${BASE}/cpp-4.8_${VER}_amd64.deb \
+                ${BASE}/libasan0_${VER}_amd64.deb \
+                ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
+                ${BASE}/gcc-4.8_${VER}_amd64.deb
+        apt-get install -y ./gcc-4.8-base_${VER}_amd64.deb \
+                           ./cpp-4.8_${VER}_amd64.deb \
+                           ./libasan0_${VER}_amd64.deb \
+                           ./libgcc-4.8-dev_${VER}_amd64.deb \
+                           ./gcc-4.8_${VER}_amd64.deb
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100

--- a/.github/actions/install-gcc48/action.yml
+++ b/.github/actions/install-gcc48/action.yml
@@ -1,5 +1,5 @@
 name: 'Install gcc-4.8'
-description: 'Download and install gcc-4.8 (Ubuntu 18.04 bionic) from mirrors.kernel.org'
+description: 'Download and install gcc-4.8 from mirrors.kernel.org'
 
 runs:
   using: composite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,10 @@ jobs:
                 ${BASE}/libasan0_${VER}_amd64.deb \
                 ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
                 ${BASE}/gcc-4.8_${VER}_amd64.deb
-        apt-get install -y ./*.deb
+        apt-get install -y ./gcc-4.8-base_${VER}_amd64.deb \
+                           ./cpp-4.8_${VER}_amd64.deb \
+                           ./libasan0_${VER}_amd64.deb \
+                           ./libgcc-4.8-dev_${VER}_amd64.deb \
+                           ./gcc-4.8_${VER}_amd64.deb
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         make CC=gcc REDIS_CFLAGS='-Werror'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
   build-old-chain-jemalloc:
     runs-on: ubuntu-latest
     container: ubuntu:22.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
     steps:
     - uses: actions/checkout@v4
     - name: make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,17 +93,6 @@ jobs:
       run: |
         apt-get update
         apt-get install -y make wget
-        BASE=https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
-        VER=4.8.5-4ubuntu8
-        wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
-                ${BASE}/cpp-4.8_${VER}_amd64.deb \
-                ${BASE}/libasan0_${VER}_amd64.deb \
-                ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
-                ${BASE}/gcc-4.8_${VER}_amd64.deb
-        apt-get install -y ./gcc-4.8-base_${VER}_amd64.deb \
-                           ./cpp-4.8_${VER}_amd64.deb \
-                           ./libasan0_${VER}_amd64.deb \
-                           ./libgcc-4.8-dev_${VER}_amd64.deb \
-                           ./gcc-4.8_${VER}_amd64.deb
-        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
-        make CC=gcc REDIS_CFLAGS='-Werror'
+    - uses: ./.github/actions/install-gcc48
+    - name: build
+      run: make CC=gcc REDIS_CFLAGS='-Werror'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       run: |
         apt-get update
         apt-get install -y make wget
-        BASE=http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
+        BASE=https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
         VER=4.8.5-4ubuntu8
         wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
                 ${BASE}/cpp-4.8_${VER}_amd64.deb \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,18 +84,20 @@ jobs:
 
   build-old-chain-jemalloc:
     runs-on: ubuntu-latest
-    container: ubuntu:20.04
+    container: ubuntu:22.04
     steps:
     - uses: actions/checkout@v4
     - name: make
       run: |
         apt-get update
-        apt-get install -y gnupg2
-        echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
-        echo "deb http://archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
-        apt-get update
-        apt-get install -y make gcc-4.8
+        apt-get install -y make wget
+        BASE=http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
+        VER=4.8.5-4ubuntu8
+        wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
+                ${BASE}/cpp-4.8_${VER}_amd64.deb \
+                ${BASE}/libasan0_${VER}_amd64.deb \
+                ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
+                ${BASE}/gcc-4.8_${VER}_amd64.deb
+        apt-get install -y ./*.deb
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         make CC=gcc REDIS_CFLAGS='-Werror'

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1254,20 +1254,9 @@ jobs:
       run: |
         apt-get update
         apt-get install -y make wget
-        BASE=https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
-        VER=4.8.5-4ubuntu8
-        wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
-                ${BASE}/cpp-4.8_${VER}_amd64.deb \
-                ${BASE}/libasan0_${VER}_amd64.deb \
-                ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
-                ${BASE}/gcc-4.8_${VER}_amd64.deb
-        apt-get install -y ./gcc-4.8-base_${VER}_amd64.deb \
-                           ./cpp-4.8_${VER}_amd64.deb \
-                           ./libasan0_${VER}_amd64.deb \
-                           ./libgcc-4.8-dev_${VER}_amd64.deb \
-                           ./gcc-4.8_${VER}_amd64.deb
-        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
-        make CC=gcc REDIS_CFLAGS='-Werror'
+    - uses: ./.github/actions/install-gcc48
+    - name: build
+      run: make CC=gcc REDIS_CFLAGS='-Werror'
     - name: testprep
       run: apt-get install -y tcl8.6 tcl-tls tclx
     - name: test
@@ -1307,20 +1296,9 @@ jobs:
       run: |
         apt-get update
         apt-get install -y make wget openssl libssl-dev
-        BASE=https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
-        VER=4.8.5-4ubuntu8
-        wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
-                ${BASE}/cpp-4.8_${VER}_amd64.deb \
-                ${BASE}/libasan0_${VER}_amd64.deb \
-                ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
-                ${BASE}/gcc-4.8_${VER}_amd64.deb
-        apt-get install -y ./gcc-4.8-base_${VER}_amd64.deb \
-                           ./cpp-4.8_${VER}_amd64.deb \
-                           ./libasan0_${VER}_amd64.deb \
-                           ./libgcc-4.8-dev_${VER}_amd64.deb \
-                           ./gcc-4.8_${VER}_amd64.deb
-        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
-        make CC=gcc BUILD_TLS=module REDIS_CFLAGS='-Werror'
+    - uses: ./.github/actions/install-gcc48
+    - name: build
+      run: make CC=gcc BUILD_TLS=module REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         apt-get install -y tcl8.6 tcl-tls tclx
@@ -1365,20 +1343,9 @@ jobs:
       run: |
         apt-get update
         apt-get install -y make wget openssl libssl-dev
-        BASE=https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
-        VER=4.8.5-4ubuntu8
-        wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
-                ${BASE}/cpp-4.8_${VER}_amd64.deb \
-                ${BASE}/libasan0_${VER}_amd64.deb \
-                ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
-                ${BASE}/gcc-4.8_${VER}_amd64.deb
-        apt-get install -y ./gcc-4.8-base_${VER}_amd64.deb \
-                           ./cpp-4.8_${VER}_amd64.deb \
-                           ./libasan0_${VER}_amd64.deb \
-                           ./libgcc-4.8-dev_${VER}_amd64.deb \
-                           ./gcc-4.8_${VER}_amd64.deb
-        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
-        make BUILD_TLS=module CC=gcc REDIS_CFLAGS='-Werror'
+    - uses: ./.github/actions/install-gcc48
+    - name: build
+      run: make BUILD_TLS=module CC=gcc REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         apt-get install -y tcl8.6 tcl-tls tclx

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1234,6 +1234,8 @@ jobs:
       !contains(github.event.inputs.skipjobs, 'oldTC')
     container: ubuntu:22.04
     timeout-minutes: 360
+    env:
+      DEBIAN_FRONTEND: noninteractive
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -1281,6 +1283,8 @@ jobs:
       !contains(github.event.inputs.skipjobs, 'tls') && !contains(github.event.inputs.skipjobs, 'oldTC')
     container: ubuntu:22.04
     timeout-minutes: 360
+    env:
+      DEBIAN_FRONTEND: noninteractive
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'
@@ -1333,6 +1337,8 @@ jobs:
       !contains(github.event.inputs.skipjobs, 'tls') && !contains(github.event.inputs.skipjobs, 'oldTC')
     container: ubuntu:22.04
     timeout-minutes: 360
+    env:
+      DEBIAN_FRONTEND: noninteractive
     steps:
     - name: prep
       if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1261,7 +1261,11 @@ jobs:
                 ${BASE}/libasan0_${VER}_amd64.deb \
                 ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
                 ${BASE}/gcc-4.8_${VER}_amd64.deb
-        apt-get install -y ./*.deb
+        apt-get install -y ./gcc-4.8-base_${VER}_amd64.deb \
+                           ./cpp-4.8_${VER}_amd64.deb \
+                           ./libasan0_${VER}_amd64.deb \
+                           ./libgcc-4.8-dev_${VER}_amd64.deb \
+                           ./gcc-4.8_${VER}_amd64.deb
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         make CC=gcc REDIS_CFLAGS='-Werror'
     - name: testprep
@@ -1310,7 +1314,11 @@ jobs:
                 ${BASE}/libasan0_${VER}_amd64.deb \
                 ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
                 ${BASE}/gcc-4.8_${VER}_amd64.deb
-        apt-get install -y ./*.deb
+        apt-get install -y ./gcc-4.8-base_${VER}_amd64.deb \
+                           ./cpp-4.8_${VER}_amd64.deb \
+                           ./libasan0_${VER}_amd64.deb \
+                           ./libgcc-4.8-dev_${VER}_amd64.deb \
+                           ./gcc-4.8_${VER}_amd64.deb
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         make CC=gcc BUILD_TLS=module REDIS_CFLAGS='-Werror'
     - name: testprep
@@ -1364,7 +1372,11 @@ jobs:
                 ${BASE}/libasan0_${VER}_amd64.deb \
                 ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
                 ${BASE}/gcc-4.8_${VER}_amd64.deb
-        apt-get install -y ./*.deb
+        apt-get install -y ./gcc-4.8-base_${VER}_amd64.deb \
+                           ./cpp-4.8_${VER}_amd64.deb \
+                           ./libasan0_${VER}_amd64.deb \
+                           ./libgcc-4.8-dev_${VER}_amd64.deb \
+                           ./gcc-4.8_${VER}_amd64.deb
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         make BUILD_TLS=module CC=gcc REDIS_CFLAGS='-Werror'
     - name: testprep

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1254,7 +1254,7 @@ jobs:
       run: |
         apt-get update
         apt-get install -y make wget
-        BASE=http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
+        BASE=https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
         VER=4.8.5-4ubuntu8
         wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
                 ${BASE}/cpp-4.8_${VER}_amd64.deb \
@@ -1303,7 +1303,7 @@ jobs:
       run: |
         apt-get update
         apt-get install -y make wget openssl libssl-dev
-        BASE=http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
+        BASE=https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
         VER=4.8.5-4ubuntu8
         wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
                 ${BASE}/cpp-4.8_${VER}_amd64.deb \
@@ -1357,7 +1357,7 @@ jobs:
       run: |
         apt-get update
         apt-get install -y make wget openssl libssl-dev
-        BASE=http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
+        BASE=https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
         VER=4.8.5-4ubuntu8
         wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
                 ${BASE}/cpp-4.8_${VER}_amd64.deb \

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1263,7 +1263,7 @@ jobs:
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         make CC=gcc REDIS_CFLAGS='-Werror'
     - name: testprep
-      run: apt-get install -y tcl tcltls tclx
+      run: apt-get install -y tcl8.6 tcl-tls tclx
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
       run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -1311,7 +1311,7 @@ jobs:
         make CC=gcc BUILD_TLS=module REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
-        apt-get install -y tcl tcltls tclx
+        apt-get install -y tcl8.6 tcl-tls tclx
         ./utils/gen-test-certs.sh
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
@@ -1363,7 +1363,7 @@ jobs:
         make BUILD_TLS=module CC=gcc REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
-        apt-get install -y tcl tcltls tclx
+        apt-get install -y tcl8.6 tcl-tls tclx
         ./utils/gen-test-certs.sh
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1232,7 +1232,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'oldTC')
-    container: ubuntu:20.04
+    container: ubuntu:22.04
     timeout-minutes: 360
     steps:
     - name: prep
@@ -1251,13 +1251,15 @@ jobs:
     - name: make
       run: |
         apt-get update
-        apt-get install -y gnupg2
-        echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
-        echo "deb http://archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
-        apt-get update
-        apt-get install -y make gcc-4.8
+        apt-get install -y make wget
+        BASE=http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
+        VER=4.8.5-4ubuntu8
+        wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
+                ${BASE}/cpp-4.8_${VER}_amd64.deb \
+                ${BASE}/libasan0_${VER}_amd64.deb \
+                ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
+                ${BASE}/gcc-4.8_${VER}_amd64.deb
+        apt-get install -y ./*.deb
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         make CC=gcc REDIS_CFLAGS='-Werror'
     - name: testprep
@@ -1277,7 +1279,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls') && !contains(github.event.inputs.skipjobs, 'oldTC')
-    container: ubuntu:20.04
+    container: ubuntu:22.04
     timeout-minutes: 360
     steps:
     - name: prep
@@ -1296,13 +1298,15 @@ jobs:
     - name: make
       run: |
         apt-get update
-        apt-get install -y gnupg2
-        echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
-        echo "deb http://archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
-        apt-get update
-        apt-get install -y make gcc-4.8 openssl libssl-dev
+        apt-get install -y make wget openssl libssl-dev
+        BASE=http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
+        VER=4.8.5-4ubuntu8
+        wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
+                ${BASE}/cpp-4.8_${VER}_amd64.deb \
+                ${BASE}/libasan0_${VER}_amd64.deb \
+                ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
+                ${BASE}/gcc-4.8_${VER}_amd64.deb
+        apt-get install -y ./*.deb
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         make CC=gcc BUILD_TLS=module REDIS_CFLAGS='-Werror'
     - name: testprep
@@ -1327,7 +1331,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls') && !contains(github.event.inputs.skipjobs, 'oldTC')
-    container: ubuntu:20.04
+    container: ubuntu:22.04
     timeout-minutes: 360
     steps:
     - name: prep
@@ -1346,13 +1350,15 @@ jobs:
     - name: make
       run: |
         apt-get update
-        apt-get install -y gnupg2 
-        echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
-        echo "deb http://archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
-        apt-get update
-        apt-get install -y make gcc-4.8 openssl libssl-dev
+        apt-get install -y make wget openssl libssl-dev
+        BASE=http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8
+        VER=4.8.5-4ubuntu8
+        wget -q ${BASE}/gcc-4.8-base_${VER}_amd64.deb \
+                ${BASE}/cpp-4.8_${VER}_amd64.deb \
+                ${BASE}/libasan0_${VER}_amd64.deb \
+                ${BASE}/libgcc-4.8-dev_${VER}_amd64.deb \
+                ${BASE}/gcc-4.8_${VER}_amd64.deb
+        apt-get install -y ./*.deb
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         make BUILD_TLS=module CC=gcc REDIS_CFLAGS='-Werror'
     - name: testprep


### PR DESCRIPTION
### Problem

The `uild-old-chain-jemalloc(ci.yml)` and `test-old-chain-* (daily.yml)` jobs have been failing consistently. 

Two root causes were identified:

1. Ubuntu 20.04 container is EOL (since April 2025)

The jobs used container: ubuntu:20.04. Ubuntu 20.04 reached end of standard support in April 2025 and entered ESM. Its security packages (e.g. libheimntlm0-heimdal, dirmngr — dependencies of gnupg2) are now ESM-only, causing Connection failed errors when trying to install them from security.ubuntu.com.

2. Ubuntu 16.04 (Xenial) apt sources were invalid

~~The jobs added `archive.ubuntu.com/ubuntu xenial` as an apt source to install gcc-4.8. Ubuntu 16.04 reached EOL in April 2021 and its packages were removed from `archive.ubuntu.com`.~~ 
The apt-get update step was silently failing or timing out, making gcc-4.8 unavailable.

Additionally, the jobs installed gnupg2 solely to run apt-key adv for importing the Xenial signing key — which is entirely unnecessary since Ubuntu 20.04 already ships with the Ubuntu archive signing keys trusted by default.

### Changed 

Upgrade container from ubuntu:20.04 to ubuntu:22.04 (supported until April 2027, ESM until 2032), eliminating the EOL base image problem.
Install gcc-4.8 by directly downloading .deb files instead of adding an EOL apt source. This approach is stable and deterministic — the files are static and will not change.
Set DEBIAN_FRONTEND: noninteractive at job level to prevent tzdata from triggering an interactive timezone prompt inside the container, which would cause the CI job to hang.

CI result: https://github.com/vitahlin/redis/actions/runs/24523542838/job/71687523333
Daily CI: https://github.com/vitahlin/redis/actions/runs/24523586224

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the build/test environment for multiple CI jobs (container OS version, toolchain install path, and Tcl package names), which could affect reproducibility or fail if the external .deb mirror changes.
> 
> **Overview**
> Fixes the *old-chain* CI failures by switching the affected jobs from `ubuntu:20.04` to `ubuntu:22.04` and setting `DEBIAN_FRONTEND=noninteractive` to avoid interactive apt prompts.
> 
> Replaces the prior Xenial apt-source/`apt-key` flow for `gcc-4.8` with a new composite action (`.github/actions/install-gcc48`) that downloads and installs a pinned set of `gcc-4.8` `.deb` packages (and updates `gcc` alternatives). The daily workflows also update Tcl deps to `tcl8.6`/`tcl-tls`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac5bac6157e1711c2ff3e2bf63d0d2eb884f34f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->