### PR TITLE
fix: cluster bus reconnect storm and pfail detection bypass on node failure

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2214,6 +2214,7 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
                 node->tls_port = msg_tls_port;
                 node->cport = ntohs(g->cport);
                 node->flags &= ~CLUSTER_NODE_NOADDR;
+                node->reconnect_retry_delay = 0;
             }
         } else if (!node) {
             /* If it's not in NOADDR state and we don't have it, we

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1349,6 +1349,8 @@ clusterNode *createClusterNode(char *nodename, int flags) {
     node->last_in_ping_gossip = 0;
     node->ping_sent = node->pong_received = 0;
     node->data_received = 0;
+    node->last_reconnect_attempt = 0;
+    node->reconnect_retry_delay = 0;
     node->fail_time = 0;
     node->link = NULL;
     node->inbound_link = NULL;
@@ -2876,7 +2878,10 @@ int clusterProcessPacket(clusterLink *link) {
      * use this in order to avoid detecting a timeout from a node that
      * is just sending a lot of data in the cluster bus, for instance
      * because of Pub/Sub. */
-    if (sender) sender->data_received = now;
+    if (sender) {
+        sender->data_received = now;
+        sender->reconnect_retry_delay = 0;
+    }
 
     if (sender && !nodeInHandshake(sender)) {
         /* Update our currentEpoch if we see a newer epoch in the cluster. */
@@ -3053,6 +3058,7 @@ int clusterProcessPacket(clusterLink *link) {
         if (!link->inbound && type == CLUSTERMSG_TYPE_PONG) {
             link->node->pong_received = now;
             link->node->ping_sent = 0;
+            link->node->reconnect_retry_delay = 0;
 
             /* The PFAIL condition can be reversed without external
              * help if it is momentary (that is, if it does not
@@ -4684,17 +4690,42 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t handshake_
     }
 
     if (node->link == NULL) {
+        /* Enforce exponential backoff between reconnect attempts to
+         * avoid a reconnect storm when a node is unreachable. */
+        if (node->reconnect_retry_delay > 0 &&
+            now - node->last_reconnect_attempt < node->reconnect_retry_delay)
+        {
+            return 0;
+        }
+
+        /* Record this attempt and grow the backoff delay.
+         * Starts at 500 ms, doubles each time, capped at node_timeout/3. */
+        node->last_reconnect_attempt = now;
+        if (node->reconnect_retry_delay == 0) {
+            node->reconnect_retry_delay = 500;
+        } else {
+            node->reconnect_retry_delay *= 2;
+            mstime_t max_delay = server.cluster_node_timeout / 3;
+            if (max_delay < 500) max_delay = 500;
+            if (node->reconnect_retry_delay > max_delay) {
+                node->reconnect_retry_delay = max_delay;
+            }
+        }
+
         clusterLink *link = createClusterLink(node);
         link->conn = connCreate(server.el, connTypeOfCluster());
         connSetPrivateData(link->conn, link);
+
+        /* Arm ping_sent before the connection attempt so that failure
+         * detection (PFAIL) starts its timeout from the attempt time,
+         * regardless of whether the connect fails synchronously or
+         * asynchronously. */
+        if (node->ping_sent == 0) node->ping_sent = now;
+
         if (connConnect(link->conn, node->ip, node->cport, server.bind_source_addr,
                     clusterLinkConnectHandler) == C_ERR) {
             /* We got a synchronous error from connect before
-             * clusterSendPing() had a chance to be called.
-             * If node->ping_sent is zero, failure detection can't work,
-             * so we claim we actually sent a ping now (that will
-             * be really sent as soon as the link is obtained). */
-            if (node->ping_sent == 0) node->ping_sent = mstime();
+             * clusterSendPing() had a chance to be called. */
             serverLog(LL_DEBUG, "Unable to connect to "
                 "Cluster Node [%s]:%d -> %s", node->ip,
                 node->cport, server.neterr);

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -316,6 +316,8 @@ struct _clusterNode {
     mstime_t ping_sent;      /* Unix time we sent latest ping */
     mstime_t pong_received;  /* Unix time we received the pong */
     mstime_t data_received;  /* Unix time we received any data */
+    mstime_t last_reconnect_attempt; /* Unix time of last reconnect attempt */
+    mstime_t reconnect_retry_delay;  /* Current backoff delay between reconnect attempts */
     mstime_t fail_time;      /* Unix time when FAIL flag was set */
     mstime_t voted_time;     /* Last time we voted for a slave of this master */
     mstime_t repl_offset_time;  /* Unix time we received offset for this node */


### PR DESCRIPTION
fixes #15181.

### why

when a cluster node goes down, other nodes attempt to reconnect on every `clustercron` iteration (~100ms) with no backoff. in large clusters this creates a reconnect storm with significant network overhead and cpu waste.

additionally, outbound connection attempts that fail asynchronously never arm `node->ping_sent`. because pfail detection requires `ping_sent > 0` to start its timeout calculation, the downed node is never flagged as `pfail` — breaking failure detection entirely for the async failure path.

### what

* add `last_reconnect_attempt` and `reconnect_retry_delay` fields to `clusternode` to track reconnect backoff state per node.
* initialize both fields to 0 in `createclusternode()`.
* add exponential backoff in `clusternodecronhandlereconnect()`: starts at 500ms, doubles each attempt, capped at `cluster_node_timeout / 3` (floor 500ms).
* arm `ping_sent` before `connconnect()` instead of only on synchronous failure, so pfail detection works regardless of whether the connect fails synchronously or asynchronously.
* reset `reconnect_retry_delay` to 0 on reachability proof: when any packet is received from the sender, and when a pong is received on an outbound link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster bus reconnection and failure-detection timing; incorrect backoff or ping timing could delay reconnection or misclassify node health.
> 
> **Overview**
> Prevents cluster bus reconnect storms by adding per-node exponential backoff state (`last_reconnect_attempt`, `reconnect_retry_delay`) and enforcing it in `clusterNodeCronHandleReconnect`.
> 
> Fixes a failure-detection edge case by arming `ping_sent` *before* `connConnect()`, and resets the backoff delay to 0 when reachability is confirmed (on any received packet, on `PONG`, or when a node address is updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0467be5f15a0e7dbb2de4eda8da34a1613f11e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->