### PR TITLE
tests:remove flaky SAMPLE 1000 case from hotkeys biased-access test

### DIFF
--- a/tests/unit/hotkeys.tcl
+++ b/tests/unit/hotkeys.tcl
@@ -324,7 +324,7 @@ start_server {tags {external:skip "hotkeys"}} {
         assert_equal {OK} [r hotkeys reset]
     }
 
-    foreach sample_ratio {1 100 500 1000} {
+    foreach sample_ratio {1 100 500} {
         test "HOTKEYS detection with biased key access, sample ratio = $sample_ratio" {
             # Generate 100 random keys
             set all_keys {}


### PR DESCRIPTION
Fixes: test faulure in https://github.com/redis/redis/actions/runs/26698983853/job/78688240089

While investigating the failure, I added temporary debug output:

```tcl
puts "cpu_time_array=$cpu_time_array"
puts "num_returned_cpu=$num_returned_cpu"
puts "res=$res"
```

The failing SAMPLE 1000 run produced:

```
cpu_time_array=key_010 3 key_000 3 key_015 2 key_005 2 key_013 2 key_056 2 key_054 2 key_046 1 key_044 1 key_049 1
num_returned_cpu=10
res=5
```

The test becomes statistically unstable at SAMPLE 1000. With only ~50 sampled operations out of 50k requests, the accumulated CPU times collapse into a very narrow range (observed: 1–3 µs), causing frequent ties between hot and cold keys near the Top-K cutoff. The resulting failures are driven by sampling variance rather than HOTKEYS correctness.

Since the test already covers sampling behavior with ratios 1, 100, and 500, removing the 1000 case preserves coverage while eliminating a configuration that is too sparse to produce stable, reproducible assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no runtime or HOTKEYS behavior is modified.
> 
> **Overview**
> Removes **SAMPLE 1000** from the parameterized *HOTKEYS detection with biased key access* test in `tests/unit/hotkeys.tcl`, so the loop only runs sample ratios **1**, **100**, and **500**.
> 
> At ratio 1000, only a tiny fraction of ~50k `SET`s are sampled, so CPU-time rankings tie often near the Top-K cutoff and assertions that expect biased “hot” keys to dominate can fail intermittently—not because HOTKEYS is wrong, but because the test is too sparse to be stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 203f07a82c5220a447276dfd2a77ce042f53b5d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->