### PR TITLE
Trim excess SDS allocation in inline command parsing

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3127,6 +3127,8 @@ int processInlineBuffer(client *c, pendingCommand *pcmd) {
 
     /* Create redis objects for all arguments. */
     for (pcmd->argc = 0, j = 0; j < argc; j++) {
+        /* Trim greedy allocation from sdssplitargs(). */
+        argv[j] = sdsRemoveFreeSpace(argv[j], 0);
         pcmd->argv[pcmd->argc] = createObject(OBJ_STRING,argv[j]);
         pcmd->argc++;
         pcmd->argv_len_sum += sdslen(argv[j]);


### PR DESCRIPTION
This PR is based on valkey-io/valkey#1213.

sdssplitargs() builds each argument one byte at a time via sdscatlen(), which uses greedy doubling allocation. This leaves significant unused space in each SDS string — for a 600-byte value, ~400 bytes are wasted.

Add sdsRemoveFreeSpace() after sdssplitargs() in processInlineBuffer() to trim each argument before wrapping it in an robj.

Measured with 1M SET commands with 600-byte values piped via `redis-cli --pipe` in inline format:
- Before: 1,021 MB vs 655 MB for RESP (55.9% overhead)
- After: 655 MB, matching RESP baseline

---------

Co-authored-by: muelstefamzn <muelstef@amazon.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path memory optimization in inline parsing with no protocol or auth changes; behavior unchanged aside from lower per-argument allocation.
> 
> **Overview**
> Inline command parsing (`processInlineBuffer`) now **trims each argument SDS** with `sdsRemoveFreeSpace()` right after `sdssplitargs()`, before arguments are wrapped in `robj`s.
> 
> `sdssplitargs()` grows strings greedily byte-by-byte, which left large unused capacity per argument (especially for big values). That extra memory showed up as much higher RSS for pipelined inline traffic than RESP; after trimming, inline usage aligns with the RESP baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24c18b1034ab9b69c44916cdad31c4b2bbccd3b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->