### PR TITLE
Fix SET mutually exclusive NX/XX and IF* options

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -322,12 +322,12 @@ int parseExtendedStringArgumentsOrReply(client *c, int start_pos, extendedString
 
         if ((opt[0] == 'n' || opt[0] == 'N') &&
             (opt[1] == 'x' || opt[1] == 'X') && opt[2] == '\0' &&
-            !(args->flags & OBJ_SET_XX) && (command_type == COMMAND_SET || command_type == COMMAND_MSETEX))
+            !(args->flags & (cond_mut_excl & ~OBJ_SET_NX)) && (command_type == COMMAND_SET || command_type == COMMAND_MSETEX))
         {
             args->flags |= OBJ_SET_NX;
         } else if ((opt[0] == 'x' || opt[0] == 'X') &&
                    (opt[1] == 'x' || opt[1] == 'X') && opt[2] == '\0' &&
-                   !(args->flags & OBJ_SET_NX) && (command_type == COMMAND_SET || command_type == COMMAND_MSETEX))
+                   !(args->flags & (cond_mut_excl & ~OBJ_SET_XX)) && (command_type == COMMAND_SET || command_type == COMMAND_MSETEX))
         {
             args->flags |= OBJ_SET_XX;
         } else if ((opt[0] == 'g' || opt[0] == 'G') &&

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -1594,6 +1594,36 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         assert_equal "world" [r get mykey]
     }
 
