### PR TITLE
Improve RESTORE REPLACE performance for new keys

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -280,7 +280,7 @@ void restoreCommand(client *c) {
      *   link  == NULL  -> an expired key might still be physically present and 
      *                     must be deleted. */
     int deleted = 0;
-    if (oldval || !link) {
+    if (replace && (oldval || !link)) {
         deleted = dbDelete(c->db,key);
         link = NULL; /* dbDelete invalidated the link */
     }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -222,9 +222,7 @@ void restoreCommand(client *c) {
 
     /* Make sure this key does not already exist here... */
     robj *key = c->argv[1];
-    kvobj *oldval = lookupKeyWrite(c->db,key);
-    int oldtype = oldval ? oldval->type : -1;
-    if (!replace && oldval) {
+    if (!replace && lookupKeyWrite(c->db,key) != NULL) {
         addReplyErrorObject(c,shared.busykeyerr);
         return;
     }
@@ -271,10 +269,21 @@ void restoreCommand(client *c) {
         return;
     }
 
-    /* Remove the old key if needed. */
+    /* Resolve the key's existence and its insertion link. On the common new-key
+     * path dbAddInternal() below reuses the link instead of probing again. */
+    dictEntryLink link = NULL;
+    kvobj *oldval = lookupKeyWriteWithLink(c->db, key, &link);
+    int oldtype = oldval ? oldval->type : -1;
+
+    /* Call dbDelete() only when a key is actually present:
+     *   oldval != NULL -> key exists.
+     *   link  == NULL  -> an expired key might still be physically present and 
+     *                     must be deleted. */
     int deleted = 0;
-    if (replace)
+    if (oldval || !link) {
         deleted = dbDelete(c->db,key);
+        link = NULL; /* dbDelete invalidated the link */
+    }
 
     if (ttl && checkAlreadyExpired(ttl)) {
         if (deleted) {
@@ -293,7 +302,7 @@ void restoreCommand(client *c) {
     }
 
     /* Create the key and set the TTL if any */
-    kvobj *kv = dbAddInternal(c->db, key, &obj, NULL, &keymeta);
+    kvobj *kv = dbAddInternal(c->db, key, &obj, &link, &keymeta);
 
     /* Save type: kv may be reallocated by module callbacks during notifyKeyspaceEvent below. */
     int kvtype = kv->type;

--- a/src/db.c
+++ b/src/db.c
@@ -371,11 +371,12 @@ kvobj *lookupKeyWrite(redisDb *db, robj *key) {
     return lookupKeyWriteWithFlags(db, key, LOOKUP_NONE);
 }
 
-/* Like lookupKeyWrite(), but accepts ref to optional `link`
+/* Like lookupKeyWrite(), but also reports an optional insertion `link`:
  *
- * link - If key found, updated to link the key.
- *        If key not found, updated to the bucket where the key should be added.
- *        If key not found and dict is empty, it is set to NULL
+ *   found & valid    -> returns the kvobj; link = the key's entry.
+ *   absent           -> returns NULL;      link = the bucket to add it to.
+ *   expired/trimmed  -> returns NULL;      link = NULL (key may still remain in the dict).
+ *   empty dict       -> returns NULL;      link = NULL.
  */
 kvobj *lookupKeyWriteWithLink(redisDb *db, robj *key, dictEntryLink *link) {
     return lookupKey(db, key, LOOKUP_NONE | LOOKUP_WRITE, link);

--- a/src/db.c
+++ b/src/db.c
@@ -371,7 +371,7 @@ kvobj *lookupKeyWrite(redisDb *db, robj *key) {
     return lookupKeyWriteWithFlags(db, key, LOOKUP_NONE);
 }
 
-/* Like lookupKeyWrite(), but also reports an optional insertion `link`:
+/* Like lookupKeyWrite(), but accepts ref to optional `link`
  *
  *   found & valid    -> returns the kvobj; link = the key's entry.
  *   absent           -> returns NULL;      link = the bucket to add it to.


### PR DESCRIPTION
For a new key, RESTORE REPLACE did three dict lookups (find, delete, add). It now reuses the link from the first lookup for the insert and skips the delete when no key is present, so it does a single lookup. The impact is more visible while the dict is rehashing: three lookups would trigger three incremental rehash steps instead of one. A similar optimization could be applied to the non-REPLACE path, but RESTORE REPLACE is the hotter path (e.g. atomic slot migration) and it would require more changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core key lookup/insert/delete semantics for RESTORE REPLACE, including expired-key edge cases, though behavior is intended to match prior logic with fewer probes.
> 
> **Overview**
> **RESTORE REPLACE** now does one dict probe on the hot path instead of separate find, optional delete, and add lookups. After loading the payload it calls `lookupKeyWriteWithLink` once, passes the returned **link** into `dbAddInternal` for insert, and only calls `dbDelete` when replacing and a key is logically present (`oldval`) or an expired entry may still sit in the dict (`link == NULL`).
> 
> The non-**REPLACE** busy-key check stays a simple `lookupKeyWrite` before load. `lookupKeyWriteWithLink` is documented with explicit outcomes for found, absent, expired/trimmed, and empty-dict cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da4aeb91d4dd2be961795f1bea7f80302580be4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->