### PR TITLE
Stricter zslParseRange: reject bare "(", empty string and embedded NULs (#15078)

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -44,6 +44,7 @@
 #include "server.h"
 #include "intset.h"  /* Compact integer set structure */
 #include <math.h>
+#include <ctype.h>
 
 #define ZSL_OFFSET_MAX_ELE  UINT16_MAX
 #define ZSL_OFFSET_NO_ELE   UINT16_MAX
@@ -709,9 +710,39 @@ zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank) {
     return zslGetElementByRankFromNode(zsl->header, zsl->level - 1, rank);
 }
 
+/* Parse a single score bound used by zslParseRange. If the string is
+ * prefixed by '(' the bound is exclusive. The parser requires that the
+ * full input (minus the optional leading '(') represents a valid double:
+ * empty strings, a bare '(', leading whitespace, and any trailing junk
+ * (including embedded NULs) are all rejected. Returns C_OK on success,
+ * storing the parsed score in *score and exclusive flag in *ex. */
+static int zslParseScoreBound(robj *item, double *score, int *ex) {
+    char *eptr;
+    char *ptr = item->ptr;
+    size_t len = sdslen(ptr);
+    size_t off = 0;
+
+    *ex = 0;
+    if (len > 0 && ptr[0] == '(') {
+        *ex = 1;
+        off = 1;
+    }
+    /* Reject empty numeric part (covers "" and a bare "("). */
+    if (len - off == 0) return C_ERR;
+    /* Reject leading whitespace to match string2d() semantics. */
+    if (isspace((unsigned char)ptr[off])) return C_ERR;
+
+    *score = fast_float_strtod(ptr + off, len - off, &eptr);
+    /* Require that the parser consumed the entire remaining input. Using
+     * a length-based check (instead of eptr[0] != '\0') also rejects
+     * inputs that contain embedded NULs such as "1\0junk". */
+    if ((size_t)(eptr - (ptr + off)) != len - off) return C_ERR;
+    if (isnan(*score)) return C_ERR;
+    return C_OK;
+}
+
 /* Populate the rangespec according to the objects min and max. */
 static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
