### PR TITLE
RED-200844: avoid recomputing allocator fragmentation twice per cron tick

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -446,7 +446,7 @@ void debugCommand(client *c) {
 "LOG <message>",
 "    Write <message> to the server log.",
 "DEFRAG-FRAG-CACHE-STATS",
-"    Return hits/skips counters for the defrag-side fragmentation cache.",
+"    Return hits counters for the defrag-side fragmentation cache.",
 "HTSTATS <dbid> [full]",
 "    Return hash table statistics of the specified Redis database.",
 "HTSTATS-KEY <key> [full]",
@@ -993,13 +993,8 @@ NULL
         sizes = sdscatprintf(sizes,"sdshdr64:%d ",(int)sizeof(struct sdshdr64));
         addReplyBulkSds(c,sizes);
     } else if (!strcasecmp(c->argv[1]->ptr,"defrag-frag-cache-stats")) {
-        /* Internal counters for the defrag-side fragmentation cache.
-         * Not exposed via INFO by design — this is a testing/diagnostic
-         * surface only. See struct defragFragCache in server.h. */
         sds stats = sdsempty();
-        stats = sdscatprintf(stats,
-            "defrag_frag_cache_hits:%lld\r\n",
-            server.defrag_frag_cache.hits);
+        stats = sdscatprintf(stats, "defrag_frag_cache_hits:%lld\r\n", server.defrag_frag_cache.hits);
         addReplyVerbatim(c,stats,sdslen(stats),"txt");
         sdsfree(stats);
     } else if (!strcasecmp(c->argv[1]->ptr,"htstats") && c->argc >= 3) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -1001,7 +1001,7 @@ NULL
             "defrag_frag_cache_hits:%lld\r\n"
             "defrag_frag_cache_skips:%lld\r\n",
             server.defrag_frag_cache.hits,
