### PR TITLE
test: stabilize HOTKEYS MULTI/EXEC test by increasing iteration count

### DIFF
--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -251,7 +251,7 @@ start_server {tags {external:skip "hotkeys"}} {
         r multi
         # Send multiple commands to avoid <1us cpu for $key2 which we assert
         # at end of test
-        for {set i 0} {$i < 7} {incr i} {
+        for {set i 0} {$i < 30} {incr i} {
             r set $key1 value1
             r set $key2 value1
             r set $key1 value2


### PR DESCRIPTION
## Problem

The test `HOTKEYS - commands inside MULTI/EXEC` in `tests/unit/hotkeys.tcl` is flaky on fast hardware. This PR raises its inner loop count from 7 to 30 to make `key2` reliably appear in the CPU top-K.

Failed CI: https://github.com/redis/redis/actions/runs/25051455424/job/73380034469?pr=15128

Inside `MULTI`/`EXEC`, each queued command's per-command CPU time is recorded as `c->duration = ustime() - call_timer` (microseconds, integer). Very fast commands such as `SET` against a small value can complete in less than 1 µs and therefore be measured as `0`.

`hotkeyStatsUpdateCurrentCmd` then forwards that zero duration as the weight to `chkTopKUpdate`, which has an explicit early return on `weight == 0`:

```c
sds chkTopKUpdate(chkTopK *topk, char *item, int itemlen, counter_t weight) {
    if (weight == 0) return NULL;
    ...
}
```

In the original test, `key2` is `SET` only 7 times inside the transaction. On fast hosts (the failure was observed on an ARM box with `ustime()` ticking at 1 µs resolution) it is possible for all 7 calls to be measured as 0 µs, which means `key2` is never inserted into the CPU top-K and the assertion

```tcl
assert [dict exists $cpu_result $key2]
```

fails. `key1` has 21 calls and is statistically safe.

The author already anticipated this and left a comment ("Send multiple commands to avoid <1us cpu for $key2"), but 7 iterations turned out to be insufficient.

## Changes

Bump the iteration count from 7 to 30. With `key2` now `SET` 30 times the probability of every single call being measured as 0 µs becomes negligible on any realistic hardware.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that increases command repetitions to reduce flakiness on fast hardware; no production code paths are modified.
> 
> **Overview**
> Makes the `HOTKEYS - commands inside MULTI/EXEC` unit test less flaky by increasing the number of queued `SET` operations in the transaction loop (from 7 to 30) so `key2` more reliably accumulates measurable CPU time and appears in the CPU top-K assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b143e0ed833b1661ce3d783a18a8a00d8baa351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->