### PR TITLE
redis-benchmark: free skipped no-slots master to avoid leak

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1061,10 +1061,13 @@ static void freeClusterNode(clusterNode *node) {
         for (i = 0; i < node->importing_count; i++) sdsfree(node->importing[i]);
         zfree(node->importing);
     }
-    /* If the node is not the reference node, that uses the address from
-     * config.conn_info.hostip and config.conn_info.hostport, then the node ip has been
-     * allocated by fetchClusterConfiguration, so it must be freed. */
-    if (node->ip && strcmp(node->ip, config.conn_info.hostip) != 0) sdsfree(node->ip);
+    /* Only firstNode borrows config.conn_info.hostip directly (see
+     * fetchClusterConfiguration); every other node->ip is a fresh sds
+     * allocation. Compare the pointer, not the string contents — a
+     * value comparison would skip the sdsfree whenever a peer master
+     * happens to share the hostip string (common in same-host
+     * multi-port deployments such as 127.0.0.1 cluster fixtures). */
+    if (node->ip && node->ip != config.conn_info.hostip) sdsfree(node->ip);
     if (node->redis_config != NULL) freeRedisConfig(node->redis_config);
     zfree(node->slots);
     zfree(node);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1245,6 +1245,9 @@ static int fetchClusterConfiguration(void) {
             fprintf(stderr,
                     "WARNING: Master node %s:%d has no slots, skipping...\n",
                     node->ip, node->port);
+            /* Non-myself entries are fresh allocations not yet transferred
+             * to config.cluster_nodes; firstNode is owned by the caller. */
+            if (node != firstNode) freeClusterNode(node);
             continue;
         }
         if (!addClusterNode(node)) {

--- a/tests/unit/cluster/redis-benchmark.tcl
+++ b/tests/unit/cluster/redis-benchmark.tcl
@@ -1,0 +1,31 @@
+source tests/support/benchmark.tcl
+
+# Place all 16384 slots on master 0 so master 1 stays a slot-less master
+# while the cluster as a whole still reaches "ok" state. This is exactly
+# the input shape that drives fetchClusterConfiguration() through the
+# slots_count == 0 branch in src/redis-benchmark.c.
+proc all_slots_to_first_master {masters} {
+    R 0 cluster addslotsrange 0 16383
+}
+
+start_cluster 2 0 {tags {external:skip cluster}} {
+    test "redis-benchmark --cluster: skipping a no-slots master does not leak" {
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+        # -n 1 -t set keeps the run short. We do not assert on the benchmark
+        # exit code; the only thing under test is fetchClusterConfiguration()'s
+        # handling of a master entry whose slot list is empty.
+        set cmd [redisbenchmark $master_host $master_port "--cluster -c 1 -n 1 -t set"]
+        set output ""
+        catch { exec {*}$cmd 2>@1 } output
+        # The warning proves the slots_count == 0 branch executed against the
+        # second master, so the test is genuinely exercising the fixed path.
+        assert_match {*has no slots, skipping*} $output
+        # Under the address sanitizer build, an unfreed allocation in that
+        # branch would surface as a leak report on stderr. Outside sanitizer
+        # builds the regex never matches, so the assertion is a no-op there.
+        if {[regexp -nocase {sanitizer.*(leak|error)|detected memory leak} $output]} {
+            fail "redis-benchmark leaked memory on no-slots master path: $output"
+        }
+    }
+} all_slots_to_first_master


### PR DESCRIPTION
## Problem

`fetchClusterConfiguration()` in `src/redis-benchmark.c` leaks the per-entry `clusterNode` allocation whenever `CLUSTER NODES` reports a master with no slot assignments and that master is not the one redis-benchmark connected to. The function logs a warning and `continue`s, but at that point the loop body has already executed:

```c
node = createClusterNode(sdsnew(ip), port);
```

so `node` is a fresh allocation that has not yet been transferred to `config.cluster_nodes` via `addClusterNode()`. Skipping the entry via `continue` drops the only reference and leaks the `clusterNode`, the `slots` array, the `name` sds, the `migrating`/`importing` arrays, and the `ip` sds.

The myself branch is not affected because `node` is just an alias for `firstNode`, whose ownership belongs to the caller frame.

## Root Cause

Two coupled defects:

1. **`fetchClusterConfiguration()` skips without releasing.** The `slots_count == 0` branch goes straight to `continue` for both myself and non-myself entries. For the non-myself entry the only owner of the freshly-allocated node is the local variable that is about to be overwritten on the next iteration.
2. **`freeClusterNode()` cannot release the borrowed-pointer-suspect ip correctly.** The function uses `strcmp(node->ip, config.conn_info.hostip)` to decide whether `node->ip` was borrowed (it is, only for the original `firstNode` created with `(char *)config.conn_info.hostip`). String comparison gets that wrong as soon as any other node->ip is a fresh sds with the same string contents — typical for same-host multi-port clusters where every node is reported as `127.0.0.1`. The fresh sds is silently treated as borrowed and never freed.

The first defect alone leaks the entire node; the second alone leaks the ip sds whenever a peer has the same hostip string. Fixing only one leaves the other half present, which the new sanitizer test surfaces directly.

## Fix

Two small commits, each addressing one of the defects independently:

**1. `redis-benchmark: use pointer compare for borrowed hostip in freeClusterNode`**

```c
- if (node->ip && strcmp(node->ip, config.conn_info.hostip) != 0) sdsfree(node->ip);
+ if (node->ip && node->ip != config.conn_info.hostip) sdsfree(node->ip);
```

Borrowed-pointer-vs-owned is a pointer-identity question by construction, so the pointer compare is the correct primitive here. `firstNode` keeps the borrowed reference only until the myself branch replaces it with `sdsnew()`, after which the new pointer differs and cleanup is restored to its original intent.

**2. `redis-benchmark: free skipped no-slots master to avoid leak`**

```c
if (node->slots_count == 0) {
    fprintf(stderr, "WARNING: ...");
    if (node != firstNode) freeClusterNode(node);
    continue;
}
```

`firstNode` is intentionally left alone — its ownership stays with the caller frame.

Behaviour for callers is unchanged: the same warning, the same skipped entry, the same return value.

## Tests Added

`tests/unit/cluster/redis-benchmark.tcl` brings up a 2-master cluster with a custom slot allocator that places all 16384 slots on master 0, leaving master 1 as a slot-less master while keeping the cluster in `ok` state. It then runs `redis-benchmark --cluster` against master 0, which drives `fetchClusterConfiguration()` exactly through the fixed branch for the master 1 entry.

| Change Point | Test |
|-------------|------|
| `node->ip != config.conn_info.hostip` pointer compare in `freeClusterNode()` | Implicit — without this change the next test reports an 11-byte `hi_sdsnewlen` leak under LSan because the peer's ip sds is silently kept alive. |
| `freeClusterNode(node)` on slots_count == 0 for non-myself entries | `redis-benchmark --cluster: skipping a no-slots master does not leak` — asserts the `has no slots, skipping` warning is printed (proving the fixed branch was hit) and scans stderr for sanitizer leak reports (caught by the `test-sanitizer-address` CI job). |

The first push of this PR with only the second commit failed `test-sanitizer-address` with `Direct leak of 11 byte(s) ... in hi_sdsnewlen`, which directly confirmed the strcmp defect was the missing piece.

## Impact

- Affects only `src/redis-benchmark.c`; no server-side code touched.
- Behaviour unchanged for callers: same warning, same skipped node, same return value.
- Eliminates two related allocation leaks: a full per-entry node leak in the no-slots-master path, and an ip sds leak in `freeClusterNode()` whenever a non-`firstNode` happens to share the connect host's string.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to redis-benchmark cluster teardown/parsing; no server or runtime behavior changes beyond fixing leaks.
> 
> **Overview**
> Fixes **memory leaks** in `redis-benchmark` cluster setup when parsing `CLUSTER NODES`, without changing visible behavior (same warnings, skipped masters, and return values).
> 
> In **`freeClusterNode`**, owned vs borrowed `node->ip` is decided with **pointer equality** to `config.conn_info.hostip` instead of `strcmp`, so peer nodes on the same host string (e.g. `127.0.0.1`) still free their own `sds` allocations.
> 
> In **`fetchClusterConfiguration`**, when a master has **no slots** and is skipped, the code now calls **`freeClusterNode(node)`** for non-`firstNode` entries that were allocated in the loop but never added to `config.cluster_nodes`.
> 
> Adds **`tests/unit/cluster/redis-benchmark.tcl`**: a 2-master cluster with all slots on master 0, runs `redis-benchmark --cluster`, checks the no-slots warning, and fails on sanitizer leak output when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a380b109dffe13b6921c201af87f950adad389f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->