### PR TITLE
MOD-15423 Add RedisModule_GetClusterNodeSlotRanges API

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2127,6 +2127,27 @@ slotRangeArray *clusterGetLocalSlotRanges(void) {
     return slots ? slots : slotRangeArrayCreate(0);
 }
 
+/* Return the slot ranges that belong to a node or its master. */
+slotRangeArray *clusterGetNodeSlotRanges(const char *id) {
+    slotRangeArray *slots = NULL;
+
+    if (!server.cluster_enabled) {
+        slots = slotRangeArrayCreate(1);
+        slotRangeArraySet(slots, 0, 0, CLUSTER_SLOTS - 1);
+        return slots;
+    }
+
+    clusterNode *node = clusterLookupNode(id, CLUSTER_NAMELEN);
+    clusterNode *master = node ? clusterNodeGetMaster(node) : NULL;
+    if (master) {
+        for (int i = 0; i < CLUSTER_SLOTS; i++) {
+            if (clusterNodeCoversSlot(master, i))
+                slots = slotRangeArrayAppend(slots, i);
+        }
+    }
+    return slots ? slots : slotRangeArrayCreate(0);
+}
+
 /* Partially flush destination DB in a cluster node, based on the slot range.
  *
  * Usage: SFLUSH <start-slot> <end slot> [<start-slot> <end slot>]* [SYNC|ASYNC]

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2128,7 +2128,7 @@ slotRangeArray *clusterGetLocalSlotRanges(void) {
 }
 
 /* Return the slot ranges that belong to a node or its master. */
-slotRangeArray *clusterGetNodeSlotRanges(const char *id) {
+slotRangeArray *getClusterNodeSlotRanges(const char *id) {
     slotRangeArray *slots = NULL;
 
     if (!server.cluster_enabled) {

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -154,6 +154,7 @@ int getSlotOrReply(client *c, robj *o);
 int clusterIsMySlot(int slot);
 int clusterCanAccessKeysInSlot(int slot);
 struct slotRangeArray *clusterGetLocalSlotRanges(void);
+struct slotRangeArray *clusterGetNodeSlotRanges(const char *id);
 
 /* functions with shared implementations */
 clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, int argc, int *hashslot,

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -154,7 +154,7 @@ int getSlotOrReply(client *c, robj *o);
 int clusterIsMySlot(int slot);
 int clusterCanAccessKeysInSlot(int slot);
 struct slotRangeArray *clusterGetLocalSlotRanges(void);
-struct slotRangeArray *clusterGetNodeSlotRanges(const char *id);
+struct slotRangeArray *getClusterNodeSlotRanges(const char *id);
 
 /* functions with shared implementations */
 clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, int argc, int *hashslot,

--- a/src/module.c
+++ b/src/module.c
@@ -9983,14 +9983,14 @@ RedisModuleSlotRangeArray *RM_ClusterGetLocalSlotRanges(RedisModuleCtx *ctx) {
  *
  * The returned array must be freed with RM_ClusterFreeSlotRanges().
  */
-RedisModuleSlotRangeArray *RM_ClusterGetNodeSlotRanges(RedisModuleCtx *ctx, const char *id) {
-    slotRangeArray *slots = clusterGetNodeSlotRanges(id);
+RedisModuleSlotRangeArray *RM_GetClusterNodeSlotRanges(RedisModuleCtx *ctx, const char *id) {
+    slotRangeArray *slots = getClusterNodeSlotRanges(id);
     if (ctx) autoMemoryAdd(ctx, REDISMODULE_AM_SLOTRANGEARRAY, slots);
     return (RedisModuleSlotRangeArray *)slots;
 }
 
 /* Frees a slot range array returned by RM_ClusterGetLocalSlotRanges()
- * or RM_ClusterGetNodeSlotRanges().
+ * or RM_GetClusterNodeSlotRanges().
  * Pass the `ctx` pointer only if the array was created with a context. */
 void RM_ClusterFreeSlotRanges(RedisModuleCtx *ctx, RedisModuleSlotRangeArray *slots) {
     if (ctx) autoMemoryFreed(ctx, REDISMODULE_AM_SLOTRANGEARRAY, slots);
@@ -15613,7 +15613,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ClusterCanAccessKeysInSlot);
     REGISTER_API(ClusterPropagateForSlotMigration);
     REGISTER_API(ClusterGetLocalSlotRanges);
-    REGISTER_API(ClusterGetNodeSlotRanges);
+    REGISTER_API(GetClusterNodeSlotRanges);
     REGISTER_API(ClusterFreeSlotRanges);
     REGISTER_API(CreateDict);
     REGISTER_API(FreeDict);

--- a/src/module.c
+++ b/src/module.c
@@ -9974,7 +9974,23 @@ RedisModuleSlotRangeArray *RM_ClusterGetLocalSlotRanges(RedisModuleCtx *ctx) {
     return (RedisModuleSlotRangeArray *)slots;
 }
 
-/* Frees a slot range array returned by RM_ClusterGetLocalSlotRanges().
+/* Returns the slot ranges for the specified node in the cluster.
+ *
+ * An optional `ctx` can be provided to enable auto-memory management.
+ * If cluster mode is disabled or if the node id is unknown
+ * a single range covering all slots is returned.
+ * If the node is a replica, the slot ranges of its master are returned.
+ *
+ * The returned array must be freed with RM_ClusterFreeSlotRanges().
+ */
+RedisModuleSlotRangeArray *RM_ClusterGetNodeSlotRanges(RedisModuleCtx *ctx, const char *id) {
+    slotRangeArray *slots = clusterGetNodeSlotRanges(id);
+    if (ctx) autoMemoryAdd(ctx, REDISMODULE_AM_SLOTRANGEARRAY, slots);
+    return (RedisModuleSlotRangeArray *)slots;
+}
+
+/* Frees a slot range array returned by RM_ClusterGetLocalSlotRanges()
+ * or RM_ClusterGetNodeSlotRanges().
  * Pass the `ctx` pointer only if the array was created with a context. */
 void RM_ClusterFreeSlotRanges(RedisModuleCtx *ctx, RedisModuleSlotRangeArray *slots) {
     if (ctx) autoMemoryFreed(ctx, REDISMODULE_AM_SLOTRANGEARRAY, slots);
@@ -15597,6 +15613,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ClusterCanAccessKeysInSlot);
     REGISTER_API(ClusterPropagateForSlotMigration);
     REGISTER_API(ClusterGetLocalSlotRanges);
+    REGISTER_API(ClusterGetNodeSlotRanges);
     REGISTER_API(ClusterFreeSlotRanges);
     REGISTER_API(CreateDict);
     REGISTER_API(FreeDict);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1409,6 +1409,7 @@ REDISMODULE_API const char *(*RedisModule_ClusterCanonicalKeyNameInSlot)(unsigne
 REDISMODULE_API int (*RedisModule_ClusterCanAccessKeysInSlot)(int slot) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ClusterPropagateForSlotMigration)(RedisModuleCtx *ctx, const char *cmdname, const char *fmt, ...) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_ClusterGetLocalSlotRanges)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_ClusterGetNodeSlotRanges)(RedisModuleCtx *ctx, const char *id) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ClusterFreeSlotRanges)(RedisModuleCtx *ctx, RedisModuleSlotRangeArray *slots) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExportSharedAPI)(RedisModuleCtx *ctx, const char *apiname, void *func) REDISMODULE_ATTR;
 REDISMODULE_API void * (*RedisModule_GetSharedAPI)(RedisModuleCtx *ctx, const char *apiname) REDISMODULE_ATTR;
@@ -1813,6 +1814,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ClusterCanAccessKeysInSlot);
     REDISMODULE_GET_API(ClusterPropagateForSlotMigration);
     REDISMODULE_GET_API(ClusterGetLocalSlotRanges);
