### PR TITLE
Fix server crash on VRANDMEMBER with LLONG_MIN count

### DIFF
--- a/modules/vector-sets/tests/vrandmember.py
+++ b/modules/vector-sets/tests/vrandmember.py
@@ -61,15 +61,27 @@ class VRANDMEMBERCountOutOfRangeTest(TestCase):
         return "VRANDMEMBER COUNT=LLONG_MIN is rejected, not crashing"
 
     def test(self):
-        # A non-empty set is required to reach the COUNT handling.
-        fill_redis_with_vectors(self.redis, self.test_key, 10, 4)
+        llong_min = -9223372036854775808
 
         # LLONG_MIN has no representable positive magnitude, so negating it is
         # undefined behavior and the previous code produced a negative reply
         # array length, crashing the server via serverAssert(length >= 0)
-        # (issue #15384). It must now be rejected with a clean error.
+        # (issue #15384). The invalid count is now rejected up front, before the
+        # missing-key / empty-set fast paths, so it is caught regardless of
+        # whether the set has any members.
+
+        # Missing key: previously returned an empty array without ever looking
+        # at the count; it must be rejected too.
         try:
-            self.redis.execute_command('VRANDMEMBER', self.test_key, -9223372036854775808)
+            self.redis.execute_command('VRANDMEMBER', self.test_key, llong_min)
+            assert False, "VRANDMEMBER with LLONG_MIN count should error even for a missing key"
+        except redis.exceptions.ResponseError as e:
+            assert "out of range" in str(e).lower(), f"unexpected error: {e}"
+
+        # Non-empty set: same rejection.
+        fill_redis_with_vectors(self.redis, self.test_key, 10, 4)
+        try:
+            self.redis.execute_command('VRANDMEMBER', self.test_key, llong_min)
             assert False, "VRANDMEMBER with LLONG_MIN count should return an error"
         except redis.exceptions.ResponseError as e:
             assert "out of range" in str(e).lower(), f"unexpected error: {e}"

--- a/modules/vector-sets/tests/vrandmember.py
+++ b/modules/vector-sets/tests/vrandmember.py
@@ -1,5 +1,6 @@
 from test import TestCase, generate_random_vector, fill_redis_with_vectors
 import struct
+import redis.exceptions
 
 class VRANDMEMBERTest(TestCase):
     def getname(self):
@@ -53,3 +54,25 @@ class VRANDMEMBERTest(TestCase):
         # Test with count = 0 (edge case)
         result = self.redis.execute_command('VRANDMEMBER', self.test_key, 0)
         assert isinstance(result, list) and len(result) == 0, "VRANDMEMBER with count=0 should return empty array"
+
+
+class VRANDMEMBERCountOutOfRangeTest(TestCase):
+    def getname(self):
+        return "VRANDMEMBER COUNT=LLONG_MIN is rejected, not crashing"
+
+    def test(self):
+        # A non-empty set is required to reach the COUNT handling.
+        fill_redis_with_vectors(self.redis, self.test_key, 10, 4)
+
+        # LLONG_MIN has no representable positive magnitude, so negating it is
+        # undefined behavior and the previous code produced a negative reply
+        # array length, crashing the server via serverAssert(length >= 0)
+        # (issue #15384). It must now be rejected with a clean error.
+        try:
+            self.redis.execute_command('VRANDMEMBER', self.test_key, -9223372036854775808)
+            assert False, "VRANDMEMBER with LLONG_MIN count should return an error"
+        except redis.exceptions.ResponseError as e:
+            assert "out of range" in str(e).lower(), f"unexpected error: {e}"
+
+        # The server must still be responsive, i.e. it did not crash.
+        assert self.redis.execute_command('PING'), "server should be alive after rejecting the count"

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -1566,13 +1566,7 @@ int VINFO_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
  * With negative count: N random members (with possible duplicates).
  *
  * If the key doesn't exist, returns NULL if count is not given, or
- * an empty array if a count was given.
- *
- * A count of LLONG_MIN is rejected up front, before the missing-key and
- * empty-set fast paths, so an invalid count is rejected consistently: negating
- * it to get abs(count) is undefined behavior and its magnitude does not fit in
- * the reply length, which would otherwise trip serverAssert(length >= 0) and
- * crash the server. */
+ * an empty array if a count was given. */
 int VRANDMEMBER_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx); /* Use automatic memory management. */
 

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -1586,6 +1586,18 @@ int VRANDMEMBER_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
         if (count == 0) {
             return RedisModule_ReplyWithEmptyArray(ctx);
         }
+        /* A negative count requests abs(count) elements (with duplicates), but
+         * LLONG_MIN has no representable positive counterpart: negating it is
+         * undefined behavior and its magnitude does not fit in the reply length.
+         * Reject it up front, before the missing-key and empty-set fast paths
+         * that would otherwise return an empty array without validating it, so
+         * an invalid count is rejected consistently. Otherwise building a reply
+         * with a negative array length would trip serverAssert(length >= 0) and
+         * crash the server. */
+        if (count == LLONG_MIN) {
+            return RedisModule_ReplyWithError(ctx,
+                "ERR COUNT value is out of range");
+        }
     }
 
     /* Open key. */
@@ -1632,15 +1644,6 @@ int VRANDMEMBER_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 
     /* Case 2: COUNT option given, return an array of elements. */
     int allow_duplicates = (count < 0);
