### PR TITLE
Add RedisModuleEvent_ClusterTopologyChange server event

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -39,15 +39,6 @@
  * that represents this node. */
 clusterNode *myself = NULL;
 
-/* RedisModuleEvent_ClusterTopologyChange is debounced: slot/role mutations and
- * the cluster's OK/FAIL transition only OR the matching reason bit into
- * server.cluster->topology_change_flags (REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_*)
- * and request CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE; the event itself is fired once
- * per event-loop iteration from clusterBeforeSleep(), which collapses a reshuffle
- * that touches many slots into a single notification. The accumulated reason bits
- * are reported together in the event data (change_flags), so a module sees every
- * reason that contributed rather than a single one taking precedence. */
-
 clusterNode *createClusterNode(char *nodename, int flags);
 void clusterAddNode(clusterNode *node);
 void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3204,6 +3204,8 @@ int clusterProcessPacket(clusterLink *link) {
                      * primary in the very first time. */
                     updateShardId(sender, master->shard_id);
 
+                    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE);
+
                     /* Update config. */
                     clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
                 }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -48,7 +48,7 @@ void clusterSendFail(char *nodename);
 void clusterSendFailoverAuthIfNeeded(clusterNode *node, clusterMsg *request);
 void clusterUpdateState(void);
 static void clusterFireTopologyChangeIfNeeded(void);
-static void clusterNotifyTopologyChange(int change_flags);
+static void clusterNotifyTopologyChange(uint64_t change_flags);
 int clusterNodeCoversSlot(clusterNode *n, int slot);
 list *clusterGetNodesInMyShard(clusterNode *node);
 int clusterNodeAddSlave(clusterNode *master, clusterNode *slave);
@@ -5216,7 +5216,7 @@ void clusterCloseAllSlots(void) {
  * REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_* bits) and request it to be fired
  * from the next clusterBeforeSleep(). Called from every slot/role mutation and
  * on the cluster's OK/FAIL transition. */
-static void clusterNotifyTopologyChange(int change_flags) {
+static void clusterNotifyTopologyChange(uint64_t change_flags) {
     server.cluster->topology_change_flags |= change_flags;
     clusterDoBeforeSleep(CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE);
 }
@@ -5241,7 +5241,7 @@ static void clusterFireTopologyChangeIfNeeded(void) {
      * RedisModule_GetClusterSize, ...). */
     RedisModuleClusterTopologyChangeInfo info = {
         .version = REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_INFO_VERSION,
-        .change_flags = (uint64_t)server.cluster->topology_change_flags,
+        .change_flags = server.cluster->topology_change_flags,
     };
     server.cluster->topology_change_flags = 0;
     moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE, 0, &info);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -47,7 +47,7 @@ void clusterSendPing(clusterLink *link, int type);
 void clusterSendFail(char *nodename);
 void clusterSendFailoverAuthIfNeeded(clusterNode *node, clusterMsg *request);
 void clusterUpdateState(void);
-static void clusterFireTopologyChangeIfNeeded(void);
+static void clusterFireTopologyChangeEventIfNeeded(void);
 static void clusterNotifyTopologyChange(uint64_t change_flags);
 int clusterNodeCoversSlot(clusterNode *n, int slot);
 list *clusterGetNodesInMyShard(clusterNode *node);
@@ -5039,7 +5039,7 @@ void clusterBeforeSleep(void) {
      * fires at most once per event-loop iteration regardless of how many slots
      * or nodes changed. */
     if (flags & CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE)
-        clusterFireTopologyChangeIfNeeded();
+        clusterFireTopologyChangeEventIfNeeded();
 }
 
 void clusterDoBeforeSleep(int flags) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5400,10 +5400,7 @@ void clusterSetMaster(clusterNode *n) {
     serverAssert(myself->numslots == 0);
 
     int was_master = clusterNodeIsMaster(myself);
-    /* This node's replication relationship is changing -- either a master being
-     * demoted to a replica, or a replica re-pointing to a different primary. Both
-     * are topology changes, so notify modules in either branch (not only on
-     * demotion) so they re-read the topology. */
+    /* Demotion or a replica re-pointing to a new primary are both role changes. */
     clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE);
     if (was_master) {
         myself->flags &= ~(CLUSTER_NODE_MASTER|CLUSTER_NODE_MIGRATE_TO);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5400,8 +5400,12 @@ void clusterSetMaster(clusterNode *n) {
     serverAssert(myself->numslots == 0);
 
     int was_master = clusterNodeIsMaster(myself);
+    /* This node's replication relationship is changing -- either a master being
+     * demoted to a replica, or a replica re-pointing to a different primary. Both
+     * are topology changes, so notify modules in either branch (not only on
+     * demotion) so they re-read the topology. */
+    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE);
     if (was_master) {
-        clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE);
         myself->flags &= ~(CLUSTER_NODE_MASTER|CLUSTER_NODE_MIGRATE_TO);
         myself->flags |= CLUSTER_NODE_SLAVE;
         clusterCloseAllSlots();

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3183,6 +3183,7 @@ int clusterProcessPacket(clusterLink *link) {
                     sender->flags &= ~(CLUSTER_NODE_MASTER|
                                        CLUSTER_NODE_MIGRATE_TO);
                     sender->flags |= CLUSTER_NODE_SLAVE;
+                    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE);
 
                     /* Update config and state. */
                     clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG|

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -39,6 +39,14 @@
  * that represents this node. */
 clusterNode *myself = NULL;
 
+/* RedisModuleEvent_ClusterTopologyChange is debounced: slot/role mutations only
+ * OR the matching subevent bit into server.cluster->topology_change_flags and
+ * request CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE; the event itself is fired once per
+ * event-loop iteration from clusterBeforeSleep(), which collapses a reshuffle
+ * that touches many slots into a single notification. The TOPOLOGY_CHANGED (1)
+ * and ROLE_CHANGED (2) subevent values are distinct bits, so they double as
+ * the pending-reason flags (ROLE_CHANGED takes precedence when both are set). */
+
 clusterNode *createClusterNode(char *nodename, int flags);
 void clusterAddNode(clusterNode *node);
 void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask);
@@ -47,6 +55,8 @@ void clusterSendPing(clusterLink *link, int type);
 void clusterSendFail(char *nodename);
 void clusterSendFailoverAuthIfNeeded(clusterNode *node, clusterMsg *request);
 void clusterUpdateState(void);
+static void clusterFireTopologyChangeIfNeeded(void);
+static void clusterNotifyTopologyChange(int change_flags);
 int clusterNodeCoversSlot(clusterNode *n, int slot);
 list *clusterGetNodesInMyShard(clusterNode *node);
 int clusterNodeAddSlave(clusterNode *master, clusterNode *slave);
