### PR TITLE
redis-cli: do not flip current_resp3 when HELLO 3 fails

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1655,6 +1655,11 @@ static int cliSwitchProto(void) {
         } else if (config.resp3 == 2) {
             result = REDIS_OK;
         }
+        /* Stay on RESP2: the connection never switched protocols. Setting
+         * current_resp3 = 1 below would later crash assertions that expect
+         * RESP3 reply shapes (e.g. REDIS_REPLY_MAP in getDatabases()). */
+        freeReplyObject(reply);
+        return result;
     }
 
     /* Retrieve server version string for later use. */

--- a/tests/helpers/fake_resp2_node.tcl
+++ b/tests/helpers/fake_resp2_node.tcl
@@ -1,0 +1,49 @@
+# A fake RESP2 Redis node for replaying predefined traffic with a client.
+#
+# Usage: tclsh fake_resp2_node.tcl PORT COMMAND REPLY [ COMMAND REPLY [ ... ] ]
+#
+# Like tests/helpers/fake_redis_node.tcl but with explicit binary-mode I/O so
+# replies that contain internal CRLFs (multi-bulk arrays, bulk strings) are
+# delivered byte-for-byte. Replies must include their full RESP framing,
+# including the trailing CRLF.
+
+set port [lindex $argv 0]
+set expected_traffic [lrange $argv 1 end]
+
+proc read_command {sock} {
+    set ch [read $sock 1]
+    if {$ch ne "*"} { return {} }
+    set numargs [string trimright [gets $sock] "\r"]
+    set cmd ""
+    for {set i 0} {$i < $numargs} {incr i} {
+        read $sock 1
+        set len [string trimright [gets $sock] "\r"]
+        lappend cmd [read $sock $len]
+        gets $sock
+    }
+    return $cmd
+}
+
+proc accept {sock host port} {
+    global expected_traffic
+    fconfigure $sock -translation binary -buffering none
+    foreach {expect_cmd reply} $expected_traffic {
+        if {[eof $sock]} break
+        set cmd [read_command $sock]
+        if {$cmd eq {}} break
+        if {[string equal -nocase $cmd $expect_cmd]} {
+            puts -nonewline $sock $reply
+            flush $sock
+        } else {
+            puts -nonewline $sock "-ERR unexpected command $cmd\r\n"
+            flush $sock
+            break
+        }
+    }
+    close $sock
+}
+
+set sockfd [socket -server accept -myaddr 127.0.0.1 $port]
+after 5000 set done timeout
+vwait done
+close $sockfd

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -580,6 +580,36 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
         # Run the cli
         assert_equal "OK" [run_cli_host_port_db "127.0.0.1" $port1 0 -c SET foo bar]
     }
