### PR TITLE
Support atomic slot migration in redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -66,6 +66,7 @@
 #define CLUSTER_MANAGER_SLOTS               16384
 #define CLUSTER_MANAGER_PORT_INCR           10000 /* same as CLUSTER_PORT_INCR */
 #define CLUSTER_MANAGER_MIGRATE_TIMEOUT     60000
+#define CLUSTER_MANAGER_ASM_MIGRATE_TIMEOUT 3600000 /* 60 minutes */
 #define CLUSTER_MANAGER_MIGRATE_PIPELINE    10
 #define CLUSTER_MANAGER_REBALANCE_THRESHOLD 2
 
@@ -117,6 +118,7 @@
 #define CLUSTER_MANAGER_CMD_FLAG_MASTERS_ONLY   1 << 11
 #define CLUSTER_MANAGER_CMD_FLAG_SLAVES_ONLY    1 << 12
 #define CLUSTER_MANAGER_CMD_FLAG_ASM            1 << 13
+#define CLUSTER_MANAGER_CMD_FLAG_TIMEOUT        1 << 14
 
 #define CLUSTER_MANAGER_OPT_GETFRIENDS  1 << 0
 #define CLUSTER_MANAGER_OPT_COLD        1 << 1
@@ -2971,6 +2973,8 @@ static int parseOptions(int argc, char **argv) {
             config.cluster_manager_command.slots = atoi(argv[++i]);
         } else if (!strcmp(argv[i],"--cluster-timeout") && !lastarg) {
             config.cluster_manager_command.timeout = atoi(argv[++i]);
+            config.cluster_manager_command.flags |=
+                CLUSTER_MANAGER_CMD_FLAG_TIMEOUT;
         } else if (!strcmp(argv[i],"--cluster-pipeline") && !lastarg) {
             config.cluster_manager_command.pipeline = atoi(argv[++i]);
         } else if (!strcmp(argv[i],"--cluster-threshold") && !lastarg) {
@@ -5526,8 +5530,12 @@ static int clusterManagerAtomicMoveSlots(clusterManagerNode *source,
     if (!(opts & CLUSTER_MANAGER_OPT_QUIET))
         printf("Waiting for migration task %s to complete", task_id);
 
-    /* Poll until completed/canceled/timeout. */
+    /* Poll until completed/canceled/timeout. When the user did not explicitly
+     * set --cluster-timeout, ASM uses a larger default since a single task may
+     * migrate a large amount of data. */
     int timeout = config.cluster_manager_command.timeout;
+    if (!(config.cluster_manager_command.flags & CLUSTER_MANAGER_CMD_FLAG_TIMEOUT))
+        timeout = CLUSTER_MANAGER_ASM_MIGRATE_TIMEOUT;
     long long start_time = mstime();
     char errbuf[256];
     int success = 0;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5431,11 +5431,48 @@ static int clusterManagerSlotIntCompare(const void *s1, const void *s2) {
     return (*(const int *)s1) - (*(const int *)s2);
 }
 
+/* CLUSTER MIGRATION task states */
+#define CLUSTER_ASM_NONE        0
+#define CLUSTER_ASM_IN_PROGRESS 1
+#define CLUSTER_ASM_CANCELED    2
+#define CLUSTER_ASM_COMPLETED   3
+
+/* Query the ASM task 'task_id' on 'node' via CLUSTER MIGRATION STATUS.
+ * Returns positive value if the task was found, 0 if not found,
+ * and -1 on other errors otherwise. */
+static int clusterManagerAsmTaskState(clusterManagerNode *node, sds task_id, char **err) {
+    redisReply *st = CLUSTER_MANAGER_COMMAND(node,
+        "CLUSTER MIGRATION STATUS ID %s", task_id);
+    if (!clusterManagerCheckRedisReply(node, st, err)) {
+        if (st) freeReplyObject(st);
+        return -1;
+    }
+
+    int state = CLUSTER_ASM_NONE;
+    if (st->type == REDIS_REPLY_ARRAY && st->elements > 0) {
+        redisReply *m = st->element[0];
+        for (size_t i = 0; i + 1 < m->elements; i += 2) {
+            redisReply *k = m->element[i], *v = m->element[i + 1];
+            if (k->type != REDIS_REPLY_STRING || v->type != REDIS_REPLY_STRING)
+                continue;
+            if (!strcmp(k->str, "state")) {
+                if (!strcmp(v->str, "canceled")) state = CLUSTER_ASM_CANCELED;
+                else if (!strcmp(v->str, "completed")) state = CLUSTER_ASM_COMPLETED;
+                else state = CLUSTER_ASM_IN_PROGRESS; /* Redis will retry even failed. */
+                break;
+            }
+        }
+    }
+    freeReplyObject(st);
+    return state;
+}
+
 /* Atomically move the given 'slots' to 'target' using ASM instead of
  * per-key MIGRATE. The slots are merged into contiguous ranges and
  * sent via "CLUSTER MIGRATION IMPORT <start end start end ...>".
- * The task is then polled until completion, and each state change is printed
- * unless CLUSTER_MANAGER_OPT_QUIET is set in 'opts'.
+ * The task is then polled until both the target and the source report
+ * completion. A heartbeat dot is printed each second unless
+ * CLUSTER_MANAGER_OPT_QUIET is set in 'opts'.
  *
  * The source node is resolved by the target from its cluster topology.
  * '--cluster-timeout' limits the wait; 0 means wait forever.
@@ -5487,7 +5524,7 @@ static int clusterManagerAtomicMoveSlots(clusterManagerNode *source,
 
     /* Print a message to inform the user the migration has started. */
     if (!(opts & CLUSTER_MANAGER_OPT_QUIET))
-        printf("Waiting for migration task %s to complete ", task_id);
+        printf("Waiting for migration task %s to complete", task_id);
 
     /* Poll until completed/canceled/timeout. */
     int timeout = config.cluster_manager_command.timeout;
@@ -5495,55 +5532,24 @@ static int clusterManagerAtomicMoveSlots(clusterManagerNode *source,
     char errbuf[256];
     int success = 0;
     while (1) {
-        redisReply *st = CLUSTER_MANAGER_COMMAND(target, "CLUSTER MIGRATION STATUS ID %s", task_id);
-        if (!clusterManagerCheckRedisReply(target, st, err)) {
-            if (st) freeReplyObject(st);
-            break;
-        }
-        char *state = NULL, *last_error = NULL;
-        if (st->type == REDIS_REPLY_ARRAY && st->elements > 0) {
-            redisReply *m = st->element[0];
-            for (size_t i = 0; i + 1 < m->elements; i += 2) {
-                redisReply *k = m->element[i], *v = m->element[i + 1];
-                if (k->type != REDIS_REPLY_STRING || v->type != REDIS_REPLY_STRING)
-                    continue;
+        int dst_state = clusterManagerAsmTaskState(target, task_id, err);
+        int src_state = clusterManagerAsmTaskState(source, task_id, err);
 
-                if (!strcmp(k->str, "state"))
-                    state = v->str;
-                else if (!strcmp(k->str, "last_error"))
-                    last_error = v->str;
-            }
-        }
-        if (state == NULL) {
-            if (err != NULL) {
-                snprintf(errbuf, sizeof(errbuf), "task %s not found", task_id);
-                *err = zstrdup(errbuf);
-            }
-            freeReplyObject(st);
-            break;
-        }
-        /* Heartbeat: print a dot each second so the user can see the
-         * migration is still in progress. */
-        if (!(opts & CLUSTER_MANAGER_OPT_QUIET)) {
-            printf(".");
-            fflush(stdout);
-        }
-        if (!strcmp(state, "completed")) {
-            freeReplyObject(st);
+        if (src_state == -1 || dst_state == -1) break; /* Handle reply errors. */
+
+        /* The migration is only considered successful when both the target
+         * and the source report "completed" */
+        if (dst_state == CLUSTER_ASM_COMPLETED && src_state == CLUSTER_ASM_COMPLETED) {
             success = 1;
             break;
         }
-        /* "failed" is not terminal, redis can retry it automatically.
-         * Only "canceled" stops us. */
-        if (!strcmp(state, "canceled")) {
-            if (err != NULL) {
-                snprintf(errbuf, sizeof(errbuf), "task %s canceled: %s", task_id, last_error ? last_error : "(none)");
-                *err = zstrdup(errbuf);
-            }
-            freeReplyObject(st);
+
+        /* If either the target or the source reports "canceled", we stop
+         * waiting and declare the migration as failed. */
+        if (dst_state == CLUSTER_ASM_CANCELED || src_state == CLUSTER_ASM_CANCELED) {
+            if (err != NULL) *err = zstrdup("atomic slot migration is canceled");
             break;
         }
-        freeReplyObject(st);
 
         /* Check if timeout */
         if (timeout > 0 && (mstime() - start_time) >= timeout) {
@@ -5554,6 +5560,13 @@ static int clusterManagerAtomicMoveSlots(clusterManagerNode *source,
                 *err = zstrdup(errbuf);
             }
             break;
+        }
+
+        /* Heartbeat: print a dot each second so the user can see the
+         * migration is still in progress. */
+        if (!(opts & CLUSTER_MANAGER_OPT_QUIET)) {
+            printf(".");
+            fflush(stdout);
         }
         sleep(1);
     }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7851,7 +7851,8 @@ static int clusterManagerCommandReshard(int argc, char **argv) {
             } else {
                 clusterManagerNode *src =
                     clusterNodeForResharding(buf, target, &raise_err);
-                if (src != NULL) listAddNodeTail(sources, src);
+                if (src != NULL && !listSearchKey(sources, src))
+                    listAddNodeTail(sources, src);
                 else if (raise_err) {
                     result = 0;
                     goto cleanup;
@@ -7868,7 +7869,8 @@ static int clusterManagerCommandReshard(int argc, char **argv) {
             } else {
                 clusterManagerNode *src =
                     clusterNodeForResharding(from, target, &raise_err);
-                if (src != NULL) listAddNodeTail(sources, src);
+                if (src != NULL && !listSearchKey(sources, src))
+                    listAddNodeTail(sources, src);
                 else if (raise_err) {
                     result = 0;
                     goto cleanup;
@@ -7882,7 +7884,8 @@ static int clusterManagerCommandReshard(int argc, char **argv) {
             if (!all) {
                 clusterManagerNode *src =
                     clusterNodeForResharding(from, target, &raise_err);
-                if (src != NULL) listAddNodeTail(sources, src);
+                if (src != NULL && !listSearchKey(sources, src))
+                    listAddNodeTail(sources, src);
                 else if (raise_err) {
                     result = 0;
                     goto cleanup;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -69,6 +69,8 @@
 #define CLUSTER_MANAGER_ASM_MIGRATE_TIMEOUT 3600000 /* 60 minutes */
 #define CLUSTER_MANAGER_MIGRATE_PIPELINE    10
 #define CLUSTER_MANAGER_REBALANCE_THRESHOLD 2
+/* CLUSTER MIGRATION, used by ASM, is available starting with Redis 8.4.0. */
+#define CLUSTER_MANAGER_ASM_MIN_VERSION     "8.4.0"
 
 #define CLUSTER_MANAGER_INVALID_HOST_ARG \
     "[ERR] Invalid arguments: you need to pass either a valid " \
@@ -117,8 +119,7 @@
 #define CLUSTER_MANAGER_CMD_FLAG_FIX_WITH_UNREACHABLE_MASTERS 1 << 10
 #define CLUSTER_MANAGER_CMD_FLAG_MASTERS_ONLY   1 << 11
 #define CLUSTER_MANAGER_CMD_FLAG_SLAVES_ONLY    1 << 12
-#define CLUSTER_MANAGER_CMD_FLAG_ASM            1 << 13
-#define CLUSTER_MANAGER_CMD_FLAG_TIMEOUT        1 << 14
+#define CLUSTER_MANAGER_CMD_FLAG_TIMEOUT        1 << 13
 
 #define CLUSTER_MANAGER_OPT_GETFRIENDS  1 << 0
 #define CLUSTER_MANAGER_OPT_COLD        1 << 1
@@ -870,20 +871,16 @@ static size_t cliLegacyCountCommands(struct commandDocs *commands, sds version) 
     return numCommands;
 }
 
-/* Gets the server version string by calling INFO SERVER.
- * Stores the result in config.server_version.
- * When not connected, or not possible, returns NULL. */
-static sds cliGetServerVersion(void) {
+/* Gets the server version string from the given context by calling INFO SERVER.
+ * The caller owns the returned SDS. When not connected, or not possible,
+ * returns NULL. */
+static sds cliGetServerVersionFromContext(redisContext *ctx) {
     static const char *key = "\nredis_version:";
     redisReply *serverInfo = NULL;
     char *pos;
 
-    if (config.server_version != NULL) {
-        return config.server_version;
-    }
-
-    if (!context) return NULL;
-    serverInfo = redisCommand(context, "INFO SERVER");
+    if (!ctx) return NULL;
+    serverInfo = redisCommand(ctx, "INFO SERVER");
     if (serverInfo == NULL || serverInfo->type == REDIS_REPLY_ERROR) {
         freeReplyObject(serverInfo);
         return sdsempty();
@@ -900,12 +897,26 @@ static sds cliGetServerVersion(void) {
         if (end) {
             sds version = sdsnewlen(pos, end - pos);
             freeReplyObject(serverInfo);
-            config.server_version = version;
             return version;
         }
     }
     freeReplyObject(serverInfo);
     return NULL;
+}
+
+/* Gets the server version string by calling INFO SERVER.
+ * Stores the result in config.server_version.
+ * When not connected, or not possible, returns NULL. */
+static sds cliGetServerVersion(void) {
+    if (config.server_version != NULL) {
+        return config.server_version;
+    }
+
+    sds version = cliGetServerVersionFromContext(context);
+    if (version != NULL && sdslen(version) != 0) {
+        config.server_version = version;
+    }
+    return version;
 }
 
 static void cliLegacyInitHelp(dict *groups) {
@@ -2997,9 +3008,6 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--cluster-use-empty-masters")) {
             config.cluster_manager_command.flags |=
                 CLUSTER_MANAGER_CMD_FLAG_EMPTYMASTER;
-        } else if (!strcmp(argv[i],"--cluster-use-atomic-slot-migration")) {
-            config.cluster_manager_command.flags |=
-                CLUSTER_MANAGER_CMD_FLAG_ASM;
         } else if (!strcmp(argv[i],"--cluster-search-multiple-owners")) {
             config.cluster_manager_command.flags |=
                 CLUSTER_MANAGER_CMD_FLAG_CHECK_OWNERS;
@@ -3834,6 +3842,7 @@ typedef struct clusterManagerNode {
     int importing_count; /* Length of the importing array (importing slots*2) */
     float weight;   /* Weight used by rebalance */
     int balance;    /* Used by rebalance */
+    sds server_version;
 } clusterManagerNode;
 
 /* Data structure used to represent a sequence of cluster nodes. */
@@ -3952,10 +3961,10 @@ clusterManagerCommandDef clusterManagerCommands[] = {
      "search-multiple-owners,fix-with-unreachable-masters"},
     {"reshard", clusterManagerCommandReshard, -1, "<host:port> or <host> <port> - separated by either colon or space",
      "from <arg>,to <arg>,slots <arg>,yes,timeout <ms>,pipeline <arg>,"
-     "replace,use-atomic-slot-migration"},
+     "replace"},
     {"rebalance", clusterManagerCommandRebalance, -1, "<host:port> or <host> <port> - separated by either colon or space",
      "weight <node1=w1...nodeN=wN>,use-empty-masters,"
-     "timeout <ms>,simulate,pipeline <arg>,threshold <arg>,replace,use-atomic-slot-migration"},
+     "timeout <ms>,simulate,pipeline <arg>,threshold <arg>,replace"},
     {"add-node", clusterManagerCommandAddNode, 2,
      "new_host:new_port existing_host:existing_port", "slave,master-id <arg>"},
     {"del-node", clusterManagerCommandDeleteNode, 2, "host:port node_id",NULL},
@@ -4124,6 +4133,7 @@ static void freeClusterManagerNode(clusterManagerNode *node) {
         freeClusterManagerNodeFlags(node->flags_str);
         node->flags_str = NULL;
     }
+    if (node->server_version != NULL) sdsfree(node->server_version);
     zfree(node);
 }
 
@@ -4176,6 +4186,7 @@ static clusterManagerNode *clusterManagerNewNode(char *ip, int port, int bus_por
     node->replicas_count = 0;
     node->weight = 1.0f;
     node->balance = 0;
+    node->server_version = NULL;
     clusterManagerNodeResetSlots(node);
     return node;
 }
@@ -5935,6 +5946,44 @@ invalid_friend:
             } else master->replicas_count++;
         }
     }
+    return 1;
+}
+
+/* Gets and caches the Redis server version for a cluster manager node. */
+static sds clusterManagerNodeGetServerVersion(clusterManagerNode *node) {
+    sds version = NULL;
+    if (node->server_version != NULL) return node->server_version;
+
+    if (node->context == NULL && !clusterManagerNodeConnect(node)) return NULL;
+
+    version = cliGetServerVersionFromContext(node->context);
+    if (version == NULL || sdslen(version) == 0) {
+        if (version) sdsfree(version);
+        return NULL;
+    }
+    node->server_version = version;
+    return node->server_version;
+}
+
+/* Returns true when ASM can be selected automatically for cluster slot moves. */
+static int clusterManagerShouldUseAtomicSlotMigration(void) {
+    if (cluster_manager.nodes == NULL) return 0;
+
+    sds min_version = sdsnew(CLUSTER_MANAGER_ASM_MIN_VERSION);
+    listIter li;
+    listNode *ln;
+    listRewind(cluster_manager.nodes, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        clusterManagerNode *n = ln->value;
+        sds server_version = clusterManagerNodeGetServerVersion(n);
+        if (server_version == NULL ||
+            !versionIsSupported(server_version, min_version))
+        {
+            sdsfree(min_version);
+            return 0;
+        }
+    }
+    sdsfree(min_version);
     return 1;
 }
 
@@ -7941,8 +7990,7 @@ static int clusterManagerCommandReshard(int argc, char **argv) {
             goto cleanup;
         }
     }
-    int use_asm = config.cluster_manager_command.flags & CLUSTER_MANAGER_CMD_FLAG_ASM;
-    if (use_asm) {
+    if (clusterManagerShouldUseAtomicSlotMigration()) {
         /* For each source, collect its slots and migrate them in one atomic
          * call. CLUSTER MIGRATION IMPORT only accepts a single source per
          * task, so we must issue one call per source node. */
@@ -8130,8 +8178,7 @@ static int clusterManagerCommandRebalance(int argc, char **argv) {
     int src_idx = nodes_involved - 1;
     int simulate = config.cluster_manager_command.flags &
                    CLUSTER_MANAGER_CMD_FLAG_SIMULATE;
-    int use_asm = config.cluster_manager_command.flags &
-                  CLUSTER_MANAGER_CMD_FLAG_ASM;
+    int use_asm = !simulate && clusterManagerShouldUseAtomicSlotMigration();
     while (dst_idx < src_idx) {
         clusterManagerNode *dst = weightedNodes[dst_idx];
         clusterManagerNode *src = weightedNodes[src_idx];

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -116,6 +116,7 @@
 #define CLUSTER_MANAGER_CMD_FLAG_FIX_WITH_UNREACHABLE_MASTERS 1 << 10
 #define CLUSTER_MANAGER_CMD_FLAG_MASTERS_ONLY   1 << 11
 #define CLUSTER_MANAGER_CMD_FLAG_SLAVES_ONLY    1 << 12
+#define CLUSTER_MANAGER_CMD_FLAG_ASM            1 << 13
 
 #define CLUSTER_MANAGER_OPT_GETFRIENDS  1 << 0
 #define CLUSTER_MANAGER_OPT_COLD        1 << 1
@@ -2992,6 +2993,9 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--cluster-use-empty-masters")) {
             config.cluster_manager_command.flags |=
                 CLUSTER_MANAGER_CMD_FLAG_EMPTYMASTER;
+        } else if (!strcmp(argv[i],"--cluster-atomic-slot-migration")) {
+            config.cluster_manager_command.flags |=
+                CLUSTER_MANAGER_CMD_FLAG_ASM;
         } else if (!strcmp(argv[i],"--cluster-search-multiple-owners")) {
             config.cluster_manager_command.flags |=
                 CLUSTER_MANAGER_CMD_FLAG_CHECK_OWNERS;
@@ -3944,10 +3948,10 @@ clusterManagerCommandDef clusterManagerCommands[] = {
      "search-multiple-owners,fix-with-unreachable-masters"},
     {"reshard", clusterManagerCommandReshard, -1, "<host:port> or <host> <port> - separated by either colon or space",
      "from <arg>,to <arg>,slots <arg>,yes,timeout <arg>,pipeline <arg>,"
-     "replace"},
+     "replace,atomic-slot-migration"},
     {"rebalance", clusterManagerCommandRebalance, -1, "<host:port> or <host> <port> - separated by either colon or space",
      "weight <node1=w1...nodeN=wN>,use-empty-masters,"
-     "timeout <arg>,simulate,pipeline <arg>,threshold <arg>,replace"},
+     "timeout <arg>,simulate,pipeline <arg>,threshold <arg>,replace,atomic-slot-migration"},
     {"add-node", clusterManagerCommandAddNode, 2,
      "new_host:new_port existing_host:existing_port", "slave,master-id <arg>"},
     {"del-node", clusterManagerCommandDeleteNode, 2, "host:port node_id",NULL},
@@ -5421,6 +5425,146 @@ static int clusterManagerMoveSlot(clusterManagerNode *source,
         target->slots[slot] = 1;
     }
     return 1;
+}
+
+static int clusterManagerSlotIntCompare(const void *s1, const void *s2) {
+    return (*(const int *)s1) - (*(const int *)s2);
+}
+
+/* Atomically move the given 'slots' to 'target' using ASM instead of
+ * per-key MIGRATE. The slots are merged into contiguous ranges and
+ * sent via "CLUSTER MIGRATION IMPORT <start end start end ...>".
+ * The task is then polled until completion, and each state change is printed
+ * unless CLUSTER_MANAGER_OPT_QUIET is set in 'opts'.
+ *
+ * The source node is resolved by the target from its cluster topology.
+ * '--cluster-timeout' limits the wait; 0 means wait forever.
+ * Returns 1 on success, 0 on failure (sets '*err' if not NULL). */
+static int clusterManagerAtomicMoveSlots(clusterManagerNode *source,
+                                         clusterManagerNode *target,
+                                         int *slots, int num_slots, 
+                                         int opts, char **err)
+{
+    if (err != NULL) *err = NULL;
+    if (num_slots <= 0) return 1;
+
+    qsort(slots, num_slots, sizeof(int), clusterManagerSlotIntCompare);
+
+    /* Build "CLUSTER MIGRATION IMPORT <start end> ..." argv. */
+    char **argv = zcalloc((3 + num_slots * 2) * sizeof(char *));
+    argv[0] = "CLUSTER";
+    argv[1] = "MIGRATION";
+    argv[2] = "IMPORT";
+    int argv_idx = 3, start = slots[0];
+    for (int i = 1; i <= num_slots; i++) {
+        if (i == num_slots || slots[i] != slots[i - 1] + 1) {
+            argv[argv_idx++] = sdscatprintf(sdsempty(), "%d", start);
+            argv[argv_idx++] = sdscatprintf(sdsempty(), "%d", slots[i - 1]);
+            if (i < num_slots) start = slots[i];
+        }
+    }
+
+    /* Send CLUSTER MIGRATION IMPORT command. */
+    redisReply *reply = NULL;
+    redisAppendCommandArgv(target->context, argv_idx, (const char **)argv, NULL);
+    redisGetReply(target->context, (void **)&reply);
+    for (int i = 3; i < argv_idx; i++)
+        sdsfree(argv[i]);
+    zfree(argv);
+    /* Handle reply of CLUSTER MIGRATION IMPORT. */
+    if (!clusterManagerCheckRedisReply(target, reply, err)) {
+        if (reply) freeReplyObject(reply);
+        return 0;
+    }
+    if (reply->type != REDIS_REPLY_STRING) {
+        if (err != NULL)
+            *err = zstrdup("unexpected reply to CLUSTER MIGRATION IMPORT");
+        freeReplyObject(reply);
+        return 0;
+    }
+    sds task_id = sdsnewlen(reply->str, reply->len);
+    freeReplyObject(reply);
+
+    /* Poll until completed/canceled/timeout, print each state change. */
+    int timeout = config.cluster_manager_command.timeout;
+    time_t start_time = time(NULL);
+    char prev_state[128] = "";
+    char errbuf[256];
+    int success = 0;
+    while (1) {
+        redisReply *st = CLUSTER_MANAGER_COMMAND(target, "CLUSTER MIGRATION STATUS ID %s", task_id);
+        if (!clusterManagerCheckRedisReply(target, st, err)) {
+            if (st) freeReplyObject(st);
+            break;
+        }
+        char *state = NULL, *last_error = NULL;
+        if (st->type == REDIS_REPLY_ARRAY && st->elements > 0) {
+            redisReply *m = st->element[0];
+            for (size_t i = 0; i + 1 < m->elements; i += 2) {
+                redisReply *k = m->element[i], *v = m->element[i + 1];
+                if (k->type != REDIS_REPLY_STRING || v->type != REDIS_REPLY_STRING)
+                    continue;
+
+                if (!strcmp(k->str, "state"))
+                    state = v->str;
+                else if (!strcmp(k->str, "last_error"))
+                    last_error = v->str;
+            }
+        }
+        if (state == NULL) {
+            if (err != NULL) {
+                snprintf(errbuf, sizeof(errbuf), "task %s not found", task_id);
+                *err = zstrdup(errbuf);
+            }
+            freeReplyObject(st);
+            break;
+        }
+        /* Print a line only when the state has changed. */
+        if (!(opts & CLUSTER_MANAGER_OPT_QUIET) && strcmp(state, prev_state) != 0) {
+            printf("    Task %s: %s\n", task_id, state);
+            fflush(stdout);
+            strncpy(prev_state, state, sizeof(prev_state) - 1);
+            prev_state[sizeof(prev_state) - 1] = '\0';
+        }
+        if (!strcmp(state, "completed")) {
+            freeReplyObject(st);
+            success = 1;
+            break;
+        }
+        /* "failed" is not terminal, redis can retry it automatically.
+         * Only "canceled" stops us. */
+        if (!strcmp(state, "canceled")) {
+            if (err != NULL) {
+                snprintf(errbuf, sizeof(errbuf), "task %s canceled: %s", task_id, last_error ? last_error : "(none)");
+                *err = zstrdup(errbuf);
+            }
+            freeReplyObject(st);
+            break;
+        }
+        freeReplyObject(st);
+
+        /* Check if timeout */
+        if (timeout > 0 && (time(NULL) - start_time) >= timeout) {
+            redisReply *c = CLUSTER_MANAGER_COMMAND(target, "CLUSTER MIGRATION CANCEL ID %s", task_id);
+            if (c) freeReplyObject(c);
+            if (err != NULL) {
+                snprintf(errbuf, sizeof(errbuf), "timed out after %d seconds, task %s cancelled", timeout, task_id);
+                *err = zstrdup(errbuf);
+            }
+            break;
+        }
+        sleep(1);
+    }
+    sdsfree(task_id);
+
+    /* Update the node logical config. */
+    if (success && (opts & CLUSTER_MANAGER_OPT_UPDATE)) {
+        for (int i = 0; i < num_slots; i++) {
+            source->slots[slots[i]] = 0;
+            target->slots[slots[i]] = 1;
+        }
+    }
+    return success;
 }
 
 /* Flush the dirty node configuration by calling replicate for slaves or
@@ -7770,19 +7914,56 @@ static int clusterManagerCommandReshard(int argc, char **argv) {
             goto cleanup;
         }
     }
-    int opts = CLUSTER_MANAGER_OPT_VERBOSE;
-    listRewind(table, &li);
-    while ((ln = listNext(&li)) != NULL) {
-        clusterManagerReshardTableItem *item = ln->value;
-        char *err = NULL;
-        result = clusterManagerMoveSlot(item->source, target, item->slot,
-                                        opts, &err);
-        if (!result) {
-            if (err != NULL) {
-                clusterManagerLogErr("clusterManagerMoveSlot failed: %s\n", err);
-                zfree(err);
+    int use_asm = config.cluster_manager_command.flags & CLUSTER_MANAGER_CMD_FLAG_ASM;
+    if (use_asm) {
+        /* For each source, collect its slots and migrate them in one atomic
+         * call. CLUSTER MIGRATION IMPORT only accepts a single source per
+         * task, so we must issue one call per source node. */
+        int *slots_arr = zmalloc(listLength(table) * sizeof(int));
+        listRewind(sources, &li);
+        while ((ln = listNext(&li)) != NULL) {
+            /* Scan the whole table, we don't rely on its items being grouped by source. */
+            clusterManagerNode *src = ln->value;
+            int slot_num = 0;
+            listIter ti;
+            listNode *tn;
+            listRewind(table, &ti);
+            while ((tn = listNext(&ti)) != NULL) {
+                clusterManagerReshardTableItem *it = tn->value;
+                if (it->source == src)
+                    slots_arr[slot_num++] = it->slot;
             }
-            goto cleanup;
+            if (slot_num == 0) continue;
+
+            printf("Moving %d slots from %s:%d to %s:%d\n",
+                    slot_num, src->ip, src->port, target->ip, target->port);
+            char *err = NULL;
+            result = clusterManagerAtomicMoveSlots(src, target, slots_arr, slot_num, 0, &err);
+            if (!result) {
+                if (err) {
+                    clusterManagerLogErr("clusterManagerAtomicMoveSlots: %s\n", err);
+                    zfree(err);
+                }
+                break;
+            }
+        }
+        zfree(slots_arr);
+        if (!result) goto cleanup;
+    } else {
+        int opts = CLUSTER_MANAGER_OPT_VERBOSE;
+        listRewind(table, &li);
+        while ((ln = listNext(&li)) != NULL) {
+            clusterManagerReshardTableItem *item = ln->value;
+            char *err = NULL;
+            result = clusterManagerMoveSlot(item->source, target, item->slot,
+                                            opts, &err);
+            if (!result) {
+                if (err != NULL) {
+                    clusterManagerLogErr("clusterManagerMoveSlot failed: %s\n", err);
+                    zfree(err);
+                }
+                goto cleanup;
+            }
         }
     }
 cleanup:
@@ -7922,6 +8103,8 @@ static int clusterManagerCommandRebalance(int argc, char **argv) {
     int src_idx = nodes_involved - 1;
     int simulate = config.cluster_manager_command.flags &
                    CLUSTER_MANAGER_CMD_FLAG_SIMULATE;
+    int use_asm = config.cluster_manager_command.flags &
+                  CLUSTER_MANAGER_CMD_FLAG_ASM;
     while (dst_idx < src_idx) {
         clusterManagerNode *dst = weightedNodes[dst_idx];
         clusterManagerNode *src = weightedNodes[src_idx];
@@ -7946,11 +8129,35 @@ static int clusterManagerCommandRebalance(int argc, char **argv) {
                 result = 0;
                 goto end_move;
             }
+            int opts = CLUSTER_MANAGER_OPT_QUIET |
+                       CLUSTER_MANAGER_OPT_UPDATE;
             if (simulate) {
                 for (i = 0; i < table_len; i++) printf("#");
+            } else if (use_asm) {
+                /* Atomically migrate the whole batch of slots at once. */
+                int *slots = zmalloc(table_len * sizeof(int));
+                int ns = 0;
+                listRewind(table, &li);
+                while ((ln = listNext(&li)) != NULL) {
+                    clusterManagerReshardTableItem *item = ln->value;
+                    slots[ns++] = item->slot;
+                    assert(item->source == src);
+                }
+                char *err = NULL;
+                result = clusterManagerAtomicMoveSlots(src, dst, slots, ns, opts, &err);
+                if (!result) {
+                    clusterManagerLogErr("*** clusterManagerAtomicMoveSlots: "
+                                         "%s\n", err ? err : "(null)");
+                    zfree(err);
+                    zfree(slots);
+                    goto end_move;
+                }
+                zfree(slots);
+                for (i = 0; i < table_len; i++)
+                    printf("#");
+                fflush(stdout);
             } else {
-                int opts = CLUSTER_MANAGER_OPT_QUIET |
-                           CLUSTER_MANAGER_OPT_UPDATE;
+                /* Migrate slots one by one. */
                 listRewind(table, &li);
                 while ((ln = listNext(&li)) != NULL) {
                     clusterManagerReshardTableItem *item = ln->value;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5554,7 +5554,10 @@ static int clusterManagerAtomicMoveSlots(clusterManagerNode *source,
         int dst_state = clusterManagerAsmTaskState(target, task_id, err);
         int src_state = clusterManagerAsmTaskState(source, task_id, err);
 
-        if (src_state == -1 || dst_state == -1) break; /* Handle reply errors. */
+        if (src_state == -1 || dst_state == -1) {
+            if (err != NULL && *err == NULL) *err = zstrdup("reply error");
+            break;
+        }
 
         /* The migration is only considered successful when both the target
          * and the source report "completed" */

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3947,11 +3947,11 @@ clusterManagerCommandDef clusterManagerCommands[] = {
     {"fix", clusterManagerCommandFix, -1, "<host:port> or <host> <port> - separated by either colon or space",
      "search-multiple-owners,fix-with-unreachable-masters"},
     {"reshard", clusterManagerCommandReshard, -1, "<host:port> or <host> <port> - separated by either colon or space",
-     "from <arg>,to <arg>,slots <arg>,yes,timeout <arg>,pipeline <arg>,"
+     "from <arg>,to <arg>,slots <arg>,yes,timeout <ms>,pipeline <arg>,"
      "replace,atomic-slot-migration"},
     {"rebalance", clusterManagerCommandRebalance, -1, "<host:port> or <host> <port> - separated by either colon or space",
      "weight <node1=w1...nodeN=wN>,use-empty-masters,"
-     "timeout <arg>,simulate,pipeline <arg>,threshold <arg>,replace,atomic-slot-migration"},
+     "timeout <ms>,simulate,pipeline <arg>,threshold <arg>,replace,atomic-slot-migration"},
     {"add-node", clusterManagerCommandAddNode, 2,
      "new_host:new_port existing_host:existing_port", "slave,master-id <arg>"},
     {"del-node", clusterManagerCommandDeleteNode, 2, "host:port node_id",NULL},
@@ -5487,7 +5487,7 @@ static int clusterManagerAtomicMoveSlots(clusterManagerNode *source,
 
     /* Poll until completed/canceled/timeout, print each state change. */
     int timeout = config.cluster_manager_command.timeout;
-    time_t start_time = time(NULL);
+    long long start_time = mstime();
     char prev_state[128] = "";
     char errbuf[256];
     int success = 0;
@@ -5544,11 +5544,11 @@ static int clusterManagerAtomicMoveSlots(clusterManagerNode *source,
         freeReplyObject(st);
 
         /* Check if timeout */
-        if (timeout > 0 && (time(NULL) - start_time) >= timeout) {
+        if (timeout > 0 && (mstime() - start_time) >= timeout) {
             redisReply *c = CLUSTER_MANAGER_COMMAND(target, "CLUSTER MIGRATION CANCEL ID %s", task_id);
             if (c) freeReplyObject(c);
             if (err != NULL) {
-                snprintf(errbuf, sizeof(errbuf), "timed out after %d seconds, task %s cancelled", timeout, task_id);
+                snprintf(errbuf, sizeof(errbuf), "timed out after %d ms, task %s cancelled", timeout, task_id);
                 *err = zstrdup(errbuf);
             }
             break;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2993,7 +2993,7 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--cluster-use-empty-masters")) {
             config.cluster_manager_command.flags |=
                 CLUSTER_MANAGER_CMD_FLAG_EMPTYMASTER;
-        } else if (!strcmp(argv[i],"--cluster-atomic-slot-migration")) {
+        } else if (!strcmp(argv[i],"--cluster-use-atomic-slot-migration")) {
             config.cluster_manager_command.flags |=
                 CLUSTER_MANAGER_CMD_FLAG_ASM;
         } else if (!strcmp(argv[i],"--cluster-search-multiple-owners")) {
@@ -3948,10 +3948,10 @@ clusterManagerCommandDef clusterManagerCommands[] = {
      "search-multiple-owners,fix-with-unreachable-masters"},
     {"reshard", clusterManagerCommandReshard, -1, "<host:port> or <host> <port> - separated by either colon or space",
      "from <arg>,to <arg>,slots <arg>,yes,timeout <ms>,pipeline <arg>,"
-     "replace,atomic-slot-migration"},
+     "replace,use-atomic-slot-migration"},
     {"rebalance", clusterManagerCommandRebalance, -1, "<host:port> or <host> <port> - separated by either colon or space",
      "weight <node1=w1...nodeN=wN>,use-empty-masters,"
-     "timeout <ms>,simulate,pipeline <arg>,threshold <arg>,replace,atomic-slot-migration"},
+     "timeout <ms>,simulate,pipeline <arg>,threshold <arg>,replace,use-atomic-slot-migration"},
     {"add-node", clusterManagerCommandAddNode, 2,
      "new_host:new_port existing_host:existing_port", "slave,master-id <arg>"},
     {"del-node", clusterManagerCommandDeleteNode, 2, "host:port node_id",NULL},
@@ -5485,10 +5485,13 @@ static int clusterManagerAtomicMoveSlots(clusterManagerNode *source,
     sds task_id = sdsnewlen(reply->str, reply->len);
     freeReplyObject(reply);
 
-    /* Poll until completed/canceled/timeout, print each state change. */
+    /* Print a message to inform the user the migration has started. */
+    if (!(opts & CLUSTER_MANAGER_OPT_QUIET))
+        printf("Waiting for migration task %s to complete ", task_id);
+
+    /* Poll until completed/canceled/timeout. */
     int timeout = config.cluster_manager_command.timeout;
     long long start_time = mstime();
-    char prev_state[128] = "";
     char errbuf[256];
     int success = 0;
     while (1) {
@@ -5519,12 +5522,11 @@ static int clusterManagerAtomicMoveSlots(clusterManagerNode *source,
             freeReplyObject(st);
             break;
         }
-        /* Print a line only when the state has changed. */
-        if (!(opts & CLUSTER_MANAGER_OPT_QUIET) && strcmp(state, prev_state) != 0) {
-            printf("    Task %s: %s\n", task_id, state);
+        /* Heartbeat: print a dot each second so the user can see the
+         * migration is still in progress. */
+        if (!(opts & CLUSTER_MANAGER_OPT_QUIET)) {
+            printf(".");
             fflush(stdout);
-            strncpy(prev_state, state, sizeof(prev_state) - 1);
-            prev_state[sizeof(prev_state) - 1] = '\0';
         }
         if (!strcmp(state, "completed")) {
             freeReplyObject(st);
@@ -5555,6 +5557,7 @@ static int clusterManagerAtomicMoveSlots(clusterManagerNode *source,
         }
         sleep(1);
     }
+    if (!(opts & CLUSTER_MANAGER_OPT_QUIET)) printf("\n");
     sdsfree(task_id);
 
     /* Update the node logical config. */

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -3093,7 +3093,7 @@ start_server {tags "cluster external:skip"} {
 }
 }
 
-# redis-cli --cluster reshard/rebalance with --cluster-use-atomic-slot-migration.
+# redis-cli --cluster reshard/rebalance automatically uses atomic slot migration.
 #
 # 3 masters, no replicas. continuous_slot_allocation distributes slots as:
 #   node 0: 0-5461     (5462 slots)
@@ -3104,24 +3104,31 @@ start_cluster 3 0 [list tags {external:skip cluster tls:skip modules} config_lin
     set id0 [R 0 cluster myid]
     set id1 [R 1 cluster myid]
 
-    test "redis-cli --cluster reshard --cluster-use-atomic-slot-migration" {
+    test "redis-cli --cluster reshard automatically uses atomic slot migration" {
         # Move the lowest 1000 slots (0-999) from node 0 to node 1 using ASM.
+        clear_module_event_log
         exec src/redis-cli --cluster reshard 127.0.0.1:[get_port 0] \
             --cluster-from $id0 --cluster-to $id1 \
-            --cluster-slots 1000 --cluster-yes \
-            --cluster-use-atomic-slot-migration
+            --cluster-slots 1000 --cluster-yes
         wait_for_asm_done
+
+        # Non-empty event logs confirm redis-cli used ASM.
+        assert {[R 0 asm.get_cluster_event_log] ne {}}
+        assert {[R 1 asm.get_cluster_event_log] ne {}}
 
         assert_equal {{1000 5461}} [R 0 asm.cluster_get_local_slot_ranges]
         assert_equal {{0 999} {5462 10922}} [R 1 asm.cluster_get_local_slot_ranges]
     }
 
-    test "redis-cli --cluster rebalance --cluster-use-atomic-slot-migration" {
+    test "redis-cli --cluster rebalance automatically uses atomic slot migration" {
         # Rebalance distributes 16384 slots evenly across the 3 nodes.
         # (0-999) will be moved back to node 0.
-        exec src/redis-cli --cluster rebalance 127.0.0.1:[get_port 0] \
-            --cluster-yes --cluster-use-atomic-slot-migration
+        clear_module_event_log
+        exec src/redis-cli --cluster rebalance 127.0.0.1:[get_port 0] --cluster-yes
         wait_for_asm_done
+        # Non-empty event logs confirm redis-cli used ASM.
+        assert {[R 1 asm.get_cluster_event_log] ne {}}
+        assert {[R 0 asm.get_cluster_event_log] ne {}}
 
         assert_equal {{0 5461}} [R 0 asm.cluster_get_local_slot_ranges]
         assert_equal {{5462 10922}} [R 1 asm.cluster_get_local_slot_ranges]

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -3092,3 +3092,39 @@ start_server {tags "cluster external:skip"} {
     }
 }
 }
+
+# redis-cli --cluster reshard/rebalance with --cluster-atomic-slot-migration.
+#
+# 3 masters, no replicas. continuous_slot_allocation distributes slots as:
+#   node 0: 0-5461     (5462 slots)
+#   node 1: 5462-10922 (5461 slots)
+#   node 2: 10923-16383 (5461 slots)
+set testmodule [file normalize tests/modules/atomicslotmigration.so]
+start_cluster 3 0 [list tags {external:skip cluster tls:skip modules} config_lines [list loadmodule $testmodule cluster-node-timeout 60000]] {
+    set id0 [R 0 cluster myid]
+    set id1 [R 1 cluster myid]
+
+    test "redis-cli --cluster reshard --cluster-atomic-slot-migration" {
+        # Move the lowest 1000 slots (0-999) from node 0 to node 1 using ASM.
+        exec src/redis-cli --cluster reshard 127.0.0.1:[get_port 0] \
+            --cluster-from $id0 --cluster-to $id1 \
+            --cluster-slots 1000 --cluster-yes \
+            --cluster-atomic-slot-migration
+        wait_for_asm_done
+
+        assert_equal {{1000 5461}} [R 0 asm.cluster_get_local_slot_ranges]
+        assert_equal {{0 999} {5462 10922}} [R 1 asm.cluster_get_local_slot_ranges]
+    }
+
+    test "redis-cli --cluster rebalance --cluster-atomic-slot-migration" {
+        # Rebalance distributes 16384 slots evenly across the 3 nodes.
+        # (0-999) will be moved back to node 0.
+        exec src/redis-cli --cluster rebalance 127.0.0.1:[get_port 0] \
+            --cluster-yes --cluster-atomic-slot-migration
+        wait_for_asm_done
+
+        assert_equal {{0 5461}} [R 0 asm.cluster_get_local_slot_ranges]
+        assert_equal {{5462 10922}} [R 1 asm.cluster_get_local_slot_ranges]
+        assert_equal {{10923 16383}} [R 2 asm.cluster_get_local_slot_ranges]
+    }
+}

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -3093,7 +3093,7 @@ start_server {tags "cluster external:skip"} {
 }
 }
 
-# redis-cli --cluster reshard/rebalance with --cluster-atomic-slot-migration.
+# redis-cli --cluster reshard/rebalance with --cluster-use-atomic-slot-migration.
 #
 # 3 masters, no replicas. continuous_slot_allocation distributes slots as:
 #   node 0: 0-5461     (5462 slots)
@@ -3104,23 +3104,23 @@ start_cluster 3 0 [list tags {external:skip cluster tls:skip modules} config_lin
     set id0 [R 0 cluster myid]
     set id1 [R 1 cluster myid]
 
-    test "redis-cli --cluster reshard --cluster-atomic-slot-migration" {
+    test "redis-cli --cluster reshard --cluster-use-atomic-slot-migration" {
         # Move the lowest 1000 slots (0-999) from node 0 to node 1 using ASM.
         exec src/redis-cli --cluster reshard 127.0.0.1:[get_port 0] \
             --cluster-from $id0 --cluster-to $id1 \
             --cluster-slots 1000 --cluster-yes \
-            --cluster-atomic-slot-migration
+            --cluster-use-atomic-slot-migration
         wait_for_asm_done
 
         assert_equal {{1000 5461}} [R 0 asm.cluster_get_local_slot_ranges]
         assert_equal {{0 999} {5462 10922}} [R 1 asm.cluster_get_local_slot_ranges]
     }
 
-    test "redis-cli --cluster rebalance --cluster-atomic-slot-migration" {
+    test "redis-cli --cluster rebalance --cluster-use-atomic-slot-migration" {
         # Rebalance distributes 16384 slots evenly across the 3 nodes.
         # (0-999) will be moved back to node 0.
         exec src/redis-cli --cluster rebalance 127.0.0.1:[get_port 0] \
-            --cluster-yes --cluster-atomic-slot-migration
+            --cluster-yes --cluster-use-atomic-slot-migration
         wait_for_asm_done
 
         assert_equal {{0 5461}} [R 0 asm.cluster_get_local_slot_ranges]


### PR DESCRIPTION
We introduced atomic slot migration in 8.4, but have not supported it in redis-cli yet.
`redis-cli --cluster reshard` and `rebalance` now move slots with server-side atomic slot migration (ASM) via CLUSTER MIGRATION IMPORT when every cluster node reports Redis ≥ 8.4.0; otherwise behavior stays on per-slot MIGRATE.

The default timeout of atomic slot migration is **60 minutes** 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster resharding/rebalance data-move paths and version detection across all nodes; wrong gating or timeout behavior could fail migrations or leave tasks in a bad state, though legacy MIGRATE remains when any node is below 8.4.
> 
> **Overview**
> **`redis-cli --cluster reshard`** and **`rebalance`** now use server-side **atomic slot migration (ASM)** via `CLUSTER MIGRATION IMPORT` when every cluster node is **Redis ≥ 8.4.0**; otherwise they keep the existing per-slot **`MIGRATE`** path.
> 
> ASM batches slots into contiguous ranges, starts an import task on the target, polls **`CLUSTER MIGRATION STATUS`** until source and target both report completed (with cancel on timeout), and applies a **60-minute** default wait unless **`--cluster-timeout`** is set explicitly. Per-node **`server_version`** is cached after **`INFO SERVER`**, and **`cliGetServerVersion`** is refactored to read from an arbitrary connection.
> 
> Reshard groups slots **per source** (one ASM task per source); rebalance uses ASM per src/dst batch when not simulating. Duplicate source nodes in reshard **`--cluster-from`** are deduplicated. Cluster manager help text labels timeout as **`<ms>`**.
> 
> Integration tests in **`atomic-slot-migration.tcl`** assert reshard/rebalance drive ASM via the test module event log and final slot ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc334a9217b7bca2350f36707df161c9e91df768. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->