### PR TITLE
Restore config after SRANDMEMBER long-chain test

### DIFF
--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1358,7 +1358,7 @@ foreach type {single multiple single_multiple} {
             set allmyset($ele) 1
         }
         unset -nocomplain auxset
-        set iterations 2000
+        set iterations 1000
         while {$iterations != 0} {
             incr iterations -1
             set res [r srandmember myset -10]

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1403,7 +1403,7 @@ foreach type {single multiple single_multiple} {
         r config set save $origin_save
         r config set set-max-listpack-entries $origin_max_lp
         r config set rdb-key-save-delay $origin_save_delay
-    } {OK} {needs:debug slow debug_defrag:skip}
+    } {OK} {needs:debug slow debug_defrag:skip config:restore}
 
     proc setup_move {} {
         r del myset3{t} myset4{t}

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1358,7 +1358,7 @@ foreach type {single multiple single_multiple} {
             set allmyset($ele) 1
         }
         unset -nocomplain auxset
-        set iterations 1000
+        set iterations 2000
         while {$iterations != 0} {
             incr iterations -1
             set res [r srandmember myset -10]


### PR DESCRIPTION

## Issue

The Redis Daily `test-sanitizer-undefined (gcc)` job reported a flaky failure in `SRANDMEMBER with a dict containing long chain`. 
If the assertion aborts before the manual config reset, later `SMOVE` tests can observe the modified `set-max-listpack-entries` value and fail encoding checks.

https://github.com/redis/redis/actions/runs/28557109221/job/84666785475#logs

> !!! WARNING The following tests failed:
*** [err]: SRANDMEMBER with a dict containing long chain in tests/unit/type/set.tcl
Expected 0 != 0 (context: type eval line 65 cmd {assert {$iterations != 0}} proc ::test)
*** [err]: SMOVE basics - from regular set to intset in tests/unit/type/set.tcl
Expected 'hashtable' to match 'listpack' (context: type source line 100 file /home/runner/work/redis/redis/tests/support/test.tcl cmd {assert_match $enc $val} proc ::assert_encoding level 1) 
*** [err]: SMOVE basics - from intset to regular set in tests/unit/type/set.tcl
Expected 'hashtable' to match 'listpack' (context: type source line 100 file /home/runner/work/redis/redis/tests/support/test.tcl cmd {assert_match $enc $val} proc ::assert_encoding level 1) 
*** [err]: SMOVE non existing key in tests/unit/type/set.tcl
Expected 'hashtable' to match 'listpack' (context: type source line 100 file /home/runner/work/redis/redis/tests/support/test.tcl cmd {assert_match $enc $val} proc ::assert_encoding level 1) 
*** [err]: SMOVE non existing src set in tests/unit/type/set.tcl
Expected 'hashtable' to match 'listpack' (context: type source line 100 file /home/runner/work/redis/redis/tests/support/test.tcl cmd {assert_match $enc $val} proc ::assert_encoding level 1) 
*** [err]: SMOVE from regular set to non existing destination set in tests/unit/type/set.tcl
Expected 'hashtable' to match 'listpack' (context: type source line 100 file /home/runner/work/redis/redis/tests/support/test.tcl cmd {assert_match $enc $val} proc ::assert_encoding level 1) 
*** [err]: SMOVE from intset to non existing destination set in tests/unit/type/set.tcl
Expected 'hashtable' to match 'listpack' (context: type source line 100 file /home/runner/work/redis/redis/tests/support/test.tcl cmd {assert_match $enc $val} proc ::assert_encoding level 1) 
Cleanup: may take some time... OK
Error: Process completed with exit code 1.


## Change

Add `config:restore` to the test tags so the test framework restores config values even if the test aborts early.

Keep the existing sampling threshold unchanged, since the test rarely fails and repeated failures may indicate a real behavior change.

## Test

Daily CI with comment: `--loops 100 --single unit/type/set`: https://github.com/vitahlin/redis/actions/runs/28649653258


As an extra smoke test, I locally inverted the assertion in the `SRANDMEMBER with a dict containing long chain` test to force it to fail before the manual config reset at the end of the test body.

The forced failure only reported the intended `SRANDMEMBER` assertion failure, while the following `SMOVE` tests passed. This shows that `config:restore` restores the modified config even when the test aborts early, so the `set-max-listpack-entries` change no longer leaks into later set tests.

```shell
[err]: SRANDMEMBER with a dict containing long chain in tests/unit/type/set.tcl
Expected 1676 == 0 (context: type eval line 65 cmd {assert {$iterations == 0}} proc ::test)
[ok]: SMOVE basics - from regular set to intset (2 ms)
[ok]: SMOVE basics - from intset to regular set (0 ms)
[ok]: SMOVE non existing key (0 ms)
[ok]: SMOVE non existing src set (1 ms)
[ok]: SMOVE from regular set to non existing destination set (1 ms)
[ok]: SMOVE from intset to non existing destination set (0 ms)
[ok]: SMOVE wrong src key type (1 ms)
[ok]: SMOVE wrong dst key type (0 ms)
[ok]: SMOVE with identical source and destination (0 ms)
[ok]: SMOVE only notify dstset when the addition is successful (1 ms)
[ok]: intsets implementation stress testing (1125 ms)
[ok]: Check for memory leaks (pid 69512) (993 ms)
[1/1 done]: unit/type/set (12 seconds)
Testing solo test
[ignore]: SADD, SCARD, SISMEMBER - large data: large memory flag not provided
[ok]: Check for memory leaks (pid 69675) (619 ms)
[1/1 done]: set-large-memory (1 seconds)

                   The End

Execution time of different units:
  12 seconds - unit/type/set
  1 seconds - set-large-memory

!!! WARNING The following tests failed:

*** [err]: SRANDMEMBER with a dict containing long chain in tests/unit/type/set.tcl
Expected 1676 == 0 (context: type eval line 65 cmd {assert {$iterations == 0}} proc ::test)
Cleanup: may take some time... OK

```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to the Redis integration test harness; no production server behavior is modified.
> 
> **Overview**
> Adds the **`config:restore`** tag to the slow **`SRANDMEMBER with a dict containing long chain`** test in `tests/unit/type/set.tcl`.
> 
> That test temporarily changes **`save`**, **`set-max-listpack-entries`**, and **`rdb-key-save-delay`**. If the probabilistic chi-square assertion fails before the manual `CONFIG SET` rollback at the end of the test body, those values could leak into later tests (e.g. **`SMOVE`** encoding checks expecting listpack under the suite’s default **`set-max-listpack-entries`**).
> 
> With **`config:restore`**, the harness saves server config before the test and restores it on failure (and on the normal exit path), so config mutations do not cascade when this test flakes or aborts early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3180291bebe9da337c593fc42a985cf3204bd4d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->