### PR TITLE
Clarify RedisModule_GetClusterNodeInfo buffer sizes

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -9758,10 +9758,10 @@ size_t RM_GetClusterSize(void) {
  * is returned.
  *
  * The arguments `ip`, `master_id`, `port` and `flags` can be NULL in case we don't
- * need to populate back certain info. If an `ip` and `master_id` (only populated
+ * need to populate back certain info. If an `ip` and/or `master_id` (only populated
  * if the instance is a slave) are specified, they point to buffers holding
- * at least REDISMODULE_NODE_ID_LEN bytes. The strings written back as `ip`
- * and `master_id` are not null terminated.
+ * at least INET6_ADDRSTRLEN (46) and REDISMODULE_NODE_ID_LEN bytes, respectively.
+ * The strings written back as `ip` and `master_id` are not null terminated.
  *
  * The list of flags reported is the following:
  *


### PR DESCRIPTION
Moved from https://github.com/redis/docs/pull/3366, as the module page is auto-generated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change to module API documentation with no code or behavior impact.
> 
> **Overview**
> Updates the in-source documentation for `RedisModule_GetClusterNodeInfo` so module authors size caller buffers correctly.
> 
> The comment now states that optional `ip` and `master_id` outputs may be requested independently (`and/or`), and documents separate minimum lengths: **`INET6_ADDRSTRLEN` (46)** for `ip` and **`REDISMODULE_NODE_ID_LEN`** for `master_id`, replacing the earlier wording that implied both buffers were the node-ID length. **No runtime behavior changes**—only the API comment in `module.c`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e0aa03603f2ece85835994b213e10881c0c997d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->