### PR TITLE
Fix mem_clients_normal accounting drift when discarding a cached master

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2266,9 +2266,12 @@ void freeClient(client *c) {
     reqresReset(c, 1);
 #endif
 
-    /* Remove the contribution that this client gave to our
-     * incrementally computed memory usage. */
-    if (c->conn)
+    /* Remove the contribution that this client gave to our incrementally
+     * computed memory usage. The cached master must be included too: its conn
+     * was already detached by replicationCacheMaster(), so gating on c->conn
+     * alone would skip the subtraction and leak its size from
+     * mem_clients_normal on every discarded partial resync. */
+    if (c->conn || c == server.cached_master)
         server.stat_clients_type_memory[c->last_memory_type] -=
             c->last_memory_usage;
 

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -2003,3 +2003,36 @@ foreach type {script function} {
         }
     }
 }
+
+start_server {tags {"repl external:skip"}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+    start_server {} {
+        set replica [srv 0 client]
+
+        # Regression: discarding a cached master (after a failed partial
+        # resync) must reverse its contribution to mem_clients_normal.
+        # freeClient() once gated that subtraction on c->conn, but the cached
+        # master's conn was already detached by replicationCacheMaster(), so
+        # the subtraction was skipped and ~one master client (~16KB) leaked
+        # on every full resync.
+        test {mem_clients_normal accounting is reversed when cached master is discarded} {
+            $replica replicaof $master_host $master_port
+            wait_for_sync $replica
+            set base [s 0 mem_clients_normal]
+
+            # change-repl-id forces the next PSYNC to be a full resync, which
+            # discards the cached master via replicationDiscardCachedMaster().
+            for {set j 0} {$j < 10} {incr j} {
+                $master debug change-repl-id
+                $replica replicaof no one
+                $replica replicaof $master_host $master_port
+                wait_for_sync $replica
+            }
+            # Before the fix this grew by ~16KB per cycle; with it, at most one
+            # live master client remains.
+            assert_lessthan [expr {[s 0 mem_clients_normal] - $base}] 50000
+        }
+    }
+}


### PR DESCRIPTION
Found by oranagra 

## The problem

`freeClient()` reverses the client's contribution to `stat_clients_type_memory` (exposed as `mem_clients_normal`) only when `c->conn` is set:

```c
if (c->conn)
    server.stat_clients_type_memory[c->last_memory_type] -= c->last_memory_usage;
```

A replica caches its master on disconnect to attempt a partial resync. replicationCacheMaster() detaches the connection (unlinkClient) before caching, so by the time the cached master is freed by replicationDiscardCachedMaster(), `c->conn` is already NULL. The subtraction is skipped, so the cached master's last accounted size is never removed from mem_clients_normal.

## Fix

Include the cached master in the subtraction by also reversing the contribution when the client being freed is `server.cached_master` (it is still set at the point `replicationDiscardCachedMaster()` calls `freeClient()`, and only cleared right after). 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to client memory accounting on a specific replication path; covered by a new integration test.
> 
> **Overview**
> Fixes **`mem_clients_normal`** drift when a replica drops its cached master after a failed partial resync.
> 
> **`freeClient()`** now reverses **`stat_clients_type_memory`** when the client is **`server.cached_master`**, not only when **`c->conn`** is set. The cached master’s connection is already detached in **`replicationCacheMaster()`**, so the old guard skipped the subtraction and leaked roughly one master client’s worth of memory (~16KB) per discard cycle.
> 
> Adds a replication integration test that repeatedly forces full resyncs via **`debug change-repl-id`** and asserts **`mem_clients_normal`** does not grow by more than a small bound across 10 cycles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dd12731a9ef05010b59186e3a21970bfe30cbf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->