### PR TITLE
Fix GCRA oversize TOKENS reply consistency

### DIFF
--- a/src/commands/gcra.json
+++ b/src/commands/gcra.json
@@ -51,15 +51,15 @@
                 },
                 {
                     "type": "integer",
-                    "description": "Number of tokens available immediately"
+                    "description": "Number of tokens available immediately. Zero if limited with TOKENS above burst capacity (unretryable at these parameters)"
                 },
                 {
                     "type": "integer",
-                    "description": "Retry after: seconds after which the caller should retry. Always -1 if not limited"
+                    "description": "Retry after: seconds after which the caller should retry when limited; -1 if allowed, or if limited because TOKENS exceeds burst capacity (cannot succeed without changing parameters)"
                 },
                 {
                     "type": "integer",
-                    "description": "Full burst after: seconds after which a full burst will be allowed"
+                    "description": "Full burst after: seconds after which a full burst will be allowed. -1 when limited with TOKENS above burst capacity"
                 }
             ]
         },

--- a/src/gcra.c
+++ b/src/gcra.c
@@ -224,11 +224,19 @@ void gcraCommand(client *c) {
         server.dirty++;
     }
 
-    long long next_us = variance_us - ttl_us;
-    if (next_us > -emission_interval_us) {
-        remaining = next_us / emission_interval_us;
+    /* TOKENS cost above burst capacity can never succeed at these parameters;
+     * retry_after stays -1. Do not derive remaining/reset_after from ttl_us in
+     * that case or the reply would imply immediate capacity. */
+    if (diff_us < 0 && increment_us > variance_us) {
+        remaining = 0;
+        reset_after_s = -1;
+    } else {
+        long long next_us = variance_us - ttl_us;
+        if (next_us > -emission_interval_us) {
+            remaining = next_us / emission_interval_us;
+        }
+        reset_after_s = ceil(ttl_us / 1000000.);
     }
-    reset_after_s = ceil(ttl_us / 1000000.);
 
     addReplyArrayLen(c, 5);
     addReply(c, limited ? shared.cone : shared.czero);

--- a/tests/unit/gcra.tcl
+++ b/tests/unit/gcra.tcl
@@ -135,6 +135,16 @@ start_server {tags {"gcra" "external:skip"}} {
         assert_equal 3 $avail2
     }
 
+    test {GCRA - TOKENS larger than burst capacity: coherent reply} {
+        r del mykey
+        # At most 6 tokens per request (max_burst 5 means 5+1); TOKENS 10 is denied
+        set result [r gcra mykey 5 1 60 TOKENS 10]
+        assert_equal 1 [lindex $result 0]
+        assert_equal 0 [lindex $result 2]
+        assert_equal -1 [lindex $result 3]
+        assert_equal -1 [lindex $result 4]
+    }
+
     test {GCRA - rate recovery over time} {
         r del mykey
         # max_burst=1, tokens_per_period=1, period=1 (1 token per second)


### PR DESCRIPTION
## Summary
Fixes inconsistent GCRA reply fields when TOKENS is larger than the configured burst capacity: the call was correctly limited with `retry_after` left at `-1`, but `remaining` and `reset_after` still came from the usual `ttl_us` path and could look like immediate capacity was available.

## Problem
For `diff_us < 0` and `increment_us > variance_us`, the implementation intentionally keeps `retry_after_s = -1` (request cannot succeed at these parameters without changing them). 

It still ran:
`next_us = variance_us - ttl_us` with `ttl_us = tat_us - now` (often 0 on a fresh key),
so remaining could equal the full burst and `reset_after` could be `0`, contradicting “unretryable”.

## Solution
If the request is limited and the token cost exceeds burst capacity (`increment_us > variance_us`), set `remaining = 0` and `reset_after_s = -1`, matching the existing `retry_after_s = -1` contract. 
All other cases keep the previous remaining / `reset_after` logic.

## Testing and Documentation
- New Tcl test: `GCRA - TOKENS` larger than burst capacity: coherent reply (`DEL` key, then `GCRA … TOKENS 10` with max burst 5 / 1 / 60), asserting limited == 1, remaining == 0, retry_after == -1, reset_after == -1.

- Updated `src/commands/gcra.json` reply schema descriptions for the `remaining`, `retry_after`, and `reset_after` fields to describe `oversize-TOKENS / -1` behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `GCRA` command’s reply semantics for the edge case where `TOKENS` exceeds burst capacity, which may affect clients that interpret `remaining`/`reset_after` fields.
> 
> **Overview**
> Fixes inconsistent `GCRA` replies when a request is rate-limited because `TOKENS` exceeds the configured burst capacity (an unretryable case).
> 
> In `gcraCommand` (`src/gcra.c`), this path now forces `remaining = 0` and `reset_after = -1` (keeping `retry_after = -1`) instead of deriving them from `ttl_us`, avoiding replies that suggest immediate capacity.
> 
> Updates the `gcra.json` reply schema descriptions to document the `-1`/`0` behavior for oversize `TOKENS`, and adds a unit test asserting the coherent reply fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f09307755501d51b3213762d19475283b1cbcf4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->