### PR TITLE
Fix invalid repl-diskless-load value in replication test

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1888,7 +1888,6 @@ foreach type {script function} {
                 $master config set repl-diskless-sync-delay 0
                 # Set small client output buffer limit to trigger fullsync quickly
                 $master config set client-output-buffer-limit "replica 1k 1k 0"
-                $replica config set repl-diskless-load yes
                 $replica config set busy-reply-threshold 1 ;# script timeout in 1 ms
 
                 # Load function


### PR DESCRIPTION
Close #15177
Follow [Fix use-after-free when fullsync happens while replica is running a timed out script (CVE-2026-23631)](https://github.com/redis/redis/commit/0cca172a174642bdae03b871615227896274d9bb)

Remove the `repl-diskless-load yes` test configuration because this option exists only in the Redis fork and is not available in Redis OSS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that relaxes replica configuration for a single integration test; main risk is reduced coverage of diskless-load behavior in that scenario.
> 
> **Overview**
> Removes the `$replica config set repl-diskless-load yes` step from `tests/integration/replication.tcl` in the "Fullsync should not free scripting engine on a replica while a script/function is running" case, so the test no longer depends on diskless-load being enabled on the replica.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7548400125beb7f3c3c1ba1bdb40cc90b6e34e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->