### PR TITLE
Backport CI fix commits 8.2

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1016,7 +1016,7 @@ jobs:
         version: 13.2
         shell: bash
         run: |
-          sudo pkg install -y bash gmake lang/tcl86 lang/tclx gcc
+          sudo pkg install -y bash gmake lang/tcl86 lang/tclX gcc
           gmake
           ./runtest --single unit/keyspace --single unit/auth --single unit/networking --single unit/protocol
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -963,7 +963,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-13, macos-15]
+        os: [macos-14, macos-26]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
@@ -990,7 +990,7 @@ jobs:
       run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
 
   test-freebsd:
-    runs-on: macos-13
+    runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'freebsd')
@@ -1009,7 +1009,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: test
-      uses: cross-platform-actions/action@v0.22.0
+      uses: cross-platform-actions/action@v0.30.0
       with:
         operating_system: freebsd
         environment_variables: MAKE

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -154,7 +154,7 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
             return C_ERR;
 
         ftval *= 1000.0;  /* seconds => millisec */
-        if (ftval > LLONG_MAX) {
+        if (ftval > (long double)LLONG_MAX) {
             addReplyError(c, "timeout is out of range");
             return C_ERR;
         }

--- a/tests/cluster/tests/17-diskless-load-swapdb.tcl
+++ b/tests/cluster/tests/17-diskless-load-swapdb.tcl
@@ -54,9 +54,12 @@ test "Main db not affected when fail to diskless load" {
     set rd [redis_deferring_client redis $master_id]
     for {set j 0} {$j < $num} {incr j} {
         $rd set $j $value
-    }
-    for {set j 0} {$j < $num} {incr j} {
-        $rd read
+
+        if {($j + 1) % 500 == 0} {
+            for {set i 0} {$i < 500} {incr i} {
+                $rd read
+            }
+        }
     }
 
     # Start the replica again

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -22,13 +22,18 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
     set start_time [clock seconds]
     set r [redis $host $port 1 $tls]
     $r client setname LOAD_HANDLER
-    $r select 9
+    $r read
+    catch {
+        $r select 9
+        $r read
+    } ;# select 9 will fail in cluster mode
 
     # fixed size value
     if {$size != 0} {
         set value [string repeat "x" $size]
     }
 
+    set count 0
     while 1 {
         if {$size == 0} {
             set value [expr rand()]
@@ -39,13 +44,28 @@ proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
         } else {
             $r set $key $value
         }
+        
+        incr count
+        if {$count % 500 == 0} {
+            for {set i 0} {$i < 500} {incr i} {
+                $r read
+            }
+            set count 0
+        }
+
         if {[clock seconds]-$start_time > $seconds} {
-            exit 0
+            break
         }
         if {$sleep ne 0} {
             after $sleep
         }
     }
+    
+    # Read remaining replies
+    for {set i 0} {$i < $count} {incr i} {
+        $r read
+    }
+    exit 0
 }
 
 gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6]

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -336,10 +336,23 @@ proc test_slave_buffers {test_name cmd_count payload_len limit_memory pipeline} 
             # send some 10mb worth of commands that don't increase the memory usage
             if {$pipeline == 1} {
                 set rd_master [redis_deferring_client -1]
+                # Send commands in batches and read responses to avoid TCP deadlock.
+                # Without interleaving reads, the client's send buffer fills up when
+                # the server's output buffers are full (because we're not reading),
+                # causing flush to block indefinitely on slow machines.
+                set batch_size 10000
                 for {set k 0} {$k < $cmd_count} {incr k} {
                     $rd_master setrange key:0 0 [string repeat A $payload_len]
+                    if {($k + 1) % $batch_size == 0} {
+                        # Drain responses to prevent TCP buffer deadlock
+                        for {set j 0} {$j < $batch_size} {incr j} {
+                            $rd_master read
+                        }
+                    }
                 }
-                for {set k 0} {$k < $cmd_count} {incr k} {
+                # Read any remaining responses
+                set remaining [expr {$cmd_count % $batch_size}]
+                for {set k 0} {$k < $remaining} {incr k} {
                     $rd_master read
                 }
             } else {

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -345,7 +345,7 @@ run_solo {defrag} {
             # create big keys with 10k items
             # Use batching to avoid TCP deadlock
             set rd [redis_deferring_client]
-            set batch_size 1000
+            set batch_size 100
             for {set j 0} {$j < 10000} {incr j} {
                 $rd hset bighash $j [concat "asdfasdfasdf" $j]
                 $rd lpush biglist [concat "asdfasdfasdf" $j]

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -24,9 +24,12 @@ proc test_memory_efficiency {range} {
         incr written [string length $key]
         incr written [string length $val]
         incr written 2 ;# A separator is the minimum to store key-value data.
-    }
-    for {set j 0} {$j < 10000} {incr j} {
-        $rd read ; # Discard replies
+
+        if {($j + 1) % 500 == 0} {
+            for {set i 0} {$i < 500} {incr i} {
+                $rd read ; # Discard replies
+            }
+        }
     }
 
     set current_mem [s used_memory]
@@ -230,12 +233,24 @@ run_solo {defrag} {
             # Populate memory with interleaving script-key pattern of same size
             set dummy_script "--[string repeat x 400]\nreturn "
             set rd [redis_deferring_client]
+            # Send commands in batches and read responses to avoid TCP deadlock.
+            # Without interleaving reads, TCP congestion control can throttle
+            # the connection when buffers fill, causing the test to hang.
+            set batch_size 1000
             for {set j 0} {$j < $n} {incr j} {
                 set val "$dummy_script[format "%06d" $j]"
                 $rd script load $val
                 $rd set k$j $val
+                if {($j + 1) % $batch_size == 0} {
+                    for {set i 0} {$i < $batch_size} {incr i} {
+                        $rd read ; # Discard script load replies
+                        $rd read ; # Discard set replies
+                    }
+                }
             }
-            for {set j 0} {$j < $n} {incr j} {
+            # Read remaining responses
+            set remaining [expr {$n % $batch_size}]
+            for {set j 0} {$j < $remaining} {incr j} {
                 $rd read ; # Discard script load replies
                 $rd read ; # Discard set replies
             }
@@ -249,8 +264,17 @@ run_solo {defrag} {
             assert_lessthan [s allocator_frag_ratio] 1.05
 
             # Delete all the keys to create fragmentation
-            for {set j 0} {$j < $n} {incr j} { $rd del k$j }
-            for {set j 0} {$j < $n} {incr j} { $rd read } ; # Discard del replies
+            # Use same batching pattern to avoid TCP deadlock
+            for {set j 0} {$j < $n} {incr j} {
+                $rd del k$j
+                if {($j + 1) % $batch_size == 0} {
+                    for {set i 0} {$i < $batch_size} {incr i} {
+                        $rd read
+                    }
+                }
+            }
+            set remaining [expr {$n % $batch_size}]
+            for {set j 0} {$j < $remaining} {incr j} { $rd read }
             $rd close
             after 120 ;# serverCron only updates the info once in 100ms
             if {$::verbose} {
@@ -319,16 +343,25 @@ run_solo {defrag} {
             r xreadgroup GROUP mygroup Alice COUNT 1 STREAMS stream >
 
             # create big keys with 10k items
+            # Use batching to avoid TCP deadlock
             set rd [redis_deferring_client]
+            set batch_size 1000
             for {set j 0} {$j < 10000} {incr j} {
                 $rd hset bighash $j [concat "asdfasdfasdf" $j]
                 $rd lpush biglist [concat "asdfasdfasdf" $j]
                 $rd zadd bigzset $j [concat "asdfasdfasdf" $j]
                 $rd sadd bigset [concat "asdfasdfasdf" $j]
                 $rd xadd bigstream * item 1 value a
+                if {($j + 1) % $batch_size == 0} {
+                    for {set i 0} {$i < [expr {$batch_size * 5}]} {incr i} {
+                        $rd read
+                    }
+                }
             }
-            for {set j 0} {$j < 50000} {incr j} {
-                $rd read ; # Discard replies
+            # Read remaining replies
+            set remaining [expr {(10000 % $batch_size) * 5}]
+            for {set j 0} {$j < $remaining} {incr j} {
+                $rd read
             }
 
             # create some small items (effective in cluster-enabled)
@@ -472,8 +505,18 @@ run_solo {defrag} {
             assert_lessthan [s allocator_frag_ratio] 1.05
 
             # Delete all the keys to create fragmentation
-            for {set j 0} {$j < $n} {incr j} { $rd del k$j }
-            for {set j 0} {$j < $n} {incr j} { $rd read } ; # Discard del replies
+            # Use batching to avoid TCP deadlock
+            set batch_size 1000
+            for {set j 0} {$j < $n} {incr j} {
+                $rd del k$j
+                if {($j + 1) % $batch_size == 0} {
+                    for {set i 0} {$i < $batch_size} {incr i} {
+                        $rd read
+                    }
+                }
+            }
+            set remaining [expr {$n % $batch_size}]
+            for {set j 0} {$j < $remaining} {incr j} { $rd read }
             $rd close
             after 120 ;# serverCron only updates the info once in 100ms
             if {$::verbose} {
@@ -543,6 +586,7 @@ run_solo {defrag} {
             r config set hash-max-listpack-entries 10
 
             # Populate memory with interleaving hash field of same size
+            # Interleave reads to avoid TCP deadlock
             set dummy_field "[string repeat x 400]"
             set rd [redis_deferring_client]
             for {set i 0} {$i < $n} {incr i} {
@@ -552,9 +596,7 @@ run_solo {defrag} {
                     $rd set "k$i$j" $dummy_field
                 }
                 $rd expire h$i 9999999 ;# Ensure expire is updated after kvobj reallocation
-            }
-            
-            for {set i 0} {$i < $n} {incr i} {
+                # Read replies for this iteration to avoid TCP deadlock
                 for {set j 0} {$j < $fields} {incr j} {
                     $rd read ; # Discard hset replies
                     $rd read ; # Discard hexpire replies
@@ -765,7 +807,7 @@ run_solo {defrag} {
                 $rd lpush biglist2 $val
 
                 incr count
-                discard_replies_every $rd $count 10000 20000
+                discard_replies_every $rd $count 1000 2000
             }
 
             # create some fragmentation

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1026,7 +1026,22 @@ foreach type {single multiple single_multiple} {
                 break
             }
         }
-        r srem $myset {*}$members
+        r deferred 1
+        set count 0
+        foreach m $members {
+            r srem $myset $m
+            incr count
+            if {$count == 500} {
+                for {set i 0} {$i < 500} {incr i} {
+                    r read
+                }
+                set count 0
+            }
+        }
+        for {set i 0} {$i < $count} {incr i} {
+            r read
+        }
+        r deferred 0
     }
 
     proc verify_rehashing_completed_key {myset table_size keys} {


### PR DESCRIPTION
Backport the following CI fix commits from unstable to 8.2:

a760d17 2025-11-12 Fix FreeBSD daily runs (#14532) (skaslev)
3bcacd8 2025-12-09 Upgrade GitHub Actions macOS runner (#14613) (vitahlin)
154fdce 2026-01-07 Test tcp deadlock fixes (#14667) (antirez)
280dab0 2026-02-25 Fix implicit conversion warning in timeout.c for newer Clang versions (#14811) (vitahlin)
a6a27f5 2026-03-30 Test tcp deadlock fixes (#14946) (sundb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CI/workflow and test harness adjustments; the only production change is a narrow cast tweak in `getTimeoutFromObjectOrReply`, so functional risk is low but CI behavior may change due to runner updates.
> 
> **Overview**
> Backports several CI stability fixes: updates `daily.yml` to run macOS builds on newer GitHub runners, runs the FreeBSD job from `ubuntu-latest` with a newer `cross-platform-actions/action`, and tweaks the FreeBSD package install step.
> 
> Hardens multiple Tcl tests/utilities to avoid pipelined TCP deadlocks by batching writes and interleaving `read`s (cluster diskless load test, `gen_write_load`, and several unit tests including `maxmemory`, `memefficiency`, and set rehashing).
> 
> Fixes a newer-Clang warning in `src/timeout.c` by explicitly casting `LLONG_MAX` when comparing against a `long double` timeout value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f90582b3f82830dd19f0d3392fec6f21029e996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->