+    test {Extended SET - mutually exclusive flags} {
+        r set mykey "hello"
+
+        assert_error "*syntax error*" {r set mykey "world" NX IFEQ "hello"}
+        assert_error "*syntax error*" {r set mykey "world" IFEQ "hello" NX}
+
+        assert_error "*syntax error*" {r set mykey "world" XX IFEQ "hello"}
+        assert_error "*syntax error*" {r set mykey "world" IFEQ "hello" XX}
+
+        assert_error "*syntax error*" {r set mykey "world" NX IFNE "hello"}
+        assert_error "*syntax error*" {r set mykey "world" IFNE "hello" NX}
+
+        assert_error "*syntax error*" {r set mykey "world" XX IFNE "hello"}
+        assert_error "*syntax error*" {r set mykey "world" IFNE "hello" XX}
+
+        assert_error "*syntax error*" {r set mykey "world" NX IFDEQ 0123456789abcdef}
+        assert_error "*syntax error*" {r set mykey "world" IFDEQ 0123456789abcdef NX}
+
+        assert_error "*syntax error*" {r set mykey "world" XX IFDNE 0123456789abcdef}
+        assert_error "*syntax error*" {r set mykey "world" IFDNE 0123456789abcdef XX}
+
+        # IF* conditions are mutually exclusive with each other
+        assert_error "*syntax error*" {r set mykey "world" IFEQ "hello" IFNE "world"}
+        assert_error "*syntax error*" {r set mykey "world" IFNE "world" IFEQ "hello"}
+        assert_error "*syntax error*" {r set mykey "world" IFEQ "hello" IFDEQ 0123456789abcdef}
+        assert_error "*syntax error*" {r set mykey "world" IFDEQ 0123456789abcdef IFDNE fedcba9876543210}
+
+        assert_equal "hello" [r get mykey]
+    }
+
     test {DIGEST always returns exactly 16 hex characters with leading zeros} {
         # Test with a value that produces a digest with leading zeros
         r set foo "v8lf0c11xh8ymlqztfd3eeq16kfn4sspw7fqmnuuq3k3t75em5wdizgcdw7uc26nnf961u2jkfzkjytls2kwlj7626sd"

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -1595,16 +1595,33 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
     }
 
     test {Extended SET - mutually exclusive flags} {
+        r set mykey "hello"
+
         assert_error "*syntax error*" {r set mykey "world" NX IFEQ "hello"}
+        assert_error "*syntax error*" {r set mykey "world" IFEQ "hello" NX}
+
         assert_error "*syntax error*" {r set mykey "world" XX IFEQ "hello"}
+        assert_error "*syntax error*" {r set mykey "world" IFEQ "hello" XX}
+
         assert_error "*syntax error*" {r set mykey "world" NX IFNE "hello"}
+        assert_error "*syntax error*" {r set mykey "world" IFNE "hello" NX}
+
         assert_error "*syntax error*" {r set mykey "world" XX IFNE "hello"}
+        assert_error "*syntax error*" {r set mykey "world" IFNE "hello" XX}
+
         assert_error "*syntax error*" {r set mykey "world" NX IFDEQ 0123456789abcdef}
+        assert_error "*syntax error*" {r set mykey "world" IFDEQ 0123456789abcdef NX}
+
         assert_error "*syntax error*" {r set mykey "world" XX IFDNE 0123456789abcdef}
+        assert_error "*syntax error*" {r set mykey "world" IFDNE 0123456789abcdef XX}
 
         # IF* conditions are mutually exclusive with each other
         assert_error "*syntax error*" {r set mykey "world" IFEQ "hello" IFNE "world"}
+        assert_error "*syntax error*" {r set mykey "world" IFNE "world" IFEQ "hello"}
         assert_error "*syntax error*" {r set mykey "world" IFEQ "hello" IFDEQ 0123456789abcdef}
+        assert_error "*syntax error*" {r set mykey "world" IFDEQ 0123456789abcdef IFDNE fedcba9876543210}
+
+        assert_equal "hello" [r get mykey]
     }
 
     test {DIGEST always returns exactly 16 hex characters with leading zeros} {

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -1595,33 +1595,16 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
     }
 
     test {Extended SET - mutually exclusive flags} {
-        r set mykey "hello"
-
         assert_error "*syntax error*" {r set mykey "world" NX IFEQ "hello"}
-        assert_error "*syntax error*" {r set mykey "world" IFEQ "hello" NX}
-
         assert_error "*syntax error*" {r set mykey "world" XX IFEQ "hello"}
-        assert_error "*syntax error*" {r set mykey "world" IFEQ "hello" XX}
-
         assert_error "*syntax error*" {r set mykey "world" NX IFNE "hello"}
-        assert_error "*syntax error*" {r set mykey "world" IFNE "hello" NX}
-
         assert_error "*syntax error*" {r set mykey "world" XX IFNE "hello"}
-        assert_error "*syntax error*" {r set mykey "world" IFNE "hello" XX}
-
         assert_error "*syntax error*" {r set mykey "world" NX IFDEQ 0123456789abcdef}
-        assert_error "*syntax error*" {r set mykey "world" IFDEQ 0123456789abcdef NX}
-
         assert_error "*syntax error*" {r set mykey "world" XX IFDNE 0123456789abcdef}
-        assert_error "*syntax error*" {r set mykey "world" IFDNE 0123456789abcdef XX}
 
         # IF* conditions are mutually exclusive with each other
         assert_error "*syntax error*" {r set mykey "world" IFEQ "hello" IFNE "world"}
-        assert_error "*syntax error*" {r set mykey "world" IFNE "world" IFEQ "hello"}
         assert_error "*syntax error*" {r set mykey "world" IFEQ "hello" IFDEQ 0123456789abcdef}
-        assert_error "*syntax error*" {r set mykey "world" IFDEQ 0123456789abcdef IFDNE fedcba9876543210}
-
-        assert_equal "hello" [r get mykey]
     }
 
     test {DIGEST always returns exactly 16 hex characters with leading zeros} {


### PR DESCRIPTION
Follow https://github.com/redis/redis/pull/14435

The conditions `NX`, `XX`, `IFEQ`, `IFNE`, `IFDEQ` and `IFDNE` belong to a single mutually-exclusive group. The `IF*` parse branches enforced this against the whole group (`cond_mut_excl`), but the `NX`/`XX` branches only checked each other.

This made rejection depend on argument order. `SET k v NX IFEQ x` was rejected (the `IFEQ` branch saw `NX` already set), but `SET k v IFEQ x NX` was accepted (the NX branch ignored the `IFEQ` flag).

Affected command examples (all silently accepted before the fix):
  - SET k v IFEQ hello NX
  - SET k v IFEQ hello XX
  - SET k v IFNE world NX
  - SET k v IFDEQ 0123456789abcdef NX


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to SET argument parsing only; it rejects previously accepted invalid syntax and does not alter successful SET semantics.
> 
> **Overview**
> **SET** extended-option parsing now treats **NX**, **XX**, and the **IFEQ / IFNE / IFDEQ / IFDNE** conditions as one mutually exclusive group during argument parsing.
> 
> Previously, the **IF\*** branches used the full `cond_mut_excl` mask, but **NX** and **XX** only blocked each other. That made validation depend on token order—for example `SET k v NX IFEQ x` failed while `SET k v IFEQ x NX` was accepted. The **NX** and **XX** branches in `parseExtendedStringArgumentsOrReply` now use the same `(cond_mut_excl & ~OBJ_SET_NX)` / `(cond_mut_excl & ~OBJ_SET_XX)` checks as the **IF\*** options, so invalid combinations always return a syntax error regardless of order.
> 
> Unit tests were added for **NX**/**XX** paired with each **IF\*** flag (both orderings) and for **IF\*** flags combined with each other, asserting the key is unchanged on error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 833bc976c35c9b86473d8b9fec0f8fcea16ec41f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->