### PR TITLE
Replace recursive rax tree freeing with iterative traversal

### DIFF
--- a/src/rax.c
+++ b/src/rax.c
@@ -1292,21 +1292,10 @@ static void raxFreeNodesWithCallback(rax *rax, raxNode *n,
     raxStackFree(&stack);
 }
 
-void raxFreeNodes(rax *rax, raxNode *n, void (*free_callback)(void*)) {
-    raxFreeNodesWithCallback(rax, n, free_callback, NULL, NULL);
-}
-
-/* Same as raxFreeNodes() but accepts an additional context argument
- * that is passed through to the free callback. */
-void raxFreeNodesWithCtx(rax *rax, raxNode *n,
-                         void (*free_callback)(void *item, void *ctx), void *ctx) {
-    raxFreeNodesWithCallback(rax, n, NULL, free_callback, ctx);
-}
-
 /* Free a whole radix tree, calling the specified callback in order to
  * free the auxiliary data. */
 void raxFreeWithCallback(rax *rax, void (*free_callback)(void*)) {
-    raxFreeNodes(rax,rax->head,free_callback);
+    raxFreeNodesWithCallback(rax, rax->head, free_callback, NULL, NULL);
     assert(rax->numnodes == 0);
     size_t *alloc_size = rax->alloc_size;
     size_t usable;
@@ -1318,7 +1307,7 @@ void raxFreeWithCallback(rax *rax, void (*free_callback)(void*)) {
  * free the auxiliary data. */
 void raxFreeWithCbAndContext(rax *rax,
                              void (*free_callback)(void *item, void *ctx), void *ctx) {
-    raxFreeNodesWithCtx(rax,rax->head,free_callback,ctx);
+    raxFreeNodesWithCallback(rax, rax->head, NULL, free_callback, ctx);
     assert(rax->numnodes == 0);
     size_t *alloc_size = rax->alloc_size;
     size_t usable;

--- a/src/rax.c
+++ b/src/rax.c
@@ -1256,8 +1256,12 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
 
 /* This is the core of raxFree(): performs an iterative depth-first scan
  * of the tree and frees all the nodes found. Uses an explicit heap stack
- * to avoid stack overflow on deep trees. */
-void raxFreeNodes(rax *rax, raxNode *n, void (*free_callback)(void*)) {
+ * to avoid stack overflow on deep trees. The caller passes exactly one
+ * callback variant and the non-NULL one is invoked. */
+static void raxFreeNodesWithCallback(rax *rax, raxNode *n,
+                                     void (*free_callback)(void *item),
+                                     void (*free_callback_withctx)(void *item, void *ctx),
+                                     void *ctx) {
     raxStack stack;
     raxStackInit(&stack);
     raxStackPush(&stack, n);
@@ -1273,8 +1277,13 @@ void raxFreeNodes(rax *rax, raxNode *n, void (*free_callback)(void*)) {
             raxStackPush(&stack, child);
         }
         debugnode("free depth-first",curr);
-        if (free_callback && curr->iskey && !curr->isnull)
-            free_callback(raxGetData(curr));
+        if (curr->iskey && !curr->isnull) {
+            void *data = raxGetData(curr);
+            if (free_callback_withctx)
+                free_callback_withctx(data, ctx);
+            else if (free_callback)
+                free_callback(data);
+        }
         raxFreeNode(rax, curr);
         rax->numnodes--;
     }
@@ -1282,32 +1291,15 @@ void raxFreeNodes(rax *rax, raxNode *n, void (*free_callback)(void*)) {
     raxStackFree(&stack);
 }
 
+void raxFreeNodes(rax *rax, raxNode *n, void (*free_callback)(void*)) {
+    raxFreeNodesWithCallback(rax, n, free_callback, NULL, NULL);
+}
+
 /* Same as raxFreeNodes() but accepts an additional context argument
  * that is passed through to the free callback. */
 void raxFreeNodesWithCtx(rax *rax, raxNode *n,
-                            void (*free_callback)(void *item, void *ctx), void *ctx) {
-    raxStack stack;
-    raxStackInit(&stack);
-    raxStackPush(&stack, n);
-
-    while (stack.items > 0) {
-        raxNode *curr = raxStackPop(&stack);
-        debugnode("free traversing",curr);
-        int numchildren = curr->iscompr ? 1 : curr->size;
-        raxNode **cp = raxNodeFirstChildPtr(curr);
-        for (int i = 0; i < numchildren; i++) {
-            raxNode *child;
-            memcpy(&child, cp + i, sizeof(child));
-            raxStackPush(&stack, child);
-        }
-        debugnode("free depth-first",curr);
-        if (free_callback && curr->iskey && !curr->isnull)
-            free_callback(raxGetData(curr), ctx);
-        raxFreeNode(rax, curr);
-        rax->numnodes--;
-    }
-
-    raxStackFree(&stack);
+                         void (*free_callback)(void *item, void *ctx), void *ctx) {
+    raxFreeNodesWithCallback(rax, n, NULL, free_callback, ctx);
 }
 
 /* Free a whole radix tree, calling the specified callback in order to

--- a/src/rax.c
+++ b/src/rax.c
@@ -1261,7 +1261,8 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
 static void raxFreeNodesWithCallback(rax *rax, raxNode *n,
                                      void (*free_callback)(void *item),
                                      void (*free_callback_withctx)(void *item, void *ctx),
-                                     void *ctx) {
+                                     void *ctx)
+{
     raxStack stack;
     raxStackInit(&stack);
     raxStackPush(&stack, n);

--- a/src/rax.c
+++ b/src/rax.c
@@ -1254,48 +1254,66 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
     return 1;
 }
 
-/* This is the core of raxFree(): performs a depth-first scan of the
- * tree and releases all the nodes found. */
-void raxRecursiveFree(rax *rax, raxNode *n, void (*free_callback)(void*)) {
-    debugnode("free traversing",n);
-    int numchildren = n->iscompr ? 1 : n->size;
-    raxNode **cp = raxNodeLastChildPtr(n);
-    while(numchildren--) {
-        raxNode *child;
-        memcpy(&child,cp,sizeof(child));
-        raxRecursiveFree(rax,child,free_callback);
-        cp--;
+/* This is the core of raxFree(): performs an iterative depth-first scan
+ * of the tree and frees all the nodes found. Uses an explicit heap stack
+ * to avoid stack overflow on deep trees. */
+void raxFreeNodes(rax *rax, raxNode *n, void (*free_callback)(void*)) {
+    raxStack stack;
+    raxStackInit(&stack);
+    raxStackPush(&stack, n);
+
+    while (stack.items > 0) {
+        raxNode *curr = raxStackPop(&stack);
+        debugnode("free traversing",curr);
+        int numchildren = curr->iscompr ? 1 : curr->size;
+        raxNode **cp = raxNodeFirstChildPtr(curr);
+        for (int i = 0; i < numchildren; i++) {
+            raxNode *child;
+            memcpy(&child, cp + i, sizeof(child));
+            raxStackPush(&stack, child);
+        }
+        debugnode("free depth-first",curr);
+        if (free_callback && curr->iskey && !curr->isnull)
+            free_callback(raxGetData(curr));
+        raxFreeNode(rax, curr);
+        rax->numnodes--;
     }
-    debugnode("free depth-first",n);
-    if (free_callback && n->iskey && !n->isnull)
-        free_callback(raxGetData(n));
-    raxFreeNode(rax,n);
-    rax->numnodes--;
+
+    raxStackFree(&stack);
 }
 
-/* Same as raxRecursiveFree() with context argument */
-void raxRecursiveFreeWithCtx(rax *rax, raxNode *n,
+/* Same as raxFreeNodes() but accepts an additional context argument
+ * that is passed through to the free callback. */
+void raxFreeNodesWithCtx(rax *rax, raxNode *n,
                             void (*free_callback)(void *item, void *ctx), void *ctx) {
-    debugnode("free traversing",n);
-    int numchildren = n->iscompr ? 1 : n->size;
-    raxNode **cp = raxNodeLastChildPtr(n);
-    while(numchildren--) {
-        raxNode *child;
-        memcpy(&child,cp,sizeof(child));
-        raxRecursiveFreeWithCtx(rax,child,free_callback, ctx);
-        cp--;
+    raxStack stack;
+    raxStackInit(&stack);
+    raxStackPush(&stack, n);
+
+    while (stack.items > 0) {
+        raxNode *curr = raxStackPop(&stack);
+        debugnode("free traversing",curr);
+        int numchildren = curr->iscompr ? 1 : curr->size;
+        raxNode **cp = raxNodeFirstChildPtr(curr);
+        for (int i = 0; i < numchildren; i++) {
+            raxNode *child;
+            memcpy(&child, cp + i, sizeof(child));
+            raxStackPush(&stack, child);
+        }
+        debugnode("free depth-first",curr);
+        if (free_callback && curr->iskey && !curr->isnull)
+            free_callback(raxGetData(curr), ctx);
+        raxFreeNode(rax, curr);
+        rax->numnodes--;
     }
-    debugnode("free depth-first",n);
-    if (free_callback && n->iskey && !n->isnull)
-        free_callback(raxGetData(n), ctx);
-    raxFreeNode(rax,n);
-    rax->numnodes--;
+
+    raxStackFree(&stack);
 }
 
 /* Free a whole radix tree, calling the specified callback in order to
  * free the auxiliary data. */
 void raxFreeWithCallback(rax *rax, void (*free_callback)(void*)) {
-    raxRecursiveFree(rax,rax->head,free_callback);
+    raxFreeNodes(rax,rax->head,free_callback);
     assert(rax->numnodes == 0);
     size_t *alloc_size = rax->alloc_size;
     size_t usable;
@@ -1307,7 +1325,7 @@ void raxFreeWithCallback(rax *rax, void (*free_callback)(void*)) {
  * free the auxiliary data. */
 void raxFreeWithCbAndContext(rax *rax,
                              void (*free_callback)(void *item, void *ctx), void *ctx) {
-    raxRecursiveFreeWithCtx(rax,rax->head,free_callback,ctx);
+    raxFreeNodesWithCtx(rax,rax->head,free_callback,ctx);
     assert(rax->numnodes == 0);
     size_t *alloc_size = rax->alloc_size;
     size_t usable;


### PR DESCRIPTION
`raxRecursiveFree` and `raxRecursiveFreeWithCtx` used C call-stack recursion to walk the entire radix tree during `raxFree`. On trees with pathologically deep paths (long keys with no shared prefixes) this could overflow the thread stack and crash the process.

This PR replaces both recursive functions with a single unified iterative helper (`raxFreeNodesWithCallback`) that maintains an explicit heap-allocated `raxStack` — the same stack structure already used elsewhere in the rax code (e.g. `raxIterator`). The helper accepts both callback variants (with and without a user-supplied context) so the two public entry points `raxFreeWithCallback` and `raxFreeWithCbAndContext` now both delegate to it. Child pointers are now enumerated forward from `raxNodeFirstChildPtr` instead of backward from `raxNodeLastChildPtr`, which is simpler and consistent with how the rest of the codebase traverses children. No functional change: every node is still visited exactly once, its optional data callback is still invoked before the node is freed, and `rax->numnodes` is decremented identically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core memory-management code in `raxFree*` by changing traversal strategy, so bugs could cause leaks/double-frees if node visitation or callback invocation order is wrong. Change is localized but impacts all tree teardown paths, especially for large/deep trees.
> 
> **Overview**
> Replaces the recursive node teardown (`raxRecursiveFree`/`raxRecursiveFreeWithCtx`) with a single iterative depth-first traversal (`raxFreeNodesWithCallback`) that uses `raxStack` to avoid C call-stack overflow on deeply nested radix trees.
> 
> Updates `raxFreeWithCallback` and `raxFreeWithCbAndContext` to route through the new shared helper, preserving optional item-free callbacks (with or without context) while freeing nodes and decrementing `rax->numnodes` during traversal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4077f3ba7dbdb2d71d940f9341b98f3a55f5828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->