### PR TITLE
docs: add vector set reply schemas

### DIFF
--- a/modules/vector-sets/commands.json
+++ b/modules/vector-sets/commands.json
@@ -97,7 +97,19 @@
     "command_flags": [
       "WRITE",
       "DENYOOM"
-    ]
+    ],
+    "reply_schema": {
+      "oneOf": [
+        {
+          "description": "A new element was added.",
+          "const": true
+        },
+        {
+          "description": "The element already existed and was updated.",
+          "const": false
+        }
+      ]
+    }
   },
   "VREM": {
     "summary": "Remove an element from a vector set",
@@ -118,7 +130,19 @@
         "name": "element",
         "type": "string"
       }
-    ]
+    ],
+    "reply_schema": {
+      "oneOf": [
+        {
+          "description": "The element was removed.",
+          "const": true
+        },
+        {
+          "description": "The element was not found.",
+          "const": false
+        }
+      ]
+    }
   },
   "VSIM": {
     "summary": "Return elements by vector similarity",
@@ -232,7 +256,12 @@
         "name": "key",
         "type": "key"
       }
-    ]
+    ],
+    "reply_schema": {
+      "description": "The vector dimension.",
+      "type": "integer",
+      "minimum": 1
+    }
   },
   "VCARD": {
     "summary": "Return the number of elements in a vector set",
@@ -250,7 +279,12 @@
         "name": "key",
         "type": "key"
       }
-    ]
+    ],
+    "reply_schema": {
+      "description": "The cardinality (number of elements) of the vector set, or 0 if key does not exist.",
+      "type": "integer",
+      "minimum": 0
+    }
   },
   "VEMB": {
     "summary": "Return the vector associated with an element",
@@ -347,7 +381,19 @@
         "name": "json",
         "type": "string"
       }
-    ]
+    ],
+    "reply_schema": {
+      "oneOf": [
+        {
+          "description": "The attributes were updated.",
+          "const": true
+        },
+        {
+          "description": "The element was not found.",
+          "const": false
+        }
+      ]
+    }
   },
   "VGETATTR": {
     "summary": "Retrieve the JSON attributes of elements",
@@ -368,7 +414,19 @@
         "name": "element",
         "type": "string"
       }
-    ]
+    ],
+    "reply_schema": {
+      "oneOf": [
+        {
+          "description": "The attributes associated with the element.",
+          "type": "string"
+        },
+        {
+          "description": "The element does not exist or has no attributes.",
+          "type": "null"
+        }
+      ]
+    }
   },
   "VRANDMEMBER": {
     "summary": "Return one or multiple random members from a vector set",
@@ -390,7 +448,26 @@
         "type": "integer",
         "optional": true
       }
-    ]
+    ],
+    "reply_schema": {
+      "oneOf": [
+        {
+          "description": "Key does not exist and count was not specified.",
+          "type": "null"
+        },
+        {
+          "description": "Randomly selected element when count is not specified.",
+          "type": "string"
+        },
+        {
+          "description": "Randomly selected elements when count is specified.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    }
   },
   "VISMEMBER": {
     "summary": "Check if an element exists in a vector set",
@@ -411,7 +488,19 @@
         "name": "element",
         "type": "string"
       }
-    ]
+    ],
+    "reply_schema": {
+      "oneOf": [
+        {
+          "description": "The element exists.",
+          "const": true
+        },
+        {
+          "description": "The element does not exist.",
+          "const": false
+        }
+      ]
+    }
   },
   "VRANGE": {
     "summary": "Return elements in a lexicographical range",


### PR DESCRIPTION
## What changed

Added `reply_schema` entries for Vector Set commands with simple, well-defined replies in `modules/vector-sets/commands.json`:

- `VADD`, `VREM`, `VSETATTR`, `VISMEMBER` boolean replies
- `VDIM`, `VCARD` integer replies
- `VGETATTR` string/null replies
- `VRANDMEMBER` null/string/array replies

## Why

The Vector Set command metadata already documents arguments and flags, but these commands were missing reply schemas. Adding the simple reply shapes makes the command metadata more complete while leaving the more complex Vector Set replies for a separate change.

## How tested

- Ran `jq empty modules/vector-sets/commands.json`
- Ran a `jq` check that the updated Vector Set commands all have `reply_schema`
- Validated representative sample replies against the new schemas with `jsonschema` in a temporary virtual environment
- Ran `git diff --check modules/vector-sets/commands.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only command metadata (`commands.json`) to document reply shapes, with no runtime logic changes.
> 
> **Overview**
> Adds `reply_schema` metadata for Vector Set commands with previously undocumented simple replies.
> 
> Covers boolean outcomes for `VADD`, `VREM`, `VSETATTR`, and `VISMEMBER`, integer replies for `VDIM`/`VCARD`, `string|null` for `VGETATTR`, and `null|string|string[]` for `VRANDMEMBER`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d73de42ca1f9d0db2d7d7f947a9452fcd8969cff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->