### PR TITLE
Fix zslParseRange to reject bare "(" and empty string as score bounds

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -723,10 +723,12 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
     } else {
         size_t len = sdslen(min->ptr);
         if (((char*)min->ptr)[0] == '(') {
+            if (len < 2) return C_ERR;
             spec->min = fast_float_strtod((char*)min->ptr+1,len-1,&eptr);
             if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
             spec->minex = 1;
         } else {
+            if (len == 0) return C_ERR;
             spec->min = fast_float_strtod((char*)min->ptr,len,&eptr);
             if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
         }
@@ -736,10 +738,12 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
     } else {
         size_t len = sdslen(max->ptr);
         if (((char*)max->ptr)[0] == '(') {
+            if (len < 2) return C_ERR;
             spec->max = fast_float_strtod((char*)max->ptr+1,len-1,&eptr);
             if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
             spec->maxex = 1;
         } else {
+            if (len == 0) return C_ERR;
             spec->max = fast_float_strtod((char*)max->ptr,len,&eptr);
             if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
         }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -44,7 +44,6 @@
 #include "server.h"
 #include "intset.h"  /* Compact integer set structure */
 #include <math.h>
-#include <ctype.h>
 
 #define ZSL_OFFSET_MAX_ELE  UINT16_MAX
 #define ZSL_OFFSET_NO_ELE   UINT16_MAX
@@ -712,7 +711,6 @@ zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank) {
 
 /* Populate the rangespec according to the objects min and max. */
 static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
-    char *eptr;
     spec->minex = spec->maxex = 0;
 
     /* Parse the min-max interval. If one of the values is prefixed
@@ -725,9 +723,7 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
         char *ptr = min->ptr;
         size_t len = sdslen(min->ptr);
         if (*ptr == '(') { ptr++; len--; spec->minex = 1; }
-        if (len == 0 || isspace((unsigned char)*ptr)) return C_ERR;
-        spec->min = fast_float_strtod(ptr,len,&eptr);
-        if ((size_t)(eptr-ptr) != len || isnan(spec->min)) return C_ERR;
+        if (!string2d(ptr, len, &spec->min)) return C_ERR;
     }
     if (max->encoding == OBJ_ENCODING_INT) {
         spec->max = (long)max->ptr;
@@ -735,9 +731,7 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
         char *ptr = max->ptr;
         size_t len = sdslen(max->ptr);
         if (*ptr == '(') { ptr++; len--; spec->maxex = 1; }
-        if (len == 0 || isspace((unsigned char)*ptr)) return C_ERR;
-        spec->max = fast_float_strtod(ptr,len,&eptr);
-        if ((size_t)(eptr-ptr) != len || isnan(spec->max)) return C_ERR;
+        if (!string2d(ptr, len, &spec->max)) return C_ERR;
     }
 
     return C_OK;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -44,6 +44,7 @@
 #include "server.h"
 #include "intset.h"  /* Compact integer set structure */
 #include <math.h>
+#include <ctype.h>
 
 #define ZSL_OFFSET_MAX_ELE  UINT16_MAX
 #define ZSL_OFFSET_NO_ELE   UINT16_MAX
@@ -721,32 +722,22 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
     if (min->encoding == OBJ_ENCODING_INT) {
         spec->min = (long)min->ptr;
     } else {
+        char *ptr = min->ptr;
         size_t len = sdslen(min->ptr);
-        if (((char*)min->ptr)[0] == '(') {
-            if (len < 2) return C_ERR;
-            spec->min = fast_float_strtod((char*)min->ptr+1,len-1,&eptr);
-            if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
-            spec->minex = 1;
-        } else {
-            if (len == 0) return C_ERR;
-            spec->min = fast_float_strtod((char*)min->ptr,len,&eptr);
-            if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
-        }
+        if (*ptr == '(') { ptr++; len--; spec->minex = 1; }
+        if (len == 0 || isspace((unsigned char)*ptr)) return C_ERR;
+        spec->min = fast_float_strtod(ptr,len,&eptr);
+        if ((size_t)(eptr-ptr) != len || isnan(spec->min)) return C_ERR;
     }
     if (max->encoding == OBJ_ENCODING_INT) {
         spec->max = (long)max->ptr;
     } else {
+        char *ptr = max->ptr;
         size_t len = sdslen(max->ptr);
-        if (((char*)max->ptr)[0] == '(') {
-            if (len < 2) return C_ERR;
-            spec->max = fast_float_strtod((char*)max->ptr+1,len-1,&eptr);
-            if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
-            spec->maxex = 1;
-        } else {
-            if (len == 0) return C_ERR;
-            spec->max = fast_float_strtod((char*)max->ptr,len,&eptr);
-            if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
-        }
+        if (*ptr == '(') { ptr++; len--; spec->maxex = 1; }
+        if (len == 0 || isspace((unsigned char)*ptr)) return C_ERR;
+        spec->max = fast_float_strtod(ptr,len,&eptr);
+        if ((size_t)(eptr-ptr) != len || isnan(spec->max)) return C_ERR;
     }
 
     return C_OK;

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -634,6 +634,41 @@ start_server {tags {"zset"}} {
             assert_error "*not*float*" {r zrangebyscore fooz 1 NaN}
         }
 
+        test "ZRANGEBYSCORE with malformed min or max - $encoding" {
+            assert_error "*not*float*" {r zrangebyscore fooz ( +inf}
+            assert_error "*not*float*" {r zrangebyscore fooz -inf (}
+            assert_error "*not*float*" {r zrangebyscore fooz ( (}
+            assert_error "*not*float*" {r zrangebyscore fooz "" +inf}
+            assert_error "*not*float*" {r zrangebyscore fooz -inf ""}
+            assert_error "*not*float*" {r zrangebyscore fooz "" ""}
+        }
+
+        test "ZREVRANGEBYSCORE with malformed min or max - $encoding" {
+            assert_error "*not*float*" {r zrevrangebyscore fooz +inf (}
+            assert_error "*not*float*" {r zrevrangebyscore fooz ( -inf}
+            assert_error "*not*float*" {r zrevrangebyscore fooz "" -inf}
+        }
+
+        test "ZCOUNT with malformed min or max - $encoding" {
+            assert_error "*not*float*" {r zcount fooz ( +inf}
+            assert_error "*not*float*" {r zcount fooz -inf (}
+            assert_error "*not*float*" {r zcount fooz "" +inf}
+        }
+
+        test "ZREMRANGEBYSCORE with malformed min or max - $encoding" {
+            create_default_zset
+            assert_error "*not*float*" {r zremrangebyscore zset ( +inf}
+            assert_error "*not*float*" {r zremrangebyscore zset -inf (}
+            assert_error "*not*float*" {r zremrangebyscore zset "" +inf}
+            assert_equal 7 [r zcard zset]
+        }
+
+        test "ZRANGESTORE BYSCORE with malformed min or max - $encoding" {
+            assert_error "*not*float*" {r zrangestore dst fooz ( +inf BYSCORE}
+            assert_error "*not*float*" {r zrangestore dst fooz -inf ( BYSCORE}
+            assert_error "*not*float*" {r zrangestore dst fooz "" +inf BYSCORE}
+        }
+
         proc create_default_lex_zset {} {
             create_zset zset {0 alpha 0 bar 0 cool 0 down
                               0 elephant 0 foo 0 great 0 hill

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -667,7 +667,7 @@ start_server {tags {"zset"}} {
             assert_error "*not*float*" {r zrangestore dst fooz ( +inf BYSCORE}
             assert_error "*not*float*" {r zrangestore dst fooz -inf ( BYSCORE}
             assert_error "*not*float*" {r zrangestore dst fooz "" +inf BYSCORE}
-        }
+        } {} {cluster:skip}
 
         proc create_default_lex_zset {} {
             create_zset zset {0 alpha 0 bar 0 cool 0 down

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -641,6 +641,13 @@ start_server {tags {"zset"}} {
             assert_error "*not*float*" {r zrangebyscore fooz "" +inf}
             assert_error "*not*float*" {r zrangebyscore fooz -inf ""}
             assert_error "*not*float*" {r zrangebyscore fooz "" ""}
+            assert_error "*not*float*" {r zrangebyscore fooz "1\x00junk" +inf}
+            assert_error "*not*float*" {r zrangebyscore fooz -inf "1\x00junk"}
+            assert_error "*not*float*" {r zrangebyscore fooz "(1\x00junk" +inf}
+            assert_error "*not*float*" {r zrangebyscore fooz " 1.5" +inf}
+            assert_error "*not*float*" {r zrangebyscore fooz -inf " 1.5"}
+            assert_error "*not*float*" {r zrangebyscore fooz "( 1.5" +inf}
+            assert_error "*not*float*" {r zrangebyscore fooz "\t1" +inf}
         }
 
         test "ZREVRANGEBYSCORE with malformed min or max - $encoding" {


### PR DESCRIPTION

## Problem

`zslParseRange()` silently accepts a bare `(` as `(0` and an empty string `""` as `0`, because the post-parse check (`eptr[0] != '\0'` + `isnan`) doesn't catch zero-length input — `fast_float_strtod` returns `0.0` for it and the SDS trailing `'\0'` makes the endptr check pass.

This affects `ZRANGEBYSCORE`, `ZREVRANGEBYSCORE`, `ZCOUNT`,`ZRANGE/ZRANGESTORE ... BYSCORE`, and `ZREMRANGEBYSCORE` (which can silently delete data).

Related issue: https://github.com/redis/redis/issues/15078

## Changed

Reject `len == 0` (normal branch) and `len < 2` (`(`-prefixed branch) in `zslParseRange` before calling `fast_float_strtod`. Single fix covers all callers.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes score-range parsing for multiple zset commands, which can alter behavior for previously-accepted edge-case inputs and affects deletion paths like `ZREMRANGEBYSCORE`. The change is small and covered by new negative tests, but touches input validation used broadly.
> 
> **Overview**
> Fixes `zslParseRange()` to **properly reject malformed BYSCORE bounds** (e.g., bare `(`, empty strings, strings with embedded NUL/leading whitespace) instead of silently treating them as `0`.
> 
> This switches range parsing to use `string2d()` after handling optional `(` exclusivity, and adds unit tests asserting `*not*float*` errors across affected commands (`ZRANGEBYSCORE`, `ZREVRANGEBYSCORE`, `ZCOUNT`, `ZREMRANGEBYSCORE`, and `ZRANGESTORE ... BYSCORE`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dfa5c26f5fa066c0e0b6e7fe445d91b388e4397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->