### PR TITLE
Add LoongArch64 backtrace support

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1448,6 +1448,8 @@ static void* getAndSetMcontextEip(ucontext_t *uc, void *eip) {
     GET_SET_RETURN(uc->uc_mcontext.arm_pc, eip);
     #elif defined(__aarch64__) /* Linux AArch64 */
     GET_SET_RETURN(uc->uc_mcontext.pc, eip);
+    #elif defined(__loongarch_lp64) /* Linux LoongArch64 */
+    GET_SET_RETURN(uc->uc_mcontext.__pc, eip);
     #else
     NOT_SUPPORTED();
     #endif
@@ -1781,6 +1783,50 @@ void logRegisters(ucontext_t *uc) {
 	      (unsigned long) uc->uc_mcontext.fault_address
 		      );
 	      logStackContent((void**)uc->uc_mcontext.arm_sp);
+    #elif defined(__loongarch_lp64) /* Linux LoongArch64 */
+    serverLog(LL_WARNING,
+        "\n"
+        "ra:%016llx tp:%016llx\nsp:%016llx a0:%016llx\n"
+        "a1:%016llx a2:%016llx\na3:%016llx a4:%016llx\n"
+        "a5:%016llx a6:%016llx\na7:%016llx t0:%016llx\n"
+        "t1:%016llx t2:%016llx\nt3:%016llx t4:%016llx\n"
+        "t5:%016llx t6:%016llx\nt7:%016llx t8:%016llx\n"
+        "fp:%016llx s0:%016llx\ns1:%016llx s2:%016llx\n"
+        "s3:%016llx s4:%016llx\ns5:%016llx s6:%016llx\n"
+        "s7:%016llx s8:%016llx\npc:%016llx\n",
+        (unsigned long long) uc->uc_mcontext.__gregs[1],
+        (unsigned long long) uc->uc_mcontext.__gregs[2],
+        (unsigned long long) uc->uc_mcontext.__gregs[3],
+        (unsigned long long) uc->uc_mcontext.__gregs[4],
+        (unsigned long long) uc->uc_mcontext.__gregs[5],
+        (unsigned long long) uc->uc_mcontext.__gregs[6],
+        (unsigned long long) uc->uc_mcontext.__gregs[7],
+        (unsigned long long) uc->uc_mcontext.__gregs[8],
+        (unsigned long long) uc->uc_mcontext.__gregs[9],
+        (unsigned long long) uc->uc_mcontext.__gregs[10],
+        (unsigned long long) uc->uc_mcontext.__gregs[11],
+        (unsigned long long) uc->uc_mcontext.__gregs[12],
+        (unsigned long long) uc->uc_mcontext.__gregs[13],
+        (unsigned long long) uc->uc_mcontext.__gregs[14],
+        (unsigned long long) uc->uc_mcontext.__gregs[15],
+        (unsigned long long) uc->uc_mcontext.__gregs[16],
+        (unsigned long long) uc->uc_mcontext.__gregs[17],
+        (unsigned long long) uc->uc_mcontext.__gregs[18],
+        (unsigned long long) uc->uc_mcontext.__gregs[19],
+        (unsigned long long) uc->uc_mcontext.__gregs[20],
+        (unsigned long long) uc->uc_mcontext.__gregs[22],
+        (unsigned long long) uc->uc_mcontext.__gregs[23],
+        (unsigned long long) uc->uc_mcontext.__gregs[24],
+        (unsigned long long) uc->uc_mcontext.__gregs[25],
+        (unsigned long long) uc->uc_mcontext.__gregs[26],
+        (unsigned long long) uc->uc_mcontext.__gregs[27],
+        (unsigned long long) uc->uc_mcontext.__gregs[28],
+        (unsigned long long) uc->uc_mcontext.__gregs[29],
+        (unsigned long long) uc->uc_mcontext.__gregs[30],
+        (unsigned long long) uc->uc_mcontext.__gregs[31],
+        (unsigned long long) uc->uc_mcontext.__pc
+    );
+    logStackContent((void**)uc->uc_mcontext.__gregs[3]);
     #else
 	NOT_SUPPORTED();
     #endif


### PR DESCRIPTION
## Problem

On Linux LoongArch64, the SIGSEGV/SIGBUS signal handler in `src/debug.c` never prints the `Crashed running the instruction at: ...` line, and the dumped register block reads Dumping of registers not supported for this OS/arch. The crash report is significantly less useful than on other supported architectures.

This also causes the "Test module crash when info crashes with a segfault" case in `tests/unit/moduleapi/crash.tcl` to fail on loongarch64-linux. 

## Cause

In `getAndSetMcontextEip` (`src/debug.c`), the Linux `#if … #elif …` chain handles `x86/x86_64/ia64/riscv/arm/aarch64` but has no LoongArch64 branch, so it falls through to `NOT_SUPPORTED()` and returns `NULL`. `logRegisters` has the same gap and hits its own `NOT_SUPPORTED()` for LoongArch64.

## Fix

Add LoongArch branches to both functions:

- `getAndSetMcontextEip`: read/write `uc->uc_mcontext.__pc`.
- `logRegisters`: dump `r1..r31` and `pc`, then feed `__gregs[3]` (sp) to `logStackContent`.

Register names follow the [LoongArch Procedure Call Standard](https://github.com/loongson/la-abi-specs/blob/release/lapcs.adoc); field names follow the glibc `<sys/ucontext.h>` for loongarch64-linux. `r0` (hardwired zero) and `r21` (reserved, non-allocatable) are intentionally omitted.

## Verification

- Built Redis 8.6.3 with this patch on NixOS loongarch64 (Loongson 3C6000, glibc 2.40, GCC 14).
- Both subtests of unit/moduleapi/crash.tcl pass, including the segfault case that previously failed.
- The crash report now includes the PC line and a full GPR dump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1adec9a4f97eed5257ce3da6a3bf7ae66dca6872. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->