### PR TITLE
Fix killIOThreads() hanging forever on shutdown

### DIFF
--- a/src/iothread.c
+++ b/src/iothread.c
@@ -942,22 +942,49 @@ void initThreadedIO(void) {
     }
 }
 
-/* Kill the IO threads, TODO: release the applied resources. */
+/* Stop all IO threads and wait for them to exit.
+ *
+ * pthread_cancel is unsafe here: IO threads run with PTHREAD_CANCEL_ASYNCHRONOUS
+ * (set by makeThreadKillable), so a cancel signal can land inside the allocator's
+ * internal lock paths, leaving those locks permanently held and causing
+ * pthread_join to hang forever.
+ *
+ * Instead we ask each thread to exit cooperatively: aeStop sets the event-loop
+ * stop flag, and triggerEventNotifier wakes the thread if it is blocked in
+ * epoll_wait. The thread exits at the top of the aeMain loop, where no lock
+ * is held. We signal all threads first, then join them in a second pass so
+ * they can exit in parallel.
+ *
+ * A second hang path: if a thread is spinning in handlePauseAndResume()
+ * waiting for IO_THREAD_RESUMING (e.g. the main thread paused it before
+ * crashing), it never reaches the aeMain loop top to see eventLoop->stop.
+ * The signal pass therefore also forces paused threads to IO_THREAD_RESUMING
+ * so they exit the spin and can observe the stop flag.
+ *
+ * TODO: release the applied resources. */
 void killIOThreads(void) {
     if (server.io_threads_num <= 1) return;
 
     int err, j;
     for (j = 1; j < server.io_threads_num; j++) {
-        if (IOThreads[j].tid == pthread_self()) continue;
-        if (IOThreads[j].tid && pthread_cancel(IOThreads[j].tid) == 0) {
-            if ((err = pthread_join(IOThreads[j].tid,NULL)) != 0) {
-                serverLog(LL_WARNING,
-                    "IO thread(tid:%lu) can not be joined: %s",
-                        (unsigned long)IOThreads[j].tid, strerror(err));
-            } else {
-                serverLog(LL_WARNING,
-                    "IO thread(tid:%lu) terminated",(unsigned long)IOThreads[j].tid);
-            }
-        }
+        if (IOThreads[j].tid == pthread_self() || !IOThreads[j].tid) continue;
+        aeStop(IOThreads[j].el);
+        /* If the thread is spinning in handlePauseAndResume waiting for
+         * IO_THREAD_RESUMING, it will never reach the aeMain loop top to
+         * see eventLoop->stop. Release it so it can exit. */
+        int paused;
+        atomicGetWithSync(IOThreads[j].paused, paused);
+        if (paused == IO_THREAD_PAUSED || paused == IO_THREAD_PAUSING)
+            atomicSetWithSync(IOThreads[j].paused, IO_THREAD_RESUMING);
+        triggerEventNotifier(IOThreads[j].pending_clients_notifier);
+    }
+
+    for (j = 1; j < server.io_threads_num; j++) {
+        if (IOThreads[j].tid == pthread_self() || !IOThreads[j].tid) continue;
+        if ((err = pthread_join(IOThreads[j].tid, NULL)) != 0)
+            serverLog(LL_WARNING, "IO thread %d: pthread_join failed: %s",
+                      j, strerror(err));
+        else
+            serverLog(LL_VERBOSE, "IO thread %d stopped.", j);
     }
 }


### PR DESCRIPTION
 ## Problem

  On shutdown, `killIOThreads()` calls `pthread_cancel()` on each IO thread.
  IO threads are set to `PTHREAD_CANCEL_ASYNCHRONOUS` mode via `makeThreadKillable()`,
  which means the cancel signal can be delivered at any point — including inside
  the allocator's internal lock paths. When this happens, the lock is never released,
  and the subsequent `pthread_join()` blocks forever, preventing clean process shutdown.

  ## Solution

  Replace forced cancellation with cooperative shutdown:

  1. **Signal phase** — call `aeStop()` on each thread's event loop and wake it with
     `triggerEventNotifier()` if it is blocked in `epoll_wait`.
  2. **Join phase** — join all threads in a separate pass, so they can exit in parallel.

  Threads exit at the top of the `aeMain` loop boundary, where no allocator lock is held,
  making the shutdown safe and deterministic.

  ## Changes

  - `src/iothread.c`: rewrite `killIOThreads()` to use cooperative stop instead of
    `pthread_cancel`; split into a signal pass and a join pass; expand function comment
    to document the unsafe-cancel invariant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes IO-thread shutdown from async `pthread_cancel` to cooperative event-loop stopping and adds logic to unpause threads before joining, which reduces deadlock risk but alters termination behavior in crash/shutdown paths.
> 
> **Overview**
> Prevents `killIOThreads()` from hanging indefinitely by removing async `pthread_cancel` and switching to a cooperative shutdown: stop each IO thread’s event loop with `aeStop()`, wake it via `triggerEventNotifier()`, then `pthread_join()` all threads in a second pass.
> 
> Also handles a corner case where an IO thread is stuck in the pause/resume spin by forcing `paused` to `IO_THREAD_RESUMING` before waking, and updates logging/commentary to document the deadlock scenario and new shutdown protocol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5533b723990dd91332d04a26149b6a29a02f7d3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->