### PR TITLE
Fix shard pubsub slot lookup using executing-command's cached slot

### DIFF
--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -253,9 +253,13 @@ int pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
     dictEntryLink link = dictFindLink(type.clientPubSubChannels(c),channel,&bucket);
     if (link == NULL) { /* Not yet subscribed to this channel */
         retval = 1;
-        /* Add the client to the channel -> list of clients hash table */
+        /* Add the client to the channel -> list of clients hash table.
+         * Compute the slot from the channel directly: server.current_client
+         * may carry a cached slot for a different key (e.g. while executing
+         * a queued command inside EXEC), and shard pubsub channels live in
+         * the slot of the channel name, not the executing command's key. */
         if (server.cluster_enabled && type.shard) {
-            slot = getKeySlot(channel->ptr);
+            slot = keyHashSlot(channel->ptr, sdslen(channel->ptr));
         }
 
         de = kvstoreDictAddRaw(*type.serverPubSubChannels, slot, channel, &existing);
@@ -291,9 +295,13 @@ int pubsubUnsubscribeChannel(client *c, robj *channel, int notify, pubsubtype ty
                             we have in the hash tables. Protect it... */
     if (dictDelete(type.clientPubSubChannels(c),channel) == DICT_OK) {
         retval = 1;
-        /* Remove the client from the channel -> clients list hash table */
+        /* Remove the client from the channel -> clients list hash table.
+         * Compute the slot from the channel directly: server.current_client
+         * may carry a cached slot for a different key (e.g. when freeClient()
+         * fires while another client is in the middle of EXEC), and shard
+         * pubsub channels live in the slot of the channel name. */
         if (server.cluster_enabled && type.shard) {
-            slot = getKeySlot(channel->ptr);
+            slot = keyHashSlot(channel->ptr, sdslen(channel->ptr));
         }
         de = kvstoreDictFind(*type.serverPubSubChannels, slot, channel);
         serverAssertWithInfo(c,NULL,de != NULL);

--- a/tests/unit/cluster/sharded-pubsub.tcl
+++ b/tests/unit/cluster/sharded-pubsub.tcl
@@ -64,4 +64,40 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         catch {[$replica EXEC]} err
         assert_match {EXECABORT*} $err
     }
+
+    test "CLIENT KILL of SSUBSCRIBE'd client inside EXEC of different-slot command does not crash" {
+        # Regression for #15085: pubsubUnsubscribeChannel() previously called
+        # getKeySlot(channel->ptr), which returns the executing client's cached
+        # slot when CLIENT_EXECUTING_COMMAND is set. During EXEC of a SET on a
+        # different-slot key, freeClient() of the SSUBSCRIBE'd client looked up
+        # the shard channel in the wrong slot bucket and asserted.
+        set chan "channel0"
+        set chan_slot [$primary CLUSTER KEYSLOT $chan]
+        # Pick a key whose slot differs from the channel's slot.
+        set other_key "k"
+        set other_slot [$primary CLUSTER KEYSLOT $other_key]
+        if {$chan_slot == $other_slot} {
+            set other_key "k2"
+            set other_slot [$primary CLUSTER KEYSLOT $other_key]
+        }
+        assert {$chan_slot != $other_slot}
+
+        set subscriber [redis_deferring_client 0]
+        $subscriber CLIENT ID
+        set sub_id [$subscriber read]
+        $subscriber SSUBSCRIBE $chan
+        $subscriber read ;# consume the ssubscribe ack
+
+        $primary MULTI
+        $primary SET $other_key v
+        $primary CLIENT KILL ID $sub_id
+        # Without the fix the server aborts here on a wrong-bucket assertion.
+        $primary EXEC
+
+        # Server must still be alive and serving traffic.
+        assert_equal "PONG" [$primary PING]
+        assert_equal 0 [$primary SPUBLISH $chan ignored]
+
+        catch {$subscriber close}
+    }
 }


### PR DESCRIPTION
## Problem

In cluster mode, killing an `SSUBSCRIBE`'d client from inside another client's `EXEC` aborts the server with a `serverAssertWithInfo()` failure in `pubsubUnsubscribeChannel()` at `src/pubsub.c:299`.

Reproduction (single-shard cluster, all 16384 slots assigned to one node):

1. Client A: `SSUBSCRIBE channel0`
2. Client B:
   ```
   MULTI
   SET k v
   CLIENT KILL ID <A's id>
   EXEC
   ```
3. The server crashes during `EXEC` with the wrong-bucket assertion.

## Root Cause

`pubsubSubscribeChannel()` (`src/pubsub.c:258`) and `pubsubUnsubscribeChannel()` (`src/pubsub.c:296`) compute the shard channel's slot via `getKeySlot(channel->ptr)`.

`getKeySlot()` (`src/db.c:475`) is documented as a *performance optimization* that returns `server.current_client->slot` whenever `CLIENT_EXECUTING_COMMAND` is set on the current client — the slot was cached by the command dispatcher for the keys of the *running command*. Shard pubsub channel names have nothing to do with those keys, so when `freeClient()` fires for the subscriber while client B is still inside `call()`, `pubsubUnsubscribeChannel()` reads B's cached slot for `"k"` and looks `channel0` up in that wrong slot's dict. The lookup misses, the assert fires, the server aborts.

`pubsubPublishMessageInternal()` at line 474 already sidesteps this by calling `keyHashSlot(channel->ptr, sdslen(channel->ptr))` directly, and `PUBSUB SHARDNUMSUB` (line 678) does the same via `calculateKeySlot()`. The subscribe / unsubscribe sites were the only ones still using the cached helper.

## Fix

Replace `getKeySlot(channel->ptr)` with `keyHashSlot(channel->ptr, sdslen(channel->ptr))` at both sites, matching the publish path. The surrounding `if (server.cluster_enabled && type.shard)` guards are kept, so non-cluster and non-shard pubsub still resolve to slot `0` exactly as before. The expanded comments document why the cached helper is unsafe here so the choice is not regressed by future refactors.

## Tests Added

`tests/unit/cluster/sharded-pubsub.tcl`: new test `CLIENT KILL of SSUBSCRIBE'd client inside EXEC of different-slot command does not crash` inside the existing `start_cluster 1 1` block.

| Change Point | Test |
|--------------|------|
| `pubsubUnsubscribeChannel()` slot computation | New test reproduces the exact crash flow: pick a key whose slot differs from the channel's slot, `SSUBSCRIBE` from a deferring client, then run `MULTI` → `SET other_key v` → `CLIENT KILL ID <subscriber>` → `EXEC` from the primary connection. Asserts the server is still alive (`PING` → `PONG`, `SPUBLISH` returns 0) afterwards. Verified locally that without this patch the test crashes the cluster server during `start_cluster` setup teardown (assertion at `pubsub.c:299`); with the patch the test passes. |
| `pubsubSubscribeChannel()` slot computation | The symmetric subscribe path is exercised by every existing `Sharded pubsub *` test in the same file (and the wider `unit/pubsubshard` suite); a regression that re-introduces `getKeySlot()` would either crash those tests under cluster mode or be detected by ASAN heap checks on `kvstoreDictAddRaw()` over a stale slot. |

Local verification: `make BUILD_TLS=no SANITIZER=address` followed by `./runtest --single unit/cluster/sharded-pubsub --single unit/pubsubshard --single unit/pubsub` — all tests pass on the patched tree, the new test fails (server crash) on the unpatched tree.

## Impact

- Scope: shard pubsub subscribe / unsubscribe paths only. Global pubsub, publish path, and `PUBSUB SHARDNUMSUB` are already correct and unchanged.
- Behavior: identical when not in cluster mode or when `type.shard == 0` (slot stays `0`). In cluster + shard mode, the slot is now always derived from the channel name as required by the shard channel kvstore layout — including when called from inside `call()` for a different command.
- Performance: `keyHashSlot()` is a CRC over the channel name; the previous `getKeySlot()` skipped that work only for the EXEC-cached case. Pubsub subscribe / unsubscribe is not on the hot data-plane path, so the difference is negligible.

Fixes #15085

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster sharded Pub/Sub bookkeeping and slot routing, where mistakes can cause asserts or misrouted subscription state. The change is small and guarded to cluster+shard mode, with a targeted regression test added.
> 
> **Overview**
> Fixes sharded Pub/Sub subscribe/unsubscribe slot selection in cluster mode by replacing `getKeySlot(channel->ptr)` with `keyHashSlot(channel->ptr, sdslen(...))`, avoiding use of an executing client’s cached slot during `EXEC` and preventing wrong-bucket lookups/asserts.
> 
> Adds a cluster unit test that reproduces the crash scenario (killing an `SSUBSCRIBE`d client during another client’s `EXEC` on a different-slot key) and asserts the server stays alive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 991e4893eab0f77a7c4f4fa52b296765e2fda793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->