### PR TITLE
hash: pause auto-resize during HGETDEL

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2722,6 +2722,8 @@ void hgetdelCommand(client *c) {
         oldlen = hashTypeLength(o, 0);
         if (server.memory_tracking_enabled)
             oldsize = kvobjAllocSize(o);
+        if (o->encoding == OBJ_ENCODING_HT)
+            dictPauseAutoResize((dict*)o->ptr);
     }
 
     addReplyArrayLen(c, num_fields);
@@ -2738,6 +2740,10 @@ void hgetdelCommand(client *c) {
             deleted++;
             serverAssert(hashTypeDelete(o, c->argv[i]->ptr) == 1);
         }
+    }
+    if (o && o->encoding == OBJ_ENCODING_HT) {
+        dictResumeAutoResize((dict*)o->ptr);
+        dictShrinkIfNeeded((dict*)o->ptr);
     }
 
     /* Return if no modification has been made. */


### PR DESCRIPTION
Match HGETDEL with the existing batch-delete pattern used by HDEL.

HDEL already pauses dict auto-resize while deleting multiple fields so resize and shrink evaluation is deferred until the batch completes. HGETDEL was missing the same optimization even though it also deletes fields in a loop.

Pause auto-resize for hash table encoded hashes before the HGETDEL delete loop and resume it once afterwards, followed by a single shrink check. This preserves observable behavior and only avoids redundant resize work during multi-field deletes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small performance optimization limited to `HGETDEL` that only defers dict resize/shrink work until after a multi-field delete loop.
> 
> **Overview**
> **Improves `HGETDEL` efficiency for hash-table encoded hashes.** The command now pauses dict auto-resizing before deleting multiple fields, then resumes auto-resize and runs one `dictShrinkIfNeeded()` after the batch completes.
> 
> This matches the existing batch-delete pattern used by `HDEL` and avoids repeated resize/shrink evaluations during multi-field `HGETDEL` operations without changing command semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32ebce20c1399aba3bb349b87a19b4681dad7e4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->