### PR TITLE
Fix typos in C source and Tcl test comments

### DIFF
--- a/src/crcspeed.c
+++ b/src/crcspeed.c
@@ -234,7 +234,7 @@ uint64_t crcspeed64little(uint64_t little_table[8][256], uint64_t crc1,
         MERGE_END(next2, 2);
     }
     /* We fall through here to handle our <CRC64_DUAL_CUTOFF inputs, and for any trailing
-     * bytes that wasn't evenly divisble by 16 or 24 above. */
+     * bytes that wasn't evenly divisible by 16 or 24 above. */
 
     /* fast processing, 8 bytes (aligned!) per loop */
     while (len >= 8) {

--- a/src/function_lua.c
+++ b/src/function_lua.c
@@ -142,7 +142,7 @@ done:
 }
 
 /*
- * Invole the give function with the given keys and args
+ * Invoke the given function with the given keys and args
  */
 static void luaEngineCall(scriptRunCtx *run_ctx,
                           void *engine_ctx,

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -855,7 +855,7 @@ int IOThreadCron(struct aeEventLoop *eventLoop, long long id, void *clientData) 
     return 1000/CONFIG_DEFAULT_HZ;
 }
 
-/* The main function of IO thread, it will run an event loop. The mian thread
+/* The main function of IO thread, it will run an event loop. The main thread
  * and IO thread will communicate through event notifier. */
 void *IOThreadMain(void *ptr) {
     IOThread *t = ptr;

--- a/src/script.c
+++ b/src/script.c
@@ -141,7 +141,7 @@ client* scriptGetCaller(void) {
 int scriptInterrupt(scriptRunCtx *run_ctx) {
     if (run_ctx->flags & SCRIPT_TIMEDOUT) {
         /* script already timedout
-           we just need to precess some events and return */
+           we just need to process some events and return */
         processEventsWhileBlocked();
         return (run_ctx->flags & SCRIPT_KILLED) ? SCRIPT_KILL : SCRIPT_CONTINUE;
     }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1771,7 +1771,7 @@ void streamReplyWithCGLag(client *c, stream *s, streamCG *cg) {
     {
         /* When both the consumer group's last_id and the maximum tombstone are behind
          * the stream's first entry, the consumer group's lag will always be equal to
-         * the number of remainin entries in the stream. */
+         * the number of remaining entries in the stream. */
         lag = s->length;
         valid = 1;
     } else if (cg->entries_read != SCG_INVALID_ENTRIES_READ && !streamRangeHasTombstones(s,&cg->last_id,NULL)) {

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -1114,13 +1114,13 @@ int jemalloc_purge(void) {
 /* For proc_pidinfo() used later in zmalloc_get_smap_bytes_by_field().
  * Note that this file cannot be included in zmalloc.h because it includes
  * a Darwin queue.h file where there is a "LIST_HEAD" macro (!) defined
- * conficting with Redis user code. */
+ * conflicting with Redis user code. */
 #include <libproc.h>
 #endif
 
 /* Get the sum of the specified field (converted form kb to bytes) in
  * /proc/self/smaps. The field must be specified with trailing ":" as it
- * apperas in the smaps output.
+ * appears in the smaps output.
  *
  * If a pid is specified, the information is extracted for such a pid,
  * otherwise if pid is -1 the information is reported is about the

--- a/tests/unit/cluster/links.tcl
+++ b/tests/unit/cluster/links.tcl
@@ -259,7 +259,7 @@ start_cluster 3 0 {tags {external:skip cluster}} {
         set link_mem_after_pubs [getInfoProperty $res mem_cluster_links]
         
         # We expect the memory to have increased by more than
-        # the culmulative size of the publish messages
+        # the cumulative size of the publish messages
         set mem_diff_floor [expr $msg_size * $num_msgs]
         set mem_diff [expr $link_mem_after_pubs - $link_mem_before_pubs]
         assert {$mem_diff > $mem_diff_floor}

--- a/tests/unit/moduleapi/keymeta.tcl
+++ b/tests/unit/moduleapi/keymeta.tcl
@@ -298,7 +298,7 @@ start_server {tags {"modules" "external:skip" "cluster:skip"} overrides {enable-
         }
     }
 
-    test "KEYMETA - Verify metadta cleanup on lazyfree" {
+    test "KEYMETA - Verify metadata cleanup on lazyfree" {
         r config set lazyfree-lazy-user-del yes
         # Class 2 has UNLINKFREE flag, so it should call unlink callback when lazyfree is enabled
         # Class 1 does not have UNLINKFREE flag, so it should only call free callback

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -553,7 +553,7 @@ start_server {tags {"multi"}} {
         catch { $r2 exec; } e
         assert_match {EXECABORT*previous errors*} $e
         set xx [r get xx]
-        # make sure that either the whole transcation passed or none of it (we actually expect none)
+        # make sure that either the whole transaction passed or none of it (we actually expect none)
         assert { $xx == 1 || $xx == 3}
         # check that the connection is no longer in multi state
         set pong [$r2 ping asdf]
@@ -578,7 +578,7 @@ start_server {tags {"multi"}} {
         r script kill
         after 200 ; # Give some time to Lua to call the hook again...
         set xx [r get xx]
-        # make sure that either the whole transcation passed or none of it (we actually expect none)
+        # make sure that either the whole transaction passed or none of it (we actually expect none)
         assert { $xx == 1 || $xx == 3}
         # check that the connection is no longer in multi state
         set pong [$r2 ping asdf]
@@ -603,7 +603,7 @@ start_server {tags {"multi"}} {
         catch { $r2 exec; } e
         assert_match {EXECABORT*previous errors*} $e
         set xx [r get xx]
-        # make sure that either the whole transcation passed or none of it (we actually expect none)
+        # make sure that either the whole transaction passed or none of it (we actually expect none)
         assert { $xx == 1 || $xx == 3}
         # check that the connection is no longer in multi state
         set pong [$r2 ping asdf]

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -1489,7 +1489,7 @@ start_server {
         # Although XTRIM doesn't update the `max-deleted-entry-id`, it always updates the
         # position of the first entry. When trimming causes the first entry to be behind
         # the consumer group's last_id, the consumer group's lag will always be equal to
-        # the number of remainin entries in the stream.
+        # the number of remaining entries in the stream.
         r XTRIM x MAXLEN 1
         set reply [r XINFO STREAM x FULL]
         set group [lindex [dict get $reply groups] 0]


### PR DESCRIPTION
## Summary

Correct 13 spelling typos in comments across `src/` and `tests/`. Comment-only and one test-description-only change; no functional impact.

## What changed

| File | Typo | Fix |
|---|---|---|
| `src/crcspeed.c` | `divisble` | `divisible` |
| `src/function_lua.c` | `Invole the give` | `Invoke the given` |
| `src/iothread.c` | `mian` | `main` |
| `src/script.c` | `precess` | `process` |
| `src/t_stream.c` | `remainin` | `remaining` |
| `src/zmalloc.c` | `conficting` | `conflicting` |
| `src/zmalloc.c` | `apperas` | `appears` |
| `tests/unit/cluster/links.tcl` | `culmulative` | `cumulative` |
| `tests/unit/moduleapi/keymeta.tcl` | `metadta` (test name) | `metadata` |
| `tests/unit/multi.tcl` (×3) | `transcation` | `transaction` |
| `tests/unit/type/stream-cgroups.tcl` | `remainin` | `remaining` |

The `keymeta.tcl` change is one `test "..."` description string; it aligns this one test name with the four sibling test names in the same file which already use the correctly-spelled `metadata` (see lines 241, 260, 276, 325).

## Why these and not others

Scope was restricted to **unambiguous spelling typos in comments**. Excluded on purpose:
- Style-only differences flagged by newer codespell dictionaries (e.g. `re-use` vs `reuse`, `Re-use` vs `Reuse`).
- The `advices` occurrences in `src/latency.c` (it's a real local variable name, not a typo).
- `modules/vector-sets/` typos (a separate PR by another contributor already touches that area in #15209, #15210, #15213).
- `deps/` (skipped by `.codespell/.codespellrc`).

## Test plan

- [x] `codespell --config=./.codespell/.codespellrc` with pinned `codespell==2.2.5` (matching `.codespell/requirements.txt` and the CI Spellcheck job) reports zero issues after the change.
- [x] No code lines touched, only comment lines and one Tcl `test "..."` description string.
- [x] `grep -rn "metadta" src/ tests/` confirms no other reference to the old typo'd test name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only spelling fixes across C sources and Tcl tests, with no changes to executable logic or test assertions; risk is limited to minor test-name string churn.
> 
> **Overview**
> Fixes a set of spelling typos in comments across `src/` (e.g., “divisible”, “Invoke”, “main”, “process”, “remaining”, “conflicting”, “appears”).
> 
> Also corrects typos in Tcl test comments and one test description string ("metadta" → "metadata") without changing test behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f84015dac54239d5b1f81abc4c4fc4b048e0393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->