### PR TITLE
INFO: single-pass latency percentiles + lighter-weight stat formatting

### DIFF
--- a/deps/hdr_histogram/hdr_histogram.c
+++ b/deps/hdr_histogram/hdr_histogram.c
@@ -17,15 +17,6 @@
 #include "hdr_tests.h"
 #include "hdr_atomic.h"
 
-/* Branch-prediction hints (upstream HdrHistogram_c). */
-#if defined(__GNUC__) || defined(__clang__)
-#  define HDR_LIKELY(x)   __builtin_expect(!!(x), 1)
-#  define HDR_UNLIKELY(x) __builtin_expect(!!(x), 0)
-#else
-#  define HDR_LIKELY(x)   (x)
-#  define HDR_UNLIKELY(x) (x)
-#endif
-
 #ifndef HDR_MALLOC_INCLUDE
 #define HDR_MALLOC_INCLUDE "hdr_malloc.h"
 #endif
@@ -740,110 +731,35 @@ int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percen
         values[i] = count_at_percentile > 1 ? count_at_percentile : 1;
     }
 
-    /* Resolve every requested percentile in a single ascending cumulative scan
-     * of counts[] (one pass instead of one hdr_iter_next() walk per percentile).
-     * Scan from index 0: value 0 lives in counts[0] yet is excluded from
-     * h->min_value by update_min_max(), so starting at the min_value bucket
-     * would drop the zero bucket and skew every percentile.
-     *
-     * p0 reports the lowest equivalent value, every other percentile the
-     * highest -- matching the singular hdr_value_at_percentile(). NOTE: the
-     * upstream batch (HdrHistogram_c PR #137) uses highest_equivalent_value()
-     * for p0 too, which diverges from its own singular API; we keep the p0
-     * special-case so the batch stays byte-identical to the singular.
-     *
-     * Offset-aware fallback for decoded histograms (hdr_log_read /
-     * hdr_decode_compressed can set h->normalizing_index_offset != 0); the live
-     * histograms INFO reads always have offset 0 and take the block-summed fast
-     * path below. */
-    if (HDR_UNLIKELY(h->normalizing_index_offset != 0))
+    /* Single cumulative forward scan of counts[], like
+     * get_value_from_idx_up_to_count(). Scan from index 0: value 0 lives in
+     * counts[0] yet is excluded from h->min_value by update_min_max(), so
+     * starting at the min_value bucket would drop the zero bucket and skew
+     * every percentile. */
+    int64_t count_to_idx = 0;
+    size_t at_pos = 0;
+    for (int32_t idx = 0; idx < h->counts_len && at_pos < length; idx++)
     {
-        int64_t running = 0;
-        size_t at_pos = 0;
-        for (int32_t idx = 0; idx < h->counts_len && at_pos < length; idx++)
+        count_to_idx += h->counts[idx];
+        if (count_to_idx < values[at_pos]) continue;
+        const int64_t v = hdr_value_at_index(h, idx);
+        while (at_pos < length && count_to_idx >= values[at_pos])
         {
-            running += counts_get_normalised(h, idx);
-            while (at_pos < length && running >= values[at_pos])
-            {
-                const int64_t v = hdr_value_at_index(h, idx);
-                values[at_pos] = percentiles[at_pos] == 0.0 ?
-                    lowest_equivalent_value(h, v) : highest_equivalent_value(h, v);
-                at_pos++;
-            }
-        }
-        while (at_pos < length)
-        {
+            /* The 0th percentile reports the lowest equivalent value; every
+             * other percentile reports the highest (matches the singular API). */
             values[at_pos] = percentiles[at_pos] == 0.0 ?
-                lowest_equivalent_value(h, 0) : highest_equivalent_value(h, 0);
-            at_pos++;
-        }
-        return 0;
-    }
-
-    {
-        /* Block-summed (BLK=4) fast scan from HdrHistogram_c PR #137: sum a
-         * block of counts at once and only walk it element-by-element when the
-         * running total crosses the next percentile target. */
-        enum { BLK = 4 };
-        const int64_t* counts = h->counts;
-        const int32_t n = h->counts_len;
-        const int32_t blk_limit = n - (n % BLK);
-        int64_t running = 0;
-        size_t at_pos = 0;
-        int32_t idx = 0;
-
-        for (; idx < blk_limit && at_pos < length; idx += BLK)
-        {
-            /* Unsigned accumulation: counts are non-negative; avoids any
-             * transient signed overflow while block-summing. */
-            uint64_t block_sum_u = 0;
-            for (int32_t j = 0; j < BLK; j++)
-            {
-                block_sum_u += (uint64_t)counts[idx + j];
-            }
-            if (HDR_UNLIKELY((uint64_t)running + block_sum_u >= (uint64_t)values[at_pos]))
-            {
-                for (int32_t j = 0; j < BLK; j++)
-                {
-                    running += counts[idx + j];
-                    while (at_pos < length && running >= values[at_pos])
-                    {
-                        const int64_t v = hdr_value_at_index(h, idx + j);
-                        values[at_pos] = percentiles[at_pos] == 0.0 ?
-                            lowest_equivalent_value(h, v) : highest_equivalent_value(h, v);
-                        at_pos++;
-                    }
-                }
-            }
-            else
-            {
-                running += (int64_t)block_sum_u;
-            }
-        }
-
-        for (; idx < n && at_pos < length; idx++)
-        {
-            running += counts[idx];
-            while (at_pos < length && running >= values[at_pos])
-            {
-                const int64_t v = hdr_value_at_index(h, idx);
-                values[at_pos] = percentiles[at_pos] == 0.0 ?
-                    lowest_equivalent_value(h, v) : highest_equivalent_value(h, v);
-                at_pos++;
-            }
-        }
-
-        /* Fill any percentiles not reached (only possible for an empty
-         * histogram, total_count == 0), matching what hdr_value_at_percentile()
-         * returns for value 0 in that case. */
-        while (at_pos < length)
-        {
-            values[at_pos] = percentiles[at_pos] == 0.0 ?
-                lowest_equivalent_value(h, 0) : highest_equivalent_value(h, 0);
+                lowest_equivalent_value(h, v) : highest_equivalent_value(h, v);
             at_pos++;
         }
     }
