### PR TITLE
fix rdb: guard streamFreeNACK calls with NULL checks

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3452,7 +3452,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                         rdbReportCorruptRDB("Duplicated consumer PEL entry "
                                                 " loading a stream consumer "
                                                 "group");
-                        if (nack != NULL) streamFreeNACK(s, nack);
+                        streamFreeNACK(s, nack);
                         decrRefCount(o);
                         return NULL;
                     }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3345,14 +3345,14 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, cgroup, rawid);
                 if (rioGetReadError(rdb)) {
                     rdbReportReadError("Stream PEL NACK loading failed.");
-                    streamFreeNACK(s, nack);
+                    if (nack != NULL) streamFreeNACK(s, nack);
                     decrRefCount(o);
                     return NULL;
                 }
                 if (!raxTryInsert(cgroup->pel,rawid,sizeof(rawid),nack,NULL)) {
                     rdbReportCorruptRDB("Duplicated global PEL entry "
                                             "loading stream consumer group");
-                    streamFreeNACK(s, nack);
+                    if (nack != NULL) streamFreeNACK(s, nack);
                     decrRefCount(o);
                     return NULL;
                 }
@@ -3447,7 +3447,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                         rdbReportCorruptRDB("Duplicated consumer PEL entry "
                                                 " loading a stream consumer "
                                                 "group");
-                        streamFreeNACK(s, nack);
+                        if (nack != NULL) streamFreeNACK(s, nack);
                         decrRefCount(o);
                         return NULL;
                     }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3340,19 +3340,24 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 streamID nack_id;
                 streamDecodeID(rawid, &nack_id);
                 streamNACK *nack = streamCreateNACK(s, NULL, &nack_id);
+                if (nack == NULL) {
+                    rdbReportReadError("Stream PEL NACK allocation failed.");
+                    decrRefCount(o);
+                    return NULL;
+                }
                 nack->delivery_time = rdbLoadMillisecondTime(rdb,RDB_VERSION);
                 nack->delivery_count = rdbLoadLen(rdb,NULL);
                 nack->cgroup_ref_node = streamLinkCGroupToEntry(s, cgroup, rawid);
                 if (rioGetReadError(rdb)) {
                     rdbReportReadError("Stream PEL NACK loading failed.");
-                    if (nack != NULL) streamFreeNACK(s, nack);
+                    streamFreeNACK(s, nack);
                     decrRefCount(o);
                     return NULL;
                 }
                 if (!raxTryInsert(cgroup->pel,rawid,sizeof(rawid),nack,NULL)) {
                     rdbReportCorruptRDB("Duplicated global PEL entry "
                                             "loading stream consumer group");
-                    if (nack != NULL) streamFreeNACK(s, nack);
+                    streamFreeNACK(s, nack);
                     decrRefCount(o);
                     return NULL;
                 }


### PR DESCRIPTION
Prevent potential double-free or use-after-free when loading stream consumer groups from RDB files.

This guards streamFreeNACK() calls in rdbLoadObject() with NULL checks since streamCreateNACK() could theoretically return NULL on allocation failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a defensive NULL check during RDB stream consumer-group PEL loading, only affecting out-of-memory/error paths in persistence loading.
> 
> **Overview**
> Improves robustness of stream consumer-group PEL loading in `rdbLoadObject()` by checking for `NULL` after `streamCreateNACK()` and failing the load with a read error if NACK allocation fails.
> 
> This prevents subsequent dereferences and cleanup paths from operating on an invalid NACK when an allocation failure occurs during RDB load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60892a4d2b78fed377f5f6db5153048c2de7b383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->