### PR TITLE
Tail-append fast path for ZRANGESTORE skiplist destination

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -338,113 +338,6 @@ zskiplistNode *zslInsert(zskiplist *zsl, double score, sds ele) {
     return node;
 }
 
-/* Tail-append cache used by zslAppendTailCached(): callers track the
- * per-level rightmost node + total level-0 hops from header to reach it,
- * so sequential sorted inserts skip the walk-from-head that zslInsertNode()
- * performs. Must be zeroed before first use; 'initialized' is set by the
- * first call. The 'rank' values here follow zslInsertNode() semantics:
- * for a node at 0-indexed position p, rank = p + 1 (i.e. hops-from-header). */
-typedef struct zslTailCache {
-    zskiplistNode *update[ZSKIPLIST_MAXLEVEL];
-    unsigned long rank[ZSKIPLIST_MAXLEVEL];
-    int initialized;
-} zslTailCache;
-
-/* Append an already-created node at the tail of the skiplist, using a
- * per-level tail cache to avoid the zslInsertNode() walk-from-head.
- *
- * CALLER CONTRACT: 'node's (score, element) must be >= the current tail's
- * (score, element) under zslCompareWithNode(). If the invariant doesn't
- * hold the resulting skiplist is corrupted, so this is intended for
- * bulk-construction paths (e.g. ZRANGESTORE forward direction) that can
- * prove the invariant by construction.
- *
- * Span bookkeeping is kept identical to zslInsertNode(): level-0 spans are
- * implicit (derived from the forward pointer); level >= 1 spans are written
- * using the same (rank[0] - rank[i]) + 1 formula so zslGetRank() /
- * zslDelete() continue to work on the resulting skiplist. */
-static void zslAppendTailCached(zskiplist *zsl, zskiplistNode *node, zslTailCache *cache) {
-    int level = zslGetNodeInfo(node)->levels;
-    unsigned long insert_rank = zsl->length;  /* 0-indexed position of the new node */
-
-    if (!cache->initialized) {
-        /* Seed the cache with the current per-level rightmost node. Empty
-         * skiplist: update[i] = header, rank = 0. Non-empty (e.g. the
-         * destination was just converted from listpack to skiplist mid-
-         * store): walk the existing tail chain so our update[]/rank[]
-         * match what zslInsertNode() would have computed, otherwise the
-         * first stitch would overwrite header.forward and corrupt the
-         * existing chain. */
-        if (zsl->length == 0) {
-            for (int i = 0; i < ZSKIPLIST_MAXLEVEL; i++) {
-                cache->update[i] = zsl->header;
-                cache->rank[i] = 0;
-            }
-        } else {
-            zskiplistNode *x = zsl->header;
-            unsigned long r = 0;
-            for (int i = zsl->level - 1; i >= 0; i--) {
-                while (x->level[i].forward != NULL) {
-                    r += zslGetNodeSpanAtLevel(x, i);
-                    x = x->level[i].forward;
-                }
-                cache->update[i] = x;
-                cache->rank[i] = r;
-            }
-            for (int i = zsl->level; i < ZSKIPLIST_MAXLEVEL; i++) {
-                cache->update[i] = zsl->header;
-                cache->rank[i] = 0;
-            }
-        }
-        cache->initialized = 1;
-    }
-
-    /* Extend skiplist level if the new node exceeds the current top. Matches
-     * the new-level branch of zslInsertNode() so headers' span accounting
-     * stays consistent (the intermediate zsl->length value is overwritten in
-     * the main stitch loop below for levels < 'level'). */
-    if (level > zsl->level) {
-        for (int i = zsl->level; i < level; i++) {
-            cache->update[i] = zsl->header;
-            cache->rank[i] = 0;
-            zslSetNodeSpanAtLevel(zsl->header, i, zsl->length);
-        }
-        zsl->level = level;
-        zslGetNodeInfo(zsl->header)->levels = level;
-    }
-
-    zskiplistNode *prev_level0 = cache->update[0];
-
-    /* Stitch the new node as the rightmost at each of its levels. */
-    for (int i = 0; i < level; i++) {
-        node->level[i].forward = NULL;  /* tail at this level */
-        cache->update[i]->level[i].forward = node;
-        /* New tail at level i has span 0; no-op at level 0 via setter. */
-        zslSetNodeSpanAtLevel(node, i, 0);
-        /* Predecessor span: distance from it (exclusive) to the new node
-         * (inclusive) in level-0 hops, using zslInsertNode's formula. */
-        zslSetNodeSpanAtLevel(cache->update[i], i, (insert_rank - cache->rank[i]) + 1);
-        cache->update[i] = node;
-        /* rank[i] = hops from header to update[i]. For a node at 0-indexed
-         * position insert_rank, that is insert_rank + 1 (matches the
-         * post-walk rank[i] zslInsertNode would produce for update[i]). */
-        cache->rank[i] = insert_rank + 1;
-    }
-
-    /* Levels above 'level': the existing rightmost at each level gains one
-     * more level-0 node beyond it, so its span grows by 1 (no-op at level 0).
-     * Its rank from header is unchanged (same node at same position). */
-    for (int i = level; i < zsl->level; i++) {
-        zslIncrNodeSpanAtLevel(cache->update[i], i, 1);
-    }
-
-    /* Backward pointer + tail update. Always-tail means node->forward[0]
-     * is NULL, so no existing node's backward pointer needs updating. */
-    node->backward = (prev_level0 == zsl->header) ? NULL : prev_level0;
-    zsl->tail = node;
-    zsl->length++;
-}
-
 /* Internal function used by zslDelete, zslDeleteRangeByScore and
  * zslDeleteRangeByRank.
  * This function only unlinks the node from the skiplist structure but does NOT free it.
@@ -3369,11 +3262,10 @@ struct zrange_result_handler {
     zrangeResultFinalizeFunction         finalizeResultEmission;
     zrangeResultEmitCBufferFunction      emitResultFromCBuffer;
     zrangeResultEmitLongLongFunction     emitResultFromLongLong;
-    /* STORE mode: tail-append cache used when the destination is skiplist
-     * encoded and the source yields elements in monotonic (score, element)
-     * ascending order. 'bulk_disarmed' switches to the generic zsetAdd() slow
-     * path on the first violation. */
-    zslTailCache                         bulk_cache;
+    /* STORE fast path state. See zrangeStoreTryAppend(). */
+    zskiplistNode                       *bulk_update[ZSKIPLIST_MAXLEVEL];
+    unsigned long                        bulk_rank[ZSKIPLIST_MAXLEVEL];
+    int                                  bulk_initialized;
     int                                  bulk_disarmed;
 };
 
