### PR TITLE
Fix TLS stale WANT flags keeping AE events registered after handler clear

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -7821,6 +7821,9 @@ typedef int redisTestProc(int argc, char **argv, int flags);
 int bitopsTest(int argc, char **argv, int flags);
 int zsetTest(int argc, char **argv, int flags);
 int vectorTest(int argc, char **argv, int flags);
+#if USE_OPENSSL == 1
+int tlsTest(int argc, char **argv, int flags);
+#endif
 struct redisTest {
     char *name;
     redisTestProc *proc;
@@ -7850,6 +7853,9 @@ struct redisTest {
     {"zset", zsetTest},
     {"topk", chkTopKTest},
     {"fastfloat", fastFloatTest},
+#if USE_OPENSSL == 1
+    {"tls", tlsTest},
+#endif
 };
 redisTestProc *getTestProcByName(const char *name) {
     int numtests = sizeof(redisTests)/sizeof(struct redisTest);

--- a/src/tls.c
+++ b/src/tls.c
@@ -1030,6 +1030,11 @@ static const char *connTLSGetLastError(connection *conn_) {
 
 static int connTLSSetWriteHandler(connection *conn, ConnectionCallbackFunc func, int barrier) {
     conn->write_handler = func;
+    /* If the write handler is cleared, drop any stale TLS_CONN_FLAG_WRITE_WANT_READ
+     * left by a prior SSL_write retry. Otherwise updateSSLEvent() below would keep
+     * AE_READABLE registered for a retry that no longer has an application callback
+     * to complete it, causing the event loop to wake up on that fd indefinitely. */
+    if (!func) ((tls_connection *) conn)->flags &= ~TLS_CONN_FLAG_WRITE_WANT_READ;
     if (barrier)
         conn->flags |= CONN_FLAG_WRITE_BARRIER;
     else
@@ -1040,6 +1045,10 @@ static int connTLSSetWriteHandler(connection *conn, ConnectionCallbackFunc func,
 
 static int connTLSSetReadHandler(connection *conn, ConnectionCallbackFunc func) {
     conn->read_handler = func;
+    /* Symmetric to connTLSSetWriteHandler: clear any stale
+     * TLS_CONN_FLAG_READ_WANT_WRITE so updateSSLEvent() does not leave AE_WRITABLE
+     * registered after the application has detached its read handler. */
+    if (!func) ((tls_connection *) conn)->flags &= ~TLS_CONN_FLAG_READ_WANT_WRITE;
     updateSSLEvent((tls_connection *) conn);
     return C_OK;
 }
@@ -1248,6 +1257,100 @@ static ConnectionType CT_TLS = {
 int RedisRegisterConnectionTypeTLS(void) {
     return connTypeRegister(&CT_TLS);
 }
+
+#ifdef REDIS_TEST
+#include "testhelp.h"
+
+static void tlsTestDummyHandler(connection *conn) { UNUSED(conn); }
+
+/* White-box unit test for issue #15080: clearing a read/write handler must
+ * also drop any stale TLS_CONN_FLAG_{READ_WANT_WRITE,WRITE_WANT_READ} so the
+ * event loop does not keep polling the fd after the application has detached.
+ *
+ * The test sets up a tls_connection with a handler installed and the matching
+ * WANT flag pre-populated, calls updateSSLEvent() to register AE events based
+ * on that state, then clears the handler via the public setter and verifies
+ * both the AE registration and the flag are cleared. A third scenario checks
+ * that setting a non-NULL handler preserves the flag (regression guard). */
+int tlsTest(int argc, char **argv, int flags) {
+    UNUSED(argc); UNUSED(argv); UNUSED(flags);
+
+    int fds[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds) != 0) {
+        test_cond("socketpair() succeeds", 0);
+        return 1;
+    }
+
+    aeEventLoop *el = aeCreateEventLoop(16);
+    if (!el) {
+        close(fds[0]); close(fds[1]);
+        test_cond("aeCreateEventLoop() succeeds", 0);
+        return 1;
+    }
+
+    /* Case 1: stale READ_WANT_WRITE after clearing read handler. */
+    tls_connection rc = {{0}};
+    rc.c.el = el;
+    rc.c.fd = fds[0];
+    rc.c.state = CONN_STATE_CONNECTED;
+    rc.c.read_handler = tlsTestDummyHandler;
+    rc.flags |= TLS_CONN_FLAG_READ_WANT_WRITE;
+    updateSSLEvent(&rc);
+    test_cond("READ_WANT_WRITE + read_handler registers AE_WRITABLE",
+              (aeGetFileEvents(el, fds[0]) & AE_WRITABLE) != 0);
+    connTLSSetReadHandler((connection *) &rc, NULL);
+    test_cond("clearing read handler drops stale AE_WRITABLE",
+              (aeGetFileEvents(el, fds[0]) & AE_WRITABLE) == 0);
+    test_cond("clearing read handler clears stale READ_WANT_WRITE",
+              (rc.flags & TLS_CONN_FLAG_READ_WANT_WRITE) == 0);
+    aeDeleteFileEvent(el, fds[0], AE_READABLE | AE_WRITABLE);
+
+    /* Case 2: stale WRITE_WANT_READ after clearing write handler. */
+    tls_connection wc = {{0}};
+    wc.c.el = el;
+    wc.c.fd = fds[1];
+    wc.c.state = CONN_STATE_CONNECTED;
+    wc.c.write_handler = tlsTestDummyHandler;
+    wc.flags |= TLS_CONN_FLAG_WRITE_WANT_READ;
+    updateSSLEvent(&wc);
+    test_cond("WRITE_WANT_READ + write_handler registers AE_READABLE",
+              (aeGetFileEvents(el, fds[1]) & AE_READABLE) != 0);
+    connTLSSetWriteHandler((connection *) &wc, NULL, 0);
+    test_cond("clearing write handler drops stale AE_READABLE",
+              (aeGetFileEvents(el, fds[1]) & AE_READABLE) == 0);
+    test_cond("clearing write handler clears stale WRITE_WANT_READ",
+              (wc.flags & TLS_CONN_FLAG_WRITE_WANT_READ) == 0);
+    aeDeleteFileEvent(el, fds[1], AE_READABLE | AE_WRITABLE);
+
+    /* Case 3 (regression): setting a non-NULL handler must NOT touch the
+     * corresponding WANT flag - it represents a genuine pending SSL retry. */
+    tls_connection rkeep = {{0}};
+    rkeep.c.el = el;
+    rkeep.c.fd = fds[0];
+    rkeep.c.state = CONN_STATE_CONNECTED;
+    rkeep.flags |= TLS_CONN_FLAG_READ_WANT_WRITE;
+    connTLSSetReadHandler((connection *) &rkeep, tlsTestDummyHandler);
+    test_cond("setting non-NULL read handler preserves READ_WANT_WRITE",
+              (rkeep.flags & TLS_CONN_FLAG_READ_WANT_WRITE) != 0);
+    aeDeleteFileEvent(el, fds[0], AE_READABLE | AE_WRITABLE);
+
+    tls_connection wkeep = {{0}};
+    wkeep.c.el = el;
+    wkeep.c.fd = fds[1];
+    wkeep.c.state = CONN_STATE_CONNECTED;
+    wkeep.flags |= TLS_CONN_FLAG_WRITE_WANT_READ;
+    connTLSSetWriteHandler((connection *) &wkeep, tlsTestDummyHandler, 0);
+    test_cond("setting non-NULL write handler preserves WRITE_WANT_READ",
+              (wkeep.flags & TLS_CONN_FLAG_WRITE_WANT_READ) != 0);
+    aeDeleteFileEvent(el, fds[1], AE_READABLE | AE_WRITABLE);
+
+    aeDeleteEventLoop(el);
+    close(fds[0]);
+    close(fds[1]);
+
+    return __failed_tests != 0;
+}
+#endif /* REDIS_TEST */
 
 #else   /* USE_OPENSSL */
 


### PR DESCRIPTION
## Summary

Fixes #15080.

`src/tls.c` kept internal OpenSSL retry-state flags
(`TLS_CONN_FLAG_READ_WANT_WRITE`, `TLS_CONN_FLAG_WRITE_WANT_READ`) set even
after the application layer cleared the corresponding event handler. Because
`updateSSLEvent()` computes event registration via

```c
int need_read  = conn->c.read_handler  || (conn->flags & TLS_CONN_FLAG_WRITE_WANT_READ);
int need_write = conn->c.write_handler || (conn->flags & TLS_CONN_FLAG_READ_WANT_WRITE);
```

a stale WANT flag keeps `AE_READABLE` / `AE_WRITABLE` registered on the fd
even though there is no application callback left to complete the pending
SSL operation. When the socket is already readable/writable, the event loop
can wake up on that fd indefinitely (e.g. the `read_handler == NULL` +
`TLS_CONN_FLAG_READ_WANT_WRITE` case drives a busy loop in `aeProcessEvents()`
and consumes 100% CPU).

### Fix

In `connTLSSetReadHandler()` / `connTLSSetWriteHandler()`, when the handler
is being cleared (`func == NULL`), also clear the matching WANT flag before
calling `updateSSLEvent()`. The WANT flag represents a pending SSL retry
tied to that handler; if the application has detached, there is nothing to
retry.

Change is 6 lines in `src/tls.c` plus a white-box C unit test registered
in the existing `redisTests[]` table in `src/server.c`.

## Test plan

- [x] `make BUILD_TLS=yes REDIS_CFLAGS='-DREDIS_TEST'` builds clean
- [x] `src/redis-server test tls` passes 8/8 with the fix
- [x] Negative control: without the fix, 4/8 of the new assertions fail (the
      two "clears stale AE_*" and "clears stale WANT_*" pairs), confirming
      the tests actually exercise the bug
- [x] `src/redis-server test all` — only pre-existing failures in
      `fastfloat` (2 NaN-parsing cases unrelated to this change); `tls` is
      8/8
- [x] `./runtest --tls --single unit/tls` — all 12 TLS integration tests
      pass (no regression)

The new unit test is picked up by the existing
`.github/workflows/daily.yml` lane that builds
`BUILD_TLS=yes REDIS_CFLAGS='-Werror -DREDIS_TEST'` and runs
`./src/redis-server test all --accurate`.

### Change points → tests

| Change point                                     | Tests                                                                                                                 |
|--------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| Clear READ_WANT_WRITE when read_handler cleared  | `clearing read handler drops stale AE_WRITABLE`, `clearing read handler clears stale READ_WANT_WRITE`                 |
| Clear WRITE_WANT_READ when write_handler cleared | `clearing write handler drops stale AE_READABLE`, `clearing write handler clears stale WRITE_WANT_READ`               |
| Non-clearing path preserved (regression)         | `setting non-NULL read handler preserves READ_WANT_WRITE`, `setting non-NULL write handler preserves WRITE_WANT_READ` |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TLS connection event-registration logic; while small, mistakes could cause missed wakeups or lingering busy loops in production TLS I/O.
> 
> **Overview**
> Fixes a TLS event-loop busy-loop condition by clearing stale OpenSSL retry-state flags when the application clears read/write callbacks, so `updateSSLEvent()` stops keeping `AE_READABLE`/`AE_WRITABLE` registered with no handler to run.
> 
> Adds a `REDIS_TEST` white-box `tls` unit test (only when `USE_OPENSSL==1`) and registers it in the `redisTests[]` table to assert both the fd event mask and WANT flags are cleared on handler removal, while preserving flags when handlers remain set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59f0455c70cb5bffee36ce57704f4538b72993f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->