### PR TITLE
networking: assemble bulk reply frame in one pass in addReplyBulkCBuffer

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -506,7 +506,13 @@ static size_t _addBulkStrRefToBuffer(client *c, const void *payload, size_t len)
     return result;
 }
 
-/* Append 'iovcnt' ordered segments as a single logical reply. The replica-reject,
+/* One segment of a multi-part reply. */
+typedef struct replySegment {
+    const char *ptr;
+    size_t len;
+} replySegment;
+
+/* Append 'nseg' ordered segments as a single logical reply. The replica-reject,
  * push-postpone and buffer-then-list spillover chain runs once for the whole batch
  * instead of once per segment, and each segment's bytes are copied at most once
  * (into the static buffer, or spilled to the reply list once the buffer fills) so
@@ -516,10 +522,10 @@ static size_t _addBulkStrRefToBuffer(client *c, const void *payload, size_t len)
  * _addReplyPayloadToBuffer short-circuits to 0 (list non-empty) for the remaining
  * segments, routing the whole tail to the list in order.
  *
- * always_inline so the single-segment wrapper below scalarizes its on-stack iovec
+ * always_inline so the single-segment wrapper below scalarizes its on-stack segment
  * and stays branch-for-branch identical to a direct append on the hot reply path. */
 static inline __attribute__((always_inline))
-void _addReplyIOVToBufferOrList(client *c, const struct iovec *iov, int iovcnt) {
+void _addReplySegmentsToBufferOrList(client *c, const replySegment *seg, int nseg) {
     if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return;
 
     /* Replicas should normally not cause any writes to the reply buffer. In case a rogue replica sent a command on the
@@ -534,7 +540,7 @@ void _addReplyIOVToBufferOrList(client *c, const struct iovec *iov, int iovcnt) 
     }
 
     size_t total = 0;
-    for (int i = 0; i < iovcnt; i++) total += iov[i].iov_len;
+    for (int i = 0; i < nseg; i++) total += seg[i].len;
     c->net_output_bytes_curr_cmd += total;
     /* We call it here because this may affect the reply buffer offset (see the
      * reqres function comment); it is idempotent per request. */
@@ -549,16 +555,16 @@ void _addReplyIOVToBufferOrList(client *c, const struct iovec *iov, int iovcnt) 
     if ((c->flags & CLIENT_PUSHING) && c == server.current_client &&
         server.executing_client && !cmdHasPushAsReply(server.executing_client->cmd))
     {
-        for (int i = 0; i < iovcnt; i++)
-            if (iov[i].iov_len)
+        for (int i = 0; i < nseg; i++)
+            if (seg[i].len)
                 _addReplyPayloadToList(c, server.pending_push_messages,
-                                       iov[i].iov_base, iov[i].iov_len, PLAIN_REPLY);
+                                       seg[i].ptr, seg[i].len, PLAIN_REPLY);
         return;
     }
 
-    for (int i = 0; i < iovcnt; i++) {
-        const char *s = iov[i].iov_base;
-        size_t len = iov[i].iov_len;
+    for (int i = 0; i < nseg; i++) {
+        const char *s = seg[i].ptr;
+        size_t len = seg[i].len;
         if (!len) continue;
         size_t reply_len = _addReplyPayloadToBuffer(c, s, len, PLAIN_REPLY);
         if (len > reply_len)
@@ -566,10 +572,10 @@ void _addReplyIOVToBufferOrList(client *c, const struct iovec *iov, int iovcnt) 
     }
 }
 
-/* Append a single contiguous reply segment (thin wrapper over the vectored form). */
+/* Append a single contiguous reply segment (thin wrapper over the batched form). */
 void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
-    struct iovec iov = { .iov_base = (void *)s, .iov_len = len };
-    _addReplyIOVToBufferOrList(c, &iov, 1);
+    replySegment seg = { s, len };
+    _addReplySegmentsToBufferOrList(c, &seg, 1);
 }
 
 /* Check if the client's pending_ref_reply_node is currently linked in the list.
@@ -1368,7 +1374,7 @@ void addReplyBulk(client *c, robj *obj) {
 /* Add a C buffer as bulk reply.
  *
  * Assemble the "$<len>\r\n" header on the stack and emit the header, payload and
- * trailing CRLF as a single vectored append. The payload is handed over by
+ * trailing CRLF as a single batched append. The payload is handed over by
  * reference rather than copied into a scratch buffer, so this collapses the
  * three per-call passes into one for payloads of any size. */
 void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
