### PR TITLE
redis-cli: Fix unbalanced bracket in hints for optional arguments

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1220,6 +1220,9 @@ static sds addHintForArgument(sds hint, cliCommandArg *arg) {
     }
 
     /* Surround an optional arg with brackets, unless it's partially matched. */
+    /* We store the result in a variable since arg->matched flag would be
+       reset inside addHintForRepeatedArgument() which is being called in this codepath
+    */
     int optional_unmatched = (arg->flags & CMD_ARG_OPTIONAL) && !arg->matched;
     if (optional_unmatched) {
         hint = sdscat(hint, "[");

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1220,7 +1220,8 @@ static sds addHintForArgument(sds hint, cliCommandArg *arg) {
     }
 
     /* Surround an optional arg with brackets, unless it's partially matched. */
-    if ((arg->flags & CMD_ARG_OPTIONAL) && !arg->matched) {
+    int optional_unmatched = (arg->flags & CMD_ARG_OPTIONAL) && !arg->matched;
+    if (optional_unmatched) {
         hint = sdscat(hint, "[");
     }
 
@@ -1263,7 +1264,7 @@ static sds addHintForArgument(sds hint, cliCommandArg *arg) {
 
     hint = addHintForRepeatedArgument(hint, arg);
 
-    if ((arg->flags & CMD_ARG_OPTIONAL) && !arg->matched) {
+    if (optional_unmatched) {
         hint = sdscat(hint, "]");
     }
 

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1220,8 +1220,10 @@ static sds addHintForArgument(sds hint, cliCommandArg *arg) {
     }
 
     /* Surround an optional arg with brackets, unless it's partially matched. */
-    /* We store the result in a variable since arg->matched flag would be
-       reset inside addHintForRepeatedArgument() which is being called in this codepath
+    /* Preserve the original unmatched state because addHintForRepeatedArgument()
+    * resets arg->matched. If an already-matched optional argument is reset to
+    * unmatched, checking arg->matched again would add a closing ']' even though
+    * no opening '[' was added, resulting in an unbalanced bracket in the hint.
     */
     int optional_unmatched = (arg->flags & CMD_ARG_OPTIONAL) && !arg->matched;
     if (optional_unmatched) {

--- a/tests/assets/test_cli_hint_suite.txt
+++ b/tests/assets/test_cli_hint_suite.txt
@@ -25,13 +25,12 @@
 "BITFIELD_RO k " "[GET encoding offset [GET encoding offset ...]]"
 "BITFIELD_RO k GE" "[GET encoding offset [GET encoding offset ...]]"
 "BITFIELD_RO k GET" "[GET encoding offset [GET encoding offset ...]]"
-# TODO: The following hints end with an unbalanced "]" which shouldn't be there.
-"BITFIELD_RO k GET " "encoding offset [GET encoding offset ...]]"
-"BITFIELD_RO k GET xyz " "offset [GET encoding offset ...]]"
-"BITFIELD_RO k GET xyz 12 " "[GET encoding offset ...]]"
-"BITFIELD_RO k GET xyz 12 GET " "encoding offset [GET encoding offset ...]]"
-"BITFIELD_RO k GET enc1 12 GET enc2 " "offset [GET encoding offset ...]]"
-"BITFIELD_RO k GET enc1 12 GET enc2 34 " "[GET encoding offset ...]]"
+"BITFIELD_RO k GET " "encoding offset [GET encoding offset ...]"
+"BITFIELD_RO k GET xyz " "offset [GET encoding offset ...]"
+"BITFIELD_RO k GET xyz 12 " "[GET encoding offset ...]"
+"BITFIELD_RO k GET xyz 12 GET " "encoding offset [GET encoding offset ...]"
+"BITFIELD_RO k GET enc1 12 GET enc2 " "offset [GET encoding offset ...]"
+"BITFIELD_RO k GET enc1 12 GET enc2 34 " "[GET encoding offset ...]"
 
 # Two-word command with multiple non-token block args:  CONFIG SET parameter value [parameter value ...]
 "CONFIG SET param " "value [parameter value ...]"


### PR DESCRIPTION
## Description

This PR fixes an issue in `redis-cli`'s command hint generation where optional arguments that were partially matched could produce unbalanced square brackets in the hint string.

### Problem

When building hints for commands with optional arguments (e.g., `BITFIELD_RO`), the code checked `(arg->flags & CMD_ARG_OPTIONAL) && !arg->matched` twice—once to open a bracket and once to close it. If the argument's `matched` state changed between these two checks (due to partial matching), the open and close decisions could differ, resulting in hints with an extra `]` at the end.

# Issue
For the below hint extra/unbalanced ']' was being suggested

"BITFIELD_RO k GET " "encoding offset [GET encoding offset ...]]"
"BITFIELD_RO k GET xyz " "offset [GET encoding offset ...]]"
"BITFIELD_RO k GET xyz 12 " "[GET encoding offset ...]]"
"BITFIELD_RO k GET xyz 12 GET " "encoding offset [GET encoding offset ...]]"
"BITFIELD_RO k GET enc1 12 GET enc2 " "offset [GET encoding offset ...]]"
"BITFIELD_RO k GET enc1 12 GET enc2 34 " "[GET encoding offset ...]]"

### Solution

Store the condition in a local variable `optional_unmatched` and reuse it for both the opening and closing bracket. This ensures that if a bracket is opened, it will always be closed, and vice versa.

### Testing

Updated `tests/assets/test_cli_hint_suite.txt` to reflect the corrected expected hints for the affected commands (the `BITFIELD_RO` examples). The test suite now passes with the fixed output.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to CLI hint formatting in redis-cli with updated golden tests; no server or runtime behavior impact.
> 
> **Overview**
> Fixes **redis-cli** command hints that showed an extra trailing `]` when optional arguments were partially typed (notably `BITFIELD_RO` with nested optional/repeatable `GET` blocks).
> 
> `addHintForArgument` now records whether to wrap the arg in `[` `]` **before** calling `addHintForRepeatedArgument()`, which clears `arg->matched` for repeatable args. Opening and closing brackets use the same `optional_unmatched` flag so they stay paired.
> 
> Expected hint strings in `tests/assets/test_cli_hint_suite.txt` are updated to match the corrected output (TODO comments removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0299ebb99d0d4de8ff5a968efdc78923dc0b0127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->