### PR TITLE
Update DataType Modules to v8.7.91

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.7.90
+MODULE_VERSION = v8.7.91
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 

--- a/modules/redisjson/Makefile
+++ b/modules/redisjson/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.7.90
+MODULE_VERSION = v8.7.91
 MODULE_REPO = https://github.com/redisjson/redisjson
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/rejson.so
 

--- a/modules/redistimeseries/Makefile
+++ b/modules/redistimeseries/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.7.90
+MODULE_VERSION = v8.7.91
 MODULE_REPO = https://github.com/redistimeseries/redistimeseries
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redistimeseries.so
 


### PR DESCRIPTION
## Summary

Bumps `MODULE_VERSION` for RedisBloom, RedisJSON, and RedisTimeSeries from `v8.7.90` to `v8.7.91`.

| Module          | From    | To      |
|-----------------|---------|---------|
| RedisBloom      | v8.7.90 | v8.7.91 |
| RedisJSON       | v8.7.90 | v8.7.91 |
| RedisTimeSeries | v8.7.90 | v8.7.91 |

## Module changes (v8.7.90 → v8.7.91)

### RedisBloom ([v8.7.90...v8.7.91](https://github.com/RedisBloom/RedisBloom/compare/v8.7.90...v8.7.91))
- RED-180951 RED-181297 RED-184457 RED-184456 RED-184458 RED-184459 — bug fixes and code improvements ([#1002](https://github.com/RedisBloom/RedisBloom/pull/1002))
- Cherry-pick: nightly snapshot improvements to 8.8 ([#982](https://github.com/RedisBloom/RedisBloom/pull/982))
- MOD-14675 — refresh OS list to 8.8 ([#976](https://github.com/RedisBloom/RedisBloom/pull/976))
- bump to 8.7.91 ([#1004](https://github.com/RedisBloom/RedisBloom/pull/1004)) + fix redis version ([#1005](https://github.com/RedisBloom/RedisBloom/pull/1005))

### RedisJSON ([v8.7.90...v8.7.91](https://github.com/RedisJSON/RedisJSON/compare/v8.7.90...v8.7.91))
- MOD-15542 — c_api: change default for `ValueWrapper` to `null` ([#1593](https://github.com/RedisJSON/RedisJSON/pull/1593))
- MOD-12730 — nightly build, upload snapshot artifact ([#1567](https://github.com/RedisJSON/RedisJSON/pull/1567))
- MOD-12730 — unique snapshot name + new output params for nightly event ([#1563](https://github.com/RedisJSON/RedisJSON/pull/1563))
- Cherry-pick bug fixes to 8.8 ([#1557](https://github.com/RedisJSON/RedisJSON/pull/1557))
- bump to 8.7.91 + fix redis version

### RedisTimeSeries ([v8.7.90...v8.7.91](https://github.com/RedisTimeSeries/RedisTimeSeries/compare/v8.7.90...v8.7.91))
- MOD-15262 — Align TimeSeries with the `RedisModule_GetUserUserName` API ([#1985](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1985))
- MOD-14420 — fix count reducers returning wrong NaN ([#2016](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2016))
- MOD-14850 — bump libmr ([#2011](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2011))
- RED-180951 RED-180027 — bug fixes and code improvements ([#2003](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2003))
- MOD-15020 — remove bionic OS support ([#1996](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1996))
- ci: skip Event CI when PR only changes `src/version.h` ([#1986](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1986))
- Cherry-pick nightly snapshot upload ([#1955](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1955))
- MOD-14674 — refresh OS list to 8.8 ([#1946](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1946))

## Test plan
- [ ] CI passes for all three modules at the new pinned version
- [ ] `make all` builds RedisBloom, RedisJSON, RedisTimeSeries cleanly against `unstable`
- [ ] Module tests run under `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Makefile-only change that updates pinned upstream module tags; main risk is downstream build/test or behavioral changes introduced by the newer module releases.
> 
> **Overview**
> Updates the pinned `MODULE_VERSION` tags for the Redis data-type modules **RedisBloom**, **RedisJSON**, and **RedisTimeSeries** from `v8.7.90` to `v8.7.91`, so builds will fetch and compile the newer upstream releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eadca9e3c11b0f25725ceaf9fda833cff6eaa53f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->