@@ -964,6 +974,8 @@ void clusterInit(void) {
     server.cluster->currentEpoch = 0;
     server.cluster->state = CLUSTER_FAIL;
     server.cluster->size = 0;
+    server.cluster->topology_change_flags = 0;
+    server.cluster->topo_startup_fired = 0;
     server.cluster->todo_before_sleep = 0;
     server.cluster->nodes = dictCreate(&clusterNodesDictType);
     server.cluster->shards = dictCreate(&clusterSdsToListType);
@@ -2327,6 +2339,7 @@ void clusterSetNodeAsMaster(clusterNode *n) {
     n->flags &= ~CLUSTER_NODE_SLAVE;
     n->flags |= CLUSTER_NODE_MASTER;
     n->slaveof = NULL;
+    clusterNotifyTopologyChange(REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED);
 
     /* Update config and state. */
     clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG|
@@ -5020,6 +5033,13 @@ void clusterBeforeSleep(void) {
     /* Broadcast a PONG to all the nodes. */
     if (flags & CLUSTER_TODO_BROADCAST_PONG)
         clusterBroadcastPong(CLUSTER_BROADCAST_ALL);
+
+    /* Notify subscribed modules about cluster topology changes. Done here, after
+     * the state update above, so the notification reflects the current state and
+     * fires at most once per event-loop iteration regardless of how many slots
+     * or nodes changed. */
+    if (flags & CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE)
+        clusterFireTopologyChangeIfNeeded();
 }
 
 void clusterDoBeforeSleep(int flags) {
@@ -5122,6 +5142,7 @@ int clusterAddSlot(clusterNode *n, int slot) {
     /* Make owner_not_claiming_slot flag consistent with slot ownership information. */
     bitmapClearBit(server.cluster->owner_not_claiming_slot, slot);
     clusterSlotStatReset(slot);
+    clusterNotifyTopologyChange(REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED);
     return C_OK;
 }
 
@@ -5141,6 +5162,7 @@ int clusterDelSlot(int slot) {
     /* Make owner_not_claiming_slot flag consistent with slot ownership information. */
     bitmapClearBit(server.cluster->owner_not_claiming_slot, slot);
     clusterSlotStatReset(slot);
+    clusterNotifyTopologyChange(REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED);
     return C_OK;
 }
 
@@ -5194,6 +5216,48 @@ void clusterCloseAllSlots(void) {
 #define CLUSTER_MAX_REJOIN_DELAY 5000
 #define CLUSTER_MIN_REJOIN_DELAY 500
 #define CLUSTER_WRITABLE_DELAY 2000
+
+/* Record a pending RedisModuleEvent_ClusterTopologyChange (the change_flags are
+ * REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_* bits) and request it to be fired
+ * from the next clusterBeforeSleep(). Called from every slot/role mutation. */
+static void clusterNotifyTopologyChange(int change_flags) {
+    server.cluster->topology_change_flags |= change_flags;
+    clusterDoBeforeSleep(CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE);
+}
+
+/* Fire the RedisModuleEvent_ClusterTopologyChange module event with the given
+ * subevent. The event carries no payload (NULL data). */
+static void clusterFireTopologyChangeEvent(int subevent) {
+    /* No data payload: a subscribing module reads whatever it needs about the
+     * new topology via the cluster info module APIs (CLUSTER SLOTS,
+     * RedisModule_GetClusterNodesList/NodeInfo, RedisModule_GetClusterSize, ...). */
+    moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE, subevent, NULL);
+}
+
+/* Fire the cluster topology-change notification to modules, if one is pending.
+ * Called once per event-loop iteration from clusterBeforeSleep() in response to
+ * CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE, which is requested by every slot/role
+ * mutation and on the cluster's OK/FAIL transition. This debounces a reshuffle
+ * that touches many slots into a single notification. STARTUP is reported once,
+ * the first time the cluster becomes OK; afterwards a pending role change is
+ * reported as ROLE_CHANGED and any other slot/membership change as
+ * TOPOLOGY_CHANGED. The checks here make a redundant TODO a harmless no-op. */
+static void clusterFireTopologyChangeIfNeeded(void) {
+    if (!server.cluster->topo_startup_fired) {
+        if (server.cluster->state == CLUSTER_OK) {
+            server.cluster->topo_startup_fired = 1;
+            server.cluster->topology_change_flags = 0;
+            clusterFireTopologyChangeEvent(
+                REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_STARTUP);
+        }
+    } else if (server.cluster->topology_change_flags) {
+        int subevent = (server.cluster->topology_change_flags & REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED) ?
+            REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED :
+            REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED;
+        server.cluster->topology_change_flags = 0;
+        clusterFireTopologyChangeEvent(subevent);
+    }
+}
 
 void clusterUpdateState(void) {
     int j, new_state;
@@ -5289,6 +5353,10 @@ void clusterUpdateState(void) {
             "Cluster state changed: %s",
             new_state == CLUSTER_OK ? "ok" : "fail");
         server.cluster->state = new_state;
+
+        /* The OK/FAIL transition (in particular the first reach of OK, i.e.
+         * startup) is itself a topology-change notification trigger. */
+        clusterDoBeforeSleep(CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE);
     }
 }
 
@@ -5342,6 +5410,7 @@ void clusterSetMaster(clusterNode *n) {
 
     int was_master = clusterNodeIsMaster(myself);
     if (was_master) {
+        clusterNotifyTopologyChange(REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED);
         myself->flags &= ~(CLUSTER_NODE_MASTER|CLUSTER_NODE_MIGRATE_TO);
         myself->flags |= CLUSTER_NODE_SLAVE;
         clusterCloseAllSlots();

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -39,13 +39,14 @@
  * that represents this node. */
 clusterNode *myself = NULL;
 
-/* RedisModuleEvent_ClusterTopologyChange is debounced: slot/role mutations only
- * OR the matching subevent bit into server.cluster->topology_change_flags and
- * request CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE; the event itself is fired once per
- * event-loop iteration from clusterBeforeSleep(), which collapses a reshuffle
- * that touches many slots into a single notification. The TOPOLOGY_CHANGED (1)
- * and ROLE_CHANGED (2) subevent values are distinct bits, so they double as
- * the pending-reason flags (ROLE_CHANGED takes precedence when both are set). */
+/* RedisModuleEvent_ClusterTopologyChange is debounced: slot/role mutations and
+ * the cluster's OK/FAIL transition only OR the matching reason bit into
+ * server.cluster->topology_change_flags (REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_*)
+ * and request CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE; the event itself is fired once
+ * per event-loop iteration from clusterBeforeSleep(), which collapses a reshuffle
+ * that touches many slots into a single notification. The accumulated reason bits
+ * are reported together in the event data (change_flags), so a module sees every
+ * reason that contributed rather than a single one taking precedence. */
 
 clusterNode *createClusterNode(char *nodename, int flags);
 void clusterAddNode(clusterNode *node);
@@ -975,7 +976,6 @@ void clusterInit(void) {
     server.cluster->state = CLUSTER_FAIL;
     server.cluster->size = 0;
     server.cluster->topology_change_flags = 0;
-    server.cluster->topo_startup_fired = 0;
     server.cluster->todo_before_sleep = 0;
     server.cluster->nodes = dictCreate(&clusterNodesDictType);
     server.cluster->shards = dictCreate(&clusterSdsToListType);
@@ -1550,6 +1550,7 @@ void clusterAddNode(clusterNode *node) {
     retval = dictAdd(server.cluster->nodes,
             sdsnewlen(node->name,CLUSTER_NAMELEN), node);
     serverAssert(retval == DICT_OK);
+    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE);
 }
 
 /* Remove a node from the cluster. The function performs the high level
@@ -1598,6 +1599,8 @@ void clusterDelNode(clusterNode *delnode) {
 
     /* 5) Free the node, unlinking it from the cluster. */
     freeClusterNode(delnode);
+
+    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE);
 }
 
 /* Node lookup by name */
@@ -2339,7 +2342,7 @@ void clusterSetNodeAsMaster(clusterNode *n) {
     n->flags &= ~CLUSTER_NODE_SLAVE;
     n->flags |= CLUSTER_NODE_MASTER;
     n->slaveof = NULL;
-    clusterNotifyTopologyChange(REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED);
+    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE);
 
     /* Update config and state. */
     clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG|
@@ -5142,7 +5145,7 @@ int clusterAddSlot(clusterNode *n, int slot) {
     /* Make owner_not_claiming_slot flag consistent with slot ownership information. */
     bitmapClearBit(server.cluster->owner_not_claiming_slot, slot);
     clusterSlotStatReset(slot);
-    clusterNotifyTopologyChange(REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED);
+    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_SLOT);
     return C_OK;
 }
 
@@ -5162,7 +5165,7 @@ int clusterDelSlot(int slot) {
     /* Make owner_not_claiming_slot flag consistent with slot ownership information. */
     bitmapClearBit(server.cluster->owner_not_claiming_slot, slot);
     clusterSlotStatReset(slot);
-    clusterNotifyTopologyChange(REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED);
+    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_SLOT);
     return C_OK;
 }
 
