### PR TITLE
Update GH Actions dependency (Node.js 20 deprecation)

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1105,7 +1105,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: test
-      uses: cross-platform-actions/action@v0.30.0
+      uses: cross-platform-actions/action@v1.0.0
       with:
         operating_system: freebsd
         environment_variables: MAKE
@@ -1221,10 +1221,14 @@ jobs:
     - name: cluster tests
       if: true && !contains(github.event.inputs.skiptests, 'cluster')
       run: ./runtest-cluster --log-req-res --dont-clean --force-resp3 ${{github.event.inputs.cluster_test_args}}
-    - name: Install Python dependencies
-      uses: py-actions/py-dependency-install@30aa0023464ed4b5b116bd9fbdab87acf01a484e # v4.1.0
+    - name: Set up Python
+      uses: actions/setup-python@v6
       with:
-        path: "./utils/req-res-validator/requirements.txt"
+        python-version: "3.x"
+        cache: "pip"
+        cache-dependency-path: "./utils/req-res-validator/requirements.txt"
+    - name: Install Python dependencies
+      run: python -m pip install -r ./utils/req-res-validator/requirements.txt
     - name: validator
       run: ./utils/req-res-log-validator.py --verbose --fail-missing-reply-schemas ${{ (!contains(github.event.inputs.skiptests, 'redis') && !contains(github.event.inputs.skiptests, 'module') && !contains(github.event.inputs.sentinel, 'redis') && !contains(github.event.inputs.skiptests, 'cluster')) && github.event.inputs.test_args == '' && github.event.inputs.cluster_test_args == '' && '--fail-commands-not-all-hit' || '' }}
 


### PR DESCRIPTION
This is a follow-up to [redis/redis#14938](https://github.com/redis/redis/pull/14938), which upgraded GitHub Actions to newer stable versions for the upcoming Node.js 20 deprecation on GitHub Actions runners.

That PR missed two remaining action updates in `daily.yml`:

- `cross-platform-actions/action`
- `py-actions/py-dependency-install`

### Why replace `py-actions/py-dependency-install`

`py-actions/py-dependency-install` is no longer an actively maintained dependency installation action, so keeping it in CI increases maintenance and supply-chain risk over time.

The replacement uses GitHub's official `actions/setup-python` action, which is actively maintained and supports built-in `pip` dependency caching. Installing dependencies with `python -m pip install -r ./utils/req-res-validator/requirements.txt` also makes the workflow behavior explicit and easier to debug.


### Test

CI: https://github.com/vitahlin/redis/actions/runs/25913378609

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI workflow changes could break or slow nightly runs if the updated FreeBSD runner action or the new Python setup/pip install sequence behaves differently than before.
> 
> **Overview**
> Updates the `daily.yml` workflow to use `cross-platform-actions/action@v1.0.0` for the FreeBSD test job.
> 
> Replaces `py-actions/py-dependency-install` with `actions/setup-python@v6` plus an explicit `pip install -r` for the reply-schema validator, enabling built-in pip caching keyed off `utils/req-res-validator/requirements.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9e631c0ed49b6db106dfa4305e4adbb7c51f27d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->