@@ -3446,9 +3338,20 @@ static void zrangeResultBeginStore(zrange_result_handler *handler, long length)
     handler->dstobj = zsetTypeCreate(length >= 0 ? length : 0, 0);
 }
 
-/* Tail-append fast path for skiplist-encoded destinations. Usable when the
- * caller-provided (score, ele) is >= the current tail's. Returns 1 when the
- * fast path was taken, 0 when the invariant failed (caller must fall back). */
+/* STORE-mode tail-append fast path for forward ZRANGESTORE.
+ *
+ * When the destination is skiplist-encoded and incoming (score, ele) is >=
+ * the current tail, append the new node directly using per-level tail
+ * pointers cached on 'handler'. On first use with a non-empty skiplist
+ * (destination was listpack and converted mid-store, e.g. ZRANGESTORE
+ * BYSCORE/BYLEX), the cache seeds from the existing tail chain. Span
+ * bookkeeping mirrors zslInsertNode() verbatim: level-0 spans are implicit,
+ * level>=1 predecessor span = (new_rank - prev_rank) + 1, new-tail span = 0;
+ * bulk_rank[i] = hops-from-header to bulk_update[i] so the formula stays
+ * invariant across calls.
+ *
+ * Returns 1 if handled, 0 to fall back to zsetAdd() (not skiplist, not
+ * monotonic, or unexpected duplicate). */
 static int zrangeStoreTryAppend(zrange_result_handler *handler, double score, sds ele) {
     if (handler->bulk_disarmed) return 0;
     if (handler->dstobj->encoding != OBJ_ENCODING_SKIPLIST) return 0;
@@ -3459,18 +3362,71 @@ static int zrangeStoreTryAppend(zrange_result_handler *handler, double score, sd
         return 0;
     }
     dictEntryLink bucket;
-    dictEntryLink link = dictFindLink(zs->dict, ele, &bucket);
-    /* ZRANGESTORE sources are zsets (elements unique by construction); if a
-     * duplicate shows up anyway, fall back so zsetAdd() can do the right
-     * thing (GT/LT/UPDATED semantics) and avoid corrupting the index. */
-    if (link != NULL) {
-        handler->bulk_disarmed = 1;
+    if (dictFindLink(zs->dict, ele, &bucket) != NULL) {
+        handler->bulk_disarmed = 1;  /* unexpected duplicate */
         return 0;
     }
+
+    if (!handler->bulk_initialized) {
+        if (zsl->length == 0) {
+            for (int i = 0; i < ZSKIPLIST_MAXLEVEL; i++) {
+                handler->bulk_update[i] = zsl->header;
+                handler->bulk_rank[i] = 0;
+            }
+        } else {
+            /* Walk the existing tail chain so update[]/rank[] match what
+             * zslInsertNode() would have computed; otherwise the first
+             * stitch would overwrite header.forward on a non-empty chain. */
+            zskiplistNode *x = zsl->header;
+            unsigned long r = 0;
+            for (int i = zsl->level - 1; i >= 0; i--) {
+                while (x->level[i].forward != NULL) {
+                    r += zslGetNodeSpanAtLevel(x, i);
+                    x = x->level[i].forward;
+                }
+                handler->bulk_update[i] = x;
+                handler->bulk_rank[i] = r;
+            }
+            for (int i = zsl->level; i < ZSKIPLIST_MAXLEVEL; i++) {
+                handler->bulk_update[i] = zsl->header;
+                handler->bulk_rank[i] = 0;
+            }
+        }
+        handler->bulk_initialized = 1;
+    }
+
     int level = zslRandomLevel();
-    zskiplistNode *znode = zslCreateNode(zsl, level, score, ele);
-    zslAppendTailCached(zsl, znode, &handler->bulk_cache);
-    dictSetKeyAtLink(zs->dict, znode, &bucket, 1);
+    zskiplistNode *node = zslCreateNode(zsl, level, score, ele);
+    unsigned long insert_rank = zsl->length;  /* 0-indexed position of new node */
+
+    if (level > zsl->level) {
+        for (int i = zsl->level; i < level; i++) {
+            handler->bulk_update[i] = zsl->header;
+            handler->bulk_rank[i] = 0;
+            zslSetNodeSpanAtLevel(zsl->header, i, zsl->length);
+        }
+        zsl->level = level;
+        zslGetNodeInfo(zsl->header)->levels = level;
+    }
+
+    zskiplistNode *prev_level0 = handler->bulk_update[0];
+    for (int i = 0; i < level; i++) {
+        node->level[i].forward = NULL;
+        handler->bulk_update[i]->level[i].forward = node;
+        zslSetNodeSpanAtLevel(node, i, 0);
+        zslSetNodeSpanAtLevel(handler->bulk_update[i], i,
+                              (insert_rank - handler->bulk_rank[i]) + 1);
+        handler->bulk_update[i] = node;
+        handler->bulk_rank[i] = insert_rank + 1;
+    }
+    for (int i = level; i < zsl->level; i++) {
+        zslIncrNodeSpanAtLevel(handler->bulk_update[i], i, 1);
+    }
+    node->backward = (prev_level0 == zsl->header) ? NULL : prev_level0;
+    zsl->tail = node;
+    zsl->length++;
+
+    dictSetKeyAtLink(zs->dict, node, &bucket, 1);
     return 1;
 }
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -338,6 +338,82 @@ zskiplistNode *zslInsert(zskiplist *zsl, double score, sds ele) {
     return node;
 }
 
+/* Tail-append cache used by zslAppendTailCached(): callers track the
+ * per-level rightmost node + its 0-indexed rank so sequential sorted inserts
+ * skip the walk-from-head that zslInsertNode() performs. Must be zeroed
+ * before first use; 'initialized' is set by the first call. */
+typedef struct zslTailCache {
+    zskiplistNode *update[ZSKIPLIST_MAXLEVEL];
+    unsigned long rank[ZSKIPLIST_MAXLEVEL];
+    int initialized;
+} zslTailCache;
+
+/* Append an already-created node at the tail of the skiplist, using a
+ * per-level tail cache to avoid the zslInsertNode() walk-from-head.
+ *
+ * CALLER CONTRACT: 'node's (score, element) must be >= the current tail's
+ * (score, element) under zslCompareWithNode(). If the invariant doesn't
+ * hold the resulting skiplist is corrupted, so this is intended for
+ * bulk-construction paths (e.g. ZRANGESTORE forward direction) that can
+ * prove the invariant by construction.
+ *
+ * Span bookkeeping is kept identical to zslInsertNode(): level-0 spans are
+ * implicit (derived from the forward pointer); level >= 1 spans are written
+ * using the same (rank[0] - rank[i]) + 1 formula so zslGetRank() /
+ * zslDelete() continue to work on the resulting skiplist. */
+static void zslAppendTailCached(zskiplist *zsl, zskiplistNode *node, zslTailCache *cache) {
+    int level = zslGetNodeInfo(node)->levels;
+    unsigned long insert_rank = zsl->length;  /* 0-indexed position of the new node */
+
+    if (!cache->initialized) {
+        for (int i = 0; i < ZSKIPLIST_MAXLEVEL; i++) {
+            cache->update[i] = zsl->header;
+            cache->rank[i] = 0;
+        }
+        cache->initialized = 1;
+    }
+
+    /* Extend skiplist level if the new node exceeds the current top. Matches
+     * the new-level branch of zslInsertNode() so headers' span accounting
+     * stays consistent (the intermediate zsl->length value is overwritten in
+     * the main stitch loop below for levels < 'level'). */
+    if (level > zsl->level) {
+        for (int i = zsl->level; i < level; i++) {
+            cache->update[i] = zsl->header;
+            cache->rank[i] = 0;
+            zslSetNodeSpanAtLevel(zsl->header, i, zsl->length);
+        }
+        zsl->level = level;
+        zslGetNodeInfo(zsl->header)->levels = level;
+    }
+
+    zskiplistNode *prev_level0 = cache->update[0];
+
+    /* Stitch the new node as the rightmost at each of its levels. */
+    for (int i = 0; i < level; i++) {
+        node->level[i].forward = NULL;  /* tail at this level */
+        cache->update[i]->level[i].forward = node;
+        /* New tail at level i has span 0; no-op at level 0 via setter. */
+        zslSetNodeSpanAtLevel(node, i, 0);
+        /* Predecessor span: distance from it (exclusive) to the new node
+         * (inclusive) in level-0 hops. */
+        zslSetNodeSpanAtLevel(cache->update[i], i, (insert_rank - cache->rank[i]) + 1);
+        cache->update[i] = node;
+        cache->rank[i] = insert_rank;
+    }
+
+    /* Levels above 'level': the existing rightmost at each level gains one
+     * more level-0 node beyond it, so its span grows by 1 (no-op at level 0). */
+    for (int i = level; i < zsl->level; i++) {
+        zslIncrNodeSpanAtLevel(cache->update[i], i, 1);
+    }
+
+    /* Backward pointer + tail update. */
+    node->backward = (prev_level0 == zsl->header) ? NULL : prev_level0;
+    zsl->tail = node;
+    zsl->length++;
+}
+
 /* Internal function used by zslDelete, zslDeleteRangeByScore and
  * zslDeleteRangeByRank.
  * This function only unlinks the node from the skiplist structure but does NOT free it.
@@ -3262,6 +3338,12 @@ struct zrange_result_handler {
     zrangeResultFinalizeFunction         finalizeResultEmission;
     zrangeResultEmitCBufferFunction      emitResultFromCBuffer;
     zrangeResultEmitLongLongFunction     emitResultFromLongLong;
+    /* STORE mode: tail-append cache used when the destination is skiplist
+     * encoded and the source yields elements in monotonic (score, element)
+     * ascending order. 'bulk_disarmed' switches to the generic zsetAdd() slow
+     * path on the first violation. */
+    zslTailCache                         bulk_cache;
+    int                                  bulk_disarmed;
 };
 
 /* Result handler methods for responding the ZRANGE to clients.
@@ -3333,12 +3415,44 @@ static void zrangeResultBeginStore(zrange_result_handler *handler, long length)
     handler->dstobj = zsetTypeCreate(length >= 0 ? length : 0, 0);
 }
 
+/* Tail-append fast path for skiplist-encoded destinations. Usable when the
+ * caller-provided (score, ele) is >= the current tail's. Returns 1 when the
+ * fast path was taken, 0 when the invariant failed (caller must fall back). */
+static int zrangeStoreTryAppend(zrange_result_handler *handler, double score, sds ele) {
+    if (handler->bulk_disarmed) return 0;
+    if (handler->dstobj->encoding != OBJ_ENCODING_SKIPLIST) return 0;
+    zset *zs = handler->dstobj->ptr;
+    zskiplist *zsl = zs->zsl;
+    if (zsl->tail != NULL && zslCompareWithNode(score, ele, zsl->tail) < 0) {
+        handler->bulk_disarmed = 1;
+        return 0;
+    }
+    dictEntryLink bucket;
+    dictEntryLink link = dictFindLink(zs->dict, ele, &bucket);
+    /* ZRANGESTORE sources are zsets (elements unique by construction); if a
+     * duplicate shows up anyway, fall back so zsetAdd() can do the right
+     * thing (GT/LT/UPDATED semantics) and avoid corrupting the index. */
+    if (link != NULL) {
+        handler->bulk_disarmed = 1;
+        return 0;
+    }
+    int level = zslRandomLevel();
+    zskiplistNode *znode = zslCreateNode(zsl, level, score, ele);
+    zslAppendTailCached(zsl, znode, &handler->bulk_cache);
+    dictSetKeyAtLink(zs->dict, znode, &bucket, 1);
+    return 1;
+}
+
 static void zrangeResultEmitCBufferForStore(zrange_result_handler *handler,
     const void *value, size_t value_length_in_bytes, double score)
 {
+    sds ele = sdsnewlen(value, value_length_in_bytes);
+    if (zrangeStoreTryAppend(handler, score, ele)) {
+        sdsfree(ele);
+        return;
+    }
     double newscore;
     int retflags = 0;
-    sds ele = sdsnewlen(value, value_length_in_bytes);
     int retval = zsetAdd(handler->dstobj, score, ele, ZADD_IN_NONE, &retflags, &newscore);
     sdsfree(ele);
     serverAssert(retval);
@@ -3347,9 +3461,13 @@ static void zrangeResultEmitCBufferForStore(zrange_result_handler *handler,
 static void zrangeResultEmitLongLongForStore(zrange_result_handler *handler,
     long long value, double score)
 {
+    sds ele = sdsfromlonglong(value);
+    if (zrangeStoreTryAppend(handler, score, ele)) {
+        sdsfree(ele);
+        return;
+    }
     double newscore;
     int retflags = 0;
-    sds ele = sdsfromlonglong(value);
     int retval = zsetAdd(handler->dstobj, score, ele, ZADD_IN_NONE, &retflags, &newscore);
     sdsfree(ele);
     serverAssert(retval);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -339,9 +339,11 @@ zskiplistNode *zslInsert(zskiplist *zsl, double score, sds ele) {
 }
 
 /* Tail-append cache used by zslAppendTailCached(): callers track the
- * per-level rightmost node + its 0-indexed rank so sequential sorted inserts
- * skip the walk-from-head that zslInsertNode() performs. Must be zeroed
- * before first use; 'initialized' is set by the first call. */
+ * per-level rightmost node + total level-0 hops from header to reach it,
+ * so sequential sorted inserts skip the walk-from-head that zslInsertNode()
+ * performs. Must be zeroed before first use; 'initialized' is set by the
+ * first call. The 'rank' values here follow zslInsertNode() semantics:
+ * for a node at 0-indexed position p, rank = p + 1 (i.e. hops-from-header). */
 typedef struct zslTailCache {
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL];
     unsigned long rank[ZSKIPLIST_MAXLEVEL];
@@ -366,9 +368,33 @@ static void zslAppendTailCached(zskiplist *zsl, zskiplistNode *node, zslTailCach
     unsigned long insert_rank = zsl->length;  /* 0-indexed position of the new node */
 
     if (!cache->initialized) {
-        for (int i = 0; i < ZSKIPLIST_MAXLEVEL; i++) {
-            cache->update[i] = zsl->header;
-            cache->rank[i] = 0;
+        /* Seed the cache with the current per-level rightmost node. Empty
+         * skiplist: update[i] = header, rank = 0. Non-empty (e.g. the
+         * destination was just converted from listpack to skiplist mid-
+         * store): walk the existing tail chain so our update[]/rank[]
+         * match what zslInsertNode() would have computed, otherwise the
+         * first stitch would overwrite header.forward and corrupt the
+         * existing chain. */
+        if (zsl->length == 0) {
+            for (int i = 0; i < ZSKIPLIST_MAXLEVEL; i++) {
+                cache->update[i] = zsl->header;
+                cache->rank[i] = 0;
+            }
+        } else {
+            zskiplistNode *x = zsl->header;
+            unsigned long r = 0;
+            for (int i = zsl->level - 1; i >= 0; i--) {
+                while (x->level[i].forward != NULL) {
+                    r += zslGetNodeSpanAtLevel(x, i);
+                    x = x->level[i].forward;
+                }
+                cache->update[i] = x;
+                cache->rank[i] = r;
+            }
+            for (int i = zsl->level; i < ZSKIPLIST_MAXLEVEL; i++) {
+                cache->update[i] = zsl->header;
+                cache->rank[i] = 0;
+            }
         }
         cache->initialized = 1;
     }
@@ -396,19 +422,24 @@ static void zslAppendTailCached(zskiplist *zsl, zskiplistNode *node, zslTailCach
         /* New tail at level i has span 0; no-op at level 0 via setter. */
         zslSetNodeSpanAtLevel(node, i, 0);
         /* Predecessor span: distance from it (exclusive) to the new node
-         * (inclusive) in level-0 hops. */
+         * (inclusive) in level-0 hops, using zslInsertNode's formula. */
         zslSetNodeSpanAtLevel(cache->update[i], i, (insert_rank - cache->rank[i]) + 1);
         cache->update[i] = node;
-        cache->rank[i] = insert_rank;
+        /* rank[i] = hops from header to update[i]. For a node at 0-indexed
+         * position insert_rank, that is insert_rank + 1 (matches the
+         * post-walk rank[i] zslInsertNode would produce for update[i]). */
+        cache->rank[i] = insert_rank + 1;
     }
 
     /* Levels above 'level': the existing rightmost at each level gains one
-     * more level-0 node beyond it, so its span grows by 1 (no-op at level 0). */
+     * more level-0 node beyond it, so its span grows by 1 (no-op at level 0).
+     * Its rank from header is unchanged (same node at same position). */
     for (int i = level; i < zsl->level; i++) {
         zslIncrNodeSpanAtLevel(cache->update[i], i, 1);
     }
 
-    /* Backward pointer + tail update. */
+    /* Backward pointer + tail update. Always-tail means node->forward[0]
+     * is NULL, so no existing node's backward pointer needs updating. */
     node->backward = (prev_level0 == zsl->header) ? NULL : prev_level0;
     zsl->tail = node;
     zsl->length++;

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2507,6 +2507,65 @@ start_server {tags {"zset"}} {
         r config set zset-max-listpack-entries $original_max
     }
 
+    test {ZRANGESTORE forward large skiplist destination - ZRANK + span integrity} {
+        # Exercises the tail-append fast path on a skiplist destination
+        # pre-sized from the range length. Verifies that span bookkeeping
+        # stays consistent by checking rank-based operations (ZRANK,
+        # ZRANGEBYSCORE LIMIT, ZCOUNT) on every 100th element.
+        set original_max [lindex [r config get zset-max-listpack-entries] 1]
+        r config set zset-max-listpack-entries 128
+        r del z1{t} z2{t}
+        # 500 elements -> destination starts as skiplist directly (above threshold).
+        for {set i 0} {$i < 500} {incr i} { r zadd z1{t} $i "e$i" }
+        assert_equal 500 [r zrangestore z2{t} z1{t} 0 -1]
+        assert_encoding skiplist z2{t}
+        assert_equal 500 [r zcard z2{t}]
+        # Probe rank at several positions. ZRANK walks level-i spans to find
+        # an element's 0-indexed rank; any span off-by-one shows up here.
+        foreach idx {0 1 99 100 249 250 498 499} {
+            assert_equal $idx [r zrank z2{t} "e$idx"]
+            assert_equal [expr {499 - $idx}] [r zrevrank z2{t} "e$idx"]
+        }
+        # ZRANGEBYSCORE LIMIT stresses rank-based offset traversal.
+        assert_equal {e100 e101 e102} [r zrangebyscore z2{t} -inf +inf LIMIT 100 3]
+        assert_equal 101 [r zcount z2{t} 200 300]
+        r config set zset-max-listpack-entries $original_max
+    }
+
+    test {ZRANGESTORE mid-store listpack->skiplist conversion - fast path init} {
+        # Covers the corner case where the destination is created as
+        # listpack (BYSCORE / BYLEX pass 0 as length hint to zsetTypeCreate),
+        # fills past zset-max-listpack-entries, converts to skiplist
+        # mid-store, and the tail-append fast path then activates. Must
+        # not corrupt the existing chain and must keep span bookkeeping
+        # consistent for ZRANK.
+        set original_max [lindex [r config get zset-max-listpack-entries] 1]
+        r config set zset-max-listpack-entries 64
+        r del z1{t} z2{t} z3{t}
+        for {set i 0} {$i < 300} {incr i} { r zadd z1{t} $i "m$i" }
+        # BYSCORE: length is not known upfront, so the destination starts
+        # as listpack and converts to skiplist when it crosses 64 elements.
+        assert_equal 300 [r zrangestore z2{t} z1{t} 0 299 BYSCORE]
+        assert_encoding skiplist z2{t}
+        assert_equal 300 [r zcard z2{t}]
+        foreach idx {0 1 63 64 65 150 298 299} {
+            assert_equal $idx [r zrank z2{t} "m$idx"]
+        }
+        assert_equal {m64 m65 m66} [r zrangebyscore z2{t} 64 66]
+        # BYLEX path (all-equal-score zset so lex range is well-defined):
+        # exercises the same mid-store conversion + fast-path init when
+        # the destination starts as listpack.
+        r del z3{t} z4{t}
+        for {set i 0} {$i < 300} {incr i} { r zadd z3{t} 0 [format "x%03d" $i] }
+        assert_equal 300 [r zrangestore z4{t} z3{t} \[x000 \[x299 BYLEX]
+        assert_encoding skiplist z4{t}
+        assert_equal 300 [r zcard z4{t}]
+        foreach idx {0 1 63 64 65 150 298 299} {
+            assert_equal $idx [r zrank z4{t} [format "x%03d" $idx]]
+        }
+        r config set zset-max-listpack-entries $original_max
+    }
+
     test {ZRANGE invalid syntax} {
         catch {r zrange z1{t} 0 -1 limit 1 2} err
         assert_match "*syntax*" $err


### PR DESCRIPTION
## Motivation

When `ZRANGESTORE` materialises a destination zset, the result handler calls `zsetAdd()` for every element in the range. For skiplist-encoded destinations `zsetAdd()` → `zslInsert()` walks the skiplist from head at every level to find the insertion position — O(log N) per call — giving O(N log N) total for an N-element range.

For large forward ranges (the common case: `ZRANGESTORE dst src 0 <large>`), the source is iterated in monotonic `(score, element)` ascending order, so the walk always lands at the rightmost position. The work is pure overhead on the hot path.

## Change

Add a tail-append fast path to the STORE-mode result handler in `src/t_zset.c`:

1. `zslTailCache` — tracks the per-level rightmost node + its `hops-from-header` rank (matches the `rank[]` semantics of `zslInsertNode()`).
2. `zslAppendTailCached()` — stitches a new node at the tail using the cache. Span bookkeeping matches `zslInsertNode()` verbatim, so `zslGetRank()`, `zslDeleteRange()`, and downstream iterators keep working unchanged. On first call with a non-empty skiplist (e.g. destination was listpack-encoded and converted mid-store via `ZRANGESTORE BYSCORE` / `BYLEX`), the cache walks the existing tail chain once (bounded by `zset-max-listpack-entries`) so `update[]` / `rank[]` match what `zslInsertNode()` would have computed.
3. `zrangeStoreTryAppend()` — checks `(score, ele) >= zsl->tail->(score, ele)` via `zslCompareWithNode()`. If yes, uses the fast path; if no, disarms the cache and falls back to `zsetAdd()` for the rest of the range. REV direction, unexpected duplicates, and any non-monotonic sequence hit the fallback.
4. Duplicate detection + dict insertion are preserved via `dictFindLink()` / `dictSetKeyAtLink()` — identical to `zsetAdd()`'s skiplist branch.

Listpack-encoded destinations (small ranges below `zset-max-listpack-entries`) are unchanged — `zsetAdd()` still runs for them.

## Correctness

- `./runtest --single unit/type/zset` passes (all pre-existing ZRANGESTORE listpack / skiplist / rev / byscore / bylex tests).
- Two new unit tests in `tests/unit/type/zset.tcl` exercise the skiplist-destination paths specifically:
  - `ZRANGESTORE forward large skiplist destination - ZRANK + span integrity` — 500-element pre-sized skiplist destination, verifies `ZRANK` / `ZREVRANK` / `ZRANGEBYSCORE LIMIT` / `ZCOUNT` on every 100th rank (catches span-bookkeeping off-by-one).
  - `ZRANGESTORE mid-store listpack->skiplist conversion - fast path init` — `zset-max-listpack-entries 64` with a 300-element `BYSCORE` range that grows through the threshold, plus a same-score `BYLEX` variant (catches non-empty-skiplist init corruption).
- Manual 200 K-element source checks: forward 100 K-copy (correct count + head/tail + ranks); `REV 5` (correct 6 elements in ascending destination order — fast path disarms after first element); `BYSCORE 50-150` (correct 101 elements starting at e50).

## Benchmark

Workload sources: `memtier_benchmark-1key-zset-600K-elements-zrangestore-300K-elements` + `-1K-elements` + `-1Mkeys-load-zset-listpack-with-100-elements-double-score` + `-1key-zset-1K-elements-zrange-all-elements` from redis-benchmarks-specification. 1 client / 1 thread, 120 s test time, `oss-standalone` topology.

**Baseline**: `redis/unstable` @ `47c51369eeffd55e1baf20df7955a3dfbe842fc4` (current `unstable` HEAD at time of measurement).
**Comparison**: this PR @ `a6b8cb1c45996c6b58c33175d3399571ea3d6466`.
3 datapoints per cell, non-overlapping σ on every row below.

### Primary + 1 K-range — tail-append fast path activates

| Test | Platform | baseline (σ) | This PR (σ) | Δ |
|---|---|---:|---:|---:|
| 300 K `ZRANGESTORE` | x86 m7i.metal-24xl (Intel Sapphire Rapids, 96 c) | 14.83 ops/s (0.5 %) | 20.01 ops/s (0.6 %) | **+34.9 %** |
| 300 K `ZRANGESTORE` | arm m8g.metal-24xl (AWS Graviton4 / Neoverse-V2, 96 c) | 13.14 ops/s (0.3 %) | 18.67 ops/s (0.1 %) | **+42.1 %** |
| 1 K `ZRANGESTORE` | x86 m7i.metal-24xl | 5,842 ops/s (0.2 %) | 8,563 ops/s (0.8 %) | **+46.6 %** |
| 1 K `ZRANGESTORE` | arm m8g.metal-24xl | 5,231 ops/s (0.2 %) | 7,273 ops/s (2.0 %) | **+39.0 %** |

### Guards — fast path does NOT activate (expected flat)

| Test | Platform | baseline (σ) | This PR (σ) | Δ |
|---|---|---:|---:|---:|
| Load 1 M keys zset-listpack-100-elements (listpack dest) | x86 m7i | 16,011 ops/s (1.1 %) | 15,875 ops/s (0.2 %) | −0.8 % |
| Load 1 M keys zset-listpack-100-elements | arm m8g | 13,790 ops/s (0.1 %) | 13,867 ops/s (0.2 %) | +0.6 % |
| 1 K-element zset `ZRANGE all` (read path) | x86 m7i | 9,023 ops/s (0.1 %) | 9,019 ops/s (0.2 %) | −0.0 % |
| 1 K-element zset `ZRANGE all` | arm m8g | 6,668 ops/s (0.3 %) | 6,658 ops/s (0.1 %) | −0.2 % |

### TMA funnel

Collected on `x86 m7i.metal-24xl-profiler` (Intel Sapphire Rapids, L4 full pipeline-slot breakdown via `pmu-tools/toplev`) for the 300 K primary:

| Pipeline Slots (share) | baseline | This PR | Δ (pp) |
|---|---:|---:|---:|
| Bad_Speculation | 17.2 % | 13.3 % | **−4.0** |
| · Branch_Mispredicts | 16.4 % | 12.6 % | **−3.8** |
| Frontend_Bound | 17.5 % | 14.1 % | **−3.4** |
| · Fetch_Bandwidth (DSB) | 12.8 % | 10.1 % | **−2.7** |
| Retiring (share) | 36.9 % | 34.6 % | −2.3 |
| Backend_Bound | 28.4 % | 37.4 % | +9.0 |
| · Memory_Bound (L3_Bound) | 13.8 % | 18.0 % | +4.1 |

The Branch_Mispredicts drop is the walk's loop-exit branch being eliminated. Frontend_Bound drops because the hot body shrinks — fewer DSB entries, fewer resteers. Retiring falls in share, but the benchmark completes in ~74 % of the cycles — the O(N log N) → O(N) shift. Backend_Bound rises in share because the residual (`zslCreateNode()` allocation + `sdsnewplacement()` memcpy + `dictSetKeyAtLink()`) now dominates a smaller total. ARM Neoverse-V2 L1 top-level shows the same qualitative shift (Bad_Speculation −2.2 pp).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches skiplist insertion/span bookkeeping in `ZRANGESTORE` storage path; mistakes could corrupt ordering/rank results even though the fast path has fallbacks and new coverage.
> 
> **Overview**
> Speeds up forward `ZRANGESTORE` when the destination zset is skiplist-encoded by adding a tail-append fast path (`zrangeStoreTryAppend`) that appends monotonic `(score, member)` results directly to the skiplist using cached per-level tail pointers/ranks, falling back to `zsetAdd()` once ordering/duplicates break the assumption.
> 
> Adds unit tests that stress rank/span correctness for large forward stores and for the corner case where the destination starts as listpack and converts to skiplist mid-store (e.g., `BYSCORE`/`BYLEX`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a7505545c7d24fb4482f420056b6d25be866110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->