### PR TITLE
Revert "Enable LTO for RediSearch module when Redis is build with modules"

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -3,9 +3,5 @@ MODULE_VERSION = v8.7.90
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 
-# Enable link-time optimization for RediSearch by default. Override with LTO=0.
-LTO ?= 1
-export LTO
-
 include ../common.mk
 


### PR DESCRIPTION
Reverts redis/redis#15166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build configuration change that only affects how the RediSearch module is compiled (LTO no longer enabled by default), with potential impacts limited to binary size/performance and build times.
> 
> **Overview**
> Reverts the previous change that enabled link-time optimization for the `modules/redisearch` build by removing the default `LTO ?= 1` export from the module `Makefile`.
> 
> As a result, RediSearch will build using its upstream/default compiler flags unless LTO is explicitly set elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ffc301313c8d667c2a7997874c320e496142ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->