### PR TITLE
Configure RediSearch to avoid regenerating C headers for Rust modules

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -7,10 +7,14 @@ TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 LTO ?= 1
 export LTO
 
+# Use the committed C headers for Rust modules, rather than regenerating them
+# from Rust source. Override with REDISEARCH_GENERATE_HEADERS=1.
+REDISEARCH_GENERATE_HEADERS ?= 0
+export REDISEARCH_GENERATE_HEADERS
+
   # Set INLINE_LSE_ATOMICS=1 for perf improvement on common ARM CPUs (i.e. Graviton2/3/4); no effect on x86 or macOS.
   # Default 0 keeps the binary runnable on pre-Armv8.1-a cores (Cortex-A72, Graviton1, RPi4) that would otherwise SIGILL at module load.
 INLINE_LSE_ATOMICS ?= 0
 export INLINE_LSE_ATOMICS
 
 include ../common.mk
-


### PR DESCRIPTION
Fixes the nightly build breakage.
It requires https://github.com/RediSearch/RediSearch/pull/9669 to be merged first.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk build configuration change that only affects how RediSearch is built, with no runtime logic changes. Potential risk is limited to build failures if upstream expects regenerated headers in some environments.
> 
> **Overview**
> Configures the RediSearch module build to **avoid regenerating C headers for Rust modules by default** by exporting `REDISEARCH_GENERATE_HEADERS ?= 0` (overrideable to `1`). This changes the default build behavior to use committed headers, reducing header-generation work during builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e50e0eb0d277a1cc77d6be947e417eb91e7d4c63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->