### PR TITLE
RED-183392 post release tarball testing

### DIFF
--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   extract-release-info:
-    if: github.repository == 'redis/redis'
+#    if: github.repository == 'redis/redis'
     runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.release-info.outputs.tag_name }}
@@ -108,7 +108,7 @@ jobs:
   #         # - Adaptation of utils/releasetools/02_upload_tarball.sh for CI environment
 
   test-release-tarball:
-    needs: [extract-release-info, create-tarball, upload-tarball]
+    needs: [extract-release-info, create-tarball] #, upload-tarball]
     runs-on: ubuntu-latest
     env:
       TAG_NAME: ${{ needs.extract-release-info.outputs.tag_name }}

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -42,8 +42,6 @@ jobs:
       TAG_NAME: ${{ needs.extract-release-info.outputs.tag_name }}
     outputs:
       sha256: ${{ steps.checksum.outputs.sha256 }}
-      size_mb: ${{ steps.size.outputs.size_mb }}
-      size_warning: ${{ steps.size.outputs.size_warning }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -53,20 +51,6 @@ jobs:
 
       - name: Create tarball
         run: ./utils/releasetools/01_create_tarball.sh "$TAG_NAME"
-
-      - name: Verify tarball size
-        id: size
-        run: |
-          TARBALL="/tmp/redis-${TAG_NAME}.tar.gz"
-          SIZE_MB=$(du -m "$TARBALL" | cut -f1)
-          echo "Tarball size: ${SIZE_MB} MB"
-          echo "size_mb=${SIZE_MB}" >> $GITHUB_OUTPUT
-          if [ "$SIZE_MB" -lt 3 ] || [ "$SIZE_MB" -gt 5 ]; then
-            echo "::warning::Tarball size ${SIZE_MB} MB is outside expected range (3-5 MB)"
-            echo "size_warning=true" >> $GITHUB_OUTPUT
-          else
-            echo "size_warning=false" >> $GITHUB_OUTPUT
-          fi
 
       - name: Calculate SHA256 checksum
         id: checksum
@@ -110,6 +94,8 @@ jobs:
   test-release-tarball:
     needs: [extract-release-info, create-tarball, upload-tarball]
     runs-on: ubuntu-latest
+    outputs:
+      size_mb: ${{ steps.tarball_size.outputs.size_mb }}
     env:
       TAG_NAME: ${{ needs.extract-release-info.outputs.tag_name }}
       EXPECTED_SHA256: ${{ needs.create-tarball.outputs.sha256 }}
@@ -123,10 +109,12 @@ jobs:
           ls -lh "redis-${TAG_NAME}.tar.gz"
 
       - name: Verify tarball size is reasonable (3-5 MB compressed)
+        id: tarball_size
         if: success() || failure()
         run: |
           TARBALL="/tmp/redis-${TAG_NAME}.tar.gz"
           SIZE_MB=$(du -m "$TARBALL" | cut -f1)
+          echo "size_mb=${SIZE_MB}" >> $GITHUB_OUTPUT
           echo "Downloaded tarball size: ${SIZE_MB} MB"
 
           if [ "$SIZE_MB" -lt 3 ] || [ "$SIZE_MB" -gt 5 ]; then
@@ -421,8 +409,7 @@ jobs:
       TAG_NAME: ${{ needs.extract-release-info.outputs.tag_name }}
       RELEASE_TYPE: ${{ needs.extract-release-info.outputs.release_type }}
       SHA256: ${{ needs.create-tarball.outputs.sha256 }}
-      SIZE_MB: ${{ needs.create-tarball.outputs.size_mb }}
-      SIZE_WARNING: ${{ needs.create-tarball.outputs.size_warning }}
+      SIZE_MB: ${{ needs.test-release-tarball.outputs.size_mb }}
     steps:
       - name: Summary
         run: |

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -123,6 +123,7 @@ jobs:
           ls -lh "redis-${TAG_NAME}.tar.gz"
 
       - name: Verify tarball size is reasonable (3-5 MB compressed)
+        if: success() || failure()
         run: |
           TARBALL="/tmp/redis-${TAG_NAME}.tar.gz"
           SIZE_MB=$(du -m "$TARBALL" | cut -f1)
@@ -135,22 +136,24 @@ jobs:
             echo "✓ Tarball size ${SIZE_MB} MB is within expected range"
           fi
 
-#      - name: Verify checksum matches (SHA256)
-#        run: |
-#          TARBALL="/tmp/redis-${TAG_NAME}.tar.gz"
-#          ACTUAL_SHA256=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
-#
-#          echo "Expected SHA256: ${EXPECTED_SHA256}"
-#          echo "Actual SHA256:   ${ACTUAL_SHA256}"
-#
-#          if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
-#            echo "::error::SHA256 checksum mismatch!"
-#            exit 1
-#          else
-#            echo "✓ SHA256 checksum matches"
-#          fi
+      - name: Verify checksum matches (SHA256)
+        if: success() || failure()
+        run: |
+          TARBALL="/tmp/redis-${TAG_NAME}.tar.gz"
+          ACTUAL_SHA256=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
+
+          echo "Expected SHA256: ${EXPECTED_SHA256}"
+          echo "Actual SHA256:   ${ACTUAL_SHA256}"
+
+          if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+            echo "::error::SHA256 checksum mismatch!"
+            exit 1
+          else
+            echo "✓ SHA256 checksum matches"
+          fi
 
       - name: Verify tarball extraction succeeds
+        if: success() || failure()
         run: |
           cd /tmp
           echo "Extracting tarball..."
@@ -165,6 +168,7 @@ jobs:
           ls -la "redis-${TAG_NAME}/"
 
       - name: Verify tarball contains all necessary files
+        if: success() || failure()
         run: |
           cd "/tmp/redis-${TAG_NAME}"
 
@@ -246,6 +250,7 @@ jobs:
           echo "✓ All necessary files are present"
 
       - name: Check file permissions are correct
+        if: success() || failure()
         run: |
           cd "/tmp/redis-${TAG_NAME}"
 
@@ -275,6 +280,7 @@ jobs:
           echo "✓ File permissions are correct"
 
       - name: Verify no missing dependencies
+        if: success() || failure()
         run: |
           cd "/tmp/redis-${TAG_NAME}"
 
@@ -303,6 +309,7 @@ jobs:
           echo "✓ All required dependencies are available"
 
       - name: Build Redis from extracted tarball (not from git repo)
+        if: success() || failure()
         run: |
           cd "/tmp/redis-${TAG_NAME}"
 
@@ -339,6 +346,7 @@ jobs:
           ./src/redis-server --version
 
       - name: Run smoke test (start redis-server, execute PING, shutdown)
+        if: success() || failure()
         run: |
           cd "/tmp/redis-${TAG_NAME}"
 
@@ -406,7 +414,7 @@ jobs:
   #         # - Git credentials for committing and pushing
 
   summary-and-notify:
-    needs: [extract-release-info, create-tarball] #, upload-tarball, test-release-tarball] # update-release-hashes
+    needs: [extract-release-info, create-tarball, test-release-tarball] #, upload-tarball] # update-release-hashes
     if: always() && github.repository == 'redis/redis'
     runs-on: ubuntu-latest
     env:
@@ -425,10 +433,13 @@ jobs:
             echo "- **Release Type:** ${RELEASE_TYPE}"
             echo "- **Tarball SHA256:** ${SHA256}"
             echo "- **Tarball Size:** ${SIZE_MB} MB"
-            if [ "${SIZE_WARNING}" == "true" ]; then
-              echo ""
-              echo "> [!WARNING]"
-              echo "> Tarball size is outside expected range, check the logs for details."
+            echo ""
+
+            # Test results
+            if [ "${{ needs.test-release-tarball.result }}" == "success" ]; then
+              echo "- **Tests:** ✅ All tests passed"
+            elif [ "${{ needs.test-release-tarball.result }}" == "failure" ]; then
+              echo "- **Tests:** ❌ One or more tests failed"
             fi
           } >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -170,19 +170,69 @@ jobs:
 
           # Check for critical files and directories
           REQUIRED_FILES=(
+            # Build files
             "Makefile"
-            "README.md"
-            "COPYING"
             "src/Makefile"
+            "deps/Makefile"
+            "modules/Makefile"
+
+            # Documentation
+            "README.md"
+            "LICENSE.txt"
+            "00-RELEASENOTES"
+            "INSTALL"
+            "CONTRIBUTING.md"
+            "CODE_OF_CONDUCT.md"
+            "SECURITY.md"
+            "TLS.md"
+            "MANIFESTO"
+            "BUGS"
+            "REDISCONTRIBUTIONS.txt"
+
+            # Configuration files
+            "redis.conf"
+            "redis-full.conf"
+            "sentinel.conf"
+
+            # Source files
             "src/redis-server.c"
             "src/redis-cli.c"
-            "deps/jemalloc"
+            "src/redis-benchmark.c"
+            "src/redis-check-rdb.c"
+            "src/redis-check-aof.c"
+            "src/server.c"
+            "src/server.h"
+            "src/sds.c"
+            "src/sds.h"
+            "src/dict.c"
+            "src/dict.h"
+            "src/ae.c"
+            "src/ae.h"
+            "src/anet.c"
+            "src/anet.h"
+            "src/commands.def"
+            "src/mkreleasehdr.sh"
+
+            # Dependencies
             "deps/hiredis"
+            "deps/linenoise"
             "deps/lua"
+            "deps/jemalloc"
+            "deps/hdr_histogram"
+            "deps/fpconv"
+            "deps/xxhash"
+
+            # Test scripts
             "runtest"
             "runtest-sentinel"
             "runtest-cluster"
             "runtest-moduleapi"
+            "tests/test_helper.tcl"
+
+            # Utilities
+            "utils/create-cluster"
+            "utils/install_server.sh"
+            "utils/gen-test-certs.sh"
           )
 
           MISSING_FILES=()

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -361,7 +361,7 @@ jobs:
   #         # - Git credentials for committing and pushing
 
   summary-and-notify:
