### PR TITLE
Update SECURITY.md vulnerability reporting instructions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,13 +27,13 @@ If you believe you have found a security vulnerability, to ensure proper review
 and assessment, we kindly ask vulnerability reports be submitted through
 our [Redis Vulnerability Disclosure Program.](https://redis.io/redis-responsible-vulnerability-disclosure/)
 
-We have found this path to be benifitial for both researchers and us for 
-a number of reasons. Including, offering fast response times to reasearchers and 
+We have found this path to be beneficial for both researchers and us for 
+a number of reasons. Including, offering fast response times to researchers and 
 opportunities for us to invite those with exceptional reports into closed paid 
-engagments.  
+engagements.  
 
-For those adverse to using our chosen platform, we will also accept reports directly
-via Github's "Report a Vulnerability".  
+For those averse to using our chosen platform, we will also accept reports directly
+via GitHub's "Report a Vulnerability".  
 
 To contact the security team directly with questions use: [security@redis.com](mailto:security@redis.com)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,10 +23,20 @@ unless this is not possible or feasible with a reasonable effort.
 
 ## Reporting a Vulnerability
 
-If you believe you've discovered a serious vulnerability, please contact the
-Redis core team at redis@redis.io. We will evaluate your report and if
-necessary issue a fix and an advisory. If the issue was previously undisclosed,
-we'll also mention your name in the credits.
+If you believe you have found a security vulnerability, to ensure proper review 
+and assessment, we kindly ask vulnerability reports be submitted through
+our [Redis Vulnerability Disclosure Program.](https://redis.io/redis-responsible-vulnerability-disclosure/)
+
+We have found this path to be benifitial for both researchers and us for 
+a number of reasons. Including, offering fast response times to reasearchers and 
+opportunities for us to invite those with exceptional reports into closed paid 
+engagments.  
+
+For those adverse to using our chosen platform, we will also accept reports directly
+via Github's "Report a Vulnerability".  
+
+To contact the security team directly with questions use: [security@redis.com](mailto:security@redis.com)
+
 
 ## Responsible Disclosure
 


### PR DESCRIPTION
Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no code or runtime behavior is affected, but it changes the official intake channels for vulnerability reports.
> 
> **Overview**
> Updates `SECURITY.md` to redirect vulnerability reporters from emailing the core team to using the **Redis Vulnerability Disclosure Program** link, with GitHub’s *Report a Vulnerability* as an alternative.
> 
> Adds a dedicated security contact email (`security@redis.com`) for questions and includes brief rationale for the new reporting path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeaa8c4ada3152c7dc37f6338f3d6f9c178dfdb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->