### PR TITLE
Fix garbled "source node not found" error in atomic slot migration

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1628,7 +1628,7 @@ void asmSyncWithSource(connection *conn) {
         /* Create RDB channel connection */
         clusterNode *source_node = clusterLookupNode(task->source, CLUSTER_NAMELEN);
         if (!source_node) {
-            task_error_msg = sdscatfmt(sdsempty(), "Source node %.40s was not found", task->source);
+            task_error_msg = sdscatprintf(sdsempty(), "Source node %.40s was not found", task->source);
             goto error;
         }
         char *ip = clusterNodeIp(source_node);


### PR DESCRIPTION
asmSyncWithSource() built the error with sdscatfmt() and a "%.40s" specifier. sdscatfmt() is not printf: it parses only the single byte after '%' and ignores width/precision, so "%.40s" emits a literal '.', consumes no argument, and task->source is never printed. The message rendered as "Source node .40s was not found", dropping the node name.

task->source is a CLUSTER_NAMELEN (40) byte, non-NUL-terminated buffer (filled via memcpy and always read with an explicit length elsewhere), so simply switching to sdscatfmt's "%s" would strlen() past the buffer. Use sdscatprintf(), which honors the "%.40s" precision and bounds the read to 40 bytes -- matching the sibling error paths in this function that already use sdscatprintf().

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to error string formatting in atomic slot migration; no protocol or data-path behavior change beyond clearer diagnostics when lookup fails.
> 
> **Overview**
> When atomic slot migration cannot resolve the source cluster node while opening the RDB channel (`ASM_INIT_RDBCHANNEL` in `asmSyncWithSource`), the failure message is built with **`sdscatprintf`** instead of **`sdscatfmt`**.
> 
> **`sdscatfmt` does not support printf width/precision**, so a format like `%.40s` was mis-parsed and users saw a garbled string such as *"Source node .40s was not found"* with no node id. **`task->source` is a fixed 40-byte, not necessarily NUL-terminated id**, so the fix uses **`sdscatprintf`** so `%.40s` safely prints up to 40 characters—consistent with other error paths in the same function.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9be06845295f5dee036fa5b34e88510557717241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->