### PR TITLE
perf+security: drop SCAN vector pre-allocation; rely on grow-by-doubling

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1896,10 +1896,6 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
     vec keys;
     void *keys_stack[256];
     vecInit(&keys, keys_stack, 256);
-    /* When COUNT exceeds the stack buffer, pre-size the heap buffer to avoid
-     * the grow-by-doubling path during scanCallback. */
-    if ((size_t)count > sizeof(keys_stack) / sizeof(keys_stack[0]))
-        vecReserve(&keys, count);
     /* Hash on dict only has pointers to dict entries; other paths allocate
      * temporary sds that must be released. */
     if (o && (!ht || o->type == OBJ_ZSET))


### PR DESCRIPTION
## Summary
Follow-up to #15065. The merged code calls `vecReserve(&keys, count)` where `count` is user-supplied. A client can pass a giant `COUNT` (e.g. `HSCAN k 0 COUNT 10000000000000`) and the server pre-allocates the corresponding pointer slots before any work happens — ~80 TB on a 64-bit build. Pre-reserve DoS surface flagged in code review.

## Fix
Drop the pre-reserve entirely. The vec already starts on a 256-pointer stack buffer and grows-by-doubling driven by **actual cardinality** of the dictionary, not by user-supplied `COUNT`.

```diff
     vec keys;
     void *keys_stack[256];
     vecInit(&keys, keys_stack, 256);
-    /* When COUNT exceeds the stack buffer, pre-size the heap buffer to avoid
-     * the grow-by-doubling path during scanCallback. */
-    if ((size_t)count > sizeof(keys_stack) / sizeof(keys_stack[0]))
-        vecReserve(&keys, count);
     /* Hash on dict only has pointers to dict entries; other paths allocate
```

## Why drop the pre-reserve (vs cap it)
The pre-reserve doesn't pay measurable performance — `vecPush()`'s grow-by-doubling path is amortized O(1) and the dominant cost on SCAN workloads is the per-entry callback work, not vector growth.

Bench on `count-500-pipeline-10` (the test where #15065 showed its peak +38–40% improvement) — `x86-aws-m7i.metal-24xl-profiler`, 3 dp per variant:

| Variant | Median ops/sec | σ | Δ vs current |
|---|---:|---:|---:|
| unstable @ `7a80aade9` (current, DoS surface) | 19316 | 0.6 % | baseline |
| cap=4096 | 19326 | 0.7 % | +0.1 % |
| cap=1024 | 19284 | 0.2 % | -0.2 % |
| **removed entirely (this PR)** | **19372** | **0.2 %** | **+0.3 %** |

All three fixes are perf-equivalent within noise. Going with the simplest: no magic constant to defend, smallest diff (-4 lines), and the fix path is then self-documenting — the user's `COUNT` is only an iteration hint, never an allocation primitive.

## DoS verification
Local repro on a small hash (`HSET hash a 1 b 2 c 3 d 4`):

| Build | `HSCAN hash 0 COUNT 10000000000000` peak memory |
|---|---|
| `unstable @ 7a80aade9` | **72.76 TB** (`used_memory_peak: 80000001484512`) |
| this PR | **821 KB** |

## Test plan
- [x] `runtest --single unit/scan unit/type/hash unit/type/set unit/type/zset` — all pass
- [x] Local sanity: HSCAN/SSCAN/ZSCAN/SCAN with normal counts return correct results
- [x] Local sanity: `HSCAN hash 0 COUNT 10000000000000` does not balloon memory
- [x] Bench: 3 dp on x86 m7i.profiler, all variants flat within noise (table above)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `scanGenericCommand` hot path; while the change is small, it alters allocation behavior during SCAN and could impact performance or memory patterns under load.
> 
> **Overview**
> **Mitigates a potential DoS in SCAN-family commands** by removing the `vecReserve(&keys, count)` pre-allocation that scaled memory usage directly with the user-supplied `COUNT`.
> 
> Key collection for `scanGenericCommand` now relies solely on the vector’s existing stack buffer and grow-by-doubling behavior, so memory growth is driven by actual returned elements rather than requested iteration hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 035fafc89dbc75da252ecf04963ae8b983c990d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->