### PR TITLE
tls: replace deprecated X509_NAME_get_text_by_NID API

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -647,10 +647,29 @@ static int getCertFieldByName(X509 *cert, const char *field, char *out, size_t o
 
     if (nid == -1) return 0;
 
-    X509_NAME *subject = X509_get_subject_name(cert);
+    const X509_NAME *subject = X509_get_subject_name(cert);
     if (!subject) return 0;
 
-    return X509_NAME_get_text_by_NID(subject, nid, out, outlen) > 0;
+    int index = X509_NAME_get_index_by_NID(subject, nid, -1);
+    if (index < 0) return 0;
+
+    X509_NAME_ENTRY *entry = X509_NAME_get_entry(subject, index);
+    ASN1_STRING *data = X509_NAME_ENTRY_get_data(entry);
+
+    unsigned char *utf8 = NULL;
+    int len = ASN1_STRING_to_UTF8(&utf8, data);
+
+    if (len < 0 || (size_t)len >= outlen) {
+        OPENSSL_free(utf8);
+        return 0;
+    }
+
+    memcpy(out, utf8, len);
+    out[len] = '\0';
+
+    OPENSSL_free(utf8);
+
+    return 1;
 }
 
 sds tlsGetPeerUsername(connection *conn_) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -659,7 +659,7 @@ static int getCertFieldByName(X509 *cert, const char *field, char *out, size_t o
     unsigned char *utf8 = NULL;
     int len = ASN1_STRING_to_UTF8(&utf8, data);
 
-    if (len < 0 || (size_t)len >= outlen) {
+    if (len <= 0 || (size_t)len >= outlen) {
         OPENSSL_free(utf8);
         return 0;
     }


### PR DESCRIPTION
Fixes #15221

OpenSSL 4 deprecates `X509_NAME_get_text_by_NID()`.

This replaces the deprecated API usage with:

* `X509_NAME_get_index_by_NID`
* `X509_NAME_get_entry`
* `X509_NAME_ENTRY_get_data`
* `ASN1_STRING_to_UTF8`

Also fixes the discarded `const` qualifier warning from `X509_get_subject_name()`.

Build tested successfully against OpenSSL 4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the peer certificate identity string is extracted for client-auth (UTF-8 conversion and length checks), which could affect username matching or reject previously-accepted cert fields.
> 
> **Overview**
> Replaces deprecated `X509_NAME_get_text_by_NID()` usage in `getCertFieldByName()` with an OpenSSL-4-compatible extraction path (`X509_NAME_get_index_by_NID` → `X509_NAME_get_entry` → `X509_NAME_ENTRY_get_data` → `ASN1_STRING_to_UTF8`).
> 
> Also fixes const-correctness by treating `X509_get_subject_name()` as returning a `const X509_NAME*`, and adds explicit UTF-8 length/bounds handling before copying into the caller buffer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34793115f89121227c5102d4b728f3a25801ff24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->