### PR TITLE
[wontfix] Add test module for RM_HashGet with various field types

### DIFF
--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -86,7 +86,8 @@ TEST_MODULES = \
     configaccess.so \
     test_keymeta.so \
     keymeta_notify.so \
-    atomicslotmigration.so
+    atomicslotmigration.so \
+    hash_null.so
 
 .PHONY: all
 

--- a/tests/modules/hash_null.c
+++ b/tests/modules/hash_null.c
@@ -1,0 +1,75 @@
+#include "redismodule.h"
+#include <stdlib.h>
+#include <string.h>
+
+int HashNull_NormalGet(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 3) return RedisModule_WrongArity(ctx);
+    RedisModule_AutoMemory(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+    if (!key || RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_HASH)
+        return RedisModule_ReplyWithError(ctx, "not a hash");
+    RedisModuleString *val = NULL;
+    RedisModule_HashGet(key, REDISMODULE_HASH_NONE, argv[2], &val, NULL);
+    if (val) RedisModule_ReplyWithString(ctx, val);
+    else RedisModule_ReplyWithNull(ctx);
+    return REDISMODULE_OK;
+}
+
+int HashNull_GetFromLongLong(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 3) return RedisModule_WrongArity(ctx);
+    RedisModule_AutoMemory(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+    if (!key || RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_HASH)
+        return RedisModule_ReplyWithError(ctx, "not a hash");
+
+    long long field_num;
+    if (RedisModule_StringToLongLong(argv[2], &field_num) != REDISMODULE_OK)
+        return RedisModule_ReplyWithError(ctx, "invalid field number");
+
+    RedisModuleString *field = RedisModule_CreateStringFromLongLong(ctx, field_num);
+    RedisModuleString *val = NULL;
+    RedisModule_HashGet(key, REDISMODULE_HASH_NONE, field, &val, NULL);
+    if (val) RedisModule_ReplyWithString(ctx, val);
+    else RedisModule_ReplyWithNull(ctx);
+    return REDISMODULE_OK;
+}
+
+int HashNull_GetFromDouble(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 3) return RedisModule_WrongArity(ctx);
+    RedisModule_AutoMemory(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+    if (!key || RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_HASH)
+        return RedisModule_ReplyWithError(ctx, "not a hash");
+
+    double field_num;
+    if (RedisModule_StringToDouble(argv[2], &field_num) != REDISMODULE_OK)
+        return RedisModule_ReplyWithError(ctx, "invalid field double");
+
+    RedisModuleString *field = RedisModule_CreateStringFromDouble(ctx, field_num);
+    RedisModuleString *val = NULL;
+    RedisModule_HashGet(key, REDISMODULE_HASH_NONE, field, &val, NULL);
+    if (val) RedisModule_ReplyWithString(ctx, val);
+    else RedisModule_ReplyWithNull(ctx);
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    (void) argv;
+    (void) argc;
+    if (RedisModule_Init(ctx, "hashnull", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "hashnull.normalget", HashNull_NormalGet,
+        "readonly",0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "hashnull.getfromll", HashNull_GetFromLongLong,
+        "readonly",0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "hashnull.getfromdouble", HashNull_GetFromDouble,
+        "readonly",0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    return REDISMODULE_OK;
+}

--- a/tests/unit/moduleapi/hash_null.tcl
+++ b/tests/unit/moduleapi/hash_null.tcl
@@ -1,0 +1,26 @@
+set testmodule [file normalize tests/modules/hash_null.so]
+
+start_server {tags {"modules external:skip"}} {
+    r module load $testmodule
+
+    test "Hash module API get with valid field" {
+        r HSET myhash f1 v1 f2 v2 f3 v3
+        assert_equal "v1" [r hashnull.normalget myhash f1]
+        assert_equal "v2" [r hashnull.normalget myhash f2]
+    }
+
+    test "Hash module API get nonexistent field returns null" {
+        assert_equal {} [r hashnull.normalget myhash nonexistent]
+    }
+
+    test "Hash module API get with long long field" {
+        r HSET myhash 1 one 2 two
+        assert_equal "one" [r hashnull.getfromll myhash 1]
+        assert_equal "two" [r hashnull.getfromll myhash 2]
+    }
+
+    test "Hash module API get with double field" {
+        r HSET myhash 1.5 onefive 2.5 twofive
+        assert_equal "onefive" [r hashnull.getfromdouble myhash 1.5]
+    }
+}


### PR DESCRIPTION
Add a minimal test module (hash_null) that exercises RM_HashGet with normal C-string fields, long long fields, and double fields, plus a Tcl test that verifies basic hash operations via the module API.

This test module was initially developed while investigating a crash reported in RediSearch/RediSearch#8946. The root cause is addressed separately in RediSearch/RediSearch#9486.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a small test-only module and unit test to exercise `RedisModule_HashGet` behavior for missing fields and numeric field conversions; no production code paths are modified in this diff.
> 
> **Overview**
> Adds a new test module `hash_null.so` exposing commands that call `RedisModule_HashGet`, and registers it in `tests/modules/Makefile`.
> 
> Introduces a Tcl unit test (`moduleapi/hash_null.tcl`) that verifies hash lookups return *null* for nonexistent fields and work when the field name is constructed from `long long`/`double`, helping prevent regressions around NULL handling in the module hash API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b53defe70ebabb003a22f1281f1c5cafe9c2984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->