### PR TITLE
Fix vecClear() to invoke free method on elements

### DIFF
--- a/src/vector.c
+++ b/src/vector.c
@@ -56,8 +56,13 @@ void vecRelease(vec *v) {
     v->free = NULL;
 }
 
-/* Reset the logical length to zero while preserving allocated storage. */
+/* Reset the logical length to zero while preserving allocated storage.
+ * If a free method is set, it is applied to every element before reset. */
 void vecClear(vec *v) {
+    if (v->free) {
+        for (size_t i = 0; i < v->size; i++)
+            v->free(v->data[i]);
+    }
     v->size = 0;
 }
 
@@ -106,8 +111,14 @@ void vecPush(vec *v, void *value) {
 
 static int vecTestFreeCalls = 0;
 static void vecTestFree(void *ptr) {
-    UNUSED(ptr);
     vecTestFreeCalls++;
+    zfree(ptr);
+}
+
+static int *vecTestNewInt(int v) {
+    int *p = zmalloc(sizeof(int));
+    *p = v;
+    return p;
 }
 
 int vectorTest(int argc, char **argv, int flags)
@@ -175,13 +186,34 @@ int vectorTest(int argc, char **argv, int flags)
     void *vstack2[2];
     vecInit(&v, vstack2, 2);
     vecSetFreeMethod(&v, vecTestFree);
-    vecPush(&v, &one);
-    vecPush(&v, &two);
-    vecPush(&v, &three); /* triggers spill to heap */
+    vecPush(&v, vecTestNewInt(1));
+    vecPush(&v, vecTestNewInt(2));
+    vecPush(&v, vecTestNewInt(3)); /* triggers spill to heap */
     vecTestFreeCalls = 0;
     vecRelease(&v);
     test_cond("vecRelease() invokes free method on each element",
               vecTestFreeCalls == 3);
+
+    /* vecClear: free method is invoked on each element, storage preserved. */
+    vecInit(&v, NULL, 4);
+    vecSetFreeMethod(&v, vecTestFree);
+    vecPush(&v, vecTestNewInt(1));
+    vecPush(&v, vecTestNewInt(2));
+    vecPush(&v, vecTestNewInt(3));
+    heap_data = vecData(&v);
+    vecTestFreeCalls = 0;
+    vecClear(&v);
+    test_cond("vecClear() invokes free method on each element preserving storage",
+              vecTestFreeCalls == 3 && vecSize(&v) == 0 &&
+              vecData(&v) == heap_data && v.cap == 4);
+    /* Push again after clear to verify the vector is still usable. */
+    vecPush(&v, vecTestNewInt(4));
+    test_cond("vecPush() works after vecClear() with free method",
+              vecSize(&v) == 1 && vecData(&v) == heap_data);
+    vecTestFreeCalls = 0;
+    vecRelease(&v);
+    test_cond("vecRelease() after vecClear()+push frees remaining element",
+              vecTestFreeCalls == 1);
 
     vecInit(&v, NULL, 4);
     vecSetFreeMethod(&v, vecTestFree);

--- a/src/vector.h
+++ b/src/vector.h
@@ -83,7 +83,8 @@ static inline void vecSetFreeMethod(vec *v, void (*freefn)(void *ptr)) {
  * before the backing storage is released. Stack storage is never freed. */
 void vecRelease(vec *v);
 
-/* Reset the logical length to zero while preserving allocated storage. */
+/* Reset the logical length to zero while preserving allocated storage.
+ * If a free method is set, it is applied to every element before reset. */
 void vecClear(vec *v);
 
 /* Requires index < vecSize(v). */


### PR DESCRIPTION
vecClear() reset the logical size without releasing element ownership, leaking elements whenever a free callback was registered via vecSetFreeMethod(). This mirrors vecRelease()'s element-freeing loop while still preserving the backing storage.

### Testing
Update the unit-tests to use heap-allocated elements (so the free callback actually frees them) and add coverage for vecClear() with a free method set, plus reuse after clear.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `vecClear()` semantics to free elements when a free callback is configured, which could expose double-free bugs in callers that previously relied on `vecClear()` not taking ownership. Scope is small and covered by updated unit tests.
> 
> **Overview**
> Fixes a memory-leak/ownership issue by making `vecClear()` invoke the configured element free callback on all current entries before resetting size, while still preserving the backing storage/capacity.
> 
> Updates the vector unit tests to use heap-allocated elements and adds coverage ensuring `vecClear()` frees all elements, keeps storage intact, and that the vector remains usable after clear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96bced9e6f9f22d507f9f5b59b2fabca10311f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->