### PR TITLE
Initial commit - aof enhancement fullsync

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -27,7 +27,7 @@ off_t getAppendOnlyFileSize(sds filename, int *status);
 off_t getBaseAndIncrAppendOnlyFilesSize(aofManifest *am, int *status);
 int getBaseAndIncrAppendOnlyFilesNum(aofManifest *am);
 int aofFileExist(char *filename);
-int rewriteAppendOnlyFile(char *filename);
+int rewriteAppendOnlyFile(char *filename, int req);
 aofManifest *aofLoadManifestFromFile(sds am_filepath);
 void aofManifestFreeAndUpdate(aofManifest *am);
 void aof_background_fsync_and_close(int fd);
@@ -743,7 +743,7 @@ void aofOpenIfNeededOnServerStart(void) {
     if (!server.aof_manifest->base_aof_info && !incr_aof_len) {
         sds base_name = getNewBaseFileNameAndMarkPreAsHistory(server.aof_manifest);
         sds base_filepath = makePath(server.aof_dirname, base_name);
-        if (rewriteAppendOnlyFile(base_filepath) != C_OK) {
+        if (rewriteAppendOnlyFile(base_filepath, SLAVE_REQ_NONE) != C_OK) {
             exit(1);
         }
         sdsfree(base_filepath);
@@ -989,20 +989,24 @@ void aof_background_fsync_and_close(int fd) {
     bioCreateCloseAofJob(fd, server.master_repl_offset, 1);
 }
 
-/* Kills an AOFRW child process if exists */
-void killAppendOnlyChild(void) {
+/* Kills an AOFRW child process if exists. If async is true, skip waitpid and
+ * cleanup; checkChildrenDone will finish after the child exits. */
+void killAppendOnlyChild(int async) {
     int statloc;
     /* No AOFRW child? return. */
     if (server.child_type != CHILD_TYPE_AOF) return;
     /* Kill AOFRW child, wait for child exit. */
     serverLog(LL_NOTICE,"Killing running AOF rewrite child: %ld",
         (long) server.child_pid);
-    if (kill(server.child_pid,SIGUSR1) != -1) {
-        while(waitpid(-1, &statloc, 0) != server.child_pid);
+    int ret = kill(server.child_pid,SIGUSR1);
+    if (!async) {
+        if (ret != -1) {
+            while(waitpid(-1, &statloc, 0) != server.child_pid);
+        }
+        aofRemoveTempFile(server.child_pid);
+        resetChildState();
+        server.aof_rewrite_time_start = -1;
     }
-    aofRemoveTempFile(server.child_pid);
-    resetChildState();
-    server.aof_rewrite_time_start = -1;
 }
 
 /* Called when the user switches from "appendonly yes" to "appendonly no"
@@ -1026,7 +1030,7 @@ void stopAppendOnly(void) {
     server.aof_last_incr_fsync_offset = 0;
     server.fsynced_reploff = -1;
     atomicSet(server.fsynced_reploff_pending, 0);
-    killAppendOnlyChild();
+    killAppendOnlyChild(0);
     sdsfree(server.aof_buf);
     server.aof_buf = sdsempty();
 }
@@ -1049,10 +1053,10 @@ int startAppendOnly(void) {
          * accumulating the AOF buffer. */
         if (server.child_type == CHILD_TYPE_AOF) {
             serverLog(LL_NOTICE,"AOF was enabled but there is already an AOF rewriting in background. Stopping background AOF and starting a rewrite now.");
-            killAppendOnlyChild();
+            killAppendOnlyChild(0);
         }
 
-        if (rewriteAppendOnlyFileBackground() == C_ERR) {
+        if (rewriteAppendOnlyFileBackground(0, SLAVE_REQ_NONE) == C_ERR) {
             server.aof_state = AOF_OFF;
             serverLog(LL_WARNING,"Redis needs to enable the AOF but can't trigger a background AOF rewrite operation. Check the above logs for more info about the error.");
             return C_ERR;
@@ -2557,7 +2561,7 @@ int rewriteObject(rio *r, robj *key, robj *o, int dbid, long long expiretime) {
     return C_OK;
 }
 
-int rewriteAppendOnlyFileRio(rio *aof) {
+int rewriteAppendOnlyFileRio(rio *aof, int req) {
     dictEntry *de;
     int j;
     long key_count = 0;
@@ -2572,7 +2576,9 @@ int rewriteAppendOnlyFileRio(rio *aof) {
         sdsfree(ts);
     }
 
-    if (rewriteFunctions(aof) == 0) goto werr;
+    if (!(req & SLAVE_REQ_RDB_EXCLUDE_FUNCTIONS) && rewriteFunctions(aof) == 0) goto werr;
+
+    if (req & SLAVE_REQ_RDB_EXCLUDE_DATA) return C_OK;
 
     for (j = 0; j < server.dbnum; j++) {
         char selectcmd[] = "*2\r\n$6\r\nSELECT\r\n";
@@ -2661,7 +2667,7 @@ werr:
  * log Redis uses variadic commands when possible, such as RPUSH, SADD
  * and ZADD. However at max AOF_REWRITE_ITEMS_PER_CMD items per time
  * are inserted using a single command. */
-int rewriteAppendOnlyFile(char *filename) {
+int rewriteAppendOnlyFile(char *filename, int req) {
     rio aof;
     FILE *fp = NULL;
     char tmpfile[256];
@@ -2686,12 +2692,12 @@ int rewriteAppendOnlyFile(char *filename) {
 
     if (server.aof_use_rdb_preamble) {
         int error;
-        if (rdbSaveRio(SLAVE_REQ_NONE,&aof,&error,RDBFLAGS_AOF_PREAMBLE,NULL) == C_ERR) {
+        if (rdbSaveRio(req,&aof,&error,RDBFLAGS_AOF_PREAMBLE,NULL) == C_ERR) {
             errno = error;
             goto werr;
         }
     } else {
-        if (rewriteAppendOnlyFileRio(&aof) == C_ERR) goto werr;
+        if (rewriteAppendOnlyFileRio(&aof, req) == C_ERR) goto werr;
     }
 
     /* Make sure data will not remain on the OS's output buffers */
@@ -2741,7 +2747,7 @@ werr:
  *    4d) persist AOF manifest file
  *    4e) Delete the history files use bio
  */
-int rewriteAppendOnlyFileBackground(void) {
+int rewriteAppendOnlyFileBackground(int for_replication, int req) {
     pid_t childpid;
 
     if (hasActiveChildProcess()) return C_ERR;
@@ -2785,7 +2791,8 @@ int rewriteAppendOnlyFileBackground(void) {
         redisSetProcTitle("redis-aof-rewrite");
         redisSetCpuAffinity(server.aof_rewrite_cpulist);
         snprintf(tmpfile,256,"temp-rewriteaof-bg-%d.aof", (int) getpid());
-        if (rewriteAppendOnlyFile(tmpfile) == C_OK) {
+        if (for_replication) server.aof_use_rdb_preamble = 0;
+        if (rewriteAppendOnlyFile(tmpfile, req) == C_OK) {
             serverLog(LL_NOTICE,
                 "Successfully created the temporary AOF base file %s", tmpfile);
             sendChildCowInfo(CHILD_INFO_TYPE_AOF_COW_SIZE, "AOF rewrite");
@@ -2806,6 +2813,7 @@ int rewriteAppendOnlyFileBackground(void) {
             "Background append only file rewriting started by pid %ld",(long) childpid);
         server.aof_rewrite_scheduled = 0;
         server.aof_rewrite_time_start = time(NULL);
+        server.aof_rewrite_for_replication = for_replication;
         return C_OK;
     }
     return C_OK; /* unreached */
@@ -2820,7 +2828,7 @@ void bgrewriteaofCommand(client *c) {
          * so that it can be executed immediately. */
         server.stat_aofrw_consecutive_failures = 0;
         addReplyStatus(c,"Background append only file rewriting scheduled");
-    } else if (rewriteAppendOnlyFileBackground() == C_OK) {
+    } else if (rewriteAppendOnlyFileBackground(0, SLAVE_REQ_NONE) == C_OK) {
         addReplyStatus(c,"Background append only file rewriting started");
     } else {
         addReplyError(c,"Can't execute an AOF background rewriting. "
@@ -3046,6 +3054,7 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
     }
 
 cleanup:
+    server.aof_rewrite_for_replication = 0;
     aofRemoveTempFile(server.child_pid);
     /* Clear AOF buffer and delete temp incr aof for next rewrite. */
     if (server.aof_state == AOF_WAIT_REWRITE) {

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -120,6 +120,7 @@ void clusterCommandMyShardId(client *c);
 sds clusterGenNodeDescription(client *c, clusterNode *node, int tls_primary);
 
 int clusterNodeCoversSlot(clusterNode *n, int slot);
+int clusterIsAnySlotMoving(void);
 int getNodeDefaultClientPort(clusterNode *n);
 int clusterNodeIsMyself(clusterNode *n);
 clusterNode *getMyClusterNode(void);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5064,6 +5064,19 @@ int clusterNodeCoversSlot(clusterNode *n, int slot) {
     return bitmapTestBit(n->slots,slot);
 }
 
+/* Return 1 if this node has any slot in MIGRATE/IMPORT state (resharding). */
+int clusterIsAnySlotMoving(void) {
+    int j;
+
+    if (!server.cluster_enabled || server.cluster == NULL) return 0;
+    for (j = 0; j < CLUSTER_SLOTS; j++) {
+        if (server.cluster->migrating_slots_to[j] != NULL ||
+            server.cluster->importing_slots_from[j] != NULL)
+            return 1;
+    }
+    return 0;
+}
+
 /* Add the specified slot to the list of slots that node 'n' will
  * serve. Return C_OK if the operation ended with success.
  * If the slot is already assigned to another instance this is considered

--- a/src/config.c
+++ b/src/config.c
@@ -112,6 +112,12 @@ configEnum repl_diskless_load_enum[] = {
     {NULL, 0}
 };
 
+configEnum repl_fullsync_format_enum[] = {
+    {"rdb", REPL_FULLSYNC_RDB},
+    {"aof", REPL_FULLSYNC_AOF},
+    {NULL, 0}
+};
+
 configEnum tls_auth_clients_enum[] = {
     {"no", TLS_CLIENT_AUTH_NO},
     {"yes", TLS_CLIENT_AUTH_YES},
@@ -3119,6 +3125,8 @@ standardConfig static_configs[] = {
     createBoolConfig("repl-disable-tcp-nodelay", NULL, MODIFIABLE_CONFIG, server.repl_disable_tcp_nodelay, 0, NULL, NULL),
     createBoolConfig("repl-diskless-sync", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.repl_diskless_sync, 1, NULL, NULL),
     createBoolConfig("repl-rdb-channel", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.repl_rdb_channel, 1, NULL, NULL),
+    createEnumConfig("repl-fullsync-format", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, repl_fullsync_format_enum, server.repl_fullsync_format, REPL_FULLSYNC_RDB, NULL, NULL),
+    createStringConfig("repl-fullsync-aof-filename", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, ALLOW_EMPTY_STRING, server.fullsync_aof_filename, "fullsync-base.aof", isValidAOFfilename, NULL),
     createBoolConfig("aof-rewrite-incremental-fsync", NULL, MODIFIABLE_CONFIG, server.aof_rewrite_incremental_fsync, 1, NULL, NULL),
     createBoolConfig("no-appendfsync-on-rewrite", NULL, MODIFIABLE_CONFIG, server.aof_no_fsync_on_rewrite, 0, NULL, NULL),
     createBoolConfig("cluster-require-full-coverage", NULL, MODIFIABLE_CONFIG, server.cluster_require_full_coverage, 1, NULL, NULL),

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4437,7 +4437,7 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
             /* Check slave has the exact requirements */
             if (slave->slave_req != req)
                 continue;
-            replicationSetupSlaveForFullResync(slave, getPsyncInitialOffset());
+            replicationSetupSlaveForFullResync(slave, getPsyncInitialOffset(), 0);
             conns[numconns++] = slave->conn;
             if (rdb_channel) {
                 /* Put the socket in blocking mode to simplify RDB transfer. */

--- a/src/replication.c
+++ b/src/replication.c
@@ -923,10 +923,11 @@ long long getPsyncInitialOffset(void) {
  * Normally this function should be called immediately after a successful
  * BGSAVE for replication was started, or when there is one already in
  * progress that we attached our slave to. */
-int replicationSetupSlaveForFullResync(client *slave, long long offset) {
+int replicationSetupSlaveForFullResync(client *slave, long long offset, int fullsync_aof) {
     char buf[128];
     int buflen;
 
+    UNUSED(fullsync_aof);
     slave->psync_initial_offset = offset;
     slave->replstate = SLAVE_STATE_WAIT_BGSAVE_END;
     /* We are going to accumulate the incremental changes for this
@@ -1176,7 +1177,7 @@ int startBgsaveForReplication(int mincapa, int req) {
                 /* Check slave has the exact requirements */
                 if (slave->slave_req != req)
                     continue;
-                replicationSetupSlaveForFullResync(slave, getPsyncInitialOffset());
+                replicationSetupSlaveForFullResync(slave, getPsyncInitialOffset(), 0);
             }
         }
     }
@@ -1363,7 +1364,7 @@ void syncCommand(client *c) {
              * We don't copy buffer if clients don't want. */
             if (!(c->flags & CLIENT_REPL_RDBONLY))
                 copyReplicaOutputBuffer(c,slave);
-            replicationSetupSlaveForFullResync(c,slave->psync_initial_offset);
+            replicationSetupSlaveForFullResync(c,slave->psync_initial_offset, 0);
             serverLog(LL_NOTICE,"Waiting for end of BGSAVE for SYNC");
         } else {
             /* No way, we need to wait for the next BGSAVE in order to

--- a/src/server.c
+++ b/src/server.c
@@ -1635,7 +1635,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
         server.aof_rewrite_scheduled &&
         !aofRewriteLimited())
     {
-        rewriteAppendOnlyFileBackground();
+        rewriteAppendOnlyFileBackground(0, SLAVE_REQ_NONE);
     }
 
     /* Check if a background saving or AOF rewrite in progress terminated. */
@@ -1679,7 +1679,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
             long long growth = (server.aof_current_size*100/base) - 100;
             if (growth >= server.aof_rewrite_perc && !aofRewriteLimited()) {
                 serverLog(LL_NOTICE,"Starting automatic rewriting of AOF on %lld%% growth",growth);
-                rewriteAppendOnlyFileBackground();
+                rewriteAppendOnlyFileBackground(0, SLAVE_REQ_NONE);
             }
         }
     }
@@ -2428,6 +2428,12 @@ void initServerConfig(void) {
     server.fsynced_reploff_pending = 0;
     server.repl_stream_lastio = server.unixtime;
     server.repl_total_sync_attempts = 0;
+    server.repl_fullsync_format = REPL_FULLSYNC_RDB;
+    server.repl_stream_offset = 0;
+    server.repl_transfer_format = REPL_SNAPSHOT_RDB;
+    server.repl_stream_dbid = -1;
+    server.repl_replica_stream_dbid = -1;
+    server.aof_rewrite_for_replication = 0;
 
     /* Replication partial resync backlog */
     server.repl_backlog = NULL;
@@ -5055,7 +5061,7 @@ int finishShutdown(void) {
         }
         serverLog(LL_WARNING,
                   "There is a child rewriting the AOF. Killing it!");
-        killAppendOnlyChild();
+        killAppendOnlyChild(0);
     }
     if (server.aof_state != AOF_OFF) {
         /* Append only file: flush buffers and fsync() the AOF at exit */
@@ -5990,6 +5996,9 @@ sds fillPercentileDistributionLatencies(sds info, const char* histogram_name, st
 
 const char *replstateToString(int replstate) {
     switch (replstate) {
+    case SLAVE_STATE_WAIT_BGREWRITE_START:
+    case SLAVE_STATE_WAIT_BGREWRITE_END:
+        return "wait_bgrewrite";
     case SLAVE_STATE_WAIT_BGSAVE_START:
     case SLAVE_STATE_WAIT_BGSAVE_END:
     case SLAVE_STATE_WAIT_RDB_CHANNEL:

--- a/src/server.h
+++ b/src/server.h
@@ -574,12 +574,15 @@ typedef enum {
                                          * we are waiting rdbchannel connection to start delivery.*/
 #define SLAVE_STATE_SEND_BULK_AND_STREAM 12 /* Main channel of a replica which uses rdb channel replication.
                                              * Sending RDB file and replication stream in parallel. */
+#define SLAVE_STATE_WAIT_BGREWRITE_START 13 /* Waiting for BG AOF snapshot for full sync. */
+#define SLAVE_STATE_WAIT_BGREWRITE_END 14   /* Snapshot generation in progress (AOF). */
 
 /* Slave capabilities. */
 #define SLAVE_CAPA_NONE             0
 #define SLAVE_CAPA_EOF              (1<<0) /* Can parse the RDB EOF streaming format. */
 #define SLAVE_CAPA_PSYNC2           (1<<1) /* Supports PSYNC2 protocol. */
 #define SLAVE_CAPA_RDB_CHANNEL_REPL (1<<2) /* Supports rdb channel replication during full sync */
+#define SLAVE_CAPA_FULLSYNC_AOF     (1<<3) /* Supports full sync using AOF command stream */
 
 /* Slave requirements. NO_COMPRESS and NO_CHECKSUM are hints rather than strict
  * requirements - the replica can handle compressed/checksummed RDB either way,
@@ -645,6 +648,16 @@ typedef enum {
 #define REPL_DISKLESS_LOAD_WHEN_DB_EMPTY 1
 #define REPL_DISKLESS_LOAD_SWAPDB 2
 #define REPL_DISKLESS_LOAD_ALWAYS 3
+
+/* Replication fullsync snapshot format (master offers / replica requests). */
+#define REPL_FULLSYNC_RDB 0
+#define REPL_FULLSYNC_AOF 1
+
+/* Snapshot payload type during replica sync (after PSYNC / on wire). */
+typedef enum {
+    REPL_SNAPSHOT_RDB = 0,
+    REPL_SNAPSHOT_AOF = 1
+} repl_snapshot_type;
 
 /* TLS Client Authentication */
 #define TLS_CLIENT_AUTH_NO 0
@@ -2339,6 +2352,8 @@ struct redisServer {
                                          * delay (start sooner if they all connect). */
     int repl_rdb_channel;           /* Config used to determine if the replica should
                                      * use rdb channel replication for full syncs. */
+    int repl_fullsync_format;       /* REPL_FULLSYNC_RDB or REPL_FULLSYNC_AOF (master). */
+    char *fullsync_aof_filename;    /* Basename for on-disk fullsync AOF snapshot file. */
     int repl_debug_pause;           /* Debug config to force the main process to pause. */
     size_t repl_buffer_mem;         /* The memory of replication buffer. */
     list *repl_buffer_blocks;       /* Replication buffers blocks list
@@ -2359,6 +2374,11 @@ struct redisServer {
     uint64_t repl_num_master_disconnection; /* Number of master connection was disconnected */
     uint64_t repl_main_ch_client_id; /* Main channel client id received in +RDBCHANNELSYNC reply. */
     off_t repl_transfer_size; /* Size of RDB to read from master during sync. */
+    long long repl_stream_offset; /* Replication offset carried with AOF fullsync. */
+    repl_snapshot_type repl_transfer_format; /* Snapshot wire format during replica sync. */
+    int repl_stream_dbid;          /* Stream DB id from master (+FULLRESYNC ... AOF). */
+    int repl_replica_stream_dbid;  /* Replica-side stream DB id for AOF fullsync. */
+    int aof_rewrite_for_replication; /* AOF rewrite child is serving replication fullsync. */
     off_t repl_transfer_read; /* Amount of RDB read from master during sync. */
     off_t repl_transfer_last_fsync_off; /* Offset when we fsync-ed last time. */
     connection *repl_transfer_s;     /* Slave -> Master SYNC connection */
@@ -3406,7 +3426,7 @@ void replicationSendNewlineToMaster(void);
 long long replicationGetSlaveOffset(void);
 char *replicationGetSlaveName(client *c);
 long long getPsyncInitialOffset(void);
-int replicationSetupSlaveForFullResync(client *slave, long long offset);
+int replicationSetupSlaveForFullResync(client *slave, long long offset, int fullsync_aof);
 void changeReplicationId(void);
 void clearReplicationId2(void);
 void createReplicationBacklog(void);
@@ -3461,14 +3481,14 @@ int bg_unlink(const char *filename);
 void flushAppendOnlyFile(int force);
 void feedAppendOnlyFile(int dictid, robj **argv, int argc);
 void aofRemoveTempFile(pid_t childpid);
-int rewriteAppendOnlyFileBackground(void);
+int rewriteAppendOnlyFileBackground(int for_replication, int req);
 int loadAppendOnlyFiles(aofManifest *am);
 void stopAppendOnly(void);
 int startAppendOnly(void);
 void startAppendOnlyWithRetry(void);
 void applyAppendOnlyConfig(void);
 void backgroundRewriteDoneHandler(int exitcode, int bysignal);
-void killAppendOnlyChild(void);
+void killAppendOnlyChild(int async);
 void aofLoadManifestFromDisk(void);
 void aofOpenIfNeededOnServerStart(void);
 void aofManifestFree(aofManifest *am);


### PR DESCRIPTION
This is a draft PR for addressing #15153

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core persistence and replication full-sync paths (AOF rewrite, replica state machine, and new replication config), where small logic errors can break synchronization or data durability.
> 
> **Overview**
> Introduces initial plumbing to support **AOF-generated snapshots for replication full sync**: adds `repl-fullsync-format` (RDB vs AOF) and `repl-fullsync-aof-filename`, plus new replica capability/state constants and server fields to track stream offsets and snapshot format.
> 
> Extends AOF rewrite entry points (`rewriteAppendOnlyFile*`, `rewriteAppendOnlyFileBackground`) to accept replication requirements (`req`) so rewrites can optionally exclude functions/data, and tracks whether a rewrite is running *for replication*.
> 
> Adds `clusterIsAnySlotMoving()` helper for detecting active slot migration/import state, and adjusts child cleanup/kill behavior (`killAppendOnlyChild(async)`) and scheduled AOFRW call sites to use the new signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb77910d18a229d25afaf853b3a7bc35a3d5e9f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->