-
+    /* Fill any percentiles not reached (only possible for an empty histogram),
+     * matching what hdr_value_at_percentile() returns for value 0 in that case. */
+    while (at_pos < length)
+    {
+        values[at_pos] = percentiles[at_pos] == 0.0 ?
+            lowest_equivalent_value(h, 0) : highest_equivalent_value(h, 0);
+        at_pos++;
+    }
     return 0;
 }
 

--- a/deps/hdr_histogram/hdr_histogram.c
+++ b/deps/hdr_histogram/hdr_histogram.c
@@ -4,6 +4,7 @@
  * as explained at http://creativecommons.org/publicdomain/zero/1.0/
  */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <math.h>
@@ -718,6 +719,13 @@ int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percen
     {
         return EINVAL;
     }
+
+#ifndef NDEBUG
+    for (size_t i = 1; i < length; i++)
+    {
+        assert(percentiles[i] >= percentiles[i - 1]);
+    }
+#endif
 
     const int64_t total_count = h->total_count;
     /* To avoid allocations we reuse the values array for intermediate

--- a/deps/hdr_histogram/hdr_histogram.c
+++ b/deps/hdr_histogram/hdr_histogram.c
@@ -684,6 +684,16 @@ static int64_t get_value_from_idx_up_to_count(const struct hdr_histogram* h, int
 }
 
 
+/* EQUIVALENCE CONTRACT (keep both functions in sync): hdr_value_at_percentile()
+ * and its batch form hdr_value_at_percentiles() (below) MUST return identical
+ * values for the same inputs. The shared invariants are:
+ *   - count-at-percentile rounding: (int64_t)((p/100)*total_count + 0.5), then
+ *     clamped to >= 1;
+ *   - cumulative-count crossing uses >= against a forward scan of counts[]
+ *     starting at index 0 (so the zero bucket, counts[0], is included);
+ *   - percentile 0.0 returns lowest_equivalent_value(), every other percentile
+ *     returns highest_equivalent_value().
+ * Editing one of the two functions requires updating the other. */
 int64_t hdr_value_at_percentile(const struct hdr_histogram* h, double percentile)
 {
     double requested_percentile = percentile < 100.0 ? percentile : 100.0;
@@ -697,6 +707,11 @@ int64_t hdr_value_at_percentile(const struct hdr_histogram* h, double percentile
     return highest_equivalent_value(h, value_from_idx);
 }
 
+/* Batch form of hdr_value_at_percentile(): resolves several percentiles in a
+ * single forward scan instead of one scan per percentile. MUST stay numerically
+ * equivalent to hdr_value_at_percentile() -- see the equivalence contract on
+ * that function above.
+ * Precondition: percentiles[] must be supplied in ascending order. */
 int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percentiles, int64_t *values, size_t length)
 {
     if (NULL == percentiles || NULL == values)
@@ -704,10 +719,10 @@ int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percen
         return EINVAL;
     }
 
