### PR TITLE
Fix CI Codecov v6 coverage upload configuration

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,9 +4,12 @@ name: "Codecov"
 # where each PR needs to be compared against the coverage of the head commit
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   code-coverage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
@@ -19,6 +22,9 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./src/redis.info
+        files: ./src/redis.info
+        disable_search: true
+        fail_ci_if_error: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,3 +28,4 @@ jobs:
         files: ./src/redis.info
         disable_search: true
         fail_ci_if_error: true
+        

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   code-coverage:
+    if: ${{ github.repository == 'redis/redis' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -28,4 +29,4 @@ jobs:
         files: ./src/redis.info
         disable_search: true
         fail_ci_if_error: true
-        
+

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -27,3 +27,4 @@ jobs:
       with:
         files: ./src/redis.info
         disable_search: true
+        fail_ci_if_error: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -27,4 +27,3 @@ jobs:
       with:
         files: ./src/redis.info
         disable_search: true
-        fail_ci_if_error: true


### PR DESCRIPTION
## Problem

PR https://github.com/redis/redis/pull/14937 updates the Codecov workflow configuration for `codecov/codecov-action` v6.

The action no longer accepts the singular `file` input, so this switches to `files` to ensure `./src/redis.info` is uploaded correctly. 

## Changes

- Use `files: ./src/redis.info` for Codecov v6 compatibility.
- Add minimal workflow permissions with `contents: read`.
- Move `CODECOV_TOKEN` to step-level `env`. GitHub Actions supports this pattern for secrets, and Codecov reads `CODECOV_TOKEN` from the environment. This preserves behavior while following GitHub's general guidance to prefer environment variables or other target-supported mechanisms for passing secrets.
- Add `disable_search: true` so only the generated lcov report is uploaded.
- Add `fail_ci_if_error: true` so upload failures are not silently ignored.
- Run the job on `ubuntu-latest`.
- Ignore this action in fork repo, like this: https://github.com/vitahlin/redis/actions/runs/25154373910

## Test

Before: https://github.com/redis/redis/actions/runs/25113586825/job/73594175608#step:4:1
After: https://github.com/redis/redis/actions/runs/25154376069/job/73732365202?pr=15147#step:4:479


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes to coverage reporting; no product code or data-path logic is affected.
> 
> **Overview**
> Updates the Codecov GitHub Actions workflow for `codecov/codecov-action` v6 by switching the upload input from `file` to `files` and explicitly uploading only `./src/redis.info` (via `disable_search: true`).
> 
> Hardens and stabilizes the CI job by adding minimal `permissions` (`contents: read`), scoping execution to `redis/redis`, moving `CODECOV_TOKEN` to step-level `env`, running on `ubuntu-latest`, and failing the job if the Codecov upload errors (`fail_ci_if_error: true`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e3f3babd9f5f6e3fea1fda4d4e6779e8a40f32e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->