-            server.defrag_frag_cache.skips);
+            server.defrag_frag_cache.defrag_skips);
         addReplyVerbatim(c,stats,sdslen(stats),"txt");
         sdsfree(stats);
     } else if (!strcasecmp(c->argv[1]->ptr,"htstats") && c->argc >= 3) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -998,10 +998,8 @@ NULL
          * surface only. See struct defragFragCache in server.h. */
         sds stats = sdsempty();
         stats = sdscatprintf(stats,
-            "defrag_frag_cache_hits:%lld\r\n"
-            "defrag_frag_cache_skips:%lld\r\n",
-            server.defrag_frag_cache.hits,
-            server.defrag_frag_cache.defrag_skips);
+            "defrag_frag_cache_hits:%lld\r\n",
+            server.defrag_frag_cache.hits);
         addReplyVerbatim(c,stats,sdslen(stats),"txt");
         sdsfree(stats);
     } else if (!strcasecmp(c->argv[1]->ptr,"htstats") && c->argc >= 3) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -445,6 +445,8 @@ void debugCommand(client *c) {
 "    Create a memory leak of the input string.",
 "LOG <message>",
 "    Write <message> to the server log.",
+"DEFRAG-FRAG-CACHE-STATS",
+"    Return hits/skips counters for the defrag-side fragmentation cache.",
 "HTSTATS <dbid> [full]",
 "    Return hash table statistics of the specified Redis database.",
 "HTSTATS-KEY <key> [full]",
@@ -990,6 +992,18 @@ NULL
         sizes = sdscatprintf(sizes,"sdshdr32:%d ",(int)sizeof(struct sdshdr32));
         sizes = sdscatprintf(sizes,"sdshdr64:%d ",(int)sizeof(struct sdshdr64));
         addReplyBulkSds(c,sizes);
+    } else if (!strcasecmp(c->argv[1]->ptr,"defrag-frag-cache-stats")) {
+        /* Internal counters for the defrag-side fragmentation cache.
+         * Not exposed via INFO by design — this is a testing/diagnostic
+         * surface only. See struct defragFragCache in server.h. */
+        sds stats = sdsempty();
+        stats = sdscatprintf(stats,
+            "defrag_frag_cache_hits:%lld\r\n"
+            "defrag_frag_cache_skips:%lld\r\n",
+            server.defrag_frag_cache.hits,
+            server.defrag_frag_cache.skips);
+        addReplyVerbatim(c,stats,sdslen(stats),"txt");
+        sdsfree(stats);
     } else if (!strcasecmp(c->argv[1]->ptr,"htstats") && c->argc >= 3) {
         long dbid;
         sds stats = sdsempty();

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1449,7 +1449,7 @@ void computeDefragCycles(void) {
     /* If we're not already running, and below the threshold, exit. */
     if (!server.active_defrag_running) {
         if(frag_pct < server.active_defrag_threshold_lower || frag_bytes < server.active_defrag_ignore_bytes) {
-            if (cache_hit) server.defrag_frag_cache.skips++;
+            if (cache_hit) server.defrag_frag_cache.defrag_skips++;
             return;
         }
     }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1386,35 +1386,8 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
 #define INTERPOLATE(x, x1, x2, y1, y2) ( (y1) + ((x)-(x1)) * ((y2)-(y1)) / ((x2)-(x1)) )
 #define LIMIT(y, min, max) ((y)<(min)? min: ((y)>(max)? max: (y)))
 
-/* ===== Defrag-check single-consumer cache ===========================
- *
- * Background: getAllocatorFragmentation() forces a jemalloc epoch refresh
- * (cross-thread stats sync via IPIs) plus a walk over every arena's
- * small-bin slabs.  On systems with many threads and/or arenas the call
- * is non-trivial and ends up being made TWICE per cron tick:
- *   1. by cronUpdateMemoryStats() to refresh INFO MEMORY allocator_* fields
- *   2. by computeDefragCycles() (immediately after, same tick) to decide
- *      whether to engage active defrag
- * Both calls compute the same numbers; the second one's result is
- * almost always discarded by the threshold check below.
- *
- * Fix: cronUpdateMemoryStats() publishes the (Lua-arena-subtracted) values
- * it just measured into a small tick-local cache, alongside the current
- * server.cronloops value as a freshness stamp. computeDefragCycles() takes
- * from the cache at its top — on hit (cronloops == server.cronloops)
- * it uses the cached values for its single threshold check, on miss it
- * falls back to a fresh getAllocatorFragmentation() call. Either way the
- * threshold check (further down, unchanged) runs once on (frag_pct,
- * frag_bytes) regardless of source.
- *
- * Freshness/invalidation: server.cronloops advances at the top of both
- * serverCron() and whileBlockedCron(), so any value published in a
- * previous tick is automatically stale on the next tick's Take — no
- * explicit invalidate call needed. Cold start (cronloops == -1
- * from initServerConfig) likewise reports miss until the first publish.
- *
- * Single-threaded by Redis's main-thread invariant; no synchronization
- * needed. */
+/* Publish (Lua-subtracted) frag values with the current cronloops stamp.
+ * See struct defragFragCache in server.h for the cache rationale. */
 void defragFragCachePut(size_t frag_bytes, size_t allocated) {
     if (allocated == 0) return;          /* avoid divide-by-zero */
     server.defrag_frag_cache.frag_pct =

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1452,6 +1452,7 @@ int defragFragCacheTake(float *out_frag_pct, size_t *out_frag_bytes) {
      * exit to cover the produce-but-no-consume case. */
     defragFragCacheInvalidate();
     if (bytes == 0) return 0;
+    server.defrag_frag_cache.hits++;
     *out_frag_pct   = server.defrag_frag_cache.frag_pct;
     *out_frag_bytes = bytes;
     return 1;
@@ -1471,13 +1472,16 @@ void computeDefragCycles(void) {
      * check below operates on whichever source provided the values. */
     size_t frag_bytes;
     float frag_pct;
-    if (!defragFragCacheTake(&frag_pct, &frag_bytes)) {
+    int cache_hit = defragFragCacheTake(&frag_pct, &frag_bytes);
+    if (!cache_hit) {
         frag_pct = getAllocatorFragmentation(&frag_bytes);
     }
     /* If we're not already running, and below the threshold, exit. */
     if (!server.active_defrag_running) {
-        if(frag_pct < server.active_defrag_threshold_lower || frag_bytes < server.active_defrag_ignore_bytes)
+        if(frag_pct < server.active_defrag_threshold_lower || frag_bytes < server.active_defrag_ignore_bytes) {
+            if (cache_hit) server.defrag_frag_cache.skips++;
             return;
+        }
     }
 
     /* Calculate the adaptive aggressiveness of the defrag based on the current

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1442,16 +1442,13 @@ void computeDefragCycles(void) {
      * check below operates on whichever source provided the values. */
     size_t frag_bytes;
     float frag_pct;
-    int cache_hit = defragFragCacheTake(&frag_pct, &frag_bytes);
-    if (!cache_hit) {
+    if (!defragFragCacheTake(&frag_pct, &frag_bytes)) {
         frag_pct = getAllocatorFragmentation(&frag_bytes);
     }
     /* If we're not already running, and below the threshold, exit. */
     if (!server.active_defrag_running) {
-        if(frag_pct < server.active_defrag_threshold_lower || frag_bytes < server.active_defrag_ignore_bytes) {
-            if (cache_hit) server.defrag_frag_cache.defrag_skips++;
+        if(frag_pct < server.active_defrag_threshold_lower || frag_bytes < server.active_defrag_ignore_bytes)
             return;
-        }
     }
 
     /* Calculate the adaptive aggressiveness of the defrag based on the current

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1386,8 +1386,101 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
 #define INTERPOLATE(x, x1, x2, y1, y2) ( (y1) + ((x)-(x1)) * ((y2)-(y1)) / ((x2)-(x1)) )
 #define LIMIT(y, min, max) ((y)<(min)? min: ((y)>(max)? max: (y)))
 
+/* ===== Defrag-check tick-local cache ================================
+ *
+ * Background: getAllocatorFragmentation() forces a jemalloc epoch refresh
+ * (cross-thread stats sync via IPIs) plus a walk over every arena's
+ * small-bin slabs.  On systems with many threads and/or arenas the call
+ * is non-trivial and ends up being made TWICE per cron tick:
+ *   1. by cronUpdateMemoryStats() to refresh INFO MEMORY allocator_* fields
+ *   2. by computeDefragCycles() (immediately after, same tick) to decide
+ *      whether to engage active defrag
+ * The decision in (2) is almost always "no engagement" on real workloads,
+ * so the second call's result is computed and then discarded.
+ *
+ * Fix: cronUpdateMemoryStats() publishes the (Lua-arena-subtracted) values
+ * it just measured into a tick-local cache.  computeDefragCycles() reads
+ * from the cache at its top; on hit, it makes the threshold decision on
+ * the cached value and returns early; on miss (cache stale or near
+ * threshold), it falls through to the original expensive call unchanged.
+ *
+ * The cache is invalidated near the end of serverCron() so it is only
+ * ever valid within the current cron tick.  Out-of-cron callers
+ * (endDefragCycle's recursive activeDefragCycle() call from a defrag
+ * time event, defragWhileBlocked() from a long Lua script / RDB load)
+ * arrive at a stale cache and fall through — safe by construction, no
+ * staleness window to reason about.
+ *
+ * Single-threaded by Redis's main-thread invariant; no synchronization
+ * needed. */
+void defragCheckCachePublish(size_t frag_bytes, size_t allocated) {
+    if (allocated == 0) {
+        /* Allocator hasn't reported usable numbers yet (cold start). */
+        server.defrag_check_cache.frag_pct_x100 = -1;
+        return;
+    }
+    /* Write frag_bytes first; only set the validity field (frag_pct_x100)
+     * last.  Same-thread context means this isn't a memory-ordering
+     * concern in practice, but it documents the intended invariant. */
+    server.defrag_check_cache.frag_bytes = frag_bytes;
+    server.defrag_check_cache.frag_pct_x100 =
+        (int64_t)((double)frag_bytes / (double)allocated * 10000.0);
+}
+
+int defragCheckCacheConsume(int64_t *out_frag_pct_x100, size_t *out_frag_bytes) {
+    int64_t pct_x100 = server.defrag_check_cache.frag_pct_x100;
+    /* Note: tick-local cache — we do NOT invalidate here so the value
+     * remains usable by any additional in-cron consumer.  serverCron()
+     * invalidates at the end of the tick. */
+    if (pct_x100 < 0) return 0;
+    *out_frag_pct_x100 = pct_x100;
+    *out_frag_bytes    = server.defrag_check_cache.frag_bytes;
+    server.defrag_check_cache.hits++;
+    return 1;
+}
+
+void defragCheckCacheInvalidate(void) {
+    server.defrag_check_cache.frag_pct_x100 = -1;
+    server.defrag_check_cache.frag_bytes = 0;
+    /* hits/skips are cumulative — do not reset on invalidate. */
+}
+
 /* decide if defrag is needed, and at what CPU effort to invest in it */
 void computeDefragCycles(void) {
+    /* Fast path: if defrag is not already running, try to make the
+     * threshold decision using the cached value the producer published
+     * earlier this cron tick.  This skips the expensive
+     * getAllocatorFragmentation() call entirely on most ticks.
+     *
+     * The cached value is microseconds-fresh on the normal cron path
+     * (cronUpdateMemoryStats() and computeDefragCycles() run on the
+     * same main-thread tick with no preemption between them), so the
+     * check mirrors the original post-call threshold check exactly,
+     * with no safety margin.  Staleness on out-of-cron paths
+     * (defragWhileBlocked, endDefragCycle's recursive call) is
+     * eliminated by serverCron()'s tick-exit invalidation: those
+     * callers always observe a stale cache and fall through. */
+    if (!server.active_defrag_running) {
+        int64_t cached_pct_x100;
+        size_t  cached_frag_bytes;
+        if (defragCheckCacheConsume(&cached_pct_x100, &cached_frag_bytes)) {
+            int threshold_x100 = server.active_defrag_threshold_lower * 100;
+            if (cached_pct_x100   < threshold_x100 ||
+                cached_frag_bytes < server.active_defrag_ignore_bytes) {
+                /* Cached value is below threshold (or bytes-floor) — skip
+                 * the expensive getAllocatorFragmentation() entirely.
+                 * This is the common case on workloads where defrag
+                 * doesn't engage. */
+                server.defrag_check_cache.skips++;
+                return;
+            }
+            /* Cached value is at or above threshold; fall through to
+             * fresh measurement so the engagement decision is on real
+             * data. */
+        }
+        /* Cache miss: fall through to the expensive call. */
+    }
+
     size_t frag_bytes;
     float frag_pct = getAllocatorFragmentation(&frag_bytes);
     /* If we're not already running, and below the threshold, exit. */
@@ -2012,6 +2105,18 @@ robj *activeDefragStringOb(robj *ob) {
 }
 
 void defragWhileBlocked(void) {
+}
+
+void defragCheckCachePublish(size_t frag_bytes, size_t allocated) {
+    UNUSED(frag_bytes); UNUSED(allocated);
+}
+
+int defragCheckCacheConsume(int64_t *out_frag_pct_x100, size_t *out_frag_bytes) {
+    UNUSED(out_frag_pct_x100); UNUSED(out_frag_bytes);
+    return 0;
+}
+
+void defragCheckCacheInvalidate(void) {
 }
 
 #endif

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1399,67 +1399,37 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
  * almost always discarded by the threshold check below.
  *
  * Fix: cronUpdateMemoryStats() publishes the (Lua-arena-subtracted) values
- * it just measured into a small tick-local cache.  computeDefragCycles()
- * takes from the cache at its top — on hit it uses the cached values for
- * its single threshold check, on miss it falls back to a fresh
- * getAllocatorFragmentation() call.  Either way the threshold check
- * (further down, unchanged) runs once on (frag_pct, frag_bytes) regardless
- * of source.
+ * it just measured into a small tick-local cache, alongside the current
+ * server.cronloops value as a freshness stamp. computeDefragCycles() takes
+ * from the cache at its top — on hit (publish_cronloops == server.cronloops)
+ * it uses the cached values for its single threshold check, on miss it
+ * falls back to a fresh getAllocatorFragmentation() call. Either way the
+ * threshold check (further down, unchanged) runs once on (frag_pct,
+ * frag_bytes) regardless of source.
  *
- * Invalidation has two rules — both required for the cache to be safe:
- *
- *   (1) Consume-once: defragFragCacheTake() ALWAYS invalidates the
- *       cache before returning, whether it returns hit or miss.  Bounds
- *       staleness: a second consumer arriving before the next publish
- *       sees the stale sentinel and falls through to a real measurement.
- *       Critical for the defragWhileBlocked() path during long AOF/RDB
- *       loads, where the function can fire many times per
- *       cronUpdateMemoryStats() publish window.
- *
- *   (2) Cron-exit invalidate: serverCron() invalidates near its exit to
- *       cover the produce-but-no-consume case — e.g. defrag disabled by
- *       config, or active_defrag_running > 0 so the engagement-side
- *       branches act on freshly-published values directly.  Without
- *       this, a value published this tick could leak past the tick
- *       boundary into a defrag time-event running between cron
- *       iterations.
+ * Freshness/invalidation: server.cronloops advances at the top of both
+ * serverCron() and whileBlockedCron(), so any value published in a
+ * previous tick is automatically stale on the next tick's Take — no
+ * explicit invalidate call needed. Cold start (publish_cronloops == -1
+ * from initServerConfig) likewise reports miss until the first publish.
  *
  * Single-threaded by Redis's main-thread invariant; no synchronization
  * needed. */
 void defragFragCachePut(size_t frag_bytes, size_t allocated) {
-    /* allocated == 0 (cold start) or frag_bytes == 0 (no fragmentation —
-     * shouldn't happen in a running server, but we still treat it as
-     * "nothing useful to cache") both reduce to leaving the cache stale. */
-    if (allocated == 0 || frag_bytes == 0) {
-        server.defrag_frag_cache.frag_bytes = 0;
-        return;
-    }
+    if (allocated == 0) return;          /* avoid divide-by-zero */
     server.defrag_frag_cache.frag_pct =
         (float)((double)frag_bytes / (double)allocated * 100.0);
-    /* frag_bytes is the validity indicator; store it last so any concurrent
-     * (impossible today, but documents intent) reader sees a coherent
-     * value. */
     server.defrag_frag_cache.frag_bytes = frag_bytes;
+    server.defrag_frag_cache.publish_cronloops = server.cronloops;
 }
 
 int defragFragCacheTake(float *out_frag_pct, size_t *out_frag_bytes) {
-    size_t bytes = server.defrag_frag_cache.frag_bytes;
-    /* Consume-once: invalidate immediately so a subsequent consumer
-     * (e.g. defragWhileBlocked() firing repeatedly during a long AOF
-     * load before the next cronUpdateMemoryStats() publish) cannot
-     * reuse the same value and miss a memory-state change.
-     * serverCron() also calls defragFragCacheInvalidate() at tick
-     * exit to cover the produce-but-no-consume case. */
-    defragFragCacheInvalidate();
-    if (bytes == 0) return 0;
+    if (server.defrag_frag_cache.publish_cronloops != server.cronloops)
+        return 0;
     server.defrag_frag_cache.hits++;
     *out_frag_pct   = server.defrag_frag_cache.frag_pct;
-    *out_frag_bytes = bytes;
+    *out_frag_bytes = server.defrag_frag_cache.frag_bytes;
     return 1;
-}
-
-void defragFragCacheInvalidate(void) {
-    server.defrag_frag_cache.frag_bytes = 0;
 }
 
 /* decide if defrag is needed, and at what CPU effort to invest in it */
@@ -2109,9 +2079,6 @@ void defragFragCachePut(size_t frag_bytes, size_t allocated) {
 int defragFragCacheTake(float *out_frag_pct, size_t *out_frag_bytes) {
     UNUSED(out_frag_pct); UNUSED(out_frag_bytes);
     return 0;
-}
-
-void defragFragCacheInvalidate(void) {
 }
 
 #endif

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1450,7 +1450,7 @@ int defragFragCacheTake(float *out_frag_pct, size_t *out_frag_bytes) {
      * reuse the same value and miss a memory-state change.
      * serverCron() also calls defragFragCacheInvalidate() at tick
      * exit to cover the produce-but-no-consume case. */
-    server.defrag_frag_cache.frag_bytes = 0;
+    defragFragCacheInvalidate();
     if (bytes == 0) return 0;
     *out_frag_pct   = server.defrag_frag_cache.frag_pct;
     *out_frag_bytes = bytes;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1395,114 +1395,85 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
  *   1. by cronUpdateMemoryStats() to refresh INFO MEMORY allocator_* fields
  *   2. by computeDefragCycles() (immediately after, same tick) to decide
  *      whether to engage active defrag
- * The decision in (2) is almost always "no engagement" on real workloads,
- * so the second call's result is computed and then discarded.
+ * Both calls compute the same numbers; the second one's result is
+ * almost always discarded by the threshold check below.
  *
  * Fix: cronUpdateMemoryStats() publishes the (Lua-arena-subtracted) values
- * it just measured into the cache.  computeDefragCycles() reads from the
- * cache at its top; on hit, it makes the threshold decision on the cached
- * value and returns early; on miss (cache stale or near threshold), it
- * falls through to the original expensive call unchanged.
+ * it just measured into a small tick-local cache.  computeDefragCycles()
+ * takes from the cache at its top — on hit it uses the cached values for
+ * its single threshold check, on miss it falls back to a fresh
+ * getAllocatorFragmentation() call.  Either way the threshold check
+ * (further down, unchanged) runs once on (frag_pct, frag_bytes) regardless
+ * of source.
  *
  * Invalidation has two rules — both required for the cache to be safe:
  *
- *   (1) Consume-once: defragCheckCacheConsume() ALWAYS sets the cache
- *       to the stale sentinel (-1) before returning, whether it returns
- *       a hit or a miss.  This bounds staleness: any second consumer
- *       arriving before the next publish sees -1 and falls through to
- *       a real measurement.  Critical for the defragWhileBlocked() path
- *       during long AOF/RDB loads, where the function can fire many
- *       times per cronUpdateMemoryStats() publish window.
+ *   (1) Consume-once: defragCheckCacheConsume() ALWAYS invalidates the
+ *       cache before returning, whether it returns hit or miss.  Bounds
+ *       staleness: a second consumer arriving before the next publish
+ *       sees the stale sentinel and falls through to a real measurement.
+ *       Critical for the defragWhileBlocked() path during long AOF/RDB
+ *       loads, where the function can fire many times per
+ *       cronUpdateMemoryStats() publish window.
  *
- *   (2) Cron-exit invalidate: serverCron() (and any future periodic-cron
- *       function that calls Publish) invalidates near its exit to cover
- *       the produce-but-no-consume case — defrag disabled by config,
- *       or active_defrag_running > 0 so the pre-check is bypassed.
- *       Without this, a value published this tick could leak past the
- *       tick boundary into a defrag time-event running between cron
+ *   (2) Cron-exit invalidate: serverCron() invalidates near its exit to
+ *       cover the produce-but-no-consume case — e.g. defrag disabled by
+ *       config, or active_defrag_running > 0 so the engagement-side
+ *       branches act on freshly-published values directly.  Without
+ *       this, a value published this tick could leak past the tick
+ *       boundary into a defrag time-event running between cron
  *       iterations.
  *
  * Single-threaded by Redis's main-thread invariant; no synchronization
  * needed. */
 void defragCheckCachePublish(size_t frag_bytes, size_t allocated) {
-    if (allocated == 0) {
-        /* Allocator hasn't reported usable numbers yet (cold start). */
-        server.defrag_check_cache.frag_pct_x100 = -1;
+    /* allocated == 0 (cold start) or frag_bytes == 0 (no fragmentation —
+     * shouldn't happen in a running server, but we still treat it as
+     * "nothing useful to cache") both reduce to leaving the cache stale. */
+    if (allocated == 0 || frag_bytes == 0) {
+        server.defrag_check_cache.frag_bytes = 0;
         return;
     }
-    /* Write frag_bytes first; only set the validity field (frag_pct_x100)
-     * last.  Same-thread context means this isn't a memory-ordering
-     * concern in practice, but it documents the intended invariant. */
+    server.defrag_check_cache.frag_pct =
+        (float)((double)frag_bytes / (double)allocated * 100.0);
+    /* frag_bytes is the validity indicator; store it last so any concurrent
+     * (impossible today, but documents intent) reader sees a coherent
+     * value. */
     server.defrag_check_cache.frag_bytes = frag_bytes;
-    server.defrag_check_cache.frag_pct_x100 =
-        (int64_t)((double)frag_bytes / (double)allocated * 10000.0);
 }
 
-int defragCheckCacheConsume(int64_t *out_frag_pct_x100, size_t *out_frag_bytes) {
-    int64_t pct_x100 = server.defrag_check_cache.frag_pct_x100;
+int defragCheckCacheConsume(float *out_frag_pct, size_t *out_frag_bytes) {
+    size_t bytes = server.defrag_check_cache.frag_bytes;
     /* Consume-once: invalidate immediately so a subsequent consumer
      * (e.g. defragWhileBlocked() firing repeatedly during a long AOF
-     * load before the next cronUpdateMemoryStats() publish, or any
-     * future in-tick reader) cannot reuse the same value and miss a
-     * memory-state change.  serverCron() also calls
-     * defragCheckCacheInvalidate() at tick exit to cover the
-     * produce-but-no-consume case (e.g. defrag disabled by config or
-     * active_defrag_running > 0 so the pre-check is bypassed). */
-    server.defrag_check_cache.frag_pct_x100 = -1;
-    if (pct_x100 < 0) return 0;
-    *out_frag_pct_x100 = pct_x100;
-    *out_frag_bytes    = server.defrag_check_cache.frag_bytes;
-    server.defrag_check_cache.hits++;
+     * load before the next cronUpdateMemoryStats() publish) cannot
+     * reuse the same value and miss a memory-state change.
+     * serverCron() also calls defragCheckCacheInvalidate() at tick
+     * exit to cover the produce-but-no-consume case. */
+    server.defrag_check_cache.frag_bytes = 0;
+    if (bytes == 0) return 0;
+    *out_frag_pct   = server.defrag_check_cache.frag_pct;
+    *out_frag_bytes = bytes;
     return 1;
 }
 
 void defragCheckCacheInvalidate(void) {
-    server.defrag_check_cache.frag_pct_x100 = -1;
     server.defrag_check_cache.frag_bytes = 0;
-    /* hits/skips are cumulative — do not reset on invalidate. */
 }
 
 /* decide if defrag is needed, and at what CPU effort to invest in it */
 void computeDefragCycles(void) {
-    /* Fast path: if defrag is not already running, try to make the
-     * threshold decision using the cached value the producer published
-     * earlier this cron tick.  This skips the expensive
-     * getAllocatorFragmentation() call entirely on most ticks.
-     *
-     * The cached value is microseconds-fresh on the normal cron path
-     * (cronUpdateMemoryStats() and computeDefragCycles() run on the
-     * same main-thread tick with no preemption between them), so the
-     * check mirrors the original post-call threshold check exactly,
-     * with no safety margin.  Consume invalidates the cache
-     * immediately, so a second consumer arriving before the next
-     * publish falls through to a real measurement — this bounds
-     * staleness on the defragWhileBlocked() / endDefragCycle paths.
-     * Out-of-cron staleness is
-     * eliminated by serverCron()'s tick-exit invalidation: those
-     * callers always observe a stale cache and fall through. */
-    if (!server.active_defrag_running) {
-        int64_t cached_pct_x100;
-        size_t  cached_frag_bytes;
-        if (defragCheckCacheConsume(&cached_pct_x100, &cached_frag_bytes)) {
-            int threshold_x100 = server.active_defrag_threshold_lower * 100;
-            if (cached_pct_x100   < threshold_x100 ||
-                cached_frag_bytes < server.active_defrag_ignore_bytes) {
-                /* Cached value is below threshold (or bytes-floor) — skip
-                 * the expensive getAllocatorFragmentation() entirely.
-                 * This is the common case on workloads where defrag
-                 * doesn't engage. */
-                server.defrag_check_cache.skips++;
-                return;
-            }
-            /* Cached value is at or above threshold; fall through to
-             * fresh measurement so the engagement decision is on real
-             * data. */
-        }
-        /* Cache miss: fall through to the expensive call. */
-    }
-
+    /* Try the tick-local cache first.  On hit, (frag_pct, frag_bytes)
+     * are populated from the value the producer published earlier this
+     * cron tick — saving a redundant getAllocatorFragmentation() call.
+     * On miss (cache stale, cold start, or invalidated by a previous
+     * consume), fall back to a fresh measurement.  The single threshold
+     * check below operates on whichever source provided the values. */
     size_t frag_bytes;
-    float frag_pct = getAllocatorFragmentation(&frag_bytes);
+    float frag_pct;
+    if (!defragCheckCacheConsume(&frag_pct, &frag_bytes)) {
+        frag_pct = getAllocatorFragmentation(&frag_bytes);
+    }
     /* If we're not already running, and below the threshold, exit. */
     if (!server.active_defrag_running) {
         if(frag_pct < server.active_defrag_threshold_lower || frag_bytes < server.active_defrag_ignore_bytes)
@@ -2131,8 +2102,8 @@ void defragCheckCachePublish(size_t frag_bytes, size_t allocated) {
     UNUSED(frag_bytes); UNUSED(allocated);
 }
 
-int defragCheckCacheConsume(int64_t *out_frag_pct_x100, size_t *out_frag_bytes) {
-    UNUSED(out_frag_pct_x100); UNUSED(out_frag_bytes);
+int defragCheckCacheConsume(float *out_frag_pct, size_t *out_frag_bytes) {
+    UNUSED(out_frag_pct); UNUSED(out_frag_bytes);
     return 0;
 }
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1408,7 +1408,7 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
  *
  * Invalidation has two rules — both required for the cache to be safe:
  *
- *   (1) Consume-once: defragCheckCacheConsume() ALWAYS invalidates the
+ *   (1) Consume-once: defragFragCacheTake() ALWAYS invalidates the
  *       cache before returning, whether it returns hit or miss.  Bounds
  *       staleness: a second consumer arriving before the next publish
  *       sees the stale sentinel and falls through to a real measurement.
@@ -1426,39 +1426,39 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
  *
  * Single-threaded by Redis's main-thread invariant; no synchronization
  * needed. */
-void defragCheckCachePublish(size_t frag_bytes, size_t allocated) {
+void defragFragCachePut(size_t frag_bytes, size_t allocated) {
     /* allocated == 0 (cold start) or frag_bytes == 0 (no fragmentation —
      * shouldn't happen in a running server, but we still treat it as
      * "nothing useful to cache") both reduce to leaving the cache stale. */
     if (allocated == 0 || frag_bytes == 0) {
-        server.defrag_check_cache.frag_bytes = 0;
+        server.defrag_frag_cache.frag_bytes = 0;
         return;
     }
-    server.defrag_check_cache.frag_pct =
+    server.defrag_frag_cache.frag_pct =
         (float)((double)frag_bytes / (double)allocated * 100.0);
     /* frag_bytes is the validity indicator; store it last so any concurrent
      * (impossible today, but documents intent) reader sees a coherent
      * value. */
-    server.defrag_check_cache.frag_bytes = frag_bytes;
+    server.defrag_frag_cache.frag_bytes = frag_bytes;
 }
 
-int defragCheckCacheConsume(float *out_frag_pct, size_t *out_frag_bytes) {
-    size_t bytes = server.defrag_check_cache.frag_bytes;
+int defragFragCacheTake(float *out_frag_pct, size_t *out_frag_bytes) {
+    size_t bytes = server.defrag_frag_cache.frag_bytes;
     /* Consume-once: invalidate immediately so a subsequent consumer
      * (e.g. defragWhileBlocked() firing repeatedly during a long AOF
      * load before the next cronUpdateMemoryStats() publish) cannot
      * reuse the same value and miss a memory-state change.
-     * serverCron() also calls defragCheckCacheInvalidate() at tick
+     * serverCron() also calls defragFragCacheInvalidate() at tick
      * exit to cover the produce-but-no-consume case. */
-    server.defrag_check_cache.frag_bytes = 0;
+    server.defrag_frag_cache.frag_bytes = 0;
     if (bytes == 0) return 0;
-    *out_frag_pct   = server.defrag_check_cache.frag_pct;
+    *out_frag_pct   = server.defrag_frag_cache.frag_pct;
     *out_frag_bytes = bytes;
     return 1;
 }
 
-void defragCheckCacheInvalidate(void) {
-    server.defrag_check_cache.frag_bytes = 0;
+void defragFragCacheInvalidate(void) {
+    server.defrag_frag_cache.frag_bytes = 0;
 }
 
 /* decide if defrag is needed, and at what CPU effort to invest in it */
@@ -1471,7 +1471,7 @@ void computeDefragCycles(void) {
      * check below operates on whichever source provided the values. */
     size_t frag_bytes;
     float frag_pct;
-    if (!defragCheckCacheConsume(&frag_pct, &frag_bytes)) {
+    if (!defragFragCacheTake(&frag_pct, &frag_bytes)) {
         frag_pct = getAllocatorFragmentation(&frag_bytes);
     }
     /* If we're not already running, and below the threshold, exit. */
@@ -2098,16 +2098,16 @@ robj *activeDefragStringOb(robj *ob) {
 void defragWhileBlocked(void) {
 }
 
-void defragCheckCachePublish(size_t frag_bytes, size_t allocated) {
+void defragFragCachePut(size_t frag_bytes, size_t allocated) {
     UNUSED(frag_bytes); UNUSED(allocated);
 }
 
-int defragCheckCacheConsume(float *out_frag_pct, size_t *out_frag_bytes) {
+int defragFragCacheTake(float *out_frag_pct, size_t *out_frag_bytes) {
     UNUSED(out_frag_pct); UNUSED(out_frag_bytes);
     return 0;
 }
 
-void defragCheckCacheInvalidate(void) {
+void defragFragCacheInvalidate(void) {
 }
 
 #endif

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1386,7 +1386,7 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
 #define INTERPOLATE(x, x1, x2, y1, y2) ( (y1) + ((x)-(x1)) * ((y2)-(y1)) / ((x2)-(x1)) )
 #define LIMIT(y, min, max) ((y)<(min)? min: ((y)>(max)? max: (y)))
 
-/* ===== Defrag-check tick-local cache ================================
+/* ===== Defrag-check single-consumer cache ===========================
  *
  * Background: getAllocatorFragmentation() forces a jemalloc epoch refresh
  * (cross-thread stats sync via IPIs) plus a walk over every arena's
@@ -1399,17 +1399,28 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
  * so the second call's result is computed and then discarded.
  *
  * Fix: cronUpdateMemoryStats() publishes the (Lua-arena-subtracted) values
- * it just measured into a tick-local cache.  computeDefragCycles() reads
- * from the cache at its top; on hit, it makes the threshold decision on
- * the cached value and returns early; on miss (cache stale or near
- * threshold), it falls through to the original expensive call unchanged.
+ * it just measured into the cache.  computeDefragCycles() reads from the
+ * cache at its top; on hit, it makes the threshold decision on the cached
+ * value and returns early; on miss (cache stale or near threshold), it
+ * falls through to the original expensive call unchanged.
  *
- * The cache is invalidated near the end of serverCron() so it is only
- * ever valid within the current cron tick.  Out-of-cron callers
- * (endDefragCycle's recursive activeDefragCycle() call from a defrag
- * time event, defragWhileBlocked() from a long Lua script / RDB load)
- * arrive at a stale cache and fall through — safe by construction, no
- * staleness window to reason about.
+ * Invalidation has two rules — both required for the cache to be safe:
+ *
+ *   (1) Consume-once: defragCheckCacheConsume() ALWAYS sets the cache
+ *       to the stale sentinel (-1) before returning, whether it returns
+ *       a hit or a miss.  This bounds staleness: any second consumer
+ *       arriving before the next publish sees -1 and falls through to
+ *       a real measurement.  Critical for the defragWhileBlocked() path
+ *       during long AOF/RDB loads, where the function can fire many
+ *       times per cronUpdateMemoryStats() publish window.
+ *
+ *   (2) Cron-exit invalidate: serverCron() (and any future periodic-cron
+ *       function that calls Publish) invalidates near its exit to cover
+ *       the produce-but-no-consume case — defrag disabled by config,
+ *       or active_defrag_running > 0 so the pre-check is bypassed.
+ *       Without this, a value published this tick could leak past the
+ *       tick boundary into a defrag time-event running between cron
+ *       iterations.
  *
  * Single-threaded by Redis's main-thread invariant; no synchronization
  * needed. */
@@ -1429,9 +1440,15 @@ void defragCheckCachePublish(size_t frag_bytes, size_t allocated) {
 
 int defragCheckCacheConsume(int64_t *out_frag_pct_x100, size_t *out_frag_bytes) {
     int64_t pct_x100 = server.defrag_check_cache.frag_pct_x100;
-    /* Note: tick-local cache — we do NOT invalidate here so the value
-     * remains usable by any additional in-cron consumer.  serverCron()
-     * invalidates at the end of the tick. */
+    /* Consume-once: invalidate immediately so a subsequent consumer
+     * (e.g. defragWhileBlocked() firing repeatedly during a long AOF
+     * load before the next cronUpdateMemoryStats() publish, or any
+     * future in-tick reader) cannot reuse the same value and miss a
+     * memory-state change.  serverCron() also calls
+     * defragCheckCacheInvalidate() at tick exit to cover the
+     * produce-but-no-consume case (e.g. defrag disabled by config or
+     * active_defrag_running > 0 so the pre-check is bypassed). */
+    server.defrag_check_cache.frag_pct_x100 = -1;
     if (pct_x100 < 0) return 0;
     *out_frag_pct_x100 = pct_x100;
     *out_frag_bytes    = server.defrag_check_cache.frag_bytes;
@@ -1456,8 +1473,11 @@ void computeDefragCycles(void) {
      * (cronUpdateMemoryStats() and computeDefragCycles() run on the
      * same main-thread tick with no preemption between them), so the
      * check mirrors the original post-call threshold check exactly,
-     * with no safety margin.  Staleness on out-of-cron paths
-     * (defragWhileBlocked, endDefragCycle's recursive call) is
+     * with no safety margin.  Consume invalidates the cache
+     * immediately, so a second consumer arriving before the next
+     * publish falls through to a real measurement — this bounds
+     * staleness on the defragWhileBlocked() / endDefragCycle paths.
+     * Out-of-cron staleness is
      * eliminated by serverCron()'s tick-exit invalidation: those
      * callers always observe a stale cache and fall through. */
     if (!server.active_defrag_running) {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1401,7 +1401,7 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
  * Fix: cronUpdateMemoryStats() publishes the (Lua-arena-subtracted) values
  * it just measured into a small tick-local cache, alongside the current
  * server.cronloops value as a freshness stamp. computeDefragCycles() takes
- * from the cache at its top — on hit (publish_cronloops == server.cronloops)
+ * from the cache at its top — on hit (cronloops == server.cronloops)
  * it uses the cached values for its single threshold check, on miss it
  * falls back to a fresh getAllocatorFragmentation() call. Either way the
  * threshold check (further down, unchanged) runs once on (frag_pct,
@@ -1410,7 +1410,7 @@ static doneStatus defragLaterStep(void *ctx, monotime endtime) {
  * Freshness/invalidation: server.cronloops advances at the top of both
  * serverCron() and whileBlockedCron(), so any value published in a
  * previous tick is automatically stale on the next tick's Take — no
- * explicit invalidate call needed. Cold start (publish_cronloops == -1
+ * explicit invalidate call needed. Cold start (cronloops == -1
  * from initServerConfig) likewise reports miss until the first publish.
  *
  * Single-threaded by Redis's main-thread invariant; no synchronization
@@ -1420,11 +1420,11 @@ void defragFragCachePut(size_t frag_bytes, size_t allocated) {
     server.defrag_frag_cache.frag_pct =
         (float)((double)frag_bytes / (double)allocated * 100.0);
     server.defrag_frag_cache.frag_bytes = frag_bytes;
-    server.defrag_frag_cache.publish_cronloops = server.cronloops;
+    server.defrag_frag_cache.cronloops = server.cronloops;
 }
 
 int defragFragCacheTake(float *out_frag_pct, size_t *out_frag_bytes) {
-    if (server.defrag_frag_cache.publish_cronloops != server.cronloops)
+    if (server.defrag_frag_cache.cronloops != server.cronloops)
         return 0;
     server.defrag_frag_cache.hits++;
     *out_frag_pct   = server.defrag_frag_cache.frag_pct;

--- a/src/server.c
+++ b/src/server.c
@@ -2390,11 +2390,7 @@ void initServerConfig(void) {
                                       updated later after loading the config.
                                       This value may be used before the server
                                       is initialized. */
-    /* Mark defrag-side fragmentation cache as stale so the first
-     * computeDefragCycles() call falls through to a real measurement
-     * until cronUpdateMemoryStats() publishes. -1 is unreachable by
-     * server.cronloops (which starts at 0 and only advances). */
-    server.defrag_frag_cache.cronloops = -1;
+    server.defrag_frag_cache.cronloops = -1; /* Mark the defrag fragmentation cache as stale */
     server.timezone = getTimeZone(); /* Initialized by tzset(). */
     server.configfile = NULL;
     server.executable = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -1508,6 +1508,24 @@ void cronUpdateMemoryStats(void) {
                                                 &server.cron_malloc_stats.lua_allocator_resident,
                                                 &server.cron_malloc_stats.lua_allocator_frag_smallbins_bytes);
         }
+        /* Publish the just-measured (Lua-arena-subtracted) fragmentation
+         * values into the defrag-side tick-local cache so
+         * computeDefragCycles() later this tick can skip its own
+         * duplicate jemalloc measurement. Mirrors
+         * getAllocatorFragmentation()'s Lua subtraction so the cached
+         * value matches the fall-through real measurement exactly.
+         * Publishing with allocated==0 leaves the cache invalid
+         * (sentinel set inside the publish) — defrag should decide on
+         * real data or none. */
+        {
+            size_t pub_frag  = server.cron_malloc_stats.allocator_frag_smallbins_bytes;
+            size_t pub_alloc = server.cron_malloc_stats.allocator_allocated;
+            if (pub_alloc > 0 && server.lua_arena != UINT_MAX) {
+                pub_frag  -= server.cron_malloc_stats.lua_allocator_frag_smallbins_bytes;
+                pub_alloc -= server.cron_malloc_stats.lua_allocator_allocated;
+            }
+            defragCheckCachePublish(pub_frag, pub_alloc);
+        }
         /* in case the allocator isn't providing these stats, fake them so that
          * fragmentation info still shows some (inaccurate metrics) */
         if (!server.cron_malloc_stats.allocator_resident)
@@ -1827,6 +1845,13 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     server.cronloops++;
 
     server.el_cron_duration = getMonotonicUs() - cron_start;
+
+    /* End-of-tick invalidation for the defrag-side fragmentation cache.
+     * The cache is valid only within the current cron tick — out-of-cron
+     * callers (defragWhileBlocked during long Lua/RDB load, or
+     * endDefragCycle's recursive activeDefragCycle from a defrag time
+     * event) see -1 and fall through to a fresh measurement. */
+    defragCheckCacheInvalidate();
 
     return 1000/server.hz;
 }
@@ -2374,6 +2399,10 @@ void initServerConfig(void) {
                                       updated later after loading the config.
                                       This value may be used before the server
                                       is initialized. */
+    defragCheckCacheInvalidate();  /* Mark defrag-side fragmentation cache as
+                                      stale so the first computeDefragCycles()
+                                      call falls through to a real measurement
+                                      until cronUpdateMemoryStats() publishes. */
     server.timezone = getTimeZone(); /* Initialized by tzset(). */
     server.configfile = NULL;
     server.executable = NULL;
@@ -6489,6 +6518,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "maxmemory_policy:%s\r\n", evict_policy,
             "allocator_frag_ratio:%.2f\r\n", mh->allocator_frag,
             "allocator_frag_bytes:%zu\r\n", mh->allocator_frag_bytes,
+            "defrag_check_cache_hits:%lld\r\n", server.defrag_check_cache.hits,
+            "defrag_check_cache_skips:%lld\r\n", server.defrag_check_cache.skips,
             "allocator_rss_ratio:%.2f\r\n", mh->allocator_rss,
             "allocator_rss_bytes:%zd\r\n", mh->allocator_rss_bytes,
             "rss_overhead_ratio:%.2f\r\n", mh->rss_extra,

--- a/src/server.c
+++ b/src/server.c
@@ -2394,7 +2394,7 @@ void initServerConfig(void) {
      * computeDefragCycles() call falls through to a real measurement
      * until cronUpdateMemoryStats() publishes. -1 is unreachable by
      * server.cronloops (which starts at 0 and only advances). */
-    server.defrag_frag_cache.publish_cronloops = -1;
+    server.defrag_frag_cache.cronloops = -1;
     server.timezone = getTimeZone(); /* Initialized by tzset(). */
     server.configfile = NULL;
     server.executable = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -6518,8 +6518,6 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "maxmemory_policy:%s\r\n", evict_policy,
             "allocator_frag_ratio:%.2f\r\n", mh->allocator_frag,
             "allocator_frag_bytes:%zu\r\n", mh->allocator_frag_bytes,
-            "defrag_check_cache_hits:%lld\r\n", server.defrag_check_cache.hits,
-            "defrag_check_cache_skips:%lld\r\n", server.defrag_check_cache.skips,
             "allocator_rss_ratio:%.2f\r\n", mh->allocator_rss,
             "allocator_rss_bytes:%zd\r\n", mh->allocator_rss_bytes,
             "rss_overhead_ratio:%.2f\r\n", mh->rss_extra,

--- a/src/server.c
+++ b/src/server.c
@@ -1913,6 +1913,9 @@ void whileBlockedCron(void) {
         atomicSet(server.shutdown_asap, 0);
         atomicSet(server.last_sig_received, 0);
     }
+
+    /* Tick-exit invalidation, mirroring serverCron(). */
+    defragFragCacheInvalidate();
 }
 
 static void sendGetackToReplicas(void) {

--- a/src/server.c
+++ b/src/server.c
@@ -1524,7 +1524,7 @@ void cronUpdateMemoryStats(void) {
                 pub_frag  -= server.cron_malloc_stats.lua_allocator_frag_smallbins_bytes;
                 pub_alloc -= server.cron_malloc_stats.lua_allocator_allocated;
             }
-            defragCheckCachePublish(pub_frag, pub_alloc);
+            defragFragCachePut(pub_frag, pub_alloc);
         }
         /* in case the allocator isn't providing these stats, fake them so that
          * fragmentation info still shows some (inaccurate metrics) */
@@ -1851,7 +1851,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
      * callers (defragWhileBlocked during long Lua/RDB load, or
      * endDefragCycle's recursive activeDefragCycle from a defrag time
      * event) see -1 and fall through to a fresh measurement. */
-    defragCheckCacheInvalidate();
+    defragFragCacheInvalidate();
 
     return 1000/server.hz;
 }
@@ -2399,7 +2399,7 @@ void initServerConfig(void) {
                                       updated later after loading the config.
                                       This value may be used before the server
                                       is initialized. */
-    defragCheckCacheInvalidate();  /* Mark defrag-side fragmentation cache as
+    defragFragCacheInvalidate();  /* Mark defrag-side fragmentation cache as
                                       stale so the first computeDefragCycles()
                                       call falls through to a real measurement
                                       until cronUpdateMemoryStats() publishes. */

--- a/src/server.c
+++ b/src/server.c
@@ -1844,13 +1844,6 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
 
     server.el_cron_duration = getMonotonicUs() - cron_start;
 
-    /* End-of-tick invalidation for the defrag-side fragmentation cache.
-     * The cache is valid only within the current cron tick — out-of-cron
-     * callers (defragWhileBlocked during long Lua/RDB load, or
-     * endDefragCycle's recursive activeDefragCycle from a defrag time
-     * event) see -1 and fall through to a fresh measurement. */
-    defragFragCacheInvalidate();
-
     return 1000/server.hz;
 }
 
@@ -1913,9 +1906,6 @@ void whileBlockedCron(void) {
         atomicSet(server.shutdown_asap, 0);
         atomicSet(server.last_sig_received, 0);
     }
-
-    /* Tick-exit invalidation, mirroring serverCron(). */
-    defragFragCacheInvalidate();
 }
 
 static void sendGetackToReplicas(void) {
@@ -2400,10 +2390,11 @@ void initServerConfig(void) {
                                       updated later after loading the config.
                                       This value may be used before the server
                                       is initialized. */
-    defragFragCacheInvalidate();  /* Mark defrag-side fragmentation cache as
-                                      stale so the first computeDefragCycles()
-                                      call falls through to a real measurement
-                                      until cronUpdateMemoryStats() publishes. */
+    /* Mark defrag-side fragmentation cache as stale so the first
+     * computeDefragCycles() call falls through to a real measurement
+     * until cronUpdateMemoryStats() publishes. -1 is unreachable by
+     * server.cronloops (which starts at 0 and only advances). */
+    server.defrag_frag_cache.publish_cronloops = -1;
     server.timezone = getTimeZone(); /* Initialized by tzset(). */
     server.configfile = NULL;
     server.executable = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -1517,15 +1517,13 @@ void cronUpdateMemoryStats(void) {
          * Publishing with allocated==0 leaves the cache invalid
          * (sentinel set inside the publish) — defrag should decide on
          * real data or none. */
-        {
-            size_t pub_frag  = server.cron_malloc_stats.allocator_frag_smallbins_bytes;
-            size_t pub_alloc = server.cron_malloc_stats.allocator_allocated;
-            if (pub_alloc > 0 && server.lua_arena != UINT_MAX) {
-                pub_frag  -= server.cron_malloc_stats.lua_allocator_frag_smallbins_bytes;
-                pub_alloc -= server.cron_malloc_stats.lua_allocator_allocated;
-            }
-            defragFragCachePut(pub_frag, pub_alloc);
+        size_t frag  = server.cron_malloc_stats.allocator_frag_smallbins_bytes;
+        size_t alloc = server.cron_malloc_stats.allocator_allocated;
+        if (alloc > 0 && server.lua_arena != UINT_MAX) {
+            frag  -= server.cron_malloc_stats.lua_allocator_frag_smallbins_bytes;
+            alloc -= server.cron_malloc_stats.lua_allocator_allocated;
         }
+        defragFragCachePut(frag, alloc);
         /* in case the allocator isn't providing these stats, fake them so that
          * fragmentation info still shows some (inaccurate metrics) */
         if (!server.cron_malloc_stats.allocator_resident)

--- a/src/server.h
+++ b/src/server.h
@@ -1929,6 +1929,8 @@ struct defragFragCache {
     float  frag_pct;        /* defrag-relevant small-bins fragmentation percentage */
     size_t frag_bytes;      /* defrag-relevant small-bins fragmentation in bytes;
                              * 0 is the stale sentinel. */
+    long long hits;         /* Take found a valid cached value (DEBUG only) */
+    long long skips;        /* cache-hit value led to a defrag skip (DEBUG only) */
 };
 
 /*-----------------------------------------------------------------------------

--- a/src/server.h
+++ b/src/server.h
@@ -1907,30 +1907,21 @@ struct malloc_stats {
  * already performs for its own purposes earlier in the same cron tick.
  *
  * Lifecycle (single-threaded by Redis's main-thread invariant):
- *   - Producer: defragFragCachePut() — called from
- *     cronUpdateMemoryStats() after its zmalloc_get_allocator_info() call,
- *     mirroring getAllocatorFragmentation()'s Lua-arena subtraction so the
- *     cached value matches the real measurement exactly.
- *   - Consumer: defragFragCacheTake() — called from
- *     computeDefragCycles(); returns 1 on cache hit (populating the out
- *     params with frag_pct/frag_bytes equivalent to what
- *     getAllocatorFragmentation() would have produced), 0 on miss.
- *     ALWAYS invalidates the cache before returning (consume-once
- *     contract) so a subsequent consumer in the same tick window
- *     falls through to a fresh measurement.
- *   - Invalidation: defragFragCacheInvalidate() — also called near the
- *     end of serverCron() (the tick-boundary invalidation point) and at
- *     startup, to cover the produce-but-no-consume case.
- *
- * Sentinel: frag_bytes == 0 means stale/invalid. In a running server with
- * allocated memory the small-bins fragmentation can never legitimately be
- * exactly zero, so this is unambiguous. */
+ *   - Producer: defragFragCachePut() — called from cronUpdateMemoryStats()
+ *     after its zmalloc_get_allocator_info() call. Records server.cronloops
+ *     at publish time alongside the (Lua-subtracted) values.
+ *   - Consumer: defragFragCacheTake() — called from computeDefragCycles().
+ *     Returns 1 only when the recorded cronloops matches server.cronloops
+ *     (same tick); returns 0 otherwise. No explicit invalidation needed —
+ *     both serverCron() and whileBlockedCron() advance server.cronloops at
+ *     entry, so any value published in a previous tick is automatically
+ *     stale on the next entry. */
 struct defragFragCache {
-    float  frag_pct;        /* defrag-relevant small-bins fragmentation percentage */
-    size_t frag_bytes;      /* defrag-relevant small-bins fragmentation in bytes;
-                             * 0 is the stale sentinel. */
-    long long hits;         /* Take found a valid cached value (DEBUG only) */
-    long long skips;        /* cache-hit value led to a defrag skip (DEBUG only) */
+    float  frag_pct;            /* defrag-relevant small-bins fragmentation percentage */
+    size_t frag_bytes;          /* defrag-relevant small-bins fragmentation in bytes */
+    int    publish_cronloops;   /* server.cronloops at publish; -1 = never published */
+    long long hits;             /* Take found a valid cached value (DEBUG only) */
+    long long skips;            /* cache-hit value led to a defrag skip (DEBUG only) */
 };
 
 /*-----------------------------------------------------------------------------
@@ -3764,7 +3755,6 @@ void activeDefragCycle(void);
 void defragWhileBlocked(void);
 void defragFragCachePut(size_t frag_bytes, size_t allocated);
 int  defragFragCacheTake(float *out_frag_pct, size_t *out_frag_bytes);
-void defragFragCacheInvalidate(void);
 unsigned int getLRUClock(void);
 unsigned int LRU_CLOCK(void);
 const char *evictPolicyToString(void);

--- a/src/server.h
+++ b/src/server.h
@@ -1907,25 +1907,25 @@ struct malloc_stats {
  * already performs for its own purposes earlier in the same cron tick.
  *
  * Lifecycle (single-threaded by Redis's main-thread invariant):
- *   - Producer: defragCheckCachePublish() — called from
+ *   - Producer: defragFragCachePut() — called from
  *     cronUpdateMemoryStats() after its zmalloc_get_allocator_info() call,
  *     mirroring getAllocatorFragmentation()'s Lua-arena subtraction so the
  *     cached value matches the real measurement exactly.
- *   - Consumer: defragCheckCacheConsume() — called from
+ *   - Consumer: defragFragCacheTake() — called from
  *     computeDefragCycles(); returns 1 on cache hit (populating the out
  *     params with frag_pct/frag_bytes equivalent to what
  *     getAllocatorFragmentation() would have produced), 0 on miss.
  *     ALWAYS invalidates the cache before returning (consume-once
  *     contract) so a subsequent consumer in the same tick window
  *     falls through to a fresh measurement.
- *   - Invalidation: defragCheckCacheInvalidate() — also called near the
+ *   - Invalidation: defragFragCacheInvalidate() — also called near the
  *     end of serverCron() (the tick-boundary invalidation point) and at
  *     startup, to cover the produce-but-no-consume case.
  *
  * Sentinel: frag_bytes == 0 means stale/invalid. In a running server with
  * allocated memory the small-bins fragmentation can never legitimately be
  * exactly zero, so this is unambiguous. */
-struct defragCheckCache {
+struct defragFragCache {
     float  frag_pct;        /* defrag-relevant small-bins fragmentation percentage */
     size_t frag_bytes;      /* defrag-relevant small-bins fragmentation in bytes;
                              * 0 is the stale sentinel. */
@@ -2172,7 +2172,7 @@ struct redisServer {
     long long stat_slowlog_time_us_sum;    /* Sum of all slowlog entry durations (usec) */
     long long stat_slowlog_time_us_max;    /* Max slowlog entry duration (usec) */
     struct malloc_stats cron_malloc_stats; /* sampled in serverCron(). */
-    struct defragCheckCache defrag_check_cache; /* see struct defragCheckCache. */
+    struct defragFragCache defrag_frag_cache; /* see struct defragFragCache. */
     redisAtomic long long stat_net_input_bytes; /* Bytes read from network. */
     redisAtomic long long stat_net_output_bytes; /* Bytes written to network. */
     redisAtomic long long stat_net_repl_input_bytes; /* Bytes read during replication, added to stat_net_input_bytes in 'info'. */
@@ -3760,9 +3760,9 @@ void exitExecutionUnit(void);
 void resetServerStats(void);
 void activeDefragCycle(void);
 void defragWhileBlocked(void);
-void defragCheckCachePublish(size_t frag_bytes, size_t allocated);
-int  defragCheckCacheConsume(float *out_frag_pct, size_t *out_frag_bytes);
-void defragCheckCacheInvalidate(void);
+void defragFragCachePut(size_t frag_bytes, size_t allocated);
+int  defragFragCacheTake(float *out_frag_pct, size_t *out_frag_bytes);
+void defragFragCacheInvalidate(void);
 unsigned int getLRUClock(void);
 unsigned int LRU_CLOCK(void);
 const char *evictPolicyToString(void);

--- a/src/server.h
+++ b/src/server.h
@@ -1911,27 +1911,24 @@ struct malloc_stats {
  *     cronUpdateMemoryStats() after its zmalloc_get_allocator_info() call,
  *     mirroring getAllocatorFragmentation()'s Lua-arena subtraction so the
  *     cached value matches the real measurement exactly.
- *   - Consumer: defragCheckCacheConsume() — called from computeDefragCycles();
- *     returns 1 on cache hit, 0 on miss. Does NOT invalidate; the value
- *     remains valid for the rest of the current cron tick so any
- *     additional in-cron consumer can also benefit.
- *   - Invalidation: defragCheckCacheInvalidate() — called near the end of
- *     serverCron() (the tick-boundary invalidation point) and at startup.
- *     Out-of-cron callers (defrag time-event recursion via endDefragCycle,
- *     or defragWhileBlocked) see a stale (-1) value and fall through to
- *     the original expensive measurement — safe by construction.
+ *   - Consumer: defragCheckCacheConsume() — called from
+ *     computeDefragCycles(); returns 1 on cache hit (populating the out
+ *     params with frag_pct/frag_bytes equivalent to what
+ *     getAllocatorFragmentation() would have produced), 0 on miss.
+ *     ALWAYS invalidates the cache before returning (consume-once
+ *     contract) so a subsequent consumer in the same tick window
+ *     falls through to a fresh measurement.
+ *   - Invalidation: defragCheckCacheInvalidate() — also called near the
+ *     end of serverCron() (the tick-boundary invalidation point) and at
+ *     startup, to cover the produce-but-no-consume case.
  *
- * Sentinel: frag_pct_x100 < 0 means stale/invalid. */
+ * Sentinel: frag_bytes == 0 means stale/invalid. In a running server with
+ * allocated memory the small-bins fragmentation can never legitimately be
+ * exactly zero, so this is unambiguous. */
 struct defragCheckCache {
-    int64_t frag_pct_x100;  /* frag_pct expressed as percentage * 100; -1 = stale */
-    size_t  frag_bytes;     /* defrag-relevant small-bins fragmentation in bytes */
-    /* Observability counters. INFO MEMORY exposes them as
-     *   defrag_check_cache_hits  : consumer found a valid value
-     *   defrag_check_cache_skips : valid value was below threshold, so
-     *                              computeDefragCycles() returned early
-     *                              (no expensive getAllocatorFragmentation() call) */
-    long long hits;
-    long long skips;
+    float  frag_pct;        /* defrag-relevant small-bins fragmentation percentage */
+    size_t frag_bytes;      /* defrag-relevant small-bins fragmentation in bytes;
+                             * 0 is the stale sentinel. */
 };
 
 /*-----------------------------------------------------------------------------
@@ -3764,7 +3761,7 @@ void resetServerStats(void);
 void activeDefragCycle(void);
 void defragWhileBlocked(void);
 void defragCheckCachePublish(size_t frag_bytes, size_t allocated);
-int  defragCheckCacheConsume(int64_t *out_frag_pct_x100, size_t *out_frag_bytes);
+int  defragCheckCacheConsume(float *out_frag_pct, size_t *out_frag_bytes);
 void defragCheckCacheInvalidate(void);
 unsigned int getLRUClock(void);
 unsigned int LRU_CLOCK(void);

--- a/src/server.h
+++ b/src/server.h
@@ -1921,7 +1921,7 @@ struct defragFragCache {
     size_t frag_bytes;          /* defrag-relevant small-bins fragmentation in bytes */
     int    cronloops;           /* server.cronloops at publish; -1 = never published */
     long long hits;             /* Take found a valid cached value (DEBUG only) */
-    long long skips;            /* cache-hit value led to a defrag skip (DEBUG only) */
+    long long defrag_skips;     /* cache-hit value led to skipping defrag (DEBUG only) */
 };
 
 /*-----------------------------------------------------------------------------

--- a/src/server.h
+++ b/src/server.h
@@ -1919,7 +1919,7 @@ struct malloc_stats {
 struct defragFragCache {
     float  frag_pct;            /* defrag-relevant small-bins fragmentation percentage */
     size_t frag_bytes;          /* defrag-relevant small-bins fragmentation in bytes */
-    int    publish_cronloops;   /* server.cronloops at publish; -1 = never published */
+    int    cronloops;           /* server.cronloops at publish; -1 = never published */
     long long hits;             /* Take found a valid cached value (DEBUG only) */
     long long skips;            /* cache-hit value led to a defrag skip (DEBUG only) */
 };

--- a/src/server.h
+++ b/src/server.h
@@ -1902,6 +1902,38 @@ struct malloc_stats {
     size_t lua_allocator_frag_smallbins_bytes;
 };
 
+/* Tick-local cache used by computeDefragCycles() to avoid duplicating the
+ * expensive jemalloc fragmentation measurement that cronUpdateMemoryStats()
+ * already performs for its own purposes earlier in the same cron tick.
+ *
+ * Lifecycle (single-threaded by Redis's main-thread invariant):
+ *   - Producer: defragCheckCachePublish() — called from
+ *     cronUpdateMemoryStats() after its zmalloc_get_allocator_info() call,
+ *     mirroring getAllocatorFragmentation()'s Lua-arena subtraction so the
+ *     cached value matches the real measurement exactly.
+ *   - Consumer: defragCheckCacheConsume() — called from computeDefragCycles();
+ *     returns 1 on cache hit, 0 on miss. Does NOT invalidate; the value
+ *     remains valid for the rest of the current cron tick so any
+ *     additional in-cron consumer can also benefit.
+ *   - Invalidation: defragCheckCacheInvalidate() — called near the end of
+ *     serverCron() (the tick-boundary invalidation point) and at startup.
+ *     Out-of-cron callers (defrag time-event recursion via endDefragCycle,
+ *     or defragWhileBlocked) see a stale (-1) value and fall through to
+ *     the original expensive measurement — safe by construction.
+ *
+ * Sentinel: frag_pct_x100 < 0 means stale/invalid. */
+struct defragCheckCache {
+    int64_t frag_pct_x100;  /* frag_pct expressed as percentage * 100; -1 = stale */
+    size_t  frag_bytes;     /* defrag-relevant small-bins fragmentation in bytes */
+    /* Observability counters. INFO MEMORY exposes them as
+     *   defrag_check_cache_hits  : consumer found a valid value
+     *   defrag_check_cache_skips : valid value was below threshold, so
+     *                              computeDefragCycles() returned early
+     *                              (no expensive getAllocatorFragmentation() call) */
+    long long hits;
+    long long skips;
+};
+
 /*-----------------------------------------------------------------------------
  * TLS Context Configuration
  *----------------------------------------------------------------------------*/
@@ -2143,6 +2175,7 @@ struct redisServer {
     long long stat_slowlog_time_us_sum;    /* Sum of all slowlog entry durations (usec) */
     long long stat_slowlog_time_us_max;    /* Max slowlog entry duration (usec) */
     struct malloc_stats cron_malloc_stats; /* sampled in serverCron(). */
+    struct defragCheckCache defrag_check_cache; /* see struct defragCheckCache. */
     redisAtomic long long stat_net_input_bytes; /* Bytes read from network. */
     redisAtomic long long stat_net_output_bytes; /* Bytes written to network. */
     redisAtomic long long stat_net_repl_input_bytes; /* Bytes read during replication, added to stat_net_input_bytes in 'info'. */
@@ -3730,6 +3763,9 @@ void exitExecutionUnit(void);
 void resetServerStats(void);
 void activeDefragCycle(void);
 void defragWhileBlocked(void);
+void defragCheckCachePublish(size_t frag_bytes, size_t allocated);
+int  defragCheckCacheConsume(int64_t *out_frag_pct_x100, size_t *out_frag_bytes);
+void defragCheckCacheInvalidate(void);
 unsigned int getLRUClock(void);
 unsigned int LRU_CLOCK(void);
 const char *evictPolicyToString(void);

--- a/src/server.h
+++ b/src/server.h
@@ -1921,7 +1921,6 @@ struct defragFragCache {
     size_t frag_bytes;          /* defrag-relevant small-bins fragmentation in bytes */
     int    cronloops;           /* server.cronloops at publish; -1 = never published */
     long long hits;             /* Take found a valid cached value (DEBUG only) */
-    long long defrag_skips;     /* cache-hit value led to skipping defrag (DEBUG only) */
 };
 
 /*-----------------------------------------------------------------------------

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -323,46 +323,6 @@ run_solo {defrag} {
             r script flush sync
         } {OK}
 
-        test "Active defrag check-cache: skip path when below threshold: $type" {
-            # Verifies the defrag-side fragmentation cache mechanism:
-            #   (A) we SKIP the expensive getAllocatorFragmentation() call
-            #       when the cached value is below the threshold, and
-            #   (C) the cache mechanism is actually wired up (consume is
-            #       being called every cron tick).
-            # The (B) "don't skip when we shouldn't" path is exercised by
-            # the "Active defrag main dictionary" test above: that test
-            # forces real fragmentation > threshold, the fall-through
-            # measurement runs, and defrag engages — which it could not
-            # do if the cache incorrectly skipped.
-            r flushdb
-            r config set hz 100
-            r config set activedefrag yes
-            # threshold-lower very high and ignore-bytes very high so the
-            # cached value is guaranteed below both skip conditions every
-            # tick (the skip path fires). With this config defrag never
-            # engages, so the cache continues to be consumed and the
-            # counters move predictably.
-            r config set active-defrag-threshold-lower 99
-            r config set active-defrag-ignore-bytes 1gb
-
-            # Baseline counter snapshot.
-            set stats1 [r debug defrag-frag-cache-stats]
-            regexp {defrag_frag_cache_hits:(\d+)} $stats1 -> hits1
-
-            # Wait for the cache to be exercised (positive condition).
-            # The producer/consumer pair fires every cron tick; this
-            # typically completes within ~100 ms. A working cache
-            # produces hits > baseline; a silently-disabled cache (Take
-            # always returning miss) would never advance the counter
-            # and this would fail.
-            wait_for_condition 50 100 {
-                [regexp {defrag_frag_cache_hits:(\d+)} [r debug defrag-frag-cache-stats] -> hits2]
-                && $hits2 > $hits1
-            } else {
-                fail "defrag_frag_cache_hits did not advance"
-            }
-        }
-
         test "Active defrag big keys: $type" {
             r flushdb
             r config set hz 100
@@ -1243,6 +1203,27 @@ run_solo {defrag} {
             assert_equal OK [r save] ;# Iterates all pointers again after defrag.
             expr 1
         } {1}
+
+        test "Active defrag check-cache: skip path when below threshold: $type" {
+            # threshold-lower=99 and ignore-bytes=1gb guarantee the cached
+            # value is below both skip conditions every tick, so defrag
+            # never engages and the cache is consumed each cron tick.
+            r flushdb
+            r config set hz 100
+            r config set activedefrag yes
+            r config set active-defrag-threshold-lower 99
+            r config set active-defrag-ignore-bytes 1gb
+
+            set stats1 [r debug defrag-frag-cache-stats]
+            regexp {defrag_frag_cache_hits:(\d+)} $stats1 -> hits1
+
+            wait_for_condition 50 100 {
+                [regexp {defrag_frag_cache_hits:(\d+)} [r debug defrag-frag-cache-stats] -> hits2]
+                && $hits2 > $hits1
+            } else {
+                fail "defrag_frag_cache_hits did not advance"
+            }
+        }
     }
     }
 

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -323,6 +323,67 @@ run_solo {defrag} {
             r script flush sync
         } {OK}
 
+        test "Active defrag check-cache: skip path when below threshold: $type" {
+            # Verifies the defrag-side fragmentation cache mechanism:
+            #   (A) we SKIP the expensive getAllocatorFragmentation() call
+            #       when the cached value is below the threshold, and
+            #   (C) the cache mechanism is actually wired up (consume is
+            #       being called every cron tick).
+            # The (B) "don't skip when we shouldn't" path is exercised by
+            # the "Active defrag main dictionary" test above: that test
+            # forces real fragmentation > threshold, the fall-through
+            # measurement runs, and defrag engages — which it could not
+            # do if the cache incorrectly skipped.
+            r flushdb
+            r config set hz 100
+            r config set activedefrag yes
+            # threshold-lower very high and ignore-bytes very high so the
+            # cached value is guaranteed below both skip conditions every
+            # tick (the skip path fires). With this config defrag never
+            # engages, so the cache continues to be consumed and the
+            # counters move predictably.
+            r config set active-defrag-threshold-lower 99
+            r config set active-defrag-ignore-bytes 1gb
+
+            # Let cron run for a few ticks so the producer/consumer pair fires.
+            after 300
+            set stats1 [r debug defrag-frag-cache-stats]
+            regexp {defrag_frag_cache_hits:(\d+)} $stats1 -> hits1
+            regexp {defrag_frag_cache_skips:(\d+)} $stats1 -> skips1
+            after 500
+            set stats2 [r debug defrag-frag-cache-stats]
+            regexp {defrag_frag_cache_hits:(\d+)} $stats2 -> hits2
+            regexp {defrag_frag_cache_skips:(\d+)} $stats2 -> skips2
+
+            # (C) Mechanism is alive: hits accumulated.
+            assert_morethan $hits2 $hits1
+            # (A) Skip path was taken on every hit in this configuration.
+            assert_morethan $skips2 $skips1
+            # Every hit led to a skip (hits delta == skips delta) because
+            # the cached value was below both threshold and ignore-bytes
+            # on every tick.
+            assert_equal [expr {$hits2 - $hits1}] [expr {$skips2 - $skips1}]
+        }
+
+        test "Active defrag check-cache: frozen when activedefrag is off: $type" {
+            # When activedefrag is disabled, activeDefragCycle() returns
+            # early before computeDefragCycles() runs — so the cache is
+            # never consumed, hits and skips must not grow.
+            r config set activedefrag no
+
+            after 300
+            set stats1 [r debug defrag-frag-cache-stats]
+            regexp {defrag_frag_cache_hits:(\d+)} $stats1 -> hits1
+            regexp {defrag_frag_cache_skips:(\d+)} $stats1 -> skips1
+            after 500
+            set stats2 [r debug defrag-frag-cache-stats]
+            regexp {defrag_frag_cache_hits:(\d+)} $stats2 -> hits2
+            regexp {defrag_frag_cache_skips:(\d+)} $stats2 -> skips2
+
+            assert_equal $hits1 $hits2
+            assert_equal $skips1 $skips2
+        }
+
         test "Active defrag big keys: $type" {
             r flushdb
             r config set hz 100

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -219,63 +219,6 @@ run_solo {defrag} {
         r config set appendonly no
         r config set key-load-delay 0
 
-        test "Active defrag check-cache: skip path when below threshold: $type" {
-            # Verifies the defrag-check tick-local cache mechanism:
-            #   (A) we SKIP the expensive getAllocatorFragmentation() call
-            #       when the cached value is below the threshold, and
-            #   (C) the cache mechanism is actually wired up (consume is
-            #       being called every cron tick).
-            # The (B) "don't skip when we shouldn't" path is exercised by
-            # the "Active defrag main dictionary" test above: that test
-            # forces real fragmentation > threshold, the fall-through
-            # measurement runs, and defrag engages — which it could not
-            # do if the cache incorrectly skipped.
-            r flushdb
-            r config set hz 100
-            r config set activedefrag yes
-            # threshold-lower very high and ignore-bytes very high so the
-            # cached value is guaranteed below both skip conditions every
-            # tick (the skip path fires). With this config defrag never
-            # engages, so the cache continues to be consumed and the
-            # counters move predictably.
-            r config set active-defrag-threshold-lower 99
-            r config set active-defrag-ignore-bytes 1gb
-
-            # Let cron run for a few ticks so the producer/consumer pair fires.
-            after 300
-            set hits1  [s defrag_check_cache_hits]
-            set skips1 [s defrag_check_cache_skips]
-            after 500
-            set hits2  [s defrag_check_cache_hits]
-            set skips2 [s defrag_check_cache_skips]
-
-            # (C) Mechanism is alive: hits accumulated.
-            assert_morethan $hits2 $hits1
-            # (A) Skip path was taken on every hit in this configuration.
-            assert_morethan $skips2 $skips1
-            # Every hit led to a skip (hits delta == skips delta) because
-            # the cached value was below both threshold and ignore-bytes
-            # on every tick.
-            assert_equal [expr {$hits2 - $hits1}] [expr {$skips2 - $skips1}]
-        }
-
-        test "Active defrag check-cache: frozen when activedefrag is off: $type" {
-            # When activedefrag is disabled, activeDefragCycle() returns
-            # early before computeDefragCycles() runs — so the cache is
-            # never consumed, hits and skips must not grow.
-            r config set activedefrag no
-
-            after 300
-            set hits1  [s defrag_check_cache_hits]
-            set skips1 [s defrag_check_cache_skips]
-            after 500
-            set hits2  [s defrag_check_cache_hits]
-            set skips2 [s defrag_check_cache_skips]
-
-            assert_equal $hits1  $hits2
-            assert_equal $skips1 $skips2
-        }
-
         test "Active defrag eval scripts: $type" {
             r flushdb
             r script flush sync

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -361,7 +361,6 @@ run_solo {defrag} {
             } else {
                 fail "defrag_frag_cache_hits did not advance"
             }
-            assert_morethan $hits2 $hits1
         }
 
         test "Active defrag big keys: $type" {

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -348,31 +348,20 @@ run_solo {defrag} {
             # Baseline counter snapshot.
             set stats1 [r debug defrag-frag-cache-stats]
             regexp {defrag_frag_cache_hits:(\d+)} $stats1 -> hits1
-            regexp {defrag_frag_cache_skips:(\d+)} $stats1 -> skips1
 
             # Wait for the cache to be exercised (positive condition).
             # The producer/consumer pair fires every cron tick; this
-            # typically completes within ~100 ms.
+            # typically completes within ~100 ms. A working cache
+            # produces hits > baseline; a silently-disabled cache (Take
+            # always returning miss) would never advance the counter
+            # and this would fail.
             wait_for_condition 50 100 {
-                [regexp {defrag_frag_cache_hits:(\d+)} [r debug defrag-frag-cache-stats] -> _h]
-                && $_h > $hits1
+                [regexp {defrag_frag_cache_hits:(\d+)} [r debug defrag-frag-cache-stats] -> hits2]
+                && $hits2 > $hits1
             } else {
                 fail "defrag_frag_cache_hits did not advance"
             }
-
-            # Take a coherent snapshot for the final assertions.
-            set stats2 [r debug defrag-frag-cache-stats]
-            regexp {defrag_frag_cache_hits:(\d+)} $stats2 -> hits2
-            regexp {defrag_frag_cache_skips:(\d+)} $stats2 -> skips2
-
-            # (C) Mechanism is alive: hits accumulated.
             assert_morethan $hits2 $hits1
-            # (A) Skip path was taken on every hit in this configuration.
-            assert_morethan $skips2 $skips1
-            # Every hit led to a skip (hits delta == skips delta) because
-            # the cached value was below both threshold and ignore-bytes
-            # on every tick.
-            assert_equal [expr {$hits2 - $hits1}] [expr {$skips2 - $skips1}]
         }
 
         test "Active defrag big keys: $type" {

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -345,12 +345,22 @@ run_solo {defrag} {
             r config set active-defrag-threshold-lower 99
             r config set active-defrag-ignore-bytes 1gb
 
-            # Let cron run for a few ticks so the producer/consumer pair fires.
-            after 300
+            # Baseline counter snapshot.
             set stats1 [r debug defrag-frag-cache-stats]
             regexp {defrag_frag_cache_hits:(\d+)} $stats1 -> hits1
             regexp {defrag_frag_cache_skips:(\d+)} $stats1 -> skips1
-            after 500
+
+            # Wait for the cache to be exercised (positive condition).
+            # The producer/consumer pair fires every cron tick; this
+            # typically completes within ~100 ms.
+            wait_for_condition 50 100 {
+                [regexp {defrag_frag_cache_hits:(\d+)} [r debug defrag-frag-cache-stats] -> _h]
+                && $_h > $hits1
+            } else {
+                fail "defrag_frag_cache_hits did not advance"
+            }
+
+            # Take a coherent snapshot for the final assertions.
             set stats2 [r debug defrag-frag-cache-stats]
             regexp {defrag_frag_cache_hits:(\d+)} $stats2 -> hits2
             regexp {defrag_frag_cache_skips:(\d+)} $stats2 -> skips2
@@ -363,25 +373,6 @@ run_solo {defrag} {
             # the cached value was below both threshold and ignore-bytes
             # on every tick.
             assert_equal [expr {$hits2 - $hits1}] [expr {$skips2 - $skips1}]
-        }
-
-        test "Active defrag check-cache: frozen when activedefrag is off: $type" {
-            # When activedefrag is disabled, activeDefragCycle() returns
-            # early before computeDefragCycles() runs — so the cache is
-            # never consumed, hits and skips must not grow.
-            r config set activedefrag no
-
-            after 300
-            set stats1 [r debug defrag-frag-cache-stats]
-            regexp {defrag_frag_cache_hits:(\d+)} $stats1 -> hits1
-            regexp {defrag_frag_cache_skips:(\d+)} $stats1 -> skips1
-            after 500
-            set stats2 [r debug defrag-frag-cache-stats]
-            regexp {defrag_frag_cache_hits:(\d+)} $stats2 -> hits2
-            regexp {defrag_frag_cache_skips:(\d+)} $stats2 -> skips2
-
-            assert_equal $hits1 $hits2
-            assert_equal $skips1 $skips2
         }
 
         test "Active defrag big keys: $type" {

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -219,6 +219,63 @@ run_solo {defrag} {
         r config set appendonly no
         r config set key-load-delay 0
 
+        test "Active defrag check-cache: skip path when below threshold: $type" {
+            # Verifies the defrag-check tick-local cache mechanism:
+            #   (A) we SKIP the expensive getAllocatorFragmentation() call
+            #       when the cached value is below the threshold, and
+            #   (C) the cache mechanism is actually wired up (consume is
+            #       being called every cron tick).
+            # The (B) "don't skip when we shouldn't" path is exercised by
+            # the "Active defrag main dictionary" test above: that test
+            # forces real fragmentation > threshold, the fall-through
+            # measurement runs, and defrag engages — which it could not
+            # do if the cache incorrectly skipped.
+            r flushdb
+            r config set hz 100
+            r config set activedefrag yes
+            # threshold-lower very high and ignore-bytes very high so the
+            # cached value is guaranteed below both skip conditions every
+            # tick (the skip path fires). With this config defrag never
+            # engages, so the cache continues to be consumed and the
+            # counters move predictably.
+            r config set active-defrag-threshold-lower 99
+            r config set active-defrag-ignore-bytes 1gb
+
+            # Let cron run for a few ticks so the producer/consumer pair fires.
+            after 300
+            set hits1  [s defrag_check_cache_hits]
+            set skips1 [s defrag_check_cache_skips]
+            after 500
+            set hits2  [s defrag_check_cache_hits]
+            set skips2 [s defrag_check_cache_skips]
+
+            # (C) Mechanism is alive: hits accumulated.
+            assert_morethan $hits2 $hits1
+            # (A) Skip path was taken on every hit in this configuration.
+            assert_morethan $skips2 $skips1
+            # Every hit led to a skip (hits delta == skips delta) because
+            # the cached value was below both threshold and ignore-bytes
+            # on every tick.
+            assert_equal [expr {$hits2 - $hits1}] [expr {$skips2 - $skips1}]
+        }
+
+        test "Active defrag check-cache: frozen when activedefrag is off: $type" {
+            # When activedefrag is disabled, activeDefragCycle() returns
+            # early before computeDefragCycles() runs — so the cache is
+            # never consumed, hits and skips must not grow.
+            r config set activedefrag no
+
+            after 300
+            set hits1  [s defrag_check_cache_hits]
+            set skips1 [s defrag_check_cache_skips]
+            after 500
+            set hits2  [s defrag_check_cache_hits]
+            set skips2 [s defrag_check_cache_skips]
+
+            assert_equal $hits1  $hits2
+            assert_equal $skips1 $skips2
+        }
+
         test "Active defrag eval scripts: $type" {
             r flushdb
             r script flush sync


### PR DESCRIPTION
## Motivation

`getAllocatorFragmentation()` was called twice per `serverCron` tick:
once by `cronUpdateMemoryStats()` for `INFO MEMORY`, then again by
`computeDefragCycles()` for the threshold decision. Each call forces a
jemalloc epoch refresh (cross-thread sync via IPI) plus a per-arena
small-bin scan. The second call's result was almost always discarded
by the threshold check.

## Change

`struct defragFragCache` on `redisServer` (`src/server.h`) caches the
Lua-arena-subtracted `(frag_pct, frag_bytes)` plus `server.cronloops`
at the moment of measurement.

- `defragFragCachePut(frag_bytes, allocated)` — called from
  `cronUpdateMemoryStats()` (`src/server.c`) after the existing arena
  walk; mirrors `getAllocatorFragmentation()`'s Lua subtraction.
- `defragFragCacheTake(&pct, &bytes)` — called at the top of
  `computeDefragCycles()` (`src/defrag.c`); returns hit only when the
  recorded `cronloops` matches `server.cronloops` (same tick). Miss →
  falls through to a fresh `getAllocatorFragmentation()` call.

Freshness gate is `server.cronloops`: it advances at the top of
`serverCron()` and `whileBlockedCron()`, so any value published in a
previous tick is automatically stale on the next `Take`. No explicit
invalidate call needed. `initServerConfig()` seeds `cronloops = -1`
so the first `Take` is a clean miss.

`HAVE_DEFRAG=0` builds get no-op `Put`/`Take` stubs so the
unconditional call site in `cronUpdateMemoryStats()` always links.

## Observability

`DEBUG DEFRAG-FRAG-CACHE-STATS` exposes `defrag_frag_cache_hits`
(testing/diagnostic surface only; not in `INFO`).

## Tests

`tests/unit/memefficiency.tcl` adds *Active defrag check-cache: skip
path when below threshold* (cluster + standalone). Sets
`active-defrag-threshold-lower=99` so defrag never engages, polls via
`wait_for_condition` until `hits` advances. A silently-disabled cache
(`Take` always returning miss) would not advance the counter and the
test would fail.

The existing *Active defrag main dictionary* test continues to force
real fragmentation above threshold and exercises the cache-miss →
fall-through → defrag-engages path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only change to defrag decision path; behavior falls back to the existing measurement on cache miss, with tests guarding the hit path.
> 
> **Overview**
> Adds a **tick-local fragmentation cache** so active defrag’s threshold logic can reuse the jemalloc stats already collected for `INFO MEMORY`, instead of calling `getAllocatorFragmentation()` again in the same `serverCron` tick.
> 
> `cronUpdateMemoryStats()` publishes Lua-subtracted `(frag_pct, frag_bytes)` via `defragFragCachePut()`; `computeDefragCycles()` tries `defragFragCacheTake()` first and only measures on a miss. Validity is tied to `server.cronloops` (stale after the next cron entry). **`DEBUG DEFRAG-FRAG-CACHE-STATS`** exposes cache hit counts for tests/diagnostics. No-op stubs when `HAVE_DEFRAG` is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccccbfe9c744cd6005c47be538fb6437b22faafe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->