### PR TITLE
Fix integer overflow on out-of-range numkeys

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3231,8 +3231,8 @@ int getKeysUsingKeySpecs(struct redisCommand *cmd, robj **argv, int argc, int se
             }
 
             first += spec->fk.keynum.firstkey;
-            /* Reject a non-positive step and bound numkeys before it overflows 'last' below. */
-            if (step <= 0 || numkeys - 1 > (argc - 1 - first) / step)
+            /* Reject invalid specs and bound numkeys before it overflows 'last' below. */
+            if (step <= 0 || first < 0 || numkeys - 1 > (argc - 1 - first) / step)
                 goto invalid_spec;
             last = first + ((long)numkeys - 1) * step;
         } else {

--- a/src/db.c
+++ b/src/db.c
@@ -3232,7 +3232,7 @@ int getKeysUsingKeySpecs(struct redisCommand *cmd, robj **argv, int argc, int se
 
             first += spec->fk.keynum.firstkey;
             /* Reject a non-positive step and bound numkeys before it overflows 'last' below. */
-            if (step <= 0 || numkeys > (argc - first) / step)
+            if (step <= 0 || numkeys - 1 > (argc - 1 - first) / step)
                 goto invalid_spec;
             last = first + ((long)numkeys - 1) * step;
         } else {

--- a/src/db.c
+++ b/src/db.c
@@ -3231,8 +3231,8 @@ int getKeysUsingKeySpecs(struct redisCommand *cmd, robj **argv, int argc, int se
             }
 
             first += spec->fk.keynum.firstkey;
-            /* Bound numkeys before it overflows 'last' below. */
-            if (numkeys > (argc - first) / step)
+            /* Reject a non-positive step and bound numkeys before it overflows 'last' below. */
+            if (step <= 0 || numkeys > (argc - first) / step)
                 goto invalid_spec;
             last = first + ((long)numkeys - 1) * step;
         } else {

--- a/src/db.c
+++ b/src/db.c
@@ -3231,6 +3231,9 @@ int getKeysUsingKeySpecs(struct redisCommand *cmd, robj **argv, int argc, int se
             }
 
             first += spec->fk.keynum.firstkey;
+            /* Bound numkeys before it overflows 'last' below. */
+            if (numkeys > (argc - first) / step)
+                goto invalid_spec;
             last = first + ((long)numkeys - 1) * step;
         } else {
             /* unknown spec */

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -159,9 +159,6 @@ start_server {tags {"introspection"}} {
 
     test {COMMAND GETKEYSANDFLAGS invalid args} {
         assert_error "ERR Invalid arguments*" {r command getkeysandflags ZINTERSTORE zz 1443677133621497600 asdf}
-    }
-
-    test {COMMAND GETKEYS numkeys overflow} {
         # A numkeys near LONG_MAX must be rejected as a syntax error, not trigger a signed integer overflow (#15403).
         set huge 9223372036854775807
         assert_error "ERR Invalid arguments*" {r command getkeys LMPOP $huge k LEFT}

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -161,6 +161,16 @@ start_server {tags {"introspection"}} {
         assert_error "ERR Invalid arguments*" {r command getkeysandflags ZINTERSTORE zz 1443677133621497600 asdf}
     }
 
+    test {COMMAND GETKEYS numkeys overflow} {
+        # A numkeys near LONG_MAX must be rejected as a syntax error, not trigger a signed integer overflow (#15403).
+        set huge 9223372036854775807
+        assert_error "ERR Invalid arguments*" {r command getkeys LMPOP $huge k LEFT}
+        assert_error "ERR Invalid arguments*" {r command getkeys ZMPOP $huge k MIN}
+        assert_error "ERR Invalid arguments*" {r command getkeys ZUNION $huge k}
+        assert_error "ERR Invalid arguments*" {r command getkeys SINTERCARD $huge k}
+        assert_error "ERR Invalid arguments*" {r command getkeysandflags ZINTERSTORE dst $huge k}
+    }
+
     test {COMMAND GETKEYSANDFLAGS MSETEX} {
         assert_equal {{k1 {OW update}}} [r command getkeysandflags msetex 1 k1 v1 ex 10]
         assert_equal {{k1 {OW update}} {k2 {OW update}}} [r command getkeysandflags msetex 2 k1 v1 k2 v2 ex 10]


### PR DESCRIPTION
`getKeysUsingKeySpecs()` computed `last = first + (numkeys-1) * step` before validating `numkeys`, so a huge client-supplied value (e.g. `LONG_MAX`) overflowed a signed `long`, causing undefined behavior. This PR fixes #15403 by rejecting `numkeys` larger than the remaining argument count before computing `last`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, defensive change in command introspection/key parsing with regression tests; no change to normal command execution paths when arguments are valid.
> 
> **Overview**
> Fixes **#15403** by validating `KSPEC_FK_KEYNUM` specs in `getKeysUsingKeySpecs()` **before** computing `last = first + (numkeys - 1) * step`. A client-supplied `numkeys` near `LONG_MAX` could overflow a signed `long`, leading to undefined behavior instead of a syntax error.
> 
> The new checks treat invalid specs as errors: `step <= 0`, negative `first`, or `numkeys` larger than the remaining argv slots can cover (`numkeys - 1 > (argc - 1 - first) / step`). Those cases now hit `invalid_spec` like other bad key specs, so `COMMAND GETKEYS` / `GETKEYSANDFLAGS` return **ERR Invalid arguments** instead of mis-parsing keys.
> 
> Tests assert that huge `numkeys` (`9223372036854775807`) fails for **LMPOP**, **ZMPOP**, **ZUNION**, **SINTERCARD**, and **ZINTERSTORE** via both `getkeys` and `getkeysandflags`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bfd17f7be43d892b2ec9a1cc8b4fbc3f51f8655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->