### PR TITLE
Fix server crash on deeply nested Lua script reply conversion

### DIFF
--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -135,7 +135,7 @@ static void redisProtocolToLuaType_Double(void *ctx, double d, const char *proto
 static void redisProtocolToLuaType_BigNumber(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len);
 static void redisProtocolToLuaType_VerbatimString(void *ctx, const char *format, const char *str, size_t len, const char *proto, size_t proto_len);
 static void redisProtocolToLuaType_Attribute(struct ReplyParser *parser, void *ctx, size_t len, const char *proto);
-static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lua);
+static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lua, int level);
 
 /*
  * Save the give pointer on Lua registry, used to save the Lua context and
@@ -578,9 +578,18 @@ int luaError(lua_State *lua) {
  * ------------------------------------------------------------------------- */
 
 /* Reply to client 'c' converting the top element in the Lua stack to a
- * Redis reply. As a side effect the element is consumed from the stack.  */
-static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lua) {
+ * Redis reply. As a side effect the element is consumed from the stack.
+ * 'level' tracks the table nesting depth so a deeply nested reply cannot
+ * exhaust the C stack and crash the server. */
+#define LUA_REPLY_MAX_RECURSION_DEPTH 500
+static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lua, int level) {
     int t = lua_type(lua,-1);
+
+    if (level++ == LUA_REPLY_MAX_RECURSION_DEPTH) {
+        addReplyError(c, "max recursion level reached");
+        lua_pop(lua,1); /* pop the element from the stack */
+        return;
+    }
 
     if (!lua_checkstack(lua, 4)) {
         /* Increase the Lua stack if needed to make sure there is enough room
@@ -708,8 +717,8 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
             while (lua_next(lua,-2)) {
                 /* Stack now: table, key, value */
                 lua_pushvalue(lua,-2);        /* Dup key before consuming. */
-                luaReplyToRedisReply(c, script_client, lua); /* Return key. */
-                luaReplyToRedisReply(c, script_client, lua); /* Return value. */
+                luaReplyToRedisReply(c, script_client, lua, level); /* Return key. */
+                luaReplyToRedisReply(c, script_client, lua, level); /* Return value. */
                 /* Stack now: table, key. */
                 maplen++;
             }
@@ -732,7 +741,7 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
                 /* Stack now: table, key, true */
                 lua_pop(lua,1);               /* Discard the boolean value. */
                 lua_pushvalue(lua,-1);        /* Dup key before consuming. */
-                luaReplyToRedisReply(c, script_client, lua); /* Return key. */
+                luaReplyToRedisReply(c, script_client, lua, level); /* Return key. */
                 /* Stack now: table, key. */
                 setlen++;
             }
@@ -754,7 +763,7 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
                 lua_pop(lua,1);
                 break;
             }
-            luaReplyToRedisReply(c, script_client, lua);
+            luaReplyToRedisReply(c, script_client, lua, level);
             mbulklen++;
         }
         setDeferredArrayLen(c,replylen,mbulklen);
@@ -1737,7 +1746,7 @@ void luaCallFunction(scriptRunCtx* run_ctx, lua_State *lua, robj** keys, size_t 
     } else {
         /* On success convert the Lua return value into Redis protocol, and
          * send it to * the client. */
-        luaReplyToRedisReply(c, run_ctx->c, lua); /* Convert and consume the reply. */
+        luaReplyToRedisReply(c, run_ctx->c, lua, 0); /* Convert and consume the reply. */
     }
 
     /* Perform some cleanup that we need to do both on error and success. */

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1044,7 +1044,23 @@ start_server {tags {"scripting"}} {
         set res [run_script {local a = {}; local b = {a}; a[1] = b; return a} 0]
         # drain the response
         while {true} {
-            if {$res == "-ERR reached lua stack limit"} {
+            if {$res == "-ERR max recursion level reached"} {
+                break
+            }
+            assert_equal $res "*1"
+            set res [r read]
+        }
+        r readraw 0
+        # make sure the connection is still valid
+        assert_equal [r ping] {PONG}
+    }
+
+    test {Script reply conversion bounds recursion depth} {
+        r readraw 1
+        set res [run_script {local t = {} for i=1,1000 do t = {t} end return t} 0]
+        # drain the response until the recursion limit is reached
+        while {true} {
+            if {$res == "-ERR max recursion level reached"} {
                 break
             }
             assert_equal $res "*1"


### PR DESCRIPTION
## The problem

`luaReplyToRedisReply()` recurses once per level of table nesting when converting a Lua return value into a Redis reply, with no depth limit. The existing `lua_checkstack()` guard only protects the Lua stack, not the C call stack, so a script returning a sufficiently deep table can exhaust the C stack and segfault the server:

```console
> EVAL 'local t = {} for i=1,50000 do t = {t} end return t' 0
Segmentation fault
```

On the default 8MB stack the recursion is bounded indirectly by `LUAI_MAXCSTACK` (the Lua stack limit is reached first and the reply is rejected), so the crash is only observable with a smaller C stack. The recursion itself is nonetheless unbounded, which is the root cause.

## Fix

Track the nesting depth and stop the conversion with a `max recursion level reached` error once it exceeds a fixed bound, mirroring the existing protection in `ldbCatStackValueRec()`. Deeply nested replies are now rejected gracefully and the server stays up. Normal (shallow) replies are unaffected.

Fixes #14687.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core Lua-to-RESP reply path for all script return values; behavior change only for pathological depth, but any client relying on very deep nested replies will now get an error instead of a full reply.
> 
> **Overview**
> **Prevents server segfaults** when EVAL/FCALL returns deeply nested Lua tables by bounding C-stack recursion in `luaReplyToRedisReply`, separate from the existing Lua `lua_checkstack` guard.
> 
> `luaReplyToRedisReply` now takes a nesting `level` and stops at **500** levels with `-ERR max recursion level reached`, popping the stack and leaving the connection usable. Recursive paths for maps, sets, and arrays pass `level` through; the top-level call from `luaCallFunction` starts at `0`.
> 
> Tests drain raw protocol until that error (including a **1000**-level nested table case) and assert **PONG** afterward, replacing the old `reached lua stack limit` expectation for cyclic replies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cfe549a220455ec092d350a05512ab66efff568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->