+    REDISMODULE_GET_API(ClusterGetNodeSlotRanges);
     REDISMODULE_GET_API(ClusterFreeSlotRanges);
     REDISMODULE_GET_API(ExportSharedAPI);
     REDISMODULE_GET_API(GetSharedAPI);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1409,7 +1409,7 @@ REDISMODULE_API const char *(*RedisModule_ClusterCanonicalKeyNameInSlot)(unsigne
 REDISMODULE_API int (*RedisModule_ClusterCanAccessKeysInSlot)(int slot) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ClusterPropagateForSlotMigration)(RedisModuleCtx *ctx, const char *cmdname, const char *fmt, ...) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_ClusterGetLocalSlotRanges)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_ClusterGetNodeSlotRanges)(RedisModuleCtx *ctx, const char *id) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_GetClusterNodeSlotRanges)(RedisModuleCtx *ctx, const char *id) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ClusterFreeSlotRanges)(RedisModuleCtx *ctx, RedisModuleSlotRangeArray *slots) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExportSharedAPI)(RedisModuleCtx *ctx, const char *apiname, void *func) REDISMODULE_ATTR;
 REDISMODULE_API void * (*RedisModule_GetSharedAPI)(RedisModuleCtx *ctx, const char *apiname) REDISMODULE_ATTR;
@@ -1814,7 +1814,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ClusterCanAccessKeysInSlot);
     REDISMODULE_GET_API(ClusterPropagateForSlotMigration);
     REDISMODULE_GET_API(ClusterGetLocalSlotRanges);
-    REDISMODULE_GET_API(ClusterGetNodeSlotRanges);
+    REDISMODULE_GET_API(GetClusterNodeSlotRanges);
     REDISMODULE_GET_API(ClusterFreeSlotRanges);
     REDISMODULE_GET_API(ExportSharedAPI);
     REDISMODULE_GET_API(GetSharedAPI);


### PR DESCRIPTION
Add a new RedisModule function that returns slot ranges for any node
in the cluster, given its node ID. This complements the existing
RedisModule_ClusterGetLocalSlotRanges which only works for the local
node. With this addition modules can fully reconstruct the cluster
topology natively.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new module API surface and a small shared helper for computing slot ownership; low behavioral risk but needs care around ABI/API naming and expected return semantics for unknown node IDs.
> 
> **Overview**
> Adds a new slot-range query path that lets modules retrieve the slot ranges owned by an arbitrary cluster node (or its master) via `RedisModule_GetClusterNodeSlotRanges`.
> 
> This introduces the underlying `getClusterNodeSlotRanges()` helper in `cluster.c`/`cluster.h`, wires the API into `module.c` (including auto-memory support), updates `redismodule.h` exports/lookup table, and clarifies that `RM_ClusterFreeSlotRanges()` also frees arrays returned by the new API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ecbbe5a5d8a15a50f518859f6e6e38e84898036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->