### PR TITLE
Optimize sdssplitlen by preventing redundant memcmp on the if condition

### DIFF
--- a/deps/hiredis/sds.c
+++ b/deps/hiredis/sds.c
@@ -833,7 +833,7 @@ hisds *hi_sdssplitlen(const char *s, int len, const char *sep, int seplen, int *
             tokens = newtokens;
         }
         /* search the separator */
-        if ((seplen == 1 && *(s+j) == sep[0]) || (memcmp(s+j,sep,seplen) == 0)) {
+        if (seplen == 1 ? (*(s+j) == sep[0]) : (memcmp(s+j, sep, seplen) == 0)) {
             tokens[elements] = hi_sdsnewlen(s+start,j-start);
             if (tokens[elements] == NULL) goto cleanup;
             elements++;

--- a/src/sds.c
+++ b/src/sds.c
@@ -918,7 +918,7 @@ sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *c
             tokens = newtokens;
         }
         /* search the separator */
-        if ((seplen == 1 && *(s+j) == sep[0]) || (memcmp(s+j,sep,seplen) == 0)) {
+        if (seplen == 1 ? (*(s+j) == sep[0]) : (memcmp(s+j, sep, seplen) == 0)) {
             tokens[elements] = sdsnewlen(s+start,j-start);
             if (tokens[elements] == NULL) goto cleanup;
             elements++;


### PR DESCRIPTION
While reading through `sds.c`, I noticed an inefficiency in the `||` logic inside the main loop of `sdssplitlen`.

Current logic: `if ((seplen == 1 && *(s+j) == sep[0]) || (memcmp(s+j,sep,seplen) == 0))`

My proposed fix: `if (seplen == 1 ? (*(s+j) == sep[0]) : (memcmp(s+j, sep, seplen) == 0))`

- If `seplen` is 1, and it does match, it's fast and good.
- If `seplen` is 1, and it does not match, the first condition evaluates to false, doesn't it end up calling `memcmp` again?

See the [Godbolt comparison](https://godbolt.org/z/8ETjnjva6)

In the original code, because of the short-circuiting fallback to `memcmp`, GCC evaluates this loop using scalar instructions and branching.

In my proposed fix, because `seplen` is loop-invariant, this strict ternary separation allows modern compilers (GCC -O3) to unswitch the loop. In the `seplen == 1` case, GCC now successfully auto-vectorizes the loop, replacing the byte-by-byte comparison with 128-bit SIMD instructions (`movdqu`, `pcmpeqb`), processing 16 bytes at a time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: tiny, localized conditional rewrite in string tokenization that should preserve semantics; only potential risk is subtle behavior change if compilers/platforms handle the ternary differently.
> 
> **Overview**
> Improves the separator-detection hot path in `sdssplitlen` (and the hiredis copy `hi_sdssplitlen`) by rewriting the `if` condition to use a `seplen == 1` ternary, preventing an unnecessary `memcmp` fallback in the single-byte separator case.
> 
> No functional behavior is intended to change; this is a micro-optimization aimed at enabling better compiler optimization in the main loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87568abb989f1b9e017bfdbcd1ef39da4b5f2b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->