### PR TITLE
Update RedisJSON module version to v8.2.11

### DIFF
--- a/modules/redisjson/Makefile
+++ b/modules/redisjson/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.2.9
+MODULE_VERSION = v8.2.19
 MODULE_REPO = https://github.com/redisjson/redisjson
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/rejson.so
 

--- a/modules/redisjson/Makefile
+++ b/modules/redisjson/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.2.19
+MODULE_VERSION = v8.2.11
 MODULE_REPO = https://github.com/redisjson/redisjson
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/rejson.so
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to a version bump in the RedisJSON build Makefile; main impact is pulling a newer upstream module release.
> 
> **Overview**
> Updates the RedisJSON module build to use upstream version `v8.2.11` (from `v8.2.9`) via the `modules/redisjson/Makefile` `MODULE_VERSION` bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1de2da0fe595902277de5990dd5a74e2144061c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->