### PR TITLE
Fix vector set tests to use RESP2 for default clients

### DIFF
--- a/modules/vector-sets/test.py
+++ b/modules/vector-sets/test.py
@@ -96,10 +96,10 @@ class TestCase:
         self.error_details = None
         self.test_key = f"test:{self.__class__.__name__.lower()}"
         # Primary Redis instance
-        self.redis = redis.Redis(port=primary_port,db=9)
+        self.redis = redis.Redis(port=primary_port,protocol=2,db=9)
         self.redis3 = redis.Redis(port=primary_port,protocol=3,db=9)
         # Replica Redis instance
-        self.replica = redis.Redis(port=replica_port,db=9)
+        self.replica = redis.Redis(port=replica_port,protocol=2,db=9)
         # Replication status
         self.replication_setup = False
         # Ports


### PR DESCRIPTION

## Issue

Failed daily CI: https://github.com/redis/redis/actions/runs/26698983853/job/78688240089

The vector set Python tests intentionally use two clients: 
- the default client (`self.redis`) for the existing RESP2-oriented test expectations
- `self.redis3` for RESP3-specific coverage.

However, the default client did not explicitly set a protocol, so it depended on redis-py's default behavior. With newer redis-py versions, RESP3 is now the default protocol(https://github.com/redis/redis-py/pull/4052). In particular, vector set replies such as `VSIM ... WITHSCORES` may be parsed into map/dict-like structures instead of the RESP2 flat-array shape assumed by existing tests.

## Changes

Explicitly create the default primary and replica Redis clients with `protocol=2`.
`self.redis3` is left unchanged and continues to use `protocol=3` for RESP3-specific test coverage.

## Testing

CI: https://github.com/vitahlin/redis/actions/runs/26733554200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness-only change; no production Redis or module behavior is modified.
> 
> **Overview**
> Fixes flaky vector-set Python CI by pinning the default **primary** and **replica** `redis.Redis` clients in `TestCase` to **`protocol=2` (RESP2)**. Most tests assert flat-array reply shapes (e.g. `WITHSCORES`); without an explicit protocol, newer **redis-py** defaults can parse vector-set replies differently and break those assertions.
> 
> **`self.redis3`** is unchanged and still uses **`protocol=3`** so RESP3-specific behavior continues to be exercised in tests like `with.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbf593b1c02dc756d0676b8f00e0ef2e918cbce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->