### PR TITLE
gcraCommand, gcraSetValueCommand use ceil operation for division (conversion us to ms)

### DIFF
--- a/src/gcra.c
+++ b/src/gcra.c
@@ -212,8 +212,9 @@ void gcraCommand(client *c) {
         /* TaT is in microseconds; expirations are absolute ms. Ceil so the key
          * does not expire in the same millisecond when increment_us < 1000us
          * (floor would truncate TaT to the current ms and active expire could
-         * drop the key immediately, losing limiter state). */
-        long long when = (new_tat_us + 999) / 1000;
+         * drop the key immediately, losing limiter state). Use ceil() rather than
+         * (tat+999)/1000 to avoid signed overflow when tat is near LLONG_MAX. */
+        long long when = (long long)ceil((double)new_tat_us / 1000.0);
         kv = setExpireByLink(c, c->db, key->ptr, when, link);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);
 
@@ -273,7 +274,7 @@ void gcraSetValueCommand(client *c) {
 
     /* Use ceil(ms) from tat microseconds so expire is not truncated to the past
      * or current millisecond. */
-    long long when_ms = (when + 999) / 1000;
+    long long when_ms = (long long)ceil((double)when / 1000.0);
     kv = setExpireByLink(c, c->db, key->ptr, when_ms, link);
     notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);
     server.dirty++;

--- a/src/gcra.c
+++ b/src/gcra.c
@@ -208,7 +208,12 @@ void gcraCommand(client *c) {
          * These keys are expected to be numerous and short lived thus the
          * decision to keep the implicit expiraty.
          * NOTE: idea is same as in redis-cell. */
-        long long when = new_tat_us / 1000;
+
+        /* TaT is in microseconds; expirations are absolute ms. Ceil so the key
+         * does not expire in the same millisecond when increment_us < 1000us
+         * (floor would truncate TaT to the current ms and active expire could
+         * drop the key immediately, losing limiter state). */
+        long long when = (new_tat_us + 999) / 1000;
         kv = setExpireByLink(c, c->db, key->ptr, when, link);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);
 
@@ -265,7 +270,10 @@ void gcraSetValueCommand(client *c) {
     notifyKeyspaceEvent(NOTIFY_RATE_LIMIT,"gcra",key,c->db->id);
 
     /* Just like the base GCRA command we set the expire time of the key implicitly. */
-    long long when_ms = when / 1000;
+
+    /* Use ceil(ms) from tat microseconds so expire is not truncated to the past
+     * or current millisecond. */
+    long long when_ms = (when + 999) / 1000;
     kv = setExpireByLink(c, c->db, key->ptr, when_ms, link);
     notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);
     server.dirty++;

--- a/tests/unit/gcra.tcl
+++ b/tests/unit/gcra.tcl
@@ -71,6 +71,18 @@ start_server {tags {"gcra" "external:skip"}} {
         assert_equal 0 $limited
     }
 
+    test {GCRA - sub-millisecond TaT does not expire key at current ms (PXAT ceil)} {
+        r del mykey
+        # 10k tokens / 1s => 100us emission interval.
+        # First allowed TaT is now+100us; still inside the same ms as commandTimeSnapshot*1000,
+        # so floor(TaT/1000) for PXAT can equal current ms and the key vanishes before the next command.
+        # Ceil ms fixes the issue.
+        set result [r gcra mykey 1 10000 1]
+        assert_equal 0 [lindex $result 0]
+        assert_equal 1 [r exists mykey]
+        assert {[r pttl mykey] > 0}
+    }
+
     test {GCRA - requests within burst are allowed} {
         r del mykey
         # max_burst=5, tokens_per_period=1, period=60

--- a/tests/unit/gcra.tcl
+++ b/tests/unit/gcra.tcl
@@ -76,11 +76,15 @@ start_server {tags {"gcra" "external:skip"}} {
         # 10k tokens / 1s => 100us emission interval.
         # First allowed TaT is now+100us; still inside the same ms as commandTimeSnapshot*1000,
         # so floor(TaT/1000) for PXAT can equal current ms and the key vanishes before the next command.
-        # Ceil ms fixes the issue.
-        set result [r gcra mykey 1 10000 1]
-        assert_equal 0 [lindex $result 0]
-        assert_equal 1 [r exists mykey]
-        assert {[r pttl mykey] > 0}
+        # Ceil ms fixes the issue. Implicit TTL can be ~1ms, so run GCRA + EXISTS + PTTL inside one
+        # EVAL: slow CI can otherwise expire the key between separate redis.tcl round trips.
+        set res [r eval {
+            local g = redis.call('GCRA', KEYS[1], '1', '10000', '1')
+            return {g[1], redis.call('EXISTS', KEYS[1]), redis.call('PTTL', KEYS[1])}
+        } 1 mykey]
+        assert_equal 0 [lindex $res 0]
+        assert_equal 1 [lindex $res 1]
+        assert {[lindex $res 2] > 0}
     }
 
     test {GCRA - requests within burst are allowed} {


### PR DESCRIPTION
## Problem

GCRA stores the next TaT in microseconds, but the key’s expiry is stored in milliseconds.

The code turned TaT into milliseconds with integer division (which will always floor). When the gap between “now” and the new TaT is smaller than one millisecond (which happens if the emission interval rounds to a few microseconds, e.g. very high tokens per second, idk in production what is the usual tokens per second rate or if this fix would make sense in real world scenarios), that floor could map TaT to the same millisecond as “now”.

Redis then treats the key as already expired. So the limiter key can disappear right after a successful, “allowed” GCRA call, even though the microsecond TaT is still in the future. The next GCRA looks like a fresh key and rate limiting is theoretically wrong.

## Test

Adding a regression test that uses parameters where TaT advances by less than a millisecond (e.g. high tokens_per_period with a 1s period so the emission interval is 1 microsecond).

Right after a single allowed GCRA, the test checks that the key still exists and PTTL is positive. The point here is to catch immediate loss of the key from bad/wrong truncation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to key expiry rounding plus a regression test; main risk is subtly extending TTL by up to 1ms in some cases.
> 
> **Overview**
> Fixes a GCRA edge case where converting microsecond TaT to millisecond expirations via integer division could truncate into the current millisecond and cause immediate key expiry, losing rate-limiter state.
> 
> `gcraCommand` and `gcraSetValueCommand` now compute the absolute expire time as `ceil(tat_us/1000)` (with comments noting overflow avoidance), and a new unit test asserts that with a sub-millisecond emission interval the key still exists and has positive `PTTL` immediately after an allowed `GCRA` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c6fedd6a9b88018669d853ffb7a08604a105c91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->