### PR TITLE
Discard stale active_clients count if wall clock moves backwards

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6054,10 +6054,18 @@ void statsUpdateActiveClients(client *c) {
         /* Clear every slot crossed since the last update. Cap at one full
          * window so large time gaps still clear each slot exactly once. */
         long long slots_to_clear = (current_window_ts - active_clients_window_ts) / SLOT_DURATION_MS;
-        if (slots_to_clear > WINDOW_SLOTS) slots_to_clear = WINDOW_SLOTS;
-        int prev_slot = (active_clients_window_ts / SLOT_DURATION_MS) % WINDOW_SLOTS;
-        for (int i = 1; i <= (int)slots_to_clear; i++) {
-            active_clients_window[(prev_slot + i) % WINDOW_SLOTS] = 0;
+        if (slots_to_clear < 0) {
+            /* Wall clock moved backwards: forward slot crossings do not apply,
+             * so stale counts must be discarded entirely. */
+            for (int i = 0; i < WINDOW_SLOTS; i++) {
+                active_clients_window[i] = 0;
+            }
+        } else {
+            if (slots_to_clear > WINDOW_SLOTS) slots_to_clear = WINDOW_SLOTS;
+            int prev_slot = (active_clients_window_ts / SLOT_DURATION_MS) % WINDOW_SLOTS;
+            for (int i = 1; i <= (int)slots_to_clear; i++) {
+                active_clients_window[(prev_slot + i) % WINDOW_SLOTS] = 0;
+            }
         }
         active_clients_window_ts = current_window_ts;
     }
@@ -6075,7 +6083,8 @@ void statsUpdateActiveClients(client *c) {
      * maintenance — otherwise a slot cleared by advancement may still
      * appear "within the window" by exact-timestamp comparison. */
     long long old_slot_boundary = (c->last_ts_when_counted_as_active / SLOT_DURATION_MS) * SLOT_DURATION_MS;
-    if (old_slot_boundary >= active_clients_window_ts - (WINDOW_SLOTS - 1) * SLOT_DURATION_MS) {
+    if (old_slot_boundary >= active_clients_window_ts - (WINDOW_SLOTS - 1) * SLOT_DURATION_MS &&
+        old_slot_boundary <= active_clients_window_ts) {
         int old_slot = (c->last_ts_when_counted_as_active / SLOT_DURATION_MS) % WINDOW_SLOTS;
         active_clients_window[old_slot]--;
     }


### PR DESCRIPTION
## Problem
When wall clock moves backwards, `slots_to_clear` would be negative 
(`slots_to_clear = (current_window_ts - active_clients_window_ts) / SLOT_DURATION_MS`)
and therefore slot counts (`active_clients_window[]`) were not cleared, so querying `active_clients` then would give false count

## Fix
Ensure slot counts (`active_clients_window[]`) are cleared when `slots_to_clear` is negative.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to active-client sliding-window accounting, but changes affect stats correctness during clock skew/backwards time adjustments.
> 
> **Overview**
> Fixes `active_clients` sliding-window maintenance when system time jumps backwards by **discarding all slot counts** instead of leaving stale values when `slots_to_clear` becomes negative.
> 
> Also tightens the “decrement old slot” path to only apply when the previous slot boundary is within `[window_start, current_window_ts]`, avoiding incorrect decrements after time skew.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae9ca5c7a9f544f18a9280bc193817bddb67256f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->