### PR TITLE
Update DataType Modules to v8.8.0

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.7.91
+MODULE_VERSION = v8.8.0
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 

--- a/modules/redisjson/Makefile
+++ b/modules/redisjson/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.7.91
+MODULE_VERSION = v8.8.0
 MODULE_REPO = https://github.com/redisjson/redisjson
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/rejson.so
 

--- a/modules/redistimeseries/Makefile
+++ b/modules/redistimeseries/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.7.91
+MODULE_VERSION = v8.8.0
 MODULE_REPO = https://github.com/redistimeseries/redistimeseries
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redistimeseries.so
 


### PR DESCRIPTION
## Summary

Bumps `MODULE_VERSION` for RedisBloom, RedisJSON, and RedisTimeSeries from `v8.7.91` to `v8.8.0`.

| Module          | From    | To     |
|-----------------|---------|--------|
| RedisBloom      | v8.7.91 | v8.8.0 |
| RedisJSON       | v8.7.91 | v8.8.0 |
| RedisTimeSeries | v8.7.91 | v8.8.0 |

## Module changes (v8.7.91 → v8.8.0)

### RedisBloom ([v8.7.91...v8.8.0](https://github.com/RedisBloom/RedisBloom/compare/v8.7.91...v8.8.0))
- MOD-15418 — fix load rdb mem leak ([#1007](https://github.com/RedisBloom/RedisBloom/pull/1007))
- Revert "fix redis version" ([#1010](https://github.com/RedisBloom/RedisBloom/pull/1010))
- bump version to v8.8.0

### RedisJSON ([v8.7.91...v8.8.0](https://github.com/RedisJSON/RedisJSON/compare/v8.7.91...v8.8.0))
- Revert "fix redis version" ([#1597](https://github.com/RedisJSON/RedisJSON/pull/1597))
- bump version v8.8.0

### RedisTimeSeries ([v8.7.91...v8.8.0](https://github.com/RedisTimeSeries/RedisTimeSeries/compare/v8.7.91...v8.8.0))
- MOD-14439 — Detect cluster topology changes during a multi-shard command and return an appropriate error ([#1930](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1930))
- Revert Docker and CI redis-ref from 8.8 back to unstable ([#2033](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2033))
- bump version v8.8.0

## Test plan
- [ ] CI passes for all three modules at the new pinned version
- [ ] \`make all\` builds RedisBloom, RedisJSON, RedisTimeSeries cleanly against \`unstable\`
- [ ] Module tests run under \`make test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code-change surface (Makefile version pins only), but it upgrades three Redis modules, so runtime behavior and compatibility may change due to upstream module updates.
> 
> **Overview**
> Updates the pinned `MODULE_VERSION` for `redisbloom`, `redisjson`, and `redistimeseries` from `v8.7.91` to `v8.8.0`, so builds pull and compile the newer upstream module releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a41306e17944442903da8db8a3df73e0845a263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->