### PR TITLE
Add inline cleanup to sentinel CONFIG SET/GET tests

### DIFF
--- a/tests/sentinel/tests/15-config-set-config-get.tcl
+++ b/tests/sentinel/tests/15-config-set-config-get.tcl
@@ -6,17 +6,22 @@ test "SENTINEL CONFIG SET and SENTINEL CONFIG GET handles multiple variables" {
     }
     assert_match {*yes*1234*} [S 1 SENTINEL CONFIG GET resolve-hostnames announce-port]
     assert_match {announce-port 1234} [S 1 SENTINEL CONFIG GET announce-port]
+    foreach_sentinel_id id {
+        S $id SENTINEL CONFIG SET resolve-hostnames no announce-port 0
+    }
 }
 
 test "SENTINEL CONFIG GET for duplicate and unknown variables" {
     assert_equal {OK} [S 1 SENTINEL CONFIG SET resolve-hostnames yes announce-port 1234]
     assert_match {resolve-hostnames yes} [S 1 SENTINEL CONFIG GET resolve-hostnames resolve-hostnames does-not-exist]
+    S 1 SENTINEL CONFIG SET resolve-hostnames no announce-port 0
 }
 
 test "SENTINEL CONFIG GET for patterns" {
     assert_equal {OK} [S 1 SENTINEL CONFIG SET loglevel notice announce-port 1234 announce-hostnames yes ]
     assert_match {loglevel notice} [S 1 SENTINEL CONFIG GET log* *level loglevel]
     assert_match {announce-hostnames yes announce-ip*announce-port 1234} [S 1 SENTINEL CONFIG GET announce*]
+    S 1 SENTINEL CONFIG SET announce-port 0 announce-hostnames no
 }
 
 test "SENTINEL CONFIG SET duplicate variables" {
@@ -36,6 +41,9 @@ test "SENTINEL CONFIG SET, one option does not exist" {
     }
     # The announce-port should not be set to 1234 as it was called with a wrong argument
     assert_match {*111*} [S 1 SENTINEL CONFIG GET announce-port]
+    foreach_sentinel_id id {
+        S $id SENTINEL CONFIG SET announce-port 0
+    }
 }
 
 test "SENTINEL CONFIG SET, one option with wrong value" {


### PR DESCRIPTION
Introduced by https://github.com/redis/redis/pull/14970

Test 15-config-set-config-get.tcl was leaving announce-port and announce-hostnames at non-default values, which breaks auto-discovery in subsequent test units. Add reset lines at the end of each test that modifies config. This PR fixes failures in Daily CI tests.
[Before the fix](https://github.com/hristostaykov-del/redis/actions/runs/25378941773)
[After applying the fix](https://github.com/hristostaykov-del/redis/actions/runs/25386710071)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that reset Sentinel config values to avoid state leaking between tests; no production code behavior changes.
> 
> **Overview**
> Prevents cross-test config leakage in Sentinel test `15-config-set-config-get.tcl` by adding inline cleanup steps after tests that modify `resolve-hostnames`, `announce-port`, and `announce-hostnames`.
> 
> These resets restore default-ish values (e.g., `announce-port 0`, `announce-hostnames no`) so subsequent Sentinel tests aren’t affected by earlier `SENTINEL CONFIG SET` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13f82e63584dbcd76ecf2cca9d1feb8b7ed1f091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->