### PR TITLE
Update RedisTimeSeries module to v8.9.81

### DIFF
--- a/modules/redistimeseries/Makefile
+++ b/modules/redistimeseries/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.9.80
+MODULE_VERSION = v8.9.81
 MODULE_REPO = https://github.com/redistimeseries/redistimeseries
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redistimeseries.so
 


### PR DESCRIPTION
## Summary
Bumps the pinned `MODULE_VERSION` for **RedisTimeSeries** from `v8.9.80` to `v8.9.81`. RedisBloom and RedisJSON are unchanged.

| Module | From | To |
| --- | --- | --- |
| RedisTimeSeries | v8.9.80 | v8.9.81 |

> **Note:** the `v8.9.80...8.9.81` range is **diverged** — 10 new commits on `8.9.81`, and `8.9.81` is 2 commits *behind* `v8.9.80` (release-branch-only version/branch-cut commits, not forward-ported). The ancestry diff contains 10 commits and **all 10 are genuinely new** — `git cherry` marks every one `+`, so **0 are backports** already in `v8.9.80`. One in-range note: **`TS.BGET` was renamed to `TS.READ`** ([#2081](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2081)) with a reworked blocking syntax, so the net-new command surface is `TS.READ`, not `TS.BGET`.

## Module changes ([v8.9.80 → v8.9.81](https://github.com/RedisTimeSeries/RedisTimeSeries/compare/v8.9.80...8.9.81))
* Use dedicated redis_ref field in ramp.yml for CI git ref ([#2059](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2059))
* pass VG=1 flag to the build as well ([#2060](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2060))
* MOD-16160 — wake parked TS.BGET clients on key deletion ([#2062](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2062))
* CI: bump GitHub Actions to Node24-compatible versions ([#2035](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2035))
* MOD-15749 — Short-form CLUSTERSET: RAMP capability + LibMR error-return ([#2065](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2065))
* CI: speed up Event CI (lean PR gate) and shard slow nightly jobs ([#2068](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2068))
* MOD-6409 — TS.INFO memoryUsage (and MEMORY USAGE, via the mem_usage callback) ([#2067](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2067))
* MOD-16266 — fix ci hang ([#2066](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2066))
* MOD-15565 — mrange aggregation execution in inner shards ([#2074](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2074))
* MOD-16505 — change TS.BGET command to TS.READ ([#2081](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2081))

**0 commits excluded — all 10 are genuinely new**
The `v8.9.80...8.9.81` ancestry diff contains exactly these 10 commits. `git cherry -v v8.9.80 8.9.81` marks every one `+` (no patch-equivalent change already in `v8.9.80`), so none are backports — unlike the `v8.8.0 → v8.9.80` bump, there is nothing to exclude here.

## Test plan
* [ ]  CI passes for RedisTimeSeries at the new pinned version
* [ ]  `make all` builds RedisTimeSeries cleanly against `unstable`
* [ ]  Module tests run under `make test`