### PR TITLE
Enable LTO for RediSearch module when Redis is build with modules

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -3,5 +3,9 @@ MODULE_VERSION = v8.7.90
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 
+# Enable link-time optimization for RediSearch by default. Override with LTO=0.
+LTO ?= 1
+export LTO
+
 include ../common.mk
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Makefile change that only alters build flags for the RediSearch module; primary risk is build/compatibility issues on some toolchains when LTO is enabled.
> 
> **Overview**
> **RediSearch module builds now default to link-time optimization.** The `modules/redisearch/Makefile` introduces `LTO ?= 1` and exports it so the upstream RediSearch build can pick it up, with an escape hatch to disable via `LTO=0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de33dc7033fc5161a3c6870b754055219c6ea538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->