### PR TITLE
Mark SISMEMBER key with ACCESS flag

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -9175,7 +9175,7 @@ struct COMMAND_ARG SINTERSTORE_Args[] = {
 #ifndef SKIP_CMD_KEY_SPECS_TABLE
 /* SISMEMBER key specs */
 keySpec SISMEMBER_Keyspecs[1] = {
-{NULL,CMD_KEY_RO,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
 };
 #endif
 

--- a/src/commands/sismember.json
+++ b/src/commands/sismember.json
@@ -16,7 +16,8 @@
         "key_specs": [
             {
                 "flags": [
-                    "RO"
+                    "RO",
+                    "ACCESS"
                 ],
                 "begin_search": {
                     "index": {

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -408,10 +408,6 @@ start_server {tags {"acl external:skip"}} {
         assert_equal "OK" [r ACL DRYRUN command-test HSTRLEN read foo]
         assert_equal "OK" [r ACL DRYRUN command-test HSTRLEN write foo]
         assert_match {*has no permissions to access the 'nothing' key*} [r ACL DRYRUN command-test HSTRLEN nothing foo]
-
-        assert_equal "OK" [r ACL DRYRUN command-test SISMEMBER read foo]
-        assert_equal "OK" [r ACL DRYRUN command-test SISMEMBER write foo]
-        assert_match {*has no permissions to access the 'nothing' key*} [r ACL DRYRUN command-test SISMEMBER nothing foo]
     }
 
     # Unlike existence test commands, intersection cardinality commands process the data
@@ -433,6 +429,19 @@ start_server {tags {"acl external:skip"}} {
         assert_equal "OK" [r ACL DRYRUN command-test ZINTERCARD 2 read read]
         assert_match {*has no permissions to access the 'write' key*} [r ACL DRYRUN command-test ZINTERCARD 2 write read]
         assert_match {*has no permissions to access the 'nothing' key*} [r ACL DRYRUN command-test ZINTERCARD 2 nothing read]
+    }
+
+    # Membership and value-lookup commands reveal the contents of a key (e.g.
+    # whether a specific member exists in a set), not just metadata, so they
+    # carry the access requirement and cannot be satisfied by WRITE alone.
+    test {Membership and value-lookup commands are access commands} {
+        assert_equal "OK" [r ACL DRYRUN command-test SISMEMBER read foo]
+        assert_match {*has no permissions to access the 'write' key*} [r ACL DRYRUN command-test SISMEMBER write foo]
+        assert_match {*has no permissions to access the 'nothing' key*} [r ACL DRYRUN command-test SISMEMBER nothing foo]
+
+        assert_equal "OK" [r ACL DRYRUN command-test SMISMEMBER read foo bar]
+        assert_match {*has no permissions to access the 'write' key*} [r ACL DRYRUN command-test SMISMEMBER write foo bar]
+        assert_match {*has no permissions to access the 'nothing' key*} [r ACL DRYRUN command-test SMISMEMBER nothing foo bar]
     }
 
     test {Test general keyspace commands require some type of permission to execute} {


### PR DESCRIPTION
SISMEMBER reads the value of the key (it tests for membership and returns the result to the client). Even though the element is supplied by the caller, the answer exposes the actual contents of the data. A caller can confirm or enumerate set members by probing. Add ACCESS to the SISMEMBER key spec in sismember.json and regenerate commands.def.

Remove the ACL DRYRUN test cases that treated SISMEMBER as a pure existence-test command, since for a set member existence checking can expose the actual elements and add a test for SISMEMBER and SMISMEMBER, which are now consistent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens ACL enforcement for SISMEMBER; deployments that relied on write-only keys for membership probes will start getting NOPERM until read access is granted.
> 
> **Overview**
> **SISMEMBER** is reclassified for ACL v2: its key spec gains the **ACCESS** flag (with **RO**) in `sismember.json`, and `commands.def` is regenerated so dry-run and enforcement treat it like other value-revealing reads, not a pure existence check.
> 
> **ACL DRYRUN** tests no longer expect **SISMEMBER** to succeed with write-only key permission. A dedicated case asserts **SISMEMBER** and **SMISMEMBER** require read (or equivalent) access on the key and fail on write-only or unmatched patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9caf0bace3298b9e8dc57e0dd4982aa291db2ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->