### PR TITLE
Fix VADD CAS SETATTR attribute accounting

### DIFF
--- a/modules/vector-sets/tests/vadd_cas_setattr.py
+++ b/modules/vector-sets/tests/vadd_cas_setattr.py
@@ -11,6 +11,11 @@ class VAddCASSetAttrAccounting(TestCase):
 
     def _vinfo_map(self):
         info = self.redis.execute_command('VINFO', self.test_key)
+        if isinstance(info, dict):
+            return {
+                self._decode_attr(k): v
+                for k, v in info.items()
+            }
         return {
             (k.decode() if isinstance(k, bytes) else k): v
             for k, v in zip(info[::2], info[1::2])
@@ -19,41 +24,52 @@ class VAddCASSetAttrAccounting(TestCase):
     def _decode_attr(self, value):
         return value.decode() if isinstance(value, bytes) else value
 
+    def _get_config_value(self, config_name):
+        config = self.redis.execute_command('CONFIG', 'GET', config_name)
+        if isinstance(config, dict):
+            return self._decode_attr(config[next(iter(config))])
+        return self._decode_attr(config[1])
+
     def test(self):
-        self.redis.execute_command(
-            'CONFIG', 'SET', 'vset-force-single-threaded-execution', 'no')
+        config_name = 'vset-force-single-threaded-execution'
+        original_value = self._get_config_value(config_name)
 
-        dim = 4
-        seed_vec = generate_random_vector(dim)
-        seed_vec_bytes = struct.pack(f'{dim}f', *seed_vec)
-        result = self.redis.execute_command(
-            'VADD', self.test_key, 'FP32', seed_vec_bytes,
-            f'{self.test_key}:seed')
-        assert result == 1, f"Seed VADD should return 1, got {result}"
+        try:
+            self.redis.execute_command('CONFIG', 'SET', config_name, 'no')
 
-        cas_vec = generate_random_vector(dim)
-        cas_vec_bytes = struct.pack(f'{dim}f', *cas_vec)
-        attr = '{"a":1}'
-        item = f'{self.test_key}:item:cas'
-        result = self.redis.execute_command(
-            'VADD', self.test_key, 'FP32', cas_vec_bytes, item,
-            'CAS', 'SETATTR', attr)
-        assert result == 1, f"CAS VADD should return 1, got {result}"
+            dim = 4
+            seed_vec = generate_random_vector(dim)
+            seed_vec_bytes = struct.pack(f'{dim}f', *seed_vec)
+            result = self.redis.execute_command(
+                'VADD', self.test_key, 'FP32', seed_vec_bytes,
+                f'{self.test_key}:seed')
+            assert result == 1, f"Seed VADD should return 1, got {result}"
 
-        stored_attr = self.redis.execute_command('VGETATTR', self.test_key, item)
-        assert self._decode_attr(stored_attr) == attr, (
-            f"Expected attribute {attr}, got {stored_attr}")
+            cas_vec = generate_random_vector(dim)
+            cas_vec_bytes = struct.pack(f'{dim}f', *cas_vec)
+            attr = '{"a":1}'
+            item = f'{self.test_key}:item:cas'
+            result = self.redis.execute_command(
+                'VADD', self.test_key, 'FP32', cas_vec_bytes, item,
+                'CAS', 'SETATTR', attr)
+            assert result == 1, f"CAS VADD should return 1, got {result}"
 
-        info_map = self._vinfo_map()
-        assert info_map['attributes-count'] == 1, (
-            "VINFO should report one attribute after VADD ... CAS SETATTR")
+            stored_attr = self.redis.execute_command('VGETATTR', self.test_key, item)
+            assert self._decode_attr(stored_attr) == attr, (
+                f"Expected attribute {attr}, got {stored_attr}")
 
-        self.redis.execute_command('DEBUG', 'RELOAD')
+            info_map = self._vinfo_map()
+            assert info_map['attributes-count'] == 1, (
+                "VINFO should report one attribute after VADD ... CAS SETATTR")
 
-        reloaded_attr = self.redis.execute_command('VGETATTR', self.test_key, item)
-        assert self._decode_attr(reloaded_attr) == attr, (
-            f"Expected attribute {attr} after reload, got {reloaded_attr}")
+            self.redis.execute_command('DEBUG', 'RELOAD')
 
-        reloaded_info = self._vinfo_map()
-        assert reloaded_info['attributes-count'] == 1, (
-            "VINFO should still report one attribute after reload")
+            reloaded_attr = self.redis.execute_command('VGETATTR', self.test_key, item)
+            assert self._decode_attr(reloaded_attr) == attr, (
+                f"Expected attribute {attr} after reload, got {reloaded_attr}")
+
+            reloaded_info = self._vinfo_map()
+            assert reloaded_info['attributes-count'] == 1, (
+                "VINFO should still report one attribute after reload")
+        finally:
+            self.redis.execute_command('CONFIG', 'SET', config_name, original_value)

--- a/modules/vector-sets/tests/vadd_cas_setattr.py
+++ b/modules/vector-sets/tests/vadd_cas_setattr.py
@@ -1,0 +1,59 @@
+from test import TestCase, generate_random_vector
+import struct
+
+
+class VAddCASSetAttrAccounting(TestCase):
+    def getname(self):
+        return "[regression] VADD CAS SETATTR keeps attribute accounting"
+
+    def estimated_runtime(self):
+        return 0.1
+
+    def _vinfo_map(self):
+        info = self.redis.execute_command('VINFO', self.test_key)
+        return {
+            (k.decode() if isinstance(k, bytes) else k): v
+            for k, v in zip(info[::2], info[1::2])
+        }
+
+    def _decode_attr(self, value):
+        return value.decode() if isinstance(value, bytes) else value
+
+    def test(self):
+        self.redis.execute_command(
+            'CONFIG', 'SET', 'vset-force-single-threaded-execution', 'no')
+
+        dim = 4
+        seed_vec = generate_random_vector(dim)
+        seed_vec_bytes = struct.pack(f'{dim}f', *seed_vec)
+        result = self.redis.execute_command(
+            'VADD', self.test_key, 'FP32', seed_vec_bytes,
+            f'{self.test_key}:seed')
+        assert result == 1, f"Seed VADD should return 1, got {result}"
+
+        cas_vec = generate_random_vector(dim)
+        cas_vec_bytes = struct.pack(f'{dim}f', *cas_vec)
+        attr = '{"a":1}'
+        item = f'{self.test_key}:item:cas'
+        result = self.redis.execute_command(
+            'VADD', self.test_key, 'FP32', cas_vec_bytes, item,
+            'CAS', 'SETATTR', attr)
+        assert result == 1, f"CAS VADD should return 1, got {result}"
+
+        stored_attr = self.redis.execute_command('VGETATTR', self.test_key, item)
+        assert self._decode_attr(stored_attr) == attr, (
+            f"Expected attribute {attr}, got {stored_attr}")
+
+        info_map = self._vinfo_map()
+        assert info_map['attributes-count'] == 1, (
+            "VINFO should report one attribute after VADD ... CAS SETATTR")
+
+        self.redis.execute_command('DEBUG', 'RELOAD')
+
+        reloaded_attr = self.redis.execute_command('VGETATTR', self.test_key, item)
+        assert self._decode_attr(reloaded_attr) == attr, (
+            f"Expected attribute {attr} after reload, got {reloaded_attr}")
+
+        reloaded_info = self._vinfo_map()
+        assert reloaded_info['attributes-count'] == 1, (
+            "VINFO should still report one attribute after reload")

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -554,6 +554,7 @@ int VADD_CASReply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             newnode = hnsw_insert(vset->hnsw, vec, NULL, 0, 0, nv, ef);
             RedisModule_Assert(newnode != NULL);
         }
