### PR TITLE
Fix module numeric config crash on missing config

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3767,6 +3767,7 @@ int moduleSetEnumConfig(client *c, sds name, sds *vals, int vals_cnt, const char
 
 int moduleSetNumericConfig(client *c, sds name, long long val, const char **err) {
     standardConfig *config = getMutableConfig(c, name, err);
+    if (!config) return 0;
     if (config->type != NUMERIC_CONFIG) return 0;
 
     sds old_value = config->interface.get(config);

--- a/tests/unit/moduleapi/configaccess.tcl
+++ b/tests/unit/moduleapi/configaccess.tcl
@@ -121,6 +121,8 @@ start_server {tags {"modules external:skip"}} {
         # Test setting a non-existent config
         catch {r configaccess.setbool nonexistent_config yes} err
         assert_match "*ERR*" $err
+        catch {r configaccess.setnumeric nonexistent_config 1} err
+        assert_match "*ERR*" $err
 
         # Test setting a read-only config
         catch {r configaccess.setbool moduleconfigs.immutable_bool yes} err


### PR DESCRIPTION

## Issue

`RedisModule_ConfigSetNumeric()` could crash when called with a non-existent config name. `moduleSetNumericConfig()` did not check whether `getMutableConfig()` returned `NULL` before dereferencing `config->type`, unlike the existing bool config setter path.



## Change

Add the missing `NULL` check in `moduleSetNumericConfig()`, matching the existing handling in `moduleSetBoolConfig()`.

Add TCL coverage for `configaccess.setnumeric nonexistent_config 1` to verify the module API returns an error instead of crashing.

## Test
Passed:

```sh
make
./runtest --single unit/moduleapi/configaccess
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive guard aligned with existing bool setter; regression test only.
> 
> **Overview**
> **Fixes a crash** when `RedisModule_ConfigSetNumeric()` is called with a config name that does not exist.
> 
> `moduleSetNumericConfig()` now returns early if `getMutableConfig()` returns `NULL`, matching **`moduleSetBoolConfig()`** and avoiding a null dereference on `config->type`.
> 
> Adds a **module API test** that `configaccess.setnumeric` on a non-existent config returns an error instead of crashing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea7033192af393cf43f17400ea7f41252566006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->