### PR TITLE
MOD-16645: Update RediSearch module to v8.9.82

### DIFF
--- a/modules/redisearch/Makefile
+++ b/modules/redisearch/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.9.81
+MODULE_VERSION = v8.9.82
 MODULE_REPO = https://github.com/redisearch/redisearch
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/search-community/redisearch.so
 


### PR DESCRIPTION
Updates modules/redisearch/Makefile to bundle RediSearch v8.9.82 on Redis 8.10.

RediSearch tag v8.9.82 points at RediSearch/RediSearch@7db8310a0609c7bfaab911ee00cd2e9e65430496, which includes the MOD-16514 bootstrap hardening backport merged in RediSearch#10340.

Validation:
- Verified the RediSearch tag exists and peels to 7db8310a0609c7bfaab911ee00cd2e9e65430496.
- Verified the tag is reachable via https://github.com/redisearch/redisearch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Makefile version pin with no local logic changes; risk is limited to upstream RediSearch behavior in the new tag.
> 
> **Overview**
> **Bumps the bundled RediSearch module** from **v8.9.81** to **v8.9.82** by updating `MODULE_VERSION` in `modules/redisearch/Makefile` for Redis 8.10 builds.
> 
> The new tag pulls in upstream **MOD-16514 bootstrap hardening** (RediSearch#10340); no other build flags or paths change in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d1aef9326faf80296c22e2c066dde722553ad83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->