### PR TITLE
[feat] Add support for command CLIENT LIST IDLE [<min-idle-seconds>]

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -1406,6 +1406,7 @@ commandHistory CLIENT_LIST_History[] = {
 {"7.2.0","Added `lib-name` and `lib-ver` fields."},
 {"7.4.0","Added `watch` field."},
 {"8.0.0","Added `io-thread` field."},
+{"8.2.0","Added optional `IDLE` filter."},
 };
 #endif
 
@@ -1433,6 +1434,7 @@ struct COMMAND_ARG CLIENT_LIST_client_type_Subargs[] = {
 struct COMMAND_ARG CLIENT_LIST_Args[] = {
 {MAKE_ARG("client-type",ARG_TYPE_ONEOF,-1,"TYPE",NULL,"5.0.0",CMD_ARG_OPTIONAL,4,NULL),.subargs=CLIENT_LIST_client_type_Subargs},
 {MAKE_ARG("client-id",ARG_TYPE_INTEGER,-1,"ID",NULL,"6.2.0",CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,0,NULL)},
+{MAKE_ARG("min-idle-seconds",ARG_TYPE_INTEGER,-1,"IDLE",NULL,"8.2.0",CMD_ARG_OPTIONAL,0,NULL)},
 };
 
 /********** CLIENT NO_EVICT ********************/
@@ -1713,7 +1715,7 @@ struct COMMAND_STRUCT CLIENT_Subcommands[] = {
 {MAKE_CMD("id","Returns the unique client ID of the connection.","O(1)","5.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_ID_History,0,CLIENT_ID_Tips,0,clientCommand,2,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_ID_Keyspecs,0,NULL,0)},
 {MAKE_CMD("info","Returns information about the connection.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_INFO_History,0,CLIENT_INFO_Tips,1,clientCommand,2,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_INFO_Keyspecs,0,NULL,0)},
 {MAKE_CMD("kill","Terminates open connections.","O(N) where N is the number of client connections","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_KILL_History,6,CLIENT_KILL_Tips,0,clientCommand,-3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_KILL_Keyspecs,0,NULL,1),.args=CLIENT_KILL_Args},
-{MAKE_CMD("list","Lists open connections.","O(N) where N is the number of client connections","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_LIST_History,9,CLIENT_LIST_Tips,1,clientCommand,-2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_LIST_Keyspecs,0,NULL,2),.args=CLIENT_LIST_Args},
+{MAKE_CMD("list","Lists open connections.","O(N) where N is the number of client connections","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_LIST_History,10,CLIENT_LIST_Tips,1,clientCommand,-2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_LIST_Keyspecs,0,NULL,3),.args=CLIENT_LIST_Args},
 {MAKE_CMD("no-evict","Sets the client eviction mode of the connection.","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_NO_EVICT_History,0,CLIENT_NO_EVICT_Tips,0,clientCommand,3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_NO_EVICT_Keyspecs,0,NULL,1),.args=CLIENT_NO_EVICT_Args},
 {MAKE_CMD("no-touch","Controls whether commands sent by the client affect the LRU/LFU of accessed keys.","O(1)","7.2.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_NO_TOUCH_History,0,CLIENT_NO_TOUCH_Tips,0,clientCommand,3,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_CONNECTION,CLIENT_NO_TOUCH_Keyspecs,0,NULL,1),.args=CLIENT_NO_TOUCH_Args},
 {MAKE_CMD("pause","Suspends commands processing.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_PAUSE_History,1,CLIENT_PAUSE_Tips,0,clientCommand,-3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_PAUSE_Keyspecs,0,NULL,2),.args=CLIENT_PAUSE_Args},

--- a/src/commands/client-list.json
+++ b/src/commands/client-list.json
@@ -43,6 +43,10 @@
             [
                 "8.0.0",
                 "Added `io-thread` field."
+            ],
+            [
+                "8.2.0",
+                "Added optional `IDLE` filter."
             ]
         ],
         "command_flags": [
@@ -99,6 +103,13 @@
                 "optional": true,
                 "multiple": true,
                 "since": "6.2.0"
+            },
+            {
+                "name": "min-idle-seconds",
+                "token": "IDLE",
+                "type": "integer",
+                "optional": true,
+                "since": "8.2.0"
             }
         ]
     }

--- a/src/networking.c
+++ b/src/networking.c
@@ -4224,6 +4224,10 @@ void clientCommand(client *c) {
 "    Return information about client connections. Options:",
 "    * TYPE (NORMAL|MASTER|REPLICA|PUBSUB)",
 "      Return clients of specified type.",
+"    * ID <client-id> [<client-id> [...]]",
+"      Return clients by client id.",
+"    * IDLE [<min-idle-seconds>]",
+"      Return clients with idle time greater than the given seconds (omit for idle > 0).",
 "UNPAUSE",
 "    Stop the current client pause, resuming traffic.",
 "PAUSE <timeout> [WRITE|ALL]",
@@ -4263,7 +4267,41 @@ NULL
         /* CLIENT LIST */
         int type = -1;
         sds o = NULL;
-        if (c->argc == 4 && !strcasecmp(c->argv[2]->ptr,"type")) {
+        /* CLIENT LIST IDLE [<min-idle-seconds>]: same seconds as idle= in catClientInfoString. */
+        if ((c->argc == 3 || c->argc == 4) &&
+            !strcasecmp(c->argv[2]->ptr,"idle"))
+        {
+            long long min_idletime = 0;
+            if (c->argc == 4 && getLongLongFromObjectOrReply(c, c->argv[3], &min_idletime,
+                            "min idle time is not an integer or out of range")) {
+                return;
+            } else if (c->argc == 4 && min_idletime <= 0) {
+                addReplyError(c, "min idle time should be greater than 0");
+                return;
+            } else {
+                /* Pause IO threads like getAllClientsInfoString before scanning clients. */
+                int allpaused = 0;
+                if (server.io_threads_num > 1 && !isCrashing() &&
+                    pthread_equal(server.main_thread_id, pthread_self()))
+                {
+                    allpaused = 1;
+                    pauseAllIOThreads();
+                }
+
+                o = sdsempty();
+                listRewind(server.clients,&li);
+                while ((ln = listNext(&li)) != NULL) {
+                    client *client = listNodeValue(ln);
+                    long long idletime =
+                        (long long)(server.unixtime - client->lastinteraction);
+                    if (idletime > min_idletime) {
+                        o = catClientInfoString(o, client);
+                        o = sdscatlen(o, "\n", 1);
+                    }
+                }
+                if (allpaused) resumeAllIOThreads();
+            }
+        } else if (c->argc == 4 && !strcasecmp(c->argv[2]->ptr,"type")) {
             type = getClientTypeByName(c->argv[3]->ptr);
             if (type == -1) {
                 addReplyErrorFormat(c,"Unknown client type '%s'",

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -64,6 +64,35 @@ start_server {tags {"introspection"}} {
         return ""
     }
 
+    test {CLIENT LIST IDLE rejects invalid arguments} {
+        assert_error "ERR syntax error*" {r client list idle 1 extra}
+        assert_error "ERR *min idle time is not an integer or out of range*" {r client list idle notanumber}
+        assert_error "ERR *greater than 0*" {r client list idle 0}
+        assert_error "ERR *greater than 0*" {r client list idle -1}
+    }
+
+    test {CLIENT LIST IDLE filters by min idle seconds} {
+        set rd [redis_deferring_client]
+        $rd client id
+        set rd_id [$rd read]
+        wait_for_condition 50 200 {
+            [get_field_in_client_list $rd_id [r client list] idle] > 2
+        } else {
+            fail "deferred client idle did not exceed 2 seconds"
+        }
+        set filtered [r client list idle 2]
+        assert_match "*id=$rd_id*" $filtered
+        assert_equal {} [string trim [r client list idle 999999]]
+        set filtered_default [r client list idle]
+        assert_match "*id=$rd_id*" $filtered_default
+        foreach line [split [string trim $filtered] "\r\n"] {
+            if {$line eq {}} continue
+            set idle [get_field_in_client_info $line idle]
+            assert_morethan $idle 2
+        }
+        $rd close
+    }
+
     test {CLIENT INFO input/output/cmds-processed stats} {
         set info1 [r client info]
         set input1 [get_field_in_client_info $info1 "tot-net-in"]


### PR DESCRIPTION
Addresses #15102 

## Feature details (user perspective)
### This PR adds support for filtering CLIENT LIST output by idle time, so operators can quickly identify inactive connections.

New usage: CLIENT LIST IDLE [<min-idle-seconds>]
CLIENT LIST IDLE (without value) returns clients idle for more than 0 seconds.
CLIENT LIST IDLE <N> returns clients with idle > N seconds.
Invalid values (non-integer / <= 0) now return clear errors.

## Implementation details (code changes)

`src/networking.c` 
- Added handling for CLIENT LIST IDLE [<min-idle-seconds>] in clientCommand.
- Validates input and returns:
    - ERR min idle time is not an integer or out of range
    - ERR min idle time should be greater than 0
    - Applies filtering using the same idle calculation already exposed in CLIENT LIST output (idle= field):
    - server.unixtime - client->lastinteraction.
    - Pauses/resumes IO threads during scan (same safety pattern as existing client-list code path).
    - Updated CLIENT HELP text to document the new IDLE option and behavior.
    
`src/commands/client-list.json`
- Updated command metadata for CLIENT LIST:
    - Added/normalized IDLE argument naming to min-idle-seconds.
    - Kept history aligned with command definitions (8.2.0 optional IDLE filter).

## Tests
### Added tests in tests/unit/introspection.tcl
 - `CLIENT LIST IDLE rejects invalid arguments`
    - Verifies syntax error for extra args.
    - Verifies non-integer validation error.
    - Verifies rejection of 0 and negative values.

- `CLIENT LIST IDLE filters by min idle seconds`
    - Creates a deferred client and waits until idle crosses threshold.
     - Verifies:
           - CLIENT LIST IDLE 2 includes that client.
           - CLIENT LIST IDLE 999999 is empty.
           - CLIENT LIST IDLE (no threshold) returns idle clients.
           - Every returned row satisfies idle > threshold.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `CLIENT LIST` filtering mode that scans all clients and pauses/resumes IO threads, which could impact performance or concurrency if edge cases are missed. Behavior is gated behind a new option and covered by unit tests, keeping overall risk moderate.
> 
> **Overview**
> Adds support for `CLIENT LIST IDLE [<min-idle-seconds>]` to filter the client list by idle time (defaulting to *idle > 0* when no threshold is provided), including argument validation and updated `CLIENT HELP` text.
> 
> Updates command metadata (`commands.def` and `commands/client-list.json`) to document the new optional `IDLE` filter (since `8.2.0`) and extends `tests/unit/introspection.tcl` with coverage for invalid inputs and correct filtering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a50b2dee8154380124ff52e4af7a7ab7f577977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->