### PR TITLE
Update RedisJSON module version to v8.4.4

### DIFF
--- a/modules/redisjson/Makefile
+++ b/modules/redisjson/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.4.2
+MODULE_VERSION = v8.4.4
 MODULE_REPO = https://github.com/redisjson/redisjson
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/rejson.so
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a single Makefile change that only bumps the RedisJSON module version used for builds.
> 
> **Overview**
> Updates the RedisJSON module build to pull `v8.4.4` instead of `v8.4.2` by changing `MODULE_VERSION` in `modules/redisjson/Makefile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fade62e739b3fa4332fbd1c593686543d87a513b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->