### PR TITLE
Fix NULL deref in ACL LOAD with internal (user-less) connections

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2464,8 +2464,11 @@ sds ACLLoadFromFile(const char *filename) {
         listRewind(server.clients,&li);
         while ((ln = listNext(&li)) != NULL) {
             client *c = listNodeValue(ln);
-            /* a MASTER client can do everything (and user = NULL) so we can skip it */
-            if (c->flags & CLIENT_MASTER)
+            /* Clients with no associated user (user = NULL) have nothing to
+             * re-resolve and must be skipped before dereferencing c->user.
+             * This covers MASTER clients as well as internal connections
+             * (CLIENT_INTERNAL), both of which run without a user. */
+            if (c->user == NULL)
                 continue;
             user *original = c->user;
             list *channels = NULL;

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1329,3 +1329,37 @@ start_server {overrides {user "default on nopass ~* +@all -flushdb"} tags {acl e
     }
 }
 
+tags {modules external:skip cluster} {
+    set testmodule [file normalize tests/modules/internalsecret.so]
+
+    # A valid ACL file must exist at startup for `ACL LOAD` to be available.
+    set aclpath [file normalize tests/tmp/internalauth-acl-load.acl]
+    set fp [open $aclpath w]
+    puts $fp "user default on nopass ~* &* +@all"
+    close $fp
+
+    start_cluster 1 0 [list \
+        config_lines [list loadmodule $testmodule] \
+        overrides [list aclfile $aclpath] \
+    ] {
+        test {ACL LOAD handles correctly an internal (NULL-user) connection present} {
+            set victim [redis_client]
+
+            # Promote the victim connection to an internal connection using the
+            # real internal secret. This sets c->user = NULL while leaving the
+            # client in server.clients, and does NOT set CLIENT_MASTER.
+            set secret [$victim internalauth.getinternalsecret]
+            assert_equal {OK} [$victim auth "internal connection" $secret]
+
+            # ACL LOAD iterates every client in server.clients.
+            assert_equal {OK} [r ACL LOAD]
+
+            # Confirm server it is responsive.
+            assert_equal {PONG} [r ping]
+
+            $victim close
+        }
+    }
+
+    file delete $aclpath
+}

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1338,10 +1338,7 @@ tags {modules external:skip cluster} {
     puts $fp "user default on nopass ~* &* +@all"
     close $fp
 
-    start_cluster 1 0 [list \
-        config_lines [list loadmodule $testmodule] \
-        overrides [list aclfile $aclpath] \
-    ] {
+    start_cluster 1 0 [list config_lines [list loadmodule $testmodule] overrides [list aclfile $aclpath]] {
         test {ACL LOAD handles correctly an internal (NULL-user) connection present} {
             set victim [redis_client]
 


### PR DESCRIPTION
## Problem
`ACLLoadFromFile()` iterates `server.clients` to rebind users and drop
pub/sub clients whose channel ACLs changed. Before this fix the loop only
skipped `CLIENT_MASTER` clients before dereferencing `c->user->name`.

Internal cluster connections (`AUTH "internal connection" <secret>`) set
`c->user = NULL` and `CLIENT_INTERNAL`, but **not** `CLIENT_MASTER`. So if
an internal connection is open when `ACL LOAD` runs, the loop dereferences
a NULL `c->user` and crashes the node.

## Fix
Guard on `c->user == NULL` instead of `CLIENT_MASTER`. This is a superset:
master clients already carry `user = NULL`, so their handling is unchanged,
while internal connections are now also skipped. Skipping internal
connections is also semantically correct — they run unrestricted (no ACL
user) and have no channel permissions to re-resolve.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ACL reload client iteration on a security-sensitive path; the change is narrow but prevents a production crash when internal connections coexist with ACL LOAD.
> 
> **Overview**
> Fixes a **crash in `ACLLoadFromFile()`** when `ACL LOAD` walks `server.clients` to rebind users and drop pub/sub clients whose channel ACLs changed.
> 
> The loop used to skip only **`CLIENT_MASTER`** before using `c->user->name`. **Internal cluster connections** (`AUTH "internal connection" <secret>`) set **`c->user = NULL`** and **`CLIENT_INTERNAL`** but not **`CLIENT_MASTER`**, so `ACL LOAD` could **NULL-dereference** and take down the node.
> 
> The guard is now **`c->user == NULL`**, which still skips master clients and also skips internal connections—appropriate because they have no ACL user or channel rules to re-resolve.
> 
> A **cluster integration test** promotes a client via the internal-auth module, runs **`ACL LOAD`**, and asserts the server stays up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0012b4afaf8890291cc481e567a4cb37f1427db2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->