### PR TITLE
Prototype: JUnit XML output for the Tcl test suite (Track 1, draft for discussion)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,14 @@ jobs:
       # build with TLS just for compilation coverage
       run: make REDIS_CFLAGS='-Werror' BUILD_TLS=yes
     - name: test
+      # NOTE: --single unit/other --force-failure --only "Failing test" is a
+      # TEMPORARY DEMO ONLY, to surface the JUnit failure-annotation experience
+      # in this draft PR. --single keeps the run scoped to a single file so
+      # moduleapi suites (whose .so modules are not built in this job) are not
+      # exercised. This block MUST be reverted before merge.
       run: |
         sudo apt-get install tcl8.6 tclx
-        ./runtest --verbose --tags -slow --dump-logs --junitxml tests/results/junit.xml
+        ./runtest --verbose --dump-logs --junitxml tests/results/junit.xml --single unit/other --force-failure --only "Failing test"
     - name: Upload JUnit report
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,21 @@ jobs:
     - name: test
       run: |
         sudo apt-get install tcl8.6 tclx
-        ./runtest --verbose --tags -slow --dump-logs
+        ./runtest --verbose --tags -slow --dump-logs --junitxml tests/results/junit.xml
+    - name: Upload JUnit report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: junit-test-ubuntu-latest
+        path: tests/results/junit.xml
+    - name: Publish test results
+      if: always()
+      uses: mikepenz/action-junit-report@v4
+      with:
+        report_paths: tests/results/junit.xml
+        check_name: Test Results (ubuntu-latest)
+        fail_on_failure: false
+        require_tests: true
     - name: validate commands.def up to date
       run: |
         touch src/commands/ping.json

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ src/nodes.conf
 deps/lua/src/lua
 deps/lua/src/luac
 deps/lua/src/liblua.a
