### PR TITLE
Fix DEBUG LOADAOF dropping the dataset on load failure

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1068,7 +1068,7 @@ long long emptyData(int dbnum, int flags, void(callback)(dict*)) {
     return removed;
 }
 
-/* Initialize temporary db on replica for use during diskless replication. */
+/* Initialize a temporary DB array for out-of-place loading. */
 redisDb *initTempDb(void) {
     int slot_count_bits = 0;
     int flags = KVSTORE_ALLOCATE_DICTS_ON_DEMAND;
@@ -1084,7 +1084,14 @@ redisDb *initTempDb(void) {
         tempDb[i].expires = kvstoreCreate(&kvstoreBaseType, &dbExpiresDictType,
                                           slot_count_bits, flags);
         tempDb[i].subexpires = estoreCreate(&subexpiresBucketsType, slot_count_bits);
+        tempDb[i].expires_cursor = 0;
+        tempDb[i].blocking_keys = dictCreate(&keylistDictType);
+        tempDb[i].blocking_keys_unblock_on_nokey = dictCreate(&objectKeyPointerValueDictType);
+        tempDb[i].stream_claim_pending_keys = dictCreate(&objectKeyPointerValueDictType);
         tempDb[i].stream_idmp_keys = dictCreate(&objectKeyNoValueDictType);
+        tempDb[i].ready_keys = dictCreate(&objectKeyPointerValueDictType);
+        tempDb[i].watched_keys = dictCreate(&keylistDictType);
+        tempDb[i].avg_ttl = 0;
     }
 
     return tempDb;
@@ -1102,7 +1109,12 @@ void discardTempDb(redisDb *tempDb) {
         estoreRelease(tempDb[i].subexpires);
         kvstoreRelease(tempDb[i].keys);
         kvstoreRelease(tempDb[i].expires);
+        dictRelease(tempDb[i].blocking_keys);
+        dictRelease(tempDb[i].blocking_keys_unblock_on_nokey);
+        dictRelease(tempDb[i].stream_claim_pending_keys);
         dictRelease(tempDb[i].stream_idmp_keys);
+        dictRelease(tempDb[i].ready_keys);
+        dictRelease(tempDb[i].watched_keys);
     }
 
     zfree(tempDb);

--- a/src/debug.c
+++ b/src/debug.c
@@ -13,6 +13,7 @@
  */
 
 #include "server.h"
+#include "functions.h"
 #include "util.h"
 #include "sha1.h"   /* SHA1 is used for DEBUG DIGEST */
 #include "crc64.h"
@@ -633,13 +634,47 @@ NULL
         serverLog(LL_NOTICE,"DB reloaded by DEBUG RELOAD");
         addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"loadaof")) {
+        redisDb *old_db = server.db, *temp_db = NULL;
+        aofManifest *old_am = server.aof_manifest;
+        functionsLibCtx *temp_functions_lib_ctx = NULL, *old_functions_lib_ctx = NULL;
+        long long old_dirty = server.dirty;
+
         if (server.aof_state != AOF_OFF) flushAppendOnlyFile(1);
-        emptyData(-1,EMPTYDB_NO_FLAGS,NULL);
+
+        temp_db = initTempDb();
+        temp_functions_lib_ctx = functionsLibCtxCreate();
         protectClient(c);
-        if (server.aof_manifest) aofManifestFree(server.aof_manifest);
+
+        server.db = temp_db;
+        old_functions_lib_ctx = functionsLibCtxReplaceCurrent(temp_functions_lib_ctx);
+        server.aof_manifest = NULL;
         aofLoadManifestFromDisk();
-        aofDelHistoryFiles();
+
         int ret = loadAppendOnlyFiles(server.aof_manifest);
+
+        server.db = old_db;
+        if (ret == AOF_OK || ret == AOF_EMPTY) {
+            swapMainDbWithTempDb(temp_db);
+            discardTempDb(temp_db);
+            temp_db = NULL;
+            temp_functions_lib_ctx = NULL; /* Kept as the current functions ctx. */
+            functionsLibCtxFree(old_functions_lib_ctx);
+            old_functions_lib_ctx = NULL;
+            if (old_am) aofManifestFree(old_am);
+            old_am = NULL;
+            aofDelHistoryFiles();
+        } else {
+            temp_functions_lib_ctx = functionsLibCtxReplaceCurrent(old_functions_lib_ctx);
+            old_functions_lib_ctx = NULL;
+            functionsLibCtxFree(temp_functions_lib_ctx);
+            temp_functions_lib_ctx = NULL;
+            discardTempDb(temp_db);
+            temp_db = NULL;
+            if (server.aof_manifest) aofManifestFree(server.aof_manifest);
+            server.aof_manifest = old_am;
+            old_am = NULL;
+            server.dirty = old_dirty;
+        }
         unprotectClient(c);
         if (ret != AOF_OK && ret != AOF_EMPTY) {
             addReplyError(c, "Error trying to load the AOF files, check server logs.");

--- a/src/functions.c
+++ b/src/functions.c
@@ -208,6 +208,14 @@ void functionsLibCtxSwapWithCurrent(functionsLibCtx *new_lib_ctx) {
     curr_functions_lib_ctx = new_lib_ctx;
 }
 
+/* Replace the current functions ctx without freeing the old one.
+ * Returns the previous current ctx. */
+functionsLibCtx* functionsLibCtxReplaceCurrent(functionsLibCtx *new_lib_ctx) {
+    functionsLibCtx *old_lib_ctx = curr_functions_lib_ctx;
+    curr_functions_lib_ctx = new_lib_ctx;
+    return old_lib_ctx;
+}
+
 /* return the current functions ctx */
 functionsLibCtx* functionsLibCtxGetCurrent(void) {
     return curr_functions_lib_ctx;

--- a/src/functions.h
+++ b/src/functions.h
@@ -111,6 +111,7 @@ dict* functionsLibGet(void);
 size_t functionsLibCtxFunctionsLen(functionsLibCtx *functions_ctx);
 functionsLibCtx* functionsLibCtxGetCurrent(void);
 functionsLibCtx* functionsLibCtxCreate(void);
+functionsLibCtx* functionsLibCtxReplaceCurrent(functionsLibCtx *lib_ctx);
 void functionsLibCtxClearCurrent(int async);
 void functionsLibCtxFree(functionsLibCtx *lib_ctx);
 void functionsLibCtxClear(functionsLibCtx *lib_ctx);

--- a/tests/unit/aofrw.tcl
+++ b/tests/unit/aofrw.tcl
@@ -1,6 +1,18 @@
 # This unit has the potential to create huge .reqres files, causing log-req-res-validator.py to run for a very long time...
 # Since this unit doesn't do anything worth validating, reply_schema-wise, we decided to skip it
 start_server {tags {"aofrw external:skip logreqres:skip"} overrides {save {}}} {
+    test {DEBUG LOADAOF failure preserves the current dataset} {
+        r set keepme value
+
+        assert_error {ERR Error trying to load the AOF files, check server logs.} {
+            r debug loadaof
+        }
+
+        assert_equal 1 [r exists keepme]
+        assert_equal {value} [r get keepme]
+        assert_equal 1 [r dbsize]
+    }
+
     # Enable the AOF
     r config set appendonly yes
     r config set auto-aof-rewrite-percentage 0 ; # Disable auto-rewrite.


### PR DESCRIPTION
## Summary
`DEBUG LOADAOF` currently clears the live dataset before attempting to load the AOF. If the load fails (for example because no AOF files exist), the command replies with an error but the in-memory dataset is already gone.

This change makes `DEBUG LOADAOF` load into a temporary DB/functions context first, and only swap the loaded state into place after a successful load.

## Changes
- load `DEBUG LOADAOF` into a temporary DB array instead of flushing the active dataset up front
- stage function libraries in a temporary functions context during the load
- swap the temporary dataset into place only on success
- restore the original dataset and manifest on failure
- extend temporary DB initialization/cleanup so it supports command-based AOF replay
- add a regression test covering the no-AOF failure path

## Validation
- `make -j4`
- `./runtest --single unit/aofrw --only 'DEBUG LOADAOF failure preserves the current dataset'`
- `./runtest --single unit/functions --only 'FUNCTION can processes create, delete and flush commands in AOF when doing "debug loadaof" in read-only slaves'`
- manual smoke test: `DEBUG LOADAOF` still returns an error without dropping keys when no AOF exists
- manual smoke test: successful `DEBUG LOADAOF` preserves digest when AOF exists


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author