### PR TITLE
MOD-16508: Update RediSearch module to v8.9.81

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.9.80
+MODULE_VERSION = v8.9.81
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
Updates the bundled RediSearch module version used by Redis module builds from `v8.9.80` to `v8.9.81`.

This picks up the tagged RediSearch 8.9.81 release for the 8.10 MS2 milestone.

Validation:
- Checked that `v8.9.81` exists in `RediSearch/RediSearch` and resolves to `ccfdde4eb4444049f5965c4aa69a97d9a23a8cf2`.
- Checked the diff is limited to `modules/redisearch/Makefile`.
- Ran `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-version Makefile change with no logic or security surface; routine upstream module pickup.
> 
> **Overview**
> Bumps the **RediSearch** bundle pin from **`v8.9.80`** to **`v8.9.81`** via `MODULE_VERSION` in `modules/redisearch/Makefile`, so Redis module builds pull the **8.9.81** tagged upstream release for the 8.10 MS2 milestone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e1f611787c3909b22e8fd6f58e8d1d35e12f4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->