### PR TITLE
string: avoid storing already-expired MSETEX values

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -786,6 +786,49 @@ void msetexCommand(client *c) {
         }
     }
 
+    /* If the expire time is already elapsed, avoid materializing the new
+     * values only to have expiration delete them later. Mirror SET's fast-path
+     * exactly while handling the multi-key case in one consolidated DEL/UNLINK:
+     * dbDelete() routes through lazyfree_lazy_server_del + DB_FLAG_KEY_DELETED,
+     * matching how Redis categorizes user-initiated writes that remove keys
+     * (as opposed to natural TTL expiration, which is the GETEX fast-path's
+     * domain with DB_FLAG_KEY_EXPIRED + lazy_expire).
+     *
+     * From stats perspective, we behave as if we inserted kv_count new keys
+     * (possibly overwrites) and later expired them, matching how SET treats
+     * the same fast-path for stat_expiredkeys. */
+    if (args.expire && checkAlreadyExpired(milliseconds)) {
+        robj *aux = server.lazyfree_lazy_server_del ? shared.unlink : shared.del;
+        robj **newargv = zmalloc(sizeof(robj *) * (kv_count + 1));
+        newargv[0] = aux;
+        incrRefCount(aux);
+        int del_idx = 1;
+
+        for (int j = 0; j < kv_count; j++) {
+            int key_idx = (j * 2) + 2;
+            robj *key = c->argv[key_idx];
+            if (dbDelete(c->db, key)) {
+                newargv[del_idx++] = key;
+                incrRefCount(key);
+                keyModified(c, c->db, key, NULL, 1);
+                notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
+                server.dirty++;
+            }
+        }
+        server.stat_expiredkeys += kv_count;
+
+        if (del_idx > 1) {
+            replaceClientCommandVector(c, del_idx, newargv);
+        } else {
+            preventCommandPropagation(c);
+            decrRefCount(aux);
+            zfree(newargv);
+        }
+
+        addReply(c, shared.cone);
+        return;
+    }
+
     /* Set all key-value pairs */
     for (int j = 0; j < kv_count; j++) {
         int key_idx = (j * 2) + 2;

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -275,6 +275,98 @@ start_server {tags {"string"}} {
         assert_morethan [r pttl pxat:key1{t}] 0
     }
 
+    test {MSETEX with past EXAT/PXAT does not store keys} {
+        r flushall
+
+        assert_equal 1 [r msetex 1 key1{t} val1 exat [expr [clock seconds] - 100]]
+        assert_equal 1 [r msetex 1 key2{t} val2 pxat [expr [clock milliseconds] - 100000]]
+
+        assert_equal 0 [r dbsize]
+        assert_equal 0 [r exists key1{t} key2{t}]
+    }
+
+    test {MSETEX with past PXAT deletes existing keys and propagates DEL/UNLINK} {
+        r flushall
+        r set key1{t} pre_existing_val1
+        r set key2{t} pre_existing_val2
+        set repl [attach_to_replication_stream]
+
+        set now [clock milliseconds]
+        r config set lazyfree-lazy-server-del no
+        assert_equal 1 [r msetex 1 key1{t} val1 pxat [expr $now - 1000]]
+        r config set lazyfree-lazy-server-del yes
+        assert_equal 1 [r msetex 1 key2{t} val2 pxat [expr $now - 1000]]
+
+        assert_equal 0 [r exists key1{t} key2{t}]
+
+        assert_replication_stream $repl {
+            {select *}
+            {del key1{t}}
+            {unlink key2{t}}
+        }
+        close_replication_stream $repl
+        r config set lazyfree-lazy-server-del no
+    } {OK} {needs:repl}
+
+    test {MSETEX with past PXAT and no existing keys does not propagate} {
+        r flushall
+        r config set lazyfree-lazy-server-del yes
+        set repl [attach_to_replication_stream]
+
+        assert_equal 1 [r msetex 2 nokey1{t} v1 nokey2{t} v2 pxat [expr [clock milliseconds] - 1000]]
+        r set sentinel{t} ok
+
+        assert_replication_stream $repl {
+            {select *}
+            {set sentinel{t} ok}
+        }
+        close_replication_stream $repl
+        r config set lazyfree-lazy-server-del no
+    } {OK} {needs:repl}
+
+    test {MSETEX with past PXAT consolidates multi-key delete into a single DEL} {
+        r flushall
+        r set k1{t} v1_old
+        r set k2{t} v2_old
+        r set k3{t} v3_old
+        r config set lazyfree-lazy-server-del no
+        set repl [attach_to_replication_stream]
+
+        # Multi-key MSETEX with past PXAT must propagate as ONE consolidated
+        # DEL (or UNLINK) of all deleted keys, not as N separate DEL commands.
+        # This is the core reason the patch builds a shared newargv.
+        assert_equal 1 [r msetex 3 k1{t} v1 k2{t} v2 k3{t} v3 \
+                        pxat [expr [clock milliseconds] - 1000]]
+
+        assert_equal 0 [r exists k1{t} k2{t} k3{t}]
+
+        assert_replication_stream $repl {
+            {select *}
+            {del k1{t} k2{t} k3{t}}
+        }
+        close_replication_stream $repl
+    } {} {needs:repl}
+
+    test {MSETEX with past PXAT consolidates multi-key delete into a single UNLINK} {
+        r flushall
+        r set k1{t} v1_old
+        r set k2{t} v2_old
+        r config set lazyfree-lazy-server-del yes
+        set repl [attach_to_replication_stream]
+
+        assert_equal 1 [r msetex 2 k1{t} v1 k2{t} v2 \
+                        pxat [expr [clock milliseconds] - 1000]]
+
+        assert_equal 0 [r exists k1{t} k2{t}]
+
+        assert_replication_stream $repl {
+            {select *}
+            {unlink k1{t} k2{t}}
+        }
+        close_replication_stream $repl
+        r config set lazyfree-lazy-server-del no
+    } {OK} {needs:repl}
+
     test {MSETEX - KEEPTTL preserves existing TTL} {
         r setex keepttl:key{t} 100 oldval
         set old_ttl [r ttl keepttl:key{t}]


### PR DESCRIPTION
MSETEX currently materializes values whose expiration time is already in the past, attaches the TTL, and relies on active/lazy expiration to remove them later. For a large multi-key MSETEX with a past PXAT this wastes N x setKey + setExpire allocations, two keyspace notifications per key (`set` + `expire`), and the subsequent expire work.

## Solution

Mirror `setGenericCommand`'s past-expire fast-path (src/t_string.c:158) for MSETEX: input keys that currently exist are deleted in place, a single consolidated DEL/UNLINK is propagated for replication/AOF, and no new values are inserted.

## Changes

- Add an already-expired fast path to `msetexCommand`.
- NX/XX semantics are evaluated before the fast path.
- When any input keys already exist, delete them and propagate a single consolidated `DEL` / `UNLINK k1 k2 ... kN` via `replaceClientCommandVector()`.
- When no keys exist (pure no-op), explicitly call `preventCommandPropagation()` rather than rely on `dirty == 0` in `call()`, so the suppression intent survives future changes to the propagation logic.
- `server.stat_expiredkeys` is incremented by `kv_count`, matching SET's "behave as if we inserted new keys and later expired them" stats philosophy (see SET's comment at src/t_string.c:150-157).

## Open question for reviewers: flag convention

Redis currently has two divergent patterns for "past-expire means delete now" in `t_string.c`:

- **SET fast-path** (line 158-172): `dbDelete()` -> `DB_FLAG_KEY_DELETED` + `lazyfree_lazy_server_del`. Modules see `REDISMODULE_SUBEVENT_KEY_DELETED`. The inline comment explicitly chooses this: *"we reflect what we've actually done in the db ... so we don't confuse modules."*

- **GETEX past-PXAT branch** (line 527): `dbGenericDelete(..., DB_FLAG_KEY_EXPIRED)` + `lazyfree_lazy_expire`. Modules see `REDISMODULE_SUBEVENT_KEY_EXPIRED`.

This commit follows SET, since MSETEX is semantically a multi-key SET and SET's inline comment looks like a deliberate design choice for user-initiated writes. A third hybrid (`DB_FLAG_KEY_EXPIRED` + `lazy_server_del`) was also considered and rejected, as it would introduce a pattern that neither SET nor GETEX follows.

Happy to switch convention if the Redis team prefers. If MSETEX should stay consistent with GETEX rather than SET, the SET/GETEX divergence itself may deserve a follow-up review - it's already observable to modules today.

## Tests

`tests/unit/type/string.tcl`:

- `MSETEX with past EXAT/PXAT does not store keys` - baseline.
- `MSETEX with past PXAT deletes existing keys and propagates DEL/UNLINK` - exercises both `lazyfree-lazy-server-del` values (no -> DEL, yes -> UNLINK) to verify aux verb selection.
- `MSETEX with past PXAT and no existing keys does not propagate` - uses a sentinel SET to verify the no-op path is actually suppressed, not just masked by `dirty == 0`.
- `MSETEX with past PXAT consolidates multi-key delete into a single DEL` and `... UNLINK` - verify single-command multi-key propagation, which is the core reason the patch builds a shared newargv.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `msetexCommand` write/replication behavior for past EXAT/PXAT timestamps, which could affect AOF/replication propagation and keyspace notifications if incorrect. Logic is localized and covered by new unit tests for deletion/no-op and DEL vs UNLINK propagation.
> 
> **Overview**
> `MSETEX` now short-circuits when the provided expire time is already in the past: it avoids writing new values, deletes any existing input keys immediately, and propagates a **single consolidated** `DEL`/`UNLINK` (depending on `lazyfree-lazy-server-del`).
> 
> The fast-path increments `stat_expiredkeys` for all keys and explicitly suppresses propagation when nothing was deleted, and new string unit tests cover the past-expire behavior (no stored keys, delete + replication stream assertions, and multi-key consolidation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe58bea8de3a1020b5150b5d4adc5cf0c5479057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->