### PR TITLE
fix: clean up IO threads on DEBUG SEGFAULT

### DIFF
--- a/src/iothread.c
+++ b/src/iothread.c
@@ -942,7 +942,57 @@ void initThreadedIO(void) {
     }
 }
 
-/* Kill the IO threads, TODO: release the applied resources. */
+static void freeIOThreadResources(int j) {
+    IOThread *t = &IOThreads[j];
+
+    if (t->el) {
+        aeDeleteFileEvent(t->el, getReadEventFd(t->pending_clients_notifier), AE_READABLE);
+        aeDeleteEventLoop(t->el);
+        t->el = NULL;
+    }
+    if (t->pending_clients_notifier) {
+        freeEventNotifier(t->pending_clients_notifier);
+        t->pending_clients_notifier = NULL;
+    }
+    if (t->pending_clients) {
+        listRelease(t->pending_clients);
+        t->pending_clients = NULL;
+    }
+    if (t->processing_clients) {
+        listRelease(t->processing_clients);
+        t->processing_clients = NULL;
+    }
+    if (t->pending_clients_to_main_thread) {
+        listRelease(t->pending_clients_to_main_thread);
+        t->pending_clients_to_main_thread = NULL;
+    }
+    if (t->clients) {
+        listRelease(t->clients);
+        t->clients = NULL;
+    }
+    pthread_mutex_destroy(&t->pending_clients_mutex);
+
+    if (mainThreadPendingClientsNotifiers[j]) {
+        aeDeleteFileEvent(server.el, getReadEventFd(mainThreadPendingClientsNotifiers[j]), AE_READABLE);
+        freeEventNotifier(mainThreadPendingClientsNotifiers[j]);
+        mainThreadPendingClientsNotifiers[j] = NULL;
+    }
+    if (mainThreadPendingClientsToIOThreads[j]) {
+        listRelease(mainThreadPendingClientsToIOThreads[j]);
+        mainThreadPendingClientsToIOThreads[j] = NULL;
+    }
+    if (mainThreadPendingClients[j]) {
+        listRelease(mainThreadPendingClients[j]);
+        mainThreadPendingClients[j] = NULL;
+    }
+    if (mainThreadProcessingClients[j]) {
+        listRelease(mainThreadProcessingClients[j]);
+        mainThreadProcessingClients[j] = NULL;
+    }
+    pthread_mutex_destroy(&mainThreadPendingClientsMutexes[j]);
+}
+
+/* Kill the IO threads. */
 void killIOThreads(void) {
     if (server.io_threads_num <= 1) return;
 
@@ -957,6 +1007,8 @@ void killIOThreads(void) {
             } else {
                 serverLog(LL_WARNING,
                     "IO thread(tid:%lu) terminated",(unsigned long)IOThreads[j].tid);
+                freeIOThreadResources(j);
+                IOThreads[j].tid = 0;
             }
         }
     }

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -92,6 +92,14 @@ if {!$::valgrind} {
         }
     }
 
+    set server_path [tmpdir server2-io-threads.log]
+    start_server [list overrides [list dir $server_path crash-memcheck-enabled no io-threads 2]] {
+        test "Crash report generated on DEBUG SEGFAULT with IO threads" {
+            catch {r debug segfault}
+            $check_cb "*crashed by signal*"
+        }
+    }
+
     # test DEBUG SIGALRM being non-fatal
     set server_path [tmpdir server3.log]
     start_server [list overrides [list dir $server_path]] {


### PR DESCRIPTION
## Summary
Fix IO thread resource cleanup on the DEBUG SEGFAULT crash path.

When Redis crashes while IO threads are enabled, `killIOThreads()` now releases the per-thread resources after successful `pthread_join()`:
- event loops
- event notifiers
- client lists
- thread mutexes
- main-thread notifier/event-loop registration

## Regression test
Added a crash-path regression test in `tests/integration/logging.tcl`:
- `Crash report generated on DEBUG SEGFAULT with IO threads`

The test exercises `DEBUG SEGFAULT` with `io-threads 2` and verifies the crash-report path still works.

## Validation
- `make -j4 redis-server`
- `./runtest --single integration/logging --only 'Crash report generated on DEBUG SEGFAULT with IO threads' --clients 1 --timeout 120 --verbose`
- `leaks` on the fixed build: `0 leaks for 0 total leaked bytes`
- `leaks` on the original build: `16 leaks for 4272 total leaked bytes`

## Notes
This change only cleans up resources on the successful thread-join path.