### PR TITLE
Fix LSET integer overflow/truncation bug by using long index in listT…

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -370,7 +370,7 @@ void listTypeReplace(listTypeEntry *entry, robj *value) {
  *
  * Returns 1 if replace happened.
  * Returns 0 if replace failed and no changes happened. */
-int listTypeReplaceAtIndex(robj *o, int index, robj *value) {
+int listTypeReplaceAtIndex(robj *o, long index, robj *value) {
     value = getDecodedObject(value);
     sds vstr = value->ptr;
     size_t vlen = sdslen(vstr);

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1981,6 +1981,12 @@ foreach {type large} [array get largevalue] {
         test "LSET out of range index - $type" {
             assert_error ERR*range* {r lset mylist 10 foo}
         }
+
+        test "LSET out of range 64-bit index does not truncate and overwrite index 0 - $type" {
+            create_$type mylist "99 98 97"
+            assert_error ERR*range* {r lset mylist 4294967296 foo}
+            assert_equal "99" [r lindex mylist 0]
+        }
     }
 
     test {LSET against non existing key} {


### PR DESCRIPTION
## What
This PR fixes a bug where passing a large out-of-range 64-bit index to `LSET` (e.g., `4294967296`) causes integer truncation to a 32-bit `int`, resulting in silent overwriting of elements at index `0` instead of returning a range error.

## Why
`LSET` parses the index argument as a C `long` (64-bit on standard Linux/macOS environments), but passes it to the internal helper `listTypeReplaceAtIndex()`, whose parameter type was a 32-bit `int`. Since both underlying list container types (`quicklist` and `listpack`) support `long` indexes, this truncation is unnecessary and leads to quiet data corruption.

## How
1. Changed `index` parameter type in `listTypeReplaceAtIndex` in `src/t_list.c` from `int` to `long`.
2. Added a unit regression test in `tests/unit/type/list.tcl` verifying that a 64-bit out-of-range index throws an out-of-range error and does not overwrite index `0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches list mutation for LSET; the change is a narrow type fix with a targeted regression test, but incorrect index handling could corrupt list data.
> 
> **Overview**
> Fixes **silent data corruption** on `LSET` when the index is a large 64-bit value that is out of range for the list.
> 
> `LSET` already parses the index as a `long`, but `listTypeReplaceAtIndex` took an `int`, so values like `4294967296` were truncated (e.g. to `0`) and could replace the wrong element instead of returning an out-of-range error. The helper’s `index` parameter is now **`long`**, matching `lsetCommand` and the quicklist/listpack paths.
> 
> A regression test covers both **listpack** and **quicklist** encodings: `LSET` with index `4294967296` must fail with a range error and leave index `0` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d70bde757269db4601571e09ae20d9b8bcb2eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->