### PR TITLE
ts v8.6.2 bloom v8.6.2

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.6.0
+MODULE_VERSION = v8.6.2
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 

--- a/modules/redistimeseries/Makefile
+++ b/modules/redistimeseries/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.6.0
+MODULE_VERSION = v8.6.2
 MODULE_REPO = https://github.com/redistimeseries/redistimeseries
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redistimeseries.so
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bump that only changes which upstream module tags are cloned and built; main risk is potential behavior/performance regressions introduced by the new module releases.
> 
> **Overview**
> Bumps the `MODULE_VERSION` used by the module build Makefiles so `redisbloom` and `redistimeseries` are cloned/built from upstream tag `v8.6.2` (was `v8.6.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a1bf1f8529df3d762f4d77c42045d208145ae9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->