### PR TITLE
fix(ae_select): move mask declaration to function prologue for C89 compliance

### DIFF
--- a/src/ae_select.c
+++ b/src/ae_select.c
@@ -57,7 +57,7 @@ static void aeApiDelEvent(aeEventLoop *eventLoop, int fd, int mask) {
 
 static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
     aeApiState *state = eventLoop->apidata;
-    int retval, j, numevents = 0;
+    int retval, j, numevents = 0, mask;
 
     memcpy(&state->_rfds,&state->rfds,sizeof(fd_set));
     memcpy(&state->_wfds,&state->wfds,sizeof(fd_set));
@@ -66,7 +66,7 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
                 &state->_rfds,&state->_wfds,NULL,tvp);
     if (retval > 0) {
         for (j = 0; j <= eventLoop->maxfd; j++) {
-            int mask = 0;
+            mask = 0;
             aeFileEvent *fe = &eventLoop->events[j];
 
             if (fe->mask == AE_NONE) continue;


### PR DESCRIPTION
Move `mask` variable declaration from inside the `for` loop body to the function prologue in `aeApiPoll()`. This ensures C89/ANSI C compliance, as mixing declarations and code is a C99 feature.

The change is purely cosmetic — the compiled code is identical. It improves portability for strict C89 compilers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-variable scope change in the select event-loop backend with no logic or API changes.
> 
> **Overview**
> Moves the **`mask`** variable in **`aeApiPoll()`** from inside the **`for`** loop to the function’s opening declaration list alongside **`retval`**, **`j`**, and **`numevents`**.
> 
> The loop now assigns **`mask = 0`** each iteration instead of declaring **`int mask = 0`**. This avoids C99-style declarations mid-block so **`ae_select.c`** builds under strict C89/ANSI C compilers; behavior and generated code are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2ea60f5421671e152bd17098800299e027b425a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->