### PR TITLE
tracking: fix self-overlap returning non-zero loop index

### DIFF
--- a/src/tracking.c
+++ b/src/tracking.c
@@ -125,7 +125,7 @@ int checkPrefixCollisionsOrReply(client *c, robj **prefixes, size_t numprefix) {
                     "Prefixes for a single client must not overlap.",
                     (unsigned char *)prefixes[i]->ptr,
                     (unsigned char *)prefixes[j]->ptr);
-                return i;
+                return 0;
             }
         }
     }

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -413,6 +413,18 @@ start_server {tags {"tracking network logreqres:skip"}} {
         $r CLIENT TRACKING OFF
     }
 
+    test {BCAST prefix self-overlap past first index reports error without enabling} {
+        # When any of the provided BCAST prefixes overlap with each other,
+        # CLIENT TRACKING ON must reply with a single error and leave tracking
+        # disabled, regardless of the position of the overlapping prefix in
+        # the argument list.
+        r CLIENT TRACKING OFF
+        catch {r CLIENT TRACKING ON BCAST PREFIX BAZ PREFIX FOOBAR PREFIX FOO} output
+        assert_match {ERR Prefix 'FOOBAR' overlaps with another provided prefix 'FOO'*} $output
+        # Tracking must not have been enabled after the overlap error.
+        assert_match {*flags off*} [r CLIENT TRACKINGINFO]
+    }
+
     test {hdel deliver invalidate message after response in the same connection} {
         r CLIENT TRACKING off
         r HELLO 3


### PR DESCRIPTION
Caller is `if (!checkPrefixCollisionsOrReply(...))` — expects 0 on collision, non-zero on success. The self-collision branch returns the outer loop index `i` instead of 0. At i=0 it's falsy so the caller bails correctly. At i>=1 it's truthy, caller proceeds to enableTracking(), client gets both the error reply AND +OK, overlapping prefixes get registered.

Repro:
  CLIENT TRACKING ON BCAST PREFIX BAZ PREFIX FOOBAR PREFIX FOO
  -ERR Prefix 'FOOBAR' overlaps with 'FOO'
  +OK

Been there since #8176. #8456 flipped the success return to match a boolean docstring but left `return i` alone. The index value isn't read anywhere — always dead info.

Return 0 and add a regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `CLIENT TRACKING ON BCAST` error handling so an overlap in later prefixes reliably aborts enabling tracking, which is user-visible and affects client state but is a small, well-scoped fix with a regression test.
> 
> **Overview**
> Fixes `checkPrefixCollisionsOrReply()` to return `0` (failure) on *any* provided-prefix self-overlap, instead of accidentally returning a non-zero loop index for overlaps found after the first prefix.
> 
> This prevents `CLIENT TRACKING ON BCAST` from replying with an error yet still proceeding to enable tracking/register overlapping prefixes, and adds a unit test ensuring tracking remains disabled after such an overlap error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 343f2c12a59a63ff8e7dcd9d261c90afe3cb0a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->