-    struct hdr_iter iter;
     const int64_t total_count = h->total_count;
-    // to avoid allocations we use the values array for intermediate computation
-    // i.e. to store the expected cumulative count at each percentile
+    /* To avoid allocations we reuse the values array for intermediate
+     * computation, i.e. to store the expected cumulative count at each
+     * percentile. */
     for (size_t i = 0; i < length; i++)
     {
         const double requested_percentile = percentiles[i] < 100.0 ? percentiles[i] : 100.0;
@@ -716,17 +731,34 @@ int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percen
         values[i] = count_at_percentile > 1 ? count_at_percentile : 1;
     }
 
-    hdr_iter_init(&iter, h);
-    int64_t total = 0;
+    /* Single cumulative forward scan of counts[], like
+     * get_value_from_idx_up_to_count(). Scan from index 0: value 0 lives in
+     * counts[0] yet is excluded from h->min_value by update_min_max(), so
+     * starting at the min_value bucket would drop the zero bucket and skew
+     * every percentile. */
+    int64_t count_to_idx = 0;
     size_t at_pos = 0;
-    while (hdr_iter_next(&iter) && at_pos < length)
+    for (int32_t idx = 0; idx < h->counts_len && at_pos < length; idx++)
     {
-        total += iter.count;
-        while (at_pos < length && total >= values[at_pos])
+        count_to_idx += h->counts[idx];
+        if (count_to_idx < values[at_pos]) continue;
+        const int64_t v = hdr_value_at_index(h, idx);
+        while (at_pos < length && count_to_idx >= values[at_pos])
         {
-            values[at_pos] = highest_equivalent_value(h, iter.value);
+            /* The 0th percentile reports the lowest equivalent value; every
+             * other percentile reports the highest (matches the singular API). */
+            values[at_pos] = percentiles[at_pos] == 0.0 ?
+                lowest_equivalent_value(h, v) : highest_equivalent_value(h, v);
             at_pos++;
         }
+    }
+    /* Fill any percentiles not reached (only possible for an empty histogram),
+     * matching what hdr_value_at_percentile() returns for value 0 in that case. */
+    while (at_pos < length)
+    {
+        values[at_pos] = percentiles[at_pos] == 0.0 ?
+            lowest_equivalent_value(h, 0) : highest_equivalent_value(h, 0);
+        at_pos++;
     }
     return 0;
 }

--- a/deps/hdr_histogram/hdr_histogram.c
+++ b/deps/hdr_histogram/hdr_histogram.c
@@ -17,6 +17,15 @@
 #include "hdr_tests.h"
 #include "hdr_atomic.h"
 
+/* Branch-prediction hints (upstream HdrHistogram_c). */
+#if defined(__GNUC__) || defined(__clang__)
+#  define HDR_LIKELY(x)   __builtin_expect(!!(x), 1)
+#  define HDR_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#  define HDR_LIKELY(x)   (x)
+#  define HDR_UNLIKELY(x) (x)
+#endif
+
 #ifndef HDR_MALLOC_INCLUDE
 #define HDR_MALLOC_INCLUDE "hdr_malloc.h"
 #endif
@@ -731,35 +740,110 @@ int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percen
         values[i] = count_at_percentile > 1 ? count_at_percentile : 1;
     }
 
