### PR TITLE
ci: declare workflow-level `contents: read` on ci, codeql-analysis, reply-schemas-linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   test-ubuntu-latest:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,9 @@ on:
     # run weekly new vulnerability was added to the database
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/reply-schemas-linter.yml
+++ b/.github/workflows/reply-schemas-linter.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'src/commands/*.json'
 
+permissions:
+  contents: read
+
 jobs:
   reply-schemas-linter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Three CI workflows just run checks (`ci` = build/test, `codeql-analysis` = security scan, `reply-schemas-linter` = schema validation). Workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

The codeql-analysis job-level `security-events: write` is intentionally untouched (job permissions override workflow-level upward where genuinely needed).

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tightens GitHub Actions workflow token permissions and should not affect build logic, but could break jobs that implicitly relied on broader default permissions.
> 
> **Overview**
> Adds workflow-level `permissions: contents: read` to the `CI`, `CodeQL`, and `reply-schemas-linter` GitHub Actions workflows to *explicitly* scope down the default `GITHUB_TOKEN` access.
> 
> No job steps or commands change; this is a permissions hardening update for repository checkout/read-only operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b185327be27324c9ad007a02f21d796203b3a45b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->