### PR TITLE
Fix SCAN OOM with huge COUNT after vec preallocation

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1897,9 +1897,11 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
     void *keys_stack[256];
     vecInit(&keys, keys_stack, 256);
     /* When COUNT exceeds the stack buffer, pre-size the heap buffer to avoid
-     * the grow-by-doubling path during scanCallback. */
-    if ((size_t)count > sizeof(keys_stack) / sizeof(keys_stack[0]))
-        vecReserve(&keys, count);
+     * the grow-by-doubling path during scanCallback. COUNT is user-provided
+     * and may be huge, so cap the allocation hint. */
+    size_t keys_prealloc = min((size_t)count, 1024);
+    if (keys_prealloc > sizeof(keys_stack) / sizeof(keys_stack[0]))
+        vecReserve(&keys, keys_prealloc);
     /* Hash on dict only has pointers to dict entries; other paths allocate
      * temporary sds that must be released. */
     if (o && (!ht || o->type == OBJ_ZSET))


### PR DESCRIPTION
## Fix SCAN OOM with huge COUNT after vec preallocation

### Problem
PR #15065 replaced the temporary SCAN key collection list with `vec` and added an optimization to preallocate the vector based on the user-provided `COUNT` value:

```c
if ((size_t)count > sizeof(keys_stack) / sizeof(keys_stack[0]))
    vecReserve(&keys, count);
```

This makes `COUNT` directly control the allocation size.

The existing `SCAN COUNT overflow` regression test sends:
```text
SCAN 0 COUNT 922337203685477581
```

That value is valid as a `long`, but `vecReserve(&keys, count)` attempts to allocate:

```text
922337203685477581 * sizeof(void *) = 7378697629483820648 bytes
```

Redis then aborts with OOM before returning a reply:

```text
Guru Meditation: Redis aborting for OUT OF MEMORY.
Allocating 7378697629483820648 bytes
...
vecReserve
scanGenericCommand
```

Failed CI: https://github.com/redis/redis/actions/runs/25000274712/job/73208178936?pr=15119

### Changes

Cap the vector preallocation hint instead of using the raw user-provided `COUNT`.

`COUNT` is a SCAN work hint, not a safe allocation size. The vector can still grow via `vecPush()` if the command actually collects more elements, but huge `COUNT` values no longer trigger an immediate oversized allocation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change confined to `SCAN` key collection allocation sizing; it reduces the chance of OOM/abort but could slightly change memory/performance characteristics for very large `COUNT` hints.
> 
> **Overview**
> Prevents `SCAN`/`HSCAN`/`SSCAN`/`ZSCAN` from attempting massive allocations when clients provide an extremely large `COUNT`.
> 
> The vector preallocation hint used for temporary key collection is now capped (using `min(count, 1024)`) instead of reserving based on the raw user-provided `COUNT`, avoiding immediate OOM/abort while still allowing the vector to grow as needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2208b6854c9f12d13b86612d08be852ca597b013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->