### PR TITLE
threads_mngr: use CLOCK_MONOTONIC instead of CLOCK_REALTIME in wait_threads()

### DIFF
--- a/src/threads_mngr.c
+++ b/src/threads_mngr.c
@@ -115,8 +115,15 @@ static void invoke_callback(int sig) {
 }
 
 static void wait_threads(void) {
+    /* Use CLOCK_MONOTONIC so the relative timeout is immune to wall-clock
+     * jumps (NTP step, DST change, manual date(1), container host time
+     * sync, VM suspend/resume). A forward jump in CLOCK_REALTIME would
+     * otherwise cause this loop to exit immediately and invoke the
+     * callback before the threads have written their output, corrupting
+     * crash-report stack traces. Same function, same struct, still
+     * async-signal-safe. */
     struct timespec timeout_time;
-    clock_gettime(CLOCK_REALTIME, &timeout_time);
+    clock_gettime(CLOCK_MONOTONIC, &timeout_time);
 
     /* calculate relative time until timeout */
     timeout_time.tv_sec += RUN_ON_THREADS_TIMEOUT;
@@ -134,7 +141,7 @@ static void wait_threads(void) {
         /* usleep isn't listed as signal safe, so we use select instead */
         select(0, NULL, NULL, NULL, &tv);
         atomicGet(g_num_threads_done, curr_done_count);
-        clock_gettime(CLOCK_REALTIME, &curr_time);
+        clock_gettime(CLOCK_MONOTONIC, &curr_time);
         atomicGet(g_tids_len, tids_len);
     } while (curr_done_count < tids_len &&
              curr_time.tv_sec <= timeout_time.tv_sec);


### PR DESCRIPTION
`wait_threads()` runs inside a signal handler and uses `CLOCK_REALTIME` for its 2s timeout. A forward wall-clock jump (NTP step, DST, VM resume, manual `date`) makes the loop exit immediately and fires `invoke_callback` before threads finish writing their stack traces, corrupting crash reports. Backward jump, it polls past 2s.

Fix: `CLOCK_MONOTONIC` in both `clock_gettime()` calls.

Still async-signal-safe. AS-safety is the function, not the clock id, same guarantee as #12658. Matches the monotonic discipline already in `monotonic.h` and `ae.c`. Linux/macOS/BSD all support it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to timeout bookkeeping that should only make thread-wait behavior more reliable under wall-clock jumps.
> 
> **Overview**
> `wait_threads()` now uses `CLOCK_MONOTONIC` instead of `CLOCK_REALTIME` for both timeout initialization and polling, making the 2s wait immune to system time changes.
> 
> Adds an explanatory comment documenting why this prevents premature timeout/early callback execution that could corrupt crash-report stack traces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 924c3c3f4871e25ed8022666eb2e8ebceeacc7e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->