### PR TITLE
Adds dir / file context to log message for replica sync fail

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -3363,9 +3363,11 @@ void syncWithMaster(connection *conn) {
         }
         if (dfd == -1) {
             char cwd[256];
+            int saved_errno = errno;
+            
             if (getcwd(cwd, sizeof(cwd)) == NULL)
                 cwd[0] = '\0';
-            serverLog(LL_WARNING,"Opening the temp file ( %s/%s ) needed for MASTER <-> REPLICA synchronization: %s",cwd,tmpfile,strerror(errno));
+            serverLog(LL_WARNING,"Opening the temp file ( %s/%s ) needed for MASTER <-> REPLICA synchronization: %s",cwd,tmpfile,strerror(saved_errno));
             goto error;
         }
         server.repl_transfer_tmpfile = zstrdup(tmpfile);

--- a/src/replication.c
+++ b/src/replication.c
@@ -3362,7 +3362,10 @@ void syncWithMaster(connection *conn) {
             sleep(1);
         }
         if (dfd == -1) {
-            serverLog(LL_WARNING,"Opening the temp file needed for MASTER <-> REPLICA synchronization: %s",strerror(errno));
+            char cwd[256];
+            if (getcwd(cwd, sizeof(cwd)) == NULL)
+                cwd[0] = '\0';
+            serverLog(LL_WARNING,"Opening the temp file ( %s/%s ) needed for MASTER <-> REPLICA synchronization: %s",cwd,tmpfile,strerror(errno));
             goto error;
         }
         server.repl_transfer_tmpfile = zstrdup(tmpfile);


### PR DESCRIPTION
Hey friends, first-time contributor here.  I spent a significant amount of time this week trying to get a sentinel cluster running in an openshift environment, and in retrospect having the value of `dir` printed in the log statement here would have probably preserved a good portion of my sanity 😬 . 

The scenario was that I was using redis-stack-server but didn't realize I needed to set the CLI param for --dir so my config was never loaded (I had a dir statement in my redis.conf but that .conf never got used) and my rdb file was in a directory without write permissions - if I could've seen the path was incorrect when I saw this log message fire, it would've helped me shortcut my troubleshooting.  Made sense in my head that if there's a problem writing to a file, it should tell me the path!

 C isn't my first language but I think I've made a fair stab at this, feel free to correct/adjust if I've misunderstood the code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change on an error path; no replication protocol or I/O behavior change.
> 
> **Overview**
> When a replica cannot create the temporary RDB file during **MASTER ↔ REPLICA** sync (disk-based path in `syncWithMaster`), the warning log now includes the **working directory** and **temp filename**, not only `strerror`.
> 
> The change captures `errno` before `getcwd`, uses `getcwd` into a 256-byte buffer (empty string if that fails), and logs `cwd/tmpfile` with the saved error. That matches the contributor’s goal: misconfigured `--dir` or unwritable paths are easier to spot from logs alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89045b27db9542f801fa67cce5bde73f6718e664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->