### PR TITLE
Fix HFE active expire slow drain on sparse slot distribution

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -303,7 +303,7 @@ void restoreCommand(client *c) {
     if (kvtype == OBJ_HASH) {
         uint64_t minExpiredField = hashTypeGetMinExpire(kv, 1);
         if (minExpiredField != EB_EXPIRE_TIME_INVALID)
-            estoreAdd(c->db->subexpires, getKeySlot(key->ptr), kv, minExpiredField);
+            subexpiryAdd(c->db, getKeySlot(key->ptr), kv, minExpiredField);
     }
 
     if (kvtype == OBJ_STREAM)

--- a/src/db.c
+++ b/src/db.c
@@ -591,7 +591,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
     /* if hash with HFEs, take care to remove from global HFE DS before attempting
      * to manipulate and maybe free kvOld object */
     if (old->type == OBJ_HASH)
-        estoreRemove(db->subexpires, slot, old);
+        subexpiryRemove(db, slot, old);
 
     if (old->type == OBJ_STREAM)
         streamKeyRemoved(db, key, old);
@@ -855,7 +855,7 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
 
         /* If hash object with expiry on fields, remove it from HFE DS of DB */
         if (type == OBJ_HASH)
-            estoreRemove(db->subexpires, slot, kv);
+            subexpiryRemove(db, slot, kv);
 
         /* If stream with IDMP tracking, remove it from stream_idmp_keys */
         if (type == OBJ_STREAM)
@@ -2223,7 +2223,7 @@ void renameGenericCommand(client *c, int nx) {
      * global HFE DS and we will lose the expiration time. */
     int srctype = o->type;
     if (srctype == OBJ_HASH)
-        minHashExpireTime = estoreRemove(c->db->subexpires, getKeySlot(c->argv[1]->ptr), o);
+        minHashExpireTime = subexpiryRemove(c->db, getKeySlot(c->argv[1]->ptr), o);
 
     /* Prepare metadata for the renamed key */
     KeyMetaSpec keymeta;
@@ -2236,7 +2236,7 @@ void renameGenericCommand(client *c, int nx) {
 
     /* If hash with HFEs, register in DB subexpires */
     if (minHashExpireTime != EB_EXPIRE_TIME_INVALID)
-        estoreAdd(c->db->subexpires, getKeySlot(c->argv[2]->ptr), o, minHashExpireTime);
+        subexpiryAdd(c->db, getKeySlot(c->argv[2]->ptr), o, minHashExpireTime);
 
     /* Re-register stream IDMP tracking under the new key name. */
     if (srctype == OBJ_STREAM)
@@ -2318,7 +2318,7 @@ void moveCommand(client *c) {
      * aside registered expiration time. Must be before removal of the
      * object since it embeds ExpireMeta that is used by subexpires */
     if (kv->type == OBJ_HASH)
-        hashExpireTime = estoreRemove(src->subexpires, slot, kv);
+        hashExpireTime = subexpiryRemove(src, slot, kv);
 
     /* Move a side metadata before dbDelete() */
     KeyMetaSpec keymeta;
@@ -2333,7 +2333,7 @@ void moveCommand(client *c) {
     /* If object of type hash with expiration on fields. Taken care to add the
      * hash to subexpires of `dst` only after dbDelete(). */
     if (hashExpireTime != EB_EXPIRE_TIME_INVALID)
-        estoreAdd(dst->subexpires, slot, kv, hashExpireTime);
+        subexpiryAdd(dst, slot, kv, hashExpireTime);
 
     /* Register stream IDMP tracking in the destination DB. */
     if (kv->type == OBJ_STREAM)
@@ -2457,7 +2457,7 @@ void copyCommand(client *c) {
     /* If minExpiredField was set, then the object is hash with expiration
      * on fields and need to register it in global HFE DS */
     if (minHashExpire != EB_EXPIRE_TIME_INVALID)
-        estoreAdd(dst->subexpires, getKeySlot(newkey->ptr), kvCopy, minHashExpire);
+        subexpiryAdd(dst, getKeySlot(newkey->ptr), kvCopy, minHashExpire);
 
     /* Register copied stream with IDMP producers for cron-based expiration. */
     if (kvCopy->type == OBJ_STREAM)
@@ -2724,7 +2724,7 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
         /* If hash with HFEs, take care to remove from global HFE DS before attempting
          * to manipulate and maybe free kv object */
         if (kv->type == OBJ_HASH)
-            subexpiry = estoreRemove(db->subexpires, slot, kv);
+            subexpiry = subexpiryRemove(db, slot, kv);
 
         kvobj *kvnew = kvobjSetExpire(kv, when); /* release kv if reallocated */
         /* if kvobj was reallocated, update dict */
@@ -2739,7 +2739,7 @@ kvobj *setExpireByLink(client *c, redisDb *db, sds key, long long when, dictEntr
         serverAssert(de != NULL);
 
         if (subexpiry != EB_EXPIRE_TIME_INVALID)
-            estoreAdd(db->subexpires, slot, kv, subexpiry);
+            subexpiryAdd(db, slot, kv, subexpiry);
     }
 
     int writable_slave = server.masterhost && server.repl_slave_ro == 0;
@@ -2757,6 +2757,42 @@ long long getExpire(redisDb *db, sds key, kvobj *kv) {
     if (kv == NULL) kv = dbFindExpires(db, key);
     if (kv == NULL) return -1;
     return kvobjGetExpire(kv);
+}
+
+/* -------------------------------------------------------------------------
+ * db->subexpires helpers
+ *
+ * The subexpires store only tracks HFE-capable hashes (LISTPACK_EX or
+ * HT-with-HFE dict type). Other types must not enter the store: the bucket
+ * type's getExpireMeta() would dereference invalid memory.
+ *
+ * These wrappers centralise the HFE-encoding gate so callers only need the
+ * pre-existing OBJ_HASH check, e.g.:
+ *
+ *     if (kv->type == OBJ_HASH)
+ *         subexpiryRemove(db, slot, kv);
+ *
+ * Add/Update assert HFE-capability (callers must only register/refresh
+ * hashes that actually carry HFE meta — re-instates the historical estore
+ * invariant). Remove gracefully no-ops for non-HFE hashes so the generic
+ * delete paths (dbGenericDelete/RENAME/MOVE/SWAPDB/keymeta) can pass any
+ * OBJ_HASH without having to inspect the encoding first.
+ * ------------------------------------------------------------------------- */
+
+void subexpiryAdd(redisDb *db, int slot, kvobj *kv, uint64_t when) {
+    serverAssert(hashTypeHasHFEMeta(kv));
+    serverAssert(estoreAdd(db->subexpires, slot, kv, when));
+}
+
+uint64_t subexpiryRemove(redisDb *db, int slot, kvobj *kv) {
+    if (!hashTypeHasHFEMeta(kv))
+        return EB_EXPIRE_TIME_INVALID;
+    return estoreRemove(db->subexpires, slot, kv);
+}
+
+void subexpiryUpdate(redisDb *db, int slot, kvobj *kv, uint64_t when) {
+    serverAssert(hashTypeHasHFEMeta(kv));
+    serverAssert(estoreUpdate(db->subexpires, slot, kv, when));
 }
 
 /* Delete the specified expired or evicted key and propagate to replicas.

--- a/src/estore.c
+++ b/src/estore.c
@@ -13,7 +13,6 @@
 #include "estore.h"
 #include "zmalloc.h"
 #include "redisassert.h"
-#include "server.h"
 #include <string.h>
 
 /* Forward declaration of the estore structure */
@@ -116,75 +115,79 @@ void estoreActiveExpire(estore *es, int eidx, ExpireInfo *info) {
     ebuckets *eb = estoreGetBuckets(es, eidx);
     uint64_t before = ebGetTotalItems(*eb, es->bucket_type);
     ebExpire(eb, es->bucket_type, info);
-    /* If items expired (or updated), update the BIT and estore count */
+    /* If items expired (or updated), update the BIT and estore count.
+     * `diff` counts items removed from the bucket, so the Fenwick tree
+     * delta must be negative to reflect the decrease. */
     if (info->itemsExpired) {
         uint64_t diff = before - ebGetTotalItems(*eb, es->bucket_type);
-        fwTreeUpdate(es->buckets_sizes, eidx, (long long) diff);
+        fwTreeUpdate(es->buckets_sizes, eidx, -(long long) diff);
         es->count -= diff;
     }
 }
 
-/* Add item to estore with the given expiration time. The item must has
- * expireMeta already allocated. */
-void estoreAdd(estore *es, int eidx, eItem item, uint64_t when) {
+/* Add item to estore with the given expiration time. The item must embed a
+ * valid ExpireMeta retrievable via es->bucket_type->getExpireMeta(item).
+ * Returns 1 on success, 0 if the item is already in the bucket. */
+int estoreAdd(estore *es, int eidx, eItem item, uint64_t when) {
     debugAssert(es != NULL && item != NULL);
-
-    /* currently only used by hash field expiration. Verify it has expireMeta */
-    debugAssert((((robj *)item)->encoding == OBJ_ENCODING_LISTPACK_EX) ||
-                ((((robj *)item)->encoding == OBJ_ENCODING_HT) &&
-                 ((dict *) ((robj *)item)->ptr)->type == &entryHashDictTypeWithHFE));
+    debugAssert(eidx < es->num_buckets);
 
     ebuckets *bucket = estoreGetBuckets(es, eidx);
-    if (ebAdd(bucket, es->bucket_type, item, when) == 0) {
-        es->count++;
-        fwTreeUpdate(es->buckets_sizes, eidx, 1);
-    }
+    if (ebAdd(bucket, es->bucket_type, item, when) != 0)
+        return 0;
+    es->count++;
+    fwTreeUpdate(es->buckets_sizes, eidx, 1);
+    return 1;
 }
 
-/* Remove an item from the expiration store. Returns the expire time or EB_EXPIRE_TIME_INVALID */
+/* Remove an item from the expiration store. Returns the removed item's
+ * expiration time, or EB_EXPIRE_TIME_INVALID if the item was not present
+ * (either its ExpireMeta was marked trash, or it wasn't in the bucket).
+ *
+ * The caller must guarantee that `item` embeds an ExpireMeta matching
+ * `es->bucket_type`. Type-specific gating (e.g. skipping non-HFE hashes
+ * for the subexpires store) is the caller's responsibility. */
 uint64_t estoreRemove(estore *es, int eidx, eItem item) {
     uint64_t expireTime;
     debugAssert(es != NULL && item != NULL);
+    debugAssert(eidx < es->num_buckets);
 
-    /* Currently only used by hash field expiration. gracefully ignore otherwise */
-    kvobj *kv = (kvobj *) item;
-    if ( (kv->type != OBJ_HASH) ||
-         (kv->encoding == OBJ_ENCODING_LISTPACK) ||
-         ((kv->encoding == OBJ_ENCODING_HT) && (((dict *)kv->ptr)->type != &entryHashDictTypeWithHFE)))
-        return EB_EXPIRE_TIME_INVALID;
-
-    /* If (ExpireMeta of kv) marked as trash, then it is already removed */
+    /* If (ExpireMeta of item) is marked as trash, then it is already removed */
     if ((expireTime = ebGetExpireTime(es->bucket_type, item)) == EB_EXPIRE_TIME_INVALID)
         return EB_EXPIRE_TIME_INVALID;
 
     ebuckets *bucket = estoreGetBuckets(es, eidx);
-    serverAssert(ebRemove(bucket, es->bucket_type, item)==1);
+    if (!ebRemove(bucket, es->bucket_type, item))
+        return EB_EXPIRE_TIME_INVALID;
+
     es->count--;
     fwTreeUpdate(es->buckets_sizes, eidx, -1);
 
     return expireTime;
 }
 
-/* Update an item's expiration time in the store */
-void estoreUpdate(estore *es, int eidx, eItem item, uint64_t when) {
+/* Update an item's expiration time in the store. Returns 1 on success, 0
+ * if the item is not currently registered in the bucket (caller must hold
+ * its own invariants if a miss is unexpected). estore->count is unchanged
+ * on either path. */
+int estoreUpdate(estore *es, int eidx, eItem item, uint64_t when) {
     debugAssert(es != NULL && item != NULL);
+    debugAssert(eidx < es->num_buckets);
 
-    /* currently only used by hash field expiration. Verify it has expireMeta */
-    debugAssert((((robj *)item)->encoding == OBJ_ENCODING_LISTPACK_EX) ||
-                ((((robj *)item)->encoding == OBJ_ENCODING_HT) &&
-                 ((dict *) ((robj *)item)->ptr)->type == &entryHashDictTypeWithHFE));
-
-    debugAssert(ebGetExpireTime(es->bucket_type, item) != EB_EXPIRE_TIME_INVALID);
+    if (ebGetExpireTime(es->bucket_type, item) == EB_EXPIRE_TIME_INVALID)
+        return 0;
 
     ebuckets *bucket = estoreGetBuckets(es, eidx);
 
     /* Remove the item from its current position */
-    serverAssert(ebRemove(bucket, es->bucket_type, item) != 0);
+    if (!ebRemove(bucket, es->bucket_type, item))
+        return 0;
 
-    /* Add the item back with the new expiration time */
-    serverAssert(ebAdd(bucket, es->bucket_type, item, when) == 0);
+    /* Add the item back with the new expiration time. */
+    if (ebAdd(bucket, es->bucket_type, item, when) != 0)
+        return 0;
 
-    /* Note that estore count remain unchanged */
+    return 1;
 }
 
 /* Get the total number of items in the expiration store */
@@ -194,9 +197,9 @@ uint64_t estoreSize(estore *es) {
 
 /* Move ebuckets from one estore to another */
 void estoreMoveEbuckets(estore *src, estore *dst, int eidx) {
-    serverAssert(src->num_buckets > eidx);
-    serverAssert(src->num_buckets == dst->num_buckets);
-    serverAssert(ebIsEmpty(dst->ebArray[eidx])); /* If it is NULL */
+    assert(src->num_buckets > eidx);
+    assert(src->num_buckets == dst->num_buckets);
+    assert(ebIsEmpty(dst->ebArray[eidx])); /* If it is NULL */
 
     /* Adjust source estore */
     ebuckets eb = src->ebArray[eidx];
@@ -217,10 +220,12 @@ void estoreMoveEbuckets(estore *src, estore *dst, int eidx) {
 #include "testhelp.h"
 
 #define TEST(name) printf("test — %s\n", name);
+#ifndef UNUSED
+#define UNUSED(x) (void)(x)
+#endif
 
 /* Test item structure for estore testing */
 typedef struct TestItem {
-    kvobj kv;  /* mimic kvobj of type HASH to pass checks in estore */
     ExpireMeta mexpire;
     int index;
 } TestItem;
@@ -246,9 +251,6 @@ static TestItem *createTestItem(int index) {
     TestItem *item = zmalloc(sizeof(TestItem));
     item->index = index;
     item->mexpire.trash = 1;
-    /* mimic kvobj of type HASH to pass checks in estore */
-    item->kv.type = OBJ_HASH;
-    item->kv.encoding = OBJ_ENCODING_LISTPACK_EX;
     return item;
 }
 
@@ -262,10 +264,6 @@ int estoreTest(int argc, char **argv, int flags) {
     UNUSED(argc);
     UNUSED(argv);
     UNUSED(flags);
-
-    /* Initialize minimal server state needed for testing */
-    server.hz = 10;
-    server.unixtime = time(NULL);
 
     TEST("Create and destroy estore") {
         estore *es = estoreCreate(&testEbucketsType, 0);
@@ -478,10 +476,17 @@ int estoreTest(int argc, char **argv, int flags) {
         /* The expired items should be removed, future item should remain */
         assert(expireInfo.itemsExpired == 2);
         assert(estoreSize(es) == 2);
-        
+
         estoreActiveExpire(es, 1, &expireInfo);
         assert(expireInfo.itemsExpired == 1);
         assert(estoreSize(es) == 1);
+
+        /* After active expiration, the Fenwick tree must reflect the bucket
+         * occupancy accurately. Bucket 0 still holds futureItem; bucket 1 was
+         * drained. Any phantom count in the tree would be reported here by
+         * estoreGetFirstNonEmptyBucket/estoreGetNextNonEmptyBucket. */
+        assert(estoreGetFirstNonEmptyBucket(es) == 0);
+        assert(estoreGetNextNonEmptyBucket(es, 0) == -1);
 
         /* Clean up remaining item */
         estoreRemove(es, 0, futureItem);

--- a/src/estore.h
+++ b/src/estore.h
@@ -63,11 +63,20 @@ void estoreRelease(estore *es);
 
 void estoreActiveExpire(estore *es, int eidx, ExpireInfo *info);
 
+/* Remove `item` from the eidx'th bucket of `es`. Returns the item's
+ * registered expire time on success; EB_EXPIRE_TIME_INVALID if the item
+ * was not present (ExpireMeta marked trash, or not in the bucket). */
 uint64_t estoreRemove(estore *es, int eidx, eItem item);
 
-void estoreAdd(estore *es, int eidx, eItem item, uint64_t when);
+/* Add `item` with expire `when` to the eidx'th bucket. The item must
+ * embed a valid ExpireMeta matching `es->bucket_type`. Returns 1 on
+ * success, 0 if the item is already in the bucket. */
+int estoreAdd(estore *es, int eidx, eItem item, uint64_t when);
 
-void estoreUpdate(estore *es, int eidx, eItem item, uint64_t when);
+/* Re-register `item` with a new expire time. Returns 1 on success, 0 if
+ * the item is not currently in the bucket. estore->count is unchanged
+ * on either path. */
+int estoreUpdate(estore *es, int eidx, eItem item, uint64_t when);
 
 uint64_t estoreSize(estore *es);
 

--- a/src/expire.c
+++ b/src/expire.c
@@ -249,16 +249,6 @@ static inline void activeSubexpiresCycle(int type) {
     if (currentSlot == -1)
         currentSlot = estoreGetFirstNonEmptyBucket(db->subexpires);
 
-    /* During atomic slot migration, keys that are being imported are in an
-     * intermediate state. We cannot expire them and therefore skip them. */
-    if (!clusterCanAccessKeysInSlot(currentSlot)) {
-        /* Move to next non-empty subexpires slot */
-        currentSlot = estoreGetNextNonEmptyBucket(db->subexpires, currentSlot);
-        if (currentSlot == -1)
-            currentDb = (currentDb + 1) % server.dbnum; /* Move to next db */
-        return;
-    }
-
     /* Maximum number of fields to actively expire on a single call */
     uint32_t maxToExpire = HFE_DB_BASE_ACTIVE_EXPIRE_FIELDS_PER_SEC / server.hz;
 
@@ -271,14 +261,35 @@ static inline void activeSubexpiresCycle(int type) {
         maxToExpire *= (factor<32) ? factor : 32;
     }
 
-    if (activeSubexpires(db, currentSlot, maxToExpire) == maxToExpire) {
-        /* active-expire reached maxToExpire limit */
+    /* Iterate non-empty slots within the maxToExpire budget so a single tick
+     * drains sparsely-populated estores (typical HFE workload: many small
+     * hashes each with a single TTL'd field land in their own slot) without
+     * exceeding the per-tick CPU cap. Skip slots that are importing (atomic
+     * slot migration). */
+    uint32_t remaining = maxToExpire;
+    while (remaining > 0 && currentSlot != -1) {
+        if (!clusterCanAccessKeysInSlot(currentSlot)) {
+            currentSlot = estoreGetNextNonEmptyBucket(db->subexpires, currentSlot);
+            continue;
+        }
+        uint32_t before = remaining;
+        uint64_t expired = activeSubexpires(db, currentSlot, remaining);
+        remaining -= (uint32_t)expired;
+        if (expired == before) {
+            /* Slot still has work left; stop here so next cycle resumes
+             * from this same slot. */
+            break;
+        }
+        /* Slot drained; advance cursor. */
+        currentSlot = estoreGetNextNonEmptyBucket(db->subexpires, currentSlot);
+    }
+
+    if (remaining == 0) {
+        /* Hit the per-cycle cap; indicate potential need to scale up. */
         activeExpirySequence += maxToExpire;
     } else {
-        /* Managed to active-expire all expired fields of currentDb */
+        /* Drained everything we could access within the budget. */
         activeExpirySequence = 0;
-        /* Move to next non-empty subexpires slot */
-        currentSlot = estoreGetNextNonEmptyBucket(db->subexpires, currentSlot);
         if (currentSlot == -1)
             currentDb = (currentDb + 1) % server.dbnum;
     }

--- a/src/keymeta.c
+++ b/src/keymeta.c
@@ -817,7 +817,7 @@ kvobj *keyMetaSetMetadata(redisDb *db, kvobj *kv, KeyMetaClassId id, uint64_t me
     /* Preserve HFE registration for hash objects (embedded in object memory). */
     uint64_t subexpiry = EB_EXPIRE_TIME_INVALID;
     if (kv->type == OBJ_HASH)
-        subexpiry = estoreRemove(db->subexpires, slot, kv);
+        subexpiry = subexpiryRemove(db, slot, kv);
 
     /* Preserve existing expire value (and whether an expires entry exists). */
     long long old_expire_val = kvobjGetExpire(kv);
@@ -854,7 +854,7 @@ kvobj *keyMetaSetMetadata(redisDb *db, kvobj *kv, KeyMetaClassId id, uint64_t me
 
     /* Re-register in HFE if needed. */
     if (subexpiry != EB_EXPIRE_TIME_INVALID)
-        estoreAdd(db->subexpires, slot, kv, subexpiry);
+        subexpiryAdd(db, slot, kv, subexpiry);
 
     return kv;
 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4153,7 +4153,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             if (kv->type == OBJ_HASH) {
                 uint64_t minExpiredField = hashTypeGetMinExpire(kv, 1);
                 if (minExpiredField != EB_EXPIRE_TIME_INVALID)
-                    estoreAdd(db->subexpires, getKeySlot(key), kv, minExpiredField);
+                    subexpiryAdd(db, getKeySlot(key), kv, minExpiredField);
             }
 
             /* Register streams with IDMP producers for cron-based expiration. */

--- a/src/server.h
+++ b/src/server.h
@@ -3830,6 +3830,7 @@ void hashTypeFree(robj *o);
 int hashTypeIsExpired(const robj *o, uint64_t expireAt);
 unsigned char *hashTypeListpackGetLp(robj *o);
 uint64_t hashTypeGetMinExpire(robj *o, int accurate);
+int hashTypeHasHFEMeta(robj *o);
 ebuckets *hashTypeGetDictMetaHFE(dict *d);
 void initDictExpireMetadata(robj *o);
 struct listpackEx *listpackExCreate(void);
@@ -4013,6 +4014,9 @@ int dbDelete(redisDb *db, robj *key);
 int dbDeleteSkipKeysizesUpdate(redisDb *db, robj *key);
 kvobj *dbUnshareStringValue(redisDb *db, robj *key, kvobj *o);
 kvobj *dbUnshareStringValueByLink(redisDb *db, robj *key, kvobj *kv, dictEntryLink link);
+void subexpiryAdd(redisDb *db, int slot, kvobj *kv, uint64_t when);
+uint64_t subexpiryRemove(redisDb *db, int slot, kvobj *kv);
+void subexpiryUpdate(redisDb *db, int slot, kvobj *kv, uint64_t when);
 
 #define FLUSH_TYPE_ALL   0
 #define FLUSH_TYPE_DB    1

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -160,6 +160,17 @@ static inline int isDictWithMetaHFE(dict *d) {
     return d->type == &entryHashDictTypeWithHFE;
 }
 
+/* Does the hash carry the HFE schema (i.e. an embedded ExpireMeta that can be
+ * safely read via hashGetExpireMeta)? Only LISTPACK_EX and HT-with-HFE dict
+ * type qualify. The subexpires* helpers in db.c use this internally; direct
+ * estoreAdd/Remove against db->subexpires must NOT be called from anywhere
+ * other than those wrappers. */
+int hashTypeHasHFEMeta(robj *o) {
+    if (o->encoding == OBJ_ENCODING_LISTPACK_EX) return 1;
+    if (o->encoding == OBJ_ENCODING_HT && isDictWithMetaHFE((dict *)o->ptr)) return 1;
+    return 0;
+}
+
 /*-----------------------------------------------------------------------------
  * setex* - Set field's expiration
  *
@@ -1270,12 +1281,12 @@ void hashTypeSetExDone(HashTypeSetEx *ex) {
     int slot = getKeySlot(ex->key->ptr);
     if (ex->minExpire != EB_EXPIRE_TIME_INVALID) {
         if (newMinExpire != EB_EXPIRE_TIME_INVALID)
-            estoreUpdate(ex->db->subexpires, slot, ex->hashObj, newMinExpire);
+            subexpiryUpdate(ex->db, slot, ex->hashObj, newMinExpire);
         else
-            estoreRemove(ex->db->subexpires, slot, ex->hashObj);
+            subexpiryRemove(ex->db, slot, ex->hashObj);
     } else {
         if (newMinExpire != EB_EXPIRE_TIME_INVALID)
-            estoreAdd(ex->db->subexpires, slot, ex->hashObj, newMinExpire);
+            subexpiryAdd(ex->db, slot, ex->hashObj, newMinExpire);
     }
 }
 
@@ -1702,7 +1713,7 @@ void hashTypeConvertListpackEx(redisDb *db, robj *o, int enc) {
         if (db && lpt->meta.trash != 1) {
             minExpire = hashTypeGetMinExpire(o, 0);
             slot = getKeySlot(kvobjGetKey(o));
-            estoreRemove(db->subexpires, slot, o);
+            subexpiryRemove(db, slot, o);
         }
 
         dict = dictCreate(&entryHashDictTypeWithHFE);
@@ -1739,7 +1750,7 @@ void hashTypeConvertListpackEx(redisDb *db, robj *o, int enc) {
         o->ptr = dict;
 
         if (minExpire != EB_EXPIRE_TIME_INVALID)
-            estoreAdd(db->subexpires, slot, o, minExpire);
+            subexpiryAdd(db, slot, o, minExpire);
     } else {
         serverPanic("Unknown hash encoding: %d", enc);
     }
@@ -1946,7 +1957,7 @@ uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexp
 
         if (updateSubexpires) {
             slot = getKeySlot(keystr);
-            estoreRemove(db->subexpires, slot, o);
+            subexpiryRemove(db, slot, o);
         }
 
         if (hashTypeLength(o, 0) == 0) {
@@ -1956,7 +1967,7 @@ uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexp
             deleted = 1;
         } else {
             if ((updateSubexpires) && (info.nextExpireTime != EB_EXPIRE_TIME_INVALID))
-                estoreAdd(db->subexpires, slot, o, info.nextExpireTime);
+                subexpiryAdd(db, slot, o, info.nextExpireTime);
         }
 
         keyModified(NULL, db, key, deleted ? NULL : o, 1);
@@ -2842,7 +2853,7 @@ void hgetdelCommand(client *c) {
         updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldsize, kvobjAllocSize(o));
     /* is it last HFE */
     if (!delete_key && hfe && (hashTypeIsFieldsWithExpire(o) == 0))
-        estoreRemove(c->db->subexpires, getKeySlot(c->argv[1]->ptr), o);
+        subexpiryRemove(c->db, getKeySlot(c->argv[1]->ptr), o);
     
     keyModified(c, c->db, c->argv[1], o, 1);
 
@@ -3091,7 +3102,7 @@ void hdelCommand(client *c) {
         } else {
             /* is it last HFE */
             if (isHFE && (hashTypeIsFieldsWithExpire(o) == 0))
-                estoreRemove(c->db->subexpires, getKeySlot(c->argv[1]->ptr), o);
+                subexpiryRemove(c->db, getKeySlot(c->argv[1]->ptr), o);
         }
 
         /* Signal key modification */

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -2585,3 +2585,41 @@ start_server {tags {"hash"}} {
         }
     }
 }
+
+start_cluster 1 0 {tags {"expire external:skip cluster"}} {
+    test "HFE active expire drains many sparse slots within budget" {
+        # In cluster mode, db->subexpires is slot-partitioned across
+        # CLUSTER_SLOTS buckets. activeSubexpiresCycle processes one slot per
+        # cron tick. When each hash lives in its own slot (typical HFE
+        # workload: many small hashes with a single TTL'd field), draining N
+        # hashes takes N cron ticks. At hz=10, N=200 hashes => ~20 s to fully
+        # drain, which is the bug this test catches. A reasonable per-tick
+        # CPU budget (maxToExpire fields) should allow draining many sparse
+        # slots in one tick.
+        r config set hz 10
+        r debug set-active-expire 0
+
+        set n 200
+        set ttl_ms 50
+        for {set i 1} {$i <= $n} {incr i} {
+            r hset "h$i" f v
+            r hpexpire "h$i" $ttl_ms FIELDS 1 f
+        }
+
+        assert_equal [get_stat_subexpiry r] $n
+
+        # Wait for the TTL to elapse in wall-clock time (no timeleap in
+        # the core testsuite).
+        after [expr {$ttl_ms + 50}]
+
+        # Re-enable active expire. Give the cron 2 seconds to drain 200
+        # sparse slots. Without the fix this takes ~20 s; test fails.
+        r debug set-active-expire 1
+
+        wait_for_condition 20 100 {
+            [get_stat_subexpiry r] == 0
+        } else {
+            fail "subexpiry stuck at [get_stat_subexpiry r] after 2 s; expected 0 (one-slot-per-tick too slow for sparse distribution)"
+        }
+    }
+}


### PR DESCRIPTION
- **Drain many cluster slots per cron tick instead of one.** HFE workloads are often "many small hashes, each with a single TTL'd field" → each hash lands in its own cluster slot. One-slot-per-tick at hz=10 took ~20 s to drain 200 hashes; expired fields stayed visible to clients. Now a single tick iterates non-empty slots within the existing per-tick deletion budget, stops where the budget runs out so the cursor resumes there next tick, and skips slots blocked by atomic slot migration inline.

- **Fix Fenwick (BIT) sign on active expire.** The bucket-occupancy index was being inflated (`+diff`) instead of decremented (`-diff`) every time fields expired. The "next non-empty slot" lookup kept returning drained slots, so even with the slot cursor advancing correctly, active-expire wasted work on phantom slots.

- **Make the expiration store type-agnostic.** It was leaking hash-encoding asserts and a hash-only header dependency into a structure that is otherwise just an indexed expiration store. Encoding gating belongs at the call site, not inside the data structure; pulling it out keeps the store reusable for future per-field-TTL types.

- **Centralise the "who is allowed in subexpires" rule.** Registration/removal/update of HFE hashes in the per-DB subexpires store happened from many places, each independently checking encoding. Replaced with thin wrappers that gate on a single named helper. Add/Update assert HFE-capable hashes (the caller already knows); Remove no-ops gracefully so generic delete paths can pass any hash without inspecting the encoding first.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes active expiration scheduling and the subexpires/estore bookkeeping used for hash-field expirations, which can impact expiry correctness and performance under cluster workloads.
> 
> **Overview**
> Fixes HFE active expiration in cluster mode so a single cron tick can iterate across multiple non-empty slots within the existing `maxToExpire` budget (skipping slots blocked by atomic slot migration), instead of expiring at most one slot per tick.
> 
> Corrects `estoreActiveExpire`’s Fenwick-tree update so bucket occupancy is decremented when items expire, and refactors `estoreAdd`/`estoreUpdate` to return success/failure rather than asserting.
> 
> Centralizes subexpires registration behind new `subexpiryAdd`/`subexpiryRemove`/`subexpiryUpdate` wrappers gated by `hashTypeHasHFEMeta`, replacing direct `estore*` calls across key lifecycle paths (RDB load/RESTORE, rename/move/copy, keymeta, hash encoding conversions). Adds a cluster regression test that ensures sparse-slot HFE expirations drain quickly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9084b5598e6b68cb26c0c89a406c9d56dd7e65aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->