-
-    /* A negative count requests abs(count) elements (with duplicates), but
-     * LLONG_MIN has no representable positive counterpart: negating it is
-     * undefined behavior and its magnitude does not fit in the reply length.
-     * Reject it instead of building a reply with a negative array length,
-     * which would trip serverAssert(length >= 0) and crash the server. */
-    if (count == LLONG_MIN)
-        return RedisModule_ReplyWithError(ctx, "ERR COUNT value is out of range");
-
     long long abs_count = (count < 0) ? -count : count;
 
     /* Cap the count to the set size if we are not allowing duplicates. */

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -112,6 +112,7 @@
 #include <string.h>
 #include <strings.h>
 #include <stdint.h>
+#include <limits.h>
 #include <math.h>
 #include <pthread.h>
 #include <stdatomic.h>
@@ -1631,6 +1632,15 @@ int VRANDMEMBER_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 
     /* Case 2: COUNT option given, return an array of elements. */
     int allow_duplicates = (count < 0);
+
+    /* A negative count requests abs(count) elements (with duplicates), but
+     * LLONG_MIN has no representable positive counterpart: negating it is
+     * undefined behavior and its magnitude does not fit in the reply length.
+     * Reject it instead of building a reply with a negative array length,
+     * which would trip serverAssert(length >= 0) and crash the server. */
+    if (count == LLONG_MIN)
+        return RedisModule_ReplyWithError(ctx, "ERR COUNT value is out of range");
+
     long long abs_count = (count < 0) ? -count : count;
 
     /* Cap the count to the set size if we are not allowing duplicates. */

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -1566,7 +1566,13 @@ int VINFO_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
  * With negative count: N random members (with possible duplicates).
  *
  * If the key doesn't exist, returns NULL if count is not given, or
- * an empty array if a count was given. */
+ * an empty array if a count was given.
+ *
+ * A count of LLONG_MIN is rejected up front, before the missing-key and
+ * empty-set fast paths, so an invalid count is rejected consistently: negating
+ * it to get abs(count) is undefined behavior and its magnitude does not fit in
+ * the reply length, which would otherwise trip serverAssert(length >= 0) and
+ * crash the server. */
 int VRANDMEMBER_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx); /* Use automatic memory management. */
 
@@ -1586,14 +1592,7 @@ int VRANDMEMBER_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
         if (count == 0) {
             return RedisModule_ReplyWithEmptyArray(ctx);
         }
-        /* A negative count requests abs(count) elements (with duplicates), but
-         * LLONG_MIN has no representable positive counterpart: negating it is
-         * undefined behavior and its magnitude does not fit in the reply length.
-         * Reject it up front, before the missing-key and empty-set fast paths
-         * that would otherwise return an empty array without validating it, so
-         * an invalid count is rejected consistently. Otherwise building a reply
-         * with a negative array length would trip serverAssert(length >= 0) and
-         * crash the server. */
+        /* Negating LLONG_MIN to get abs(count) is UB and overflows the reply length. */
         if (count == LLONG_MIN) {
             return RedisModule_ReplyWithError(ctx,
                 "ERR COUNT value is out of range");


### PR DESCRIPTION
## The problem

`VRANDMEMBER key <count>` crashes the server when `count` is `LLONG_MIN` (`-9223372036854775808`) and the set is non-empty. It is remotely triggerable, so it is a DoS.

A negative count means "return `abs(count)` elements, allowing duplicates". The code computes the magnitude as:

```c
long long abs_count = (count < 0) ? -count : count;
```

For `count == LLONG_MIN`, `-count` is undefined behavior and the true magnitude (`2^63`) is not representable as a positive `long long`, so `abs_count` stays negative. That negative value is passed to `RedisModule_ReplyWithArray()`, and Redis aborts on `serverAssert(length >= 0)` in `addReplyAggregateLen()`.

## The fix

Reject `count == LLONG_MIN` with an out-of-range error before computing the magnitude. This matches core `SRANDMEMBER`, which validates its count with `getRangeLongFromObjectOrReply(c, c->argv[2], -LONG_MAX, LONG_MAX, ...)` and therefore already excludes `LONG_MIN`.

Other large in-range negative counts are unchanged (they still return that many elements with duplicates, exactly as before and as core `SRANDMEMBER` does); only the unrepresentable `LLONG_MIN` is rejected.

## Reproduce / verify

Before the fix, on a non-empty vector set:

```
> VADD myset VALUES 3 1 2 3 elem1
> VRANDMEMBER myset -9223372036854775808
Error: Server closed the connection      # server aborted on the assertion
```

After the fix:

```
> VRANDMEMBER myset -9223372036854775808
(error) ERR COUNT value is out of range
> PING
PONG                                      # server stays up
```

Added a regression test (`VRANDMEMBERCountOutOfRangeTest` in `modules/vector-sets/tests/vrandmember.py`) that asserts the command returns an error and the server remains responsive. It fails (server crash) without this change and passes with it; the existing `VRANDMEMBER` test continues to pass.

Fixes #15384

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard on one invalid integer edge case in the vector-sets module; behavior for all other counts is unchanged.
> 
> **Overview**
> Fixes a **remotely triggerable DoS** where `VRANDMEMBER` with `count` equal to `LLONG_MIN` could abort the server on a non-empty vector set.
> 
> The handler now returns **`ERR COUNT value is out of range`** when `count == LLONG_MIN`, **before** missing-key or empty-set handling, so invalid counts are rejected even when the key does not exist. Other negative counts are unchanged.
> 
> A regression test (`VRANDMEMBERCountOutOfRangeTest`) asserts the error response and that the server stays up after rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8644db7f3cfcd280c49f6de2715b6809412100f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->