### PR TITLE
Close extra clients in slot-stats tests

### DIFF
--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -237,6 +237,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
             ]
         ]
         assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+        $rd close
     }
     R 0 CONFIG RESETSTAT
     R 0 FLUSHALL
@@ -259,6 +260,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
             ]
         ]
         assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+        $rd close
     }
     R 0 CONFIG RESETSTAT
     R 0 FLUSHALL
@@ -283,6 +285,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
             ]
         ]
         assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+        $r1 close
     }
     R 0 CONFIG RESETSTAT
     R 0 FLUSHALL
@@ -398,6 +401,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
         ]
 
         assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+        $rd close
     }
     R 0 CONFIG RESETSTAT
     R 0 FLUSHALL
@@ -424,6 +428,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
         ]
 
         assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+        $rd close
     }
     R 0 CONFIG RESETSTAT
     R 0 FLUSHALL
@@ -445,6 +450,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
         ]
 
         assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+        $r close
     }
     R 0 CONFIG RESETSTAT
     R 0 FLUSHALL
@@ -467,6 +473,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
 
         set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
         assert_empty_slot_stats $slot_stats $metrics_to_assert
+        $rd close
     }
     R 0 CONFIG RESETSTAT
     R 0 FLUSHALL
@@ -511,6 +518,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
             ]
         ]
         assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+        $replica_subcriber close
     }
     R 0 CONFIG RESETSTAT
     R 0 FLUSHALL
@@ -572,6 +580,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
             ]
         ]
         assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+        $rd close
     }
     R 0 CONFIG RESETSTAT
     R 0 FLUSHALL
@@ -620,7 +629,6 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         set slot [R 0 cluster keyslot $channel]
         set publisher [Rn 0]
         set subscriber [redis_client]
-        set replica [redis_deferring_client -1]
 
         # Subscriber client) *3\r\n$10\r\nssubscribe\r\n$7\r\nchannel\r\n:1\r\n --> 38 bytes
         $subscriber SSUBSCRIBE $channel
@@ -643,6 +651,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         ]
         assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
         $subscriber QUIT
+        $subscriber close
     }
     R 0 FLUSHALL
     R 0 CONFIG RESETSTAT
@@ -651,7 +660,6 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         set slot [R 0 cluster keyslot $channel]
         set publisher [Rn 0]
         set subscriber [redis_client]
-        set replica [redis_deferring_client -1]
 
         # Stack multi-slot subscriptions against a single client.
         # For primary channel;
@@ -691,6 +699,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
                 ]
         ]
         assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+        $subscriber close
     }
 }
 


### PR DESCRIPTION
# Close extra clients in slot-stats tests

### Issue
While testing [redis/redis#15279](https://github.com/redis/redis/pull/15279) with: `--loops 100 --single unit/cluster/slot-stats`

I hit this failure after repeated runs:

```text
[ok]: CLUSTER SLOT-STATS metrics replication for new keys (4326 ms)
[ok]: CLUSTER SLOT-STATS metrics replication for existing keys (4361 ms)
[ok]: CLUSTER SLOT-STATS metrics replication for deleting keys (4379 ms)
=== (external:skip cluster) Starting server 127.0.0.1:22819 ok
=== (external:skip cluster) Starting server 127.0.0.1:22820 ok
=== (external:skip cluster) Starting server 127.0.0.1:22821 ok
*** bit out of range 0 - FD_SETSIZE on fd_set ***: terminated
expected non-negative integer but got ""
    while executing
"read $fd $bytes"
    (procedure "read_from_test_client" line 3)
    invoked from within
"read_from_test_client sock55747a39a8c0"
[TIMEOUT]: clients state report follows.
sock55747a39a8c0 => (SPAWNED SERVER) pid:135994
Killing still running Redis server 135907
Killing still running Redis server 135951
Killing still running Redis server 135994
```

Failed CI: https://github.com/vitahlin/redis/actions/runs/26564855022/job/78256792410

`slot-stats.tcl` creates extra Redis test clients that were not closed, so they can accumulate across `--loops` runs in the same Tcl test client process.

### Change

1. Close manually created Redis test clients in `slot-stats.tcl`.
2. Also remove unused replica clients.

### Test

Run daily CI `--loops 100 --single unit/cluster/slot-stats` all passed: https://github.com/vitahlin/redis/actions/runs/26616331202

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only cleanup in slot-stats.tcl with no production or server behavior changes.
> 
> **Overview**
> Fixes **resource leaks in `slot-stats.tcl`** by explicitly closing Redis test clients (`redis_deferring_client`, `redis_client`) at the end of tests that create them, and by dropping unused `replica` deferring-client setup in sharded pub/sub cases.
> 
> This prevents open connections from piling up when running **`--loops 100 --single unit/cluster/slot-stats`**, which previously could trigger **`FD_SETSIZE` / `bit out of range`** failures in the Tcl test harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e473312bc950e2708f123c07a37a578efd50f0c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->