### PR TITLE
Fix compile on some linux distros

### DIFF
--- a/deps/tre/lib/xmalloc.c
+++ b/deps/tre/lib/xmalloc.c
@@ -126,7 +126,7 @@ hash_table_add(hashTable *tbl, void *ptr, size_t bytes,
 }
 
 static void
-#if defined(__GNUC__) && __GNUC__ >= 10
+#if defined(__GNUC__) && __GNUC__ >= 11
 __attribute__((access(none, 2)))
 #endif
 hash_table_del(hashTable *tbl, void *ptr)
@@ -344,12 +344,12 @@ xrealloc_impl(void *ptr, size_t new_size, const char *file, int line,
   new_ptr = realloc(ptr, new_size);
   if (new_ptr != NULL && new_ptr != ptr)
     {
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 12
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuse-after-free"
 #endif
       hash_table_del(xmalloc_table, ptr);
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 12
 #pragma GCC diagnostic pop
 #endif
       hash_table_add(xmalloc_table, new_ptr, (int)new_size, file, line, func);

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ ifeq ($(OPTIMIZATION),-O3)
 	ifeq (clang,$(CLANG))
 		ENABLE_LTO=-flto
 	else
-		ENABLE_LTO=-flto=auto
+		ENABLE_LTO=-flto=auto -ffat-lto-objects
 	endif
 	OPTIMIZATION+=$(ENABLE_LTO)
 endif

--- a/src/module.c
+++ b/src/module.c
@@ -13373,7 +13373,7 @@ int moduleOnLoad(int (*onload)(void *, void **, int), const char *path, void *ha
     moduleCreateContext(&ctx, NULL, REDISMODULE_CTX_TEMP_CLIENT); /* We pass NULL since we don't have a module yet. */
     if (onload((void*)&ctx,module_argv,module_argc) == REDISMODULE_ERR) {
         serverLog(LL_WARNING,
-            "Module %s initialization failed. Module not loaded",path);
+            "Module %s initialization failed. Module not loaded", path ? path : "(null)");
         if (ctx.module) {
             moduleUnregisterCleanup(ctx.module);
             moduleRemoveCateogires(ctx.module);


### PR DESCRIPTION
Fixes: 

1. After #15096, we pass -flto to jemalloc. On Azure Linux, the resulting jemalloc library cannot be handled at link time and the build fails. Adding -ffat-lto-objects so the compiler also emits regular object code that the linker can fall back to when it cannot handle the LTO-compiled library.
2.  Fixed a warning about `path` being NULL in `moduleLoadInternalModules()`.
3. Fixed compile warnings on older GCC versions introduced by #15162  
    (reported on Ubuntu 20.04)

Co-authored-by: debing.sun <debing.sun@redis.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to build flags and compiler-version guards, plus a minor log formatting fix when `path` can be NULL.
> 
> **Overview**
> Improves build compatibility on some Linux toolchains by adding `-ffat-lto-objects` alongside GCC `-flto=auto`, letting linkers fall back to non-LTO objects when needed.
> 
> Adjusts GCC-version guards in `deps/tre` `xmalloc.c` to avoid warnings on older GCC (moves `__attribute__((access))` to GCC 11+ and only suppresses `-Wuse-after-free` on GCC 12+). Also makes the module load failure log in `moduleOnLoad` handle a NULL `path` (internal modules) without warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 394bb0cfd08438345c580ba2f0b8abef0ab02cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->