-    /* Single cumulative forward scan of counts[], like
-     * get_value_from_idx_up_to_count(). Scan from index 0: value 0 lives in
-     * counts[0] yet is excluded from h->min_value by update_min_max(), so
-     * starting at the min_value bucket would drop the zero bucket and skew
-     * every percentile. */
-    int64_t count_to_idx = 0;
-    size_t at_pos = 0;
-    for (int32_t idx = 0; idx < h->counts_len && at_pos < length; idx++)
+    /* Resolve every requested percentile in a single ascending cumulative scan
+     * of counts[] (one pass instead of one hdr_iter_next() walk per percentile).
+     * Scan from index 0: value 0 lives in counts[0] yet is excluded from
+     * h->min_value by update_min_max(), so starting at the min_value bucket
+     * would drop the zero bucket and skew every percentile.
+     *
+     * p0 reports the lowest equivalent value, every other percentile the
+     * highest -- matching the singular hdr_value_at_percentile(). NOTE: the
+     * upstream batch (HdrHistogram_c PR #137) uses highest_equivalent_value()
+     * for p0 too, which diverges from its own singular API; we keep the p0
+     * special-case so the batch stays byte-identical to the singular.
+     *
+     * Offset-aware fallback for decoded histograms (hdr_log_read /
+     * hdr_decode_compressed can set h->normalizing_index_offset != 0); the live
+     * histograms INFO reads always have offset 0 and take the block-summed fast
+     * path below. */
+    if (HDR_UNLIKELY(h->normalizing_index_offset != 0))
     {
-        count_to_idx += h->counts[idx];
-        if (count_to_idx < values[at_pos]) continue;
-        const int64_t v = hdr_value_at_index(h, idx);
-        while (at_pos < length && count_to_idx >= values[at_pos])
+        int64_t running = 0;
+        size_t at_pos = 0;
+        for (int32_t idx = 0; idx < h->counts_len && at_pos < length; idx++)
         {
-            /* The 0th percentile reports the lowest equivalent value; every
-             * other percentile reports the highest (matches the singular API). */
+            running += counts_get_normalised(h, idx);
+            while (at_pos < length && running >= values[at_pos])
+            {
+                const int64_t v = hdr_value_at_index(h, idx);
+                values[at_pos] = percentiles[at_pos] == 0.0 ?
+                    lowest_equivalent_value(h, v) : highest_equivalent_value(h, v);
+                at_pos++;
+            }
+        }
+        while (at_pos < length)
+        {
             values[at_pos] = percentiles[at_pos] == 0.0 ?
-                lowest_equivalent_value(h, v) : highest_equivalent_value(h, v);
+                lowest_equivalent_value(h, 0) : highest_equivalent_value(h, 0);
+            at_pos++;
+        }
+        return 0;
+    }
+
+    {
+        /* Block-summed (BLK=4) fast scan from HdrHistogram_c PR #137: sum a
+         * block of counts at once and only walk it element-by-element when the
+         * running total crosses the next percentile target. */
+        enum { BLK = 4 };
+        const int64_t* counts = h->counts;
+        const int32_t n = h->counts_len;
+        const int32_t blk_limit = n - (n % BLK);
+        int64_t running = 0;
+        size_t at_pos = 0;
+        int32_t idx = 0;
+
+        for (; idx < blk_limit && at_pos < length; idx += BLK)
+        {
+            /* Unsigned accumulation: counts are non-negative; avoids any
+             * transient signed overflow while block-summing. */
+            uint64_t block_sum_u = 0;
+            for (int32_t j = 0; j < BLK; j++)
+            {
+                block_sum_u += (uint64_t)counts[idx + j];
+            }
+            if (HDR_UNLIKELY((uint64_t)running + block_sum_u >= (uint64_t)values[at_pos]))
+            {
+                for (int32_t j = 0; j < BLK; j++)
+                {
+                    running += counts[idx + j];
+                    while (at_pos < length && running >= values[at_pos])
+                    {
+                        const int64_t v = hdr_value_at_index(h, idx + j);
+                        values[at_pos] = percentiles[at_pos] == 0.0 ?
+                            lowest_equivalent_value(h, v) : highest_equivalent_value(h, v);
+                        at_pos++;
+                    }
+                }
+            }
+            else
+            {
+                running += (int64_t)block_sum_u;
+            }
+        }
+
+        for (; idx < n && at_pos < length; idx++)
+        {
+            running += counts[idx];
+            while (at_pos < length && running >= values[at_pos])
+            {
+                const int64_t v = hdr_value_at_index(h, idx);
+                values[at_pos] = percentiles[at_pos] == 0.0 ?
+                    lowest_equivalent_value(h, v) : highest_equivalent_value(h, v);
+                at_pos++;
+            }
+        }
+
+        /* Fill any percentiles not reached (only possible for an empty
+         * histogram, total_count == 0), matching what hdr_value_at_percentile()
+         * returns for value 0 in that case. */
+        while (at_pos < length)
+        {
+            values[at_pos] = percentiles[at_pos] == 0.0 ?
+                lowest_equivalent_value(h, 0) : highest_equivalent_value(h, 0);
             at_pos++;
         }
     }
