### PR TITLE
Set default for INLINE_LSE_ATOMICS to 0 for compatibility across architectures

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -7,5 +7,9 @@ TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 LTO ?= 1
 export LTO
 
+# Default to 0 to maintain backward compatibility and ensure support across multiple architectures
+INLINE_LSE_ATOMICS ?= 0
+export INLINE_LSE_ATOMICS
+
 include ../common.mk
 

--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -7,7 +7,8 @@ TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 LTO ?= 1
 export LTO
 
-# Default to 0 to maintain backward compatibility and ensure support across multiple architectures
+  # Set INLINE_LSE_ATOMICS=1 for perf improvement on common ARM CPUs (i.e. Graviton2/3/4); no effect on x86 or macOS.
+  # Default 0 keeps the binary runnable on pre-Armv8.1-a cores (Cortex-A72, Graviton1, RPi4) that would otherwise SIGILL at module load.
 INLINE_LSE_ATOMICS ?= 0
 export INLINE_LSE_ATOMICS
 


### PR DESCRIPTION
Ensure backward compatibility and consistent behavior across different architectures by explicitly setting the default value.

Fixes #15175

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: build-time default change only, affecting module compilation behavior on ARM; functional code paths are unchanged but incorrect overrides could impact ARM runtime compatibility/perf.
> 
> **Overview**
> Makes `modules/redisearch/Makefile` explicitly default `INLINE_LSE_ATOMICS` to `0` and exports it, with comments explaining that enabling it improves performance on Armv8.1+ (e.g., Graviton2/3/4) but can cause `SIGILL` on older ARM cores.
> 
> This standardizes the build output for RediSearch across architectures while keeping the optimization as an opt-in flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a35aa1e18c6a2797b72658be8a25fbba91b4cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->