@@ -5218,45 +5221,38 @@ void clusterCloseAllSlots(void) {
 #define CLUSTER_WRITABLE_DELAY 2000
 
 /* Record a pending RedisModuleEvent_ClusterTopologyChange (the change_flags are
- * REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_* bits) and request it to be fired
- * from the next clusterBeforeSleep(). Called from every slot/role mutation. */
+ * REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_* bits) and request it to be fired
+ * from the next clusterBeforeSleep(). Called from every slot/role mutation and
+ * on the cluster's OK/FAIL transition. */
 static void clusterNotifyTopologyChange(int change_flags) {
     server.cluster->topology_change_flags |= change_flags;
     clusterDoBeforeSleep(CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE);
-}
-
-/* Fire the RedisModuleEvent_ClusterTopologyChange module event with the given
- * subevent. The event carries no payload (NULL data). */
-static void clusterFireTopologyChangeEvent(int subevent) {
-    /* No data payload: a subscribing module reads whatever it needs about the
-     * new topology via the cluster info module APIs (CLUSTER SLOTS,
-     * RedisModule_GetClusterNodesList/NodeInfo, RedisModule_GetClusterSize, ...). */
-    moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE, subevent, NULL);
 }
 
 /* Fire the cluster topology-change notification to modules, if one is pending.
  * Called once per event-loop iteration from clusterBeforeSleep() in response to
  * CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE, which is requested by every slot/role
  * mutation and on the cluster's OK/FAIL transition. This debounces a reshuffle
- * that touches many slots into a single notification. STARTUP is reported once,
- * the first time the cluster becomes OK; afterwards a pending role change is
- * reported as ROLE_CHANGED and any other slot/membership change as
- * TOPOLOGY_CHANGED. The checks here make a redundant TODO a harmless no-op. */
+ * that touches many slots into a single notification, and reports every reason
+ * that contributed via the change_flags bitmask in the event data. The check
+ * here makes a redundant TODO a harmless no-op.
+ *
+ * The cluster first becoming ready is delivered through this same path: the
+ * OK/FAIL transition records a STATE reason (slot assignment at startup records
+ * a SLOT reason too), so no dedicated "startup" notification is needed. */
 static void clusterFireTopologyChangeIfNeeded(void) {
-    if (!server.cluster->topo_startup_fired) {
-        if (server.cluster->state == CLUSTER_OK) {
-            server.cluster->topo_startup_fired = 1;
-            server.cluster->topology_change_flags = 0;
-            clusterFireTopologyChangeEvent(
-                REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_STARTUP);
-        }
-    } else if (server.cluster->topology_change_flags) {
-        int subevent = (server.cluster->topology_change_flags & REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED) ?
-            REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED :
-            REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED;
-        server.cluster->topology_change_flags = 0;
-        clusterFireTopologyChangeEvent(subevent);
-    }
+    if (!server.cluster->topology_change_flags) return;
+
+    /* No data payload beyond the change reasons: a subscribing module reads
+     * whatever else it needs about the new topology via the cluster info module
+     * APIs (CLUSTER SLOTS, RedisModule_GetClusterNodesList/NodeInfo,
+     * RedisModule_GetClusterSize, ...). */
+    RedisModuleClusterTopologyChangeInfo info = {
+        .version = REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_INFO_VERSION,
+        .change_flags = (uint64_t)server.cluster->topology_change_flags,
+    };
+    server.cluster->topology_change_flags = 0;
+    moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE, 0, &info);
 }
 
 void clusterUpdateState(void) {
@@ -5354,9 +5350,9 @@ void clusterUpdateState(void) {
             new_state == CLUSTER_OK ? "ok" : "fail");
         server.cluster->state = new_state;
 
-        /* The OK/FAIL transition (in particular the first reach of OK, i.e.
-         * startup) is itself a topology-change notification trigger. */
-        clusterDoBeforeSleep(CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE);
+        /* The OK/FAIL transition (in particular the first reach of OK, i.e. the
+         * cluster becoming ready at startup) is itself a topology-change reason. */
+        clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_STATE);
     }
 }
 
