### PR TITLE
redis-cli: add configurable latency percentiles to --latency modes

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -8479,7 +8479,9 @@ static void latencyModePrint(long long min, long long max, double avg,
 #define LATENCY_SAMPLE_RATE 10 /* milliseconds. */
 #define LATENCY_HISTORY_DEFAULT_INTERVAL 15000 /* milliseconds. */
 #define LATENCY_HISTOGRAM_MIN_VALUE 1L         /* >= 1 usec. */
-#define LATENCY_HISTOGRAM_MAX_VALUE 3000000L   /* <= 3 secs (usec precision). */
+#define LATENCY_HISTOGRAM_MAX_VALUE 60000000L  /* <= 60 secs (usec precision) — large
+                                                * enough to track a server stalled by
+                                                * a slow command, fork or swap. */
 static void latencyMode(void) {
     redisReply *reply;
     long long start, latency, min = 0, max = 0, tot = 0, count = 0;
@@ -8493,9 +8495,7 @@ static void latencyMode(void) {
      * matches min/max/avg. */
     struct hdr_histogram *histogram = NULL;
     if (config.latency_percentiles_count > 0 &&
-        hdr_init(LATENCY_HISTOGRAM_MIN_VALUE, LATENCY_HISTOGRAM_MAX_VALUE, 3,
-                 &histogram))
-    {
+        hdr_init(LATENCY_HISTOGRAM_MIN_VALUE, LATENCY_HISTOGRAM_MAX_VALUE, 3, &histogram)) {
         fprintf(stderr, "Failed to initialize latency histogram\n");
         exit(1);
     }
@@ -8537,9 +8537,8 @@ static void latencyMode(void) {
         /* Record the sample for percentile computation, clamping to the
          * histogram's trackable range. */
         if (histogram) {
-            hdr_record_value(histogram,
-                latency <= LATENCY_HISTOGRAM_MAX_VALUE ? latency :
-                                                         LATENCY_HISTOGRAM_MAX_VALUE);
+            if (latency > LATENCY_HISTOGRAM_MAX_VALUE) latency = LATENCY_HISTOGRAM_MAX_VALUE;
+            hdr_record_value(histogram, latency);
         }
 
         if (config.output == OUTPUT_STANDARD) {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -8495,7 +8495,8 @@ static void latencyMode(void) {
      * matches min/max/avg. */
     struct hdr_histogram *histogram = NULL;
     if (config.latency_percentiles_count > 0 &&
-        hdr_init(LATENCY_HISTOGRAM_MIN_VALUE, LATENCY_HISTOGRAM_MAX_VALUE, 3, &histogram)) {
+        hdr_init(LATENCY_HISTOGRAM_MIN_VALUE, LATENCY_HISTOGRAM_MAX_VALUE, 3, &histogram))
+    {
         fprintf(stderr, "Failed to initialize latency histogram\n");
         exit(1);
     }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -217,6 +217,9 @@ static struct config {
     int latency_mode;
     int latency_dist_mode;
     int latency_history;
+    double *latency_percentiles; /* Percentiles to report, e.g. 50,99,99.9. */
+    char **latency_percentiles_labels; /* Original tokens, used for display. */
+    int latency_percentiles_count;
     int lru_test_mode;
     long long lru_test_sample_size;
     int cluster_mode;
@@ -2776,6 +2779,37 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--latency-history")) {
             config.latency_mode = 1;
             config.latency_history = 1;
+        } else if (!strcmp(argv[i],"--latency-percentiles") && !lastarg) {
+            /* Parse a comma separated list of percentiles, e.g. "50,99,99.9".
+             * Enables latency mode if not already requested. */
+            config.latency_mode = 1;
+            int pcount;
+            char *plist = argv[++i];
+            sds *pvec = sdssplitlen(plist,strlen(plist),",",1,&pcount);
+            if (pvec == NULL || pcount == 0) {
+                fprintf(stderr,"Invalid --latency-percentiles list.\n");
+                exit(1);
+            }
+            config.latency_percentiles = zmalloc(sizeof(double)*pcount);
+            config.latency_percentiles_labels = zmalloc(sizeof(char*)*pcount);
+            config.latency_percentiles_count = pcount;
+            for (int j = 0; j < pcount; j++) {
+                char *endptr;
+                double p = strtod(pvec[j],&endptr);
+                if (endptr == pvec[j] || *endptr != '\0' || isnan(p) ||
+                    p < 0 || p > 100)
+                {
+                    fprintf(stderr,
+                        "Invalid percentile '%s' in --latency-percentiles "
+                        "(must be a number between 0 and 100).\n", pvec[j]);
+                    exit(1);
+                }
+                config.latency_percentiles[j] = p;
+                /* Keep the original token verbatim for display so the label
+                 * is never lossy (e.g. "99.99" stays "99.99"). */
+                config.latency_percentiles_labels[j] = zstrdup(pvec[j]);
+            }
+            sdsfreesplitres(pvec,pcount);
         } else if (!strcmp(argv[i],"--vset-recall") && !lastarg) {
             config.vset_recall_mode = 1;
             config.vset_recall_key = sdsnew(argv[++i]);
@@ -3200,14 +3234,21 @@ version,tls_usage);
 
     fprintf(target,
 "  --latency          Enter a special mode continuously sampling latency.\n"
-"                     If you use this mode in an interactive session it runs\n"
-"                     forever displaying real-time stats. Otherwise if --raw or\n"
-"                     --csv is specified, or if you redirect the output to a non\n"
-"                     TTY, it samples the latency for 1 second (you can use\n"
-"                     -i to change the interval), then produces a single output\n"
-"                     and exits.\n"
+"                     Stats (min/max/avg) are reported in milliseconds with\n"
+"                     sub-millisecond precision. If you use this mode in an\n"
+"                     interactive session it runs forever displaying real-time\n"
+"                     stats. Otherwise if --raw or --csv is specified, or if you\n"
+"                     redirect the output to a non TTY, it samples the latency\n"
+"                     for 1 second (you can use -i to change the interval), then\n"
+"                     produces a single output and exits.\n"
 "  --latency-history  Like --latency but tracking latency changes over time.\n"
 "                     Default time interval is 15 sec. Change it using -i.\n"
+"  --latency-percentiles <p1,p2,...>\n"
+"                     Also report the given latency percentiles in milliseconds\n"
+"                     (e.g. 50,99,99.9) in --latency and --latency-history modes.\n"
+"                     Resolution is limited by the sample count: a percentile\n"
+"                     finer than 100/samples resolves to the maximum, so use a\n"
+"                     longer interval (-i) for meaningful high percentiles.\n"
 "  --latency-dist     Shows latency as a spectrum, requires xterm 256 colors.\n"
 "                     Default time interval is 1 sec. Change it using -i.\n"
 "  --vset-recall <key> Enable VSIM recall test mode for the specified key\n"
@@ -8390,22 +8431,55 @@ static int clusterManagerCommandHelp(int argc, char **argv) {
  * Latency and latency history modes
  *--------------------------------------------------------------------------- */
 
-static void latencyModePrint(long long min, long long max, double avg, long long count) {
+/* Print one latency report line. Latencies are measured in microseconds and
+ * reported in milliseconds with sub-millisecond precision. When percentiles
+ * are requested they are read from the HDR 'histogram' (also in microseconds,
+ * shares the same windowing as min/max/avg). */
+static void latencyModePrint(long long min, long long max, double avg,
+                             long long count, struct hdr_histogram *histogram)
+{
+    int npct = config.latency_percentiles_count;
+    /* Convert the microsecond accumulators to milliseconds for display. */
+    double min_ms = min/1000.0, max_ms = max/1000.0, avg_ms = avg/1000.0;
+
     if (config.output == OUTPUT_STANDARD) {
-        printf("min: %lld, max: %lld, avg: %.2f (%lld samples)",
-                min, max, avg, count);
+        printf("min: %.3f, max: %.3f, avg: %.3f (%lld samples)",
+                min_ms, max_ms, avg_ms, count);
+        for (int j = 0; j < npct && histogram; j++) {
+            printf(", p%s: %.3f", config.latency_percentiles_labels[j],
+                    hdr_value_at_percentile(histogram, config.latency_percentiles[j])/1000.0);
+        }
         fflush(stdout);
     } else if (config.output == OUTPUT_CSV) {
-        printf("%lld,%lld,%.2f,%lld\n", min, max, avg, count);
+        printf("%.3f,%.3f,%.3f,%lld", min_ms, max_ms, avg_ms, count);
+        for (int j = 0; j < npct && histogram; j++)
+            printf(",%.3f", hdr_value_at_percentile(histogram, config.latency_percentiles[j])/1000.0);
+        printf("\n");
     } else if (config.output == OUTPUT_RAW) {
-        printf("%lld %lld %.2f %lld\n", min, max, avg, count);
+        printf("%.3f %.3f %.3f %lld", min_ms, max_ms, avg_ms, count);
+        for (int j = 0; j < npct && histogram; j++)
+            printf(" %.3f", hdr_value_at_percentile(histogram, config.latency_percentiles[j])/1000.0);
+        printf("\n");
     } else if (config.output == OUTPUT_JSON) {
-        printf("{\"min\": %lld, \"max\": %lld, \"avg\": %.2f, \"count\": %lld}\n", min, max, avg, count);
+        printf("{\"min\": %.3f, \"max\": %.3f, \"avg\": %.3f, \"count\": %lld",
+                min_ms, max_ms, avg_ms, count);
+        if (npct > 0 && histogram) {
+            printf(", \"percentiles\": {");
+            for (int j = 0; j < npct; j++) {
+                printf("%s\"%s\": %.3f", j ? ", " : "",
+                        config.latency_percentiles_labels[j],
+                        hdr_value_at_percentile(histogram, config.latency_percentiles[j])/1000.0);
+            }
+            printf("}");
+        }
+        printf("}\n");
     }
 }
 
 #define LATENCY_SAMPLE_RATE 10 /* milliseconds. */
 #define LATENCY_HISTORY_DEFAULT_INTERVAL 15000 /* milliseconds. */
+#define LATENCY_HISTOGRAM_MIN_VALUE 1L         /* >= 1 usec. */
+#define LATENCY_HISTOGRAM_MAX_VALUE 3000000L   /* <= 3 secs (usec precision). */
 static void latencyMode(void) {
     redisReply *reply;
     long long start, latency, min = 0, max = 0, tot = 0, count = 0;
@@ -8414,6 +8488,17 @@ static void latencyMode(void) {
                           LATENCY_HISTORY_DEFAULT_INTERVAL;
     double avg;
     long long history_start = mstime();
+    /* HDR histogram for percentiles, only allocated when percentiles are
+     * requested. Reset (hdr_reset) at every history window so its windowing
+     * matches min/max/avg. */
+    struct hdr_histogram *histogram = NULL;
+    if (config.latency_percentiles_count > 0 &&
+        hdr_init(LATENCY_HISTOGRAM_MIN_VALUE, LATENCY_HISTOGRAM_MAX_VALUE, 3,
+                 &histogram))
+    {
+        fprintf(stderr, "Failed to initialize latency histogram\n");
+        exit(1);
+    }
 
     /* Set a default for the interval in case of --latency option
      * with --raw, --csv or when it is redirected to non tty. */
@@ -8425,13 +8510,18 @@ static void latencyMode(void) {
 
     if (!context) exit(1);
     while(1) {
-        start = mstime();
+        /* Measure the round-trip in microseconds for sub-millisecond
+         * resolution; min/max/avg/percentiles are reported in milliseconds. */
+        start = ustime();
         reply = reconnectingRedisCommand(context,"PING");
         if (reply == NULL) {
             fprintf(stderr,"\nI/O error\n");
             exit(1);
         }
-        latency = mstime()-start;
+        latency = ustime()-start;
+        /* ustime() is wall-clock based, so a backward clock adjustment could
+         * yield a negative delta; clamp it to avoid skewing the stats. */
+        if (latency < 0) latency = 0;
         freeReplyObject(reply);
         count++;
         if (count == 1) {
@@ -8444,14 +8534,23 @@ static void latencyMode(void) {
             avg = (double) tot/count;
         }
 
+        /* Record the sample for percentile computation, clamping to the
+         * histogram's trackable range. */
+        if (histogram) {
+            hdr_record_value(histogram,
+                latency <= LATENCY_HISTOGRAM_MAX_VALUE ? latency :
+                                                         LATENCY_HISTOGRAM_MAX_VALUE);
+        }
+
         if (config.output == OUTPUT_STANDARD) {
             printf("\x1b[0G\x1b[2K"); /* Clear the line. */
-            latencyModePrint(min,max,avg,count);
+            latencyModePrint(min,max,avg,count,histogram);
         } else {
             if (config.latency_history) {
-                latencyModePrint(min,max,avg,count);
+                latencyModePrint(min,max,avg,count,histogram);
             } else if (mstime()-history_start > config.interval) {
-                latencyModePrint(min,max,avg,count);
+                latencyModePrint(min,max,avg,count,histogram);
+                if (histogram) hdr_close(histogram);
                 exit(0);
             }
         }
@@ -8461,6 +8560,7 @@ static void latencyMode(void) {
             printf(" -- %.2f seconds range\n", (float)(mstime()-history_start)/1000);
             history_start = mstime();
             min = max = tot = count = 0;
+            if (histogram) hdr_reset(histogram);
         }
         usleep(LATENCY_SAMPLE_RATE * 1000);
     }
@@ -10916,6 +11016,9 @@ int main(int argc, char **argv) {
     config.latency_mode = 0;
     config.latency_dist_mode = 0;
     config.latency_history = 0;
+    config.latency_percentiles = NULL;
+    config.latency_percentiles_labels = NULL;
+    config.latency_percentiles_count = 0;
     config.lru_test_mode = 0;
     config.lru_test_sample_size = 0;
     config.cluster_mode = 0;

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -623,6 +623,48 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
         file delete $tmpfile
     }
 
+    test_nontty_cli "Latency mode reports requested percentiles" {
+        # Single-shot --latency in CSV mode samples for one second then exits.
+        # Without percentiles the line is "min,max,avg,count" (4 fields); with
+        # --latency-percentiles one extra column per percentile is appended.
+        set base [run_cli --csv -i 1 --latency]
+        assert_equal 4 [llength [split [string trim $base] ","]]
+
+        set out [run_cli --csv -i 1 --latency --latency-percentiles 50,99]
+        set fields [split [string trim $out] ","]
+        assert_equal 6 [llength $fields]
+
+        # Sanity-check the values: all are non-negative numbers reported in ms
+        # (fields: min,max,avg,count,p50,p99). Percentiles come from an HDR
+        # histogram and are bucket-quantized, so we only assert that they are
+        # monotonic (p50 <= p99); comparing them against the exact min/max
+        # scalars could differ by a quantum and is intentionally avoided.
+        lassign $fields min max avg count p50 p99
+        foreach v [list $min $max $avg $p50 $p99] {
+            assert {[string is double -strict $v]}
+            assert {$v >= 0}
+        }
+        assert {$p50 <= $p99}
+    }
+
+    test_nontty_cli "Latency mode reports percentiles as JSON object" {
+        set out [run_cli --json -i 1 --latency --latency-percentiles 50,99.9]
+        # Labels are echoed verbatim (not reformatted), so "99.9" stays "99.9".
+        assert_match {*"percentiles":*"50":*"99.9":*} $out
+    }
+
+    test_nontty_cli "Latency mode rejects invalid percentiles" {
+        # The argument is validated during option parsing, before any server
+        # connection or the sampling loop, so each invocation exits immediately
+        # with a nonzero status; exec folds the stderr message into $output.
+        foreach bad {bogus nan inf -1 101} {
+            set cmd [rediscli [srv host] [srv port] \
+                [list --latency --latency-percentiles 50,$bad]]
+            catch {exec {*}$cmd} output
+            assert_match "*Invalid percentile*" $output
+        }
+    }
+
     test_nontty_cli "Test command-line hinting - latest server" {
         # cli will connect to the running server and will use COMMAND DOCS
         catch {run_cli --test_hint_file tests/assets/test_cli_hint_suite.txt} output


### PR DESCRIPTION
## Summary

`redis-cli --latency` / `--latency-history` previously reported only **min**, **max** and **avg**. This PR adds a `--latency-percentiles <p1,p2,...>` option to also report arbitrary latency percentiles (e.g. `50,99,99.9,99.99`) in **all four** output formats (standard, CSV, raw, JSON).

```
$ redis-cli --latency --latency-percentiles 50,99,99.9
min: 0.031, max: 0.336, avg: 0.103 (812 samples), p50: 0.089, p99: 0.315, p99.9: 0.336

$ redis-cli --json --latency --latency-percentiles 50,99,99.9
{"min": 0.031, "max": 0.336, "avg": 0.103, "count": 812, "percentiles": {"50": 0.089, "99": 0.315, "99.9": 0.336}}
```

## HDR histogram

Percentiles are accumulated in an **HDR histogram** — the same library already used by redis-cli's `--vset-recall` mode and by `redis-benchmark` for latency percentiles. This keeps memory bounded and recording O(1) (no growing buffer, no per-tick sort).

In `--latency-history`, the histogram is `hdr_reset()` at every window boundary, in lockstep with the `min`/`max`/`avg` accumulators, so a reported percentile is always the percentile **of the current window**. The histogram is `hdr_init(1us, 3s, 3 sig figs)`; out-of-range samples are clamped like in redis-benchmark.

## Sub-millisecond resolution

To make percentiles meaningful, the per-PING round-trip is now measured with **microsecond** resolution (`ustime()`) instead of whole milliseconds, and all latency figures are reported in **milliseconds with 3-decimal precision**.

## ⚠️ Behavior change

This also changes the output of plain `--latency`/`--latency-history` (without the new flag): `min`/`max`/`avg` switch from integer milliseconds (`0`, `1`) to fractional milliseconds (`0.030`, `1.233`) across standard/CSV/raw/JSON. The `count` field and the column/field layout for the no-percentiles case are unchanged. Tooling that parsed the old integer columns will now see decimals.

## Details

- Percentile labels are **echoed verbatim** from user input, so they are never lossy (`99.99` stays `99.99`, distinct high-precision percentiles never collapse to the same JSON key).
- Invalid percentiles (`NaN`, `inf`, out-of-range, junk, empty) are rejected at **parse time**, before any server connection.
- Negative deltas from backward wall-clock adjustments are clamped to zero.
- Percentile *values* are HDR-quantized (≤0.1% at 3 sig figs), the same standard used elsewhere in Redis; `min`/`max`/`avg` remain exact.
- `--help` documents the unit (ms), the sub-ms precision, and a resolution caveat: a percentile finer than `100/samples` resolves to the max, so use a longer interval (`-i`) for meaningful high percentiles.

## Tests

`tests/integration/redis-cli.tcl` adds coverage for: the appended percentile columns, value sanity (numeric, non-negative, monotonic `p50 <= p99`), the JSON `percentiles` object shape with verbatim labels, and rejection of invalid percentile inputs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes redis-cli output format for existing `--latency` users (integer → fractional ms) and adds optional percentile columns/JSON fields; logic is localized to the CLI tool with no server impact.
> 
> **Overview**
> Adds **`--latency-percentiles <p1,p2,...>`** to `--latency` / `--latency-history`, reporting user-chosen percentiles (labels echoed verbatim) in standard, CSV, raw, and JSON (`percentiles` object) via an HDR histogram that resets with each history window.
> 
> **Behavior change:** round-trip timing moves from **millisecond** (`mstime`) to **microsecond** (`ustime`) resolution, so **min/max/avg are always printed as ms with three decimals** even when percentiles are not requested—parsers expecting integer ms will break.
> 
> Also clamps negative clock-skew deltas, validates percentile args at CLI parse time, updates `--help`, and adds integration tests for CSV/JSON output and invalid inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb5205ce79adc6a210fe92f691f4a14fbffe01d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->