### PR TITLE
docs: fix key spec firstkey typos

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1778,7 +1778,7 @@ int RM_SetCommandACLCategories(RedisModuleCommand *command, const char *aclflags
  *             * `keynumidx`: Index of the argument containing the number of
  *               keys to come, relative to the result of the begin search step.
  *
- *             * `firstkey`: Index of the fist key relative to the result of the
+ *             * `firstkey`: Index of the first key relative to the result of the
  *               begin search step. (Usually it's just after `keynumidx`, in
  *               which case it should be set to `keynumidx + 1`.)
  *

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -460,7 +460,7 @@ typedef struct {
             /* Index of the argument containing the number of keys to come
              * relative to the result of the begin search step */
             int keynumidx;
-            /* Index of the fist key. (Usually it's just after keynumidx, in
+            /* Index of the first key. (Usually it's just after keynumidx, in
              * which case it should be set to keynumidx + 1.) */
             int firstkey;
             /* How many args should we skip after finding a key, in order to

--- a/src/server.h
+++ b/src/server.h
@@ -2742,7 +2742,7 @@ typedef struct {
         struct {
             /* Index of the argument containing the number of keys to come */
             int keynumidx;
-            /* Index of the fist key (Usually it's just after keynumidx, in
+            /* Index of the first key (Usually it's just after keynumidx, in
              * which case it should be set to keynumidx+1). */
             int firstkey;
             /* How many args should we skip after finding a key, in order to find the next one. */


### PR DESCRIPTION
## What changed

Fixed three `fist key` typos in key-spec documentation comments, changing them to `first key`.

## Why

These comments document the `firstkey` field for module command key specs. The typo appears in the public module header and matching internal documentation.

## How tested

- Ran `rg -n "fist key" src/redismodule.h src/module.c src/server.h` and confirmed no matches
- Ran `git diff --check src/redismodule.h src/module.c src/server.h`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely comment/documentation typo fixes in headers and source with no behavioral or API changes.
> 
> **Overview**
> Fixes a typo in key-spec documentation comments by changing `fist key` to `first key` for the `firstkey` field in `module.c`, the public module header `redismodule.h`, and internal `server.h`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 772d2f26daf787321bba4e17f0ffa74536fa499e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->