@@ -5410,7 +5406,7 @@ void clusterSetMaster(clusterNode *n) {
 
     int was_master = clusterNodeIsMaster(myself);
     if (was_master) {
-        clusterNotifyTopologyChange(REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED);
+        clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE);
         myself->flags &= ~(CLUSTER_NODE_MASTER|CLUSTER_NODE_MIGRATE_TO);
         myself->flags |= CLUSTER_NODE_SLAVE;
         clusterCloseAllSlots();

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5237,7 +5237,7 @@ static void clusterNotifyTopologyChange(uint64_t change_flags) {
  * The cluster first becoming ready is delivered through this same path: the
  * OK/FAIL transition records a STATE reason (slot assignment at startup records
  * a SLOT reason too), so no dedicated "startup" notification is needed. */
-static void clusterFireTopologyChangeIfNeeded(void) {
+static void clusterFireTopologyChangeEventIfNeeded(void) {
     if (!server.cluster->topology_change_flags) return;
 
     /* No data payload beyond the change reasons: a subscribing module reads

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2317,6 +2317,9 @@ int nodeUpdateAddressIfNeeded(clusterNode *node, clusterLink *link,
      * replication target as well. */
     if (nodeIsSlave(myself) && myself->slaveof == node)
         replicationSetMaster(node->ip, getNodeDefaultReplicationPort(node));
+
+    /* A node moving to a different address is a topology change. */
+    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE);
     return 1;
 }
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5402,8 +5402,6 @@ void clusterSetMaster(clusterNode *n) {
     serverAssert(myself->numslots == 0);
 
     int was_master = clusterNodeIsMaster(myself);
-    /* Demotion or a replica re-pointing to a new primary are both role changes. */
-    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE);
     if (was_master) {
         myself->flags &= ~(CLUSTER_NODE_MASTER|CLUSTER_NODE_MIGRATE_TO);
         myself->flags |= CLUSTER_NODE_SLAVE;
@@ -5421,6 +5419,10 @@ void clusterSetMaster(clusterNode *n) {
 
     /* Cancel all ASM tasks when switching into slave */
     if (was_master) clusterAsmCancel(NULL, "switching to replica");
+
+    /* Role change is now applied (a demotion, or a replica re-pointing to a new
+     * primary); notify modules. */
+    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE);
 }
 
 /* -----------------------------------------------------------------------------

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -338,8 +338,7 @@ struct clusterState {
     uint64_t currentEpoch;
     int state;            /* CLUSTER_OK, CLUSTER_FAIL, ... */
     int size;             /* Num of master nodes with at least one slot */
-    int topology_change_flags; /* Pending RedisModuleEvent_ClusterTopologyChange subevents (REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_* bits) */
-    int topo_startup_fired;  /* STARTUP topology-change subevent already fired (on first OK) */
+    int topology_change_flags; /* Pending RedisModuleEvent_ClusterTopologyChange reasons (REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_* bits) */
     dict *nodes;          /* Hash table of name -> clusterNode structures */
     dict *shards;         /* Hash table of shard_id -> list (of nodes) structures */
     dict *nodes_black_list; /* Nodes we don't re-add for a few seconds. */

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -338,7 +338,7 @@ struct clusterState {
     uint64_t currentEpoch;
     int state;            /* CLUSTER_OK, CLUSTER_FAIL, ... */
     int size;             /* Num of master nodes with at least one slot */
-    int topology_change_flags; /* Pending RedisModuleEvent_ClusterTopologyChange reasons (REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_* bits) */
+    uint64_t topology_change_flags; /* Pending RedisModuleEvent_ClusterTopologyChange reasons (REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_* bits) */
     dict *nodes;          /* Hash table of name -> clusterNode structures */
     dict *shards;         /* Hash table of shard_id -> list (of nodes) structures */
     dict *nodes_black_list; /* Nodes we don't re-add for a few seconds. */

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -40,6 +40,7 @@
 #define CLUSTER_TODO_FSYNC_CONFIG (1<<3)
 #define CLUSTER_TODO_HANDLE_MANUALFAILOVER (1<<4)
 #define CLUSTER_TODO_BROADCAST_PONG (1<<5)
+#define CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE (1<<6) /* Fire RedisModuleEvent_ClusterTopologyChange */
 
 /* clusterLink encapsulates everything needed to talk with a remote node. */
 typedef struct clusterLink {
@@ -337,6 +338,8 @@ struct clusterState {
     uint64_t currentEpoch;
     int state;            /* CLUSTER_OK, CLUSTER_FAIL, ... */
     int size;             /* Num of master nodes with at least one slot */
+    int topology_change_flags; /* Pending RedisModuleEvent_ClusterTopologyChange subevents (REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_* bits) */
+    int topo_startup_fired;  /* STARTUP topology-change subevent already fired (on first OK) */
     dict *nodes;          /* Hash table of name -> clusterNode structures */
     dict *shards;         /* Hash table of shard_id -> list (of nodes) structures */
     dict *nodes_black_list; /* Nodes we don't re-add for a few seconds. */

--- a/src/module.c
+++ b/src/module.c
@@ -12564,6 +12564,7 @@ static uint64_t moduleEventVersions[] = {
     REDISMODULE_KEYINFO_VERSION, /* REDISMODULE_EVENT_KEY */
     REDISMODULE_CLUSTER_SLOT_MIGRATION_INFO_VERSION, /* REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION */
     REDISMODULE_CLUSTER_SLOT_MIGRATION_TRIMINFO_VERSION, /* REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM */
+    -1, /* REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE (no data; module queries cluster info itself) */
 };
 
 /* Register to be notified, via a callback, when the specified server event
@@ -12922,6 +12923,31 @@ static uint64_t moduleEventVersions[] = {
  *
  *         RedisModuleSlotRangeArray *slots;  // Slot ranges
  *
+ * * RedisModuleEvent_ClusterTopologyChange
+ *
+ *     Called, in cluster mode, when the topology of the cluster changes: when the
+ *     cluster first becomes ready, when slot ownership or node membership changes
+ *     (resharding, a node joining or leaving), and when a primary changes (a
+ *     failover or a replica being promoted). It lets modules that route to other
+ *     shards (e.g. via slot ranges) refresh their cached view of the cluster
+ *     without polling or requiring an explicit command. Fires are debounced to at
+ *     most one per event loop iteration, so a single reshuffle touching many slots
+ *     yields one event.
+ *
+ *     The following sub events are available:
+ *
+ *     * `REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_STARTUP`:
+ *         The cluster reached the OK state for the first time since startup.
+ *     * `REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED`:
+ *         Slot ownership or node membership changed.
+ *     * `REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED`:
+ *         A node changed its primary/replica role (e.g. a failover).
+ *
+ *     The data pointer is NULL: the module reads whatever it needs about the new
+ *     topology via the cluster info APIs (e.g. `CLUSTER SLOTS`,
+ *     RedisModule_GetClusterNodesList / RedisModule_GetClusterNodeInfo /
+ *     RedisModule_GetClusterSize).
+ *
  * The function returns REDISMODULE_OK if the module was successfully subscribed
  * for the specified event. If the API is called from a wrong context or unsupported event
  * is given then REDISMODULE_ERR is returned. */
@@ -13007,6 +13033,8 @@ int RM_IsSubEventSupported(RedisModuleEvent event, int64_t subevent) {
         return subevent < _REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_NEXT;
     case REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM:
         return subevent < _REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_NEXT;
+    case REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE:
+        return subevent < _REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_NEXT;
     default:
         break;
     }

--- a/src/module.c
+++ b/src/module.c
@@ -12948,7 +12948,8 @@ static uint64_t moduleEventVersions[] = {
  *         The cluster OK/FAIL state changed (this also covers the cluster
  *         first becoming ready at startup).
  *     * `REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE`:
- *         A node joined or left the cluster.
+ *         A node joined or left the cluster, or an existing node's address
+ *         (ip/port) changed.
  *
  *     More than one bit may be set. Beyond the change reasons, the module reads
  *     whatever else it needs about the new topology via the cluster info APIs

--- a/src/module.c
+++ b/src/module.c
@@ -12564,7 +12564,7 @@ static uint64_t moduleEventVersions[] = {
     REDISMODULE_KEYINFO_VERSION, /* REDISMODULE_EVENT_KEY */
     REDISMODULE_CLUSTER_SLOT_MIGRATION_INFO_VERSION, /* REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION */
     REDISMODULE_CLUSTER_SLOT_MIGRATION_TRIMINFO_VERSION, /* REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM */
-    -1, /* REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE (no data; module queries cluster info itself) */
+    REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_INFO_VERSION, /* REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE */
 };
 
 /* Register to be notified, via a callback, when the specified server event
@@ -12934,19 +12934,26 @@ static uint64_t moduleEventVersions[] = {
  *     most one per event loop iteration, so a single reshuffle touching many slots
  *     yields one event.
  *
- *     The following sub events are available:
+ *     This event has no meaningful sub event (it is always fired with subevent 0).
  *
- *     * `REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_STARTUP`:
- *         The cluster reached the OK state for the first time since startup.
- *     * `REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED`:
- *         Slot ownership or node membership changed.
- *     * `REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED`:
+ *     The data pointer can be casted to a RedisModuleClusterTopologyChangeInfo
+ *     structure. Its `change_flags` field is a bitmask of the reasons that
+ *     contributed to this (possibly debounced) notification:
+ *
+ *     * `REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_SLOT`:
+ *         Slot ownership changed.
+ *     * `REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE`:
  *         A node changed its primary/replica role (e.g. a failover).
+ *     * `REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_STATE`:
+ *         The cluster OK/FAIL state changed (this also covers the cluster
+ *         first becoming ready at startup).
+ *     * `REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE`:
+ *         A node joined or left the cluster.
  *
- *     The data pointer is NULL: the module reads whatever it needs about the new
- *     topology via the cluster info APIs (e.g. `CLUSTER SLOTS`,
- *     RedisModule_GetClusterNodesList / RedisModule_GetClusterNodeInfo /
- *     RedisModule_GetClusterSize).
+ *     More than one bit may be set. Beyond the change reasons, the module reads
+ *     whatever else it needs about the new topology via the cluster info APIs
+ *     (e.g. `CLUSTER SLOTS`, RedisModule_GetClusterNodesList /
+ *     RedisModule_GetClusterNodeInfo / RedisModule_GetClusterSize).
  *
  * The function returns REDISMODULE_OK if the module was successfully subscribed
  * for the specified event. If the API is called from a wrong context or unsupported event
@@ -13125,6 +13132,8 @@ void moduleFireServerEvent(uint64_t eid, int subid, void *data) {
             } else if (eid == REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION) {
                 moduledata = data;
             } else if (eid == REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM) {
+                moduledata = data;
+            } else if (eid == REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE) {
                 moduledata = data;
             }
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -539,7 +539,8 @@ typedef void (*RedisModuleEventLoopOneShotFunc)(void *user_data);
 #define REDISMODULE_EVENT_KEY 17
 #define REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION 18
 #define REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM 19
-#define _REDISMODULE_EVENT_NEXT 20 /* Next event flag, should be updated if a new event added. */
+#define REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE 20
+#define _REDISMODULE_EVENT_NEXT 21 /* Next event flag, should be updated if a new event added. */
 
 typedef struct RedisModuleEvent {
     uint64_t id;        /* REDISMODULE_EVENT_... defines. */
@@ -658,6 +659,10 @@ static const RedisModuleEvent
     RedisModuleEvent_ClusterSlotMigrationTrim = {
         REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM,
         1
+    },
+    RedisModuleEvent_ClusterTopologyChange = {
+        REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE,
+        1
     };
 
 /* Those are values that are used for the 'subevent' callback argument. */
@@ -751,6 +756,11 @@ static const RedisModuleEvent
 #define REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_COMPLETED 1
 #define REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_BACKGROUND 2
 #define _REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_NEXT 3
+
+#define REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_STARTUP 0
+#define REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED 1
+#define REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED 2
+#define _REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_NEXT 3
 
 /* RedisModuleClientInfo flags. */
 #define REDISMODULE_CLIENTINFO_FLAG_SSL (1<<0)

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -757,10 +757,8 @@ static const RedisModuleEvent
 #define REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_BACKGROUND 2
 #define _REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_NEXT 3
 
-#define REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_STARTUP 0
-#define REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED 1
-#define REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED 2
-#define _REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_NEXT 3
+/* RedisModuleEvent_ClusterTopologyChange has no meaningful subevent. */
+#define _REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_NEXT 0
 
 /* RedisModuleClientInfo flags. */
 #define REDISMODULE_CLIENTINFO_FLAG_SSL (1<<0)
@@ -925,6 +923,26 @@ typedef struct RedisModuleClusterSlotMigrationTrimInfo {
 } RedisModuleClusterSlotMigrationTrimInfoV1;
 
 #define RedisModuleClusterSlotMigrationTrimInfo RedisModuleClusterSlotMigrationTrimInfoV1
+
+/* Reason flags reported in RedisModuleClusterTopologyChangeInfo.change_flags.
+ * More than one bit may be set when several changes were collapsed into a
+ * single (debounced) RedisModuleEvent_ClusterTopologyChange notification. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_SLOT  (1<<0) /* Slot ownership changed. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE  (1<<1) /* A node changed its primary/replica role. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_STATE (1<<2) /* The cluster OK/FAIL state changed. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE  (1<<3) /* A node joined or left the cluster. */
+
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_INFO_VERSION 1
+
+typedef struct RedisModuleClusterTopologyChangeInfo {
+    uint64_t version;       /* Not used since this structure is never passed
+                               from the module to the core right now. Here
+                               for future compatibility. */
+    uint64_t change_flags;  /* Bitmask of REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_*
+                               reasons that contributed to this notification. */
+} RedisModuleClusterTopologyChangeInfoV1;
+
+#define RedisModuleClusterTopologyChangeInfo RedisModuleClusterTopologyChangeInfoV1
 
 typedef enum {
     REDISMODULE_ACL_LOG_AUTH = 0, /* Authentication failure */

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -930,7 +930,7 @@ typedef struct RedisModuleClusterSlotMigrationTrimInfo {
 #define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_SLOT  (1<<0) /* Slot ownership changed. */
 #define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE  (1<<1) /* A node changed its primary/replica role. */
 #define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_STATE (1<<2) /* The cluster OK/FAIL state changed. */
-#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE  (1<<3) /* A node joined or left the cluster. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE  (1<<3) /* A node joined or left the cluster, or its address changed. */
 
 #define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_INFO_VERSION 1
 

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -87,7 +87,8 @@ TEST_MODULES = \
     test_keymeta.so \
     keymeta_notify.so \
     postnotifications_perkey_metadata.so \
-    atomicslotmigration.so
+    atomicslotmigration.so \
+    cluster_topology.so
 
 .PHONY: all
 

--- a/tests/modules/cluster_topology.c
+++ b/tests/modules/cluster_topology.c
@@ -1,7 +1,8 @@
 /* This module is used to test the RedisModuleEvent_ClusterTopologyChange
  * server event: it subscribes to the event and counts how many times each
- * subevent fired, exposing the counters via a command so the TCL tests can
- * assert that modules are notified on cluster topology changes.
+ * change reason (carried as a bitmask in the event data) fired, exposing the
+ * counters via a command so the TCL tests can assert that modules are notified
+ * on cluster topology changes.
  *
  * -----------------------------------------------------------------------------
  *
@@ -15,39 +16,46 @@
 
 #include "redismodule.h"
 
-static long long startup_count = 0;
-static long long topology_count = 0;
-static long long role_count = 0;
-static long long other_count = 0;
+static long long event_count = 0;      /* Total notifications received. */
+static long long slot_count = 0;       /* Notifications with the SLOT flag. */
+static long long role_count = 0;       /* Notifications with the ROLE flag. */
+static long long state_count = 0;      /* Notifications with the STATE flag. */
+static long long node_count = 0;       /* Notifications with the NODE flag. */
 
 static void clusterTopologyCallback(RedisModuleCtx *ctx, RedisModuleEvent e,
                                     uint64_t subevent, void *data)
 {
     REDISMODULE_NOT_USED(ctx);
-    REDISMODULE_NOT_USED(data); /* The event carries no payload. */
+    REDISMODULE_NOT_USED(subevent); /* Single subevent; reasons are in the data. */
     if (e.id != REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE) return;
 
-    switch (subevent) {
-    case REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_STARTUP:
-        startup_count++; break;
-    case REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED:
-        topology_count++; break;
-    case REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED:
-        role_count++; break;
-    default:
-        other_count++; break;
-    }
+    RedisModuleClusterTopologyChangeInfo *info = data;
+    event_count++;
+    if (info->change_flags & REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_SLOT)
+        slot_count++;
+    if (info->change_flags & REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE)
+        role_count++;
+    if (info->change_flags & REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_STATE)
+        state_count++;
+    if (info->change_flags & REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE)
+        node_count++;
 }
 
-/* cluster_topology.stats -> [startup, topology, role, other] */
+/* cluster_topology.stats -> {events, slot, role, state, node} */
 static int statsCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     if (argc != 1) return RedisModule_WrongArity(ctx);
-    RedisModule_ReplyWithArray(ctx, 4);
-    RedisModule_ReplyWithLongLong(ctx, startup_count);
-    RedisModule_ReplyWithLongLong(ctx, topology_count);
+    RedisModule_ReplyWithMap(ctx, 5);
+    RedisModule_ReplyWithCString(ctx, "events");
+    RedisModule_ReplyWithLongLong(ctx, event_count);
+    RedisModule_ReplyWithCString(ctx, "slot");
+    RedisModule_ReplyWithLongLong(ctx, slot_count);
+    RedisModule_ReplyWithCString(ctx, "role");
     RedisModule_ReplyWithLongLong(ctx, role_count);
-    RedisModule_ReplyWithLongLong(ctx, other_count);
+    RedisModule_ReplyWithCString(ctx, "state");
+    RedisModule_ReplyWithLongLong(ctx, state_count);
+    RedisModule_ReplyWithCString(ctx, "node");
+    RedisModule_ReplyWithLongLong(ctx, node_count);
     return REDISMODULE_OK;
 }
 

--- a/tests/modules/cluster_topology.c
+++ b/tests/modules/cluster_topology.c
@@ -1,0 +1,70 @@
+/* This module is used to test the RedisModuleEvent_ClusterTopologyChange
+ * server event: it subscribes to the event and counts how many times each
+ * subevent fired, exposing the counters via a command so the TCL tests can
+ * assert that modules are notified on cluster topology changes.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * Copyright (c) 2024-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of (a) the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#include "redismodule.h"
+
+static long long startup_count = 0;
+static long long topology_count = 0;
+static long long role_count = 0;
+static long long other_count = 0;
+
+static void clusterTopologyCallback(RedisModuleCtx *ctx, RedisModuleEvent e,
+                                    uint64_t subevent, void *data)
+{
+    REDISMODULE_NOT_USED(ctx);
+    REDISMODULE_NOT_USED(data); /* The event carries no payload. */
+    if (e.id != REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE) return;
+
+    switch (subevent) {
+    case REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_STARTUP:
+        startup_count++; break;
+    case REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED:
+        topology_count++; break;
+    case REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED:
+        role_count++; break;
+    default:
+        other_count++; break;
+    }
+}
+
+/* cluster_topology.stats -> [startup, topology, role, other] */
+static int statsCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    if (argc != 1) return RedisModule_WrongArity(ctx);
+    RedisModule_ReplyWithArray(ctx, 4);
+    RedisModule_ReplyWithLongLong(ctx, startup_count);
+    RedisModule_ReplyWithLongLong(ctx, topology_count);
+    RedisModule_ReplyWithLongLong(ctx, role_count);
+    RedisModule_ReplyWithLongLong(ctx, other_count);
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx, "cluster_topology", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_SubscribeToServerEvent(ctx,
+            RedisModuleEvent_ClusterTopologyChange, clusterTopologyCallback) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "cluster_topology.stats", statsCommand,
+            "", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    return REDISMODULE_OK;
+}

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -1,0 +1,57 @@
+# Tests for the RedisModuleEvent_ClusterTopologyChange server event. A test
+# module (cluster_topology.so) subscribes to the event and counts the subevents;
+# here we drive topology changes and assert that modules get notified.
+
+set testmodule [file normalize tests/modules/cluster_topology.so]
+
+# Returns the cluster_topology.stats list of a node:
+#   {startup topology primary other}
+proc topo_stats {node} {
+    R $node cluster_topology.stats
+}
+
+start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list loadmodule $testmodule cluster-node-timeout 3000]] {
+    test "ClusterTopologyChange STARTUP fires once the cluster becomes ready" {
+        # cluster_setup has already waited for the cluster to be OK on every node.
+        for {set i 0} {$i < 6} {incr i} {
+            assert {[lindex [topo_stats $i] 0] >= 1}
+        }
+    }
+
+    test "ClusterTopologyChange TOPOLOGY_CHANGED fires on slot ownership change" {
+        set before [lindex [topo_stats 0] 1]
+        R 0 cluster DELSLOTSRANGE 0 100
+        wait_for_condition 50 100 {
+            [lindex [topo_stats 0] 1] > $before
+        } else {
+            fail "TOPOLOGY_CHANGED was not fired after removing slots"
+        }
+        # Restore the slots so the cluster is whole again for the next test.
+        R 0 cluster ADDSLOTSRANGE 0 100
+        wait_for_cluster_state ok
+    }
+
+    test "ClusterTopologyChange ROLE_CHANGED fires on failover" {
+        # Find a replica and trigger a coordinated manual failover.
+        set replica -1
+        for {set i 0} {$i < 6} {incr i} {
+            if {[lindex [R $i role] 0] eq "slave"} { set replica $i; break }
+        }
+        assert {$replica != -1}
+
+        set before [lindex [topo_stats $replica] 2]
+        R $replica cluster failover
+        # Wait for the replica to actually take over as a primary.
+        wait_for_condition 50 100 {
+            [lindex [R $replica role] 0] eq "master"
+        } else {
+            fail "manual failover did not promote the replica"
+        }
+        # The promotion must have notified the module via ROLE_CHANGED.
+        wait_for_condition 50 100 {
+            [lindex [topo_stats $replica] 2] > $before
+        } else {
+            fail "ROLE_CHANGED was not fired on the promoted node"
+        }
+    }
+}

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -49,7 +49,11 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
         }
         assert {$replica != -1}
 
-        set before [dict get [topo_stats $replica] role]
+        # Snapshot the ROLE counters on every node before the failover.
+        set before {}
+        for {set i 0} {$i < 6} {incr i} {
+            dict set before $i [dict get [topo_stats $i] role]
+        }
         R $replica cluster failover
         # Wait for the replica to actually take over as a primary.
         wait_for_condition 50 100 {
@@ -57,11 +61,14 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
         } else {
             fail "manual failover did not promote the replica"
         }
-        # The promotion must have notified the module with the ROLE reason.
-        wait_for_condition 50 100 {
-            [dict get [topo_stats $replica] role] > $before
-        } else {
-            fail "ROLE change reason was not reported on the promoted node"
+        # The role change propagates across the cluster, so every node must be
+        # notified with the ROLE reason, not just the promoted node.
+        for {set i 0} {$i < 6} {incr i} {
+            wait_for_condition 50 100 {
+                [dict get [topo_stats $i] role] > [dict get $before $i]
+            } else {
+                fail "ROLE change reason was not reported on node $i"
+            }
         }
     }
 }

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -4,34 +4,44 @@
 
 set testmodule [file normalize tests/modules/cluster_topology.so]
 
-# Returns the cluster_topology.stats list of a node:
-#   {startup topology primary other}
+# Returns the cluster_topology.stats of a node as a dict with the fields:
+#   events slot role state node
+# where 'slot'/'role'/'state'/'node' count the notifications whose change_flags
+# bitmask had the SLOT / ROLE / STATE / NODE reason set.
 proc topo_stats {node} {
     R $node cluster_topology.stats
 }
 
 start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list loadmodule $testmodule cluster-node-timeout 3000]] {
-    test "ClusterTopologyChange STARTUP fires once the cluster becomes ready" {
+    test "ClusterTopologyChange notifies modules once the cluster becomes ready" {
         # cluster_setup has already waited for the cluster to be OK on every node.
         for {set i 0} {$i < 6} {incr i} {
-            assert {[lindex [topo_stats $i] 0] >= 1}
+            assert {[dict get [topo_stats $i] state] >= 1}
         }
     }
 
-    test "ClusterTopologyChange TOPOLOGY_CHANGED fires on slot ownership change" {
-        set before [lindex [topo_stats 0] 1]
+    test "ClusterTopologyChange reports the NODE reason as nodes are discovered" {
+        # Bringing the cluster up adds every node to each node's view, so the
+        # NODE reason must have been reported at least once on startup.
+        for {set i 0} {$i < 6} {incr i} {
+            assert {[dict get [topo_stats $i] node] >= 1}
+        }
+    }
+
+    test "ClusterTopologyChange reports the SLOT reason on slot ownership change" {
+        set before [dict get [topo_stats 0] slot]
         R 0 cluster DELSLOTSRANGE 0 100
         wait_for_condition 50 100 {
-            [lindex [topo_stats 0] 1] > $before
+            [dict get [topo_stats 0] slot] > $before
         } else {
-            fail "TOPOLOGY_CHANGED was not fired after removing slots"
+            fail "SLOT change reason was not reported after removing slots"
         }
         # Restore the slots so the cluster is whole again for the next test.
         R 0 cluster ADDSLOTSRANGE 0 100
         wait_for_cluster_state ok
     }
 
-    test "ClusterTopologyChange ROLE_CHANGED fires on failover" {
+    test "ClusterTopologyChange reports the ROLE reason on failover" {
         # Find a replica and trigger a coordinated manual failover.
         set replica -1
         for {set i 0} {$i < 6} {incr i} {
@@ -39,7 +49,7 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
         }
         assert {$replica != -1}
 
-        set before [lindex [topo_stats $replica] 2]
+        set before [dict get [topo_stats $replica] role]
         R $replica cluster failover
         # Wait for the replica to actually take over as a primary.
         wait_for_condition 50 100 {
@@ -47,11 +57,11 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
         } else {
             fail "manual failover did not promote the replica"
         }
-        # The promotion must have notified the module via ROLE_CHANGED.
+        # The promotion must have notified the module with the ROLE reason.
         wait_for_condition 50 100 {
-            [lindex [topo_stats $replica] 2] > $before
+            [dict get [topo_stats $replica] role] > $before
         } else {
-            fail "ROLE_CHANGED was not fired on the promoted node"
+            fail "ROLE change reason was not reported on the promoted node"
         }
     }
 }

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -41,6 +41,25 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
         wait_for_cluster_state ok
     }
 
+    test "ClusterTopologyChange reports the SLOT reason on atomic slot migration" {
+        # Atomically migrate a slot range from node 0 to node 1 and back. Both
+        # the losing and the gaining owner must observe the SLOT reason.
+        set before0 [dict get [topo_stats 0] slot]
+        set before1 [dict get [topo_stats 1] slot]
+        R 1 cluster migration import 0 100
+        wait_for_condition 50 100 {
+            [dict get [topo_stats 0] slot] > $before0 &&
+            [dict get [topo_stats 1] slot] > $before1
+        } else {
+            fail "SLOT change reason was not reported on atomic slot migration"
+        }
+        # Migrate the slots back so the cluster layout is restored.
+        wait_for_cluster_propagation
+        R 0 cluster migration import 0 100
+        wait_for_cluster_propagation
+        wait_for_cluster_state ok
+    }
+
     test "ClusterTopologyChange reports the STATE reason when the cluster turns FAIL" {
         set before [dict get [topo_stats 0] state]
         # Dropping ownership of slots leaves them uncovered, which (with the

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -28,6 +28,34 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
         }
     }
 
+    test "ClusterTopologyChange reports the NODE reason on a node address change" {
+        # Changing node 0's announced port makes the other nodes observe a new
+        # address for node 0 (learned via gossip), which is a topology change.
+        if {$::tls} {
+            set baseport [lindex [R 0 config get tls-port] 1]
+        } else {
+            set baseport [lindex [R 0 config get port] 1]
+        }
+        set newport [find_available_port $baseport [expr [llength $::servers] + 1]]
+
+        set before [dict get [topo_stats 1] node]
+        R 0 config set cluster-announce-tls-port $newport
+        R 0 config set cluster-announce-port $newport
+
+        # Node 1 must both learn the new address and be notified with NODE.
+        wait_for_condition 50 100 {
+            [string match "*:$newport@*" [R 1 cluster nodes]] &&
+            [dict get [topo_stats 1] node] > $before
+        } else {
+            fail "NODE change reason was not reported on a node address change"
+        }
+
+        # Restore node 0's announced port for the following tests.
+        R 0 config set cluster-announce-tls-port 0
+        R 0 config set cluster-announce-port 0
+        wait_for_cluster_state ok
+    }
+
     test "ClusterTopologyChange reports the SLOT reason on slot ownership change" {
         set before [dict get [topo_stats 0] slot]
         R 0 cluster DELSLOTSRANGE 0 100

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -91,4 +91,37 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
             }
         }
     }
