### PR TITLE
Bump RediSearch 8.4.10

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.4.9
+MODULE_VERSION = v8.4.10
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single Makefile version bump with no application or security logic changes in this repository.
> 
> **Overview**
> Bumps the **RediSearch** community module build pin from `v8.4.9` to **`v8.4.10`** in `modules/redisearch/Makefile`.
> 
> `MODULE_VERSION` drives the tagged `git clone` in `modules/common.mk`, so builds will fetch and compile the newer upstream release artifact (`redisearch.so`) instead of the previous patch version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b2298621c9718ef59963c82eda1d95cba379b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->