### PR TITLE
Fix integer overflow in cluster bus PUBLISH and MODULE message length validation

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2839,11 +2839,16 @@ int clusterProcessPacket(clusterLink *link) {
         explen = sizeof(clusterMsg)-sizeof(union clusterMsgData);
         explen += sizeof(clusterMsgDataFail);
     } else if (type == CLUSTERMSG_TYPE_PUBLISH || type == CLUSTERMSG_TYPE_PUBLISHSHARD) {
+        uint32_t ch_len = ntohl(hdr->data.publish.msg.channel_len);
+        uint32_t msg_len = ntohl(hdr->data.publish.msg.message_len);
         explen = sizeof(clusterMsg)-sizeof(union clusterMsgData);
-        explen += sizeof(clusterMsgDataPublish) -
-                8 +
-                ntohl(hdr->data.publish.msg.channel_len) +
-                ntohl(hdr->data.publish.msg.message_len);
+        explen += sizeof(clusterMsgDataPublish) - 8;
+        if (ch_len > UINT32_MAX - explen || msg_len > UINT32_MAX - explen - ch_len) {
+            serverLog(LL_WARNING, "Received invalid %s packet with overflow in length fields "
+                "(channel_len:%u, message_len:%u)", clusterGetMessageTypeString(type), ch_len, msg_len);
+            return 1;
+        }
+        explen += ch_len + msg_len;
     } else if (type == CLUSTERMSG_TYPE_FAILOVER_AUTH_REQUEST ||
                type == CLUSTERMSG_TYPE_FAILOVER_AUTH_ACK ||
                type == CLUSTERMSG_TYPE_MFSTART)
@@ -2853,9 +2858,15 @@ int clusterProcessPacket(clusterLink *link) {
         explen = sizeof(clusterMsg)-sizeof(union clusterMsgData);
         explen += sizeof(clusterMsgDataUpdate);
     } else if (type == CLUSTERMSG_TYPE_MODULE) {
+        uint32_t module_len = ntohl(hdr->data.module.msg.len);
         explen = sizeof(clusterMsg)-sizeof(union clusterMsgData);
-        explen += sizeof(clusterMsgModule) -
-                3 + ntohl(hdr->data.module.msg.len);
+        explen += sizeof(clusterMsgModule) - 3;
+        if (module_len > UINT32_MAX - explen) {
+            serverLog(LL_WARNING, "Received invalid %s packet with overflow in length field "
+                "(len:%u)", clusterGetMessageTypeString(type), module_len);
+            return 1;
+        }
+        explen += module_len;
     } else {
         /* We don't know this type of packet, so we assume it's well formed. */
         explen = totlen;


### PR DESCRIPTION
## Summary

Add overflow checks for attacker-controlled `uint32_t` length fields in `clusterProcessPacket()` before adding them to `explen` (`uint32_t`). Without these checks, crafted PUBLISH/PUBLISHSHARD and MODULE cluster bus messages can wrap `explen` to a small value, bypassing the `totlen != explen` validation and causing heap out-of-bounds reads or OOM aborts in the processing path.

## Problem

In `clusterProcessPacket()`, the expected packet length for PUBLISH and MODULE messages is computed by summing struct overhead with variable-length fields read from the packet header via `ntohl()`:

```c
// PUBLISH (line 2841-2846)
explen += sizeof(clusterMsgDataPublish) - 8 +
    ntohl(hdr->data.publish.msg.channel_len) +
    ntohl(hdr->data.publish.msg.message_len);

// MODULE (line 2855-2858)
explen += sizeof(clusterMsgModule) - 3 + ntohl(hdr->data.module.msg.len);
```

Both `channel_len + message_len` (PUBLISH) and `len` (MODULE) are `uint32_t` values from the network packet. Their addition to `explen` can overflow `uint32_t`, wrapping to a small value that matches `totlen`, passing the size validation at line 2864.

**Example (PUBLISH):** With `channel_len = 0x80000000` and `message_len = 0x80000000`, their sum overflows to `0`, making `explen` equal to just the base struct size. An attacker sets `totlen` to match. The validation passes, and the processing path at line 3273 calls `createStringObject()` with the original 2GB lengths, reading far past the received buffer.

**Attack vector:** Reachable via the cluster bus port (default: data port + 10000), which does not require authentication by default.

## Fix

Extract `ntohl` values into local variables and check each addition against `UINT32_MAX` before performing it. Reject the packet with a warning log if overflow is detected. The computed `explen` is identical to the original for all non-overflowing (legitimate) inputs.

## Related Security Issues

This fix addresses the same class of vulnerability seen in several prior CVEs:

**Redis integer overflow precedents:**
- [CVE-2023-41056](https://github.com/redis/redis/security/advisories/GHSA-xr47-pcmx-fq2m) - Integer overflow in `sdsMakeRoomFor()` causing undersized allocation, leading to heap buffer overflow (CVSS 8.1)
- [CVE-2023-25155](https://github.com/redis/redis/security/advisories/GHSA-x2r7-j9vw-3w83) - Integer overflow in SRANDMEMBER/ZRANDMEMBER/HRANDFIELD count argument causing crash (CVSS 5.5)
- [CVE-2024-31449](https://github.com/redis/redis/security/advisories/GHSA-whxg-wx83-85p5) - Integer overflow in Lua `bit.tohex()` causing stack buffer overflow (CVSS 7.0)
- [CVE-2021-32761](https://github.com/redis/redis/security/advisories/GHSA-8wxq-j7rp-g8wj) - Integer overflow in BITFIELD on 32-bit builds causing heap corruption (CVSS 7.5)

**Same bug class in other projects:**
- [CVE-2016-8704](https://talosintelligence.com/vulnerability_reports/TALOS-2016-0219) (memcached) - Integer underflow in binary protocol `bodylen - keylen` bypasses size check, causing heap overflow (CVSS 9.8)
- [CVE-2017-7529](https://nvd.nist.gov/vuln/detail/CVE-2017-7529) (nginx) - Integer overflow in HTTP Range filter module bypasses bounds checks, leaking cache data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster-bus network packet length validation and adds new rejection paths; a mistake could incorrectly drop legitimate cluster messages, but the change is small and narrowly scoped to overflow cases.
> 
> **Overview**
> Hardens `clusterProcessPacket()` length validation for `PUBLISH`/`PUBLISHSHARD` and `MODULE` cluster bus messages by extracting attacker-controlled `uint32_t` length fields and adding explicit `UINT32_MAX` overflow checks before updating `explen`.
> 
> On detected overflow, the packet is rejected early with a warning log, preventing wrapped expected-length calculations from bypassing the `totlen != explen` guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a3a1e7cc019899fcf70634636474dc2066a184a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->