### PR TITLE
[8.2] Fix overflowing memory unit conversions

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -321,6 +321,8 @@ unsigned long long memtoull(const char *p, int *err) {
         if (err) *err = 1;
         return 0;
     }
+    /* Clamp to ULLONG_MAX if the unit conversion overflows. */
+    if (val > ULLONG_MAX / mul) return ULLONG_MAX;
     return val*mul;
 }
 

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -23,6 +23,10 @@ start_server {tags {"obuf-limits external:skip logreqres:skip"}} {
         set res [lindex [r config get client-output-buffer-limit] 1]
         assert_equal $res "normal 1048576 2097152 60 slave 3145728 4194304 70 pubsub 5242880 6291456 80"
 
+        r config set client-output-buffer-limit "normal 18014398509481985kb 0 0 replica 0 0 0 pubsub 0 0 0"
+        set res [lindex [r config get client-output-buffer-limit] 1]
+        assert_equal $res "normal 18446744073709551615 0 0 slave 0 0 0 pubsub 0 0 0"
+
         # Set back to the original value.
         r config set client-output-buffer-limit $oldval
     }


### PR DESCRIPTION
## Summary

Backport of #15390 / `ec26d01fbac74acd243083d95c1068023f0310ab` to the **8.2** release branch.

`memtoull()` can overflow when multiplying a parsed number by its memory unit. A very large `kb` (or other unit) value wraps to a small number, so configs such as `maxmemory` and `client-output-buffer-limit` can silently accept values that become tiny after wraparound:

```
CONFIG SET maxmemory 18014398509481985kb  →  effectively 1024 bytes
```

## Change

Clamp overflowing unit conversions in `memtoull()` to `ULLONG_MAX`, consistent with how oversized numeric input is already handled on `unstable`.

Includes the regression coverage added in #15390 for `client-output-buffer-limit`.

## Cherry-pick

```
git cherry-pick -x ec26d01fbac74acd243083d95c1068023f0310ab
```

Applied cleanly onto `8.2` (`memtoull` and the obuf-limits test context match the upstream change).

## Test plan

- [ ] CI on this PR
- [ ] `./runtest --single unit/obuf-limits` (or full unit suite in CI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared parsing for memory-related CONFIG values; behavior change is intentional (clamp vs wrap) but affects limit enforcement across the server.
> 
> **Overview**
> **`memtoull()`** no longer lets `val * mul` wrap on huge values with units (`kb`, `mb`, etc.). Before multiply, it checks `val > ULLONG_MAX / mul` and returns **`ULLONG_MAX`** instead of a tiny wrapped byte count.
> 
> That fixes silent misconfiguration for memory-style settings (e.g. **`maxmemory`**, **`client-output-buffer-limit`**) where an oversized `kb` value could look valid but apply a near-zero limit.
> 
> A unit test in **`obuf-limits.tcl`** sets `normal 18014398509481985kb` and expects the stored normal hard limit to be **`18446744073709551615`** (`ULLONG_MAX`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2443b8ea0e1d809d62b0eae2f779b725950cdada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->