### PR TITLE
modules: remove -Werror hack and improve Makefile logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Tested with the following Docker image:
 
    ```sh
    cd /usr/src/redis-<version>
-   export BUILD_TLS=yes BUILD_WITH_MODULES=yes INSTALL_RUST_TOOLCHAIN=yes DISABLE_WERRORS=yes
+   export BUILD_TLS=yes BUILD_WITH_MODULES=yes INSTALL_RUST_TOOLCHAIN=yes
    make -j "$(nproc)" all
    ```
 
@@ -339,7 +339,7 @@ Tested with the following Docker image:
 
    ```sh
    cd /usr/src/redis-<version>
-   export BUILD_TLS=yes BUILD_WITH_MODULES=yes INSTALL_RUST_TOOLCHAIN=yes DISABLE_WERRORS=yes
+   export BUILD_TLS=yes BUILD_WITH_MODULES=yes INSTALL_RUST_TOOLCHAIN=yes
    make -j "$(nproc)" all
    ```
 
@@ -393,7 +393,7 @@ Tested with the following Docker image:
 
    ```sh
    cd /usr/src/redis-<version>
-   export BUILD_TLS=yes BUILD_WITH_MODULES=yes INSTALL_RUST_TOOLCHAIN=yes DISABLE_WERRORS=yes
+   export BUILD_TLS=yes BUILD_WITH_MODULES=yes INSTALL_RUST_TOOLCHAIN=yes
    make -j "$(nproc)" all
    ```
 
@@ -450,7 +450,7 @@ Tested with the following Docker images:
 
    ```sh
    cd /usr/src/redis-<version>
-   export BUILD_TLS=yes BUILD_WITH_MODULES=yes INSTALL_RUST_TOOLCHAIN=yes DISABLE_WERRORS=yes
+   export BUILD_TLS=yes BUILD_WITH_MODULES=yes INSTALL_RUST_TOOLCHAIN=yes
    make -j "$(nproc)" all
    ```
 
@@ -569,7 +569,7 @@ Tested with the following Docker images:
    ```sh
    source /etc/profile.d/gcc-toolset-13.sh
    cd /usr/src/redis-<version>
-   export BUILD_TLS=yes BUILD_WITH_MODULES=yes INSTALL_RUST_TOOLCHAIN=yes DISABLE_WERRORS=yes
+   export BUILD_TLS=yes BUILD_WITH_MODULES=yes INSTALL_RUST_TOOLCHAIN=yes
    make -j "$(nproc)" all
    ```
 
@@ -686,7 +686,7 @@ Tested with the following Docker images:
    ```sh
    source /etc/profile.d/gcc-toolset-13.sh
    cd /usr/src/redis-<version>
-   export BUILD_TLS=yes BUILD_WITH_MODULES=yes INSTALL_RUST_TOOLCHAIN=yes DISABLE_WERRORS=yes
+   export BUILD_TLS=yes BUILD_WITH_MODULES=yes INSTALL_RUST_TOOLCHAIN=yes
    make -j "$(nproc)" all
    ```
 
@@ -758,7 +758,6 @@ Tested with the following Docker images:
    export HOMEBREW_PREFIX="$(brew --prefix)"
    export BUILD_WITH_MODULES=yes
    export BUILD_TLS=yes
-   export DISABLE_WERRORS=yes
    PATH="$HOMEBREW_PREFIX/opt/libtool/libexec/gnubin:$HOMEBREW_PREFIX/opt/llvm@18/bin:$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH"
    export LDFLAGS="-L$HOMEBREW_PREFIX/opt/llvm@18/lib"
    export CPPFLAGS="-I$HOMEBREW_PREFIX/opt/llvm@18/include"

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -70,7 +70,6 @@ install: $(MODULES_ALL_INSTALL)
 
 
 # Keep all of the Rust stuff in one place
-# Keep all of the Rust stuff in one place
 install-rust:
 ifeq ($(INSTALL_RUST_TOOLCHAIN),yes)
 	@RUST_VERSION=1.94.0; \

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -1,34 +1,75 @@
+MODULES_RUST := redisjson redisearch
+MODULES_C := redistimeseries redisbloom redisearch
+MODULES_ALL := $(sort $(MODULES_RUST) $(MODULES_C))
+.PHONY: $(MODULES_ALL)
 
-SUBDIRS = redisjson redistimeseries redisbloom redisearch
+MODULES_RUST_GET_SOURCE := $(MODULES_RUST:%=%_get_source)
+MODULES_ALL_GET_SOURCE := $(MODULES_ALL:%=%_get_source)
+.PHONY: $(MODULES_ALL_GET_SOURCE)
 
-define submake
-	for dir in $(SUBDIRS); do $(MAKE) -C $$dir $(1); done
-endef
+MODULES_RUST_DISTCLEAN := $(MODULES_RUST:%=%_distclean)
+MODULES_ALL_DISTCLEAN := $(MODULES_ALL:%=%_distclean)
+.PHONY: $(MODULES_ALL_DISTCLEAN)
 
-all: prepare_source
-	$(call submake,$@)
+MODULES_ALL_CLEAN := $(MODULES_ALL:%=%_clean)
+.PHONY: $(MODULES_ALL_CLEAN)
 
-get_source:
-	$(call submake,$@)
+MODULES_ALL_PRISTINE := $(MODULES_ALL:%=%_pristine)
+.PHONY: $(MODULES_ALL_PRISTINE)
 
