### PR TITLE
Fix memory leak on malformed legacy help entry in redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -472,7 +472,7 @@ static void cliLegacyIntegrateHelp(void) {
         if (entry->type != REDIS_REPLY_ARRAY || entry->elements < 4 ||
             entry->element[0]->type != REDIS_REPLY_STRING ||
             entry->element[1]->type != REDIS_REPLY_INTEGER ||
-            entry->element[3]->type != REDIS_REPLY_INTEGER) return;
+            entry->element[3]->type != REDIS_REPLY_INTEGER) break;
         char *cmdname = entry->element[0]->str;
         int i;
 


### PR DESCRIPTION
Close #15134 

## Description
In cliLegacyIntegrateHelp(), malformed COMMAND entries could return early and skip freeReplyObject(reply). Use break instead so the loop exits and the existing cleanup still frees the reply.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: replaces an early `return` with `break` in `cliLegacyIntegrateHelp()` so cleanup code still runs; behavior only changes for malformed `COMMAND` replies.
> 
> **Overview**
> Fixes a potential memory leak in `cliLegacyIntegrateHelp()` when iterating over `COMMAND` output: malformed entries no longer cause an early function exit.
> 
> The loop now `break`s on invalid entry types, allowing the existing `freeReplyObject(reply)` cleanup to always run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9af5953f55c87a9368823ea361fef120997d55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->