### PR TITLE
Batch applying events to kqueue

### DIFF
--- a/src/ae_kqueue.c
+++ b/src/ae_kqueue.c
@@ -33,14 +33,20 @@
 #include <sys/event.h>
 #include <sys/time.h>
 
+#define MAX_QUEUED_EVENTS 1024
+
 typedef struct aeApiState {
     int kqfd;
     struct kevent *events;
+    /* changes is used to buffer incoming events that will be
+     * registered in bulk via kevent(2). */
+    struct kevent changes[MAX_QUEUED_EVENTS];
+    unsigned int num_changes;
 
     /* Events mask for merge read and write event.
      * To reduce memory consumption, we use 2 bits to store the mask
      * of an event, so that 1 byte will store the mask of 4 events. */
-    char *eventsMask; 
+    char *eventsMask;
 } aeApiState;
 
 #define EVENT_MASK_MALLOC_SIZE(sz) (((sz) + 3) / 4)
@@ -75,6 +81,7 @@ static int aeApiCreate(aeEventLoop *eventLoop) {
         return -1;
     }
     anetCloexec(state->kqfd);
+    state->num_changes = 0;
     state->eventsMask = zmalloc(EVENT_MASK_MALLOC_SIZE(eventLoop->setsize));
     memset(state->eventsMask, 0, EVENT_MASK_MALLOC_SIZE(eventLoop->setsize));
     eventLoop->apidata = state;
