### PR TITLE
zmalloc: reuse proc stat fd for RSS sampling

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -725,21 +725,46 @@ void zmadvise_dontneed(void *ptr) {
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+
+static int proc_stat_fd = -1;
+static pid_t proc_stat_pid = -1;
+
+static void close_proc_stat_fd(void) {
+    if (proc_stat_fd != -1) close(proc_stat_fd);
+    proc_stat_fd = -1;
+    proc_stat_pid = -1;
+}
+
+static int get_proc_stat_fd(void) {
+    pid_t pid = getpid();
+
+    /* A forked child must reopen /proc/self/stat for its own process. */
+    if (proc_stat_fd != -1 && proc_stat_pid != pid) close_proc_stat_fd();
+    if (proc_stat_fd == -1) {
+        proc_stat_fd = open("/proc/self/stat", O_RDONLY | O_CLOEXEC);
+        if (proc_stat_fd != -1) proc_stat_pid = pid;
+    }
+    return proc_stat_fd;
+}
 #endif
 
 /* Get the i'th field from "/proc/self/stat" note i is 1 based as appears in the 'proc' man page */
 int get_proc_stat_ll(int i, long long *res) {
 #if defined(HAVE_PROC_STAT)
     char buf[4096];
-    int fd, l;
+    ssize_t l = -1;
     char *p, *x;
 
-    if ((fd = open("/proc/self/stat",O_RDONLY)) == -1) return 0;
-    if ((l = read(fd,buf,sizeof(buf)-1)) <= 0) {
-        close(fd);
-        return 0;
+    for (int attempts = 0; attempts < 2; attempts++) {
+        int fd = get_proc_stat_fd();
+        if (fd == -1) return 0;
+
+        l = pread(fd, buf, sizeof(buf)-1, 0);
+        if (l > 0) break;
+
+        close_proc_stat_fd();
     }
-    close(fd);
+    if (l <= 0) return 0;
     buf[l] = '\0';
     if (buf[l-1] == '\n') buf[l-1] = '\0';
 


### PR DESCRIPTION
## Summary

`zmalloc_get_rss()` reads `/proc/self/stat` through `get_proc_stat_ll()` when Redis is built with procfs support. That path is sampled from the memory cron stats, so the current code opens and closes `/proc/self/stat` repeatedly.

This change keeps a cached process-local fd for `/proc/self/stat` and reads it with `pread()`. If Redis forks, the child reopens the descriptor so `/proc/self/stat` still refers to the current process. If a read fails, the descriptor is closed and retried once.

## Validation

- `make -j32`
- `./runtest --single unit/info-command --clients 1`
- Local strace smoke on repeated `INFO memory`: one `/proc/self/stat` open and repeated `pread()` calls, with `used_memory`, `used_memory_rss`, and `mem_fragmentation_ratio` still returned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized procfs read optimization with fork-safe reopen and a single retry; no change to RSS parsing semantics beyond I/O behavior.
> 
> **Overview**
> On Linux builds that use `/proc/self/stat`, RSS sampling no longer **opens and closes** that file on every read. **`get_proc_stat_ll()`** now keeps a process-local cached descriptor (with **`O_CLOEXEC`**) and reads from offset 0 via **`pread()`**, which cuts syscall overhead on paths like the memory cron that call **`zmalloc_get_rss()`** often.
> 
> After **`fork()`**, the cached fd is dropped and reopened so reads still target the current process. A failed **`pread()`** closes the cache and retries once before giving up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3500664b29cc9caea2743791777365994edbab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->