### PR TITLE
Reduce BGSAVE/AOF COW by freeing SDS strings in fork child instead of madvise

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -2736,9 +2736,10 @@ int rewriteAppendOnlyFileRio(rio *aof) {
             /* In fork child process, we can try to release memory back to the
              * OS and possibly avoid or decrease COW. We give the dismiss
              * mechanism a hint about an estimated size of the object we stored. */
-            size_t dump_size = aof->processed_bytes - aof_bytes_before_key;
-            if (server.in_fork_child && dump_size > server.page_size/2)
+            if (server.in_fork_child) {
+                size_t dump_size = aof->processed_bytes - aof_bytes_before_key;
                 dismissObject(o, dump_size);
+            }
 
             /* Update info every 1 second (approximately).
              * in order to avoid calling mstime() on each iteration, we will

--- a/src/object.c
+++ b/src/object.c
@@ -690,7 +690,7 @@ void decrRefCount(robj *o) {
 
 /* See dismissObject() */
 void dismissSds(sds s) {
-    dismissMemory(sdsAllocPtr(s), sdsAllocSize(s));
+    sdsfree(s);
 }
 
 /* See dismissObject() */
@@ -863,6 +863,11 @@ void dismissObject(robj *o, size_t size_hint) {
      * so we avoid these pointless loops when they're not going to do anything. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
     if (o->refcount != 1) return;
+    /* For strings, sdsfree() works at any allocation size, so always proceed.
+     * For complex types, skip when serialized size is too small for the
+     * page-granular madvise to be effective. When size_hint is 0 (unknown),
+     * proceed and let the type-specific functions decide. */
+    if (o->type != OBJ_STRING && size_hint && size_hint <= server.page_size/2) return;
     switch(o->type) {
         case OBJ_STRING: dismissStringObject(o); break;
         case OBJ_LIST: dismissListObject(o, size_hint); break;

--- a/src/object.c
+++ b/src/object.c
@@ -856,8 +856,10 @@ void dismissGCRAObject(robj *o, size_t size_hint) {
  * it can reduce unnecessary iteration for complex data types that are probably
  * not going to release any memory. */
 void dismissObject(robj *o, size_t size_hint) {
-    /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled. */
-    if (server.thp_enabled) return;
+    /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled.
+     * Strings use sdsfree() which doesn't depend on madvise, so skip this
+     * check for them. */
+    if (server.thp_enabled && o->type != OBJ_STRING) return;
 
     /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
      * so we avoid these pointless loops when they're not going to do anything. */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -370,21 +370,28 @@ writeerr:
     return -1;
 }
 
+/* Reusable compression buffer to avoid dynamic allocation in the BGSAVE child.
+ * Without this, zmalloc may reuse pages freed by dismissSds(), dirtying shared
+ * pages and triggering copy-on-write. */
+#define RDB_LZF_STATIC_BUF_SIZE (8 * 1024)
+
 ssize_t rdbSaveLzfStringObject(rio *rdb, unsigned char *s, size_t len) {
     size_t comprlen, outlen;
     void *out;
+    static void *lzf_buf = NULL;
 
     /* We require at least four bytes compression for this to be worth it */
     if (len <= 4) return 0;
     outlen = len-4;
-    if ((out = zmalloc(outlen+1)) == NULL) return 0;
-    comprlen = lzf_compress(s, len, out, outlen);
-    if (comprlen == 0) {
-        zfree(out);
-        return 0;
+    if (outlen < RDB_LZF_STATIC_BUF_SIZE) {
+        if (!lzf_buf) lzf_buf = zmalloc(RDB_LZF_STATIC_BUF_SIZE);
+        out = lzf_buf;
+    } else {
+        if ((out = zmalloc(outlen+1)) == NULL) return 0;
     }
-    ssize_t nwritten = rdbSaveLzfBlob(rdb, out, comprlen, len);
-    zfree(out);
+    comprlen = lzf_compress(s, len, out, outlen);
+    ssize_t nwritten = comprlen ? rdbSaveLzfBlob(rdb, out, comprlen, len) : 0;
+    if (out != lzf_buf) zfree(out);
     return nwritten;
 }
 
@@ -1845,9 +1852,10 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter, unsigned 
         /* In fork child process, we can try to release memory back to the
          * OS and possibly avoid or decrease COW. We give the dismiss
          * mechanism a hint about an estimated size of the object we stored. */
-        size_t dump_size = rdb->processed_bytes - rdb_bytes_before_key;
-        if (server.in_fork_child && dump_size > server.page_size/2)
+        if (server.in_fork_child) {
+            size_t dump_size = rdb->processed_bytes - rdb_bytes_before_key;
             dismissObject(kv, dump_size);
+        }
 
         /* Update child info every 1 second (approximately).
          * in order to avoid calling mstime() on each iteration, we will


### PR DESCRIPTION
This PR is based on [Valkey PR #905](https://github.com/valkey-io/valkey/pull/905) and the prerequisite `zfree_with_size` merged via #15071.

Replace `dismissMemory(MADV_DONTNEED)` with `sdsfree()` in the fork child's dismiss path for SDS strings. `madvise` operates at page granularity and is ineffective for typical string values (< 4KB). `sdsfree()` lets jemalloc coalesce freed regions and release whole pages back to the OS.
  - `object.c`: `dismissSds()` calls `sdsfree()`. Bypass the page-size threshold and THP check for `OBJ_STRING` in `dismissObject()` since sdsfree works at any allocation size and doesn't depend on madvise.
  - `rdb.c`: Lazily-allocated 8KB reusable LZF compression buffer to prevent jemalloc from reusing just-freed pages for compression output.
  - `aof.c`: Same threshold bypass for the AOF rewrite fork child.

**Results** (3M keys, 80/20 read/write, 10% fragmentation, setup similar to [Valkey PR #905](https://github.com/valkey-io/valkey/pull/905)):

  | Value size | COW overhead vs vanilla | Child RSS released |
  |-----------|------------------------|--------------------|
  | 2000B | 65% (1127→736 MB) | 79.4% (6222→1282 MB) |
  | 500B | 96% (542→519 MB) | 12.8% (1682→1467 MB) |

Without this change, child RSS never decreases during BGSAVE because madvise cannot release sub-page allocations.

Valkey PR #905](https://github.com/valkey-io/valkey/pull/905) reported ~53% COW overhead for 2000B and ~80% for 500B with up to 12M keys.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fork-child memory release for persistence (strings freed via jemalloc, LZF static buffer); scoped to child with refcount checks, but incorrect free timing could affect rewrite/snapshot correctness.
> 
> **Overview**
> This PR reduces **copy-on-write (CoW)** during **BGSAVE** and **AOF rewrite** in the fork child by changing how serialized string data is released after each key is written.
> 
> **String dismiss path:** `dismissSds()` now calls **`sdsfree()`** instead of **`dismissMemory(MADV_DONTNEED)`**, so jemalloc can return small string allocations to the OS rather than relying on page-granular `madvise`. **`dismissObject()`** skips the transparent-huge-pages guard and the half-page **`size_hint`** cutoff for **`OBJ_STRING`**, while non-string types still use the existing **`madvise`**-based dismiss rules.
> 
> **Fork-child call sites:** **`aof.c`** and **`rdb.c`** always invoke **`dismissObject()`** when **`server.in_fork_child`** (they no longer require serialized size above half a page before calling in).
> 
> **RDB LZF:** **`rdbSaveLzfStringObject`** uses a lazily allocated **8KB static** compression buffer for small outputs so the child does not **`zmalloc`** into pages just freed by **`dismissSds()`**, which would dirty shared pages and worsen CoW.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8de0fe3417f7685065a6c8a25543155753e8cea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->