@@ -101,47 +108,91 @@ static void aeApiFree(aeEventLoop *eventLoop) {
 
 static int aeApiAddEvent(aeEventLoop *eventLoop, int fd, int mask) {
     aeApiState *state = eventLoop->apidata;
-    struct kevent evs[2];
-    int nch = 0;
-
-    if (mask & AE_READABLE) EV_SET(evs + nch++, fd, EVFILT_READ, EV_ADD, 0, 0, NULL);
-    if (mask & AE_WRITABLE) EV_SET(evs + nch++, fd, EVFILT_WRITE, EV_ADD, 0, 0, NULL);
-
-    return kevent(state->kqfd, evs, nch, NULL, 0, NULL);
+    /* Instead of registering events to kqueue one by one, we buffer events and
+     * register them at once along with retrieving pending events in aeApiPoll. */
+    while (mask & AE_READABLE || mask & AE_WRITABLE) {
+        if (mask & AE_READABLE) {
+            mask &= ~AE_READABLE;
+            EV_SET(state->changes + state->num_changes, fd, EVFILT_READ, EV_ADD, 0, 0, NULL);
+        } else if (mask & AE_WRITABLE) {
+            mask &= ~AE_WRITABLE;
+            EV_SET(state->changes + state->num_changes, fd, EVFILT_WRITE, EV_ADD, 0, 0, NULL);
+        }
+        /* The current changelist is full, register it to kqueue now and
+         * then rewind it to make room for follow-up events. */
+        if (++state->num_changes == MAX_QUEUED_EVENTS) {
+            if (kevent(state->kqfd, state->changes, state->num_changes, NULL, 0, NULL))
+                /* An error occurs while processing an element of the changelist,
+                 * this is unexpected and indicates somewhere went wrong.
+                 * We panic for this situation directly because we won't be unable to
+                 * learn about this failure later. */
+                panic("aeApiAddEvent: kevent, %s", strerror(errno));
+            state->num_changes = 0; /* rewind the changelist. */
+        }
+    }
+    return 0;
 }
 
 static void aeApiDelEvent(aeEventLoop *eventLoop, int fd, int mask) {
     aeApiState *state = eventLoop->apidata;
-    struct kevent evs[2];
-    int nch = 0;
+    /* Due to the deferred nature of event registration, we may receive
+     * deletion requests for events that are not registered in kqueue yet,
+     * which could cause kevent(2) to fail and return ENOENT. Therefore, we
+     * need to use aeEventLoop->events to mask out the events that are not
+     * registered in kqueue and get the valid events which are requested to
+     * be deleted. */
+    int delmask = eventLoop->events[fd].mask & mask;
 
-    if (mask & AE_READABLE) EV_SET(evs + nch++, fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
-    if (mask & AE_WRITABLE) EV_SET(evs + nch++, fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);
+    /* Instead of applying events to kqueue one by one, we buffer events
+     * and apply them at once. */
+    while (delmask & AE_READABLE || delmask & AE_WRITABLE) {
+        if (delmask & AE_READABLE) {
+            delmask &= ~AE_READABLE;
+            EV_SET(state->changes + state->num_changes, fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+        } else if (delmask & AE_WRITABLE) {
+            delmask &= ~AE_WRITABLE;
+            EV_SET(state->changes + state->num_changes, fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);
+        }
+        /* The current changelist is full, apply it to kqueue now and
+         * then rewind it to make room for follow-up events. */
+        if (++state->num_changes == MAX_QUEUED_EVENTS) {
+            if (kevent(state->kqfd, state->changes, state->num_changes, NULL, 0, NULL))
+                panic("aeApiDelEvent: kevent, %s", strerror(errno));
+            state->num_changes = 0; /* rewind the changelist. */
+        }
+    }
 
-    kevent(state->kqfd, evs, nch, NULL, 0, NULL);
+    /* When it comes to EV_DELETE events, we don't defer but apply them immediately
+     * because the caller often closed the file descriptor right after they called
+     * aeDeleteFileEvent(), and kevent(2) would report ENOENT or EBADF if the changelist
+     * contained any closed file descriptors. */
+    if (state->num_changes > 0) {
+        if (kevent(state->kqfd, state->changes, state->num_changes, NULL, 0, NULL))
+            panic("aeApiDelEvent: kevent, %s", strerror(errno));
+        state->num_changes = 0; /* rewind the changelist. */
+    }
 }
 
 static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
     aeApiState *state = eventLoop->apidata;
     int retval, numevents = 0;
 
+    struct timespec ts, *timeout = NULL;
     if (tvp != NULL) {
-        struct timespec timeout;
-        timeout.tv_sec = tvp->tv_sec;
-        timeout.tv_nsec = tvp->tv_usec * 1000;
-        retval = kevent(state->kqfd, NULL, 0, state->events, eventLoop->setsize,
-                        &timeout);
-    } else {
-        retval = kevent(state->kqfd, NULL, 0, state->events, eventLoop->setsize,
-                        NULL);
+        ts.tv_sec = tvp->tv_sec;
+        ts.tv_nsec = tvp->tv_usec * 1000;
+        timeout = &ts;
     }
+    retval = kevent(state->kqfd, state->changes, state->num_changes, state->events, eventLoop->setsize,
+                    timeout);
+    state->num_changes = 0; /* rewind the changelist. */
 
     if (retval > 0) {
         int j;
 
         /* Normally we execute the read event first and then the write event.
          * When the barrier is set, we will do it reverse.
-         * 
+         *
          * However, under kqueue, read and write events would be separate
          * events, which would make it impossible to control the order of
          * reads and writes. So we store the event's mask we've got and merge
@@ -149,7 +200,7 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
         for (j = 0; j < retval; j++) {
             struct kevent *e = state->events+j;
             int fd = e->ident;
-            int mask = 0; 
+            int mask = 0;
 
             if (e->filter == EVFILT_READ) mask = AE_READABLE;
             else if (e->filter == EVFILT_WRITE) mask = AE_WRITABLE;


### PR DESCRIPTION
`kqueue` has the capability of batch applying events:

> The kevent() system call	is used	to register events with	the queue, and
       return  any  pending  events to the user.  The changelist argument is a
       pointer to an array of kevent structures, as defined in	<sys/event.h>.
       All  changes contained in the changelist	are applied before any pending
       events are read from the	queue.	The nchanges argument gives  the  size
       of  changelist.

, which can be leveraged to conserve plenty of extra system calls to kevent(2), which should have a significant benefit to the performance.

## Benchmark

### Environment
     Model : Mac Studio (2022)
        OS : macOS 14.1.2
       CPU : Apple M1 Max, 10-core CPU with 8 performance cores and 2 efficiency cores
    Memory : 32GB unified memory

### Case 1
```bash
# With RDB and AOF disabled on the server.
redis-benchmark -r 10000000 -d 100 -n 10000000 -q
```

### Comparison

#### redis:unstable

```c
PING_INLINE: 141031.80 requests per second, p50=0.175 msec
PING_MBULK: 164306.14 requests per second, p50=0.159 msec
SET: 160627.09 requests per second, p50=0.191 msec
GET: 156184.11 requests per second, p50=0.175 msec
INCR: 161022.81 requests per second, p50=0.167 msec
LPUSH: 164573.83 requests per second, p50=0.167 msec
RPUSH: 164098.53 requests per second, p50=0.167 msec
LPOP: 163655.41 requests per second, p50=0.167 msec
RPOP: 162211.27 requests per second, p50=0.167 msec
SADD: 160130.66 requests per second, p50=0.167 msec
HSET: 151906.42 requests per second, p50=0.191 msec
SPOP: 158737.72 requests per second, p50=0.175 msec
ZADD: 127665.01 requests per second, p50=0.319 msec
ZPOPMIN: 158866.33 requests per second, p50=0.175 msec
LPUSH (needed to benchmark LRANGE): 164546.77 requests per second, p50=0.167 msec
LRANGE_100 (first 100 elements): 86594.33 requests per second, p50=0.311 msec
LRANGE_300 (first 300 elements): 36351.34 requests per second, p50=0.663 msec
LRANGE_500 (first 500 elements): 22212.60 requests per second, p50=0.751 msec
LRANGE_600 (first 600 elements): 19722.66 requests per second, p50=0.839 msec
MSET (10 keys): 54174.70 requests per second, p50=0.839 msec
XADD: 157696.38 requests per second, p50=0.175 msec
```

#### panjf2000:kqueue-batch
```c
PING_INLINE: 159212.86 requests per second, p50=0.159 msec
PING_MBULK: 184396.38 requests per second, p50=0.143 msec
SET: 173722.70 requests per second, p50=0.207 msec
GET: 179742.97 requests per second, p50=0.159 msec
INCR: 182832.06 requests per second, p50=0.159 msec
LPUSH: 174146.25 requests per second, p50=0.151 msec
RPUSH: 174794.62 requests per second, p50=0.151 msec
LPOP: 173250.17 requests per second, p50=0.151 msec
RPOP: 175260.27 requests per second, p50=0.151 msec
SADD: 181957.12 requests per second, p50=0.159 msec
HSET: 174380.08 requests per second, p50=0.175 msec
SPOP: 186985.80 requests per second, p50=0.159 msec
ZADD: 139279.66 requests per second, p50=0.303 msec
ZPOPMIN: 182648.41 requests per second, p50=0.151 msec
LPUSH (needed to benchmark LRANGE): 180554.31 requests per second, p50=0.151 msec
LRANGE_100 (first 100 elements): 93919.64 requests per second, p50=0.287 msec
LRANGE_300 (first 300 elements): 37977.62 requests per second, p50=0.639 msec
LRANGE_500 (first 500 elements): 23096.98 requests per second, p50=0.719 msec
LRANGE_600 (first 600 elements): 20357.48 requests per second, p50=0.815 msec
MSET (10 keys): 54659.74 requests per second, p50=0.823 msec
XADD: 170558.23 requests per second, p50=0.159 msec
```

### Case 2 (counting the number of system calls during benchmark within around 12s)
```bash
redis-benchmark -r 10000000 -d 1024 -n 10000000 -P 100 -t get,lpop,rpop,spop,zpopmin -q
```

```c
GET: 3372681.50 requests per second, p50=1.271 msec
LPOP: 3453038.75 requests per second, p50=1.263 msec
RPOP: 3447087.25 requests per second, p50=1.255 msec
SPOP: 3487966.50 requests per second, p50=1.255 msec
ZPOPMIN: 3455425.00 requests per second, p50=1.271 msec
```

### redis:unstable 
```c
CALL                                        COUNT
…
accept                                         64
fcntl                                         174
setsockopt                                    263
kevent                                       1227
read                                        22255
write                                       22257
```

### panjf2000:kqueue-batch

```c
GET: 3612717.00 requests per second, p50=1.183 msec
LPOP: 3777861.50 requests per second, p50=1.151 msec
RPOP: 3865481.50 requests per second, p50=1.135 msec
SPOP: 3883495.00 requests per second, p50=1.143 msec
ZPOPMIN: 3828484.00 requests per second, p50=1.167 msec
```

```c
CALL                                        COUNT
…
accept                                         67
fcntl                                         174
setsockopt                                    263
kevent                                        903
read                                        21085
write                                       21114
```

## Reference
[kqueue on FreeBSD](https://man.freebsd.org/cgi/man.cgi?query=kqueue)
[kqueue on macOS](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kqueue.2.html)
[kqueue on DragonflyBSD](https://man.dragonflybsd.org/?command=kqueue&section=2)
[kqueue on NetBSD](https://man.netbsd.org/kqueue.2)
[kqueue on OpenBSD](https://man.openbsd.org/kqueue.2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core event-loop backend on kqueue platforms with deferred registration and stricter kevent error handling (panic on add-path failures).
> 
> **Overview**
> **Batches kqueue `kevent(2)` changelist updates** so Redis’s BSD/macOS event loop does fewer syscalls per connection churn. `EV_ADD` registrations are queued (up to 1024) and applied together with the next poll; overflow flushes early with `panic` on failure.
> 
> **Deletes** still use the same buffer but are **flushed immediately** so closed FDs are not left in a deferred changelist. Deletes are intersected with `eventLoop->events[fd].mask` so removing events that were only queued—not yet in kqueue—does not trigger `ENOENT`.
> 
> `aeApiPoll` now passes the pending changelist into `kevent` in one call (register + wait), then clears the queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8a39fe3eaa88400feae0b8fe29cad0a68023c33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->