+
+    # NOTE: keep this test last. It removes a node from the cluster, so it must
+    # run after the failover test (which asserts that *every* node is notified).
+    test "ClusterTopologyChange reports the NODE reason when a node is removed" {
+        # Remove a replica (dropping a replica keeps every slot covered).
+        set removed -1
+        for {set i 1} {$i < 6} {incr i} {
+            if {[lindex [R $i role] 0] eq "slave"} { set removed $i; break }
+        }
+        assert {$removed != -1}
+
+        # Snapshot the NODE counters on every surviving node.
+        set before {}
+        for {set i 0} {$i < 6} {incr i} {
+            if {$i == $removed} continue
+            dict set before $i [dict get [topo_stats $i] node]
+        }
+
+        # isolate_node resets the node and forgets it; the FORGET propagates so
+        # every surviving node eventually drops it from its view.
+        isolate_node $removed
+
+        # The removal must have notified the module with the NODE reason on each
+        # surviving node, not just the one that issued the FORGET.
+        for {set i 0} {$i < 6} {incr i} {
+            if {$i == $removed} continue
+            wait_for_condition 50 100 {
+                [dict get [topo_stats $i] node] > [dict get $before $i]
+            } else {
+                fail "NODE change reason was not reported on node $i"
+            }
+        }
+    }
 }

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -41,6 +41,26 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
         wait_for_cluster_state ok
     }
 
