### PR TITLE
fix: gate AVX2 BITOP dispatch with minimum length threshold

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -31,6 +31,11 @@
 
 #ifdef HAVE_AVX2
 #define BITOP_USE_AVX2 (__builtin_cpu_supports("avx2"))
+/* Minimum byte-length before dispatching to bitopCommandAVX. The AVX2
+ * function cannot be inlined (target("avx2") attribute) so each call pays
+ * a vzeroupper + constant-setup overhead.  For short strings that overhead
+ * exceeds the SIMD gain, making the scalar word-at-a-time path faster. */
+#define BITOP_AVX2_MIN_LEN 1024
 #else
 #define BITOP_USE_AVX2 0
 #endif
@@ -1335,7 +1340,7 @@ void bitopCommand(client *c) {
 #endif
 
 #if defined(HAVE_AVX2)
-        if (!useAVX && BITOP_USE_AVX2) {
+        if (!useAVX && BITOP_USE_AVX2 && (minlen >= BITOP_AVX2_MIN_LEN)) {
             j = bitopCommandAVX(src, res, op, numkeys, minlen);
 
             serverAssert(minlen >= j);


### PR DESCRIPTION
Fixes #15289

## Problem

After PR #13898 introduced AVX2 support for BITOP, operations on short string values regressed by 3–5%.

Unlike the AVX512 path, which is only used when `minlen >= 10000`, the AVX2 path is selected for all operations with `minlen >= 32`. For short strings, the cost of dispatching to the AVX2 implementation outweighs the SIMD benefit, causing the existing scalar fast path to perform better.

## Solution

Introduce `BITOP_AVX2_MIN_LEN` (1024) and only dispatch to the AVX2 implementation when the input length is large enough to amortize the call overhead.

This restores the previous performance characteristics for short strings while preserving the AVX2 speedup for larger inputs.

## Testing

Verified using the benchmark provided in #15289.

Short string workloads no longer show the regression, while larger inputs continue to benefit from AVX2 acceleration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single performance dispatch threshold in BITOP; no API or semantics change, only which implementation runs for a given input size.
> 
> **Overview**
> Fixes a **3–5% regression** on short-string `BITOP` workloads by only calling the non-inlinable AVX2 path when inputs are long enough to pay for dispatch overhead.
> 
> Adds **`BITOP_AVX2_MIN_LEN` (1024)** in `bitops.c` with a comment explaining `vzeroupper` and setup cost versus SIMD gain. **`bitopCommand`** now requires `minlen >= BITOP_AVX2_MIN_LEN` before `bitopCommandAVX`, mirroring the existing AVX512 length gate (10k). Shorter operations stay on the scalar word-at-a-time fast path; large inputs still use AVX2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee01123db26e80a2904bd233b479fcbb7f5fcad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->