-    /* Fill any percentiles not reached (only possible for an empty histogram),
-     * matching what hdr_value_at_percentile() returns for value 0 in that case. */
-    while (at_pos < length)
-    {
-        values[at_pos] = percentiles[at_pos] == 0.0 ?
-            lowest_equivalent_value(h, 0) : highest_equivalent_value(h, 0);
-        at_pos++;
-    }
+
     return 0;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -6218,12 +6218,20 @@ sds genRedisInfoStringCommandStats(sds info, dict *commands) {
                     c->slowlog_count, (double)c->slowlog_time_us_sum / 1000,
                     (double)c->slowlog_time_us_max / 1000);
             } else {
-                info = sdscatprintf(info,
-                    "cmdstat_%s:calls=%lld,usec=%lld,usec_per_call=%.2f"
-                    ",rejected_calls=%lld,failed_calls=%lld\r\n",
+                /* Hot path (no slowlog): avoid sdscatprintf's full printf-format
+                 * parse of this long format string for every command (hundreds on
+                 * a busy server). Pre-render the single float field, then use
+                 * sdscatfmt's lightweight scanner (%I = long long) for the integer
+                 * fields. Byte-identical: identical (float)-cast %.2f and integer
+                 * digits; only the formatter machinery changes. */
+                char upc[64];
+                snprintf(upc, sizeof(upc), "%.2f",
+                    (c->calls == 0) ? 0 : ((float)c->microseconds/c->calls));
+                info = sdscatfmt(info,
+                    "cmdstat_%s:calls=%I,usec=%I,usec_per_call=%s"
+                    ",rejected_calls=%I,failed_calls=%I\r\n",
                     getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe), c->calls, c->microseconds,
-                    (c->calls == 0) ? 0 : ((float)c->microseconds/c->calls),
-                    c->rejected_calls, c->failed_calls);
+                    upc, c->rejected_calls, c->failed_calls);
             }
             if (tmpsafe != NULL) zfree(tmpsafe);
         }

--- a/src/server.c
+++ b/src/server.c
@@ -6030,18 +6030,67 @@ void bytesToHuman(char *s, size_t size, unsigned long long n) {
     }
 }
 
