### PR TITLE
Bump Redisearch module version to v8.6.8

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.6.7
+MODULE_VERSION = v8.6.8
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single Makefile version constant; no runtime or security logic changes.
> 
> **Overview**
> Bumps the **Redisearch** module build pin from `v8.6.7` to `v8.6.8` in `modules/redisearch/Makefile`, so `get_source` clones that tag when building `redisearch.so`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ddbc0ee9d2c024f05f1e9660d5c83641c098103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->