### PR TITLE
perf: Async Redis Connection Handling to Prevent Main Thread Blocking

### DIFF
--- a/redis-benchmark.c
+++ b/redis-benchmark.c
@@ -1,0 +1,25 @@
+redisContext* getRedisContext(const char* host, int port) {
+    redisContext* context = redisConnectNonBlock(host, port);
+    if (context == NULL) {
+        return NULL;
+    }
+    
+    // Wait for connection to complete
+    int fd = context->fd;
+    struct timeval timeout = {1, 0}; // 1 second timeout
+    fd_set write_fds;
+    FD_ZERO(&write_fds);
+    FD_SET(fd, &write_fds);
+    
+    if (select(fd + 1, NULL, &write_fds, NULL, &timeout) > 0 && FD_ISSET(fd, &write_fds)) {
+        // Check if connection succeeded
+        int error = 0;
+        socklen_t len = sizeof(error);
+        if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &len) == 0 && error == 0) {
+            return context;
+        }
+    }
+    
+    redisFree(context);
+    return NULL;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Isolated benchmark helper using standard non-blocking connect completion; no auth, persistence, or server core changes.
> 
> **Overview**
> Adds **`getRedisContext`** in `redis-benchmark.c` to obtain a hiredis **`redisContext`** without a fully blocking connect: it uses **`redisConnectNonBlock`**, then waits up to **1 second** with **`select`** on the socket’s write readiness, confirms success via **`getsockopt(SO_ERROR)`**, and **`redisFree`**s the context on timeout or connect failure.
> 
> This matches the goal of avoiding indefinite blocking on connect while still returning a ready context (or `NULL`) for benchmark use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 261f5d2f93b44f539de85fbecb55890c5c5734e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->