+        if (attrib != NULL) vset->numattribs++;
         RedisModule_DictSet(vset->dict,val,newnode);
         val = NULL; // Don't free it later.
         attrib = NULL; // Don't free it later.


### PR DESCRIPTION
Fixes #15269.

This keeps `VADD ... CAS SETATTR` in sync with the normal insert path by incrementing `numattribs` when a CAS insert actually stores an attribute.

Before this change, the CAS path attached the attribute to the node but left the set-wide counter unchanged. That made `VINFO` under-report `attributes-count`, and if the set-wide count stayed at zero, RDB save skipped attribute serialization for the whole vector set.

The new regression test covers the exact path from the issue:

- create the set with a normal insert
- add a second item with `VADD ... CAS SETATTR`
- verify `VINFO` reports one attribute
- `DEBUG RELOAD`
- verify the attribute is still there after reload

Testing:

- `/tmp/redis-vset-venv/bin/python modules/vector-sets/test.py --primary-port 6390 --replica-port 6391`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line counter fix aligned with existing insert logic plus a module regression test; no auth or API surface changes.
> 
> **Overview**
> Fixes **attribute accounting** on the threaded **`VADD ... CAS SETATTR`** path by incrementing `vset->numattribs` in `VADD_CASReply` when an attribute is stored—matching the synchronous `vectorSetInsert` path.
> 
> Without that bump, **`VINFO`** `attributes-count` stayed wrong and RDB could skip attribute serialization when the counter remained zero, so attributes could disappear after reload.
> 
> Adds a regression test: seed insert, CAS insert with `SETATTR`, assert `VINFO` and `VGETATTR`, **`DEBUG RELOAD`**, then assert counts and attributes again (with CAS enabled via config).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f861860093bfd4f901f8371e3d7b64403754be4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->