@@ -1387,12 +1393,12 @@ void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
         *h++ = '\r';
         *h++ = '\n';
     }
-    struct iovec iov[3] = {
-        { .iov_base = hdr,         .iov_len = (size_t)(h - hdr) },
-        { .iov_base = (void *)p,   .iov_len = len },
-        { .iov_base = (void *)"\r\n", .iov_len = 2 },
+    replySegment seg[3] = {
+        { hdr,    (size_t)(h - hdr) },
+        { p,      len },
+        { "\r\n", 2 },
     };
-    _addReplyIOVToBufferOrList(c, iov, sizeof(iov) / sizeof(iov[0]));
+    _addReplySegmentsToBufferOrList(c, seg, sizeof(seg) / sizeof(seg[0]));
 }
 
 /* Add sds to reply (takes ownership of sds and frees it) */

--- a/src/networking.c
+++ b/src/networking.c
@@ -543,6 +543,61 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
         _addReplyPayloadToList(c, c->reply, s + reply_len, len - reply_len, PLAIN_REPLY);
 }
 
+/* One segment of a multi-part reply, used by _addReplyListToBufferOrList. */
+typedef struct strreply {
+    const char *s;
+    size_t l;
+} strreply;
+
+/* Vectored form of _addReplyToBufferOrList: append 'n' ordered segments as a
+ * single logical reply, running the replica-reject / push-postpone / buffer-
+ * then-list spillover chain once for the whole batch instead of once per
+ * segment. Each segment is copied at most once (into the static buffer, or
+ * spilled to the reply list once the buffer fills), so callers can hand the
+ * payload over by reference instead of pre-assembling it in a scratch buffer.
+ *
+ * Spillover is handled implicitly: once any segment overflows into the reply
+ * list, _addReplyPayloadToBuffer short-circuits to 0 (list non-empty) for the
+ * remaining segments, routing the whole tail to the list in order. */
+static void _addReplyListToBufferOrList(client *c, const strreply *replies, int n) {
+    if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return;
+
+    if (unlikely(clientTypeIsSlave(c))) {
+        sds cmdname = c->lastcmd ? c->lastcmd->fullname : NULL;
+        logInvalidUseAndFreeClientAsync(c, "Replica generated a reply to command '%s'",
+                                        cmdname ? cmdname : "<unknown>");
+        return;
+    }
+
+    size_t total = 0;
+    for (int i = 0; i < n; i++) total += replies[i].l;
+    c->net_output_bytes_curr_cmd += total;
+
+    /* Called once for the whole batch; idempotent per request (see function). */
+    reqresSaveClientReplyOffset(c);
+
+    /* Postpone push messages emitted while processing the current client's
+     * command, mirroring _addReplyToBufferOrList. */
+    if ((c->flags & CLIENT_PUSHING) && c == server.current_client &&
+        server.executing_client && !cmdHasPushAsReply(server.executing_client->cmd))
+    {
+        for (int i = 0; i < n; i++)
+            if (replies[i].l)
+                _addReplyPayloadToList(c, server.pending_push_messages,
+                                       replies[i].s, replies[i].l, PLAIN_REPLY);
+        return;
+    }
+
+    for (int i = 0; i < n; i++) {
+        const char *s = replies[i].s;
+        size_t len = replies[i].l;
+        if (!len) continue;
+        size_t reply_len = _addReplyPayloadToBuffer(c, s, len, PLAIN_REPLY);
+        if (len > reply_len)
+            _addReplyPayloadToList(c, c->reply, s + reply_len, len - reply_len, PLAIN_REPLY);
+    }
+}
+
 /* Check if the client's pending_ref_reply_node is currently linked in the list.
  * A node is considered linked if it has neighbors (prev/next), or if it's the
  * only node in the list (head points to it). */
@@ -1336,49 +1391,33 @@ void addReplyBulk(client *c, robj *obj) {
     addReplyBulkWithFlag(c, obj, 1);
 }
 
