### PR TITLE
Fix LSET out-of-range 64-bit index truncation

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -370,7 +370,7 @@ void listTypeReplace(listTypeEntry *entry, robj *value) {
  *
  * Returns 1 if replace happened.
  * Returns 0 if replace failed and no changes happened. */
-int listTypeReplaceAtIndex(robj *o, int index, robj *value) {
+int listTypeReplaceAtIndex(robj *o, long index, robj *value) {
     value = getDecodedObject(value);
     sds vstr = value->ptr;
     size_t vlen = sdslen(vstr);

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1984,8 +1984,8 @@ foreach {type large} [array get largevalue] {
 
         test "LSET out of range 64-bit index is not truncated - $type" {
             create_$type mylist "99 98 $large 96 95"
-            # Out-of-range indexes must be rejected even when they would narrow
-            # to an in-range index on 64-bit builds (#15402).
+            # These indexes are out of range and must be rejected.
+            # As mentioned in #15402, they were truncated to a valid index.
             assert_error ERR*range* {r lset mylist 4294967296 foo}
             assert_error ERR*range* {r lset mylist 4294967298 foo}
             assert_error ERR*range* {r lset mylist -4294967296 foo}

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1981,6 +1981,16 @@ foreach {type large} [array get largevalue] {
         test "LSET out of range index - $type" {
             assert_error ERR*range* {r lset mylist 10 foo}
         }
+
+        test "LSET out of range 64-bit index is not truncated - $type" {
+            create_$type mylist "99 98 $large 96 95"
+            # Out-of-range indexes must be rejected even when they would narrow
+            # to an in-range index on 64-bit builds (#15402).
+            assert_error ERR*range* {r lset mylist 4294967296 foo}
+            assert_error ERR*range* {r lset mylist 4294967298 foo}
+            assert_error ERR*range* {r lset mylist -4294967296 foo}
+            assert_equal "99 98 $large 96 95" [r lrange mylist 0 -1]
+        }
     }
 
     test {LSET against non existing key} {


### PR DESCRIPTION
`lsetCommand()` parses the index as a `long`, but `listTypeReplaceAtIndex()` took an `int`. On 64-bit builds this narrowed out-of-range indexes to valid ones (e.g. `4294967296` -> `0`, `4294967298` -> `2`), silently overwriting existing elements instead of returning `ERR index out of range`. This PR fixes #15402 by changing `listTypeReplaceAtIndex()` to take a `long` index.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-parameter type fix on the LSET code path with targeted regression tests; behavior change only for previously mis-handled out-of-range 64-bit indexes.
> 
> **Overview**
> Fixes **#15402**: on 64-bit builds, `LSET` could **silently replace** list elements when the index was far out of range instead of returning an index error.
> 
> `lsetCommand()` already parses the index as a `long`, but `listTypeReplaceAtIndex()` took an `int`, so huge indexes were **narrowed** (e.g. `4294967296` → `0`, `4294967298` → `2`) before quicklist/listpack logic ran. The helper’s index parameter is now **`long`** end-to-end.
> 
> Regression tests assert `LSET` with indexes like `4294967296` / `-4294967296` returns a range error and leaves the list unchanged, for both listpack and quicklist encodings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e20baf360ca179708d97e701ed792b87cae0304a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->