### PR TITLE
Add CLIENT LIST IDLE <seconds> server-side idle-time filter (#15102)

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -1406,6 +1406,7 @@ commandHistory CLIENT_LIST_History[] = {
 {"7.2.0","Added `lib-name` and `lib-ver` fields."},
 {"7.4.0","Added `watch` field."},
 {"8.0.0","Added `io-thread` field."},
+{"8.2.0","Added optional `IDLE` filter."},
 };
 #endif
 
@@ -1433,6 +1434,7 @@ struct COMMAND_ARG CLIENT_LIST_client_type_Subargs[] = {
 struct COMMAND_ARG CLIENT_LIST_Args[] = {
 {MAKE_ARG("client-type",ARG_TYPE_ONEOF,-1,"TYPE",NULL,"5.0.0",CMD_ARG_OPTIONAL,4,NULL),.subargs=CLIENT_LIST_client_type_Subargs},
 {MAKE_ARG("client-id",ARG_TYPE_INTEGER,-1,"ID",NULL,"6.2.0",CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,0,NULL)},
+{MAKE_ARG("min-idle-seconds",ARG_TYPE_INTEGER,-1,"IDLE",NULL,"8.2.0",CMD_ARG_OPTIONAL,0,NULL)},
 };
 
 /********** CLIENT NO_EVICT ********************/
@@ -1713,7 +1715,7 @@ struct COMMAND_STRUCT CLIENT_Subcommands[] = {
 {MAKE_CMD("id","Returns the unique client ID of the connection.","O(1)","5.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_ID_History,0,CLIENT_ID_Tips,0,clientCommand,2,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_ID_Keyspecs,0,NULL,0)},
 {MAKE_CMD("info","Returns information about the connection.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_INFO_History,0,CLIENT_INFO_Tips,1,clientCommand,2,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_INFO_Keyspecs,0,NULL,0)},
 {MAKE_CMD("kill","Terminates open connections.","O(N) where N is the number of client connections","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_KILL_History,6,CLIENT_KILL_Tips,0,clientCommand,-3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_KILL_Keyspecs,0,NULL,1),.args=CLIENT_KILL_Args},
-{MAKE_CMD("list","Lists open connections.","O(N) where N is the number of client connections","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_LIST_History,9,CLIENT_LIST_Tips,1,clientCommand,-2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_LIST_Keyspecs,0,NULL,2),.args=CLIENT_LIST_Args},
+{MAKE_CMD("list","Lists open connections.","O(N) where N is the number of client connections","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_LIST_History,10,CLIENT_LIST_Tips,1,clientCommand,-2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_LIST_Keyspecs,0,NULL,3),.args=CLIENT_LIST_Args},
 {MAKE_CMD("no-evict","Sets the client eviction mode of the connection.","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_NO_EVICT_History,0,CLIENT_NO_EVICT_Tips,0,clientCommand,3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_NO_EVICT_Keyspecs,0,NULL,1),.args=CLIENT_NO_EVICT_Args},
 {MAKE_CMD("no-touch","Controls whether commands sent by the client affect the LRU/LFU of accessed keys.","O(1)","7.2.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_NO_TOUCH_History,0,CLIENT_NO_TOUCH_Tips,0,clientCommand,3,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_CONNECTION,CLIENT_NO_TOUCH_Keyspecs,0,NULL,1),.args=CLIENT_NO_TOUCH_Args},
 {MAKE_CMD("pause","Suspends commands processing.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_PAUSE_History,1,CLIENT_PAUSE_Tips,0,clientCommand,-3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_PAUSE_Keyspecs,0,NULL,2),.args=CLIENT_PAUSE_Args},

--- a/src/commands/client-list.json
+++ b/src/commands/client-list.json
@@ -43,6 +43,10 @@
             [
                 "8.0.0",
                 "Added `io-thread` field."
+            ],
+            [
+                "8.2.0",
+                "Added optional `IDLE` filter."
             ]
         ],
         "command_flags": [
@@ -99,6 +103,13 @@
                 "optional": true,
                 "multiple": true,
                 "since": "6.2.0"
+            },
+            {
+                "name": "min-idle-seconds",
+                "token": "IDLE",
+                "type": "integer",
+                "optional": true,
+                "since": "8.2.0"
             }
         ]
     }

--- a/src/debug.c
+++ b/src/debug.c
@@ -2208,7 +2208,7 @@ void logServerInfo(void) {
     }
     serverLogRaw(LL_WARNING|LL_RAW, infostring);
     serverLogRaw(LL_WARNING|LL_RAW, "\n------ CLIENT LIST OUTPUT ------\n");
-    clients = getAllClientsInfoString(-1);
+    clients = getAllClientsInfoString(-1, 0);
     serverLogRaw(LL_WARNING|LL_RAW, clients);
     sdsfree(infostring);
     sdsfree(clients);

--- a/src/networking.c
+++ b/src/networking.c
@@ -4039,7 +4039,7 @@ sds catClientInfoString(sds s, client *client) {
     return ret;
 }
 
-sds getAllClientsInfoString(int type) {
+sds getAllClientsInfoString(int type, long long min_idle) {
     listNode *ln;
     listIter li;
     client *client;
@@ -4060,6 +4060,9 @@ sds getAllClientsInfoString(int type) {
     while ((ln = listNext(&li)) != NULL) {
         client = listNodeValue(ln);
         if (type != -1 && getClientType(client) != type) continue;
+        if (min_idle > 0 &&
+            (long long)(server.unixtime - client->lastinteraction) < min_idle)
+            continue;
         o = catClientInfoString(o,client);
         o = sdscatlen(o,"\n",1);
     }
@@ -4262,12 +4265,24 @@ NULL
     } else if (!strcasecmp(c->argv[1]->ptr,"list")) {
         /* CLIENT LIST */
         int type = -1;
+        long long min_idle = 0;
         sds o = NULL;
         if (c->argc == 4 && !strcasecmp(c->argv[2]->ptr,"type")) {
             type = getClientTypeByName(c->argv[3]->ptr);
             if (type == -1) {
                 addReplyErrorFormat(c,"Unknown client type '%s'",
                     (char*) c->argv[3]->ptr);
+                return;
+            }
+        } else if (c->argc == 4 && !strcasecmp(c->argv[2]->ptr,"idle")) {
+            /* CLIENT LIST IDLE <seconds>
+             * Return only clients whose idle time is greater than or equal
+             * to the given threshold (in seconds). */
+            if (getLongLongFromObjectOrReply(c, c->argv[3], &min_idle,
+                        "Invalid idle time") != C_OK)
+                return;
+            if (min_idle < 0) {
+                addReplyError(c, "Idle time threshold must be non-negative");
                 return;
             }
         } else if (c->argc > 3 && !strcasecmp(c->argv[2]->ptr,"id")) {
@@ -4292,7 +4307,7 @@ NULL
         }
 
         if (!o)
-            o = getAllClientsInfoString(type);
+            o = getAllClientsInfoString(type, min_idle);
         addReplyVerbatim(c,o,sdslen(o),"txt");
         sdsfree(o);
     } else if (!strcasecmp(c->argv[1]->ptr,"reply") && c->argc == 3) {

--- a/src/server.h
+++ b/src/server.h
@@ -3226,7 +3226,7 @@ void *dupClientReplyValue(void *o);
 char *getClientPeerId(client *client);
 char *getClientSockName(client *client);
 sds catClientInfoString(sds s, client *client);
-sds getAllClientsInfoString(int type);
+sds getAllClientsInfoString(int type, long long min_idle);
 int clientSetName(client *c, robj *name, const char **err);
 void rewriteClientCommandVector(client *c, int argc, ...);
 void rewriteClientCommandArgument(client *c, int i, robj *newval);

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -33,6 +33,24 @@ start_server {tags {"introspection"}} {
         assert_match "id=$myid * cmd=client|list *" [lindex $cl 0]
     }
 
+    test {CLIENT LIST IDLE filters by minimum idle time} {
+        # A threshold of 0 must keep the existing behaviour and return all
+        # clients (at least our own connection).
+        set all [string trim [r client list]]
+        set all_zero [string trim [r client list idle 0]]
+        assert_equal [llength [split $all "\r\n"]] [llength [split $all_zero "\r\n"]]
+
+        # A very large threshold should filter every client out, including
+        # the one issuing the command (which has just interacted with the
+        # server). Expect an empty payload.
+        assert_equal "" [string trim [r client list idle 1000000]]
+    }
+
+    test {CLIENT LIST IDLE rejects invalid values} {
+        assert_error "*Invalid idle time*" {r client list idle notanumber}
+        assert_error "*non-negative*" {r client list idle -1}
+    }
+
     test {CLIENT INFO} {
         set client [r client info]
         if {[lindex [r config get io-threads] 1] == 1} {


### PR DESCRIPTION
Closes #15102.
 
## Motivation
On large deployments, `CLIENT LIST` returns a very large payload, and the
typical operator workflow for spotting "zombie" / leaked connections is
`CLIENT LIST | grep idle=...`, which transfers the entire client list over
the network just to discard most of it.
 
## What this PR does
Adds an optional `IDLE <seconds>` modifier to `CLIENT LIST` that filters
clients server-side by their `idle` field before serializing the response:
 
CLIENT LIST IDLE

 
- `CLIENT LIST IDLE 0` keeps the existing behaviour (returns all clients).
- `CLIENT LIST IDLE N` (N > 0) returns only clients whose idle time in
  seconds is `>= N`.
- Negative thresholds and non-integer values return an error.
- All other forms of `CLIENT LIST` (no args, `TYPE`, `ID`) are unchanged
  and fully backward-compatible.
 
## Implementation notes
- The filter is applied while iterating `server.clients` in
  [getAllClientsInfoString()](cci:1://file:///root/redis/src/networking.c:4041:0-4071:1), reusing the existing `lastinteraction`
  bookkeeping that already powers the `idle=` field, so there is no extra
  per-client cost beyond a single comparison.
- [src/commands/client-list.json](cci:7://file:///root/redis/src/commands/client-list.json:0:0-0:0) gains a new optional `IDLE` argument and
  a history entry; `src/commands.def` is regenerated via
  [utils/generate-command-code.py](cci:7://file:///root/redis/utils/generate-command-code.py:0:0-0:0).
 
## Tests
New cases in [tests/unit/introspection.tcl](cci:7://file:///root/redis/tests/unit/introspection.tcl:0:0-0:0):
- `CLIENT LIST IDLE filters by minimum idle time` — verifies that
  `IDLE 0` matches plain `CLIENT LIST`, and that a very large threshold
  filters out every client.
- `CLIENT LIST IDLE rejects invalid values` — verifies error replies for
  non-integer and negative thresholds.
 
`./runtest --single unit/introspection` passes locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `CLIENT LIST` parsing and the client-iteration path, so any mistakes could change admin tooling output or performance characteristics. The change is small and guarded (only filters when `IDLE > 0`) with new tests covering behavior and input validation.
> 
> **Overview**
> Adds an optional `IDLE <seconds>` modifier to `CLIENT LIST` to filter the output server-side by minimum client idle time, reducing payload size for large deployments.
> 
> Updates the implementation to pass an idle-threshold into `getAllClientsInfoString()` and skip clients that haven’t been idle long enough; invalid or negative thresholds now return errors. Command metadata (`commands.def` and `commands/client-list.json`) is regenerated to document the new option, debug logging is updated for the new function signature, and unit tests are added to validate filtering and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c23f3c2069f01695839614f1a56e5de8ddff337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->