### PR TITLE
Add concurrency groups to cancel stale GH workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   test-ubuntu-latest:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 concurrency:
-  group: ci-${{ github.head_ref || github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,7 +5,7 @@ name: "Codecov"
 on: [push, pull_request]
 
 concurrency:
-  group: codecov-${{ github.event.pull_request.number || github.ref }}
+  group: codecov-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,7 +5,7 @@ name: "Codecov"
 on: [push, pull_request]
 
 concurrency:
-  group: codecov-${{ github.event.pull_request.number || github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,7 +5,7 @@ name: "Codecov"
 on: [push, pull_request]
 
 concurrency:
-  group: codecov-${{ github.head_ref || github.ref }}
+  group: codecov-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,6 +4,10 @@ name: "Codecov"
 # where each PR needs to be compared against the coverage of the head commit
 on: [push, pull_request]
 
+concurrency:
+  group: codecov-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 3 * * 0'
 
 concurrency:
-  group: clang-${{ github.head_ref || github.ref }}
+  group: codeql-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 0 * * 0'
 
 concurrency:
-  group: codeql-${{ github.event.pull_request.number || github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   schedule:
     # run weekly new vulnerability was added to the database
-    - cron: '0 3 * * 0'
+    - cron: '0 0 * * 0'
 
 concurrency:
   group: codeql-${{ github.head_ref || github.ref }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 0 * * 0'
 
 concurrency:
-  group: codeql-${{ github.head_ref || github.ref }}
+  group: codeql-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,7 +4,11 @@ on:
   pull_request:
   schedule:
     # run weekly new vulnerability was added to the database
-    - cron: '0 0 * * 0'
+    - cron: '0 3 * * 0'
+
+concurrency:
+  group: clang-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: coverity-${{ github.head_ref || github.ref }}
+  group: coverity-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,9 +3,14 @@ name: Coverity Scan
 on:
   schedule:
   # Run once daily, since below 500k LOC can have 21 builds per week, per https://scan.coverity.com/faq#frequency
-  - cron: '0 0 * * *'
+  - cron: '0 1 * * *'
   # Support manual execution
   workflow_dispatch:
+
+concurrency:
+  group: coverity-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverity:
     if: github.repository == 'redis/redis'

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: coverity-${{ github.event.pull_request.number || github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,7 +3,7 @@ name: Coverity Scan
 on:
   schedule:
   # Run once daily, since below 500k LOC can have 21 builds per week, per https://scan.coverity.com/faq#frequency
-  - cron: '0 1 * * *'
+  - cron: '0 0 * * *'
   # Support manual execution
   workflow_dispatch:
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -28,6 +28,9 @@ on:
         description: 'git branch or sha to use'
         default: 'unstable'
 
+concurrency:
+  group: daily-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -28,10 +28,6 @@ on:
         description: 'git branch or sha to use'
         default: 'unstable'
 
-concurrency:
-  group: daily-${{ github.event_name }}-${{ github.event.inputs.use_repo || github.repository }}-${{ github.event.inputs.use_git_ref || github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   test-ubuntu-jemalloc:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -27,6 +27,8 @@ on:
       use_git_ref:
         description: 'git branch or sha to use'
         default: 'unstable'
+
+
 jobs:
 
   test-ubuntu-jemalloc:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -29,7 +29,7 @@ on:
         default: 'unstable'
 
 concurrency:
-  group: daily-${{ github.head_ref || github.ref }}
+  group: daily-${{ github.event_name }}-${{ github.event.inputs.use_repo || github.repository }}-${{ github.event.inputs.use_git_ref || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -27,7 +27,6 @@ on:
       use_git_ref:
         description: 'git branch or sha to use'
         default: 'unstable'
-
 jobs:
 
   test-ubuntu-jemalloc:

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -7,7 +7,7 @@ on:
       - cron: '0 0 * * *'
 
 concurrency:
-  group: external-${{ github.event.pull_request.number || github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -4,7 +4,7 @@ on:
     pull_request:
     push:
     schedule:
-      - cron: '0 2 * * *'
+      - cron: '0 0 * * *'
 
 concurrency:
   group: external-${{ github.head_ref || github.ref }}

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -4,7 +4,11 @@ on:
     pull_request:
     push:
     schedule:
-      - cron: '0 0 * * *'
+      - cron: '0 2 * * *'
+
+concurrency:
+  group: external-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-external-standalone:

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -7,7 +7,7 @@ on:
       - cron: '0 0 * * *'
 
 concurrency:
-  group: external-${{ github.head_ref || github.ref }}
+  group: external-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/reply-schemas-linter.yml
+++ b/.github/workflows/reply-schemas-linter.yml
@@ -9,7 +9,7 @@ on:
       - 'src/commands/*.json'
 
 concurrency:
-  group: reply-schemas-linter-${{ github.event.pull_request.number || github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/reply-schemas-linter.yml
+++ b/.github/workflows/reply-schemas-linter.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'src/commands/*.json'
 
+concurrency:
+  group: reply-schemas-linter-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   reply-schemas-linter:
     runs-on: ubuntu-latest

--- a/.github/workflows/reply-schemas-linter.yml
+++ b/.github/workflows/reply-schemas-linter.yml
@@ -9,7 +9,7 @@ on:
       - 'src/commands/*.json'
 
 concurrency:
-  group: reply-schemas-linter-${{ github.head_ref || github.ref }}
+  group: reply-schemas-linter-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 concurrency:
-  group: spellcheck-${{ github.head_ref || github.ref }}
+  group: spellcheck-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 concurrency:
-  group: spellcheck-${{ github.event.pull_request.number || github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -9,6 +9,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: spellcheck-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Spellcheck


### PR DESCRIPTION
This is based on [valkey-io/valkey#849](https://github.com/valkey-io/valkey/pull/849)

Introduce `concurrency` and `group` keywords into workflows execpt from `redis_docs_sync` (which is triggered on release event only) and `daily`.
https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency

With this, only one workflow can run in a group at any time.

Co-authored-by: Yury-Fridlyand <yury.fridlyand@improving.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow configuration only; no application, auth, or runtime behavior changes.
> 
> **Overview**
> Adds **GitHub Actions workflow concurrency** to eight CI-related workflows (`ci`, `codecov`, `codeql-analysis`, `coverity`, `external`, `reply-schemas-linter`, `spell-check`) so only one run per workflow per ref/PR group is active at a time, with **`cancel-in-progress: true`** superseding older runs when new pushes or PR updates trigger the same group.
> 
> Each workflow uses the same **`group`** expression: workflow name plus PR number, head ref, or ref. **`redis_docs_sync`** is left unchanged (release-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f607eeac786917f939b19f31e87d63aa518a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->