### PR TITLE
Cancel ASM tasks on RM_ResetDataset and RM_RdbLoad

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1036,8 +1036,19 @@ long long emptyData(int dbnum, int flags, void(callback)(dict*)) {
         return -1;
     }
 
-    if (dbnum == -1 || dbnum == 0)
+    if (server.cluster_enabled && (dbnum == -1 || dbnum == 0)) {
+        /* Wiping the whole keyspace can't coexist with an active ASM task:
+         * On the migrating side, the flush would need to be propagated as a
+         * slot based command (FLUSHALL becomes SFLUSH <slots>) and forwarded
+         * to the ASM destination client even though it is a keyless command.
+         * On the importing side it would need to spare the slots still being
+         * imported. Rather than handle this complexity, we just cancel the ASM
+         * task. As this is not a common operation, the next ASM retry will
+         * succeed. Trim jobs are canceled too, since there is no data left to
+         * trim. */
+        clusterAsmCancel(NULL, "flush");
         asmCancelTrimJobs();
+    }
 
     /* Fire the flushdb modules event. */
     moduleFireServerEvent(REDISMODULE_EVENT_FLUSHDB,
@@ -1342,9 +1353,6 @@ int flushCommandCommon(client *c, int type, int flags, asmTrimCtx *trim_ctx) {
         flags |= EMPTYDB_ASYNC;
         blocking_async = 1;
     }
-
-    /* Cancel all ASM tasks that overlap with the given slot ranges. */
-    clusterAsmCancelBySlotRangeArray(trim_ctx ? trim_ctx->slots : NULL, c->argv[0]->ptr);
 
     if (type == FLUSH_TYPE_ALL)
         flushAllDataAndResetRDB(flags | EMPTYDB_NOFUNCTIONS);

--- a/tests/modules/atomicslotmigration.c
+++ b/tests/modules/atomicslotmigration.c
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include <memory.h>
+#include <string.h>
 #include <errno.h>
 
 #define MAX_EVENTS 1024
@@ -540,6 +541,35 @@ int asmGetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return REDISMODULE_OK;
 }
 
+/* Wipe the whole dataset via RM_ResetDataset. Used to verify that resetting
+ * the dataset cancels any in-progress atomic slot migration. */
+int resetDatasetCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    RedisModule_ResetDataset(0, 0);
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+/* Save the dataset to an internal file and load it back via RM_RdbLoad. Used
+ * to verify that loading an RDB cancels any in-progress atomic slot migration. */
+int rdbLoadCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    RedisModuleRdbStream *stream = RedisModule_RdbStreamCreateFromFile("asm_rdbload_test.rdb");
+    if (RedisModule_RdbSave(ctx, stream, 0) != REDISMODULE_OK ||
+        RedisModule_RdbLoad(ctx, stream, 0) != REDISMODULE_OK)
+    {
+        RedisModule_RdbStreamFree(stream);
+        RedisModule_ReplyWithError(ctx, strerror(errno));
+        return REDISMODULE_OK;
+    }
+    RedisModule_RdbStreamFree(stream);
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
@@ -599,6 +629,12 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx, "asm.get", asmGetCommand, "", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "asm.reset_dataset", resetDatasetCmd, "", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "asm.rdbload", rdbLoadCmd, "", 0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx, "asm.parent", NULL, "", 0, 0, 0) == REDISMODULE_ERR)

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -2295,6 +2295,30 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
         assert_equal {item1} [R 3 lrange $listkey 0 -1]
     }
 
+    test "RM_ResetDataset and RM_RdbLoad will cancel slot migration task" {
+        # RM_ResetDataset and RM_RdbLoad both flush the whole dataset, so they
+        # must cancel any ASM task on that node.
+        foreach resetcmd {asm.reset_dataset asm.rdbload} {
+            # node 0 is the source (migrate task), node 1 the destination (import task)
+            foreach node {0 1} {
+                R 0 flushall
+                R 1 flushall
+                set task_id [setup_slot_migration_with_delay 0 1 0 100]
+                assert_equal 1 [CI $node cluster_slot_migration_active_tasks]
+
+                assert_equal "OK" [R $node $resetcmd]
+                assert_equal "canceled" [migration_status $node $task_id state]
+                assert_equal 0 [CI $node cluster_slot_migration_active_tasks]
+
+                # cleanup
+                R 0 config set rdb-key-save-delay 0
+                R 0 CLUSTER MIGRATION CANCEL ID $task_id
+                R 1 CLUSTER MIGRATION CANCEL ID $task_id
+                wait_for_asm_done
+            }
+        }
+    }
+
     test "Test RM_ClusterCanAccessKeysInSlot" {
         # Test invalid slots
         assert_equal 0 [R 0 asm.cluster_can_access_keys_in_slot -1]


### PR DESCRIPTION
Both RM_ResetDataset and RM_RdbLoad flush the whole dataset but bypassed the flush command path, so in-progress ASM tasks were left running. As a result, after the task completed some deleted keys could re-appear, while others could be dropped that should have been kept.

Move the cancellation into emptyData() so every full keyspace flush (RM_ResetDataset, RM_RdbLoad, FLUSHALL, FLUSHDB) cancels the ASM task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster migration behavior on full flushes and affects module reset/RDB load paths; scope is narrow but wrong cancellation timing could leave inconsistent keys after ASM.
> 
> **Overview**
> **Full keyspace wipes** now cancel in-progress atomic slot migration (ASM) and trim jobs centrally in `emptyData()`, so module APIs like `RM_ResetDataset` and `RM_RdbLoad` behave like `FLUSHALL`/`FLUSHDB` instead of leaving ASM running after the data is gone.
> 
> When cluster mode is on and the flush targets the whole keyspace (`dbnum == -1` or `0`), the server calls `clusterAsmCancel(NULL, "flush")` and `asmCancelTrimJobs()` before the flush proceeds. **Slot-range cancellation** was removed from `flushCommandCommon`; overlapping-slot logic remains on slot-scoped flush (`SFLUSH`).
> 
> Tests add `asm.reset_dataset` / `asm.rdbload` in the ASM module and assert migration tasks move to **canceled** on both source and destination while a delayed migration is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6e65479175baca204807c9cfa0da8af9b219b76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->