### PR TITLE
Add missing since field to DELEX condition arguments

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -11591,10 +11591,10 @@ keySpec DELEX_Keyspecs[1] = {
 
 /* DELEX condition argument table */
 struct COMMAND_ARG DELEX_condition_Subargs[] = {
-{MAKE_ARG("ifeq-value",ARG_TYPE_STRING,-1,"IFEQ",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("ifne-value",ARG_TYPE_STRING,-1,"IFNE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("ifdeq-digest",ARG_TYPE_INTEGER,-1,"IFDEQ",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("ifdne-digest",ARG_TYPE_INTEGER,-1,"IFDNE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("ifeq-value",ARG_TYPE_STRING,-1,"IFEQ",NULL,"8.4.0",CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("ifne-value",ARG_TYPE_STRING,-1,"IFNE",NULL,"8.4.0",CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("ifdeq-digest",ARG_TYPE_INTEGER,-1,"IFDEQ",NULL,"8.4.0",CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("ifdne-digest",ARG_TYPE_INTEGER,-1,"IFDNE",NULL,"8.4.0",CMD_ARG_NONE,0,NULL)},
 };
 
 /* DELEX argument table */

--- a/src/commands/delex.json
+++ b/src/commands/delex.json
@@ -65,22 +65,26 @@
                     {
                         "name": "ifeq-value",
                         "type": "string",
-                        "token": "IFEQ"
+                        "token": "IFEQ",
+                        "since": "8.4.0"
                     },
                     {
                         "name": "ifne-value",
                         "type": "string",
-                        "token": "IFNE"
+                        "token": "IFNE",
+                        "since": "8.4.0"
                     },
                     {
                         "name": "ifdeq-digest",
                         "type": "integer",
-                        "token": "IFDEQ"
+                        "token": "IFDEQ",
+                        "since": "8.4.0"
                     },
                     {
                         "name": "ifdne-digest",
                         "type": "integer",
-                        "token": "IFDNE"
+                        "token": "IFDNE",
+                        "since": "8.4.0"
                     }
                 ]
             }


### PR DESCRIPTION
## Summary

The `IFEQ`/`IFNE`/`IFDEQ`/`IFDNE` condition arguments in `src/commands/delex.json` are missing the `since` field, while the equivalent arguments in `src/commands/set.json` carry `"since": "8.4.0"`. This adds the field for consistency.

## What changed

- Added `"since": "8.4.0"` to the `ifeq-value`, `ifne-value`, `ifdeq-digest`, and `ifdne-digest` arguments in `delex.json`.
- Regenerated `src/commands.def` via `utils/generate-command-code.py`.

## Why 8.4.0

`DELEX` was introduced in 8.4.0 (its top-level `since` is `8.4.0`), in the same commit that added these condition arguments (#14435, tagged `8.4-int`). So 8.4.0 is the correct introduction version for these arguments, matching the `since` values already present for the same conditions in `set.json`.

## Test plan

- [x] `cd src && python3 ../utils/generate-command-code.py` regenerates cleanly.
- [x] Builds successfully.
- [x] `./runtest --single unit/introspection-2 --clients 1` passes.

## Notes for reviewers

This is metadata-only and scoped strictly to the missing `since` field. The separate type fix for the digest arguments (integer → string) is handled independently in #15305; this PR intentionally leaves the argument types untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only introspection updates with no changes to command execution or parsing logic.
> 
> **Overview**
> Adds **`since`: `8.4.0`** to the **`DELEX`** optional condition arguments **`IFEQ`**, **`IFNE`**, **`IFDEQ`**, and **`IFDNE`** in `delex.json`, aligning command introspection metadata with the same conditional options on **`SET`**.
> 
> Regenerates **`commands.def`** so the generated `DELEX_condition_Subargs` table carries the matching version strings. No runtime command behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e4f9c283f353253b0d518fb21b735807cbad0f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->