-    needs: [extract-release-info, create-tarball, upload-tarball, test-release-tarball] # update-release-hashes
+    needs: [extract-release-info, create-tarball] #, upload-tarball, test-release-tarball] # update-release-hashes
     if: always() && github.repository == 'redis/redis'
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   extract-release-info:
-#    if: github.repository == 'redis/redis'
+    if: github.repository == 'redis/redis' || github.repository == 'stav-nachmias/fork-redis'
     runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.release-info.outputs.tag_name }}

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -195,11 +195,6 @@ jobs:
             "sentinel.conf"
 
             # Source files
-            "src/redis-server.c"
-            "src/redis-cli.c"
-            "src/redis-benchmark.c"
-            "src/redis-check-rdb.c"
-            "src/redis-check-aof.c"
             "src/server.c"
             "src/server.h"
             "src/sds.c"

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -135,20 +135,20 @@ jobs:
             echo "✓ Tarball size ${SIZE_MB} MB is within expected range"
           fi
 
-      - name: Verify checksum matches (SHA256)
-        run: |
-          TARBALL="/tmp/redis-${TAG_NAME}.tar.gz"
-          ACTUAL_SHA256=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
-
-          echo "Expected SHA256: ${EXPECTED_SHA256}"
-          echo "Actual SHA256:   ${ACTUAL_SHA256}"
-
-          if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
-            echo "::error::SHA256 checksum mismatch!"
-            exit 1
-          else
-            echo "✓ SHA256 checksum matches"
-          fi
+#      - name: Verify checksum matches (SHA256)
+#        run: |
+#          TARBALL="/tmp/redis-${TAG_NAME}.tar.gz"
+#          ACTUAL_SHA256=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
+#
+#          echo "Expected SHA256: ${EXPECTED_SHA256}"
+#          echo "Actual SHA256:   ${ACTUAL_SHA256}"
+#
+#          if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+#            echo "::error::SHA256 checksum mismatch!"
+#            exit 1
+#          else
+#            echo "✓ SHA256 checksum matches"
+#          fi
 
       - name: Verify tarball extraction succeeds
         run: |

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -107,16 +107,247 @@ jobs:
   #         # - SSH credentials/keys for upload to download.redis.io
   #         # - Adaptation of utils/releasetools/02_upload_tarball.sh for CI environment
 
