### PR TITLE
Fix missing and incorrect test tag references

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -38,8 +38,11 @@ The following compatibility and capability tags are currently used:
 | `external:skip`           | Not compatible with external servers. |
 | `cluster:skip`            | Not compatible with `--cluster-mode`. |
 | `large-memory`            | Test that requires more than 100mb |
+| `singledb:skip`           | Not compatible with `--singledb`. |
 | `tls:skip`                | Not compatible with `--tls`. |
 | `tsan:skip`               | Not compatible with running under thread sanitizer. |
+| `debug_defrag:skip`       | Not compatible with a server built with `DEBUG_DEFRAG`. |
+| `logreqres:skip`          | Not compatible with `--log-req-res`. |
 | `needs:repl`              | Uses replication and needs to be able to `SYNC` from server. |
 | `needs:debug`             | Uses the `DEBUG` command or other debugging focused commands (like `OBJECT REFCOUNT`). |
 | `needs:pfdebug`           | Uses the `PFDEBUG` command. |
@@ -54,11 +57,10 @@ When using an external server (`--host` and `--port`), filtering using the
 When using `--cluster-mode`, filtering using the `cluster:skip` tag is done
 automatically.
 
-When not using `--large-memory`, filtering using the `largemem:skip` tag is done
+When not using `--large-memory`, filtering using the `large-memory` tag is done
 automatically.
 
 In addition, it is possible to specify additional configuration. For example, to
 run tests on a server that does not permit `SYNC` use:
 
     ./runtest --host <host> --port <port> --tags -needs:repl
-


### PR DESCRIPTION

**Repo:** redis/redis (⭐ 68000)
**Type:** docs
**Files changed:** 1
**Lines:** +4/-2

## What
This change updates the test suite documentation in `tests/README.md` so it matches the tags that the harness actually supports. It adds entries for `singledb:skip`, `debug_defrag:skip`, and `logreqres:skip`, and fixes the large-memory filtering note to reference the real `large-memory` tag instead of the nonexistent `largemem:skip` name.

## Why
Contributors use `tests/README.md` to understand how the Tcl test harness filters test cases across different run modes. Before this patch, the document omitted several supported skip tags from `tests/support/server.tcl` and pointed readers to an incorrect large-memory tag name, which could lead to mis-tagged tests or confusion when trying to run subsets of the suite.

## Testing
Verified by cross-checking `tests/README.md` against the tag handling logic in `tests/support/server.tcl` and existing tag usage across the `tests/` tree. No runtime tests were needed because this patch only updates documentation.

## Risk
Low / Documentation-only change aligned to existing code paths.
