### PR TITLE
Fix LSET encoding converion after element replacement

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -650,12 +650,12 @@ void lsetCommand(client *c) {
 
     if (server.memory_tracking_enabled)
         oldsize = kvobjAllocSize(o);
-    listTypeTryConversionAppend(o,c->argv,3,3,NULL,NULL);
+
     if (listTypeReplaceAtIndex(o,index,value)) {
-        /* We might replace a big item with a small one or vice versa, but we've
-         * already handled the growing case in listTypeTryConversionAppend()
-         * above, so here we just need to try the conversion for shrinking. */
-        listTypeTryConversion(o,LIST_CONV_SHRINKING,NULL,NULL);
+        /* We might replace a big item with a small one or vice versa, 
+           so here we handle both growing case as well as shrinking case */
+        if (o->encoding == OBJ_ENCODING_QUICKLIST) listTypeTryConversion(o,LIST_CONV_SHRINKING,NULL,NULL);
+        else if (o->encoding == OBJ_ENCODING_LISTPACK) listTypeTryConversion(o,LIST_CONV_GROWING,NULL,NULL);
         addReply(c,shared.ok);
         keyModified(c,c->db,c->argv[1],o,1);
         notifyKeyspaceEvent(NOTIFY_LIST,"lset",c->argv[1],c->db->id);

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -2110,6 +2110,26 @@ foreach {pop} {BLPOP BLMPOP_RIGHT} {
 }
 
     foreach {max_lp_size large} "3 $largevalue(listpack) -1 $largevalue(quicklist)" {
+        test "List LSET keeps listpack encoding when replacement stays within limits - $max_lp_size" {
+            set origin_conf [config_get_set list-max-listpack-size $max_lp_size]
+
+            create_listpack lst "a b c"
+            r LSET lst 0 x
+            assert_encoding listpack lst
+
+            r config set list-max-listpack-size $origin_conf
+        }
+
+        test "List LSET converts listpack when replacement exceeds safety limit - $max_lp_size" {
+            set origin_conf [config_get_set list-max-listpack-size $max_lp_size]
+
+            create_listpack lst "a"
+            r LSET lst 0 [string repeat x 9000]
+            assert_encoding quicklist lst
+
+            r config set list-max-listpack-size $origin_conf
+        }
+        
         test "List listpack -> quicklist encoding conversion" {
             set origin_conf [config_get_set list-max-listpack-size $max_lp_size]
 
@@ -2126,7 +2146,11 @@ foreach {pop} {BLPOP BLMPOP_RIGHT} {
             # LSET
             create_listpack lst "a b c"
             r LSET lst 0 $large
-            assert_encoding quicklist lst
+            if {$max_lp_size == 3} {
+                assert_encoding listpack lst
+            } else {
+                assert_encoding quicklist lst
+            }
 
             # LMOVE
             create_quicklist lsrc{t} "a b c $large"


### PR DESCRIPTION
**LSET replaces an existing list element, but the old conversion check treated the new value like an appended element.** 

For example:
* With list-max-listpack-size 3, replacing one small value in a 3-element listpack could wrongly convert it to quicklist.

# Issue
Fixes #15335

```
127.0.0.1:7000> FLUSHALL
OK
127.0.0.1:7000> config set list-max-listpack-size 3
OK
127.0.0.1:7000> lpush a hello hello hello
(integer) 3
127.0.0.1:7000> OBJECT a
(error) ERR unknown subcommand 'a'. Try OBJECT HELP.
127.0.0.1:7000> OBJECT ENCODING a
"listpack"
127.0.0.1:7000> lset a 0 b
OK
127.0.0.1:7000> llen a
(integer) 3
127.0.0.1:7000> OBJECT ENCODING a
"quicklist"
```
The index 0 value is update from hello to a, but encoding is changed to quicklist (while it should remain listpack).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to LSET encoding logic with targeted regression tests; no auth, persistence, or cross-command behavior beyond list encoding correctness.
> 
> **Overview**
> Fixes **LSET** wrongly upgrading a **listpack** to **quicklist** when the new element still fits under `list-max-listpack-size` (e.g. swapping one element in a full 3-item listpack).
> 
> **`lsetCommand`** no longer calls **`listTypeTryConversionAppend`** before **`listTypeReplaceAtIndex`**. That path assumed an extra element was being added, so limits were checked on inflated size/count. After a successful replace, encoding is adjusted on the **actual** list: **`LIST_CONV_SHRINKING`** for quicklist, **`LIST_CONV_GROWING`** for listpack (post-replace limits only).
> 
> Tests cover listpack retention on small replacements, conversion on oversized replacements, and updated expectations for the shared listpack→quicklist conversion suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bada0a537242db15a2be6ca75fe33ef5581df95c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->