### PR TITLE
Fix flaky slot-stats inline network-bytes-in test

### DIFF
--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -388,6 +388,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
         # SET key value\r\n --> 15 bytes.
         $rd write "SET $key value\r\n"
         $rd flush
+        assert_equal OK [$rd read]
 
         set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
         set expected_slot_stats [


### PR DESCRIPTION
### Issue

CLUSTER SLOT-STATS network-bytes-in, in-line buffer processing can fail because the test sends an inline SET through a deferring client and immediately checks slot stats from another client.

$rd flush only guarantees the request was written to the socket; it does not guarantee Redis has processed the command and updated network-bytes-in.

Failed daily CI: https://github.com/redis/redis/actions/runs/26546983220/job/78200860449

### Change

Wait for the inline SET reply before reading CLUSTER SLOT-STATS.

### Test

Daily CI `--loops 100 --single unit/cluster/slot-stat`: https://github.com/vitahlin/redis/actions/runs/26564855022/job/78256792125

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization change; no production code paths affected.
> 
> **Overview**
> Fixes a **race in the CLUSTER SLOT-STATS inline `network-bytes-in` test** by waiting for the inline `SET` to finish before asserting slot stats.
> 
> The test sends `SET key value\r\n` through a deferring client and used to call `CLUSTER SLOT-STATS` right after `flush`, which only guarantees the bytes left the client socket—not that Redis had processed the command and updated **`network-bytes-in`**. It now **`assert_equal OK [$rd read]`** so processing completes before the stats check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be5b50b9c5806b9f12d85d50af7610628c0e33d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->