### PR TITLE
Reject malformed zset listpack payloads on untrusted RESTORE

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2393,6 +2393,29 @@ int lpValidateIntegrityAndDups(unsigned char *lp, size_t size, int deep, int tup
     return ret;
 }
 
+/* Scan a zset listpack for a non-finite (NaN) score. The listpack alternates
+ * [member, score, member, score, ...]. lpValidateIntegrityAndDups() validates
+ * the listpack structure and duplicate members, but not score finiteness, so a
+ * crafted "nan" score is otherwise accepted at load and later crashes
+ * zslInsert()'s serverAssert(!isnan(score)) when a write converts the zset to a
+ * skiplist. The skiplist load path (RDB_TYPE_ZSET/_2) already rejects NaN
+ * directly; this lets the listpack path do the same. Returns 1 if any score is
+ * NaN, 0 otherwise.
+ *
+ * The caller must have deep-validated the listpack first, so every member is
+ * followed by a score (even element count is guaranteed) - hence the assert. */
+static int zsetListpackHasNanScore(unsigned char *lp) {
+    unsigned char *eptr = lpFirst(lp);
+    while (eptr != NULL) {
+        unsigned char *sptr = lpNext(lp, eptr);
+        serverAssert(sptr != NULL);
+        if (isnan(zzlGetScore(sptr)))
+            return 1;
+        eptr = lpNext(lp, sptr);
+    }
+    return 0;
+}
+
 /* Load a Redis object of the specified type from the specified file.
  * On success a newly allocated object is returned, otherwise NULL.
  *
@@ -3187,7 +3210,13 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 }
             case RDB_TYPE_ZSET_LISTPACK:
                 if (deep_integrity_validation) server.stat_dump_payload_sanitizations++;
-                if (!lpValidateIntegrityAndDups(encoded, encoded_len, deep_integrity_validation, 2)) {
+                /* Deep-validate untrusted RESTORE payloads, not only when sanitize-dump-payload is
+                 * enabled. The shallow check accepts malformed listpacks (duplicate members, odd
+                 * element count, corrupt entries, header/count mismatch) that later crash on access
+                 * or on the listpack->skiplist conversion. Deep validation safely walks the entries
+                 * (bounds-checked) and rejects them at load. */
+                if (!lpValidateIntegrityAndDups(encoded, encoded_len,
+                        deep_integrity_validation || isRestoreContext(), 2)) {
                     rdbReportCorruptRDB("Zset listpack integrity check failed.");
                     zfree(encoded);
                     o->ptr = NULL;
@@ -3196,6 +3225,17 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 }
                 o->type = OBJ_ZSET;
                 o->encoding = OBJ_ENCODING_LISTPACK;
+
+                /* Structural validation above does not check score finiteness. A crafted NaN score
+                 * would still be accepted and later crash zslInsert() on a listpack->skiplist
+                 * conversion. Scan for it under the same condition that ran deep validation, so the
+                 * listpack is already known to be well-formed here. */
+                if ((deep_integrity_validation || isRestoreContext()) && zsetListpackHasNanScore(o->ptr)) {
+                    rdbReportCorruptRDB("Zset listpack with NaN score detected");
+                    decrRefCount(o);
+                    return NULL;
+                }
+
                 if (zsetLength(o) == 0) {
                     decrRefCount(o);
                     goto emptykey;

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -971,14 +971,47 @@ test {corrupt payload: fuzzer findings - set with invalid length causes sscan to
     }
 }
 