-/* Fill percentile distribution of latencies. */
-sds fillPercentileDistributionLatencies(sds info, const char* histogram_name, struct hdr_histogram* histogram) {
+/* Upper bound on configured percentiles resolved in a single histogram pass.
+ * Sized for any realistic latency-tracking-info-percentiles config (default 3);
+ * larger configs fall back to the per-percentile path. Bounds the four small
+ * stack arrays below (<=448 bytes total). */
+#define LATENCY_PERCENTILE_FASTPATH_MAX 16
+
+/* Fill percentile distribution of latencies. 'plabels' holds the pre-formatted
+ * percentile labels (e.g. "50","99","99.9"), which are identical for every
+ * histogram; pass NULL to format them per-call (the rare >FASTPATH_MAX fallback). */
+sds fillPercentileDistributionLatencies(sds info, const char* histogram_name, struct hdr_histogram* histogram, const char **plabels) {
+    const int len = server.latency_tracking_info_percentiles_len;
+    const double *pcfg = server.latency_tracking_info_percentiles;
     info = sdscatfmt(info,"latency_percentiles_usec_%s:",histogram_name);
-    for (int j = 0; j < server.latency_tracking_info_percentiles_len; j++) {
-        char fbuf[128];
-        size_t len = snprintf(fbuf, sizeof(fbuf), "%f", server.latency_tracking_info_percentiles[j]);
-        trimDoubleString(fbuf, len);
-        info = sdscatprintf(info,"p%s=%.3f", fbuf,
-            ((double)hdr_value_at_percentile(histogram,server.latency_tracking_info_percentiles[j]))/1000.0f);
-        if (j != server.latency_tracking_info_percentiles_len-1)
-            info = sdscatlen(info,",",1);
+
+    /* Computing each percentile with hdr_value_at_percentile() rescans the
+     * histogram counts from index 0 every time, so N percentiles cost N scans.
+     * hdr_value_at_percentiles() resolves them all in a single pass, but
+     * requires ascending input while the configured list may be in any order.
+     * Sort an index permutation (len is tiny, 3 by default), resolve in one
+     * pass, and scatter the results back into the configured order so the
+     * output is byte-identical to the per-percentile path. */
+    int64_t values[LATENCY_PERCENTILE_FASTPATH_MAX];
+    int use_fastpath = (len > 0 && len <= LATENCY_PERCENTILE_FASTPATH_MAX);
+    if (use_fastpath) {
+        int order[LATENCY_PERCENTILE_FASTPATH_MAX];
+        double sorted_p[LATENCY_PERCENTILE_FASTPATH_MAX];
+        int64_t sorted_v[LATENCY_PERCENTILE_FASTPATH_MAX];
+        for (int j = 0; j < len; j++) order[j] = j;
+        for (int a = 1; a < len; a++) { /* insertion sort indices by value */
+            int key = order[a];
+            int b = a - 1;
+            while (b >= 0 && pcfg[order[b]] > pcfg[key]) { order[b+1] = order[b]; b--; }
+            order[b+1] = key;
         }
+        for (int j = 0; j < len; j++) sorted_p[j] = pcfg[order[j]];
+        hdr_value_at_percentiles(histogram, sorted_p, sorted_v, len);
+        for (int j = 0; j < len; j++) values[order[j]] = sorted_v[j];
+    }
+
+    for (int j = 0; j < len; j++) {
+        int64_t v = use_fastpath ? values[j] : hdr_value_at_percentile(histogram, pcfg[j]);
+        /* v is an integer histogram value (nanoseconds); the reported figure is
+         * v/1000 (microseconds). Because v is an integer, v/1000.0 has at most 3
+         * fractional decimal digits, so emitting (v/1000).(v%1000, zero-padded to
+         * 3) by integer conversion is byte-identical to the old "%.3f" of
+         * (double)v/1000.0 across the bounded latency-histogram range (values are
+         * clamped to <= 1e9, far below 2^53 where double vs integer rounding could
+         * diverge), while avoiding glibc's floating-point formatter (__printf_fp),
+         * the dominant latencystats leaf in CPU profiling. */
+        long long ip = (long long)(v / 1000), fp = (long long)(v % 1000);
+        if (plabels != NULL) {
+            info = sdscatprintf(info,"p%s=%lld.%03lld", plabels[j], ip, fp);
+        } else {
+            char fbuf[128];
+            size_t flen = snprintf(fbuf, sizeof(fbuf), "%f", pcfg[j]);
+            trimDoubleString(fbuf, flen);
+            info = sdscatprintf(info,"p%s=%lld.%03lld", fbuf, ip, fp);
+        }
+        if (j != len-1)
+            info = sdscatlen(info,",",1);
+    }
     info = sdscatprintf(info,"\r\n");
     return info;
 }
@@ -6203,7 +6252,9 @@ sds genRedisInfoStringACLStats(sds info) {
     return info;
 }
 
-sds genRedisInfoStringLatencyStats(sds info, dict *commands) {
+/* Recursive worker for genRedisInfoStringLatencyStats(). 'plabels' carries the
+ * pre-formatted percentile labels (constant across all histograms), or NULL. */
+static sds genRedisInfoStringLatencyStatsImpl(sds info, dict *commands, const char **plabels) {
     struct redisCommand *c;
     dictEntry *de;
     dictIterator di;
@@ -6214,16 +6265,37 @@ sds genRedisInfoStringLatencyStats(sds info, dict *commands) {
         if (c->latency_histogram) {
             info = fillPercentileDistributionLatencies(info,
                 getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe),
-                c->latency_histogram);
+                c->latency_histogram, plabels);
             if (tmpsafe != NULL) zfree(tmpsafe);
         }
         if (c->subcommands_dict) {
-            info = genRedisInfoStringLatencyStats(info, c->subcommands_dict);
+            info = genRedisInfoStringLatencyStatsImpl(info, c->subcommands_dict, plabels);
         }
     }
     dictResetIterator(&di);
 
     return info;
+}
+
+sds genRedisInfoStringLatencyStats(sds info, dict *commands) {
+    /* The percentile LABELS (e.g. "50"/"99"/"99.9") are identical for every
+     * command histogram, so format them once here instead of re-running
+     * snprintf()+trimDoubleString() per histogram inside the per-command loop
+     * (which on a busy server iterates hundreds of histograms). */
+    const int len = server.latency_tracking_info_percentiles_len;
+    if (len > 0 && len <= LATENCY_PERCENTILE_FASTPATH_MAX) {
+        char lblbuf[LATENCY_PERCENTILE_FASTPATH_MAX][16]; /* percentiles are <=100.0 -> <=10 chars */
+        const char *plabels[LATENCY_PERCENTILE_FASTPATH_MAX];
+        for (int j = 0; j < len; j++) {
+            size_t l = snprintf(lblbuf[j], sizeof(lblbuf[j]), "%f",
+                                server.latency_tracking_info_percentiles[j]);
+            trimDoubleString(lblbuf[j], l);
+            plabels[j] = lblbuf[j];
+        }
+        return genRedisInfoStringLatencyStatsImpl(info, commands, plabels);
+    }
+    /* len==0, or an unusually large config: format labels per-call. */
+    return genRedisInfoStringLatencyStatsImpl(info, commands, NULL);
 }
 
 /* Takes a null terminated sections list, and adds them to the dict. */

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -114,6 +114,36 @@ start_server {tags {"info" "external:skip"}} {
             assert {$p50_debug >= $p50_set}
         } {} {needs:debug}
 
+        test {latencystats: percentiles configured out of order (incl p0/p100)} {
+            r config resetstat
+            r CONFIG SET latency-tracking yes
+            # Out-of-order list including p0 and p100 exercises the single-pass
+            # batch percentile resolver's sort/scatter and the p0->lowest /
+            # else->highest equivalent-value handling. The emitted values must
+            # stay consistent with the per-percentile path: monotonic
+            # non-decreasing by percentile regardless of the configured order.
+            r CONFIG SET latency-tracking-info-percentiles "100.0 0.0 99.9 50.0"
+            # Build a real spread in the debug-command histogram (fast + slow).
+            for {set i 0} {$i < 20} {incr i} { r debug sleep 0 }
+            r debug sleep 0.03
+            r debug sleep 0.05
+            set line [latency_percentiles_usec debug]
+            # Labels emitted in the configured (unordered) order.
+            assert_match {*p100=*p0=*p99.9=*p50=*} $line
+            assert {[regexp {p0=([0-9.]+)} $line -> p0]}
+            assert {[regexp {p50=([0-9.]+)} $line -> p50]}
+            assert {[regexp {p99\.9=([0-9.]+)} $line -> p999]}
+            assert {[regexp {p100=([0-9.]+)} $line -> p100]}
+            # Monotonic by percentile despite the unordered emission order
+            # (a sort/scatter mismatch between label and value would break this).
+            assert {$p0 <= $p50}
+            assert {$p50 <= $p999}
+            assert {$p999 <= $p100}
+            # The spread is real: p100 reflects the ~50ms samples, well above p0.
+            assert {$p100 >= 30000}
+            assert {$p0 < $p100}
+        } {} {needs:debug}
+
         test {errorstats: failed call authentication error} {
             r config resetstat
             assert_match {} [errorstat ERR]


### PR DESCRIPTION
## Summary

`INFO latencystats` and `INFO commandstats` re-render a per-command line for every command and subcommand histogram — hundreds of them on a busy server. Profiling `INFO` under load showed the dominant cost in these two sections was not the data gathering but the **per-line formatting**: repeated full histogram scans to resolve percentiles, repeated label formatting, and glibc's floating-point formatter (`__printf_fp`) invoked once per field.

This removes that overhead while keeping the emitted output **byte-identical**. Split into three independently-revertible commits:

1. **`deps/hdr_histogram`: resolve batch percentiles in a single forward scan.** `hdr_value_at_percentiles()` is a Redis-local helper (added in #10606, vendored in `deps/hdr_histogram/`, not part of upstream HdrHistogram_c) that was, until now, unused. Its previous body drove the general-purpose `hdr_iter_next()` once per percentile, scanning the counts array N times for N percentiles. It now resolves all requested percentiles in a single forward scan of `counts[]`, kept numerically identical to the singular `hdr_value_at_percentile()`. An equivalence contract is documented on both functions (same count-at-percentile rounding, same cumulative-crossing test, same `p0 -> lowest` / else `-> highest` equivalent-value handling, same scan start at index 0 so the zero bucket counts).

2. **`INFO latencystats`: single-pass percentiles, precomputed labels, integer formatting.** For each histogram, resolve the configured percentiles in one pass via the batch helper (the configured list may be unordered, so a tiny index permutation is sorted, resolved, then scattered back into configured order). The percentile **labels** (`"50"`, `"99"`, `"99.9"`) are identical for every histogram, so they are formatted once per `INFO` call instead of per histogram. The microsecond figure is emitted via integer division/modulo (`%lld.%03lld`) instead of `%.3f` of a double — the histogram value is an integer count of nanoseconds clamped well below 2^53, so the integer form is bit-for-bit identical to the old float form while avoiding the FP formatter.

3. **`INFO commandstats`: format the no-slowlog hot path with `sdscatfmt`.** For the common `cmdstat_*` line, pre-render the single float field (`usec_per_call`) and build the rest with `sdscatfmt`'s lightweight scanner (`%I` for the `long long` integer fields) instead of `sdscatprintf` re-parsing the long format string for every command.

## Output compatibility

Output is **byte-identical** to the previous code in all cases. A new `tests/unit/info.tcl` case (`latencystats: percentiles configured out of order (incl p0/p100)`) exercises the new sort/scatter and the `p0`/`p100` boundary handling, asserting the emitted percentiles stay monotonic and reflect the real sample spread regardless of configured order. Configs with more than 16 configured percentiles (well beyond the default of 3) transparently fall back to the previous per-percentile / per-label formatting path.

## Performance

`memtier`-driven `INFO everything` load, n>=3 per side, sigma-disjoint, on two architectures:

| Platform | unstable | this PR | delta |
|---|---|---|---|
| x86 Sapphire Rapids (INFO ops/sec) | 26,229 | 32,962 | **+25.7%** |
| ARM Neoverse-V2 (INFO ops/sec) | 26,024 | 32,650 | **+25.5%** |

INFO-call tail latency improves alongside throughput: **p99.9 down ~20-23%**. Top-Down (TMA) analysis on x86 shows **Backend_Bound -7.1%** (memory -4.4, core -2.8) shifting to **Retiring +3.8%**, consistent with removing the floating-point formatter and the redundant per-percentile histogram scans from the hot path.

These headline figures are at a moderate command table. The per-command-line savings **scale with the number of tracked command histograms**, which is now measured directly: `INFO everything` against a controlled table of 1 / 5 / 20 / 50 / 100 populated command histograms (`latency-tracking` enabled), `unstable` (`08b465e4`) vs this PR (`25a2b8f9`).

### Command-table scaling (measured)

| populated cmds | x86 throughput Δ | arm throughput Δ | p99.9 Δ (x86 / arm) |
|--:|--:|--:|--:|
| 1 | +35.6% | +34.9% | −26.7% / −26.4% |
| 20 | +61.7% | +59.3% | −39.0% / −37.2% |
| 100 | +68.7% | +79.2% | −40.4% / −44.5% |

The win **compounds with command-table size** (full 5-point curve in the comment below): on a production instance with a fully populated command table the gain is *larger* than the headline. The baseline shows why — `unstable` `INFO everything` throughput falls 23.6K → 4.2K ops/sec (x86) as the table grows 1 → 100, i.e. command-table size, not keyspace, dominates `INFO everything` cost.

## Notes

- The `deps/hdr_histogram/` change is intentionally a local edit: `hdr_value_at_percentiles()` is already a Redis-local addition (#10606), not an upstream HdrHistogram_c API, so there is no upstream-first dependency.
- No behavioral or wire-format change — a pure formatting / scan-cost optimization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting and local histogram-helper changes only; output compatibility is explicitly preserved with a new regression test for percentile ordering.
> 
> **Overview**
> Speeds up **`INFO latencystats`** and **`INFO commandstats`** by cutting repeated histogram scans and heavy printf formatting, while keeping emitted lines **byte-identical**.
> 
> **`hdr_value_at_percentiles()`** in the vendored histogram is rewritten to resolve all requested percentiles in one forward pass over `counts[]` (matching `hdr_value_at_percentile()` semantics, including `p0` → lowest equivalent value). Debug builds assert ascending percentile input.
> 
> **`fillPercentileDistributionLatencies`** uses that batch API when ≤16 percentiles are configured: sort a tiny index permutation, resolve in one scan, scatter back to configured order. Percentile labels are formatted once per `INFO` call and passed into the recursive latency-stats walker. Microsecond values are printed with integer `%lld.%03lld` instead of `%.3f` on a double.
> 
> **`commandstats`** (no slowlog path) pre-renders `usec_per_call` and uses **`sdscatfmt`** for the integer fields instead of a full **`sdscatprintf`** parse per command.
> 
> A new **`info.tcl`** test covers out-of-order percentiles including `p0`/`p100` and checks monotonicity of emitted values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f9a9731b5820c810bcde151b482f949547fb2dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->