### PR TITLE
Fix crash on CONFIG SET of TLS options in non-TLS builds

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2764,20 +2764,32 @@ int updateClusterHumanNodename(const char **err) {
 }
 
 static int applyTlsCfg(const char **err) {
-    UNUSED(err);
-
     /* If TLS is enabled, try to configure OpenSSL. */
-    if ((server.tls_port || server.tls_replication || server.tls_cluster)
-         && connTypeConfigure(connectionTypeTls(), &server.tls_ctx_config, 1) == C_ERR) {
-        *err = "Unable to update TLS configuration. Check server logs.";
-        return 0;
+    if (server.tls_port || server.tls_replication || server.tls_cluster) {
+        ConnectionType *ct_tls = connectionTypeTls();
+        /* Refuse if no TLS support compiled in */
+        if (!ct_tls) {
+            *err = "TLS support is not compiled in, cannot enable TLS options.";
+            return 0;
+        }
+        if (connTypeConfigure(ct_tls, &server.tls_ctx_config, 1) == C_ERR) {
+            *err = "Unable to update TLS configuration. Check server logs.";
+            return 0;
+        }
     }
     return 1;
 }
 
 static int applyTLSPort(const char **err) {
+    ConnectionType *ct_tls = connectionTypeTls();
+    /* Refuse if no TLS support compiled in */
+    if (!ct_tls) {
+        *err = "TLS support is not compiled in, cannot set a TLS port.";
+        return 0;
+    }
+
     /* Configure TLS in case it wasn't enabled */
-    if (connTypeConfigure(connectionTypeTls(), &server.tls_ctx_config, 0) == C_ERR) {
+    if (connTypeConfigure(ct_tls, &server.tls_ctx_config, 0) == C_ERR) {
         *err = "Unable to update TLS configuration. Check server logs.";
         return 0;
     }

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1195,3 +1195,13 @@ start_server {tags {introspection external:skip} overrides {requirepass secret}}
         assert_equal 0 [string match "*WARNING: Redis does not require authentication*" $loglines]
     }
 }
+
+start_server {tags {introspection external:skip}} {
+    test {CONFIG SET of TLS options must not crash the server} {
+        # These `config set` commands used to crash a non-TLS build (see #15404)
+        catch {r config set tls-port 6380}
+        catch {r config set tls-replication yes}
+        catch {r config set tls-cluster yes}
+        assert_equal {PONG} [r ping]
+    }
+}


### PR DESCRIPTION
When Redis is built without `OpenSSL/TLS`, `tls-port`, `tls-replication`, and `tls-cluster` remain runtime-modifiable via `CONFIG SET`. Their config apply callbacks call `connTypeConfigure(connectionTypeTls(), ...)`, but in a non-TLS build `connectionTypeTls()` returns `NULL` and `connTypeConfigure()` dereferences it unconditionally. This PR fixes #15404 by checking returned pointer in `applyTlsCfg()` and `applyTLSPort()`, the two caller functions of `connectionTypeTls()`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to config apply error handling; TLS-enabled builds behave as before when TLS is available.
> 
> **Overview**
> Fixes a **crash (SIGSEGV)** when `CONFIG SET` touches TLS-related options on builds **without** OpenSSL/TLS support (#15404).
> 
> `applyTlsCfg` and `applyTLSPort` now check whether `connectionTypeTls()` is `NULL` before calling `connTypeConfigure`. On non-TLS builds they return a clear error instead of dereferencing a null connection type.
> 
> A regression test in `introspection.tcl` asserts that setting `tls-port`, `tls-replication`, and `tls-cluster` leaves the server responding to `PING`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f81d6591809e9a39c85175ecb5eed9ee2b9fef9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->