### PR TITLE
Use the path argument instead of server.configfile in rewriteConfig()

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1794,7 +1794,7 @@ int rewriteConfig(char *path, int force_write) {
     /* Step 4: generate a new configuration file from the modified state
      * and write it into the original file. */
     newcontent = rewriteConfigGetContentFromState(state);
-    retval = rewriteConfigOverwriteFile(server.configfile,newcontent);
+    retval = rewriteConfigOverwriteFile(path, newcontent);
 
     sdsfree(newcontent);
     rewriteConfigReleaseState(state);


### PR DESCRIPTION
`rewriteConfig()` accepts a path and reads the existing config from that path, but the writeback path used `server.configfile`. 

Since current callers all pass `server.configfile`, this does not affect the normal CONFIG REWRITE path, but using the passed-in path keeps the function behavior consistent with its interface and comments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-argument fix in config rewrite; production CONFIG REWRITE behavior is unchanged when callers pass server.configfile.
> 
> **Overview**
> **`rewriteConfig()`** now persists the rewritten config to the **`path`** argument instead of always using **`server.configfile`**.
> 
> Read and write both target the same file, matching the function’s contract and comments. **`CONFIG REWRITE`** is unchanged because it already passes **`server.configfile`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c343660bf317f83ad772f91fa97b1ab0c09b5bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->