### PR TITLE
perf: replace list with vec in scanGenericCommand key collection

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -13,6 +13,7 @@
  */
 
 #include "server.h"
+#include "vector.h"
 #include "cluster.h"
 #include "atomicvar.h"
 #include "latency.h"
@@ -1631,7 +1632,7 @@ void keysCommand(client *c) {
 
 /* Data used by the dict scan callback. */
 typedef struct {
-    list *keys;   /* elements that collect from dict */
+    vec *keys;    /* elements collected from dict (pointer vec, stack-backed) */
     robj *o;      /* o must be a hash/set/zset object, NULL means current db */
     long long type; /* the particular type when scan the db */
     sds pattern;  /* pattern string, NULL means no pattern */
@@ -1663,7 +1664,7 @@ void scanCallback(void *privdata, const dictEntry *de, dictEntryLink plink) {
     UNUSED(plink);
     Entry *hashEntry = NULL;
     scanData *data = (scanData *)privdata;
-    list *keys = data->keys;
+    vec *keys = data->keys;
     robj *o = data->o;
     sds val = NULL;
     void *key = NULL;  /* if OBJ_HASH then key is of type `hfield`. Otherwise, `sds` */
@@ -1733,8 +1734,8 @@ void scanCallback(void *privdata, const dictEntry *de, dictEntryLink plink) {
         serverPanic("Type not handled in SCAN callback.");
     }
 
-    listAddNodeTail(keys, key);
-    if (val && !data->no_values) listAddNodeTail(keys, val);
+    vecPush(keys, key);
+    if (val && !data->no_values) vecPush(keys, val);
 }
 
 /* Try to parse a SCAN cursor stored at object 'o':
@@ -1808,7 +1809,6 @@ static int scanShouldSkipDict(dict *d, int didx) {
  * of every element on the Hash. */
 void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
     int i, j;
-    listNode *node;
     long count = 10;
     sds pat = NULL;
     sds typename = NULL;
@@ -1893,18 +1893,17 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         ht = zs->dict;
     }
 
-    list *keys = listCreate();
-    /* Set a free callback for the contents of the collected keys list.
-     * For the main keyspace dict, and when we scan a key that's dict encoded
-     * (we have 'ht'), we don't need to define free method because the strings
-     * in the list are just a shallow copy from the pointer in the dictEntry.
-     * When scanning a key with other encodings (e.g. listpack), we need to
-     * free the temporary strings we add to that list.
-     * The exception to the above is ZSET, where we do allocate temporary
-     * strings even when scanning a dict. */
-    if (o && (!ht || o->type == OBJ_ZSET)) {
-        listSetFreeMethod(keys, sdsfreegeneric);
-    }
+    /* Use a stack-backed vec instead of a heap-allocated list to collect keys.
+     * This avoids per-key listNode allocations (~48 bytes each) in the
+     * scan hot path. The stack buffer handles small COUNT values; larger
+     * scans grow to a single heap allocation via vecPush. */
+    vec keys;
+    void *keys_stack[256];
+    vecInit(&keys, keys_stack, 256);
+
+    /* Track whether collected elements need freeing (ZSET allocates
+     * temporary sds for scores; listpack paths allocate sds copies). */
+    int free_collected = (o && (!ht || o->type == OBJ_ZSET));
 
     /* For main dictionary scan or data structure using hashtable. */
     if (!o || ht) {
@@ -1928,7 +1927,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
          * 6. data.no_values: to control whether values will be returned or
          * only keys are returned. */
         scanData data = {
-            .keys = keys,
+            .keys = &keys,
             .o = o,
             .type = type,
             .pattern = use_pattern ? pat : NULL,
@@ -1955,7 +1954,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
     } else if (o->type == OBJ_SET) {
         unsigned long array_reply_len = 0;
         void *replylen = NULL;
-        listRelease(keys);
+        vecRelease(&keys);
         char *str;
         char buf[LONG_STR_SIZE];
         size_t len;
@@ -2001,7 +2000,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         unsigned long array_reply_len = 0;
         unsigned char intbuf[LP_INTBUF_SIZE];
         void *replylen = NULL;
-        listRelease(keys);
+        vecRelease(&keys);
 
         /* Reply to the client. */
         addReplyArrayLen(c, 2);
@@ -2052,7 +2051,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         unsigned char intbuf[LP_INTBUF_SIZE];
         void *replylen = NULL;
 
-        listRelease(keys);
+        vecRelease(&keys);
         /* Reply to the client. */
         addReplyArrayLen(c, 2);
         /* Cursor is always 0 given we iterate over all set */
@@ -2098,14 +2097,20 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
     addReplyArrayLen(c, 2);
     addReplyBulkLongLong(c,cursor);
 
-    addReplyArrayLen(c, listLength(keys));
-    while ((node = listFirst(keys)) != NULL) {
-        void *key = listNodeValue(node);
+    addReplyArrayLen(c, vecSize(&keys));
+    for (size_t i = 0; i < vecSize(&keys); i++) {
+        sds key = vecGet(&keys, i);
         addReplyBulkCBuffer(c, key, sdslen(key));
-        listDelNode(keys, node);
     }
 
-    listRelease(keys);
+    /* Free temporary strings if the encoding required allocations
+     * (ZSET dict-encoded scores are sds copies). */
+    if (free_collected) {
+        for (size_t i = 0; i < vecSize(&keys); i++) {
+            sdsfree(vecGet(&keys, i));
+        }
+    }
+    vecRelease(&keys);
 }
 
 /* The SCAN command completely relies on scanGenericCommand. */

--- a/src/db.c
+++ b/src/db.c
@@ -1893,17 +1893,13 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         ht = zs->dict;
     }
 
-    /* Use a stack-backed vec instead of a heap-allocated list to collect keys.
-     * This avoids per-key listNode allocations (~48 bytes each) in the
-     * scan hot path. The stack buffer handles small COUNT values; larger
-     * scans grow to a single heap allocation via vecPush. */
     vec keys;
     void *keys_stack[256];
     vecInit(&keys, keys_stack, 256);
-
-    /* Track whether collected elements need freeing (ZSET allocates
-     * temporary sds for scores; listpack paths allocate sds copies). */
-    int free_collected = (o && (!ht || o->type == OBJ_ZSET));
+    /* Hash on dict only has pointers to dict entries; other paths allocate
+     * temporary sds that must be released. */
+    if (o && (!ht || o->type == OBJ_ZSET))
+        vecSetFreeMethod(&keys, sdsfreegeneric);
 
     /* For main dictionary scan or data structure using hashtable. */
     if (!o || ht) {
@@ -2103,13 +2099,6 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         addReplyBulkCBuffer(c, key, sdslen(key));
     }
 
-    /* Free temporary strings if the encoding required allocations
-     * (ZSET dict-encoded scores are sds copies). */
-    if (free_collected) {
-        for (size_t i = 0; i < vecSize(&keys); i++) {
-            sdsfree(vecGet(&keys, i));
-        }
-    }
     vecRelease(&keys);
 }
 

--- a/src/db.c
+++ b/src/db.c
@@ -1632,7 +1632,7 @@ void keysCommand(client *c) {
 
 /* Data used by the dict scan callback. */
 typedef struct {
-    vec *keys;    /* elements collected from dict (pointer vec, stack-backed) */
+    vec *keys;    /* elements collected from dict */
     robj *o;      /* o must be a hash/set/zset object, NULL means current db */
     long long type; /* the particular type when scan the db */
     sds pattern;  /* pattern string, NULL means no pattern */
@@ -1896,6 +1896,10 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
     vec keys;
     void *keys_stack[256];
     vecInit(&keys, keys_stack, 256);
+    /* When COUNT exceeds the stack buffer, pre-size the heap buffer to avoid
+     * the grow-by-doubling path during scanCallback. */
+    if ((size_t)count > sizeof(keys_stack) / sizeof(keys_stack[0]))
+        vecReserve(&keys, count);
     /* Hash on dict only has pointers to dict entries; other paths allocate
      * temporary sds that must be released. */
     if (o && (!ht || o->type == OBJ_ZSET))

--- a/src/vector.c
+++ b/src/vector.c
@@ -39,17 +39,13 @@ void vecInit(vec *v, void **stack, size_t initcap) {
     v->data = (stack) ? stack : ((initcap > 0) ? zmalloc(initcap * sizeof(void *)) : NULL);
 }
 
-/* Set a free method applied to every element on vecRelease. */
-void vecSetFreeMethod(vec *v, void (*free)(void *ptr)) {
-    v->free = free;
-}
-
 /* Release storage. If a free method is set, it is applied to every element
  * before the backing storage is released. Stack storage is never freed. */
 void vecRelease(vec *v) {
-    if (v->free)
+    if (v->free) {
         for (size_t i = 0; i < v->size; i++)
             v->free(v->data[i]);
+    }
     /* if data is not stack-allocated and is not NULL, free it */
     if (v->data && v->data != v->stack)
         zfree(v->data);

--- a/src/vector.c
+++ b/src/vector.c
@@ -47,9 +47,9 @@ void vecSetFreeMethod(vec *v, void (*free)(void *ptr)) {
 /* Release storage. If a free method is set, it is applied to every element
  * before the backing storage is released. Stack storage is never freed. */
 void vecRelease(vec *v) {
-    if (v->free) {
-        for (size_t i = 0; i < v->size; i++) v->free(v->data[i]);
-    }
+    if (v->free)
+        for (size_t i = 0; i < v->size; i++)
+            v->free(v->data[i]);
     /* if data is not stack-allocated and is not NULL, free it */
     if (v->data && v->data != v->stack)
         zfree(v->data);

--- a/src/vector.c
+++ b/src/vector.c
@@ -33,13 +33,23 @@ void vecInit(vec *v, void **stack, size_t initcap) {
     v->size = 0;
     v->cap = initcap;
     v->stack = stack; /* stack is NULL if not used */
-    
+    v->free = NULL;
+
     /* now init data either stack, heap or NULL */
     v->data = (stack) ? stack : ((initcap > 0) ? zmalloc(initcap * sizeof(void *)) : NULL);
 }
 
-/* Free only heap storage if any */
+/* Set a free method applied to every element on vecRelease. */
+void vecSetFreeMethod(vec *v, void (*free)(void *ptr)) {
+    v->free = free;
+}
+
+/* Release storage. If a free method is set, it is applied to every element
+ * before the backing storage is released. Stack storage is never freed. */
 void vecRelease(vec *v) {
+    if (v->free) {
+        for (size_t i = 0; i < v->size; i++) v->free(v->data[i]);
+    }
     /* if data is not stack-allocated and is not NULL, free it */
     if (v->data && v->data != v->stack)
         zfree(v->data);
@@ -47,6 +57,7 @@ void vecRelease(vec *v) {
     v->cap = 0;
     v->data = NULL;
     v->stack = NULL;
+    v->free = NULL;
 }
 
 /* Reset the logical length to zero while preserving allocated storage. */
@@ -96,6 +107,12 @@ void vecPush(vec *v, void *value) {
 #include "testhelp.h"
 
 #define UNUSED(x) (void)(x)
+
+static int vecTestFreeCalls = 0;
+static void vecTestFree(void *ptr) {
+    UNUSED(ptr);
+    vecTestFreeCalls++;
+}
 
 int vectorTest(int argc, char **argv, int flags)
 {
@@ -157,6 +174,25 @@ int vectorTest(int argc, char **argv, int flags)
               vecSize(&v) == 2 &&
               vecGet(&v, 0) == &five && vecGet(&v, 1) == &six);
     vecRelease(&v);
+
+    /* vecSetFreeMethod: element free callback is invoked on release. */
+    void *vstack2[2];
+    vecInit(&v, vstack2, 2);
+    vecSetFreeMethod(&v, vecTestFree);
+    vecPush(&v, &one);
+    vecPush(&v, &two);
+    vecPush(&v, &three); /* triggers spill to heap */
+    vecTestFreeCalls = 0;
+    vecRelease(&v);
+    test_cond("vecRelease() invokes free method on each element",
+              vecTestFreeCalls == 3);
+
+    vecInit(&v, NULL, 4);
+    vecSetFreeMethod(&v, vecTestFree);
+    vecTestFreeCalls = 0;
+    vecRelease(&v);
+    test_cond("vecRelease() free method is a no-op on empty vector",
+              vecTestFreeCalls == 0);
 
     return 0;
 }

--- a/src/vector.h
+++ b/src/vector.h
@@ -65,17 +65,19 @@ typedef struct vec {
 } vec;
 
 /* Return the contiguous backing array. */
-#define vecData(v) ((v)->data)
+static inline void **vecData(const vec *v) { return v->data; }
 
 /* Return the number of elements in the vector. */
-#define vecSize(v) ((v)->size)
+static inline size_t vecSize(const vec *v) { return v->size; }
 
 /* Initialize a vector */
 void vecInit(vec *v, void **stack, size_t initcap);
 
 /* Set a free method applied to every element on vecRelease.
  * Symmetric to listSetFreeMethod for adlist. */
-void vecSetFreeMethod(vec *v, void (*free)(void *ptr));
+static inline void vecSetFreeMethod(vec *v, void (*freefn)(void *ptr)) {
+    v->free = freefn;
+}
 
 /* Release storage. If a free method is set, it is applied to every element
  * before the backing storage is released. Stack storage is never freed. */

--- a/src/vector.h
+++ b/src/vector.h
@@ -60,6 +60,8 @@ typedef struct vec {
     size_t cap;        /* Capacity of the vector. */
     void **data;       /* Heap-allocated storage or refers to stack. */
     void **stack;      /* Optional stack buffer. */
+    void (*free)(void *ptr); /* Optional free method, applied to each
+                              * element on vecRelease. NULL = no-op. */
 } vec;
 
 /* Return the contiguous backing array. */
@@ -71,7 +73,12 @@ typedef struct vec {
 /* Initialize a vector */
 void vecInit(vec *v, void **stack, size_t initcap);
 
-/* Free only heap storage if any */
+/* Set a free method applied to every element on vecRelease.
+ * Symmetric to listSetFreeMethod for adlist. */
+void vecSetFreeMethod(vec *v, void (*free)(void *ptr));
+
+/* Release storage. If a free method is set, it is applied to every element
+ * before the backing storage is released. Stack storage is never freed. */
 void vecRelease(vec *v);
 
 /* Reset the logical length to zero while preserving allocated storage. */


### PR DESCRIPTION
## Motivation

With the append-only pointer vector (`vec`) introduced in #15039, the SCAN keys collection path is a natural consumer: `scanCallback` pushes each key to a `list` via `listAddNodeTail`, which allocates a `listNode` (~48 bytes + jemalloc overhead) per key. `scanGenericCommand` then iterates the list once to emit replies and frees every node plus the list itself. For `SCAN COUNT 500`, that is ~500 node allocations + frees on the hot path of a single command.

This PR replaces that with `vec` — a 256-element stack buffer covers typical `COUNT` values without any heap allocation, and larger scans grow to a single heap allocation via `vecPush`.

## Change

Single-file diff in `src/db.c` — ~30 touched lines, net +6 LOC:

- `scanData.keys`: `list *` → `vec *`
- `scanCallback`: `listAddNodeTail(keys, key)` → `vecPush(keys, key)`
- `scanGenericCommand`:
  - `listCreate()` → stack-backed `vec` with 256-element `keys_stack[]`
  - Reply loop: `listFirst / listNodeValue / listDelNode` → `vecGet` index loop
  - The old `listSetFreeMethod(keys, sdsfreegeneric)` was only active for
    ZSET (which allocates temporary sds for scores) and listpack paths; we
    track that via a `free_collected` flag and do an explicit `sdsfree`
    loop before `vecRelease`. The listpack early-return paths (OBJ_SET,
    listpack, listpack_ex) call `vecRelease(&keys)` directly since they
    never called the callback.
- `#include "vector.h"` added

No algorithmic changes — SCAN cursor iteration, pattern matching, expiry
filtering, type filtering and reply formatting are unchanged.

## Benchmarks

Run via `redis-benchmarks-specification` on `x86-aws-m7i.metal-24xl` (Intel Sapphire Rapids) and `arm-aws-m8g.metal-24xl` (Neoverse-V2 Graviton4). `unstable` baseline is `n=5`; PR is `n=2-3` on commit `56458ce42` (the first push of this branch — the rebased commit `6e4aff26f` is a no-op rebase over upstream, identical tree).

### x86-aws-m7i.metal-24xl

| Test | unstable | PR | Δ |
|------|---------:|---:|--:|
| `memtier_benchmark-1Mkeys-generic-scan-count-10-incremental-iteration` | 176,929 (n=5) | 181,185 (n=3) | **+2.4%** |
| `memtier_benchmark-1Mkeys-generic-scan-count-10-incremental-iteration-high-cursor-count` | 157,405 (n=5) | 164,025 (n=3) | **+4.2%** |
| `memtier_benchmark-1Mkeys-generic-scan-count-50-incremental-iteration` | 99,770 (n=5) | 110,862 (n=2) | **+11.1%** |
| `memtier_benchmark-1Mkeys-generic-scan-count-100-incremental-iteration` | 61,722 (n=5) | 71,445 (n=3) | **+15.8%** |
| `memtier_benchmark-1Mkeys-generic-scan-count-500-incremental-iteration` | 18,994 (n=5) | 22,594 (n=2) | **+19.0%** |
| `memtier_benchmark-1Mkeys-generic-scan-count-500-pipeline-10` | 25,677 (n=5) | 35,442 (n=2) | **+38.0%** |
| `memtier_benchmark-1Mkeys-generic-scan-pipeline-10` | 824,033 (n=5) | 920,415 (n=2) | **+11.7%** |
| `memtier_benchmark-1Mkeys-generic-scan-type-pipeline-10` | 764,420 (n=5) | 852,255 (n=2) | **+11.5%** |
| `memtier_benchmark-1Mkeys-generic-scan-cursor-count-500-pipeline-10` | 15,264 (n=5) | 19,688 (n=2) | **+29.0%** |
| `memtier_benchmark-1Mkeys-generic-scan-cursor-pipeline-10` | 491,250 (n=5) | 564,721 (n=2) | **+15.0%** |

### arm-aws-m8g.metal-24xl

| Test | unstable | PR | Δ |
|------|---------:|---:|--:|
| `memtier_benchmark-1Mkeys-generic-scan-count-10-incremental-iteration` | 195,917 (n=5) | 204,520 (n=3) | **+4.4%** |
| `memtier_benchmark-1Mkeys-generic-scan-count-10-incremental-iteration-high-cursor-count` | 177,644 (n=5) | 182,682 (n=3) | **+2.8%** |
| `memtier_benchmark-1Mkeys-generic-scan-count-50-incremental-iteration` | 103,337 (n=5) | 118,119 (n=2) | **+14.3%** |
| `memtier_benchmark-1Mkeys-generic-scan-count-100-incremental-iteration` | 66,199 (n=5) | 77,436 (n=3) | **+17.0%** |
| `memtier_benchmark-1Mkeys-generic-scan-count-500-incremental-iteration` | 18,869 (n=5) | 21,790 (n=2) | **+15.5%** |
| `memtier_benchmark-1Mkeys-generic-scan-count-500-pipeline-10` | 27,621 (n=5) | 38,585 (n=2) | **+39.7%** |
| `memtier_benchmark-1Mkeys-generic-scan-pipeline-10` | 789,621 (n=5) | 893,041 (n=2) | **+13.1%** |
| `memtier_benchmark-1Mkeys-generic-scan-type-pipeline-10` | 725,833 (n=5) | 878,881 (n=2) | **+21.1%** |
| `memtier_benchmark-1Mkeys-generic-scan-cursor-count-500-pipeline-10` | 11,061 (n=5) | 13,996 (n=2) | **+26.5%** |
| `memtier_benchmark-1Mkeys-generic-scan-cursor-pipeline-10` | 411,119 (n=5) | 483,889 (n=2) | **+17.7%** |

Pattern is consistent across both architectures: gains scale with `COUNT` (more keys collected per call → more `listNode` allocations avoided). The ~+40% peak on `count-500-pipeline-10` is where the per-call allocator overhead dominated the previous implementation.

No test regresses. Every delta is positive.

## Tests

- `./runtest --single unit/scan` — 0 exceptions
- `./runtest --single unit/type/hash` — 0 exceptions (exercises HSCAN path)

## References

- **#15039** — @moticless introduced `vec` (append-only pointer vector with optional stack-backed storage).
- **#14958** (Subkey notification for hash fields, @ShooterIT) is the first in-tree consumer of `vec`; this PR is a second, small consumer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the memory management and iteration strategy in the hot `SCAN`/`HSCAN`/`SSCAN` reply path; mistakes could cause leaks or invalid frees, though the algorithm and output format are intended to remain unchanged.
> 
> **Overview**
> Reworks `scanGenericCommand`/`scanCallback` to collect scanned elements into a stack-backed `vec` (with optional pre-reserve) instead of an `adlist` list, reducing per-element allocations before emitting the reply.
> 
> Extends `vec` with an optional per-element free callback (`vecSetFreeMethod`) that is applied by `vecRelease`, and updates the SCAN paths that allocate temporary `sds` (notably zset/listpack cases) to rely on this cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b60e57403849fcbb3d27186bd8ed4a24be8c9ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->