### PR TITLE
Update RedisJSON module version to v8.6.3

### DIFF
--- a/modules/redisjson/Makefile
+++ b/modules/redisjson/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.6.0
+MODULE_VERSION = v8.6.3
 MODULE_REPO = https://github.com/redisjson/redisjson
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/rejson.so
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bump that only changes which redisjson git tag is cloned and built; primary risk is upstream incompatibility or build changes in v8.6.3.
> 
> **Overview**
> **Updates the RedisJSON module dependency** by bumping `MODULE_VERSION` from `v8.6.0` to `v8.6.3`, changing the git tag used during `git clone --branch` in the module build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed657a4623fc9092ad6286b4edd8b0c193934b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->