-prepare_source: get_source handle-werrors setup_environment
+MODULES_ALL_INSTALL := $(MODULES_ALL:%=%_install)
+.PHONY: $(MODULES_ALL_INSTALL)
 
-clean:
-	$(call submake,$@)
+# all
+all: $(MODULES_ALL)
 
-distclean: clean_environment
-	$(call submake,$@)
+$(MODULES_ALL):
+	$(MAKE) -C $@ all
 
-pristine:
-	$(call submake,$@)
+# get_source #
+# static template for one2one relations: each module requires its own get_source
+$(MODULES_ALL): % : %_get_source
 
-install:
-	$(call submake,$@)
+# rust modules require installing rust
+$(MODULES_RUST_GET_SOURCE): install-rust
 
-setup_environment: install-rust handle-werrors
+$(MODULES_ALL_GET_SOURCE):
+	$(MAKE) -C $(@:%_get_source=%) get_source
 
-clean_environment: uninstall-rust
+get_source: $(MODULES_ALL_GET_SOURCE)
 
+# clean #
+$(MODULES_ALL_CLEAN):
+	$(MAKE) -C $(@:%_clean=%) clean
+
+clean: $(MODULES_ALL_CLEAN)
+
+# distclean #
+# rust modules require uninstalling rust on distclean
+$(MODULES_RUST_DISTCLEAN): uninstall-rust
+
+$(MODULES_ALL_DISTCLEAN):
+	$(MAKE) -C $(@:%_distclean=%) distclean
+
+distclean: $(MODULES_ALL_DISTCLEAN)
+
+# pristine #
+$(MODULES_ALL_PRISTINE):
+	$(MAKE) -C $(@:%_pristine=%) pristine
+
+pristine: $(MODULES_ALL_PRISTINE)
+
+# install #
+# static template for one2one relations: each module install requires its own module build
+$(MODULES_ALL_INSTALL): %_install : %
+
+$(MODULES_ALL_INSTALL):
+	$(MAKE) -C $(@:%_install=%) install
+
+install: $(MODULES_ALL_INSTALL)
+
+
+# Keep all of the Rust stuff in one place
 # Keep all of the Rust stuff in one place
 install-rust:
 ifeq ($(INSTALL_RUST_TOOLCHAIN),yes)
@@ -74,17 +115,4 @@ ifeq ($(INSTALL_RUST_TOOLCHAIN),yes)
 	fi
 endif
 
-handle-werrors: get_source
-ifeq ($(DISABLE_WERRORS),yes)
-	@echo "Disabling -Werror for all modules"
-	@for dir in $(SUBDIRS); do \
-		echo "Processing $$dir"; \
-		find $$dir/src -type f \
-			\( -name "Makefile" \
-			-o -name "*.mk" \
-			-o -name "CMakeLists.txt" \) \
-			-exec sed -i 's/-Werror//g' {} +; \
-	done
-endif
-
-.PHONY: all clean distclean install $(SUBDIRS) setup_environment clean_environment install-rust uninstall-rust handle-werrors
+.PHONY: all clean distclean pristine install install-rust uninstall-rust get_source

--- a/modules/redisjson/Makefile
+++ b/modules/redisjson/Makefile
@@ -5,7 +5,8 @@ TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/rejson.so
 
 include ../common.mk
 
-$(SRC_DIR)/.cargo_fetched:
+$(SRC_DIR)/.cargo_fetched: $(SRC_DIR)/.prepared
 	cd $(SRC_DIR) && cargo fetch
+	touch $@
 
 get_source: $(SRC_DIR)/.cargo_fetched


### PR DESCRIPTION
* Drop the handle-werror sed hack that rewrote upstream Makefiles and broke the build. Seems like there is no need to remove -Werror anymore
* Any module build error now fails the top-level build instead of being swallowed by the shell for-loop.
* Enable parallel module build (`make -j`).
* Fix `make install` from clean - depend on the module being built.
* Fix race in redisjson/Makefile (`.cargo_fetched` vs `.prepared`) that prevented parallel `get_source`.

Modules are now first-class Make targets rather than iterations of a shell loop, which streamlines the build graph: each module's get_source, build, and install steps participate in Make's normal dependency resolution and parallel scheduling.
Parallel build slightly decreases build time by about 20% on larger machines (16 cores), on smaller ones the difference is subtle (about 9%)

Makefile targets graph before changes:

<img width="456" height="443" alt="before" src="https://github.com/user-attachments/assets/92017f69-452a-4fe9-9eea-2b67247006bb" />

Looks nice, but there are no any module targets because they are hidden in a shell loop.


Install target after changes:

<img width="1355" height="443" alt="graph-install" src="https://github.com/user-attachments/assets/315e16fd-5c23-4e0f-beaf-c5981711274e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the module build graph and dependency ordering (including parallelism), which could affect CI/build reproducibility across environments, but is limited to build tooling and docs.
> 
> **Overview**
> Refactors `modules/Makefile` to make each module a first-class Make target with explicit `get_source`, `clean`, `distclean`, `pristine`, and `install` dependencies, enabling proper failure propagation and parallel module builds.
> 
> Removes the `DISABLE_WERRORS`/`handle-werrors` sed-based hack (and updates `README.md` build instructions accordingly), and fixes a parallel-build race in `modules/redisjson/Makefile` by making `.cargo_fetched` depend on `.prepared` and creating the stamp file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7717386bb202783f3862ec25a858f57513782c4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->