### PR TITLE
Fix AUTH failure on URIs with empty username in redis-cli

### DIFF
--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -324,26 +324,20 @@ void parseRedisUri(const char *uri, const char* tool_name, cliConnInfo *connInfo
     /* Extract user info. */
     if ((userinfo = strchr(curr,'@'))) {
         if ((username = strchr(curr, ':')) && username < userinfo) {
-            /* "user:pass" form: both components are explicitly defined
-             * by the URI (possibly as the empty string). Free any value
-             * previously set by --user / -a and use NULL for explicitly
-             * empty components so cliAuth() falls back to legacy AUTH
-             * (or skips AUTH entirely) rather than sending an empty ACL
-             * username or password, which the server rejects. */
+            /* Free any value previously set via --user / -a (later
+             * parameters override earlier ones) and use NULL for an
+             * explicitly empty component, so cliAuth() falls back to the
+             * legacy single-argument AUTH (empty username) or skips AUTH
+             * entirely (empty password) instead of sending an empty ACL
+             * component, which the server rejects. */
             sdsfree(connInfo->user);
             connInfo->user = (username > curr)
                 ? percentDecode(curr, username - curr) : NULL;
             curr = username + 1;
-            sdsfree(connInfo->auth);
-            connInfo->auth = (userinfo > curr)
-                ? percentDecode(curr, userinfo - curr) : NULL;
-        } else if (userinfo > curr) {
-            /* "user@host" form: only the username is defined by the URI;
-             * leave the password (e.g. from -a) untouched. */
-            sdsfree(connInfo->user);
-            connInfo->user = percentDecode(curr, userinfo - curr);
         }
-        /* else "redis://@host": empty userinfo, leave both untouched. */
+        sdsfree(connInfo->auth);
+        connInfo->auth = (userinfo > curr)
+            ? percentDecode(curr, userinfo - curr) : NULL;
         curr = userinfo + 1;
     }
     if (curr == end) return;

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -324,11 +324,26 @@ void parseRedisUri(const char *uri, const char* tool_name, cliConnInfo *connInfo
     /* Extract user info. */
     if ((userinfo = strchr(curr,'@'))) {
         if ((username = strchr(curr, ':')) && username < userinfo) {
-            connInfo->user = percentDecode(curr, username - curr);
+            /* "user:pass" form: both components are explicitly defined
+             * by the URI (possibly as the empty string). Free any value
+             * previously set by --user / -a and use NULL for explicitly
+             * empty components so cliAuth() falls back to legacy AUTH
+             * (or skips AUTH entirely) rather than sending an empty ACL
+             * username or password, which the server rejects. */
+            sdsfree(connInfo->user);
+            connInfo->user = (username > curr)
+                ? percentDecode(curr, username - curr) : NULL;
             curr = username + 1;
+            sdsfree(connInfo->auth);
+            connInfo->auth = (userinfo > curr)
+                ? percentDecode(curr, userinfo - curr) : NULL;
+        } else if (userinfo > curr) {
+            /* "user@host" form: only the username is defined by the URI;
+             * leave the password (e.g. from -a) untouched. */
+            sdsfree(connInfo->user);
+            connInfo->user = percentDecode(curr, userinfo - curr);
         }
-
-        connInfo->auth = percentDecode(curr, userinfo - curr);
+        /* else "redis://@host": empty userinfo, leave both untouched. */
         curr = userinfo + 1;
     }
     if (curr == end) return;

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -331,13 +331,11 @@ void parseRedisUri(const char *uri, const char* tool_name, cliConnInfo *connInfo
              * entirely (empty password) instead of sending an empty ACL
              * component, which the server rejects. */
             sdsfree(connInfo->user);
-            connInfo->user = (username > curr)
-                ? percentDecode(curr, username - curr) : NULL;
+            connInfo->user = (username > curr) ? percentDecode(curr, username - curr) : NULL;
             curr = username + 1;
         }
         sdsfree(connInfo->auth);
-        connInfo->auth = (userinfo > curr)
-            ? percentDecode(curr, userinfo - curr) : NULL;
+        connInfo->auth = (userinfo > curr) ? percentDecode(curr, userinfo - curr) : NULL;
         curr = userinfo + 1;
     }
     if (curr == end) return;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2735,8 +2735,10 @@ static int parseOptions(int argc, char **argv) {
         } else if ((!strcmp(argv[i],"-a") || !strcmp(argv[i],"--pass"))
                    && !lastarg)
         {
+            sdsfree(config.conn_info.auth);
             config.conn_info.auth = sdsnew(argv[++i]);
         } else if (!strcmp(argv[i],"--user") && !lastarg) {
+            sdsfree(config.conn_info.user);
             config.conn_info.user = sdsnew(argv[++i]);
         } else if (!strcmp(argv[i],"-u") && !lastarg) {
             parseRedisUri(argv[++i],"redis-cli",&config.conn_info,&config.tls);

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -863,4 +863,94 @@ start_server {tags {"cli external:skip"}} {
     }
 }
 
+start_server {tags {"cli external:skip"}} {
+    # Regression for the parseRedisUri() bug where "redis://:password@host"
+    # produced an empty ACL username and the server replied WRONGPASS.
+    r config set requirepass "uri-no-username-pass"
+    set host [srv host]
+    set port [srv port]
+    if {$::tls} {
+        set scheme "rediss"
+    } else {
+        set scheme "redis"
+    }
+    set tls_args [rediscli_tls_config "tests"]
+
+    test "redis-cli -u with empty username falls back to legacy AUTH" {
+        set cmd [list src/redis-cli --no-auth-warning {*}$tls_args \
+            -u "$scheme://:uri-no-username-pass@$host:$port" PING]
+        assert_equal "PONG" [exec {*}$cmd]
+    }
+
+    test "redis-cli -u with explicit username uses ACL AUTH" {
+        set cmd [list src/redis-cli --no-auth-warning {*}$tls_args \
+            -u "$scheme://default:uri-no-username-pass@$host:$port" PING]
+        assert_equal "PONG" [exec {*}$cmd]
+    }
+
+    test "redis-cli -u after -a overrides auth without leaking" {
+        # -a sets connInfo->auth first, then -u must free the previous
+        # value before assigning the URI-provided one.
+        set cmd [list src/redis-cli --no-auth-warning {*}$tls_args \
+            -a wrong-pass \
+            -u "$scheme://default:uri-no-username-pass@$host:$port" PING]
+        assert_equal "PONG" [exec {*}$cmd]
+    }
+
+    test "redis-cli -u after --user overrides user without leaking" {
+        set cmd [list src/redis-cli --no-auth-warning {*}$tls_args \
+            --user wronguser \
+            -u "$scheme://default:uri-no-username-pass@$host:$port" PING]
+        assert_equal "PONG" [exec {*}$cmd]
+    }
+
+    test "redis-cli -u with explicit empty username clears stale --user" {
+        # A previously set --user must be cleared (not left stale) when
+        # the URI explicitly empties the username component, otherwise
+        # cliAuth() would send ACL AUTH with the stale username instead
+        # of the intended legacy single-argument AUTH.
+        set cmd [list src/redis-cli --no-auth-warning {*}$tls_args \
+            --user wronguser \
+            -u "$scheme://:uri-no-username-pass@$host:$port" PING]
+        assert_equal "PONG" [exec {*}$cmd]
+    }
+
+    test "redis-cli -u with empty userinfo keeps previously set -a auth" {
+        # "redis://@host" has empty userinfo, so the URI must not
+        # clobber the password already supplied via -a.
+        set cmd [list src/redis-cli --no-auth-warning {*}$tls_args \
+            -a uri-no-username-pass \
+            -u "$scheme://@$host:$port" PING]
+        assert_equal "PONG" [exec {*}$cmd]
+    }
+
+    r config set requirepass ""
+}
+
+start_server {tags {"cli external:skip"}} {
+    # Regression for empty userinfo URIs: "redis://@host" and
+    # "redis://user:@host" should leave connInfo->auth unset so that
+    # cliAuth() skips AUTH entirely instead of sending an empty password.
+    set host [srv host]
+    set port [srv port]
+    if {$::tls} {
+        set scheme "rediss"
+    } else {
+        set scheme "redis"
+    }
+    set tls_args [rediscli_tls_config "tests"]
+
+    test "redis-cli -u with empty userinfo skips AUTH" {
+        set cmd [list src/redis-cli {*}$tls_args \
+            -u "$scheme://@$host:$port" PING]
+        assert_equal "PONG" [exec {*}$cmd]
+    }
+
+    test "redis-cli -u with empty password skips AUTH" {
+        set cmd [list src/redis-cli {*}$tls_args \
+            -u "$scheme://default:@$host:$port" PING]
+        assert_equal "PONG" [exec {*}$cmd]
+    }
+}
+
 file delete ./.rediscli_history_test

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -915,13 +915,16 @@ start_server {tags {"cli external:skip"}} {
         assert_equal "PONG" [exec {*}$cmd]
     }
 
-    test "redis-cli -u with empty userinfo keeps previously set -a auth" {
-        # "redis://@host" has empty userinfo, so the URI must not
-        # clobber the password already supplied via -a.
+    test "redis-cli -u with empty userinfo overrides previously set -a" {
+        # "redis://@host" has empty userinfo. Since later parameters
+        # override earlier ones, the URI clears the password supplied via
+        # -a, so cliAuth() sends no AUTH and the password-protected server
+        # rejects the command with NOAUTH.
         set cmd [list src/redis-cli --no-auth-warning {*}$tls_args \
             -a uri-no-username-pass \
             -u "$scheme://@$host:$port" PING]
-        assert_equal "PONG" [exec {*}$cmd]
+        catch {exec {*}$cmd 2>@1} e
+        assert_match "*NOAUTH*" $e
     }
 
     r config set requirepass ""


### PR DESCRIPTION
Partial fix #11085

## Bug

`parseRedisUri()` called `percentDecode(curr, 0)` for URIs of the form `redis://:password@host` and stored the resulting **empty-but-non-NULL** sds into `connInfo->user`.
`cliAuth()` only checks `user == NULL` when deciding between legacy `AUTH <pass>` and ACL `AUTH <user> <pass>`, so the empty username was sent as `AUTH "" <password>`, which the server rejects with `WRONGPASS`.

## Fix

In parseRedisUri(), treat explicitly empty username or password
components as NULL rather than empty SDS strings. This allows cliAuth()
to fall back to legacy single-argument AUTH when the username is empty,
and to skip AUTH entirely when the password is empty.

Before replacing URI-parsed credentials, existing connInfo->user and
connInfo->auth values are freed to avoid leaks and preserve the expected
"later arguments override earlier ones" behavior.

As a related cleanup, -a/--pass and --user now also free previously
assigned values before reassignment, fixing the same leak pattern when
those options are specified multiple times.

## Test

Add regression tests covering both empty-username URIs (legacy AUTH) and explicit "default:" URIs (ACL AUTH).



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized redis-cli connection/auth parsing with regression tests; no server or security policy changes.
> 
> **Overview**
> Fixes **redis-cli** authentication when credentials come from **`-u` URIs** with optional empty username or password segments (e.g. `redis://:pass@host`), which previously produced empty `sds` values and caused **WRONGPASS** or invalid ACL **AUTH** instead of legacy single-arg **AUTH** or no auth.
> 
> **`parseRedisUri()`** now sets empty username/password components to **`NULL`**, frees prior **`--user` / `-a`** values before applying URI userinfo (later CLI args override earlier), and **`-a` / `--user`** free existing strings before reassignment to avoid leaks. Integration tests cover legacy vs ACL auth, override order, and empty userinfo skipping **AUTH**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd57da6cbee48cced070464f3f9c27e1eb8a1412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->