### PR TITLE
RED-191923 Enable LTO for redisearch when Redis is builed with BUILD_WITH_MODULES

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -1,8 +1,21 @@
 
 SUBDIRS = redisjson redistimeseries redisbloom redisearch
 
+# Modules built with link-time optimization. Add a module here once its build
+# system has been verified to honor LTO=1.
+LTO_MODULES = redisearch
+
+# Default RediSearch (and any future LTO-capable module) to LTO=1.
+LTO ?= 1
+
 define submake
-	for dir in $(SUBDIRS); do $(MAKE) -C $$dir $(1); done
+	for dir in $(SUBDIRS); do \
+		case " $(LTO_MODULES) " in \
+			*" $$dir "*) extra='LTO=$(LTO)' ;; \
+			*)           extra= ;; \
+		esac; \
+		$(MAKE) -C $$dir $(1) $$extra; \
+	done
 endef
 
 all: prepare_source


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the module build invocation to pass `LTO=1` for `redisearch`, which can affect build tooling compatibility and produced binaries. Scope is limited to build-time behavior and only for modules opted into LTO.
> 
> **Overview**
> **Enables link-time optimization for module builds.** The `modules/Makefile` now defaults `LTO ?= 1` and selectively passes `LTO=$(LTO)` when invoking sub-makes for modules listed in `LTO_MODULES` (currently only `redisearch`).
> 
> Other modules continue to build unchanged, and LTO can be overridden via the top-level `LTO` variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 924e5a6faaf8f3b961f88e55ac69a149c1ae19dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->