### PR TITLE
Fix NULL deref in usUntilEarliestTimer when all time events are deleted

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -271,6 +271,11 @@ static int64_t usUntilEarliestTimer(aeEventLoop *eventLoop) {
         te = te->next;
     }
 
+    /* The list may hold only events marked AE_DELETED_EVENT_ID, leaving no
+     * earliest timer. Mirror the empty-list case above and report "no timer"
+     * instead of dereferencing a NULL earliest. */
+    if (earliest == NULL) return -1;
+
     monotime now = getMonotonicUs();
     return (now >= earliest->when) ? 0 : earliest->when - now;
 }


### PR DESCRIPTION
Fixes #13992

## The problem

`usUntilEarliestTimer()` in `src/ae.c` scans the time event list for the nearest non-deleted timer. It already guards the empty-list case (`if (te == NULL) return -1;`), but when the list is non-empty yet every event is marked `AE_DELETED_EVENT_ID`, the loop finishes with `earliest == NULL` and the subsequent `earliest->when` access is a NULL pointer dereference.

## The fix

Add `if (earliest == NULL) return -1;` after the scan, mirroring the existing empty-list guard.

`-1` is the correct value here rather than `0`: the caller in `aeProcessEvents()` treats a negative result as "no timer to wait for" and leaves the poll timeout unset (blocking on I/O), whereas `0` would make it poll with a zero timeout and busy-loop until the deleted events are reclaimed.

Note: Harmless in practice — Redis always has the self-rearming serverCron timer, so earliest is never NULL. This is defensive hardening for the generic ae.c loop rather than a real crash fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive guard in the event loop timer path; behavior matches the documented “no timers” case with no API or security surface change.
> 
> **Overview**
> Fixes a **NULL pointer dereference** in `usUntilEarliestTimer()` when the time-event list is non-empty but every entry is soft-deleted (`AE_DELETED_EVENT_ID`). The scan could leave `earliest` unset while the function still read `earliest->when`.
> 
> After the loop, the change returns **`-1`** when no active timer exists—the same contract as an empty list—so `aeProcessEvents()` keeps an **infinite poll wait** instead of using a zero timeout and busy-looping until deleted nodes are reclaimed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1db84216918797ebdd85ea6f9d2386f0690c99f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->