### PR TITLE
Fix XREAD MAXSIZE test under force-resp3

### DIFF
--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -3184,6 +3184,9 @@ start_server {
         r XREAD MAXSIZE 1000 STREAMS stream 0
         set res [r EXEC]
         set in_exec [lindex $res 1]
+        if {$::force_resp3} {
+            set in_exec [transfrom_map_to_tupple_array {XREAD} $in_exec]
+        }
         assert_equal [xread_total_entries $solo] [xread_total_entries $in_exec]
     }
 


### PR DESCRIPTION
Follow https://github.com/redis/redis/pull/15282

## Issue

The `reply-schemas-validator` job runs the test suite with `--force-resp3`. In that mode, top-level `XREAD` replies are transformed back to the RESP2-style shape expected by existing tests, but `XREAD` replies nested inside `EXEC` are returned as RESP3 maps because the top-level command is `EXEC`.

This made the `XREAD MAXSIZE budget is per-command inside MULTI/EXEC` test compare two equivalent replies with different Tcl shapes.

Failed CI: https://github.com/redis/redis/actions/runs/28272944921/job/83773851123
> *** [err]: XREAD MAXSIZE budget is per-command inside MULTI/EXEC in tests/unit/type/stream.tcl
Expected '22' to be equal to '2' (context: type eval line 15 cmd {assert_equal [xread_total_entries $solo] [xread_total_entries $in_exec]} proc ::test)
Error: Process completed with exit code 1.

## Change

Normalize the nested `XREAD` reply from `EXEC` when running with `--force-resp3`, so the test compares the same RESP2-style structure for both the standalone and transactional `XREAD` replies.

## Test

Daily CI with command `--single unit/type/stream`: 
https://github.com/vitahlin/redis/actions/runs/28279302375

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in `stream.tcl`; no server or protocol behavior is modified.
> 
> **Overview**
> Fixes a **reply-schemas-validator** / `--force-resp3` failure in the **XREAD MAXSIZE budget is per-command inside MULTI/EXEC** test.
> 
> With `--force-resp3`, standalone `XREAD` replies are reshaped to the RESP2-style tuples tests expect, but the `XREAD` result nested inside `EXEC` stays a RESP3 map because the outer command is `EXEC`. That made `xread_total_entries` compare equivalent data with different Tcl list shapes (e.g. 22 vs 2).
> 
> When `$::force_resp3` is set, the test now runs the nested `XREAD` reply through `transfrom_map_to_tupple_array` before comparing entry counts to the solo `XREAD` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6313ddf3067851c7d75a25febabbe9be34e1d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->