### PR TITLE
Enable LTO for RediSearch module when Redis is build has BUILD_WITH_MODULES enabled

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -1,8 +1,21 @@
 
 SUBDIRS = redisjson redistimeseries redisbloom redisearch
 
+# Modules built with link-time optimization. Add a module here once its build
+# system has been verified to honor LTO=1.
+LTO_MODULES = redisearch
+
+# Default RediSearch to LTO=1.
+LTO ?= 1
+
 define submake
-	for dir in $(SUBDIRS); do $(MAKE) -C $$dir $(1); done
+	for dir in $(SUBDIRS); do \
+		case " $(LTO_MODULES) " in \
+			*" $$dir "*) extra='LTO=$(LTO)' ;; \
+			*)           extra= ;; \
+		esac; \
+		$(MAKE) -C $$dir $(1) $$extra; \
+	done
 endef
 
 all: prepare_source


### PR DESCRIPTION
**Summary**

Default LTO=1 for RediSearch when building with BUILD_WITH_MODULES=yes. RediSearch build system already supports LTO. This just makes it the default and routes the flag through modules/Makefile so callers don't have to thread it manually.

The other modules (redisjson, redistimeseries, redisbloom) are unchanged. They don't reference LTO, and the new submake only forwards the flag to modules listed in LTO_MODULES.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Build-system change that alters compilation flags for `redisearch`, which may surface toolchain/compatibility issues or change produced binaries, but is scoped to a single module.
> 
> **Overview**
> Enables link-time optimization for the `redisearch` module when building Redis modules by introducing `LTO_MODULES` and conditionally passing `LTO=$(LTO)` into the per-module `make` invocation.
> 
> Defaults `LTO` to `1` (while still allowing overrides) and leaves other modules’ build flags unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a50ae5e58fba514afd007b3f2fe04c0e626e2cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->