### PR TITLE
Fix double ERR prefix in XNACK error replies

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3878,7 +3878,7 @@ void xnackCommand(client *c) {
     } else if (!strcasecmp(c->argv[3]->ptr,"FATAL")) {
         mode = XNACK_FATAL;
     } else {
-        addReplyError(c,"ERR mode must be SILENT, FAIL, or FATAL");
+        addReplyError(c,"mode must be SILENT, FAIL, or FATAL");
         return;
     }
 
@@ -3897,7 +3897,7 @@ void xnackCommand(client *c) {
             numids = (int)numids_long;
             ids_start = i + 2;
             if (numids > (c->argc - ids_start)) {
-                addReplyError(c,"ERR number of IDs doesn't match numids");
+                addReplyError(c,"number of IDs doesn't match numids");
                 return;
             }
             i = ids_start + numids - 1;
@@ -3908,18 +3908,18 @@ void xnackCommand(client *c) {
             if (getLongLongFromObjectOrReply(c,c->argv[i],&retrycount,NULL) != C_OK)
                 return;
             if (retrycount < 0) {
-                addReplyError(c,"ERR Invalid RETRYCOUNT value, must be >= 0");
+                addReplyError(c,"Invalid RETRYCOUNT value, must be >= 0");
                 return;
             }
         } else {
-            addReplyErrorFormat(c,"ERR Unrecognized XNACK option '%s'",
+            addReplyErrorFormat(c,"Unrecognized XNACK option '%s'",
                                 (char *)c->argv[i]->ptr);
             return;
         }
     }
 
     if (ids_start == 0) {
-        addReplyError(c,"ERR syntax error, expected IDS keyword");
+        addReplyError(c,"syntax error, expected IDS keyword");
         return;
     }
 

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -3402,47 +3402,47 @@ start_server {
 
         # Unrecognized option at various positions — the parser accepts options
         # both before and after the IDS block, so verify rejection in each slot.
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp FAIL BADOPT IDS 1 1-0}
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp FAIL IDS 1 1-0 BADOPT}
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp SILENT BADOPT IDS 1 1-0 FORCE}
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp SILENT FORCE BADOPT IDS 1 1-0}
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp FAIL RETRYCOUNT 5 BADOPT IDS 1 1-0}
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp FAIL IDS 1 1-0 RETRYCOUNT 5 BADOPT}
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp FAIL FORCE IDS 1 1-0 BADOPT RETRYCOUNT 5}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp FAIL BADOPT IDS 1 1-0}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp FAIL IDS 1 1-0 BADOPT}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp SILENT BADOPT IDS 1 1-0 FORCE}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp SILENT FORCE BADOPT IDS 1 1-0}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp FAIL RETRYCOUNT 5 BADOPT IDS 1 1-0}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp FAIL IDS 1 1-0 RETRYCOUNT 5 BADOPT}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp FAIL FORCE IDS 1 1-0 BADOPT RETRYCOUNT 5}
 
         # Invalid mode
-        assert_error "*mode must be SILENT, FAIL, or FATAL*" {r XNACK mystream grp BADMODE IDS 1 1-0}
+        assert_error "ERR mode must be SILENT, FAIL, or FATAL" {r XNACK mystream grp BADMODE IDS 1 1-0}
 
         # Multiple mode words — only one mode is allowed per invocation.
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp FAIL FATAL IDS 1 1-0}
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp SILENT FAIL IDS 1 1-0}
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp FATAL SILENT IDS 1 1-0}
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp FAIL SILENT FATAL IDS 1 1-0}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp FAIL FATAL IDS 1 1-0}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp SILENT FAIL IDS 1 1-0}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp FATAL SILENT IDS 1 1-0}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp FAIL SILENT FATAL IDS 1 1-0}
 
         # IDS keyword validation
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp SILENT NOTIDS 1 1-0}
-        assert_error "*expected IDS keyword*" {r XNACK mystream grp SILENT FORCE RETRYCOUNT 5}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp SILENT NOTIDS 1 1-0}
+        assert_error "ERR syntax error, expected IDS keyword" {r XNACK mystream grp SILENT FORCE RETRYCOUNT 5}
 
         # numids validation