+
+    test_nontty_cli "--json --stat survives RESP2-only server (HELLO 3 returning ERR)" {
+        # Regression for cliSwitchProto leaving config.current_resp3 = 1 after
+        # HELLO 3 was rejected. With config.resp3 == 2 (--json), redis-cli is
+        # supposed to tolerate the error and stay on RESP2. Before the fix,
+        # statMode -> getDatabases() would assert on the RESP2 array reply
+        # while expecting REDIS_REPLY_MAP and abort the process. The fake
+        # node here speaks pure RESP2 (HELLO replies with -ERR) so the
+        # CONFIG GET databases response exercises the assertion.
+        set tclsh [info nameofexecutable]
+        set script "tests/helpers/fake_resp2_node.tcl"
+        set port [find_available_port $::baseport $::portcount]
+        exec $tclsh $script $port \
+                "HELLO 3" "-ERR unknown command 'HELLO'\r\n" \
+                "CONFIG GET databases" "*2\r\n\$9\r\ndatabases\r\n\$2\r\n16\r\n" \
+                "INFO" "\$2\r\nok\r\n" &
+        wait_for_condition 50 50 {
+            [catch {close [socket "127.0.0.1" $port]}] == 0
+        } else {
+            fail "fake resp2 node didn't start"
+        }
+        # Without the fix this exec aborts inside getDatabases(); with the fix
+        # statMode reaches the INFO loop and the connection eventually closes
+        # cleanly. exec may report a non-zero status either way; we only
+        # require the absence of an assertion / abort marker.
+        catch {exec src/redis-cli -h 127.0.0.1 -p $port --json --stat -i 0.05 2>@1} output
+        if {[regexp -nocase {assertion failed|aborted|core dumped|sigabrt} $output]} {
+            fail "redis-cli aborted on RESP2-only server: $output"
+        }
+    }
 }
 
     test_nontty_cli "Quoted input arguments" {


### PR DESCRIPTION
## Problem

`cliSwitchProto()` in `src/redis-cli.c` unconditionally sets `config.current_resp3 = 1` even when the `HELLO 3` reply was `REDIS_REPLY_ERROR`. With `config.resp3 == 2` (the lenient mode used by `--json` / `--quoted-json` when the user has not asked for RESP3 explicitly) the function then returns `REDIS_OK`, and the rest of `redis-cli` believes the connection negotiated RESP3 even though it is still on RESP2.

The most visible consequence: `statMode()` calls `getDatabases()`, which sends `CONFIG GET databases` and then asserts that the reply matches `config.current_resp3 ? REDIS_REPLY_MAP : REDIS_REPLY_ARRAY`. Against a pre-6.0 Redis (or any Redis-protocol-compatible server that does not implement `HELLO`), the reply is a RESP2 array but `current_resp3 == 1`, so the libc `assert()` aborts the process.

Reproduction (against a server that returns `-ERR` for `HELLO`):

```
$ redis-cli -h <host> -p <port> --json --stat -i 0.05
HELLO 3 failed: ERR unknown command 'HELLO'
Assertion failed: (reply->type == (config.current_resp3 ? REDIS_REPLY_MAP : REDIS_REPLY_ARRAY)),
function getDatabases, file redis-cli.c, line 9357.
Abort trap: 6
```

The same wrong state also misclassifies pubsub pushes in `isPubsubPush()` (line 1964 expects `REDIS_REPLY_PUSH` instead of `REDIS_REPLY_ARRAY`), but that path is a functional regression rather than a crash.

## Root Cause

```c
int result = REDIS_OK;
if (reply->type == REDIS_REPLY_ERROR) {
    fprintf(stderr,"HELLO 3 failed: %s\n",reply->str);
    if (config.resp3 == 1) {
        result = REDIS_ERR;
    } else if (config.resp3 == 2) {
        result = REDIS_OK;
    }
}

/* Retrieve server version string for later use. */
for (size_t i = 0; i < reply->elements; i += 2) {
    ...
}
freeReplyObject(reply);
config.current_resp3 = 1;        /* ← runs even when reply was an ERROR */
return result;
```

When the reply is an error, `reply->elements == 0`, so the version loop is a no-op (and would be undefined for non-string elements anyway). But the trailing `config.current_resp3 = 1` runs unconditionally and lies about the negotiated protocol.

## Fix

Take the error branch out via an early `freeReplyObject(reply); return result;`. The version extraction and the `current_resp3 = 1` assignment then only run when `HELLO 3` actually succeeded, which keeps the optimisation on modern servers and leaves `current_resp3` at its initial `0` on the fallback path. No public protocol or output change; the only observable effect is that `getDatabases()` now sees the correct RESP2 array shape and the pubsub-push detection in `isPubsubPush()` correctly looks for `REDIS_REPLY_ARRAY`.

## Tests Added

`tests/integration/redis-cli.tcl`: new test `--json --stat survives RESP2-only server (HELLO 3 returning ERR)`.

| Change Point | Test |
|--------------|------|
| Early-return on `REDIS_REPLY_ERROR`, leaving `current_resp3 = 0` | New integration test exec's `redis-cli --json --stat -i 0.05` against a fake RESP2 server that responds to `HELLO 3` with `-ERR unknown command 'HELLO'` and to `CONFIG GET databases` with a real RESP2 multi-bulk array. Verified locally that without the patch the test catches `Assertion failed: (reply->type == ...)` from `getDatabases()`; with the patch the assertion no longer fires and the test passes (the connection eventually closes when the fake server's lifetime expires). |

A small new helper `tests/helpers/fake_resp2_node.tcl` is required because the existing `fake_redis_node.tcl` runs with the default channel translation, which mangles internal `\r\n` inside multi-bulk frames; the new helper sets `-translation binary` and emits replies byte-for-byte, so the regression test can serve a real RESP2 `CONFIG GET databases` reply. The helper mirrors the calling convention of `fake_redis_node.tcl` (`tclsh fake_resp2_node.tcl PORT CMD REPLY [...]`).

Local verification: `make BUILD_TLS=no SANITIZER=address && ./runtest --single integration/redis-cli` — all tests pass on the patched tree, and the new test fails (with the expected `redis-cli aborted on RESP2-only server` failure message) on the unpatched tree.

## Impact

- Scope: `redis-cli` only. No server-side code touched.
- Behavior change is limited to the `HELLO 3` failure path: previously this path silently corrupted `config.current_resp3`; now it correctly leaves the connection on RESP2.
- Successful `HELLO 3` (the common case on Redis ≥ 6.0) is unchanged: the version-string extraction still runs and `current_resp3` still flips to `1`.
- No public API or wire-protocol change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> redis-cli-only bugfix on the HELLO failure path; successful HELLO 3 behavior is unchanged.
> 
> **Overview**
> Fixes **`redis-cli`** aborting on RESP2-only servers when **`--json --stat`** (or other lenient RESP3 modes) is used: **`cliSwitchProto()`** now **returns early** after a failed **`HELLO 3`** instead of still setting **`config.current_resp3 = 1`**, so reply parsing (e.g. **`getDatabases()`** expecting arrays vs maps) matches the actual wire protocol.
> 
> Adds **`tests/helpers/fake_resp2_node.tcl`** for byte-accurate RESP2 replay and an integration test that runs **`redis-cli --json --stat`** against a fake node that rejects **`HELLO`** and serves a real RESP2 **`CONFIG GET databases`** reply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6e9b7ee2da1920dc4608fc5c85d5d5a8a4d0069. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->