### PR TITLE
Pass size hint to jemalloc for faster deallocation

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -241,7 +241,8 @@ jobs:
     - name: make
       run: |
         apt-get update && apt-get install -y make gcc
-        make CC=gcc REDIS_CFLAGS='-Werror -DREDIS_TEST -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3'
+        # Also enables jemalloc's sized deallocation checks to catch sdallocx()/zfree_with_size() misuse.
+        make CC=gcc REDIS_CFLAGS='-Werror -DREDIS_TEST -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3' JEMALLOC_CONFIGURE_OPTS='--enable-opt-size-checks'
     - name: testprep
       run: sudo apt-get install -y tcl8.6 tclx procps
     - name: test

--- a/src/object.c
+++ b/src/object.c
@@ -635,6 +635,14 @@ void decrRefCount(robj *o) {
     }
 
     if (--(o->refcount) == 0) {
+        /* Fast path for embedded strings: no inner allocation to free, and we
+         * can compute the alloc size to hint jemalloc for a faster deallocation. */
+        if (likely(o->type == OBJ_STRING && o->encoding == OBJ_ENCODING_EMBSTR && !o->iskvobj)) {
+            serverAssert(sdsType(o->ptr) == SDS_TYPE_8); /* embstr always type_8 */
+            zfree_with_size(o, sizeof(robj) + sdsAllocSize(o->ptr));
+            return;
+        }
+
         void *alloc = o;
         
         if (o->iskvobj) {

--- a/src/object.c
+++ b/src/object.c
@@ -635,14 +635,6 @@ void decrRefCount(robj *o) {
     }
 
     if (--(o->refcount) == 0) {
-        /* Fast path for embedded strings: no inner allocation to free, and we
-         * can compute the alloc size to hint jemalloc for a faster deallocation. */
-        if (likely(o->type == OBJ_STRING && o->encoding == OBJ_ENCODING_EMBSTR && !o->iskvobj)) {
-            serverAssert(sdsType(o->ptr) == SDS_TYPE_8); /* embstr always type_8 */
-            zfree_with_size(o, sizeof(robj) + sdsAllocSize(o->ptr));
-            return;
-        }
-
         void *alloc = o;
         
         if (o->iskvobj) {

--- a/src/sds.c
+++ b/src/sds.c
@@ -213,12 +213,14 @@ sds sdsdup(const sds s) {
 /* Free an sds string. No operation is performed if 's' is NULL. */
 void sdsfree(sds s) {
     if (s == NULL) return;
-    s_free((char*)s-sdsHdrSize(s[-1]));
-}
-
-void sdsfreeusable(sds s, size_t *usable) {
-    if (s == NULL) return;
-    s_free_usable((char*)s-sdsHdrSize(s[-1]), usable);
+    if (sdsType(s) == SDS_TYPE_5) {
+        /* TYPE_5 has no alloc field so sdsAllocSize() returns the requested
+         * size which may not match the actual allocation, so not suitable for
+         * s_free_with_size(). */
+        s_free(sdsAllocPtr(s));
+    } else {
+        s_free_with_size(sdsAllocPtr(s), sdsAllocSize(s));
+    }
 }
 
 /* Generic version of sdsfree. */

--- a/src/sds.h
+++ b/src/sds.h
@@ -267,7 +267,6 @@ sds sdsempty(void);
 sds sdsdup(const sds s);
 void sdsfree(sds s);
 void sdsfreegeneric(void *s);
-void sdsfreeusable(sds s, size_t *usable);
 sds sdsgrowzero(sds s, size_t len);
 sds sdscatlen(sds s, const void *t, size_t len);
 sds sdscat(sds s, const char *t);

--- a/src/sdsalloc.h
+++ b/src/sdsalloc.h
@@ -2,6 +2,9 @@
  *
  * Copyright (c) 2006-Present, Redis Ltd.
  * All rights reserved.
+ * 
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
  *
  * Licensed under your choice of (a) the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
@@ -24,6 +27,7 @@
 #define s_trymalloc ztrymalloc
 #define s_tryrealloc ztryrealloc
 #define s_free zfree
+#define s_free_with_size zfree_with_size
 #define s_malloc_usable zmalloc_usable
 #define s_realloc_usable zrealloc_usable
 #define s_trymalloc_usable ztrymalloc_usable

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -2,6 +2,9 @@
  *
  * Copyright (c) 2009-Present, Redis Ltd.
  * All rights reserved.
+ * 
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
  *
  * Licensed under your choice of (a) the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
@@ -550,6 +553,21 @@ void zfree_usable(void *ptr, size_t *usable) {
     free(realptr);
 #endif
     if (usable) *usable = oldsize;
+}
+
+/* Free with a size hint to skip the emap lookup in jemalloc's free path.
+ * jemalloc's sdallocx() accepts any size that rounds to the correct size class
+ * (i.e. both requested and usable sizes work), but 'size' must be the usable
+ * size to keep zmalloc used_memory accounting accurate. */
+void zfree_with_size(void *ptr, size_t size) {
+    if (ptr == NULL) return;
+#ifdef USE_JEMALLOC
+    update_zmalloc_stat_free(size);
+    je_sdallocx(ptr, size, 0);
+#else
+    UNUSED(size);
+    zfree(ptr);
+#endif
 }
 
 char *zstrdup_usable(const char *s, size_t *usable) {

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -2,6 +2,9 @@
  *
  * Copyright (c) 2009-Present, Redis Ltd.
  * All rights reserved.
+ * 
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
  *
  * Licensed under your choice of (a) the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
@@ -100,13 +103,14 @@ __attribute__((malloc,alloc_size(1),noinline)) void *ztrymalloc(size_t size);
 __attribute__((malloc,alloc_size(1),noinline)) void *ztrycalloc(size_t size);
 __attribute__((alloc_size(2),noinline)) void *ztryrealloc(void *ptr, size_t size);
 void zfree(void *ptr);
+void zfree_usable(void *ptr, size_t *usable);
+void zfree_with_size(void *ptr, size_t size);
 void *zmalloc_usable(size_t size, size_t *usable);
 void *zcalloc_usable(size_t size, size_t *usable);
 void *zrealloc_usable(void *ptr, size_t size, size_t *usable, size_t *old_usable);
 void *ztrymalloc_usable(size_t size, size_t *usable);
 void *ztrycalloc_usable(size_t size, size_t *usable);
 void *ztryrealloc_usable(void *ptr, size_t size, size_t *usable, size_t *old_usable);
-void zfree_usable(void *ptr, size_t *usable);
 __attribute__((malloc)) char *zstrdup(const char *s);
 __attribute__((malloc)) char *zstrdup_usable(const char *s, size_t *usable);
 size_t zmalloc_used_memory(void);

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -81,7 +81,8 @@ proc sanitizer_errors_from_file {filename} {
 
         # GCC UBSAN output does not contain 'Sanitizer' but 'runtime error'.
         if {[string match {*runtime error*} $line] ||
-            [string match {*Sanitizer*} $line]} {
+            [string match {*Sanitizer*} $line] ||
+            [string match {*<jemalloc>:*size mismatch*} $line]} {
             return $log
         }
     }


### PR DESCRIPTION
This PR is based on https://github.com/valkey-io/valkey/pull/453 and https://github.com/valkey-io/valkey/pull/694

When jemalloc frees memory, it performs a lookup to find the allocation's size class. `sdallocx()` lets us skip this lookup by passing the size we already know. Introduced a new free function wrapper for this: `zfree_with_size()`. 
Note: Impact of this optimization is only visible on hot paths e.g. on repeated memory deallocations.

For the initial phase, I integrated this at `sdsfree()` only. Over time, we may expand the usage of this new API for other performance sensitive paths.

For testing, added jemalloc config `--enable-opt-size-checks` to the daily fortify build. This makes jemalloc validate that the size passed to `sdallocx()` matches the actual allocation's size class, aborting on mismatch. 

----


Signed-off-by: Vadym Khoptynets <vadymkh@amazon.com>
Signed-off-by: Madelyn Olson <madelyneolson@gmail.com>
Co-authored-by: Madelyn Olson <madelyneolson@gmail.com>
Signed-off-by: ranshid <ranshid@amazon.com>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level memory deallocation paths (`zmalloc`/`sdsfree`) and introduces sized frees, where an incorrect size hint could crash under jemalloc or skew memory accounting (mitigated by added jemalloc size-check CI coverage).
> 
> **Overview**
> Speeds up jemalloc deallocation by adding `zfree_with_size()` (wrapping `je_sdallocx()` with a usable-size hint) and wiring it through SDS via a new `s_free_with_size` macro.
> 
> Updates `sdsfree()` to use sized free for all SDS types except `SDS_TYPE_5` (which lacks reliable allocation metadata), and removes the unused `sdsfreeusable()` API.
> 
> Strengthens test coverage by enabling jemalloc `--enable-opt-size-checks` in the daily fortify workflow and treating jemalloc "size mismatch" output as a sanitizer failure in the test harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22168fe8743133f37f96d07f944c968438e5dab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->