### PR TITLE
Update RediSearch to 8.8 RC1 (v8.7.90)

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.5.90
+MODULE_VERSION = v8.7.90
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
Update RediSearch module version to 8.8 RC1 (v8.7.90)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single version bump that changes which RediSearch git tag is cloned/built; main risk is build/runtime incompatibility from the upstream RC update.
> 
> **Overview**
> Updates the RediSearch module build configuration to fetch and build upstream `redisearch` tag `v8.7.90` (8.8 RC1) instead of `v8.5.90`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e121c7380568130846f9d202c90f72ad93e0f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->