-  # test-release-tarball:
-  #   needs: upload-tarball
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Test release tarball
-  #       run: |
-  #         echo "TODO: Implement release testing using utils/releasetools/03_test_release.sh"
-  #         # This will:
-  #         # - Download the uploaded tarball
-  #         # - Extract and build Redis
+  test-release-tarball:
+    needs: [extract-release-info, create-tarball, upload-tarball]
+    runs-on: ubuntu-latest
+    env:
+      TAG_NAME: ${{ needs.extract-release-info.outputs.tag_name }}
+      EXPECTED_SHA256: ${{ needs.create-tarball.outputs.sha256 }}
+      DOWNLOAD_URL: http://download.redis.io/releases/redis-${{ needs.extract-release-info.outputs.tag_name }}.tar.gz
+    steps:
+      - name: Download tarball from public URL
+        run: |
+          echo "Downloading tarball from: ${DOWNLOAD_URL}"
+          cd /tmp
+          wget -O "redis-${TAG_NAME}.tar.gz" "${DOWNLOAD_URL}"
+          ls -lh "redis-${TAG_NAME}.tar.gz"
+
+      - name: Verify tarball size is reasonable (3-5 MB compressed)
+        run: |
+          TARBALL="/tmp/redis-${TAG_NAME}.tar.gz"
+          SIZE_MB=$(du -m "$TARBALL" | cut -f1)
+          echo "Downloaded tarball size: ${SIZE_MB} MB"
+
+          if [ "$SIZE_MB" -lt 3 ] || [ "$SIZE_MB" -gt 5 ]; then
+            echo "::error::Tarball size ${SIZE_MB} MB is outside expected range (3-5 MB)"
+            exit 1
+          else
+            echo "✓ Tarball size ${SIZE_MB} MB is within expected range"
+          fi
+
+      - name: Verify checksum matches (SHA256)
+        run: |
+          TARBALL="/tmp/redis-${TAG_NAME}.tar.gz"
+          ACTUAL_SHA256=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
+
+          echo "Expected SHA256: ${EXPECTED_SHA256}"
+          echo "Actual SHA256:   ${ACTUAL_SHA256}"
+
+          if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+            echo "::error::SHA256 checksum mismatch!"
+            exit 1
+          else
+            echo "✓ SHA256 checksum matches"
+          fi
+
+      - name: Verify tarball extraction succeeds
+        run: |
+          cd /tmp
+          echo "Extracting tarball..."
+          tar -xzf "redis-${TAG_NAME}.tar.gz"
+
+          if [ ! -d "redis-${TAG_NAME}" ]; then
+            echo "::error::Extraction failed - directory redis-${TAG_NAME} not found"
+            exit 1
+          fi
+
+          echo "✓ Tarball extracted successfully"
+          ls -la "redis-${TAG_NAME}/"
+
+      - name: Verify tarball contains all necessary files
+        run: |
+          cd "/tmp/redis-${TAG_NAME}"
+
+          # Check for critical files and directories
+          REQUIRED_FILES=(
+            "Makefile"
+            "README.md"
+            "COPYING"
+            "src/Makefile"
+            "src/redis-server.c"
+            "src/redis-cli.c"
+            "deps/jemalloc"
+            "deps/hiredis"
+            "deps/lua"
+            "runtest"
+            "runtest-sentinel"
+            "runtest-cluster"
+            "runtest-moduleapi"
+          )
+
+          MISSING_FILES=()
+          for file in "${REQUIRED_FILES[@]}"; do
+            if [ ! -e "$file" ]; then
+              MISSING_FILES+=("$file")
+            fi
+          done
+
+          if [ ${#MISSING_FILES[@]} -gt 0 ]; then
+            echo "::error::Missing required files:"
+            printf '%s\n' "${MISSING_FILES[@]}"
+            exit 1
+          fi
+
+          echo "✓ All necessary files are present"
+
+      - name: Check file permissions are correct
+        run: |
+          cd "/tmp/redis-${TAG_NAME}"
+
+          # Check that scripts are executable
+          SCRIPTS=(
+            "runtest"
+            "runtest-sentinel"
+            "runtest-cluster"
+            "runtest-moduleapi"
+            "src/mkreleasehdr.sh"
+            "utils/install_server.sh"
+          )
+
+          PERMISSION_ISSUES=()
+          for script in "${SCRIPTS[@]}"; do
+            if [ -f "$script" ] && [ ! -x "$script" ]; then
+              PERMISSION_ISSUES+=("$script is not executable")
+            fi
+          done
+
+          if [ ${#PERMISSION_ISSUES[@]} -gt 0 ]; then
+            echo "::error::Permission issues found:"
+            printf '%s\n' "${PERMISSION_ISSUES[@]}"
+            exit 1
+          fi
+
+          echo "✓ File permissions are correct"
+
+      - name: Verify no missing dependencies
+        run: |
+          cd "/tmp/redis-${TAG_NAME}"
+
+          # Check for build dependencies on Ubuntu
+          echo "Checking for required build tools..."
+
+          REQUIRED_TOOLS=(
+            "gcc"
+            "make"
+            "pkg-config"
+          )
+
+          MISSING_TOOLS=()
+          for tool in "${REQUIRED_TOOLS[@]}"; do
+            if ! command -v "$tool" &> /dev/null; then
+              MISSING_TOOLS+=("$tool")
+            fi
+          done
+
+          if [ ${#MISSING_TOOLS[@]} -gt 0 ]; then
+            echo "::error::Missing required build tools:"
+            printf '%s\n' "${MISSING_TOOLS[@]}"
+            exit 1
+          fi
+
+          echo "✓ All required dependencies are available"
+
+      - name: Build Redis from extracted tarball (not from git repo)
+        run: |
+          cd "/tmp/redis-${TAG_NAME}"
+
+          # Ensure we're building from tarball, not a git repo
+          if [ -d ".git" ]; then
+            echo "::error::Tarball should not contain .git directory"
+            exit 1
+          fi
+
+          echo "Building Redis from extracted tarball..."
+          make -j$(nproc)
+
+          # Verify binaries were created
+          BINARIES=(
+            "src/redis-server"
+            "src/redis-cli"
+            "src/redis-benchmark"
+          )
+
+          MISSING_BINARIES=()
+          for binary in "${BINARIES[@]}"; do
+            if [ ! -f "$binary" ]; then
+              MISSING_BINARIES+=("$binary")
+            fi
+          done
+
+          if [ ${#MISSING_BINARIES[@]} -gt 0 ]; then
+            echo "::error::Build failed - missing binaries:"
+            printf '%s\n' "${MISSING_BINARIES[@]}"
+            exit 1
+          fi
+
+          echo "✓ Redis built successfully from tarball"
+          ./src/redis-server --version
+
+      - name: Run smoke test (start redis-server, execute PING, shutdown)
+        run: |
+          cd "/tmp/redis-${TAG_NAME}"
+
+          echo "Starting Redis server..."
+          ./src/redis-server --daemonize yes --port 6379 --save "" --appendonly no
+
+          # Wait for Redis to start
+          sleep 2
+
+          # Check if Redis is running
+          if ! pgrep -f redis-server > /dev/null; then
+            echo "::error::Redis server failed to start"
+            exit 1
+          fi
+
+          echo "Testing PING command..."
+          PING_RESPONSE=$(./src/redis-cli PING)
+
+          if [ "$PING_RESPONSE" != "PONG" ]; then
+            echo "::error::PING test failed. Expected 'PONG', got '${PING_RESPONSE}'"
+            ./src/redis-cli SHUTDOWN NOSAVE || true
+            exit 1
+          fi
+
+          echo "✓ PING test passed"
+
+          # Test a few more basic commands
+          echo "Testing SET/GET commands..."
+          ./src/redis-cli SET test_key "test_value"
+          GET_RESPONSE=$(./src/redis-cli GET test_key)
+
+          if [ "$GET_RESPONSE" != "test_value" ]; then
+            echo "::error::SET/GET test failed"
+            ./src/redis-cli SHUTDOWN NOSAVE || true
+            exit 1
+          fi
+
+          echo "✓ SET/GET test passed"
+
+          # Shutdown Redis
+          echo "Shutting down Redis..."
+          ./src/redis-cli SHUTDOWN NOSAVE
+
+          # Wait for shutdown
+          sleep 1
+
+          # Verify Redis has stopped
+          if pgrep -f redis-server > /dev/null; then
+            echo "::error::Redis server did not shutdown properly"
+            pkill -9 redis-server || true
+            exit 1
+          fi
+
+          echo "✓ Smoke test completed successfully"
 
   # update-release-hashes:
   #   needs: test-release-tarball
@@ -130,7 +361,7 @@ jobs:
   #         # - Git credentials for committing and pushing
 
   summary-and-notify:
-    needs: [extract-release-info, create-tarball] # update-release-hashes
+    needs: [extract-release-info, create-tarball, upload-tarball, test-release-tarball] # update-release-hashes
     if: always() && github.repository == 'redis/redis'
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   extract-release-info:
-    if: github.repository == 'redis/redis' || github.repository == 'stav-nachmias/fork-redis'
+    if: github.repository == 'redis/redis'
     runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.release-info.outputs.tag_name }}
@@ -108,7 +108,7 @@ jobs:
   #         # - Adaptation of utils/releasetools/02_upload_tarball.sh for CI environment
 
   test-release-tarball:
-    needs: [extract-release-info, create-tarball] #, upload-tarball]
+    needs: [extract-release-info, create-tarball, upload-tarball]
     runs-on: ubuntu-latest
     env:
       TAG_NAME: ${{ needs.extract-release-info.outputs.tag_name }}
@@ -414,7 +414,7 @@ jobs:
   #         # - Git credentials for committing and pushing
 
   summary-and-notify:
-    needs: [extract-release-info, create-tarball, test-release-tarball] #, upload-tarball] # update-release-hashes
+    needs: [extract-release-info, create-tarball, upload-tarball, test-release-tarball]  # update-release-hashes
     if: always()
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/post-release-automation.yml
+++ b/.github/workflows/post-release-automation.yml
@@ -415,7 +415,7 @@ jobs:
 
   summary-and-notify:
     needs: [extract-release-info, create-tarball, test-release-tarball] #, upload-tarball] # update-release-hashes
-    if: always() && github.repository == 'redis/redis'
+    if: always()
     runs-on: ubuntu-latest
     env:
       TAG_NAME: ${{ needs.extract-release-info.outputs.tag_name }}
@@ -444,6 +444,7 @@ jobs:
           } >> $GITHUB_STEP_SUMMARY
 
       # - name: Send Slack notification
+      #   if: github.repository == 'redis/redis'
       #   run: |
       #     echo "TODO: Implement Slack notification"
       #     # This will require:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the release automation workflow and adds a build/run step that can fail releases due to environment/network/tooling differences (and currently depends on an `upload-tarball` job that appears disabled), but does not change product code.
> 
> **Overview**
> Adds a new `test-release-tarball` job to the post-release GitHub Actions workflow that downloads the published release tarball from `download.redis.io`, **fails fast** on size/sha256 mismatches, validates required files/permissions, builds Redis from the extracted archive, and runs a minimal runtime smoke test (PING + SET/GET).
> 
> Simplifies `create-tarball` by removing the inline size check there, and updates `summary-and-notify` to always run, include the downloaded tarball size, and surface the overall tarball test result in the GitHub step summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e58faadcae492b38174a837a88b58b9728ddace8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->