-/* Size of the on-stack scratch buffer used by the addReplyBulkCBuffer fast path. */
-#define ADDREPLY_BULK_STACKBUF 256
-/* Bytes reserved in that buffer for framing on top of the payload: the bulk
- * header ('$' + length digits + "\r\n") plus the trailing "\r\n". Only payloads
- * that fit the buffer take the fast path, so the length never exceeds 3 digits
- * and the true worst case is 8 bytes ('$' + 3 + "\r\n" + "\r\n"); 16 leaves a
- * safe margin. */
-#define ADDREPLY_BULK_FRAME_OVERHEAD 16
-
 /* Add a C buffer as bulk reply.
  *
- * Fast path: assemble the whole "$<len>\r\n<payload>\r\n" frame in a stack
- * buffer and emit it via a single _addReplyToBufferOrList call instead of three
- * (header, payload, trailing CRLF). The helper keeps full ownership of the
- * replica/push/CLOSE/encoded/overflow safety chain; this only collapses the
- * three per-call passes into one. Payloads too large for the stack buffer fall
- * through to the original three-call slow path. */
+ * Assemble the "$<len>\r\n" header on the stack and emit the header, payload,
+ * and trailing CRLF as a single vectored append (_addReplyListToBufferOrList)
+ * instead of three separate _addReplyToBufferOrList calls. The payload is never
+ * copied into a scratch buffer — it is handed to the helper by reference — so
+ * this collapses the three per-call passes into one for payloads of any size. */
 void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
     if (_prepareClientToWrite(c) != C_OK) return;
-    char buf[ADDREPLY_BULK_STACKBUF];
-    /* Subtraction form (not "len + N <= sizeof") so a huge len can't wrap. */
-    if (likely(len <= sizeof(buf) - ADDREPLY_BULK_FRAME_OVERHEAD)) {
-        char *dst = buf;
-        if (likely(len < OBJ_SHARED_BULKHDR_LEN)) {
-            const size_t hl = OBJ_SHARED_HDR_STRLEN(len);
-            memcpy(dst, shared.bulkhdr[len]->ptr, hl);
-            dst += hl;
-        } else {
-            *dst++ = '$';
-            dst += ll2string(dst, sizeof(buf) - ADDREPLY_BULK_FRAME_OVERHEAD, (long long)len);
-            *dst++ = '\r';
-            *dst++ = '\n';
-        }
-        memcpy(dst, p, len);
-        dst += len;
-        *dst++ = '\r';
-        *dst++ = '\n';
-        _addReplyToBufferOrList(c, buf, dst - buf);
-        return;
+    char hdr[LONG_STR_SIZE + 3]; /* '$' + up to LONG_STR_SIZE digits + "\r\n" */
+    char *h = hdr;
+    if (likely(len < OBJ_SHARED_BULKHDR_LEN)) {
+        const size_t hl = OBJ_SHARED_HDR_STRLEN(len);
+        memcpy(h, shared.bulkhdr[len]->ptr, hl);
+        h += hl;
+    } else {
+        *h++ = '$';
+        h += ll2string(h, sizeof(hdr) - 3, (long long)len);
+        *h++ = '\r';
+        *h++ = '\n';
     }
-    _addReplyLongLongBulk(c, len);
-    _addReplyToBufferOrList(c, p, len);
-    _addReplyToBufferOrList(c, "\r\n", 2);
+    strreply replies[3] = {
+        { hdr, (size_t)(h - hdr) },
+        { (const char *)p, len },
+        { "\r\n", 2 },
+    };
+    _addReplyListToBufferOrList(c, replies, 3);
 }
 
 /* Add sds to reply (takes ownership of sds and frees it) */

--- a/src/networking.c
+++ b/src/networking.c
@@ -514,8 +514,12 @@ static size_t _addBulkStrRefToBuffer(client *c, const void *payload, size_t len)
  *
  * Spillover is implicit: once any segment overflows into the reply list,
  * _addReplyPayloadToBuffer short-circuits to 0 (list non-empty) for the remaining
