### PR TITLE
Diskless replication: Add on-demand per replica buffer for slow replicas

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -205,6 +205,7 @@ client *createClient(connection *conn) {
     c->io_repl_ack_time = 0;
     c->repl_aof_off = 0;
     c->repl_last_partial_write = 0;
+    c->repldbpipe = NULL;
     c->slave_listening_port = 0;
     c->slave_addr = NULL;
     c->slave_capa = SLAVE_CAPA_NONE;
@@ -2236,6 +2237,7 @@ void freeClient(client *c) {
     sdsfree(c->peerid);
     sdsfree(c->sockname);
     sdsfree(c->slave_addr);
+    sdsfree(c->repldbpipe);
     sdsfree(c->node_id);
     zfree(c);
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -1820,8 +1820,11 @@ void rdbPipeWriteHandlerConnRemoved(struct connection *conn) {
     client *slave = connGetPrivateData(conn);
     slave->repl_last_partial_write = 0;
     server.rdb_pipe_numconns_writing--;
-    /* if there are no more writes for now for this conn, or write error: */
-    if (server.rdb_pipe_numconns_writing == 0) {
+    /* If rdb pipe reads were paused because all replicas were blocked,
+     * resume reads as soon as one replica drains enough and becomes writable. */
+    if (server.rdb_pipe_read != -1 &&
+        !(aeGetFileEvents(server.el, server.rdb_pipe_read) & AE_READABLE))
+    {
         if (aeCreateFileEvent(server.el, server.rdb_pipe_read, AE_READABLE, rdbPipeReadHandler,NULL) == AE_ERR) {
             serverPanic("Unrecoverable error creating server.rdb_pipe_read file event.");
         }
@@ -1831,11 +1834,12 @@ void rdbPipeWriteHandlerConnRemoved(struct connection *conn) {
 /* Called in diskless master during transfer of data from the rdb pipe, when
  * the replica becomes writable again. */
 void rdbPipeWriteHandler(struct connection *conn) {
-    serverAssert(server.rdb_pipe_bufflen>0);
     client *slave = connGetPrivateData(conn);
+    serverAssert(slave->repldbpipe != NULL);
+    serverAssert(slave->repldboff < (off_t)sdslen(slave->repldbpipe));
     ssize_t nwritten;
-    if ((nwritten = connWrite(conn, server.rdb_pipe_buff + slave->repldboff,
-                              server.rdb_pipe_bufflen - slave->repldboff)) == -1)
+    if ((nwritten = connWrite(conn, slave->repldbpipe + slave->repldboff,
+                              sdslen(slave->repldbpipe) - slave->repldboff)) == -1)
     {
         if (connGetState(conn) == CONN_STATE_CONNECTED)
             return; /* equivalent to EAGAIN */
@@ -1846,11 +1850,14 @@ void rdbPipeWriteHandler(struct connection *conn) {
     } else {
         slave->repldboff += nwritten;
         atomicIncr(server.stat_net_repl_output_bytes, nwritten);
-        if (slave->repldboff < server.rdb_pipe_bufflen) {
+        if (slave->repldboff < (off_t)sdslen(slave->repldbpipe)) {
             slave->repl_last_partial_write = server.unixtime;
             return; /* more data to write.. */
         }
     }
+    sdsfree(slave->repldbpipe);
+    slave->repldbpipe = NULL;
+    slave->repldboff = 0;
     rdbPipeWriteHandlerConnRemoved(conn);
 }
 
@@ -1862,7 +1869,6 @@ void rdbPipeReadHandler(struct aeEventLoop *eventLoop, int fd, void *clientData,
     int i;
     if (!server.rdb_pipe_buff)
         server.rdb_pipe_buff = zmalloc(PROTO_IOBUF_LEN);
-    serverAssert(server.rdb_pipe_numconns_writing==0);
 
     while (1) {
         server.rdb_pipe_bufflen = read(fd, server.rdb_pipe_buff, PROTO_IOBUF_LEN);
@@ -1903,6 +1909,7 @@ void rdbPipeReadHandler(struct aeEventLoop *eventLoop, int fd, void *clientData,
         }
 
         int stillAlive = 0;
+        int numBlocked = 0;
         for (i=0; i < server.rdb_pipe_numconns; i++)
         {
             ssize_t nwritten;
@@ -1911,6 +1918,13 @@ void rdbPipeReadHandler(struct aeEventLoop *eventLoop, int fd, void *clientData,
                 continue;
 
             client *slave = connGetPrivateData(conn);
+            if (slave->repldbpipe) {
+                slave->repldbpipe = sdscatlen(slave->repldbpipe, server.rdb_pipe_buff, server.rdb_pipe_bufflen);
+                numBlocked++;
+                stillAlive++;
+                continue;
+            }
+
             if ((nwritten = connWrite(conn, server.rdb_pipe_buff, server.rdb_pipe_bufflen)) == -1) {
                 if (connGetState(conn) != CONN_STATE_CONNECTED) {
                     serverLog(LL_WARNING,"Diskless rdb transfer, write error sending DB to replica: %s",
@@ -1920,19 +1934,22 @@ void rdbPipeReadHandler(struct aeEventLoop *eventLoop, int fd, void *clientData,
                     continue;
                 }
                 /* An error and still in connected state, is equivalent to EAGAIN */
-                slave->repldboff = 0;
+                nwritten = 0;
             } else {
-                /* Note: when use diskless replication, 'repldboff' is the offset
-                 * of 'rdb_pipe_buff' sent rather than the offset of entire RDB. */
-                slave->repldboff = nwritten;
                 atomicIncr(server.stat_net_repl_output_bytes, nwritten);
             }
             /* If we were unable to write all the data to one of the replicas,
-             * setup write handler (and disable pipe read handler, below) */
+             * queue the unsent bytes for this replica and continue with others. */
             if (nwritten != server.rdb_pipe_bufflen) {
+                slave->repldbpipe = sdsnewlen(server.rdb_pipe_buff + nwritten,
+                                              server.rdb_pipe_bufflen - nwritten);
+                slave->repldboff = 0;
                 slave->repl_last_partial_write = server.unixtime;
-                server.rdb_pipe_numconns_writing++;
-                connSetWriteHandler(conn, rdbPipeWriteHandler);
+                numBlocked++;
+                if (!connHasWriteHandler(conn)) {
+                    server.rdb_pipe_numconns_writing++;
+                    connSetWriteHandler(conn, rdbPipeWriteHandler);
+                }
             }
             stillAlive++;
         }
@@ -1944,8 +1961,9 @@ void rdbPipeReadHandler(struct aeEventLoop *eventLoop, int fd, void *clientData,
             killRDBChild();
             break;
         }
-        /* Remove the pipe read handler if at least one write handler was set. */
-        else if (server.rdb_pipe_numconns_writing) {
+        /* Pause pipe reads only when all replicas are backpressured.
+         * In mixed-speed scenarios, keep serving fast replicas. */
+        else if (numBlocked == stillAlive) {
             aeDeleteFileEvent(server.el, server.rdb_pipe_read, AE_READABLE);
             break;
         }

--- a/src/server.h
+++ b/src/server.h
@@ -1527,6 +1527,7 @@ typedef struct client {
     int repldbfd;           /* Replication DB file descriptor. */
     off_t repldboff;        /* Replication DB file offset. */
     off_t repldbsize;       /* Replication DB file size. */
+    sds repldbpipe;         /* Pending RDB pipe bytes for diskless replication. */
     sds replpreamble;       /* Replication DB preamble. */
     long long read_reploff; /* Read replication offset if this is a master. */
     long long io_read_reploff; /* Copy of read_reploff but only used when


### PR DESCRIPTION
Fixes #14983

## Problem
During diskless replication, if **any single replica** cannot accept a write (TCP send buffer full / `EAGAIN`), the master stops reading the RDB pipe entirely, stalling data delivery to **all** replicas — including fast ones that are ready to receive data.
\- subdb

## Root Cause

In `rdbPipeReadHandler`, the master reads from the child's RDB pipe and writes to all replica sockets in a loop. When `connWrite` to any replica returns a partial write (socket send buffer full), the handler:

1. Installs a per-replica `rdbPipeWriteHandler` and increments `rdb_pipe_numconns_writing`
2. **Removes the pipe read event** via `aeDeleteFileEvent(server.el, server.rdb_pipe_read, AE_READABLE)`, stopping all pipe reads

The pipe read event is only re-enabled when **all** pending write handlers complete (`rdb_pipe_numconns_writing == 0`), meaning the **slowest replica dictates the throughput for all replicas**.
\- sundb

## Approach / Solution
- Whenever **any single replica** cannot accept a full write (TCP send buffer full / `EAGAIN`), a buffer is created only for that replica (per-replica buffer) and buffers currently unsent rdbpipe data (and also further rounds data is appended here), while for the other replicas normal write process is unaffected.
- rdb read operation is only blocked when **all the replicas** cannot accept a full write for that round.
- rdb read operation is unblocked even if **one replica** is able to accept writes.

 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5111dbcd1fa03165876ae97821dcd3fa5f6ae869. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->