### PR TITLE
Add LATENCY event for dict rehash during command execution

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -44,6 +44,18 @@
 static dictResizeEnable dict_can_resize = DICT_RESIZE_ENABLE;
 static unsigned int dict_force_resize_ratio = 4;
 
+/* Accumulator of microseconds spent in incremental rehash steps performed
+ * inside dict lookup/insert/delete operations. Read and reset by higher
+ * layers (server.c call()) to attribute per-command rehash cost. */
+uint64_t dictRehashStepElapsedUs = 0;
+
+/* Non-zero when latency monitoring is active
+ * (server.latency_monitor_threshold != 0). Set by server.c at the outermost
+ * call() entry and cleared at the outermost call() exit. While zero, the
+ * rehash timing path is skipped entirely: no clock reads, no accumulator
+ * writes - just one predictable branch. */
+int dictRehashStepTiming = 0;
+
 /* -------------------------- types ----------------------------------------- */
 struct dictEntry {
     struct dictEntry *next;  /* Must be first */
@@ -466,7 +478,19 @@ int dictRehashMicroseconds(dict *d, uint64_t us) {
  * dictionary so that the hash table automatically migrates from H1 to H2
  * while it is actively used. */
 static void _dictRehashStep(dict *d) {
-    if (d->pauserehash == 0) dictRehash(d,1);
+    if (d->pauserehash == 0) {
+        /* Skip the timing path when latency monitoring is off, and also
+         * when getMonotonicUs is still NULL during early startup (core
+         * module registration runs dictAdd before monotonicInit). */
+        if (!dictRehashStepTiming || getMonotonicUs == NULL) {
+            dictRehash(d,1);
+            return;
+        }
+        monotime t;
+        elapsedStart(&t);
+        dictRehash(d,1);
+        dictRehashStepElapsedUs += elapsedUs(t);
+    }
 }
 
 /* Performs rehashing on a single bucket. */
@@ -1705,6 +1729,12 @@ static void _dictShrinkIfNeeded(dict *d)
 static void _dictRehashStepIfNeeded(dict *d, uint64_t visitedIdx) {
     if ((!dictIsRehashing(d)) || (d->pauserehash != 0))
         return;
+    /* Skip the timing path when latency monitoring is off, and also when
+     * getMonotonicUs is still NULL during early startup (core module
+     * registration runs dictAdd before monotonicInit). */
+    const int time_it = dictRehashStepTiming && (getMonotonicUs != NULL);
+    monotime t;
+    if (time_it) elapsedStart(&t);
     /* rehashing not in progress if rehashidx == -1 */
     if ((long)visitedIdx >= d->rehashidx && d->ht_table[0][visitedIdx]) {
         /* If we have a valid hash entry at `idx` in ht0, we perform
@@ -1715,6 +1745,7 @@ static void _dictRehashStepIfNeeded(dict *d, uint64_t visitedIdx) {
          * on the rehashidx (not CPU cache friendly). */
         dictRehash(d,1);
     }
+    if (time_it) dictRehashStepElapsedUs += elapsedUs(t);
 }
 
 /* Our hash table capability is a power of two */

--- a/src/dict.h
+++ b/src/dict.h
@@ -273,6 +273,8 @@ void dictEmpty(dict *d, void(callback)(dict*));
 void dictSetResizeEnabled(dictResizeEnable enable);
 int dictRehash(dict *d, int n);
 int dictRehashMicroseconds(dict *d, uint64_t us);
+extern uint64_t dictRehashStepElapsedUs;
+extern int dictRehashStepTiming;
 void dictSetHashFunctionSeed(uint8_t *seed);
 unsigned long dictScan(dict *d, unsigned long v, dictScanFunction *fn, void *privdata);
 unsigned long dictScanDefrag(dict *d, unsigned long v, dictScanFunction *fn, dictDefragFunctions *defragfns, void *privdata);

--- a/src/server.c
+++ b/src/server.c
@@ -3949,6 +3949,17 @@ void call(client *c, int flags) {
     /* Pass current server.ustime to avoid ustime() call if monotonic clock is used
      * and time will be updated before command execution based on monotonic clock. */
     const long long call_timer = use_hw_clock ? server.ustime : ustime();
+    /* Arm dict-rehash attribution at the outermost call() only. The
+     * accumulator starts at zero so that only rehash work performed during
+     * this top-level command's proc is attributed to it, and the timing
+     * flag is set so that the dict-side path starts collecting samples
+     * while this command runs. When the feature is disabled
+     * (latency_monitor_threshold == 0), the flag stays 0 and the entire
+     * timing path is a single predictable branch. */
+    if (server.execution_nesting == 0) {
+        dictRehashStepElapsedUs = 0;
+        dictRehashStepTiming = (server.latency_monitor_threshold != 0);
+    }
     enterExecutionUnit(1, call_timer);
 
     /* setting the CLIENT_EXECUTING_COMMAND flag so we will avoid
@@ -4005,8 +4016,16 @@ void call(client *c, int flags) {
         char *latency_event = (real_cmd->flags & CMD_FAST) ?
                                "fast-command" : "command";
         latencyAddSampleIfNeeded(latency_event,duration/1000);
-        if (server.execution_nesting == 0)
+        if (server.execution_nesting == 0) {
             durationAddSample(EL_DURATION_TYPE_CMD, duration);
+            latencyAddSampleIfNeeded("dict-rehash-during-command",
+                                     (long long)(dictRehashStepElapsedUs/1000));
+            /* Disarm the dict-rehash timing path between top-level calls so
+             * any rehash work done in cron (e.g. via active expire) does not
+             * pay the timing cost. The accumulator is zeroed again at the
+             * next top-level entry. */
+            dictRehashStepTiming = 0;
+        }
     }
 
     /* Log the command into the Slow log if needed.

--- a/src/server.c
+++ b/src/server.c
@@ -4020,13 +4020,15 @@ void call(client *c, int flags) {
             durationAddSample(EL_DURATION_TYPE_CMD, duration);
             latencyAddSampleIfNeeded("dict-rehash-during-command",
                                      (long long)(dictRehashStepElapsedUs/1000));
-            /* Disarm the dict-rehash timing path between top-level calls so
-             * any rehash work done in cron (e.g. via active expire) does not
-             * pay the timing cost. The accumulator is zeroed again at the
-             * next top-level entry. */
-            dictRehashStepTiming = 0;
         }
     }