+tests/results/
 deps/hdr_histogram/libhdrhistogram.a
 deps/fpconv/libfpconv.a
 tests/tls/*

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -226,11 +226,21 @@ proc restore_server_configs {saved_configs} {
     }
 }
 
+# Forward a per-test result to the test server in JUnit-friendly form.
+# Result is one of: pass, fail, skip. elapsed_ms may be 0 for skips.
+# No-op when --junitxml was not requested.
+proc emit_junit {name file result message elapsed_ms} {
+    if {$::junitxml eq ""} return
+    send_data_packet $::test_server_fd junit \
+        [list $name $file $result $message] $elapsed_ms
+}
+
 proc test {name code {okpattern undefined} {tags {}}} {
     # abort if test name in skiptests
     if {[search_pattern_list $name $::skiptests]} {
         incr ::num_skipped
         send_data_packet $::test_server_fd skip $name
+        emit_junit $name $::curfile skip "" 0
         return
     }
     if {$::verbose > 1} {
@@ -240,6 +250,7 @@ proc test {name code {okpattern undefined} {tags {}}} {
     if {[llength $::only_tests] > 0 && ![search_pattern_list $name $::only_tests]} {
         incr ::num_skipped
         send_data_packet $::test_server_fd skip $name
+        emit_junit $name $::curfile skip "" 0
         return
     }
 
@@ -247,6 +258,7 @@ proc test {name code {okpattern undefined} {tags {}}} {
     if {![tags_acceptable $tags err]} {
         incr ::num_aborted
         send_data_packet $::test_server_fd ignore "$name: $err"
+        emit_junit $name $::curfile skip $err 0
         return
     }
 
@@ -311,6 +323,8 @@ proc test {name code {okpattern undefined} {tags {}}} {
             incr ::num_failed
             set failed true
             send_data_packet $::test_server_fd err [join $details "\n"]
+            emit_junit $name $::curfile fail [join $details "\n"] \
+                [expr {[clock milliseconds]-$test_start_time}]
 
             if {$::stop_on_failure} {
                 puts "Test error (last server port:[srv port], log:[srv stdout]), press enter to teardown the test."
@@ -333,6 +347,7 @@ proc test {name code {okpattern undefined} {tags {}}} {
             incr ::num_passed
             set elapsed [expr {[clock milliseconds]-$test_start_time}]
             send_data_packet $::test_server_fd ok $name $elapsed
+            emit_junit $name $::curfile pass "" $elapsed
         } else {
             set msg "Expected '$okpattern' to equal or match '$retval'"
             lappend details $msg
@@ -341,6 +356,8 @@ proc test {name code {okpattern undefined} {tags {}}} {
             incr ::num_failed
             set failed true
             send_data_packet $::test_server_fd err [join $details "\n"]
+            emit_junit $name $::curfile fail [join $details "\n"] \
+                [expr {[clock milliseconds]-$test_start_time}]
         }
     }
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -90,6 +90,8 @@ set ::large_memory 0
 set ::log_req_res 0
 set ::force_resp3 0
 set ::debug_defrag 0
+set ::junitxml ""
+set ::junit_results {}
 
 # Set to 1 when we are running in client mode. The Redis test uses a
 # server-client model to run tests simultaneously. The server instance
@@ -399,6 +401,9 @@ proc read_from_test_client fd {
         puts "\[[colorstr red $status]\]: $data"
         kill_clients
         force_kill_all_servers
+        if {$::junitxml ne ""} {
+            catch {write_junit_xml $::junitxml $::junit_results}
+        }
         exit 1
     } elseif {$status eq {testing}} {
         set ::active_clients_task($fd) "(IN PROGRESS) $data"
@@ -414,6 +419,10 @@ proc read_from_test_client fd {
         set ::active_clients_task($fd) "(KILLED SERVER) pid:$data"
     } elseif {$status eq {run_solo}} {
         lappend ::run_solo_tests $data
+    } elseif {$status eq {junit}} {
+        # Silent aggregation of per-test JUnit data sent by clients.
+        # data is a list: {name file result message}; elapsed is ms.
+        lappend ::junit_results [list {*}$data $elapsed]
     } else {
         if {!$::quiet} {
             puts "\[$status\]: $data"
@@ -497,6 +506,105 @@ proc signal_idle_client fd {
     }
 }
 
+# Escape a string for safe inclusion as XML attribute or PCDATA.
+# Also strips ASCII control chars (except TAB/LF/CR) which are illegal in XML 1.0.
+proc xml_escape {s} {
+    set s [string map {& &amp; < &lt; > &gt; \" &quot; ' &apos;} $s]
+    set out ""
+    foreach ch [split $s ""] {
+        scan $ch %c c
+        if {$c == 9 || $c == 10 || $c == 13 || ($c >= 32 && $c != 127)} {
+            append out $ch
+        } else {
+            append out "?"
+        }
+    }
+    return $out
+}
+
+# Sanitize a string for inclusion inside a CDATA section by neutralizing the
+# only forbidden token "]]>".
+proc cdata_escape {s} {
+    return [string map {\]\]> {]]]]><![CDATA[>}} $s]
+}
+
+# Write an aggregated JUnit XML report from ::junit_results to the given path.
+# Each .tcl test file becomes one <testsuite>; each `test "..." { ... }` block
+# becomes one <testcase>. Failures and skips are emitted as nested elements.
+proc write_junit_xml {path results} {
+    array set suites {}
+    set suite_order {}
+    foreach r $results {
+        lassign $r name file result message elapsed_ms
+        if {![info exists suites($file)]} {
+            set suites($file) {}
+            lappend suite_order $file
+        }
+        lappend suites($file) $r
+    }
+
+    set total_tests 0
+    set total_failures 0
+    set total_skipped 0
+    set total_time_ms 0
+    foreach r $results {
+        lassign $r name file result message elapsed_ms
+        incr total_tests
+        if {$result eq "fail"} { incr total_failures }
+        if {$result eq "skip"} { incr total_skipped }
+        incr total_time_ms $elapsed_ms
+    }
+
+    set parent [file dirname $path]
+    if {$parent ne "" && $parent ne "." && ![file exists $parent]} {
+        file mkdir $parent
+    }
+    set fp [open $path w]
+    fconfigure $fp -encoding utf-8
+    puts $fp {<?xml version="1.0" encoding="UTF-8"?>}
+    puts $fp [format {<testsuites tests="%d" failures="%d" skipped="%d" time="%.3f">} \
+        $total_tests $total_failures $total_skipped [expr {$total_time_ms / 1000.0}]]
+
+    foreach file $suite_order {
+        set s_tests 0; set s_fail 0; set s_skip 0; set s_time_ms 0
+        foreach r $suites($file) {
+            lassign $r _ _ result _ elapsed_ms
+            incr s_tests
+            if {$result eq "fail"} { incr s_fail }
+            if {$result eq "skip"} { incr s_skip }
+            incr s_time_ms $elapsed_ms
+        }
+        puts $fp [format {  <testsuite name="%s" tests="%d" failures="%d" skipped="%d" time="%.3f">} \
+            [xml_escape $file] $s_tests $s_fail $s_skip [expr {$s_time_ms / 1000.0}]]
+        foreach r $suites($file) {
+            lassign $r name file result message elapsed_ms
+            set t [expr {$elapsed_ms / 1000.0}]
+            set tc [format {    <testcase classname="%s" name="%s" time="%.3f"} \
+                [xml_escape $file] [xml_escape $name] $t]
+            if {$result eq "pass"} {
+                puts $fp "$tc/>"
+            } elseif {$result eq "fail"} {
+                puts $fp "$tc>"
+                set summary [string range $message 0 199]
+                puts $fp [format {      <failure message="%s" type="assertion"><![CDATA[%s]]></failure>} \
+                    [xml_escape $summary] [cdata_escape $message]]
+                puts $fp "    </testcase>"
+            } else {
+                puts $fp "$tc>"
+                if {$message ne ""} {
+                    puts $fp [format {      <skipped message="%s"/>} [xml_escape $message]]
+                } else {
+                    puts $fp {      <skipped/>}
+                }
+                puts $fp "    </testcase>"
+            }
+        }
+        puts $fp "  </testsuite>"
+    }
+    puts $fp "</testsuites>"
+    close $fp
+}
+
 # The the_end function gets called when all the test units were already
 # executed, so the test finished.
 proc the_end {} {
@@ -505,6 +613,13 @@ proc the_end {} {
     puts "Execution time of different units:"
     foreach {time name} $::clients_time_history {
         puts "  $time seconds - $name"
+    }
+    if {$::junitxml ne ""} {
+        if {[catch {write_junit_xml $::junitxml $::junit_results} err]} {
+            puts "Warning: failed to write JUnit XML to $::junitxml: $err"
+        } else {
+            puts "JUnit XML report written to $::junitxml ([llength $::junit_results] testcases)"
+        }
     }
     if {[llength $::failed_tests]} {
         puts "\n[colorstr bold-red {!!! WARNING}] The following tests failed:\n"
@@ -595,6 +710,7 @@ proc print_help_screen {} {
         "--ignore-digest    Don't use debug digest validations."
         "--large-memory     Run tests using over 100mb."
         "--debug-defrag     Indicate the test is running against server compiled with DEBUG_DEFRAG option"
+        "--junitxml <path>  Write JUnit XML report of test results to the given path."
         "--help             Print this help screen."
     } "\n"]
 }
@@ -728,6 +844,9 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         set ::ignoredigest 1
     } elseif {$opt eq {--debug-defrag}} {
         set ::debug_defrag 1
+    } elseif {$opt eq {--junitxml}} {
+        set ::junitxml $arg
+        incr j
     } elseif {$opt eq {--help}} {
         print_help_screen
         exit 0


### PR DESCRIPTION
## Purpose

This is a **draft prototype for discussion**, not a merge candidate as-is.

It teaches the existing Tcl test harness to emit a standard JUnit XML report alongside its existing human-readable output, and wires one CI job to publish the report on PRs. The goal is to evaluate the *reviewer experience* — inline test-failure annotations on the diff, structured pass/fail summary in the Checks tab, downloadable artifact for offline analysis — without rewriting any tests or the harness.

No existing test, helper, or runner behavior changes when `--junitxml` is not supplied.

## What's in this PR

**Commit 1 — `tests: add --junitxml flag to emit JUnit XML report from Tcl harness`**

- `tests/support/test.tcl`: `emit_junit` helper called from each outcome path (pass / fail / skip / ignore-by-tag) inside `proc test`.
- `tests/test_helper.tcl`: new `--junitxml <path>` CLI option, server-side aggregation of `junit` packets sent by parallel test clients, and a `<testsuites>`/`<testsuite>`/`<testcase>` writer grouped by `.tcl` file. Includes XML/CDATA escaping helpers.
- `.github/workflows/ci.yml` (only `test-ubuntu-latest`): pass `--junitxml`, upload as artifact, publish via `mikepenz/action-junit-report@v4` with `fail_on_failure: false` so the existing `runtest` exit code remains the only source of truth for job status.
- `.gitignore`: ignore `tests/results/`.

**Commit 2 — `DEMO ONLY (revert before merge): force one failing test ...`**

- Adds `--force-failure --only "Failing test"` to the `test-ubuntu-latest` test step so reviewers can see, on this draft PR, how a failing test surfaces:
  - inline annotation on the diff in *Files changed*,
  - a structured failure entry in the new **Test Results (ubuntu-latest)** check,
  - the message inside the downloadable `junit-test-ubuntu-latest` artifact's `junit.xml`.
- **This commit must be reverted (or dropped) before any merge.** It exists only to make the failure-annotation experience visible on a draft PR.

## What reviewers should look at

1. The new check **Test Results (ubuntu-latest)** in the Checks tab.
2. The diff annotation that appears once Commit 2's failing run completes.
3. The artifact `junit-test-ubuntu-latest` → `junit.xml` for the raw report.
4. The diff itself: ~150 lines, all in the test harness and one CI workflow.

## Local smoke-test commands

```sh
# Green run
./runtest --single unit/auth --junitxml /tmp/junit.xml

# Red run (one deliberate failure)
./runtest --single unit/other --force-failure --only "Failing test" --junitxml /tmp/junit_fail.xml
```

Both produce well-formed XML validated by `xml.etree.ElementTree` / standard JUnit consumers.

## Out of scope (intentional)

- `tests/cluster/run.tcl` and `tests/sentinel/run.tcl` use a separate harness in `tests/instances.tcl`; not wired here. Same pattern can be applied later if the prototype is well received.
- Other CI jobs (`test-sanitizer-address`, `daily.yml`, `external.yml`) intentionally untouched, so the prototype is reversible by reverting one workflow file.
- This is **not** a replacement for the Tcl harness, **not** a switch to GoogleTest/pytest, and **not** related to true C unit tests of internal data structures (separate, larger discussion).

## Questions for reviewers

1. Do the inline annotations on Commit 2's failed run match what you'd want to see during PR triage, instead of scrolling the full log?
2. Should the JUnit step also be wired into `test-sanitizer-address` (and others) before this lands, or done in a follow-up?
3. Naming: `--junitxml` vs `--junit-xml` vs `--report-junit`?
4. Is `tests/results/junit.xml` an acceptable output path, or would `tests/tmp/junit.xml` (already gitignored implicitly via `*.log`-adjacent conventions) be preferred?

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author