### PR TITLE
Add LMOVEM/BLMOVEM commands

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -183,6 +183,7 @@ void queueClientForReprocessing(client *c) {
  * of operation the client is blocking for. */
 void unblockClient(client *c, int queue_for_reprocessing) {
     if (c->bstate.btype == BLOCKED_LIST ||
+        c->bstate.btype == BLOCKED_LIST_NONEMPTY ||
         c->bstate.btype == BLOCKED_ZSET ||
         c->bstate.btype == BLOCKED_STREAM) {
         unblockClientWaitingData(c);
@@ -222,6 +223,7 @@ int blockedClientMayTimeout(client *c) {
     }
 
     if (c->bstate.btype == BLOCKED_LIST ||
+        c->bstate.btype == BLOCKED_LIST_NONEMPTY ||
         c->bstate.btype == BLOCKED_ZSET ||
         c->bstate.btype == BLOCKED_STREAM ||
         c->bstate.btype == BLOCKED_WAIT ||
@@ -243,6 +245,7 @@ void replyToBlockedClientTimedOut(client *c) {
         else
             addReply(c, shared.ok); /* No reason lazy-free to fail */
     } else if (c->bstate.btype == BLOCKED_LIST ||
+        c->bstate.btype == BLOCKED_LIST_NONEMPTY ||
         c->bstate.btype == BLOCKED_ZSET ||
         c->bstate.btype == BLOCKED_STREAM) {
         addReplyNullArray(c);
@@ -474,28 +477,44 @@ static blocking_type getBlockedTypeByType(int type) {
     }
 }
 
-/* If the specified key has clients blocked waiting for list pushes, this
- * function will put the key reference into the server.ready_keys list.
- * Note that db->ready_keys is a hash table that allows us to avoid putting
- * the same key again and again in the list in case of multiple pushes
- * made by a script or in the context of MULTI/EXEC.
+/* Core of the signalKeyAsReady*() family. 'btype' is the kind of blockers this
+ * signal should serve:
  *
- * The list will be finally processed by handleClientsBlockedOnKeys() */
-static void signalKeyAsReadyLogic(redisDb *db, robj *key, int type, int deleted) {
+ *   BLOCKED_LIST / BLOCKED_ZSET / BLOCKED_STREAM
+ *       The key became available (created/loaded/explicit ready). Serves the
+ *       matching native blockers and module clients. A BLOCKED_LIST signal also
+ *       serves BLOCKED_LIST_NONEMPTY waiters, since a just-created list can be
+ *       what they were waiting for.
+ *   BLOCKED_LIST_NONEMPTY
+ *       An already-existing list grew. Serves only BLOCKED_LIST_NONEMPTY waiters
+ *       (e.g. BLMOVEM EXACTLY) and never module clients, which by contract are
+ *       not notified of writes to keys that already exist.
+ *   BLOCKED_NONE
+ *       The object type can never block anyone; nothing to do.
+ *
+ * The key reference is queued into server.ready_keys (deduped via db->ready_keys)
+ * and finally processed by handleClientsBlockedOnKeys(). */
+static void signalKeyAsReadyLogic(redisDb *db, robj *key, int btype, int deleted) {
     readyList *rl;
 
-    /* Quick returns. */
-    int btype = getBlockedTypeByType(type);
-    if (btype == BLOCKED_NONE) {
-        /* The type can never block. */
+    if (btype == BLOCKED_NONE)
         return;
+
+    /* Only "list grew" signals (BLOCKED_LIST_NONEMPTY) must skip module clients. */
+    int wake_modules = (btype != BLOCKED_LIST_NONEMPTY);
+
+    /* Quick return if no client this signal could serve is blocked. A list
+     * availability signal serves both plain and nonempty-waiting list blockers;
+     * a "list grew" signal serves only the nonempty waiters. */
+    int has_blocked_clients;
+    if (btype == BLOCKED_LIST) {
+        has_blocked_clients = server.blocked_clients_by_type[BLOCKED_LIST] ||
+                              server.blocked_clients_by_type[BLOCKED_LIST_NONEMPTY];
+    } else {
+        has_blocked_clients = server.blocked_clients_by_type[btype];
     }
-    if (!server.blocked_clients_by_type[btype] &&
-        !server.blocked_clients_by_type[BLOCKED_MODULE]) {
-        /* No clients block on this type. Note: Blocked modules are represented
-         * by BLOCKED_MODULE, even if the intention is to wake up by normal
-         * types (list, zset, stream), so we need to check that there are no
-         * blocked modules before we do a quick return here. */
+    if (!has_blocked_clients &&
+        !(wake_modules && server.blocked_clients_by_type[BLOCKED_MODULE])) {
         return;
     }
 
@@ -526,6 +545,7 @@ static void signalKeyAsReadyLogic(redisDb *db, robj *key, int type, int deleted)
     rl = zmalloc(sizeof(*rl));
     rl->key = key;
     rl->db = db;
+    rl->wake_modules = wake_modules;
     incrRefCount(key);
     listAddNodeTail(server.ready_keys,rl);
 }
@@ -577,11 +597,20 @@ static void releaseBlockedEntry(client *c, dictEntry *de, int remove_key) {
 }
 
 void signalKeyAsReady(redisDb *db, robj *key, int type) {
-    signalKeyAsReadyLogic(db, key, type, 0);
+    signalKeyAsReadyLogic(db, key, getBlockedTypeByType(type), 0);
+}
+
+/* Signal that a pre-existing list gained elements. This wakes native list
+ * blockers (e.g. BLMOVEM EXACTLY waiting for more elements) but, unlike
+ * signalKeyAsReady(), does not wake module clients: modules blocked on keys are
+ * only notified via RM_SignalKeyAsReady() or key (re)creation, not by plain
+ * writes to an already-existing key. */
+void signalKeyAsReadyNonEmptyList(redisDb *db, robj *key) {
+    signalKeyAsReadyLogic(db, key, BLOCKED_LIST_NONEMPTY, 0);
 }
 
 void signalDeletedKeyAsReady(redisDb *db, robj *key, int type) {
-    signalKeyAsReadyLogic(db, key, type, 1);
+    signalKeyAsReadyLogic(db, key, getBlockedTypeByType(type), 1);
 }
 
 /* Helper function for handleClientsBlockedOnKeys(). This function is called
@@ -611,14 +640,24 @@ static void handleClientsBlockedOnKey(readyList *rl) {
              *    regardless of the object type: we don't know what the
              *    module is trying to accomplish right now.
              * 3. In case of XREADGROUP call we will want to unblock on any change in object type
-             *    or in case the key was deleted, since the group is no longer valid. */
-            if ((o != NULL && (receiver->bstate.btype == getBlockedTypeByType(o->type))) ||
+             *    or in case the key was deleted, since the group is no longer valid.
+             * 4. A list object matches both plain BLOCKED_LIST waiters and
+             *    BLOCKED_LIST_NONEMPTY waiters (e.g. BLMOVEM EXACTLY). */
+            blocking_type obtype = (o != NULL) ? getBlockedTypeByType(o->type) : BLOCKED_NONE;
+            int native_match = (o != NULL) &&
+                (receiver->bstate.btype == obtype ||
+                 (obtype == BLOCKED_LIST &&
+                  receiver->bstate.btype == BLOCKED_LIST_NONEMPTY));
+            if (native_match ||
                 (o != NULL && (receiver->bstate.btype == BLOCKED_MODULE)) ||
                 (receiver->bstate.unblock_on_nokey))
             {
                 if (receiver->bstate.btype != BLOCKED_MODULE)
                     unblockClientOnKey(receiver, rl->key);
-                else
+                else if (rl->wake_modules)
+                    /* Module clients are only woken by signals that opted in
+                     * (RM_SignalKeyAsReady, key (re)creation, deletion/swap),
+                     * not by plain writes to a pre-existing key. */
                     moduleUnblockClientOnKey(receiver, rl->key);
             }
         }
@@ -681,6 +720,7 @@ static void unblockClientOnKey(client *c, robj *key) {
        however we should force unblock the entire blocking keys */
     serverAssert(c->bstate.btype == BLOCKED_STREAM ||
                 c->bstate.btype == BLOCKED_LIST   ||
+                c->bstate.btype == BLOCKED_LIST_NONEMPTY ||
                 c->bstate.btype == BLOCKED_ZSET);
 
     /* We need to unblock the client before calling processCommandAndResetClient

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -497,6 +497,7 @@ static blocking_type getBlockedTypeByType(int type) {
 static void signalKeyAsReadyLogic(redisDb *db, robj *key, int btype, int deleted) {
     readyList *rl;
 
+    /* The type can never block. */
     if (btype == BLOCKED_NONE)
         return;
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1501,6 +1501,7 @@ int clusterRedirectBlockedClientIfNeeded(client *c) {
     clusterNode *myself = getMyClusterNode();
     if (c->flags & CLIENT_BLOCKED &&
         (c->bstate.btype == BLOCKED_LIST ||
+         c->bstate.btype == BLOCKED_LIST_NONEMPTY ||
          c->bstate.btype == BLOCKED_ZSET ||
          c->bstate.btype == BLOCKED_STREAM ||
          c->bstate.btype == BLOCKED_MODULE))

--- a/src/commands.def
+++ b/src/commands.def
@@ -4989,6 +4989,65 @@ struct COMMAND_ARG BLMOVE_Args[] = {
 {MAKE_ARG("timeout",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
+/********** BLMOVEM ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* BLMOVEM history */
+#define BLMOVEM_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* BLMOVEM tips */
+#define BLMOVEM_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* BLMOVEM key specs */
+keySpec BLMOVEM_Keyspecs[2] = {
+{NULL,CMD_KEY_RW|CMD_KEY_ACCESS|CMD_KEY_DELETE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}},{NULL,CMD_KEY_RW|CMD_KEY_INSERT,KSPEC_BS_INDEX,.bs.index={2},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+};
+#endif
+
+/* BLMOVEM wherefrom argument table */
+struct COMMAND_ARG BLMOVEM_wherefrom_Subargs[] = {
+{MAKE_ARG("left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* BLMOVEM whereto argument table */
+struct COMMAND_ARG BLMOVEM_whereto_Subargs[] = {
+{MAKE_ARG("left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* BLMOVEM how_many selector argument table */
+struct COMMAND_ARG BLMOVEM_how_many_selector_Subargs[] = {
+{MAKE_ARG("count",ARG_TYPE_INTEGER,-1,"COUNT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("exactly",ARG_TYPE_INTEGER,-1,"EXACTLY",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* BLMOVEM how_many ordering argument table */
+struct COMMAND_ARG BLMOVEM_how_many_ordering_Subargs[] = {
+{MAKE_ARG("obo",ARG_TYPE_PURE_TOKEN,-1,"OBO",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("bulk",ARG_TYPE_PURE_TOKEN,-1,"BULK",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* BLMOVEM how_many argument table */
+struct COMMAND_ARG BLMOVEM_how_many_Subargs[] = {
+{MAKE_ARG("selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=BLMOVEM_how_many_selector_Subargs},
+{MAKE_ARG("ordering",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=BLMOVEM_how_many_ordering_Subargs},
+};
+
+/* BLMOVEM argument table */
+struct COMMAND_ARG BLMOVEM_Args[] = {
+{MAKE_ARG("source",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("destination",ARG_TYPE_KEY,1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("wherefrom",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=BLMOVEM_wherefrom_Subargs},
+{MAKE_ARG("whereto",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=BLMOVEM_whereto_Subargs},
+{MAKE_ARG("timeout",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("how-many",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=BLMOVEM_how_many_Subargs},
+};
+
 /********** BLMPOP ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -5224,6 +5283,64 @@ struct COMMAND_ARG LMOVE_Args[] = {
 {MAKE_ARG("destination",ARG_TYPE_KEY,1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("wherefrom",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=LMOVE_wherefrom_Subargs},
 {MAKE_ARG("whereto",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=LMOVE_whereto_Subargs},
+};
+
+/********** LMOVEM ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* LMOVEM history */
+#define LMOVEM_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* LMOVEM tips */
+#define LMOVEM_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* LMOVEM key specs */
+keySpec LMOVEM_Keyspecs[2] = {
+{NULL,CMD_KEY_RW|CMD_KEY_ACCESS|CMD_KEY_DELETE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}},{NULL,CMD_KEY_RW|CMD_KEY_INSERT,KSPEC_BS_INDEX,.bs.index={2},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+};
+#endif
+
+/* LMOVEM wherefrom argument table */
+struct COMMAND_ARG LMOVEM_wherefrom_Subargs[] = {
+{MAKE_ARG("left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* LMOVEM whereto argument table */
+struct COMMAND_ARG LMOVEM_whereto_Subargs[] = {
+{MAKE_ARG("left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* LMOVEM how_many selector argument table */
+struct COMMAND_ARG LMOVEM_how_many_selector_Subargs[] = {
+{MAKE_ARG("count",ARG_TYPE_INTEGER,-1,"COUNT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("exactly",ARG_TYPE_INTEGER,-1,"EXACTLY",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* LMOVEM how_many ordering argument table */
+struct COMMAND_ARG LMOVEM_how_many_ordering_Subargs[] = {
+{MAKE_ARG("obo",ARG_TYPE_PURE_TOKEN,-1,"OBO",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("bulk",ARG_TYPE_PURE_TOKEN,-1,"BULK",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* LMOVEM how_many argument table */
+struct COMMAND_ARG LMOVEM_how_many_Subargs[] = {
+{MAKE_ARG("selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=LMOVEM_how_many_selector_Subargs},
+{MAKE_ARG("ordering",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=LMOVEM_how_many_ordering_Subargs},
+};
+
+/* LMOVEM argument table */
+struct COMMAND_ARG LMOVEM_Args[] = {
+{MAKE_ARG("source",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("destination",ARG_TYPE_KEY,1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("wherefrom",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=LMOVEM_wherefrom_Subargs},
+{MAKE_ARG("whereto",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=LMOVEM_whereto_Subargs},
+{MAKE_ARG("how-many",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=LMOVEM_how_many_Subargs},
 };
 
 /********** LMPOP ********************/
@@ -12529,6 +12646,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("pfselftest","An internal command for testing HyperLogLog values.","N/A","2.8.9",CMD_DOC_SYSCMD,NULL,NULL,"hyperloglog",COMMAND_GROUP_HYPERLOGLOG,PFSELFTEST_History,0,PFSELFTEST_Tips,0,pfselftestCommand,1,CMD_ADMIN,ACL_CATEGORY_HYPERLOGLOG,PFSELFTEST_Keyspecs,0,NULL,0)},
 /* list */
 {MAKE_CMD("blmove","Pops an element from a list, pushes it to another list and returns it. Blocks until an element is available otherwise. Deletes the list if the last element was moved.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"list",COMMAND_GROUP_LIST,BLMOVE_History,0,BLMOVE_Tips,0,blmoveCommand,6,CMD_WRITE|CMD_DENYOOM|CMD_BLOCKING,ACL_CATEGORY_LIST,BLMOVE_Keyspecs,2,NULL,5),.args=BLMOVE_Args},
+{MAKE_CMD("blmovem","Moves up to (or exactly) a number of elements from one list to another and returns them. Blocks until the elements are available otherwise. Deletes the source list if it becomes empty.","O(N) where N is the number of elements moved.","8.10.0",CMD_DOC_NONE,NULL,NULL,"list",COMMAND_GROUP_LIST,BLMOVEM_History,0,BLMOVEM_Tips,0,blmovemCommand,-6,CMD_WRITE|CMD_DENYOOM|CMD_BLOCKING,ACL_CATEGORY_LIST,BLMOVEM_Keyspecs,2,NULL,6),.args=BLMOVEM_Args},
 {MAKE_CMD("blmpop","Pops the first element from one of multiple lists. Blocks until an element is available otherwise. Deletes the list if the last element was popped.","O(N+M) where N is the number of provided keys and M is the number of elements returned.","7.0.0",CMD_DOC_NONE,NULL,NULL,"list",COMMAND_GROUP_LIST,BLMPOP_History,0,BLMPOP_Tips,0,blmpopCommand,-5,CMD_WRITE|CMD_BLOCKING,ACL_CATEGORY_LIST,BLMPOP_Keyspecs,1,blmpopGetKeys,5),.args=BLMPOP_Args},
 {MAKE_CMD("blpop","Removes and returns the first element in a list. Blocks until an element is available otherwise. Deletes the list if the last element was popped.","O(N) where N is the number of provided keys.","2.0.0",CMD_DOC_NONE,NULL,NULL,"list",COMMAND_GROUP_LIST,BLPOP_History,1,BLPOP_Tips,0,blpopCommand,-3,CMD_WRITE|CMD_BLOCKING,ACL_CATEGORY_LIST,BLPOP_Keyspecs,1,NULL,2),.args=BLPOP_Args},
 {MAKE_CMD("brpop","Removes and returns the last element in a list. Blocks until an element is available otherwise. Deletes the list if the last element was popped.","O(N) where N is the number of provided keys.","2.0.0",CMD_DOC_NONE,NULL,NULL,"list",COMMAND_GROUP_LIST,BRPOP_History,1,BRPOP_Tips,0,brpopCommand,-3,CMD_WRITE|CMD_BLOCKING,ACL_CATEGORY_LIST,BRPOP_Keyspecs,1,NULL,2),.args=BRPOP_Args},
@@ -12537,6 +12655,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("linsert","Inserts an element before or after another element in a list.","O(N) where N is the number of elements to traverse before seeing the value pivot. This means that inserting somewhere on the left end on the list (head) can be considered O(1) and inserting somewhere on the right end (tail) is O(N).","2.2.0",CMD_DOC_NONE,NULL,NULL,"list",COMMAND_GROUP_LIST,LINSERT_History,0,LINSERT_Tips,0,linsertCommand,5,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_LIST,LINSERT_Keyspecs,1,NULL,4),.args=LINSERT_Args},
 {MAKE_CMD("llen","Returns the length of a list.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"list",COMMAND_GROUP_LIST,LLEN_History,0,LLEN_Tips,0,llenCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_LIST,LLEN_Keyspecs,1,NULL,1),.args=LLEN_Args},
 {MAKE_CMD("lmove","Returns an element after popping it from one list and pushing it to another. Deletes the list if the last element was moved.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"list",COMMAND_GROUP_LIST,LMOVE_History,0,LMOVE_Tips,0,lmoveCommand,5,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_LIST,LMOVE_Keyspecs,2,NULL,4),.args=LMOVE_Args},
+{MAKE_CMD("lmovem","Moves up to (or exactly) a number of elements from one list to another and returns them. Deletes the source list if it becomes empty.","O(N) where N is the number of elements moved.","8.10.0",CMD_DOC_NONE,NULL,NULL,"list",COMMAND_GROUP_LIST,LMOVEM_History,0,LMOVEM_Tips,0,lmovemCommand,-5,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_LIST,LMOVEM_Keyspecs,2,NULL,5),.args=LMOVEM_Args},
 {MAKE_CMD("lmpop","Returns multiple elements from a list after removing them. Deletes the list if the last element was popped.","O(N+M) where N is the number of provided keys and M is the number of elements returned.","7.0.0",CMD_DOC_NONE,NULL,NULL,"list",COMMAND_GROUP_LIST,LMPOP_History,0,LMPOP_Tips,0,lmpopCommand,-4,CMD_WRITE,ACL_CATEGORY_LIST,LMPOP_Keyspecs,1,lmpopGetKeys,4),.args=LMPOP_Args},
 {MAKE_CMD("lpop","Returns the first elements in a list after removing it. Deletes the list if the last element was popped.","O(N) where N is the number of elements returned","1.0.0",CMD_DOC_NONE,NULL,NULL,"list",COMMAND_GROUP_LIST,LPOP_History,1,LPOP_Tips,0,lpopCommand,-2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_LIST,LPOP_Keyspecs,1,NULL,2),.args=LPOP_Args},
 {MAKE_CMD("lpos","Returns the index of matching elements in a list.","O(N) where N is the number of elements in the list, for the average case. When searching for elements near the head or the tail of the list, or when the MAXLEN option is provided, the command may run in constant time.","6.0.6",CMD_DOC_NONE,NULL,NULL,"list",COMMAND_GROUP_LIST,LPOS_History,0,LPOS_Tips,0,lposCommand,-3,CMD_READONLY,ACL_CATEGORY_LIST,LPOS_Keyspecs,1,NULL,5),.args=LPOS_Args},

--- a/src/commands/blmovem.json
+++ b/src/commands/blmovem.json
@@ -1,0 +1,159 @@
+{
+    "BLMOVEM": {
+        "summary": "Moves up to (or exactly) a number of elements from one list to another and returns them. Blocks until the elements are available otherwise. Deletes the source list if it becomes empty.",
+        "complexity": "O(N) where N is the number of elements moved.",
+        "group": "list",
+        "since": "8.10.0",
+        "arity": -6,
+        "function": "blmovemCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "BLOCKING"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Operation timed-out.",
+                    "type": "null"
+                },
+                {
+                    "description": "The moved elements, in destination order.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "source",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 1
+            },
+            {
+                "name": "wherefrom",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "left",
+                        "type": "pure-token",
+                        "token": "LEFT"
+                    },
+                    {
+                        "name": "right",
+                        "type": "pure-token",
+                        "token": "RIGHT"
+                    }
+                ]
+            },
+            {
+                "name": "whereto",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "left",
+                        "type": "pure-token",
+                        "token": "LEFT"
+                    },
+                    {
+                        "name": "right",
+                        "type": "pure-token",
+                        "token": "RIGHT"
+                    }
+                ]
+            },
+            {
+                "name": "timeout",
+                "type": "double"
+            },
+            {
+                "name": "how-many",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "selector",
+                        "type": "oneof",
+                        "arguments": [
+                            {
+                                "name": "count",
+                                "type": "integer",
+                                "token": "COUNT"
+                            },
+                            {
+                                "name": "exactly",
+                                "type": "integer",
+                                "token": "EXACTLY"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "ordering",
+                        "type": "oneof",
+                        "arguments": [
+                            {
+                                "name": "obo",
+                                "type": "pure-token",
+                                "token": "OBO"
+                            },
+                            {
+                                "name": "bulk",
+                                "type": "pure-token",
+                                "token": "BULK"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/src/commands/lmovem.json
+++ b/src/commands/lmovem.json
@@ -1,0 +1,154 @@
+{
+    "LMOVEM": {
+        "summary": "Moves up to (or exactly) a number of elements from one list to another and returns them. Deletes the source list if it becomes empty.",
+        "complexity": "O(N) where N is the number of elements moved.",
+        "group": "list",
+        "since": "8.10.0",
+        "arity": -5,
+        "function": "lmovemCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Not enough elements to satisfy EXACTLY; nothing moved.",
+                    "type": "null"
+                },
+                {
+                    "description": "The moved elements, in destination order.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "source",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 1
+            },
+            {
+                "name": "wherefrom",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "left",
+                        "type": "pure-token",
+                        "token": "LEFT"
+                    },
+                    {
+                        "name": "right",
+                        "type": "pure-token",
+                        "token": "RIGHT"
+                    }
+                ]
+            },
+            {
+                "name": "whereto",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "left",
+                        "type": "pure-token",
+                        "token": "LEFT"
+                    },
+                    {
+                        "name": "right",
+                        "type": "pure-token",
+                        "token": "RIGHT"
+                    }
+                ]
+            },
+            {
+                "name": "how-many",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "selector",
+                        "type": "oneof",
+                        "arguments": [
+                            {
+                                "name": "count",
+                                "type": "integer",
+                                "token": "COUNT"
+                            },
+                            {
+                                "name": "exactly",
+                                "type": "integer",
+                                "token": "EXACTLY"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "ordering",
+                        "type": "oneof",
+                        "arguments": [
+                            {
+                                "name": "obo",
+                                "type": "pure-token",
+                                "token": "OBO"
+                            },
+                            {
+                                "name": "bulk",
+                                "type": "pure-token",
+                                "token": "BULK"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/src/server.c
+++ b/src/server.c
@@ -2288,6 +2288,10 @@ void createSharedObjects(void) {
     shared.rpoplpush = createStringObject("RPOPLPUSH",9);
     shared.lmove = createStringObject("LMOVE",5);
     shared.blmove = createStringObject("BLMOVE",6);
+    shared.lmovem = createStringObject("LMOVEM",6);
+    shared.exactly = createStringObject("EXACTLY",7);
+    shared.obo = createStringObject("OBO",3);
+    shared.bulk = createStringObject("BULK",4);
     shared.zpopmin = createStringObject("ZPOPMIN",7);
     shared.zpopmax = createStringObject("ZPOPMAX",7);
     shared.multi = createStringObject("MULTI",5);

--- a/src/server.h
+++ b/src/server.h
@@ -495,6 +495,12 @@ typedef enum blocking_type {
     BLOCKED_POSTPONE_TRIM, /* Master client is blocked due to an active trim job. */
     BLOCKED_SHUTDOWN, /* SHUTDOWN. */
     BLOCKED_LAZYFREE, /* LAZYFREE */
+    BLOCKED_LIST_NONEMPTY, /* Blocked waiting for an already-existing list to
+                            * grow enough (BLMOVEM EXACTLY). Woken by list
+                            * creation (like BLOCKED_LIST) and by writes that
+                            * grow a pre-existing list, but NOT limited to key
+                            * availability. Unlike BLOCKED_LIST, module clients
+                            * are not woken by the "list grew" signal. */
     BLOCKED_NUM,      /* Number of blocked states. */
     BLOCKED_END       /* End of enumeration */
 } blocking_type;
@@ -1323,6 +1329,12 @@ typedef struct blockingState {
 typedef struct readyList {
     redisDb *db;
     robj *key;
+    int wake_modules;           /* Whether module-blocked clients on this key
+                                 * should be served. Set to 0 by signals coming
+                                 * from BLOCKED_LIST_NONEMPTY (plain writes to a
+                                 * pre-existing list), so module clients keep
+                                 * being woken only by RM_SignalKeyAsReady or
+                                 * key (re)creation. */
 } readyList;
 
 /* List of pending commands. */
@@ -1735,7 +1747,8 @@ struct sharedObjectsStruct {
     *masterdownerr, *roslaveerr, *execaborterr, *noautherr, *noreplicaserr,
     *busykeyerr, *oomerr, *plus, *messagebulk, *pmessagebulk, *subscribebulk,
     *unsubscribebulk, *psubscribebulk, *punsubscribebulk, *del, *unlink,
-    *rpop, *lpop, *lpush, *rpoplpush, *lmove, *blmove, *zpopmin, *zpopmax,
+    *rpop, *lpop, *lpush, *rpoplpush, *lmove, *blmove, *lmovem, *exactly,
+    *obo, *bulk, *zpopmin, *zpopmax,
     *emptyscan, *multi, *exec, *left, *right, *hset, *srem, *xgroup, *xclaim, *xack,
     *script, *replconf, *eval, *persist, *set, *pexpireat, *pexpire,
     *hdel, *hpexpireat, *hpersist, *hsetex,
@@ -4224,6 +4237,7 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
 void disconnectAllBlockedClients(void);
 void handleClientsBlockedOnKeys(void);
 void signalKeyAsReady(redisDb *db, robj *key, int type);
+void signalKeyAsReadyNonEmptyList(redisDb *db, robj *key);
 void blockForKeys(client *c, int btype, robj **keys, int numkeys, mstime_t timeout, int unblock_on_nokey);
 void blockClientShutdown(client *c);
 void blockPostponeClient(client *c);
@@ -4391,6 +4405,7 @@ void lremCommand(client *c);
 void lposCommand(client *c);
 void rpoplpushCommand(client *c);
 void lmoveCommand(client *c);
+void lmovemCommand(client *c);
 void infoCommand(client *c);
 void mgetCommand(client *c);
 void monitorCommand(client *c);
@@ -4442,6 +4457,7 @@ void brpopCommand(client *c);
 void blmpopCommand(client *c);
 void brpoplpushCommand(client *c);
 void blmoveCommand(client *c);
+void blmovemCommand(client *c);
 void appendCommand(client *c);
 void strlenCommand(client *c);
 void zrankCommand(client *c);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -489,6 +489,7 @@ void pushGenericCommand(client *c, int where, int xx) {
 
     kvobj *lobj = lookupKeyWriteWithLink(c->db, c->argv[1], &link);
     if (checkType(c,lobj,OBJ_LIST)) return;
+    int existed = (lobj != NULL);
     if (!lobj) {
         if (xx) {
             addReply(c, shared.czero);
@@ -512,6 +513,12 @@ void pushGenericCommand(client *c, int where, int xx) {
 
     char *event = (where == LIST_HEAD) ? "lpush" : "rpush";
     keyModified(c,c->db,c->argv[1],lobj,1);
+    /* Wake clients blocked on this key. dbAdd() already signals a freshly
+     * created key, but a push to a pre-existing list must signal too, so that
+     * clients blocked on an existing key (e.g. BLMOVEM EXACTLY waiting for more
+     * elements) are re-processed. */
+    if (existed)
+        signalKeyAsReadyNonEmptyList(c->db, c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_LIST,event,c->argv[1],c->db->id);
     updateKeysizesHist(c->db, OBJ_LIST, llen - (c->argc - 2), llen);
     if (server.memory_tracking_enabled)
@@ -586,6 +593,9 @@ void linsertCommand(client *c) {
 
     if (inserted) {
         keyModified(c,c->db,c->argv[1],subject,1);
+        /* LINSERT only operates on a pre-existing list, so this is always a
+         * write to an existing key (module clients are not woken). */
+        signalKeyAsReadyNonEmptyList(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_LIST,"linsert",
                             c->argv[1],c->db->id);
         server.dirty++;
@@ -1163,6 +1173,7 @@ void lremCommand(client *c) {
 void lmoveHandlePush(client *c, robj *dstkey, robj *dstobj, robj *value,
                      int where) {
     size_t oldsize = 0;
+    int existed = (dstobj != NULL);
     /* Create the list if the key does not exist */
     if (!dstobj) {
         dstobj = createListListpackObject();
@@ -1175,6 +1186,10 @@ void lmoveHandlePush(client *c, robj *dstkey, robj *dstobj, robj *value,
     if (server.memory_tracking_enabled)
         updateSlotAllocSize(c->db, getKeySlot(dstkey->ptr), dstobj, oldsize, kvobjAllocSize(dstobj));
     keyModified(c,c->db,dstkey,dstobj,1);
+    /* dbAdd() already signals a freshly created key; only a push to a
+     * pre-existing destination needs to signal blocked clients here. */
+    if (existed)
+        signalKeyAsReadyNonEmptyList(c->db, dstkey);
 
     notifyKeyspaceEvent(NOTIFY_LIST,
                         where == LIST_HEAD ? "lpush" : "rpush",
@@ -1467,4 +1482,269 @@ void lmpopCommand(client *c) {
 /* BLMPOP timeout numkeys <key> [<key> ...] (LEFT|RIGHT) [COUNT count] */
 void blmpopCommand(client *c) {
     lmpopGenericCommand(c, 2, 1);
+}
+
+/* "How many" modes for [B]LMOVEM. */
+#define LMOVEM_DEFAULT 0 /* No COUNT/EXACTLY: move a single element. */
+#define LMOVEM_UPTO    1 /* COUNT: move min(count, available). */
+#define LMOVEM_EXACTLY 2 /* EXACTLY: move exactly count or fail/block. */
+
+/* Destination ordering for [B]LMOVEM. */
+#define LMOVEM_ORDER_OBO  0 /* Push each element as popped (block reversed). */
+#define LMOVEM_ORDER_BULK 1 /* Preserve the source relative order. */
+
+/* Parse the optional "[<COUNT|EXACTLY> count <OBO|BULK>]" trailer of [B]LMOVEM,
+ * starting at argv index 'opt_idx'. On success fills *mode, *count and
+ * *ordering and returns C_OK; otherwise it replies with an error and returns
+ * C_ERR. When the trailer is absent, the single-element defaults are used. */
+static int lmovemParseOptions(client *c, int opt_idx, int *mode, long *count, int *ordering) {
+    if (opt_idx == c->argc) {
+        *mode = LMOVEM_DEFAULT;
+        *count = 1;
+        *ordering = LMOVEM_ORDER_BULK; /* Irrelevant for a single element. */
+        return C_OK;
+    }
+
+    /* When present, the trailer is always exactly three tokens:
+     * <COUNT|EXACTLY> <count> <OBO|BULK>. */
+    if (c->argc - opt_idx != 3) {
+        addReplyErrorObject(c, shared.syntaxerr);
+        return C_ERR;
+    }
+
+    char *selector = c->argv[opt_idx]->ptr;
+    if (!strcasecmp(selector, "COUNT")) {
+        *mode = LMOVEM_UPTO;
+    } else if (!strcasecmp(selector, "EXACTLY")) {
+        *mode = LMOVEM_EXACTLY;
+    } else {
+        addReplyErrorObject(c, shared.syntaxerr);
+        return C_ERR;
+    }
+
+    if (getRangeLongFromObjectOrReply(c, c->argv[opt_idx + 1], 1, LONG_MAX,
+                                      count, "count should be greater than 0") != C_OK)
+        return C_ERR;
+
+    char *ordstr = c->argv[opt_idx + 2]->ptr;
+    if (!strcasecmp(ordstr, "OBO")) {
+        *ordering = LMOVEM_ORDER_OBO;
+    } else if (!strcasecmp(ordstr, "BULK")) {
+        *ordering = LMOVEM_ORDER_BULK;
+    } else {
+        addReplyErrorObject(c, shared.syntaxerr);
+        return C_ERR;
+    }
+    return C_OK;
+}
+
+/* Move 'count' elements (count >= 1, and 'srcobj' is known to hold at least
+ * 'count' elements) from the source list, popping at 'wherefrom', into the
+ * destination list, pushing at 'whereto'. Reply with the moved elements in
+ * destination order and perform all keyspace bookkeeping.
+ *
+ * 'dstobj' is the destination list, or NULL if it does not exist yet (in which
+ * case it is created). When source and destination resolve to the same object
+ * the operation is an in-place rotation. */
+static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
+                               robj *dstkey, kvobj *dstobj,
+                               int wherefrom, int whereto, long count, int ordering)
+{
+    int samekey = (dstobj == srcobj);
+
+    /* Pop the 'count' elements out of the source, preserving pop order. */
+    robj **vals = zmalloc(sizeof(robj*) * count);
+    size_t src_oldsize = 0;
+    if (server.memory_tracking_enabled)
+        src_oldsize = kvobjAllocSize(srcobj);
+    for (long i = 0; i < count; i++) {
+        vals[i] = listTypePop(srcobj, wherefrom);
+        serverAssert(vals[i] != NULL);
+    }
+
+    /* The moved block, read left-to-right in the destination, must equal:
+     *   - BULK: the source relative order of the block.
+     *   - OBO : the order produced by pushing each element as it was popped.
+     * Both reduce to "pop order, optionally reversed". */
+    int reverse_block = (ordering == LMOVEM_ORDER_OBO) ? (whereto == LIST_HEAD)
+                                                       : (wherefrom == LIST_TAIL);
+
+    /* Create the destination list if needed (never the case when samekey). */
+    int dst_existed = (dstobj != NULL);
+    if (dstobj == NULL) {
+        dstobj = createListListpackObject();
+        dbAdd(c->db, dstkey, &dstobj);
+    }
+
+    long dst_oldlen = samekey ? 0 : (long) listTypeLength(dstobj);
+    size_t dst_oldsize = 0;
+    if (!samekey && server.memory_tracking_enabled)
+        dst_oldsize = kvobjAllocSize(dstobj);
+
+    /* Reply with the moved elements in destination order, and push them so the
+     * destination block reads left-to-right as that same order. When pushing at
+     * the head we push in reverse so the final block keeps destination order. */
+    addReplyArrayLen(c, count);
+    for (long i = 0; i < count; i++) {
+        robj *v = reverse_block ? vals[count - 1 - i] : vals[i];
+        addReplyBulk(c, v);
+    }
+    if (whereto == LIST_TAIL) {
+        for (long i = 0; i < count; i++) {
+            robj *v = reverse_block ? vals[count - 1 - i] : vals[i];
+            listTypeTryConversionAppend(dstobj, &v, 0, 0, NULL, NULL);
+            listTypePush(dstobj, v, whereto);
+        }
+    } else {
+        for (long i = count - 1; i >= 0; i--) {
+            robj *v = reverse_block ? vals[count - 1 - i] : vals[i];
+            listTypeTryConversionAppend(dstobj, &v, 0, 0, NULL, NULL);
+            listTypePush(dstobj, v, whereto);
+        }
+    }
+
+    /* listTypePush() copies the value, so we still own the popped references. */
+    for (long i = 0; i < count; i++) decrRefCount(vals[i]);
+    zfree(vals);
+
+    if (samekey) {
+        /* In-place rotation: the length is unchanged, so there is no key
+         * creation/deletion and no histogram change. Fire both the pop and the
+         * push notifications and account for the (possibly re-encoded) object. */
+        notifyKeyspaceEvent(NOTIFY_LIST, wherefrom == LIST_HEAD ? "lpop" : "rpop",
+                            srckey, c->db->id);
+        notifyKeyspaceEvent(NOTIFY_LIST, whereto == LIST_HEAD ? "lpush" : "rpush",
+                            srckey, c->db->id);
+        keyModified(c, c->db, srckey, srcobj, 1);
+        if (server.memory_tracking_enabled)
+            updateSlotAllocSize(c->db, getKeySlot(srckey->ptr), srcobj,
+                                src_oldsize, kvobjAllocSize(srcobj));
+        server.dirty += count;
+        return;
+    }
+
+    /* Destination accounting (a batched version of lmoveHandlePush). */
+    updateKeysizesHist(c->db, OBJ_LIST, dst_oldlen, dst_oldlen + count);
+    if (server.memory_tracking_enabled)
+        updateSlotAllocSize(c->db, getKeySlot(dstkey->ptr), dstobj,
+                            dst_oldsize, kvobjAllocSize(dstobj));
+    keyModified(c, c->db, dstkey, dstobj, 1);
+    /* dbAdd() already signals a freshly created destination; only signal here
+     * when pushing into a pre-existing list. */
+    if (dst_existed)
+        signalKeyAsReadyNonEmptyList(c->db, dstkey);
+    notifyKeyspaceEvent(NOTIFY_LIST, whereto == LIST_HEAD ? "lpush" : "rpush",
+                        dstkey, c->db->id);
+
+    /* Source accounting: notifications, histogram, deletion if emptied and the
+     * dirty counter (dirty += count) are all handled here. */
+    listElementsRemoved(c, srckey, wherefrom, srcobj, count, src_oldsize, 1, NULL);
+}
+
+/* Core of LMOVEM, also reused by BLMOVEM once the source has enough elements. */
+void lmovemGenericCommand(client *c, int wherefrom, int whereto, int mode,
+                          long count, int ordering)
+{
+    /* A missing source is treated as an empty list. */
+    kvobj *srcobj = lookupKeyWrite(c->db, c->argv[1]);
+    if (checkType(c, srcobj, OBJ_LIST)) return;
+    long srclen = srcobj ? (long) listTypeLength(srcobj) : 0;
+
+    /* Resolve how many elements we will actually move. */
+    long tomove;
+    if (mode == LMOVEM_EXACTLY) {
+        if (srclen < count) {
+            /* Not enough elements to satisfy EXACTLY: move nothing and reply
+             * with a null array, like LMOVE against an empty/missing source. */
+            addReplyNullArray(c);
+            return;
+        }
+        tomove = count;
+    } else {
+        /* DEFAULT (count == 1) or UPTO: move at most 'count'. */
+        tomove = (count < srclen) ? count : srclen;
+    }
+
+    /* Nothing to move: empty/missing source in DEFAULT/UPTO mode. Reply with a
+     * null array, like LMOVE against an empty/missing source. */
+    if (tomove == 0) {
+        addReplyNullArray(c);
+        return;
+    }
+
+    /* Validate the destination type before mutating anything. */
+    kvobj *dstobj = lookupKeyWrite(c->db, c->argv[2]);
+    if (checkType(c, dstobj, OBJ_LIST)) return;
+
+    lmovemMoveAndReply(c, c->argv[1], srcobj, c->argv[2], dstobj,
+                       wherefrom, whereto, tomove, ordering);
+
+    /* When invoked from BLMOVEM, replicate deterministically as a non-blocking
+     * LMOVEM that moves exactly the elements we moved here. */
+    if (c->cmd->proc == blmovemCommand) {
+        robj *count_obj = createStringObjectFromLongLong(tomove);
+        rewriteClientCommandVector(c, 8, shared.lmovem,
+                                   c->argv[1], c->argv[2], c->argv[3], c->argv[4],
+                                   shared.exactly, count_obj,
+                                   ordering == LMOVEM_ORDER_OBO ? shared.obo : shared.bulk);
+        decrRefCount(count_obj);
+    }
+}
+
+/* LMOVEM source destination <LEFT|RIGHT> <LEFT|RIGHT> [<COUNT|EXACTLY> count <OBO|BULK>] */
+void lmovemCommand(client *c) {
+    int wherefrom, whereto, mode, ordering;
+    long count;
+    if (getListPositionFromObjectOrReply(c, c->argv[3], &wherefrom) != C_OK) return;
+    if (getListPositionFromObjectOrReply(c, c->argv[4], &whereto) != C_OK) return;
+    if (lmovemParseOptions(c, 5, &mode, &count, &ordering) != C_OK) return;
+    lmovemGenericCommand(c, wherefrom, whereto, mode, count, ordering);
+}
+
+void blmovemGenericCommand(client *c, int wherefrom, int whereto, mstime_t timeout,
+                           int mode, long count, int ordering)
+{
+    kvobj *srcobj = lookupKeyWrite(c->db, c->argv[1]);
+    if (checkType(c, srcobj, OBJ_LIST)) return;
+    long srclen = srcobj ? (long) listTypeLength(srcobj) : 0;
+
+    /* Number of elements the source must hold before we can serve the client:
+     * EXACTLY blocks until 'count' are available, the others until there is at
+     * least one. */
+    long needed = (mode == LMOVEM_EXACTLY) ? count : 1;
+
+    if (srclen < needed) {
+        if (c->flags & CLIENT_DENY_BLOCKING) {
+            /* Blocking is not allowed (e.g. inside MULTI/Lua): behave like a
+             * timeout and move nothing. */
+            addReplyNullArray(c);
+        } else {
+            /* Choose the block type by what we are waiting for. When we only
+             * need one element (single/COUNT), the source can only be missing
+             * or empty, so plain BLOCKED_LIST (woken by key creation) suffices.
+             * When we need more than one (EXACTLY count>1), we may be waiting on
+             * an already-existing list to grow, which requires BLOCKED_LIST_NONEMPTY
+             * so that writes to the existing key re-process us. */
+            int btype = (needed > 1) ? BLOCKED_LIST_NONEMPTY : BLOCKED_LIST;
+            blockForKeys(c, btype, c->argv + 1, 1, timeout, 0);
+        }
+        return;
+    }
+
+    /* Enough elements: perform the move just like a non-blocking LMOVEM. The
+     * replication rewrite (to LMOVEM EXACTLY) is handled inside the generic
+     * command, keyed on the BLMOVEM proc. */
+    lmovemGenericCommand(c, wherefrom, whereto, mode, count, ordering);
+}
+
+/* BLMOVEM source destination <LEFT|RIGHT> <LEFT|RIGHT> timeout [<COUNT|EXACTLY> count <OBO|BULK>] */
+void blmovemCommand(client *c) {
+    int wherefrom, whereto, mode, ordering;
+    long count;
+    mstime_t timeout;
+    if (getListPositionFromObjectOrReply(c, c->argv[3], &wherefrom) != C_OK) return;
+    if (getListPositionFromObjectOrReply(c, c->argv[4], &whereto) != C_OK) return;
+    if (getTimeoutFromObjectOrReply(c, c->argv[5], &timeout, UNIT_SECONDS) != C_OK) return;
+    if (lmovemParseOptions(c, 6, &mode, &count, &ordering) != C_OK) return;
+    blmovemGenericCommand(c, wherefrom, whereto, timeout, mode, count, ordering);
 }

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1562,12 +1562,22 @@ static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
         serverAssert(vals[i] != NULL);
     }
 
-    /* The moved block, read left-to-right in the destination, must equal:
-     *   - BULK: the source relative order of the block.
-     *   - OBO : the order produced by pushing each element as it was popped.
-     * Both reduce to "pop order, optionally reversed". */
-    int reverse_block = (ordering == LMOVEM_ORDER_OBO) ? (whereto == LIST_HEAD)
-                                                       : (wherefrom == LIST_TAIL);
+    /* Reorder the popped elements (vals[0] = first popped) into destination
+     * order: the left-to-right order the moved block will have in the
+     * destination, which is also the order we reply in.
+     *   - OBO : elements are inserted one-by-one as popped, reading in pop order
+     *           at the tail and reversed at the head.
+     *   - BULK: the block keeps the source's relative order: pop order when
+     *           popped from the head, reversed when popped from the tail.
+     * After this, vals[] holds exactly the destination order. */
+    if ((ordering == LMOVEM_ORDER_OBO) ? (whereto == LIST_HEAD)
+                                       : (wherefrom == LIST_TAIL)) {
+        for (long i = 0, j = count - 1; i < j; i++, j--) {
+            robj *tmp = vals[i];
+            vals[i] = vals[j];
+            vals[j] = tmp;
+        }
+    }
 
     /* Create the destination list if needed (never the case when samekey). */
     int dst_existed = (dstobj != NULL);
@@ -1581,26 +1591,20 @@ static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
     if (!samekey && server.memory_tracking_enabled)
         dst_oldsize = kvobjAllocSize(dstobj);
 
-    /* Reply with the moved elements in destination order, and push them so the
-     * destination block reads left-to-right as that same order. When pushing at
-     * the head we push in reverse so the final block keeps destination order. */
+    /* Reply with the moved elements in destination order. */
     addReplyArrayLen(c, count);
+    for (long i = 0; i < count; i++)
+        addReplyBulk(c, vals[i]);
+
+    /* Convert once for the whole batch (the conversion decision is order-independent). */
+    listTypeTryConversionAppend(dstobj, vals, 0, count - 1, NULL, NULL);
+
+    /* Insert the block into the destination so it reads left-to-right as vals[].
+     * A head push prepends, so push back-to-front to keep the order; a tail push
+     * appends, so push front-to-back. */
     for (long i = 0; i < count; i++) {
-        robj *v = reverse_block ? vals[count - 1 - i] : vals[i];
-        addReplyBulk(c, v);
-    }
-    if (whereto == LIST_TAIL) {
-        for (long i = 0; i < count; i++) {
-            robj *v = reverse_block ? vals[count - 1 - i] : vals[i];
-            listTypeTryConversionAppend(dstobj, &v, 0, 0, NULL, NULL);
-            listTypePush(dstobj, v, whereto);
-        }
-    } else {
-        for (long i = count - 1; i >= 0; i--) {
-            robj *v = reverse_block ? vals[count - 1 - i] : vals[i];
-            listTypeTryConversionAppend(dstobj, &v, 0, 0, NULL, NULL);
-            listTypePush(dstobj, v, whereto);
-        }
+        robj *v = (whereto == LIST_HEAD) ? vals[count - 1 - i] : vals[i];
+        listTypePush(dstobj, v, whereto);
     }
 
     /* listTypePush() copies the value, so we still own the popped references. */

--- a/tests/unit/moduleapi/blockonkeys.tcl
+++ b/tests/unit/moduleapi/blockonkeys.tcl
@@ -311,7 +311,57 @@ start_server {tags {"modules external:skip"}} {
         assert_equal {gg ff ee dd cc} [$rd read]
         $rd close
     }
-    
+
+    test {LINSERT does not wake a module blocked on a list key} {
+        r del k
+        r rpush k a b
+        # Module client blocks to pop 5 elements from the (existing) list.
+        set rd [redis_deferring_client]
+        $rd blockonkeys.blpopn k 5
+        wait_for_blocked_clients_count 1
+        # Plain writes to a pre-existing list must NOT wake a module client, even
+        # once the list is long enough to satisfy it.
+        r linsert k before a x  ;# 3 elements
+        r linsert k before a y  ;# 4 elements
+        r linsert k before a z  ;# 5 elements -> enough, but LINSERT doesn't signal
+        assert_equal 1 [s blocked_clients]
+        # Only an explicit RM_SignalKeyAsReady wakes it.
+        r blockonkeys.lpush_unblock k q
+        assert_equal 5 [llength [$rd read]]
+        assert_equal 1 [r llen k]
+        $rd close
+    }
+
+    test {BLMOVEM does not wake a module blocked on the destination list} {
+        r del src dst
+        r rpush dst a b        ;# destination pre-exists with 2 elements
+        r rpush src c d e f
+        set rd [redis_deferring_client]
+        $rd blockonkeys.blpopn dst 5
+        wait_for_blocked_clients_count 1
+        # BLMOVEM grows the pre-existing destination to 5, but as a plain list
+        # write it must NOT wake the blocked module client.
+        assert_equal {c d e} [r blmovem src dst left right 0 count 3 bulk]
+        assert_equal 1 [s blocked_clients]
+        # An explicit module signal still unblocks it.
+        r blockonkeys.lpush_unblock dst z
+        assert_equal 5 [llength [$rd read]]
+        $rd close
+    }
+
+    test {BLMOVEM wakes a module blocked on a non-existent destination list} {
+        r del src dst
+        r rpush src a b c
+        set rd [redis_deferring_client]
+        $rd blockonkeys.popall dst   ;# dst does not exist -> module blocks
+        wait_for_blocked_clients_count 1
+        # BLMOVEM creates dst via dbAdd, which fires an availability signal that
+        # DOES wake the module (unlike a plain write to a pre-existing dst).
+        assert_equal {a b c} [r blmovem src dst left right 0 count 3 bulk]
+        assert_equal {a b c} [$rd read]
+        $rd close
+    }
+
     test {Module explicit unblock when blocked on keys} {
         r del k
         r set somekey someval

--- a/tests/unit/type/list-4.tcl
+++ b/tests/unit/type/list-4.tcl
@@ -1,0 +1,249 @@
+start_server {
+    tags {"list"}
+    overrides {
+        "list-max-ziplist-size" -1
+    }
+} {
+    array set largevalue [generate_largevalue_test_array]
+
+    proc create_listpack {key entries} {
+        r del $key
+        foreach entry $entries { r rpush $key $entry }
+        assert_encoding listpack $key
+    }
+
+    proc create_quicklist {key entries} {
+        r del $key
+        foreach entry $entries { r rpush $key $entry }
+        assert_encoding quicklist $key
+    }
+
+foreach {type large} [array get largevalue] {
+    test "LMOVEM single element, array reply (like LMOVE) - $type" {
+        r del src{t} dst{t}
+        create_$type src{t} "a b c $large"
+        assert_equal {a} [r lmovem src{t} dst{t} left right]
+        assert_equal {a} [r lrange dst{t} 0 -1]
+        assert_equal "b c $large" [r lrange src{t} 0 -1]
+    }
+
+    test "LMOVEM COUNT left pop, OBO vs BULK ordering - $type" {
+        r del src{t} dst{t}
+        create_$type src{t} "1 2 3 4 5 $large"
+        # OBO: each element pushed as popped -> block order reversed at head.
+        assert_equal {3 2 1} [r lmovem src{t} dst{t} left left count 3 obo]
+        assert_equal {3 2 1} [r lrange dst{t} 0 -1]
+        assert_equal "4 5 $large" [r lrange src{t} 0 -1]
+
+        r del src{t} dst{t}
+        create_$type src{t} "1 2 3 4 5 $large"
+        # BULK: source relative order preserved at head.
+        assert_equal {1 2 3} [r lmovem src{t} dst{t} left left count 3 bulk]
+        assert_equal {1 2 3} [r lrange dst{t} 0 -1]
+        assert_equal "4 5 $large" [r lrange src{t} 0 -1]
+    }
+
+    test "LMOVEM COUNT right pop, OBO vs BULK ordering - $type" {
+        r del src{t} dst{t}
+        create_$type src{t} "$large 1 2 3 4 5"
+        # pop order from the tail is 5 4 3.
+        assert_equal {5 4 3} [r lmovem src{t} dst{t} right right count 3 obo]
+        assert_equal {5 4 3} [r lrange dst{t} 0 -1]
+        assert_equal "$large 1 2" [r lrange src{t} 0 -1]
+
+        r del src{t} dst{t}
+        create_$type src{t} "$large 1 2 3 4 5"
+        assert_equal {3 4 5} [r lmovem src{t} dst{t} right right count 3 bulk]
+        assert_equal {3 4 5} [r lrange dst{t} 0 -1]
+    }
+
+    test "LMOVEM COUNT moves fewer when source is shorter - $type" {
+        r del src{t} dst{t}
+        create_$type src{t} "a b $large"
+        assert_equal "a b $large" [r lmovem src{t} dst{t} left right count 100 bulk]
+        assert_equal 0 [r exists src{t}]
+        assert_equal "a b $large" [r lrange dst{t} 0 -1]
+    }
+
+    test "LMOVEM EXACTLY success - $type" {
+        r del src{t} dst{t}
+        create_$type src{t} "1 2 3 $large"
+        assert_equal {1 2 3} [r lmovem src{t} dst{t} left right exactly 3 bulk]
+        assert_equal {1 2 3} [r lrange dst{t} 0 -1]
+        assert_equal "$large" [r lrange src{t} 0 -1]
+    }
+
+    test "LMOVEM EXACTLY too few moves nothing, replies nil - $type" {
+        r del src{t} dst{t}
+        create_$type src{t} "a b $large"
+        assert_equal {} [r lmovem src{t} dst{t} left right exactly 4 bulk]
+        # Source unchanged, destination not created.
+        assert_equal "a b $large" [r lrange src{t} 0 -1]
+        assert_equal 0 [r exists dst{t}]
+    }
+
+    test "LMOVEM into existing destination - $type" {
+        r del src{t} dst{t}
+        create_$type src{t} "1 2 3 $large"
+        create_$type dst{t} "x y $large"
+        assert_equal {1 2} [r lmovem src{t} dst{t} left right count 2 bulk]
+        assert_equal "x y $large 1 2" [r lrange dst{t} 0 -1]
+    }
+
+    test "LMOVEM same source and destination rotates - $type" {
+        r del k{t}
+        create_$type k{t} "1 2 3 4 $large"
+        assert_equal {1 2} [r lmovem k{t} k{t} left right count 2 bulk]
+        assert_equal "3 4 $large 1 2" [r lrange k{t} 0 -1]
+    }
+}
+
+    test {LMOVEM missing or empty source} {
+        r del src{t} dst{t}
+        assert_equal {} [r lmovem src{t} dst{t} left right]
+        assert_equal {} [r lmovem src{t} dst{t} left right count 5 bulk]
+        assert_equal 0 [r exists dst{t}]
+    }
+
+    test {LMOVEM count must be positive} {
+        r del src{t} dst{t}
+        r rpush src{t} a b c
+        assert_error "ERR count*" {r lmovem src{t} dst{t} left right count 0 bulk}
+        assert_error "ERR count*" {r lmovem src{t} dst{t} left right exactly 0 bulk}
+        assert_error "ERR count*" {r lmovem src{t} dst{t} left right count -1 bulk}
+        assert_error "ERR count*" {r lmovem src{t} dst{t} left right count a bulk}
+    }
+
+    test {LMOVEM syntax errors} {
+        r del src{t} dst{t}
+        r rpush src{t} a b c
+        assert_error "ERR wrong number of arguments for 'lmovem' command" {r lmovem src{t} dst{t} left}
+        # OBO|BULK is required when COUNT/EXACTLY is given.
+        assert_error "ERR syntax error*" {r lmovem src{t} dst{t} left right count 2}
+        assert_error "ERR syntax error*" {r lmovem src{t} dst{t} left right count 2 obo extra}
+        assert_error "ERR syntax error*" {r lmovem src{t} dst{t} left right bad 2 obo}
+        assert_error "ERR syntax error*" {r lmovem src{t} dst{t} left right count 2 badorder}
+        assert_error "ERR syntax error*" {r lmovem src{t} dst{t} badwhere right count 2 obo}
+        assert_error "ERR syntax error*" {r lmovem src{t} dst{t} left badwhere count 2 obo}
+    }
+
+    test {LMOVEM wrong type} {
+        r del s{t} d{t}
+        r set s{t} foo
+        assert_error "WRONGTYPE*" {r lmovem s{t} d{t} left right}
+
+        r del s{t} d{t}
+        r rpush s{t} a b
+        r set d{t} foo
+        assert_error "WRONGTYPE*" {r lmovem s{t} d{t} left right count 2 bulk}
+        # Nothing moved out of the source on a destination type error.
+        assert_equal {a b} [r lrange s{t} 0 -1]
+    }
+
+    test {LMOVEM propagates verbatim to replica} {
+        r del src{t} dst{t}
+        r rpush src{t} 1 2 3 4
+        set repl [attach_to_replication_stream]
+        r lmovem src{t} dst{t} left right count 2 bulk
+        r lmovem src{t} dst{t} left right exactly 1 obo
+        assert_replication_stream $repl {
+            {select *}
+            {lmovem src{t} dst{t} left right count 2 bulk}
+            {lmovem src{t} dst{t} left right exactly 1 obo}
+        }
+        close_replication_stream $repl
+    } {} {needs:repl}
+
+    test {BLMOVEM with elements available behaves like LMOVEM} {
+        r del src{t} dst{t}
+        r rpush src{t} 1 2 3
+        assert_equal {1 2} [r blmovem src{t} dst{t} left right 0 count 2 bulk]
+        assert_equal {1 2} [r lrange dst{t} 0 -1]
+    }
+
+    test {BLMOVEM propagates as LMOVEM EXACTLY to replica} {
+        r del src{t} dst{t}
+        r rpush src{t} 1 2 3 4
+        set repl [attach_to_replication_stream]
+        r blmovem src{t} dst{t} left right 0 count 2 bulk
+        assert_replication_stream $repl {
+            {select *}
+            {lmovem src{t} dst{t} left right EXACTLY 2 BULK}
+        }
+        close_replication_stream $repl
+    } {} {needs:repl}
+
+    test {BLMOVEM COUNT unblocks on first push} {
+        r del src{t} dst{t}
+        set rd [redis_deferring_client]
+        $rd blmovem src{t} dst{t} left right 0 count 5 bulk
+        wait_for_blocked_client
+        r rpush src{t} a b
+        assert_equal {a b} [$rd read]
+        assert_equal {a b} [r lrange dst{t} 0 -1]
+        $rd close
+    }
+
+    test {BLMOVEM EXACTLY blocks until enough elements then moves atomically} {
+        r del src{t} dst{t}
+        set rd [redis_deferring_client]
+        $rd blmovem src{t} dst{t} left right 0 exactly 3 bulk
+        wait_for_blocked_client
+
+        # Not enough yet: the client must stay blocked and nothing is moved.
+        r rpush src{t} 1 2
+        wait_for_blocked_client
+        assert_equal {1 2} [r lrange src{t} 0 -1]
+        assert_equal 0 [r exists dst{t}]
+
+        # Now there are enough elements: move exactly 3.
+        r rpush src{t} 3
+        assert_equal {1 2 3} [$rd read]
+        assert_equal {1 2 3} [r lrange dst{t} 0 -1]
+        assert_equal 0 [r exists src{t}]
+        $rd close
+    }
+
+    test {BLMOVEM EXACTLY is woken by LINSERT growing the source} {
+        r del src{t} dst{t}
+        r rpush src{t} 1 2
+        set rd [redis_deferring_client]
+        $rd blmovem src{t} dst{t} left right 0 exactly 3 bulk
+        wait_for_blocked_client
+        r linsert src{t} before 1 0   ;# src -> 0 1 2, reaches 3
+        assert_equal {0 1 2} [$rd read]
+        assert_equal {0 1 2} [r lrange dst{t} 0 -1]
+        assert_equal 0 [r exists src{t}]
+        $rd close
+    }
+
+    test {BLMOVEM EXACTLY is woken by LMOVE into the source} {
+        r del src{t} dst{t} feed{t}
+        r rpush src{t} 1 2
+        r rpush feed{t} 9
+        set rd [redis_deferring_client]
+        $rd blmovem src{t} dst{t} left right 0 exactly 3 bulk
+        wait_for_blocked_client
+        r lmove feed{t} src{t} left right   ;# src -> 1 2 9, reaches 3
+        assert_equal {1 2 9} [$rd read]
+        assert_equal {1 2 9} [r lrange dst{t} 0 -1]
+        assert_equal 0 [r exists src{t}]
+        $rd close
+    }
+
+    test {BLMOVEM times out with null array} {
+        r del src{t} dst{t}
+        set rd [redis_deferring_client]
+        $rd blmovem src{t} dst{t} left right 1 exactly 3 bulk
+        wait_for_blocked_client
+        assert_equal {} [$rd read]
+        $rd close
+    }
+
+    test {BLMOVEM inside MULTI does not block} {
+        r del src{t} dst{t}
+        r multi
+        r blmovem src{t} dst{t} left right 0 exactly 3 bulk
+        assert_equal {{}} [r exec]
+    }
+}


### PR DESCRIPTION
Add LMOVEM and BLMOVEM commands.

# LMOVEM

## Syntax

```
LMOVEM source destination <LEFT|RIGHT> <LEFT|RIGHT> [<COUNT|EXACTLY> count <OBO|BULK>]
```

## Description

Command is similar to LMOVE, but it moves multiple elements. To facilitate that, besides the source and destination keys and LEFT/RIGHT positions for each list we have additional arguments

* **COUNT** - move up-to `count` elements. Same semantics as `count` param for `LPOP`
* **EXACTLY** - move exactly `count` elements or return nil if source list does not have enough elements

The above two have additional mandatory param:
* **OBO** - move elements one by one
* **BULK** - move all elements in bulk

## Notes

Without `COUNT` or `EXACTLY` params LMOVEM is equivalent to LMOVE.

## Examples

```
> RPUSH l1 1 2 3 4
> RPUSH l2 5 6 7
> LMOVEM l1 l2 LEFT LEFT COUNT 2 OBO
1) "2"
2) "1"
> LRANGE l2 0 -1
1) "2"
2) "1"
3) "6"
4) "7"
5) "8"
```

```
> RPUSH l1 1 2 3 4
> RPUSH l2 5 6 7
> LMOVEM l1 l2 LEFT LEFT COUNT 2 BULK
1) "1"
2) "2"
> LRANGE l2 0 -1
1) "1"
2) "2"
3) "6"
4) "7"
5) "8"
```

```
> RPUSH l1 1 2
> RPUSH l2 5 6 7
> LMOVEM l1 l2 LEFT LEFT EXACTLY 3 BULK
(nil)
```

#  BLMOVEM

## Syntax

```
BLMOVEM source destination <LEFT|RIGHT> <LEFT|RIGHT> timeout [<COUNT|EXACTLY> count <OBO|BULK>]
```

## Description

Blocking version of LMOVEM command.

## Notes

With `COUNT` param blocks only if source list is empty.
With `EXACTLY` param blocks whenever source list is empty or does not have enough elements. Unblocks only if source list was extended with enough elements (or of course until timeout).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core blocking and key-ready signaling used by all list blockers and module key blocking; incorrect wake semantics could cause stuck clients or unexpected module unblocks, though behavior is covered by new tests.
> 
> **Overview**
> Adds **LMOVEM** and **BLMOVEM** (8.10.0) to move one or more list elements between keys, with optional `COUNT` / `EXACTLY` and `OBO` / `BULK` ordering. Without the optional block, behavior matches single-element **LMOVE** / **BLMOVE**.
> 
> **LMOVEM** returns an array of moved elements (or null when `EXACTLY` cannot be satisfied). **BLMOVEM** blocks until the source has enough elements: `COUNT` waits for at least one; `EXACTLY` waits until the list length reaches the requested count and moves atomically. Successful **BLMOVEM** replication is rewritten to `LMOVEM … EXACTLY N …`.
> 
> Blocking support introduces **`BLOCKED_LIST_NONEMPTY`** for waiters that need an existing list to grow (e.g. `BLMOVEM EXACTLY` with count &gt; 1). **`signalKeyAsReadyNonEmptyList`** wakes only those native blockers; **`readyList.wake_modules`** keeps module clients off plain writes to pre-existing keys while still allowing key creation and explicit ready signals. List pushes, **LINSERT**, and destination pushes in multi-move paths call the nonempty signal where appropriate.
> 
> Command metadata is wired through JSON defs and generated `commands.def`; tests cover list behavior, replication, blocking edge cases, and module interaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a477a1f56af814f042f54cfc29dce8ca7237a043. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->