### PR TITLE
Fix unit mismatch that disabled the FAST expire cycle stale trigger

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -321,7 +321,7 @@ void activeExpireCycle(int type) {
          * too high. Also never repeat a fast cycle for the same period
          * as the fast cycle total duration itself. */
         if (!timelimit_exit &&
-            server.stat_expired_stale_perc < config_cycle_acceptable_stale)
+            server.stat_expired_stale_perc * 100 < config_cycle_acceptable_stale)
             return;
 
         if (start < last_fast_cycle + (long long)config_cycle_fast_duration*2)


### PR DESCRIPTION
Fixes #15410

`stat_expired_stale_perc` is a fraction in [0, 1] (`total_expired/total_sampled`, multiplied by 100 only when printed in INFO), but the FAST-cycle gate compared it directly against `config_cycle_acceptable_stale`, which is a percentage in [1, 10]:

```c
if (!timelimit_exit &&
    server.stat_expired_stale_perc < config_cycle_acceptable_stale)
    return;
```

A value in [0, 1] is (almost) always below a threshold in [1, 10], so the branch always returned early: FAST cycles could only run after the previous SLOW cycle hit its time cap. The "percentage of estimated stale keys is too high" trigger has been dead code since it was introduced in 6.0.

Scale the fraction to percent in the comparison, matching the per-DB repeat condition in the same function, which already compares in percent units (`data.expired * 100 / data.sampled > config_cycle_acceptable_stale`).

### Behavior change

Workloads whose stale estimate exceeds the threshold (10% at the default `active-expire-effort`) now run FAST cycles between SLOW cycles as originally intended — still bounded to one `config_cycle_fast_duration` cycle per 2x that duration — reclaiming expired keys sooner at the cost of slightly more expiration work. Workloads below the threshold are unaffected.

### Verification

A/B test with a temporary log probe on the FAST path (not included in this PR): standalone server, 400K live keys plus 5K/s SETEX inflow with 2s TTLs, holding the stale estimate in the 10-30% band.

- old gate: zero stale-triggered FAST cycles; the only engagements came from the time-cap path (`timelimit_exit=1`)
- fixed gate: first FAST cycle engaged exactly as the estimate crossed the threshold (`stale=0.1001, timelimit_exit=0`), 1,800+ engagements over the run

`make` and `./runtest --single unit/expire` pass locally.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core active expiration scheduling for workloads with high stale-key ratios; behavior was unintentionally disabled for years but re-enabling it increases expire-cycle work when estimates exceed the threshold.
> 
> **Overview**
> Fixes a **unit mismatch** in the FAST path of `activeExpireCycle()`: `stat_expired_stale_perc` is stored as a **fraction in [0, 1]**, but it was compared directly to `config_cycle_acceptable_stale`, which is a **percent threshold** (default 10, scaled by `active-expire-effort`). That comparison almost always skipped FAST cycles unless the previous SLOW cycle hit its time cap.
> 
> The gate now uses `stat_expired_stale_perc * 100`, aligning with how INFO reports the stat and with the per-DB repeat check (`data.expired * 100 / data.sampled > config_cycle_acceptable_stale`).
> 
> **Effect:** When the EWMA stale estimate is above the configured threshold, FAST expire cycles can run between SLOW cycles (still rate-limited by `config_cycle_fast_duration`), so expired keys may be reclaimed sooner at the cost of slightly more expiration CPU. Workloads below the threshold behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6ad1a44fed85e950fc8bef10e754d5be11f895d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
