### PR TITLE
Update RedisTimeSeries module to v8.9.80

### DIFF
--- a/modules/redistimeseries/Makefile
+++ b/modules/redistimeseries/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.8.0
+MODULE_VERSION = v8.9.80
 MODULE_REPO = https://github.com/redistimeseries/redistimeseries
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redistimeseries.so
 


### PR DESCRIPTION
## Summary

Bumps the pinned `MODULE_VERSION` for **RedisTimeSeries** from `v8.8.0` to `v8.9.80`. RedisBloom and RedisJSON are unchanged.

| Module          | From    | To       |
|-----------------|---------|----------|
| RedisTimeSeries | v8.8.0  | v8.9.80  |

> **Note:** `v8.9.80` is the **8.10 LTS branch cut** (targets Redis 8.10) and has diverged from `v8.8.0`. The `v8.8.0...v8.9.80` ancestry diff contains 37 commits, but **7 are backports already shipped in `v8.8.0`** (verified with `git cherry`, see below); the **30 genuinely new** changes are listed here.

## Module changes ([v8.8.0 → v8.9.80](https://github.com/RedisTimeSeries/RedisTimeSeries/compare/v8.8.0...v8.9.80))

- MOD-14124 — m commands acl ([#1913](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1913))
- MOD-14250 — missing artifacts logs fix ([#1932](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1932))
- MOD-14289 — Increase LibMR execution timeout for Valgrind builds ([#1933](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1933))
- MOD-12726 — unique snapshot name + new output params for nighly event ([#1937](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1937))
- MOD-14674 — oss refresh list ([#1935](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1935))
- nightly build, upload snapshot artifact ([#1954](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1954))
- MOD-14902 — existence check to prevent Timeseries crash when Redis is not aligned with new redis-core changes ([#1940](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1940))
- MOD-14850 — Bump libmr ([#1962](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1962))
- MOD-14715 — add apt retries/timeouts to Debian/Ubuntu Dockerfiles ([#1965](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1965))
- MOD-15262 — Align TimeSeries with the RedisModule_GetUserUserName API changes ([#1975](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1975))
- RED-180951 RED-180027 — fixing bugs and improving the code ([#2004](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2004))
- MOD-14239 — Ignore known init-rdbchannel migration timeout under sanitizer ([#1979](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1979))
- MOD-15105 — make one generic getUser function ([#1981](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1981))
- MOD-15741 MOD-14091 — add dont-cache command tip to non-cacheable read commands ([#2031](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2031))
- MOD-15731 — modules modernization alignment ([#2027](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2027))
- MOD-15728 — Tal.ba/feat/blocking get ([#2028](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2028))
- MOD-8187 — fix the aggregation bugs (fix reverse iterator) ([#2036](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2036))
- MOD-15749 — Link to new version of LibMR with short-form CLUSTERSET and add tests ([#2034](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2034))
- Fix REDISMODULE_MAIN typo + drop common.h forward-decl workarounds ([#2044](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2044))
- CI: switch flow-linux arm64 runner to standard ubuntu-24.04-arm ([#2048](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2048))
- MOD-15999 — Centralize Redis ref into a single source-of-truth file for CI ([#2045](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2045))
- CI: trigger OSS cluster (multi-shard) benchmarks on demand ([#2050](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2050))
- MOD-15899 — oom try calloc ([#2051](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2051))
- MOD-8187 — fix non twa aggregation ([#2053](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2053))
- MOD-16224 — Fix filter-blind neighbor lookups in EMPTY aggregation ([#2056](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2056))
- MOD-15893 — Nrange new command ([#2052](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2052))
- MOD-16160 — update blocking get syntax ([#2054](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2054))
- MOD-16160 — Fix client-side cache tips for TS.BGET and TS.NRANGE/TS.NREVRANGE ([#2057](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2057))
- Cut 8.10 LTS branch: bump version to 8.9.80, target Redis 8.10 ([27484f7](https://github.com/RedisTimeSeries/RedisTimeSeries/commit/27484f7))
- Fix event-nightly CI on 8.10: read Redis ref from dedicated redis_ref field ([#2058](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2058))

<details>
<summary>7 commits excluded — already shipped in v8.8.0 as backports</summary>

These show up in the `v8.8.0...v8.9.80` ancestry diff with different SHAs, but `git cherry` confirms their patch content is already in `v8.8.0`: they were backported to the 8.8 release branch (the "in 8.8 via" PR below), so they are **not** new in this bump.

- MOD-9320 — Multiple aggregators single command ([#1916](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1916)) → in 8.8 via [#1921](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1921)
- MOD-9320 — rename AGGREGATION token in m commands ([#1926](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1926)) → in 8.8 via [#1927](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1927)
- MOD-13142 — Allow changing number of threads while pool hasn't started ([#1928](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1928)) → in 8.8 via [#1934](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1934)
- MOD-14439 — Detect cluster topology changes during a multi-shard command ([#1930](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1930)) → in 8.8 under the same PR
- ci: skip Event CI when PR only changes src/version.h ([#1984](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1984)) → in 8.8 via [#1986](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1986)
- MOD-15020 — remove bionic os support ([#1983](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1983)) → in 8.8 via [#1996](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1996)
- MOD-14420 — fix count reducers return wrong NaN ([#2013](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2013)) → in 8.8 via [#2016](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2016)

</details>

## Test plan
- [ ] CI passes for RedisTimeSeries at the new pinned version
- [ ] `make all` builds RedisTimeSeries cleanly against `unstable`
- [ ] Module tests run under `make test`