+
+    /* Disarm the dict-rehash timing path unconditionally at outermost call()
+     * exit, so cron work between commands does not pay the timing cost. This
+     * must run regardless of update_command_stats (e.g. during AOF loading)
+     * so the flag cannot stay armed across paths that skip the stats block. */
+    if (server.execution_nesting == 0)
+        dictRehashStepTiming = 0;
 
     /* Log the command into the Slow log if needed.
      * If the client is blocked we will handle slowlog when it is unblocked. */


### PR DESCRIPTION
## Motivation

This addresses operator pain seen in issues like #12602 that a command was slow (via `SLOWLOG` and per-command `LATENCY HISTOGRAM`) but cannot tell whether the slowness came from dict rehash work amortized into that command.

`_dictRehashStep` and `_dictRehashStepIfNeeded` (`src/dict.c`) migrate one bucket from `ht[0]` to `ht[1]` on common lookup / insert / delete paths while a resize is in progress. During an active resize, this cost is paid synchronously inside `call()`, but it is not surfaced anywhere.

The existing `LATENCY` event set already covers cron-level stealers (`expire-cycle`, `eviction-cycle`, `active-defrag-cycle`, the `aof-*` events, etc.), so per-command rehash attribution is a notable gap.

Cron rehashing (`databasesCron -> kvstoreIncrementallyRehash -> dictRehashMicroseconds`) goes through a distinct code path and is already controlled via `activerehashing`.

This PR addresses specifically the incremental work that happens synchronously *inside* command execution.

## Change

One new named event:

```text
dict-rehash-during-command
```

It is emitted through the existing `latencyAddSampleIfNeeded` macro, so it inherits `latency-monitor-threshold` gating and appears automatically in:

- `LATENCY LATEST`
- `LATENCY HISTORY`
- `LATENCY GRAPH`
- `LATENCY DOCTOR`

No additional command or API surface is introduced.

## Not in Scope

This PR intentionally does **not** include:

- a general per-subsystem attribution framework
- changes to `SLOWLOG` schema or `SLOWLOG GET`
- new configuration parameters
- new commands or subcommands
- per-inner-command reporting inside `MULTI/EXEC`, `EVAL/FCALL`, or module `RM_Call`
- instrumentation of `dictRehashMicroseconds` (cron / `FLUSHDB` paths)

## Benchmarks

### Enabled-path value demonstration

```text
dict-rehash-during-command   last=598   peak=598   (ms)
command                      last=1612  peak=1612  (ms)
```

~37% of the command’s wall time was attributable to dict rehash.

### Disabled-path parity benchmark

| Metric | Stock (mean / 6) | Patched (mean / 6) | Delta |
|---|---:|---:|---:|
| Throughput (req/s) | 188,516.89 | 188,807.24 | +0.15% |
| p50 latency (ms) | 0.223 | 0.223 | 0 |
| p95 latency (ms) | 0.303 | 0.303 | 0 |
| p99 latency (ms) | 0.319 | 0.319 | 0 |

The patched-vs-stock mean delta sits within run-to-run noise and shows no measurable disabled-path regression.

## Tests

Existing suites pass unchanged:

- `unit/latency-monitor`
- `unit/slowlog`
- `unit/expire`
- `unit/scripting`

## Anticipated Questions

### Does this double-count with cron rehash?

No.

Cron rehashing runs through `dictRehashMicroseconds`, a distinct code path not touched by this patch.

This PR instruments only `_dictRehashStep*`, i.e. command-synchronous amortized work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path dict rehash stepping and the core `call()` execution loop; while gated behind latency monitoring, any timing/accumulator logic in these paths could impact performance or skew latency stats if mis-armed.
> 
> **Overview**
> Adds per-command latency attribution for dict incremental rehash work by timing `_dictRehashStep` and `_dictRehashStepIfNeeded` and accumulating elapsed microseconds in new globals (`dictRehashStepElapsedUs`, `dictRehashStepTiming`).
> 
> `server.c` now arms/disarms this timing only at the outermost `call()` and emits a new `LATENCY` event, `dict-rehash-during-command`, reporting the accumulated rehash time (ms) alongside existing command latency samples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd97d597448a1c8158dc96826466cd46ba1bc135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->