### PR TITLE
Switch from the archived `redis-docs` to the new `doc` repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,9 +82,9 @@ There is also an active community of Redis users at Stack Overflow:
 
     https://stackoverflow.com/questions/tagged/redis
 
-Issues and pull requests for documentation belong on the redis-doc repo:
+Issues and pull requests for documentation belong on the `docs` repo:
 
-    https://github.com/redis/redis-doc
+    https://github.com/redis/docs
 
 If you are reporting a security bug or vulnerability, see SECURITY.md.
 

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -4,7 +4,7 @@ Each JSON contains all the information about the command itself, but these JSON 
 Any third party who needs access to command information must get it from `COMMAND INFO` and `COMMAND DOCS`.
 The output can be extracted in a JSON format by using `redis-cli --json`, in the same manner as in `utils/generate-commands-json.py`.
 
-The JSON files are used to generate commands.def (and https://github.com/redis/redis-doc/blob/master/commands.json) in Redis, and
+The JSON files are used to generate commands.def (and https://github.com/redis/docs/blob/main/data/commands.json) in Redis, and
 despite looking similar to the output of `COMMAND` there are some fields and flags that are implicitly populated, and that's the
 reason one shouldn't rely on the raw files.
 

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -962,7 +962,7 @@ size_t zmalloc_get_frag_smallbins(void) {
  *
  * refresh_stats indicates whether to refresh cached statistics.
  * For the meaning of the other parameters, please refer to the function implementation
- * and INFO's allocator_* in redis-doc. */
+ * and INFO's allocator_* at https://redis.io/docs/latest/commands/info/ */
 int zmalloc_get_allocator_info(int refresh_stats, size_t *allocated, size_t *active, size_t *resident,
                                size_t *retained, size_t *muzzy, size_t *frag_smallbins_bytes)
 {
@@ -1015,7 +1015,7 @@ int zmalloc_get_allocator_info(int refresh_stats, size_t *allocated, size_t *act
  *
  * refresh_stats indicates whether to refresh cached statistics.
  * For the meaning of the other parameters, please refer to the function implementation
- * and INFO's allocator_* in redis-doc. */
+ * and INFO's allocator_* at https://redis.io/docs/latest/commands/info/ */
 int zmalloc_get_allocator_info_by_arena(unsigned int arena, int refresh_stats, size_t *allocated,
                                         size_t *active, size_t *resident, size_t *frag_smallbins_bytes)
 {


### PR DESCRIPTION
`redis-docs` got archived in March 2026, but we still referenced it in some parts. We migrate them to the new `docs` repo.

This makes it easier for contributors to find where things are.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment-only link updates with no runtime or behavioral changes.
> 
> **Overview**
> Updates stale references to the archived **`redis-doc`** repo so contributors and readers land on the current **`redis/docs`** site and GitHub repo.
> 
> **`CONTRIBUTING.md`** now directs documentation issues and PRs to `https://github.com/redis/docs` (with the repo name styled as `` `docs` ``). **`src/commands/README.md`** updates the generated `commands.json` link to `redis/docs` on `main/data/commands.json`. In **`src/zmalloc.c`**, comments that pointed at INFO `allocator_*` fields in redis-doc now link to `https://redis.io/docs/latest/commands/info/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682b27d9b1c94e724ec718168d02d06a1e3a2043. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->