### PR TITLE
fix: linenoise example's is_sensitive=0

### DIFF
--- a/deps/linenoise/example.c
+++ b/deps/linenoise/example.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
         /* Do something with the string. */
         if (line[0] != '\0' && line[0] != '/') {
             printf("echo: '%s'\n", line);
-            linenoiseHistoryAdd(line); /* Add to the history. */
+            linenoiseHistoryAdd(line, 0); /* Add to the history. */
             linenoiseHistorySave("history.txt"); /* Save the history on disk. */
         } else if (!strncmp(line,"/historylen",11)) {
             /* The "/historylen" command will change the history len. */

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -203,6 +203,7 @@ enum KEY_ACTION{
 
 static void linenoiseAtExit(void);
 int linenoiseHistoryAdd(const char *line, int is_sensitive);
+int linenoiseHistoryAddInsensitive(const char *line);
 static void refreshLine(struct linenoiseState *l);
 static void refreshSearchResult(struct linenoiseState *ls);
 
@@ -1311,6 +1312,10 @@ static void freeHistory(void) {
 static void linenoiseAtExit(void) {
     disableRawMode(STDIN_FILENO);
     freeHistory();
+}
+
+int linenoiseHistoryAddInsensitive(const char *line) {
+    return linenoiseHistoryAdd(line, 0);
 }
 
 /* This is the API call to add a new entry in the linenoise history.

--- a/deps/linenoise/linenoise.h
+++ b/deps/linenoise/linenoise.h
@@ -59,6 +59,7 @@ void linenoiseAddCompletion(linenoiseCompletions *, const char *);
 char *linenoise(const char *prompt);
 void linenoiseFree(void *ptr);
 int linenoiseHistoryAdd(const char *line, int is_sensitive);
+int linenoiseHistoryAddInsensitive(const char *line);
 int linenoiseHistorySetMaxLen(int len);
 int linenoiseHistorySave(const char *filename);
 int linenoiseHistoryLoad(const char *filename);


### PR DESCRIPTION
I noticed this example didn't compile as-is. Happy to remove the additional API (or keep it) as maintainers desire.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Vendored linenoise-only changes: example compile fix and a thin history helper with no security or product-path impact.
> 
> **Overview**
> Fixes a **build break** in the vendored linenoise **example**: `linenoiseHistoryAdd` now takes an `is_sensitive` flag, so the demo calls `linenoiseHistoryAdd(line, 0)` for normal (non-password) history lines.
> 
> Also adds **`linenoiseHistoryAddInsensitive`**, a small public wrapper that forwards to `linenoiseHistoryAdd(line, 0)` for callers that don’t need sensitive-history handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3fc44ae7e976b5f3a8a1725305bfb8435195051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->