### PR TITLE
ci: use ubuntu:16.04 for build-old-chain-jemalloc job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,17 +84,11 @@ jobs:
 
   build-old-chain-jemalloc:
     runs-on: ubuntu-latest
-    container: ubuntu:20.04
+    container: ubuntu:16.04
     steps:
     - uses: actions/checkout@v4
     - name: make
       run: |
-        apt-get update
-        apt-get install -y gnupg2
-        echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
-        echo "deb http://archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update
         apt-get install -y make gcc-4.8
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100


### PR DESCRIPTION
## Problem

The `build-old-chain-jemalloc` CI job runs on `ubuntu:20.04` and patches in Ubuntu 16.04 (Xenial) repositories to install `gcc-4.8`. This approach is fragile: when `archive.ubuntu.com/focal` or `security.ubuntu.com/focal` are unreachable, the `apt-get update` step fails and the subsequent `apt-get install gcc-4.8` cannot resolve `libc6` and other Focal-era dependencies, causing the job to fail with exit code 100.

This has been observed consistently across multiple CI runs (both manual retriggers fail identically), and the failure log confirms the root cause is a network connectivity issue to the Focal mirror — not a code issue:

```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/glibc/libc6_2.31-0ubuntu9.18_amd64.deb
   Connection failed [IP: 91.189.92.23 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

## Fix

Switch the container from `ubuntu:20.04` to `ubuntu:16.04` (Xenial), where `gcc-4.8` is a **native package** in the default repos. This removes the need for:
- Adding Xenial repo entries to `sources.list`
- Importing APT keys via `apt-key adv`
- Cross-distro dependency resolution that depends on Focal mirrors being reachable

The `make` step becomes a straightforward `apt-get install gcc-4.8` with no extra configuration.

## Testing

The job logic (compile Redis with `gcc-4.8` and `-Werror`) is unchanged. Only the base image and the now-unnecessary repo setup are modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that swaps the container image and removes fragile APT repo/key setup; main risk is the job behaving differently due to the older base image/packages.
> 
> **Overview**
> Switches the `build-old-chain-jemalloc` GitHub Actions job from `ubuntu:20.04` to `ubuntu:16.04` so `gcc-4.8` can be installed from native repos.
> 
> Removes the previous Xenial `sources.list` edits and `apt-key` imports, leaving a simpler `apt-get install make gcc-4.8` + `update-alternatives` build step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e0d06168edd6301ae8cb87198e1f803db4d2d38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->