+    test "ClusterTopologyChange reports the STATE reason when the cluster turns FAIL" {
+        set before [dict get [topo_stats 0] state]
+        # Dropping ownership of slots leaves them uncovered, which (with the
+        # default cluster-require-full-coverage) turns the cluster state to FAIL.
+        R 0 cluster DELSLOTSRANGE 0 100
+        wait_for_condition 50 100 {
+            [CI 0 cluster_state] eq "fail"
+        } else {
+            fail "cluster did not turn FAIL after dropping slots"
+        }
+        wait_for_condition 50 100 {
+            [dict get [topo_stats 0] state] > $before
+        } else {
+            fail "STATE change reason was not reported when the cluster turned FAIL"
+        }
+        # Restore the slots and let the cluster become OK again.
+        R 0 cluster ADDSLOTSRANGE 0 100
+        wait_for_cluster_state ok
+    }
+
     test "ClusterTopologyChange reports the ROLE reason on failover" {
         # Find a replica and trigger a coordinated manual failover.
         set replica -1

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -70,16 +70,19 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
     }
 
     test "ClusterTopologyChange reports the SLOT reason on atomic slot migration" {
-        # Atomically migrate a slot range from node 0 to node 1 and back. Both
-        # the losing and the gaining owner must observe the SLOT reason.
-        set before0 [dict get [topo_stats 0] slot]
-        set before1 [dict get [topo_stats 1] slot]
+        # An atomic migration reassigns slot ownership cluster-wide, so every node
+        # (not just the losing and gaining owners) must observe the SLOT reason.
+        set before {}
+        for {set i 0} {$i < 6} {incr i} {
+            dict set before $i [dict get [topo_stats $i] slot]
+        }
         R 1 cluster migration import 0 100
-        wait_for_condition 50 100 {
-            [dict get [topo_stats 0] slot] > $before0 &&
-            [dict get [topo_stats 1] slot] > $before1
-        } else {
-            fail "SLOT change reason was not reported on atomic slot migration"
+        for {set i 0} {$i < 6} {incr i} {
+            wait_for_condition 50 100 {
+                [dict get [topo_stats $i] slot] > [dict get $before $i]
+            } else {
+                fail "SLOT change reason was not reported on node $i after atomic slot migration"
+            }
         }
         # Migrate the slots back so the cluster layout is restored.
         wait_for_cluster_propagation


### PR DESCRIPTION
## Summary

Adds a new module server event, **`RedisModuleEvent_ClusterTopologyChange`**, so modules can be notified when the OSS cluster topology changes instead of polling or relying on operators to call an undocumented per-module refresh command on every node.

### Motivation

Data-structure modules that fan out to other shards by slot range — RedisTimeSeries (via LibMR: `TS.MGET`/`TS.MRANGE`/`TS.QUERYINDEX`), RediSearch, etc. — keep their own cached view of the cluster. Today they have no hook to learn that the topology changed, so:

- RedisTimeSeries requires operators to run the undocumented internal `TIMESERIES.REFRESHCLUSTER` on **every primary** after cluster creation and after **every** reshard.
- RediSearch periodically re-reads topology, which is wasteful and laggy.

This is poor operator/developer experience and a recurring source of broken keyless multi-shard commands after resharding/failover. See community reports referenced in RED-148990 (e.g. RedisTimeSeries issues #1348, #1683, #1215) and redis/redis#15286.

### What this does

Fires `RedisModuleEvent_ClusterTopologyChange` in cluster mode. The event has a **single subevent (always `0`)**; the reasons that triggered it are carried as a bitmask in the event data, so a module can react selectively. The data pointer is a `RedisModuleClusterTopologyChangeInfo` whose `change_flags` field is any combination of:

| Flag | When |
|---|---|
| `REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_SLOT`  | Slot ownership changed (reshard, atomic slot migration, `ADD`/`DELSLOTS[RANGE]`). |
| `REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE`  | A node changed its primary/replica role (e.g. failover, replica re-pointing to a new primary). |
| `REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_STATE` | The cluster OK/FAIL state changed (this also covers the cluster first becoming ready at startup). |
| `REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE`  | A node joined or left the cluster, or an existing node's address (ip/port) changed. |

More than one bit may be set when several changes are coalesced into one (debounced) notification. Beyond the change reasons, the module reads whatever else it needs about the new topology via the cluster info APIs (`CLUSTER SLOTS`, `RedisModule_GetClusterNodesList` / `RedisModule_GetClusterNodeInfo` / `RedisModule_GetClusterSize`, …) — no topology snapshot is passed in the event data.

### Design / debouncing

Every mutation site only records a pending reason: it calls `clusterNotifyTopologyChange(flag)`, which ORs the bit into `clusterState.topology_change_flags` and requests `CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE`. The notify calls are wired into:

- slot mutators — `clusterAddSlot` / `clusterDelSlot` (`SLOT`)
- role flips — `clusterSetNodeAsMaster` / `clusterSetMaster`, and the gossip-driven demotion in `clusterProcessPacket` (`ROLE`)
- membership / address — `clusterAddNode` / `clusterDelNode` / `nodeUpdateAddressIfNeeded` (`NODE`)
- the OK/FAIL transition in `clusterUpdateState` (`STATE`)

The event is actually fired from the **tail of `clusterBeforeSleep()`** (via `clusterFireTopologyChangeIfNeeded`), which runs at most once per event-loop iteration. So a reshuffle touching thousands of slots is coalesced into a **single** event whose `change_flags` reflects every reason that contributed. The cluster first becoming ready needs no special case — it is delivered through the `STATE` (and, at startup, `SLOT`/`NODE`) reasons on the first `FAIL -> OK` transition.

Wiring lives in:
- `src/redismodule.h` — event id 20, the `RedisModuleClusterTopologyChangeInfo` struct, the `..._FLAG_*` bits, the (single) subevent define.
- `src/module.c` — version array entry, `IsSubEventSupported`, `moduleFireServerEvent` dispatch, doc comment.
- `src/cluster_legacy.{c,h}` — the `CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE` todo, the `clusterState.topology_change_flags` field, and the `clusterNotifyTopologyChange` / `clusterFireTopologyChangeIfNeeded` helpers.

### Testing

- New test module `tests/modules/cluster_topology.c` subscribes to the event and counts, per reason bit, how many notifications carried it; the counters are exposed via `cluster_topology.stats`.
- New `tests/unit/cluster/cluster-topology-change.tcl` asserts the event fires (with the expected reason bit) on:
  - **startup** — cluster becoming ready (`STATE`), and nodes being discovered (`NODE`);
  - a **node address change** (`NODE`);
  - a **slot ownership change** via `CLUSTER DELSLOTSRANGE` (`SLOT`);
  - an **atomic slot migration** — both losing and gaining owner observe `SLOT`;
  - the cluster turning **FAIL** (`STATE`);
  - a **failover** — every node, not just the promoted one, observes `ROLE`;
  - a **node removal** (`NODE`).
- `redis-server` boots clean (the `moduleEventVersions` length assert passes) and the existing `moduleapi/hooks` suite is unaffected.

### Consumer

The RedisTimeSeries side that subscribes to this event and drops the manual `TIMESERIES.REFRESHCLUSTER` requirement is a companion change (LibMR + RedisTimeSeries). Verified end-to-end against this branch: a 3-node OSS cluster auto-refreshes its topology on formation and on reshard with no manual command.

Relates-to: RED-161109, RED-148990

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core cluster state transitions and module event dispatch; behavior is additive but any missed or over-fired notification could break multi-shard modules that depend on timely topology refresh.
> 
> **Overview**
> Introduces **`RedisModuleEvent_ClusterTopologyChange`** so modules in cluster mode can refresh cached shard/slot routing when topology changes, instead of polling or manual refresh commands.
> 
> Cluster mutations (slot add/del, node join/leave/address updates, role changes, OK/FAIL state) call **`clusterNotifyTopologyChange`**, which ORs reason bits into **`topology_change_flags`** and schedules **`CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE`**. **`clusterBeforeSleep`** fires at most **one** debounced notification per event-loop iteration via **`moduleFireServerEvent`**, with **`RedisModuleClusterTopologyChangeInfo.change_flags`** (`SLOT`, `ROLE`, `STATE`, `NODE`). Public API lives in **`redismodule.h`**; **`module.c`** registers the event. A **`cluster_topology`** test module and **`cluster-topology-change.tcl`** cover startup, address change, slots, migration, FAIL, failover, and node removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2d25443c2cd53b0564db395561f8d92bc916621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->