-    char *eptr;
     spec->minex = spec->maxex = 0;
 
     /* Parse the min-max interval. If one of the values is prefixed
@@ -721,28 +752,14 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
     if (min->encoding == OBJ_ENCODING_INT) {
         spec->min = (long)min->ptr;
     } else {
-        size_t len = sdslen(min->ptr);
-        if (((char*)min->ptr)[0] == '(') {
-            spec->min = fast_float_strtod((char*)min->ptr+1,len-1,&eptr);
-            if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
-            spec->minex = 1;
-        } else {
-            spec->min = fast_float_strtod((char*)min->ptr,len,&eptr);
-            if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
-        }
+        if (zslParseScoreBound(min, &spec->min, &spec->minex) != C_OK)
+            return C_ERR;
     }
     if (max->encoding == OBJ_ENCODING_INT) {
         spec->max = (long)max->ptr;
     } else {
-        size_t len = sdslen(max->ptr);
-        if (((char*)max->ptr)[0] == '(') {
-            spec->max = fast_float_strtod((char*)max->ptr+1,len-1,&eptr);
-            if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
-            spec->maxex = 1;
-        } else {
-            spec->max = fast_float_strtod((char*)max->ptr,len,&eptr);
-            if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
-        }
+        if (zslParseScoreBound(max, &spec->max, &spec->maxex) != C_OK)
+            return C_ERR;
     }
 
     return C_OK;

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -634,6 +634,47 @@ start_server {tags {"zset"}} {
             assert_error "*not*float*" {r zrangebyscore fooz 1 NaN}
         }
 
+        test "Score range parser rejects malformed bounds - $encoding" {
+            # Regression for redis/redis#15078: zslParseRange silently
+            # accepted a bare "(" as (0 and an empty string as 0. The
+            # stricter parser also rejects leading whitespace and any
+            # trailing junk (including embedded NULs).
+            create_default_zset
+
+            # bare "(" (len == 1) - both as min and as max
+            assert_error "*not*float*" {r zrangebyscore zset "(" +inf}
+            assert_error "*not*float*" {r zrangebyscore zset -inf "("}
+            assert_error "*not*float*" {r zrevrangebyscore zset "(" -inf}
+            assert_error "*not*float*" {r zrevrangebyscore zset +inf "("}
+            assert_error "*not*float*" {r zcount zset "(" +inf}
+            assert_error "*not*float*" {r zrangestore dst zset "(" +inf BYSCORE}
+
+            # empty string
+            assert_error "*not*float*" {r zrangebyscore zset "" +inf}
+            assert_error "*not*float*" {r zrangebyscore zset -inf ""}
+            assert_error "*not*float*" {r zcount zset "" +inf}
+
+            # leading whitespace is not accepted as a valid float
+            assert_error "*not*float*" {r zrangebyscore zset " 1" +inf}
+            assert_error "*not*float*" {r zrangebyscore zset "-inf" " 1"}
+
+            # embedded NUL: "1\0junk" must not be accepted as 1
+            assert_error "*not*float*" {r zrangebyscore zset "1\x00junk" +inf}
+            assert_error "*not*float*" {r zrangebyscore zset "(1\x00junk" +inf}
+
+            # ZREMRANGEBYSCORE must not silently delete data on malformed
+            # bounds. The set must still contain all its elements after
+            # the rejected calls.
+            set before [r zcard zset]
+            assert_error "*not*float*" {r zremrangebyscore zset "(" +inf}
+            assert_error "*not*float*" {r zremrangebyscore zset "" +inf}
+            assert_equal $before [r zcard zset]
+
+            # Sanity: well-formed exclusive and inclusive bounds still work.
+            assert_equal {b c d e f g} [r zrangebyscore zset (0 +inf]
+            assert_equal {c d e f g} [r zrangebyscore zset (1 +inf]
+        }
+
         proc create_default_lex_zset {} {
             create_zset zset {0 alpha 0 bar 0 cool 0 down
                               0 elephant 0 foo 0 great 0 hill


### PR DESCRIPTION
## Problem
 
Fixes #15078.
 
[zslParseRange()](cci:1://file:///root/redis/src/t_zset.c:742:0-764:1) in [src/t_zset.c](cci:7://file:///root/redis/src/t_zset.c:0:0-0:0) silently accepts several malformed
score bounds because the post-parse check uses `eptr[0] != '\0'` instead
of verifying that the parser consumed the full input length:
 
- A bare `(` (`len == 1`) strips the prefix and calls
  `fast_float_strtod` on a zero-length buffer, which returns `0.0` with
  `eptr[0] == '\0'`, so it is treated as `(0`.
- An empty string `""` takes the same path in the non-`(` branch and is
  treated as `0`.
- SDS strings can hold embedded NULs, so inputs like `"1\0junk"` pass
  the endptr check and are silently accepted.
 
This affects `ZRANGEBYSCORE`, `ZREVRANGEBYSCORE`, `ZCOUNT`,
`ZRANGE`/`ZRANGESTORE ... BYSCORE`, and — most seriously —
`ZREMRANGEBYSCORE`, where it could cause silent data loss.
 
### Reproducer (before this PR)
 
127.0.0.1:6379> ZADD zs -2 neg2 -1 neg1 0 zero 1 pos1 2 pos2 (integer) 5 127.0.0.1:6379> ZRANGEBYSCORE zs "(" +inf

"pos1"
"pos2" 127.0.0.1:6379> ZRANGEBYSCORE zs "" +inf
"zero"
"pos1"
"pos2" 127.0.0.1:6379> ZCOUNT zs "(" +inf (integer) 2
 
### After this PR
 
127.0.0.1:6379> ZRANGEBYSCORE zs "(" +inf (error) ERR min or max is not a float 127.0.0.1:6379> ZRANGEBYSCORE zs "" +inf (error) ERR min or max is not a float 127.0.0.1:6379> ZRANGEBYSCORE zs "(1.5" +inf

"pos2"
 
## Fix
 
Factor the per-bound logic into [zslParseScoreBound()](cci:1://file:///root/redis/src/t_zset.c:711:0-740:1) and:
 
- Reject empty numeric input up front (covers `""` and a bare `(`).
- Reject leading whitespace (matches [string2d()](cci:1://file:///root/redis/src/util.c:652:0-677:1) semantics in
  [src/util.c](cci:7://file:///root/redis/src/util.c:0:0-0:0)).
- Replace `eptr[0] != '\0'` with `(eptr - ptr) == len`, matching how
  [string2d()](cci:1://file:///root/redis/src/util.c:652:0-677:1) validates full-input consumption. This also rejects
  embedded NULs such as `"1\0junk"` — the gap the Cursor bot flagged on
  #15098.
 
One helper replaces four duplicated branches.
 
## Relation to #15098
 
This PR targets the same issue (#15078) as #15098, but strengthens the
validation so that the cases [string2d()](cci:1://file:///root/redis/src/util.c:652:0-677:1) already rejects are also
rejected here. Specifically, #15098 keeps `eptr[0] != '\0'`, which still
accepts inputs containing embedded NULs (the medium-severity Cursor bot
review on that PR). I'm happy to close this in favour of folding these
changes into #15098 — whichever the maintainers prefer.
 
## Tests
 
Added regression tests in [tests/unit/type/zset.tcl](cci:7://file:///root/redis/tests/unit/type/zset.tcl:0:0-0:0) that cover:
 
- bare `(` as min and as max across `ZRANGEBYSCORE`, `ZREVRANGEBYSCORE`,
  `ZCOUNT`, and `ZRANGESTORE ... BYSCORE`
- empty string `""`
- leading whitespace (`" 1"`)
- embedded NULs (`"1\x00junk"`, `"(1\x00junk"`)
- `ZREMRANGEBYSCORE` with malformed bounds must not delete data
- sanity: well-formed inclusive and exclusive bounds still work
 
The full `unit/type/zset` suite passes on `unstable` (tested on both
`listpack` and `skiplist` encodings):
 
\o/ All tests passed without errors!

 
## Risk
 
Medium — this tightens validation of score range bounds used by multiple
zset commands, so any client that was relying on the previous lenient
parsing of `(`, `""`, leading whitespace, or embedded NULs will now see
`ERR min or max is not a float`. The documented behaviour of these
commands does not allow these inputs, so this aligns the implementation
with the docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this changes input validation for multiple zset score-range commands and may break clients that relied on previously-accepted malformed bounds; it also affects `ZREMRANGEBYSCORE`, where stricter rejection prevents unintended deletions.
> 
> **Overview**
> Makes score-range parsing in `zslParseRange` **strict** by factoring bound parsing into `zslParseScoreBound()` and rejecting malformed bounds (bare `(`, empty strings, leading whitespace, trailing junk, and embedded NULs) instead of silently treating them as `0`.
> 
> Adds unit tests covering the rejected cases across `ZRANGEBYSCORE`/`ZREVRANGEBYSCORE`/`ZCOUNT`/`ZRANGESTORE ... BYSCORE`, and verifies `ZREMRANGEBYSCORE` does not delete data when bounds are invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 264682a5e6a09a76344aa7c361fc080c36324758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->