### PR TITLE
Fix incorrect memmove size in LDB breakpoint deletion

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -1027,7 +1027,7 @@ int ldbDelBreakpoint(int line) {
     for (j = 0; j < ldb.bpcount; j++) {
         if (ldb.bp[j] == line) {
             ldb.bpcount--;
-            memmove(ldb.bp+j,ldb.bp+j+1,ldb.bpcount-j);
+            memmove(ldb.bp+j,ldb.bp+j+1,(ldb.bpcount-j) * sizeof(int));
             return 1;
         }
     }


### PR DESCRIPTION
# Description
There is an array corruption bug in LDB caused by an incorrect size argument being passed to `memmove` inside the `ldbDelBreakpoint` function.

When deleting a breakpoint, `memmove` is used to shift the remaining breakpoints in the ldb.bp integer array forward. However, the size parameter passes the number of elements rather than the number of bytes. Because ldb.bp is an array of type `int`, this results in an under-copy.

# Code block
```c
int ldbDelBreakpoint(int line) {
    int j;
    for (j = 0; j < ldb.bpcount; j++) {
        if (ldb.bp[j] == line) {
            ldb.bpcount--;
            memmove(ldb.bp+j,ldb.bp+j+1,ldb.bpcount-j); // <--- Here
            return 1;
        }
    }
    return 0;
}
```
`memmove` copies partial bytes of the integer array.

# Proof Of Concept
```bash
echo "local a = {}" > test.lua
seq 1 260 | awk '{print "a["$1"] = "$1}' >> test.lua
echo "return a[260]" >> test.lua

# Start debugger
redis-cli --ldb --eval test.lua

# Set breakpoints at 1,2, 260
lua debugger> b 1
lua debugger> b 2
lua debugger> b 260

# Check breakpoints
lua debugger> b
3 breakpoints set:
->#1   local a = {}
  #2   a[1] = 1
  #260 a[259] = 259

# Delete breakpoint 2
lua debugger> b -2
Breakpoint removed.
```

## Output
```bash
# Line 260 is silently deleted and a breakpoint at line 4 is created.
lua debugger> b
2 breakpoints set:
->#1   local a = {}
  #4   a[3] = 3
```

# Possible fix
Multiply the remaining elements by `sizeof(int)` (or `sizeof(*ldb.bp)`) to fulfill the byte count expected by `memmove`

```c
-            memmove(ldb.bp+j,ldb.bp+j+1,ldb.bpcount-j);
+            memmove(ldb.bp+j,ldb.bp+j+1,(ldb.bpcount-j)*sizeof(int));
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized fix to Lua debugger breakpoint deletion that corrects a `memmove` length calculation and prevents breakpoint list corruption without affecting core command execution.
> 
> **Overview**
> Fixes an under-copy bug in the Lua debugger’s `ldbDelBreakpoint` by passing the correct byte length to `memmove` when shifting the remaining entries in `ldb.bp`.
> 
> This prevents silent corruption of the breakpoint list when a breakpoint is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c130badd2ff47cb8af25a68260305291be3bd49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->