### PR TITLE
MOD-16291: Update RediSearch module to v8.9.80

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.8.0
+MODULE_VERSION = v8.9.80
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
Jira: https://redislabs.atlassian.net/browse/MOD-16291

Updates the bundled RediSearch module version used by Redis module builds from `v8.8.0` to `v8.9.80`.

This picks up the tagged RediSearch 8.9.80 release.

Validation:
- Checked that `v8.9.80` exists in `RediSearch/RediSearch` and resolves to `280c3ce1bd65fd7306cae75a1d54bce3a05518e4`.
- Checked the diff is limited to `modules/redisearch/Makefile`.
- Ran `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Makefile version pin with no application logic changes; main risk is behavioral differences in the upstream RediSearch 8.9.80 release at runtime.
> 
> **Overview**
> **RediSearch module version bump** from `v8.8.0` to `v8.9.80` via `MODULE_VERSION` in `modules/redisearch/Makefile`, so Redis module builds fetch and compile the tagged 8.9.80 release instead of 8.8.0.
> 
> No other build flags or paths change in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bd487572e48e94f852dacc2506ffb74f1ca6c6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->