### PR TITLE
Fix overflowing memory unit conversions

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -321,6 +321,7 @@ unsigned long long memtoull(const char *p, int *err) {
         if (err) *err = 1;
         return 0;
     }
+    if (val > ULLONG_MAX / mul) return ULLONG_MAX;
     return val*mul;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -321,6 +321,7 @@ unsigned long long memtoull(const char *p, int *err) {
         if (err) *err = 1;
         return 0;
     }
+    /* Clamp to ULLONG_MAX if the unit conversion overflows. */
     if (val > ULLONG_MAX / mul) return ULLONG_MAX;
     return val*mul;
 }

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -23,6 +23,10 @@ start_server {tags {"obuf-limits external:skip logreqres:skip"}} {
         set res [lindex [r config get client-output-buffer-limit] 1]
         assert_equal $res "normal 1048576 2097152 60 slave 3145728 4194304 70 pubsub 5242880 6291456 80"
 
+        r config set client-output-buffer-limit "normal 18014398509481985kb 0 0 replica 0 0 0 pubsub 0 0 0"
+        set res [lindex [r config get client-output-buffer-limit] 1]
+        assert_equal $res "normal 18446744073709551615 0 0 slave 0 0 0 pubsub 0 0 0"
+
         # Set back to the original value.
         r config set client-output-buffer-limit $oldval
     }


### PR DESCRIPTION
## Issue

`memtoull()` can overflow when multiplying a parsed number by its memory unit. For example, a very large `kb` value can wrap around to a small number:

```sh
127.0.0.1:6379> CONFIG SET maxmemory 18014398509481985kb
OK
127.0.0.1:6379> CONFIG GET maxmemory
1) "maxmemory"
2) "1024"
```

The same parser is also used by other memory configs, such as `client-output-buffer-limit`.

## Change

Clamp overflowing unit conversions in `memtoull()` to `ULLONG_MAX`, consistent with how oversized numeric input is already handled.

## Test

```sh
127.0.0.1:6379> CONFIG SET maxmemory 18014398509481985kb
OK
127.0.0.1:6379> CONFIG GET maxmemory
1) "maxmemory"
2) "18446744073709551615"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Central config parsing change affects every memory-sized setting (`maxmemory`, output buffer limits, etc.); behavior shifts from silent wrap to max clamp on overflow.
> 
> **Overview**
> Fixes **unsigned overflow** in `memtoull()` when a parsed numeric value times its unit suffix (e.g. `kb`) exceeds `ULLONG_MAX`. Previously that product could wrap to a tiny byte count, so configs like `maxmemory` or `client-output-buffer-limit` could silently accept huge inputs yet store wrong limits.
> 
> Before returning `val * mul`, the parser now checks `val > ULLONG_MAX / mul` and returns **`ULLONG_MAX`**, matching how oversized bare numeric input is already handled.
> 
> A unit test sets `client-output-buffer-limit` with `18014398509481985kb` and expects the normal class hard limit to round-trip as `18446744073709551615`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39bece05c3d989626f03211a8b79d003deb69fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->