### PR TITLE
Fix MULTI queue memory accounting in multiStateMemOverhead

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -504,6 +504,6 @@ size_t multiStateMemOverhead(client *c) {
     /* Add watched keys overhead, Note: this doesn't take into account the watched keys themselves, because they aren't managed per-client. */
     mem += listLength(c->watched_keys) * (sizeof(listNode) + sizeof(watchedKey));
     /* Reserved memory for queued multi commands. */
-    mem += c->mstate.alloc_count * sizeof(pendingCommand);
+    mem += c->mstate.alloc_count * sizeof(pendingCommand*);
     return mem;
 }

--- a/src/multi.c
+++ b/src/multi.c
@@ -505,5 +505,6 @@ size_t multiStateMemOverhead(client *c) {
     mem += listLength(c->watched_keys) * (sizeof(listNode) + sizeof(watchedKey));
     /* Reserved memory for queued multi commands. */
     mem += c->mstate.alloc_count * sizeof(pendingCommand*);
+    mem += c->mstate.count * sizeof(pendingCommand);
     return mem;
 }


### PR DESCRIPTION
PR #14440 changed `mstate.commands` from an array of `multiCmd` structs to an array of `pendingCommand` pointers. This PR fixes the overhead calculation in multiStateMemOverhead to account for both the pointer array and the actual structs:
- The pointer array: `alloc_count * sizeof(pendingCommand*)`
- The individually allocated structs: `count * sizeof(pendingCommand)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `multiStateMemOverhead` accounting for MULTI queue storage and does not affect execution or data handling.
> 
> **Overview**
> Fixes `multiStateMemOverhead` to stop over-reporting memory after `mstate.commands` became an array of `pendingCommand*`. It now accounts separately for the allocated pointer array (`alloc_count * sizeof(pendingCommand*)`) and the actually queued `pendingCommand` structs (`count * sizeof(pendingCommand)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 498b1d713ea981e435560f2f3111c80adce42144. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->