### PR TITLE
t_string: rewrite SET GET propagation in place

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -215,10 +215,10 @@ void setGenericCommand(client *c, int flags, robj *key, robj **valref, robj *exp
         for (int j = c->argc - 1; j >= 3; j--) {
             char *a = c->argv[j]->ptr;
             /* Skip GET which may be repeated multiple times. */
-            if (j >= 3 &&
-                (a[0] == 'g' || a[0] == 'G') &&
+            if ((a[0] == 'g' || a[0] == 'G') &&
                 (a[1] == 'e' || a[1] == 'E') &&
-                (a[2] == 't' || a[2] == 'T') && a[3] == '\0') {
+                (a[2] == 't' || a[2] == 'T') && a[3] == '\0')
+            {
                 rewriteClientCommandArgument(c, j, NULL);
             }
         }

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -212,21 +212,16 @@ void setGenericCommand(client *c, int flags, robj *key, robj **valref, robj *exp
 
     /* Propagate without the GET argument (Isn't needed if we had expire since in that case we completely re-written the command argv) */
     if ((flags & OBJ_SET_GET) && !expire) {
-        int argc = 0;
-        int j;
-        robj **argv = zmalloc((c->argc-1)*sizeof(robj*));
-        for (j=0; j < c->argc; j++) {
+        for (int j = c->argc - 1; j >= 3; j--) {
             char *a = c->argv[j]->ptr;
             /* Skip GET which may be repeated multiple times. */
             if (j >= 3 &&
                 (a[0] == 'g' || a[0] == 'G') &&
                 (a[1] == 'e' || a[1] == 'E') &&
-                (a[2] == 't' || a[2] == 'T') && a[3] == '\0')
-                continue;
-            argv[argc++] = c->argv[j];
-            incrRefCount(c->argv[j]);
+                (a[2] == 't' || a[2] == 'T') && a[3] == '\0') {
+                rewriteClientCommandArgument(c, j, NULL);
+            }
         }
-        replaceClientCommandVector(c, argc, argv);
     }
 }
 

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -119,6 +119,12 @@ start_server {tags {"repl external:skip"}} {
             } else {
                 fail "set get wasn't propagated"
             }
+            assert_equal [r set test qaz get get] vaz
+            wait_for_condition 500 10 {
+                [$A get test] eq "qaz"
+            } else {
+                fail "set get get wasn't propagated"
+            }
             assert_match {*calls=3,*} [cmdrstat set $A]
             assert_match {} [cmdrstat getset $A]
         }

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -125,7 +125,7 @@ start_server {tags {"repl external:skip"}} {
             } else {
                 fail "set get get wasn't propagated"
             }
-            assert_match {*calls=3,*} [cmdrstat set $A]
+            assert_match {*calls=4,*} [cmdrstat set $A]
             assert_match {} [cmdrstat getset $A]
         }
 

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -635,6 +635,14 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         list $old_value $new_value
     } {{} bar}
 
+    test {Extended SET GET option accepts repeated GET tokens} {
+        r del foo
+        r set foo bar
+        set old_value [r set foo baz GET GET]
+        set new_value [r get foo]
+        list $old_value $new_value
+    } {bar baz}
+
     test {Extended SET GET option with XX} {
         r del foo
         r set foo bar


### PR DESCRIPTION
 Optimize `SET key value GET` propagation rewriting in `setGenericCommand()` by removing `GET` arguments in-place with `rewriteClientCommandArgument(c, j, NULL)` instead of allocating a new argv vector and incrementing refcounts for       every retained argument. The change stays scoped to the no-expire `SET ... GET` rewrite path and adds coverage for repeated `GET` tokens in both string semantics and replication.
                                                                                 
 ## Benchmark result                                                             
                                                                                 
 - Baseline: `HEAD` in a clean worktree                                          
 - Patched: current branch `set-get-inplace-command-rewrite`                     
 - Server config: `--save "" --appendonly no`                                    
 - Benchmark command: 
 `src/redis-benchmark -h 127.0.0.1 -p <port> -n 1000000 -c 50 -P 16 --precision 3 set benchkey xxx get`
 - Method: 3 alternating baseline/patched runs after a short warmup              
                                                                                 
 Median results:                                                                 
                                                                                 
 - Throughput: `1,194,743.12 -> 1,319,261.12 req/s` (**+10.42%**)                
 - Average latency: `0.625 -> 0.563 ms` (**-9.92%**)                             
 - P99 latency: `0.871 -> 0.815 ms` (**-6.43%**)                                 
                                                                                 
 Per-run throughput:                                                             
                                                                                 
 - Baseline: `1,194,743.12`, `1,223,990.25`, `1,189,060.62` req/s                
 - Patched: `1,308,900.50`, `1,349,527.62`, `1,319,261.12` req/s   

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `setGenericCommand()` replication/AOF command rewriting for `SET ... GET`, so mistakes could impact propagation correctness, but the change is narrowly scoped and covered by new unit/integration tests.
> 
> **Overview**
> Optimizes propagation rewriting for `SET key value GET` by stripping `GET` tokens **in-place** via `rewriteClientCommandArgument(..., NULL)` instead of rebuilding a new argv vector.
> 
> Extends coverage to ensure repeated `GET` tokens (e.g. `SET k v GET GET`) behave correctly and replicate as expected, adding both unit tests and a replication regression test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9155c6b88f47c2b2cf8ab5b70774f346282c4e32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->