-        assert_error "*numids must be a positive integer*" {r XNACK mystream grp SILENT IDS abc 1-0}
-        assert_error "*numids must be a positive integer*" {r XNACK mystream grp SILENT IDS 0 1-0}
-        assert_error "*numids must be a positive integer*" {r XNACK mystream grp SILENT IDS -1 1-0}
-        assert_error "*number of IDs doesn't match numids*" {r XNACK mystream grp SILENT IDS 2 1-0}
+        assert_error "ERR numids must be a positive integer*" {r XNACK mystream grp SILENT IDS abc 1-0}
+        assert_error "ERR numids must be a positive integer*" {r XNACK mystream grp SILENT IDS 0 1-0}
+        assert_error "ERR numids must be a positive integer*" {r XNACK mystream grp SILENT IDS -1 1-0}
+        assert_error "ERR number of IDs doesn't match numids" {r XNACK mystream grp SILENT IDS 2 1-0}
 
         # Invalid stream ID format
-        assert_error "*Invalid stream ID*" {r XNACK mystream grp FAIL IDS 1 not-a-valid-id}
+        assert_error "ERR Invalid stream ID*" {r XNACK mystream grp FAIL IDS 1 not-a-valid-id}
 
         # RETRYCOUNT validation — non-integer, negative, overflow, missing value
-        assert_error "*value is not an integer or out of range*" {r XNACK mystream grp FAIL IDS 1 1-0 RETRYCOUNT abc}
-        assert_error "*Invalid RETRYCOUNT*" {r XNACK mystream grp FAIL IDS 1 1-0 RETRYCOUNT -1}
-        assert_error "*value is not an integer or out of range*" {r XNACK mystream grp FAIL IDS 1 1-0 RETRYCOUNT 99999999999999999999}
+        assert_error "ERR value is not an integer or out of range" {r XNACK mystream grp FAIL IDS 1 1-0 RETRYCOUNT abc}
+        assert_error "ERR Invalid RETRYCOUNT value, must be >= 0" {r XNACK mystream grp FAIL IDS 1 1-0 RETRYCOUNT -1}
+        assert_error "ERR value is not an integer or out of range" {r XNACK mystream grp FAIL IDS 1 1-0 RETRYCOUNT 99999999999999999999}
         # RETRYCOUNT without a following value — consumed as trailing option
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp FAIL IDS 1 1-0 RETRYCOUNT}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp FAIL IDS 1 1-0 RETRYCOUNT}
         # RETRYCOUNT right after mode with no IDS — too few arguments
-        assert_error "*wrong number of arguments*" {r XNACK mystream grp FAIL RETRYCOUNT}
+        assert_error "ERR wrong number of arguments for 'xnack' command" {r XNACK mystream grp FAIL RETRYCOUNT}
 
         # Extra args after numids IDs — the surplus ID is parsed as an option
-        assert_error "*Unrecognized XNACK option*" {r XNACK mystream grp FAIL IDS 1 1-0 2-0}
+        assert_error "ERR Unrecognized XNACK option*" {r XNACK mystream grp FAIL IDS 1 1-0 2-0}
     }
 
     # Verify SILENT mode decrements delivery_count by 1, clamped at 0.


### PR DESCRIPTION
Several `addReplyError` and `addReplyErrorFormat` calls in `xnackCommand` included a redundant `"ERR "` prefix in the message string. Since `addReplyErrorLength` already prepends `-ERR ` to the RESP reply, clients received `ERR ERR ...` for these error paths.

This PR removes the redundant prefix from all five affected calls and tightens the corresponding test patterns to match from the beginning of the error message (`"ERR ..."` instead of `"*...*"`), so any future double-prefix regression will be caught.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes XNACK argument-validation error strings and tightens unit tests; no behavioral changes to stream/PEL logic.
> 
> **Overview**
> Fixes `xnackCommand` error replies to avoid double-prefixing by removing the redundant `"ERR "` text from several `addReplyError`/`addReplyErrorFormat` messages.
> 
> Updates `stream-cgroups.tcl` XNACK validation tests to match the corrected RESP error format (anchoring on `ERR ...`) so regressions that reintroduce `ERR ERR` are caught.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12e4931159ca026c2e397aee0529f0075f34658a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->