### PR TITLE
Fix Codecov action GPG verification failure

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,7 +26,7 @@ jobs:
         make lcov
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+      uses: codecov/codecov-action@v7
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,7 +26,7 @@ jobs:
         make lcov
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:


### PR DESCRIPTION
## Issue

The Codecov workflow failed while running `codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2` (`v6`) because the downloaded Codecov CLI could not be verified with GPG.

```text
Run codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
==> Running Action version 6.0.0
...
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
    Exiting...
```

## Change

Update the Codecov upload step to use `codecov/codecov-action v7.0.0`, which includes the updated wrapper/signature verification behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow dependency pin with no application or coverage logic changes.
> 
> **Overview**
> Fixes the **Codecov** GitHub Actions workflow failing on GPG verification when downloading the Codecov CLI (`No public key` / signature check failure on **v6**).
> 
> The upload step in `.github/workflows/codecov.yml` now pins **`codecov/codecov-action@v7.0.0`** (commit `fb8b3582…`) instead of **v6**. Coverage inputs are unchanged: `./src/redis.info`, `disable_search: true`, and `fail_ci_if_error: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9ae6bdbe58d84f5592e033af37cc15c678e371c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->