### PR TITLE
Update RediSearch module to v8.8.0

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.7.91
+MODULE_VERSION = v8.8.0
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
Updates the bundled RediSearch module version used by the Redis 8.8 branch from `v8.7.91` to `v8.8.0`.

This picks up the tagged RediSearch 8.8.0 release for Redis module builds.

Validation:
- Checked the diff is limited to `modules/redisearch/Makefile`.
- Ran `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only updates the pinned RediSearch module tag; main risk is any upstream behavior/build differences introduced by the new release.
> 
> **Overview**
> Updates the bundled RediSearch module build to use release `v8.8.0` instead of `v8.7.91` by bumping `MODULE_VERSION` in `modules/redisearch/Makefile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 945fe96915f8fea64a8005c6545086822c343e90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->