### PR TITLE
Fix a flaky ACL unit test when running with I/O threads enabled

### DIFF
--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -277,7 +277,13 @@ start_server {tags {"acl external:skip"}} {
         $rd SUBSCRIBE foo:1
         $rd read
         r ACL setuser psuser resetchannels
-        assert_no_match {*deathrow*} [r CLIENT LIST]
+        # ACL revocation schedules the pub/sub client for async close, so wait
+        # until CLIENT LIST no longer exposes the client.
+        wait_for_condition 50 100 {
+            [string match {*deathrow*} [r CLIENT LIST]] == 0
+        } else {
+            fail "Client still listed in CLIENT LIST after ACL channel permission revocation."
+        }
         $rd close
     } {0}
 
@@ -291,7 +297,13 @@ start_server {tags {"acl external:skip"}} {
         $rd SSUBSCRIBE foo:1
         $rd read
         r ACL setuser psuser resetchannels
-        assert_no_match {*deathrow*} [r CLIENT LIST]
+        # ACL revocation schedules the pub/sub client for async close, so wait
+        # until CLIENT LIST no longer exposes the client.
+        wait_for_condition 50 100 {
+            [string match {*deathrow*} [r CLIENT LIST]] == 0
+        } else {
+            fail "Client still listed in CLIENT LIST after ACL channel permission revocation."
+        }
         $rd close
     } {0}
 
@@ -305,7 +317,13 @@ start_server {tags {"acl external:skip"}} {
         $rd PSUBSCRIBE bar:*
         $rd read
         r ACL setuser psuser resetchannels
-        assert_no_match {*deathrow*} [r CLIENT LIST]
+        # ACL revocation schedules the pub/sub client for async close, so wait
+        # until CLIENT LIST no longer exposes the client.
+        wait_for_condition 50 100 {
+            [string match {*deathrow*} [r CLIENT LIST]] == 0
+        } else {
+            fail "Client still listed in CLIENT LIST after ACL channel permission revocation."
+        }
         $rd close
     } {0}
 
@@ -319,7 +337,13 @@ start_server {tags {"acl external:skip"}} {
         $rd PSUBSCRIBE foo
         $rd read
         r ACL setuser psuser resetchannels
-        assert_no_match {*deathrow*} [r CLIENT LIST]
+        # ACL revocation schedules the pub/sub client for async close, so wait
+        # until CLIENT LIST no longer exposes the client.
+        wait_for_condition 50 100 {
+            [string match {*deathrow*} [r CLIENT LIST]] == 0
+        } else {
+            fail "Client still listed in CLIENT LIST after ACL channel permission revocation."
+        }
         $rd close
     } {0}
 


### PR DESCRIPTION
## Summary

This fixes flakes in four ACL pub/sub tests:

- `Subscribers are killed when revoked of channel permission` with `SUBSCRIBE foo:1`
- `Subscribers are killed when revoked of channel permission` with `SSUBSCRIBE foo:1`
- `Subscribers are killed when revoked of pattern permission` with `PSUBSCRIBE bar:*`
- `Subscribers are killed when revoked of allchannels permission` with `PSUBSCRIBE foo`

In these cases, the test revokes the user's channel permissions and immediately checks that the client named `deathrow` is gone from `CLIENT LIST`. The server has already scheduled the subscribed client for closing, but the close is asynchronous, so `CLIENT LIST` can briefly still show the client.

## Reproduction
The failure can be reproduced with:
```
sh ./runtest --config io-threads 4 --single unit/acl --clients 1 --loops 200 --stop
```


Error message:
```
Test error (last server port:22020, log:./tests/tmp/server.29171.2324/stdout), press enter to teardown the test.
[err]: Subscribers are killed when revoked of allchannels permission in tests/unit/acl.tcl
Expected 'id=4 addr=127.0.0.1:44736 laddr=127.0.0.1:22020 fd=21 name= age=0 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=0 argv-mem=10 multi-mem=0 rbs=16384 rbp=422 obl=0 oll=0 omem=0 tot-mem=17690 events=r cmd=client|list user=psuser redir=-1 resp=2 lib-name= lib-ver= io-thread=1 tot-net-in=3668 tot-net-out=4069 tot-cmds=67 read-events=79 avg-pipeline-len-sum=79 avg-pipeline-len-cnt=79
id=15 addr=127.0.0.1:44762 laddr=127.0.0.1:22020 fd=22 name=deathrow age=0 idle=0 flags=PA db=9 sub=0 psub=1 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=0 argv-mem=0 multi-mem=0 rbs=16384 rbp=34 obl=0 oll=0 omem=0 tot-mem=17720 events=r cmd=psubscribe user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0 tot-net-in=134 tot-net-out=49 tot-cmds=4 read-events=4 avg-pipeline-len-sum=4 avg-pipeline-len-cnt=4
' to not match '*deathrow*' (context: type eval line 11 cmd {assert_no_match {*deathrow*} [r CLIENT LIST]} proc ::test)
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds a bounded wait to account for asynchronous client close after ACL revocation, reducing flakiness without altering server behavior.
> 
> **Overview**
> Fixes flakiness in four ACL pub/sub unit tests where channel permissions are revoked and the test immediately asserts the subscriber is gone from `CLIENT LIST`.
> 
> The tests now use `wait_for_condition` to poll until the named client (`deathrow`) disappears, reflecting that ACL-triggered pub/sub disconnects are scheduled asynchronously (not immediate) when I/O threads are enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fad58edf6b52c0344e6614f457be41d616744d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->