### PR TITLE
Reject dupe fields when loading hash RDB payloads via RESTORE

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2636,9 +2636,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
         /* Too many entries? Use a hash table right from the start. */
         if (len > server.hash_max_listpack_entries)
             hashTypeConvert(NULL, o, OBJ_ENCODING_HT);
-        else if (deep_integrity_validation) {
-            /* In this mode, we need to guarantee that the server won't crash
-             * later when the ziplist is converted to a dict.
+        else if (deep_integrity_validation || isRestoreContext()) {
+            /* In the deep-validation mode or for untrusted RESTORE, we need to guarantee
+             * that the server won't crash later when the ziplist is converted to a dict.
              * Create a set (dict with no values) to for a dup search.
              * We can dismiss it as soon as we convert the ziplist to a hash. */
             dupSearchDict = dictCreate(&hashDictType);
@@ -2790,9 +2790,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             initDictExpireMetadata(o);
         } else {
             hashTypeConvert(NULL, o, OBJ_ENCODING_LISTPACK_EX);
-            if (deep_integrity_validation) {
-                /* In this mode, we need to guarantee that the server won't crash
-                * later when the listpack is converted to a dict.
+            if (deep_integrity_validation || isRestoreContext()) {
+                /* In the deep-validation mode or for untrusted RESTORE, we need to guarantee
+                * that the server won't crash later when the listpack is converted to a dict.
                 * Create a set (dict with no values) for dup search.
                 * We can dismiss it as soon as we convert the listpack to a hash. */
                 dupSearchDict = dictCreate(&hashDictType);

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -59,6 +59,26 @@ test {corrupt payload: valid zipped hash header, dup records} {
     }
 }
 
+test {corrupt payload: RDB_TYPE_HASH listpack with duplicate fields} {
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        catch {
+            r restore key 0 "\x04\x02\x01\x66\x01\x61\x01\x66\x01\x62\x0e\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        } err
+        assert_match "*Bad data format*" $err
+        r ping
+    }
+}
+
+test {corrupt payload: RDB_TYPE_HASH_METADATA listpackex with duplicate fields} {
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        catch {
+            r restore key 0 "\x16\x02\x00\x01\x66\x01\x61\x00\x01\x66\x01\x62\x0e\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        } err
+        assert_match "*Bad data format*" $err
+        r ping
+    }
+}
+
 test {corrupt payload: hash listpackex with invalid string TTL} {
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
         r config set sanitize-dump-payload yes


### PR DESCRIPTION
## Issue
A crafted `RESTORE` payload with a duplicate hash field is accepted under the default `sanitize-dump-payload no`. The malformed hash loads fine, but a later listpack->hashtable conversion hits the duplicate and aborts the server via `serverPanic()` — an authenticated remote DoS. Duplicate detection only ran under deep validation, so the default config was vulnerable.

## Fix
Gate the existing `dupSearchDict` check on `deep_integrity_validation || isRestoreContext()`, so untrusted `RESTORE` rejects duplicate fields regardless of `sanitize-dump-payload` while trusted disk/replication loads stay on the fast path. Covers `RDB_TYPE_HASH` and `RDB_TYPE_HASH_METADATA`/`_PRE_GA`, with regression tests. Fixes #15413.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RDB hash load paths used by RESTORE and persistence; behavior change is narrowly scoped to duplicate detection on untrusted RESTORE and deep validation, with regression tests.
> 
> **Overview**
> Fixes an authenticated **remote DoS** where a crafted `RESTORE` hash payload with **duplicate field names** could load when `sanitize-dump-payload` was off, then **panic** the server on a later listpack→hashtable conversion.
> 
> **`rdbLoadObject`** now enables the existing `dupSearchDict` duplicate-field check when loading **`RDB_TYPE_HASH`** and **`RDB_TYPE_HASH_METADATA`** listpack encodings if **`deep_integrity_validation || isRestoreContext()`**, so untrusted `RESTORE` always rejects dupes while trusted RDB/replication loads stay on the fast path unless deep validation is on.
> 
> Adds **`corrupt-dump.tcl`** regressions for listpack and listpackex hash payloads with duplicate fields (`Bad data format`, server survives `PING`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31bb01d878ad58ec518e7397ac8f81c7ec86518e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->