### PR TITLE
redis-cli: free COMMAND reply on malformed legacy help entry

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -472,7 +472,7 @@ static void cliLegacyIntegrateHelp(void) {
         if (entry->type != REDIS_REPLY_ARRAY || entry->elements < 4 ||
             entry->element[0]->type != REDIS_REPLY_STRING ||
             entry->element[1]->type != REDIS_REPLY_INTEGER ||
-            entry->element[3]->type != REDIS_REPLY_INTEGER) return;
+            entry->element[3]->type != REDIS_REPLY_INTEGER) goto cleanup;
         char *cmdname = entry->element[0]->str;
         int i;
 
@@ -511,6 +511,7 @@ static void cliLegacyIntegrateHelp(void) {
         new->docs.since = "Not known";
         new->docs.group = "generic";
     }
+cleanup:
     freeReplyObject(reply);
 }
 


### PR DESCRIPTION
## Summary

When `redis-cli` falls back to legacy help initialization and parses `COMMAND`, a malformed entry can trigger an early return path that skips freeing the top-level reply object.

This patch keeps the same behavior for malformed input (stop integrating help entries) but guarantees cleanup of the allocated reply object.

## Root Cause

In `cliLegacyIntegrateHelp()`, validation inside the loop returned directly on malformed entry, bypassing the final `freeReplyObject(reply)` call.

## Fix

- Replace the early `return` in the validation branch with `goto cleanup`.
- Keep a single cleanup point that always frees `reply`.

## Why This Is Safe

- No behavior change for valid `COMMAND` replies.
- For malformed replies, the function still exits early from integration, but now releases memory correctly.
- Change scope is minimal and localized to one function.

## Testing

- `LC_ALL=C LANG=C ./runtest --single integration/redis-cli --baseport 26000`

## Issue

Fixes #15066 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change that only alters an error/early-exit path to ensure `freeReplyObject(reply)` is always executed; behavior for valid `COMMAND` replies is unchanged.
> 
> **Overview**
> Fixes a small memory-leak path in `cliLegacyIntegrateHelp()` when parsing the `COMMAND` reply during legacy help initialization.
> 
> Instead of `return`ing immediately on a malformed entry (skipping cleanup), the loop now jumps to a single `cleanup` label so the top-level `reply` is always freed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6893c2a8a90dea515492a2ecb494b24407dc3f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->