-test {corrupt payload: zset listpack encoded with invalid length causes zscan to hang} {
+test {corrupt payload: zset listpack encoded with invalid length is rejected at load} {
+    # The listpack header's element count does not match its actual entries. Untrusted RESTORE now
+    # deep-validates and rejects it at load, rather than accepting it and crashing on a later access.
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
         r config set sanitize-dump-payload no
-        assert_equal {OK} [r restore _zset 0 "\x11\x16\x16\x00\x00\x00\x1a\x00\x81\x61\x02\x01\x01\x81\x62\x02\x02\x01\x81\x63\x02\x03\x01\xff\x0c\x00\x81\xa7\xcd\x31\x22\x6c\xef\xf7" replace]
-        assert_encoding listpack _zset
-        catch { r ZSCAN _zset 0 } err
-        assert_equal [count_log_message 0 "crashed by signal"] 0
-        assert_equal [count_log_message 0 "ASSERTION FAILED"] 1
+        catch {r restore _zset 0 "\x11\x16\x16\x00\x00\x00\x1a\x00\x81\x61\x02\x01\x01\x81\x62\x02\x02\x01\x81\x63\x02\x03\x01\xff\x0c\x00\x81\xa7\xcd\x31\x22\x6c\xef\xf7" replace} err
+        assert_match "*Bad data format*" $err
+        r ping
+    }
+}
+
+test {corrupt payload: zset listpack with NaN score} {
+    # RDB_TYPE_ZSET_LISTPACK with a "nan" score must be rejected at load (see #15414).
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        r config set sanitize-dump-payload no
+        r debug set-skip-checksum-validation 1
+        catch {r restore _nan_zset_lp 0 "\x11\x0f\x0f\x00\x00\x00\x02\x00\x81\x61\x02\x83\x6e\x61\x6e\x04\xff\x0e\x00\x00\x00\x00\x00\x00\x00\x00\x00"} err
+        assert_match "*Bad data format*" $err
+        r ping
+    }
+}
+
+test {corrupt payload: zset listpack with duplicate members} {
+    # RDB_TYPE_ZSET_LISTPACK listpack with a duplicate member must be rejected at load (see #15415).
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        r config set sanitize-dump-payload no
+        r debug set-skip-checksum-validation 1
+        catch {r restore _dup_zset_lp 0 "\x11\x11\x11\x00\x00\x00\x04\x00\x81\x61\x02\x01\x01\x81\x61\x02\x02\x01\xff\x0e\x00\x00\x00\x00\x00\x00\x00\x00\x00"} err
+        assert_match "*Bad data format*" $err
+        r ping
+    }
+}
+
+test {corrupt payload: zset listpack with odd element count} {
+    # RDB_TYPE_ZSET_LISTPACK listpack: a trailing member with no score must be rejected at load.
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        r config set sanitize-dump-payload no
+        r debug set-skip-checksum-validation 1
+        catch {r restore _odd_zset_lp 0 "\x11\x0f\x0f\x00\x00\x00\x03\x00\x81\x61\x02\x01\x01\x81\x62\x02\xff\x0e\x00\x00\x00\x00\x00\x00\x00\x00\x00"} err
+        assert_match "*Bad data format*" $err
+        r ping
     }
 }
 


### PR DESCRIPTION
## Issue
Under the default `sanitize-dump-payload no`, `RESTORE` of an `RDB_TYPE_ZSET_LISTPACK` payload runs only shallow validation, so a crafted payload is accepted at load and crashes the server later (on a read or on listpack->skiplist conversion).

## Fix
Run deep listpack validation for untrusted payloads, not just when `sanitize-dump-payload` is on. This rejects duplicates, odd counts, and malformed entries (fixes #15415). An additional `zsetListpackHasNanScore` check rejects NaN scores (fixes #15414).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes untrusted RESTORE/RDB load behavior for zset listpacks (security-sensitive input path); behavior is stricter rejection at load with limited blast radius to that encoding.
> 
> **Overview**
> **Untrusted `RESTORE` of `RDB_TYPE_ZSET_LISTPACK` payloads is hardened** so crafted dumps are rejected at load instead of being accepted under `sanitize-dump-payload no` and crashing later on read or listpack→skiplist conversion.
> 
> Deep listpack validation (`lpValidateIntegrityAndDups` with tuple length 2) now runs whenever `isRestoreContext()` is true, not only when `sanitize-dump-payload` is enabled. That catches duplicates, odd element counts, corrupt entries, and header/count mismatches at load.
> 
> A new **`zsetListpackHasNanScore`** scan rejects NaN scores after structural validation (aligned with the skiplist zset load path). Integration tests in `corrupt-dump.tcl` were updated to expect `*Bad data format*` at restore time for invalid length, NaN score, duplicate members, and trailing member without score.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c69cb2120decdc9f2f5dccdb50b909e60867e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->