### PR TITLE
Update RediSearch to v8.7.91

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.7.90
+MODULE_VERSION = v8.7.91
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bump that only changes the RediSearch module tag used for builds; any risk is limited to upstream behavior changes in v8.7.91.
> 
> **Overview**
> Bumps the RediSearch module version from `v8.7.90` to `v8.7.91` in `modules/redisearch/Makefile`, so builds pull and compile the newer upstream release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98ddf91205d5a3ceef2827b7808957b76eda18ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->