- * segments, routing the whole tail to the list in order. */
-static void _addReplyIOVToBufferOrList(client *c, const struct iovec *iov, int iovcnt) {
+ * segments, routing the whole tail to the list in order.
+ *
+ * always_inline so the single-segment wrapper below scalarizes its on-stack iovec
+ * and stays branch-for-branch identical to a direct append on the hot reply path. */
+static inline __attribute__((always_inline))
+void _addReplyIOVToBufferOrList(client *c, const struct iovec *iov, int iovcnt) {
     if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return;
 
     /* Replicas should normally not cause any writes to the reply buffer. In case a rogue replica sent a command on the

--- a/src/networking.c
+++ b/src/networking.c
@@ -539,9 +539,7 @@ void _addReplySegmentsToBufferOrList(client *c, const replySegment *seg, int nse
         return;
     }
 
-    size_t total = 0;
-    for (int i = 0; i < nseg; i++) total += seg[i].len;
-    c->net_output_bytes_curr_cmd += total;
+    for (int i = 0; i < nseg; i++) c->net_output_bytes_curr_cmd += seg[i].len;
     /* We call it here because this may affect the reply buffer offset (see the
      * reqres function comment); it is idempotent per request. */
     reqresSaveClientReplyOffset(c);

--- a/src/networking.c
+++ b/src/networking.c
@@ -506,7 +506,16 @@ static size_t _addBulkStrRefToBuffer(client *c, const void *payload, size_t len)
     return result;
 }
 
-void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
+/* Append 'iovcnt' ordered segments as a single logical reply. The replica-reject,
+ * push-postpone and buffer-then-list spillover chain runs once for the whole batch
+ * instead of once per segment, and each segment's bytes are copied at most once
+ * (into the static buffer, or spilled to the reply list once the buffer fills) so
+ * callers can hand a payload over by reference instead of pre-assembling it.
+ *
+ * Spillover is implicit: once any segment overflows into the reply list,
+ * _addReplyPayloadToBuffer short-circuits to 0 (list non-empty) for the remaining
+ * segments, routing the whole tail to the list in order. */
+static void _addReplyIOVToBufferOrList(client *c, const struct iovec *iov, int iovcnt) {
     if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return;
 
     /* Replicas should normally not cause any writes to the reply buffer. In case a rogue replica sent a command on the
@@ -520,9 +529,11 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
         return;
     }
 
-    c->net_output_bytes_curr_cmd += len;
-    /* We call it here because this function may affect the reply
-     * buffer offset (see function comment) */
+    size_t total = 0;
+    for (int i = 0; i < iovcnt; i++) total += iov[i].iov_len;
+    c->net_output_bytes_curr_cmd += total;
+    /* We call it here because this may affect the reply buffer offset (see the
+     * reqres function comment); it is idempotent per request. */
     reqresSaveClientReplyOffset(c);
 
     /* If we're processing a push message into the current client (i.e. executing PUBLISH
@@ -534,68 +545,27 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
     if ((c->flags & CLIENT_PUSHING) && c == server.current_client &&
         server.executing_client && !cmdHasPushAsReply(server.executing_client->cmd))
     {
-        _addReplyPayloadToList(c,server.pending_push_messages,s,len,PLAIN_REPLY);
-        return;
-    }
-
-    size_t reply_len = _addReplyPayloadToBuffer(c, s, len, PLAIN_REPLY);
-    if (len > reply_len)
-        _addReplyPayloadToList(c, c->reply, s + reply_len, len - reply_len, PLAIN_REPLY);
-}
-
-/* One segment of a multi-part reply, used by _addReplyListToBufferOrList. */
-typedef struct strreply {
-    const char *s;
-    size_t l;
-} strreply;
-
-/* Vectored form of _addReplyToBufferOrList: append 'n' ordered segments as a
- * single logical reply, running the replica-reject / push-postpone / buffer-
- * then-list spillover chain once for the whole batch instead of once per
- * segment. Each segment is copied at most once (into the static buffer, or
- * spilled to the reply list once the buffer fills), so callers can hand the
- * payload over by reference instead of pre-assembling it in a scratch buffer.
- *
- * Spillover is handled implicitly: once any segment overflows into the reply
- * list, _addReplyPayloadToBuffer short-circuits to 0 (list non-empty) for the
- * remaining segments, routing the whole tail to the list in order. */
-static void _addReplyListToBufferOrList(client *c, const strreply *replies, int n) {
-    if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return;
-
-    if (unlikely(clientTypeIsSlave(c))) {
-        sds cmdname = c->lastcmd ? c->lastcmd->fullname : NULL;
-        logInvalidUseAndFreeClientAsync(c, "Replica generated a reply to command '%s'",
-                                        cmdname ? cmdname : "<unknown>");
-        return;
-    }
-
-    size_t total = 0;
-    for (int i = 0; i < n; i++) total += replies[i].l;
-    c->net_output_bytes_curr_cmd += total;
-
-    /* Called once for the whole batch; idempotent per request (see function). */
-    reqresSaveClientReplyOffset(c);
-
-    /* Postpone push messages emitted while processing the current client's
-     * command, mirroring _addReplyToBufferOrList. */
-    if ((c->flags & CLIENT_PUSHING) && c == server.current_client &&
-        server.executing_client && !cmdHasPushAsReply(server.executing_client->cmd))
-    {
-        for (int i = 0; i < n; i++)
-            if (replies[i].l)
+        for (int i = 0; i < iovcnt; i++)
+            if (iov[i].iov_len)
                 _addReplyPayloadToList(c, server.pending_push_messages,
-                                       replies[i].s, replies[i].l, PLAIN_REPLY);
+                                       iov[i].iov_base, iov[i].iov_len, PLAIN_REPLY);
         return;
     }
 
-    for (int i = 0; i < n; i++) {
-        const char *s = replies[i].s;
-        size_t len = replies[i].l;
+    for (int i = 0; i < iovcnt; i++) {
+        const char *s = iov[i].iov_base;
+        size_t len = iov[i].iov_len;
         if (!len) continue;
         size_t reply_len = _addReplyPayloadToBuffer(c, s, len, PLAIN_REPLY);
         if (len > reply_len)
             _addReplyPayloadToList(c, c->reply, s + reply_len, len - reply_len, PLAIN_REPLY);
     }
+}
+
+/* Append a single contiguous reply segment (thin wrapper over the vectored form). */
+void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
+    struct iovec iov = { .iov_base = (void *)s, .iov_len = len };
+    _addReplyIOVToBufferOrList(c, &iov, 1);
 }
 
 /* Check if the client's pending_ref_reply_node is currently linked in the list.
@@ -1393,14 +1363,14 @@ void addReplyBulk(client *c, robj *obj) {
 
 /* Add a C buffer as bulk reply.
  *
- * Assemble the "$<len>\r\n" header on the stack and emit the header, payload,
- * and trailing CRLF as a single vectored append (_addReplyListToBufferOrList)
- * instead of three separate _addReplyToBufferOrList calls. The payload is never
- * copied into a scratch buffer — it is handed to the helper by reference — so
- * this collapses the three per-call passes into one for payloads of any size. */
+ * Assemble the "$<len>\r\n" header on the stack and emit the header, payload and
+ * trailing CRLF as a single vectored append. The payload is handed over by
+ * reference rather than copied into a scratch buffer, so this collapses the
+ * three per-call passes into one for payloads of any size. */
 void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
     if (_prepareClientToWrite(c) != C_OK) return;
-    char hdr[LONG_STR_SIZE + 3]; /* '$' + up to LONG_STR_SIZE digits + "\r\n" */
+    /* '$' + up to 20 digits (64-bit) + "\r\n"; LONG_STR_SIZE already budgets the NUL. */
+    char hdr[LONG_STR_SIZE + 3];
     char *h = hdr;
     if (likely(len < OBJ_SHARED_BULKHDR_LEN)) {
         const size_t hl = OBJ_SHARED_HDR_STRLEN(len);
@@ -1408,16 +1378,17 @@ void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
         h += hl;
     } else {
         *h++ = '$';
-        h += ll2string(h, sizeof(hdr) - 3, (long long)len);
+        /* Room left after '$', reserving the 2 trailing bytes for "\r\n". */
+        h += ll2string(h, sizeof(hdr) - (size_t)(h - hdr) - 2, (long long)len);
         *h++ = '\r';
         *h++ = '\n';
     }
-    strreply replies[3] = {
-        { hdr, (size_t)(h - hdr) },
-        { (const char *)p, len },
-        { "\r\n", 2 },
+    struct iovec iov[3] = {
+        { .iov_base = hdr,         .iov_len = (size_t)(h - hdr) },
+        { .iov_base = (void *)p,   .iov_len = len },
+        { .iov_base = (void *)"\r\n", .iov_len = 2 },
     };
-    _addReplyListToBufferOrList(c, replies, 3);
+    _addReplyIOVToBufferOrList(c, iov, sizeof(iov) / sizeof(iov[0]));
 }
 
 /* Add sds to reply (takes ownership of sds and frees it) */

--- a/src/networking.c
+++ b/src/networking.c
@@ -1336,9 +1336,31 @@ void addReplyBulk(client *c, robj *obj) {
     addReplyBulkWithFlag(c, obj, 1);
 }
 
-/* Add a C buffer as bulk reply */
+/* Add a C buffer as bulk reply.
+ *
+ * Fast path: assemble "$N\r\n<payload>\r\n" into a stack buffer and emit
+ * via a single _addReplyToBufferOrList call. Reuses the existing helper's
+ * full safety chain (replica/push/CLOSE/encoded/overflow), but pays one
+ * per-call branch chain instead of three. Slow path covers payloads too
+ * large for the stack buffer. */
 void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
     if (_prepareClientToWrite(c) != C_OK) return;
+    char buf[256];
+    if (likely(len + 16 <= sizeof(buf))) {
+        char *dst = buf;
+        if (likely(len < OBJ_SHARED_BULKHDR_LEN)) {
+            const size_t hl = OBJ_SHARED_HDR_STRLEN(len);
+            memcpy(dst, shared.bulkhdr[len]->ptr, hl); dst += hl;
+        } else {
+            *dst++ = '$';
+            dst += ll2string(dst, sizeof(buf) - 16, (long long)len);
+            *dst++ = '\r'; *dst++ = '\n';
+        }
+        memcpy(dst, p, len); dst += len;
+        *dst++ = '\r'; *dst++ = '\n';
+        _addReplyToBufferOrList(c, buf, dst - buf);
+        return;
+    }
     _addReplyLongLongBulk(c, len);
     _addReplyToBufferOrList(c, p, len);
     _addReplyToBufferOrList(c, "\r\n", 2);

--- a/src/networking.c
+++ b/src/networking.c
@@ -1336,28 +1336,43 @@ void addReplyBulk(client *c, robj *obj) {
     addReplyBulkWithFlag(c, obj, 1);
 }
 
+/* Size of the on-stack scratch buffer used by the addReplyBulkCBuffer fast path. */
+#define ADDREPLY_BULK_STACKBUF 256
+/* Bytes reserved in that buffer for framing on top of the payload: the bulk
+ * header ('$' + length digits + "\r\n") plus the trailing "\r\n". Only payloads
+ * that fit the buffer take the fast path, so the length never exceeds 3 digits
+ * and the true worst case is 8 bytes ('$' + 3 + "\r\n" + "\r\n"); 16 leaves a
+ * safe margin. */
+#define ADDREPLY_BULK_FRAME_OVERHEAD 16
+
 /* Add a C buffer as bulk reply.
  *
- * Fast path: assemble "$N\r\n<payload>\r\n" into a stack buffer and emit
- * via a single _addReplyToBufferOrList call. Reuses the existing helper's
- * full safety chain (replica/push/CLOSE/encoded/overflow), but pays one
- * per-call branch chain instead of three. Slow path covers payloads too
- * large for the stack buffer. */
+ * Fast path: assemble the whole "$<len>\r\n<payload>\r\n" frame in a stack
+ * buffer and emit it via a single _addReplyToBufferOrList call instead of three
+ * (header, payload, trailing CRLF). The helper keeps full ownership of the
+ * replica/push/CLOSE/encoded/overflow safety chain; this only collapses the
+ * three per-call passes into one. Payloads too large for the stack buffer fall
+ * through to the original three-call slow path. */
 void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
     if (_prepareClientToWrite(c) != C_OK) return;
-    char buf[256];
-    if (likely(len + 16 <= sizeof(buf))) {
+    char buf[ADDREPLY_BULK_STACKBUF];
+    /* Subtraction form (not "len + N <= sizeof") so a huge len can't wrap. */
+    if (likely(len <= sizeof(buf) - ADDREPLY_BULK_FRAME_OVERHEAD)) {
         char *dst = buf;
         if (likely(len < OBJ_SHARED_BULKHDR_LEN)) {
             const size_t hl = OBJ_SHARED_HDR_STRLEN(len);
-            memcpy(dst, shared.bulkhdr[len]->ptr, hl); dst += hl;
+            memcpy(dst, shared.bulkhdr[len]->ptr, hl);
+            dst += hl;
         } else {
             *dst++ = '$';
-            dst += ll2string(dst, sizeof(buf) - 16, (long long)len);
-            *dst++ = '\r'; *dst++ = '\n';
+            dst += ll2string(dst, sizeof(buf) - ADDREPLY_BULK_FRAME_OVERHEAD, (long long)len);
+            *dst++ = '\r';
+            *dst++ = '\n';
         }
-        memcpy(dst, p, len); dst += len;
-        *dst++ = '\r'; *dst++ = '\n';
+        memcpy(dst, p, len);
+        dst += len;
+        *dst++ = '\r';
+        *dst++ = '\n';
         _addReplyToBufferOrList(c, buf, dst - buf);
         return;
     }

--- a/src/networking.c
+++ b/src/networking.c
@@ -1379,22 +1379,26 @@ void addReplyBulk(client *c, robj *obj) {
  * three per-call passes into one for payloads of any size. */
 void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
     if (_prepareClientToWrite(c) != C_OK) return;
+    const char *hdr;
+    size_t hdr_len;
     /* '$' + up to 20 digits (64-bit) + "\r\n"; LONG_STR_SIZE already budgets the NUL. */
-    char hdr[LONG_STR_SIZE + 3];
-    char *h = hdr;
+    char hdrbuf[LONG_STR_SIZE + 3];
     if (likely(len < OBJ_SHARED_BULKHDR_LEN)) {
-        const size_t hl = OBJ_SHARED_HDR_STRLEN(len);
-        memcpy(h, shared.bulkhdr[len]->ptr, hl);
-        h += hl;
+        /* Point straight at the shared "$<len>\r\n" object — no copy needed. */
+        hdr = shared.bulkhdr[len]->ptr;
+        hdr_len = OBJ_SHARED_HDR_STRLEN(len);
     } else {
+        char *h = hdrbuf;
         *h++ = '$';
         /* Room left after '$', reserving the 2 trailing bytes for "\r\n". */
-        h += ll2string(h, sizeof(hdr) - (size_t)(h - hdr) - 2, (long long)len);
+        h += ll2string(h, sizeof(hdrbuf) - (size_t)(h - hdrbuf) - 2, (long long)len);
         *h++ = '\r';
         *h++ = '\n';
+        hdr = hdrbuf;
+        hdr_len = (size_t)(h - hdrbuf);
     }
     replySegment seg[3] = {
-        { hdr,    (size_t)(h - hdr) },
+        { hdr,    hdr_len },
         { p,      len },
         { "\r\n", 2 },
     };


### PR DESCRIPTION
### What

`addReplyBulkCBuffer()` emits a single bulk reply with **three** calls into `_addReplyToBufferOrList()` — one for the `$<len>\r\n` header, one for the payload, and one for the trailing `\r\n`:

```c
_addReplyLongLongBulk(c, len);          /* "$<len>\r\n" */
_addReplyToBufferOrList(c, p, len);     /* payload     */
_addReplyToBufferOrList(c, "\r\n", 2);  /* CRLF        */
```

Each of those calls re-runs the same per-call work (client-flag checks, the replica/push branches, the output-byte accounting, and the buffer-vs-reply-list decision).

This PR introduces a small **batched** helper, `_addReplySegmentsToBufferOrList(c, seg, nseg)`, that appends an ordered set of segments as one logical reply — running that per-call chain **once** for the whole batch. `addReplyBulkCBuffer()` now hands it three segments (header, payload **by reference**, trailing CRLF), so the frame is emitted in a single pass with the payload copied at most once and with no size ceiling. For lengths below `OBJ_SHARED_BULKHDR_LEN` the header segment points straight at the shared `$<len>\r\n` object, so there is no header copy at all; longer lengths are formatted into a small stack buffer.

As suggested in review, the helper is the single implementation of the buffer/list safety chain: `_addReplyToBufferOrList(c, s, len)` is now a thin one-segment wrapper over it. This removes the previously-duplicated replica/push/accounting/spillover logic — there is exactly one copy to keep correct. Segments use a small `replySegment { const char *ptr; size_t len; }` container rather than `struct iovec`, since these buffers never reach `writev()`/`readv()`. The helper is `always_inline`, so the one-segment wrapper scalarizes its on-stack segment and the common single-segment callers (`addReply`, length/count headers, errors) compile to the same straight-line code as before — verified at the disassembly level on both x86-64 and aarch64, no added per-reply overhead.

### Why

For commands that emit many small bulk elements per reply (`HGETALL` on a hash with many fields, `LRANGE`, `SMEMBERS`, …), the per-call overhead of the three-call sequence is a measurable fraction of the command's CPU. Collapsing to one pass removes that repeated work. The bytes written to the client are unchanged.

### Correctness

- Output is **byte-identical** to the previous three-call path for every encoding and size: header via the existing `shared.bulkhdr[]` for short lengths, otherwise `$` + `ll2string` + CRLF; then the payload; then CRLF.
- The single-segment wrapper is behaviourally identical to the previous `_addReplyToBufferOrList` (a zero-length append remains a no-op; replica/push/CLOSE/encoded/spillover handling is the same code, run once per batch).
- Payloads of any size are handled uniformly; a reply that overflows the static buffer spills to the reply list mid-frame in order (verified: a 100 KB value round-trips byte-identically; boundary sizes straddling the static-buffer edge are exact).
- `unit/protocol`, `integration/logging`, `unit/pubsub` (push path), and the `unit/type/{hash,list,set,incr}` / `unit/keyspace` / `unit/scan` suites pass locally.

### Benchmarks

Fixed-baseline A/B — each arm runs against **this PR's own merge-base** on the same host, in the same run window, `oss-standalone`, n=3 per arm. Values are medians of `Totals.Ops/sec`; CVs on the cells below are 0.0–0.8%, so the ordering is not run-to-run noise.

- baseline `23b90e906fbf4ee6207d94e97e224b8c31a90e03` (merge-base)
- PR head `eea2d8804315d3556746628e57d40f299a32a8a1`

| Test | m7i.metal-24xl (Sapphire Rapids) | m8g.metal-24xl (Graviton4) |
|---|--:|--:|
| `1key-set-1K-elements-smembers` | 31690 → 41643 &nbsp;**+31.4%** | 34406 → 37300 &nbsp;**+8.4%** |
| `1key-list-1K-elements-lrange-all-elements` | 34610 → 43256 &nbsp;**+25.0%** | 37113 → 39068 &nbsp;**+5.3%** |
| `1key-list-100-elements-lrange-all-elements-pipeline-10` | 276283 → 322137 &nbsp;**+16.6%** | 299405 → 311944 &nbsp;+4.2% |
| `1key-hash-1K-fields-hgetall` | 19287 → 21321 &nbsp;**+10.5%** | 18318 → 19953 &nbsp;**+8.9%** |
| `1key-hash-1K-fields-hgetall-pipeline-10` | 18886 → 18458 &nbsp;−2.3% | 17383 → 19187 &nbsp;**+10.4%** |
| `1key-list-1K-elements-lrange-all-elements-pipeline-10` | 36564 → 35542 &nbsp;−2.8% | 34165 → 37278 &nbsp;**+9.1%** |

Controls — the single-segment path must stay inert:

| Test | m7i | m8g |
|---|--:|--:|
| `1Mkeys-string-get-100B` | −1.1% | −0.1% |
| `1Mkeys-string-get-100B-pipeline-10` | +0.8% | −0.5% |
| `1Mkeys-bitmap-getbit-pipeline-10` | +0.1% | −0.6% |
| `3Mkeys-string-get-with-1KiB-values-pipeline-10-2000_conns` | +0.3% | −0.1% |

No regression beyond 3% on either host. The largest wins land on **element-dense** replies (many small elements per command); replies with few or large elements move little, as expected.

**One caveat, stated plainly:** the *pipelined* LRANGE/HGETALL variants are microarchitecture-dependent — +9–10% on Graviton4, −2.3%/−2.8% on Sapphire Rapids. The non-pipelined forms win consistently on both. I do not claim a blanket win on the pipelined ones.

This also supersedes my earlier comment reporting ARM as neutral: that measurement came from the pre-vectored revision. The current revision wins on ARM too, and `_addReplyToBufferOrList` still compiles to the same 25 instructions as the baseline on aarch64 — no call, no stack frame, no canary added — so the single-segment wrapper is free there exactly as on x86.

Full report, including the header-copy-elision ablation and the baseline-variance analysis: [benchmark report for `eea2d880`](https://github.com/redis/redis/pull/15313#issuecomment-5198251085).

### Notes

- `addReplyBulkSds` intentionally keeps its existing multi-call form: it `sdsfree()`s the payload between the payload and CRLF appends, so it cannot share the single vectored call without reordering the free — a mechanical follow-up if wanted.

### Risk

Low. No protocol or behaviour change (byte-identical replies). The safety chain logic is unchanged — it is now in one place instead of two, and runs the same number of times for single-segment callers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hot-path reply buffering only; behavior and on-the-wire output are intended to stay byte-identical, with logic consolidated rather than changed.
> 
> **Overview**
> Refactors client reply assembly so **multiple byte segments** can be appended in **one pass** through the replica/push/accounting and static-buffer-vs-reply-list logic.
> 
> Adds `_addReplySegmentsToBufferOrList()` with a small `replySegment` type; `_addReplyToBufferOrList()` becomes a single-segment wrapper (inlined so the common one-chunk path stays equivalent). **`addReplyBulkCBuffer()`** now builds the `$<len>\r\n` header (shared bulk header or stack buffer) and emits **header + payload by reference + trailing CRLF** as one three-segment batch instead of three separate `_addReplyToBufferOrList()` calls.
> 
> Wire format is unchanged; the win is fewer repeated safety checks and buffer decisions on element-dense replies (e.g. many bulks per command).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eea2d8804315d3556746628e57d40f299a32a8a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

