### PR TITLE
Fix VSIM crash on restored empty vector set

### DIFF
--- a/modules/vector-sets/tests/rdb_validation.py
+++ b/modules/vector-sets/tests/rdb_validation.py
@@ -1,0 +1,26 @@
+from test import TestCase
+import redis.exceptions
+
+
+# MODULE_2 payload for vectorset encver 0 with dim=2 and elements=0.
+EMPTY_VECTOR_SET_DUMP = bytes.fromhex(
+    "0781bde72da2bb1eb400020202000250000200000e000000000000000000"
+)
+
+
+class EmptyVectorSetRdbLoad(TestCase):
+    def getname(self):
+        return "[regression] RESTORE rejects an empty vector set"
+
+    def test(self):
+        try:
+            self.redis.execute_command(
+                'RESTORE', self.test_key, 0, EMPTY_VECTOR_SET_DUMP, 'REPLACE')
+            assert False, "RESTORE should reject an empty vector set"
+        except redis.exceptions.ResponseError as error:
+            assert "Bad data format" in str(error), (
+                f"Expected a bad data format error, got: {error}")
+
+        assert self.redis.exists(self.test_key) == 0, (
+            "RESTORE must not install the invalid vector set")
+        assert self.redis.ping(), "Redis should remain responsive after RESTORE"

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -834,23 +834,38 @@ void VSIM_execute(RedisModuleCtx *ctx, struct vsetObject *vset,
     int slot = hnsw_acquire_read_slot(vset->hnsw);
     if (ef > vset->hnsw->node_count) ef = vset->hnsw->node_count;
 
-    /* Perform search */
-    hnswNode **neighbors = RedisModule_Alloc(sizeof(hnswNode*)*ef);
-    float *distances = RedisModule_Alloc(sizeof(float)*ef);
-    unsigned int found;
-    if (ground_truth) {
-        found = hnsw_ground_truth_with_filter(vset->hnsw, vec, ef, neighbors,
-                    distances, slot, 0,
-                    filter_expr ? vectorSetFilterCallback : NULL,
-                    filter_expr);
-    } else {
-        if (filter_expr == NULL) {
-            found = hnsw_search(vset->hnsw, vec, ef, neighbors,
-                                distances, slot, 0);
+    /* Perform search. An empty HNSW index can only originate from invalid
+     * serialized data, but handle it defensively without invoking the search
+     * functions with k == 0. */
+    hnswNode **neighbors = NULL;
+    float *distances = NULL;
+    int found = 0;
+    if (ef != 0) {
+        neighbors = RedisModule_Alloc(sizeof(hnswNode*)*ef);
+        distances = RedisModule_Alloc(sizeof(float)*ef);
+        if (ground_truth) {
+            found = hnsw_ground_truth_with_filter(vset->hnsw, vec, ef, neighbors,
+                        distances, slot, 0,
+                        filter_expr ? vectorSetFilterCallback : NULL,
+                        filter_expr);
         } else {
-            found = hnsw_search_with_filter(vset->hnsw, vec, ef, neighbors,
-                        distances, slot, 0, vectorSetFilterCallback,
-                        filter_expr, filter_ef);
+            if (filter_expr == NULL) {
+                found = hnsw_search(vset->hnsw, vec, ef, neighbors,
+                                    distances, slot, 0);
+            } else {
+                found = hnsw_search_with_filter(vset->hnsw, vec, ef, neighbors,
+                            distances, slot, 0, vectorSetFilterCallback,
+                            filter_expr, filter_ef);
+            }
+        }
+        if (found < 0) {
+            hnsw_release_read_slot(vset->hnsw,slot);
+            RedisModule_ReplyWithError(ctx, "ERR vector similarity search failed");
+            RedisModule_Free(vec);
+            RedisModule_Free(neighbors);
+            RedisModule_Free(distances);
+            if (filter_expr) exprFree(filter_expr);
+            return;
         }
     }
 
@@ -864,7 +879,7 @@ void VSIM_execute(RedisModuleCtx *ctx, struct vsetObject *vset,
         RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
 
     long long arraylen = 0;
-    for (unsigned int i = 0; i < found && i < count; i++) {
+    for (int i = 0; i < found && (unsigned long)i < count; i++) {
         if (distances[i]/2 > epsilon) break;
         struct vsetNodeVal *nv = neighbors[i]->value;
         RedisModule_ReplyWithString(ctx, nv->item);
@@ -903,8 +918,8 @@ void VSIM_execute(RedisModuleCtx *ctx, struct vsetObject *vset,
     }
 
     RedisModule_Free(vec);
-    RedisModule_Free(neighbors);
-    RedisModule_Free(distances);
+    if (neighbors) RedisModule_Free(neighbors);
+    if (distances) RedisModule_Free(distances);
     if (filter_expr) exprFree(filter_expr);
 }
 
@@ -1976,6 +1991,12 @@ void *VectorSetRdbLoad(RedisModuleIO *rdb, int encver) {
     if (RedisModule_IsIOError(rdb)) return NULL;
     uint32_t quant_type = hnsw_config & 0xff;
     uint32_t hnsw_m = (hnsw_config >> 8) & 0xffff;
+
+    if (elements == 0) {
+        RedisModule_LogIOError(rdb, "warning",
+            "Invalid vector set cardinality in RDB: elements must be positive");
+        return NULL;
+    }
 
     /* Validate dimension loaded from RDB to enforce invariants and
      * avoid absurd allocations or inconsistent state. */


### PR DESCRIPTION
Fixes #15386.

A crafted vector-set RDB payload can declare `elements = 0`, which currently creates a live but empty vector set. `VSIM` then clamps its search size to zero, and the HNSW search returns `-1`. Because that result was stored in an unsigned variable, the reply loop treated it as a large positive count and read from zero-length result arrays.

This change:

- rejects zero-element vector sets in `VectorSetRdbLoad()`
- avoids calling HNSW search functions with `k == 0`
- keeps search results signed and returns an error for negative search results
- adds a regression test using the 30-byte payload from the issue

I reproduced the crash on the current `unstable` branch before the change: `RESTORE` succeeded, `VCARD` returned `0`, and `VSIM` terminated the server with signal 11. After the change, the same payload is rejected with `ERR Bad data format`, no key is installed, and the server remains responsive.

Testing:

- `make -j8`
- `uv run --with redis -- ./runtest --single vectorset/vectorset` (41/41 vector-set tests passed)
- `uv run --with redis -- make test` (all standard test units passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RDB load validation and VSIM search/reply paths in the vector-sets module; behavior change for invalid zero-element payloads, with defensive handling for empty indexes.
> 
> **Overview**
> Fixes a **server crash (SIGSEGV)** when a crafted vector-set RDB declares **zero elements**: `RESTORE` used to succeed, then **`VSIM`** could treat a failed HNSW search (`-1` stored in an unsigned count) as a huge hit list and read past empty neighbor buffers.
> 
> **`VectorSetRdbLoad`** now fails load when **`elements == 0`**, so invalid dumps surface as **`ERR Bad data format`** and no key is installed. **`VSIM_execute`** skips HNSW when the effective search width is **0**, keeps the match count **signed**, returns **`ERR vector similarity search failed`** on negative search results, and only frees neighbor buffers when allocated. A regression test asserts **`RESTORE`** rejects the issue’s 30-byte payload and Redis stays up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f47e02681516c531327632b36c8f8ce57ac7dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->