### PR TITLE
Fix GCC warnings by using const pointers for strchr/memchr results

### DIFF
--- a/src/keymeta.c
+++ b/src/keymeta.c
@@ -92,7 +92,7 @@ static uint64_t keyMetaClassEncode(const char *name, int metaver, uint64_t flags
     /* Encode last 4-char into 32-bit serialized class ID (24b name + 5b version + 3b flags) */
     uint32_t encName4chars = 0;
     for (int j = 0; j < KM_FULLNAME_LEN; j++) {
-        char *p = strchr(keyMetaCharSet, fullname[j]);
+        const char *p = strchr(keyMetaCharSet, fullname[j]);
         if (!p) return 0; /* Invalid character in name */
         unsigned long pos = p - keyMetaCharSet;
         encName9Chars = (encName9Chars << KM_ENC_CHAR_BITS) | pos;

--- a/src/module.c
+++ b/src/module.c
@@ -7206,7 +7206,7 @@ uint64_t moduleTypeEncodeId(const char *name, int encver) {
 
     uint64_t id = 0;
     for (int j = 0; j < 9; j++) {
-        char *p = strchr(cset,name[j]);
+        const char *p = strchr(cset,name[j]);
         if (!p) return 0;
         unsigned long pos = p-cset;
         id = (id << 6) | pos;

--- a/src/networking.c
+++ b/src/networking.c
@@ -657,7 +657,7 @@ void afterErrorReply(client *c, const char *s, size_t len, int flags) {
         if (s[0] != '-') {
             incrementErrorCount("ERR", 3);
         } else {
-            char *spaceloc = memchr(s, ' ', len < 32 ? len : 32);
+            const char *spaceloc = memchr(s, ' ', len < 32 ? len : 32);
             if (spaceloc) {
                 const size_t errEndPos = (size_t)(spaceloc - s);
                 incrementErrorCount(s+1, errEndPos-1);

--- a/src/resp_parser.c
+++ b/src/resp_parser.c
@@ -41,7 +41,7 @@
 
 static int parseBulk(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     long long bulklen;
     parser->curr_location = p + 2; /* for \r\n */
 
@@ -60,7 +60,7 @@ static int parseBulk(ReplyParser *parser, void *p_ctx) {
 
 static int parseSimpleString(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     parser->curr_location = p + 2; /* for \r\n */
     parser->callbacks.simple_str_callback(p_ctx, proto+1, p-proto-1, proto, parser->curr_location - proto);
     return C_OK;
@@ -68,7 +68,7 @@ static int parseSimpleString(ReplyParser *parser, void *p_ctx) {
 
 static int parseError(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     parser->curr_location = p + 2; // for \r\n
     parser->callbacks.error_callback(p_ctx, proto+1, p-proto-1, proto, parser->curr_location - proto);
     return C_OK;
@@ -76,7 +76,7 @@ static int parseError(ReplyParser *parser, void *p_ctx) {
 
 static int parseLong(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     parser->curr_location = p + 2; /* for \r\n */
     long long val;
     string2ll(proto+1,p-proto-1,&val);
@@ -86,7 +86,7 @@ static int parseLong(ReplyParser *parser, void *p_ctx) {
 
 static int parseAttributes(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     long long len;
     string2ll(proto+1,p-proto-1,&len);
     p += 2;
@@ -97,7 +97,7 @@ static int parseAttributes(ReplyParser *parser, void *p_ctx) {
 
 static int parseVerbatimString(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     long long bulklen;
     parser->curr_location = p + 2; /* for \r\n */
     string2ll(proto+1,p-proto-1,&bulklen);
@@ -110,7 +110,7 @@ static int parseVerbatimString(ReplyParser *parser, void *p_ctx) {
 
 static int parseBigNumber(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     parser->curr_location = p + 2; /* for \r\n */
     parser->callbacks.big_number_callback(p_ctx, proto+1, p-proto-1, proto, parser->curr_location - proto);
     return C_OK;
@@ -118,7 +118,7 @@ static int parseBigNumber(ReplyParser *parser, void *p_ctx) {
 
 static int parseNull(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     parser->curr_location = p + 2; /* for \r\n */
     parser->callbacks.null_callback(p_ctx, proto, parser->curr_location - proto);
     return C_OK;
@@ -126,7 +126,7 @@ static int parseNull(ReplyParser *parser, void *p_ctx) {
 
 static int parseDouble(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     parser->curr_location = p + 2; /* for \r\n */
     size_t len = p-proto-1;
     double d;
@@ -141,7 +141,7 @@ static int parseDouble(ReplyParser *parser, void *p_ctx) {
 
 static int parseBool(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     parser->curr_location = p + 2; /* for \r\n */
     parser->callbacks.bool_callback(p_ctx, proto[1] == 't', proto, parser->curr_location - proto);
     return C_OK;
@@ -149,7 +149,7 @@ static int parseBool(ReplyParser *parser, void *p_ctx) {
 
 static int parseArray(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     long long len;
     string2ll(proto+1,p-proto-1,&len);
     p += 2;
@@ -164,7 +164,7 @@ static int parseArray(ReplyParser *parser, void *p_ctx) {
 
 static int parseSet(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     long long len;
     string2ll(proto+1,p-proto-1,&len);
     p += 2;
@@ -175,7 +175,7 @@ static int parseSet(ReplyParser *parser, void *p_ctx) {
 
 static int parseMap(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto+1,'\r');
+    const char *p = strchr(proto+1,'\r');
     long long len;
     string2ll(proto+1,p-proto-1,&len);
     p += 2;


### PR DESCRIPTION

### Problem


On Ubuntu 26.04, running `make test` shows these GCC warnings:
```shell
resp_parser.c: In function ‘parseBulk’:
resp_parser.c:44:15: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   44 |     char *p = strchr(proto+1,'\r');
      |               ^~~~~~
resp_parser.c: In function ‘parseSimpleString’:
resp_parser.c:63:15: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   63 |     char *p = strchr(proto+1,'\r');
      |               ^~~~~~
resp_parser.c: In function ‘parseError’:
resp_parser.c:71:15: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   71 |     char *p = strchr(proto+1,'\r');
      |               ^~~~~~
resp_parser.c: In function ‘parseLong’:
resp_parser.c:79:15: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   79 |     char *p = strchr(proto+1,'\r');
      |               ^~~~~~
```

### Changed

It updates local pointer types from `char *` to `const char *` without changing runtime behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical change that only adjusts local pointer types to preserve `const` correctness; behavior and data flow are unchanged.
> 
> **Overview**
> Fixes GCC `-Wdiscarded-qualifiers` warnings by updating local variables that capture `strchr`/`memchr` results from `char *` to `const char *`.
> 
> This is applied across key metadata encoding (`keymeta.c`), module type ID encoding (`module.c`), error stats parsing (`networking.c`), and RESP reply parsing (`resp_parser.c`), with no intended runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f059c42dcbb9d2812f9153ffea83d46c288255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->