### PR TITLE
Fix potential TCP deadlock in module datatype defrag test

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -627,6 +627,26 @@ proc wait_load_handlers_disconnected {{level 0}} {
 
 proc K { x y } { set x } 
 
+# Send count commands on a deferring client, draining replies in batches to
+# avoid TCP deadlock when deferred replies accumulate.
+proc deferred_batch {rd count cmd_script {batch_size 1000}} {
+    set pending 0
+    for {set idx 0} {$idx < $count} {incr idx} {
+        uplevel 1 [list set i $idx]
+        uplevel 1 $cmd_script
+        incr pending
+        if {$pending == $batch_size} {
+            for {set reply_idx 0} {$reply_idx < $pending} {incr reply_idx} {
+                $rd read
+            }
+            set pending 0
+        }
+    }
+    for {set reply_idx 0} {$reply_idx < $pending} {incr reply_idx} {
+        $rd read
+    }
+}
+
 # Shuffle a list with Fisher-Yates algorithm.
 proc lshuffle {list} {
     set n [llength $list]

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -151,22 +151,7 @@ start_server {tags {"modules external:skip"}} {
             set n 20000
             set dummy "[string repeat x 400]"
             set rd [redis_deferring_client]
-
-            # Use batching to avoid TCP deadlock when deferred replies accumulate.
-            set batch_size 1000
-            for {set i 0} {$i < $n} {incr i} {
-                $rd datatype.set k$i 1 $dummy
-
-                if {($i + 1) % $batch_size == 0} {
-                    for {set j 0} {$j < $batch_size} {incr j} {
-                        $rd read
-                    }
-                }
-            }
-            set remaining [expr {$n % $batch_size}]
-            for {set i 0} {$i < $remaining} {incr i} {
-                $rd read
-            }
+            deferred_batch $rd $n { $rd datatype.set k$i 1 $dummy }
 
             after 120 ;# serverCron only updates the info once in 100ms
             if {$::verbose} {
@@ -177,21 +162,7 @@ start_server {tags {"modules external:skip"}} {
             }
             assert_lessthan [s allocator_frag_ratio] 1.05
 
-            set del_replies 0
-            for {set i 0} {$i < $n} {incr i 2} {
-                $rd del k$i
-                incr del_replies
-
-                if {$del_replies % $batch_size == 0} {
-                    for {set j 0} {$j < $batch_size} {incr j} {
-                        $rd read
-                    }
-                }
-            }
-            set remaining [expr {$del_replies % $batch_size}]
-            for {set i 0} {$i < $remaining} {incr i} {
-                $rd read
-            }
+            deferred_batch $rd [expr {$n / 2}] { $rd del k[expr {$i * 2}] }
             after 120 ;# serverCron only updates the info once in 100ms
             assert_morethan [s allocator_frag_ratio] 1.4
 

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -151,8 +151,22 @@ start_server {tags {"modules external:skip"}} {
             set n 20000
             set dummy "[string repeat x 400]"
             set rd [redis_deferring_client]
-            for {set i 0} {$i < $n} {incr i} { $rd datatype.set k$i 1 $dummy }
-            for {set i 0} {$i < [expr $n]} {incr i} { $rd read } ;# Discard replies
+
+            # Use batching to avoid TCP deadlock when deferred replies accumulate.
+            set batch_size 1000
+            for {set i 0} {$i < $n} {incr i} {
+                $rd datatype.set k$i 1 $dummy
+
+                if {($i + 1) % $batch_size == 0} {
+                    for {set j 0} {$j < $batch_size} {incr j} {
+                        $rd read
+                    }
+                }
+            }
+            set remaining [expr {$n % $batch_size}]
+            for {set i 0} {$i < $remaining} {incr i} {
+                $rd read
+            }
 
             after 120 ;# serverCron only updates the info once in 100ms
             if {$::verbose} {
@@ -163,8 +177,21 @@ start_server {tags {"modules external:skip"}} {
             }
             assert_lessthan [s allocator_frag_ratio] 1.05
 
-            for {set i 0} {$i < $n} {incr i 2} { $rd del k$i }
-            for {set j 0} {$j < $n} {incr j 2} { $rd read } ; # Discard del replies
+            set del_replies 0
+            for {set i 0} {$i < $n} {incr i 2} {
+                $rd del k$i
+                incr del_replies
+
+                if {$del_replies % $batch_size == 0} {
+                    for {set j 0} {$j < $batch_size} {incr j} {
+                        $rd read
+                    }
+                }
+            }
+            set remaining [expr {$del_replies % $batch_size}]
+            for {set i 0} {$i < $remaining} {incr i} {
+                $rd read
+            }
             after 120 ;# serverCron only updates the info once in 100ms
             assert_morethan [s allocator_frag_ratio] 1.4
 


### PR DESCRIPTION
### Issue
The module datatype defrag test sends 20k commands through a deferred client before reading any replies. On slower CI environments this can cause replies to accumulate and fill TCP/socket buffers, leading to flaky `I/O error reading reply` failures.

Failed daily CI: https://github.com/redis/redis/actions/runs/26483280016/job/77985080308

### Change

Fix by batching deferred writes and reply drains, following the same approach used in #14886.

### Test

Daily CI with command: `--loops 200 --single unit/moduleapi/datatype`: https://github.com/vitahlin/redis/actions/runs/26511634526/job/78077483092

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only TCL changes; no production server or module behavior is modified.
> 
> **Overview**
> Adds a shared **`deferred_batch`** helper in `tests/support/util.tcl` that pipelines commands on a deferring Redis client and **drains replies every 1000 commands** (configurable), so large batches do not fill TCP buffers and deadlock.
> 
> The **module datatype active-defrag test** now uses this helper for its ~20k `datatype.set` writes and ~10k `del` passes instead of sending all commands before reading any replies—addressing flaky **`I/O error reading reply`** failures on slow CI, in line with the approach from #14886.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b9dcd47287c64b867ed3dec0e8cc22640ef75b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->