### PR TITLE
Fix activeExpireCycle starvation when a concurrent SCAN keeps the expires cursor's neighborhood clean

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -144,6 +144,49 @@ static inline int expirySamplingShouldSkipDict(dict *d, int didx) {
     return 0;
 }
 
+/* During atomic slot migration, keys that are being imported are in an
+ * intermediate state. We cannot expire them and therefore skip them. */
+static int expiryRandomSamplingShouldSkipDictIndex(int didx) {
+    return !clusterCanAccessKeysInSlot(didx);
+}
+
+/* Estimate the fraction of logically expired keys in the expires table of
+ * 'db' by inspecting up to 'count' keys picked at random locations. The
+ * number of keys checked is stored in 'sampled', and how many of them were
+ * found to be already expired in 'stale'.
+ *
+ * The active expire cycle advances db->expires_cursor sequentially and uses
+ * the staleness observed around the cursor to decide whether it is worth
+ * keeping scanning the current database. However that local estimate may be
+ * arbitrarily biased: for instance a long-running client SCAN lazily expires
+ * every key it visits, and since it traverses the keyspace in the same order
+ * used by the expires cursor, the slower cursor may end up sampling only
+ * regions that the SCAN front has just cleaned. In that case every cycle
+ * observes almost no expired keys and gives up immediately, while expired
+ * keys accumulate unreclaimed in the rest of the keyspace (issue #15411).
+ *
+ * The random sample provides a position independent estimate that is immune
+ * to this kind of bias. Keys are only inspected, never deleted here: the
+ * reclamation is left to the cursor driven scan, that guarantees complete
+ * coverage of the keyspace. */
+static void expiresStalenessProbe(redisDb *db, long long now, unsigned long count,
+                                  unsigned long *sampled, unsigned long *stale)
+{
+    dictEntry *des[count];
+
+    *sampled = *stale = 0;
+    int didx = kvstoreGetFairRandomDictIndex(db->expires,
+                                             expiryRandomSamplingShouldSkipDictIndex, 1, 0);
+    if (didx == -1) return;
+
+    unsigned int found = kvstoreDictGetSomeKeys(db->expires, didx, des, count);
+    for (unsigned int i = 0; i < found; i++) {
+        kvobj *kv = dictGetKV(des[i]);
+        if (kvobjGetExpire(kv) <= now) (*stale)++;
+    }
+    *sampled = found;
+}
+
 /* SubexpireCtx passed to activeSubexpiresCb() */
 typedef struct SubexpireCtx {
     uint32_t fieldsToExpireQuota;
@@ -389,6 +432,20 @@ void activeExpireCycle(int type) {
         if (kvstoreSize(db->expires))
             dbs_performed++;
 
+        /* Take a small random sample of the expires table to obtain a
+         * staleness estimate that does not depend on the position of the
+         * expires cursor: see the expiresStalenessProbe() top comment for
+         * the rationale. The sample contributes to the global stale keys
+         * estimator and, below, to the decision to keep scanning the
+         * current database. */
+        unsigned long probe_sampled = 0, probe_stale = 0;
+        if (kvstoreSize(db->expires)) {
+            expiresStalenessProbe(db, mstime(), config_keys_per_loop,
+                                  &probe_sampled, &probe_stale);
+            total_sampled += probe_sampled;
+            total_expired += probe_stale;
+        }
+
         /* Continue to expire if at the end of the cycle there are still
          * a big percentage of keys to expire, compared to the number of keys
          * we scanned. The percentage, stored in config_cycle_acceptable_stale
@@ -443,8 +500,15 @@ void activeExpireCycle(int type) {
 
             /* We don't repeat the cycle for the current database if the db is done
              * for scanning or an acceptable number of stale keys (logically expired
-             * but yet not reclaimed). */
-            repeat = db_done ? 0 : (data.sampled == 0 || (data.expired * 100 / data.sampled) > config_cycle_acceptable_stale);
+             * but yet not reclaimed) was observed both around the cursor and in the
+             * random sample taken above. Considering the random sample too prevents
+             * an unrepresentative neighborhood of the cursor (for instance one just
+             * cleaned by a concurrent client SCAN) from stopping the cycle while the
+             * rest of the keyspace is full of expired keys. */
+            repeat = db_done ? 0 : (data.sampled == 0 ||
+                                    (data.expired * 100 / data.sampled) > config_cycle_acceptable_stale ||
+                                    (probe_sampled &&
+                                     (probe_stale * 100 / probe_sampled) > config_cycle_acceptable_stale));
 
             /* We can't block forever here even if there are many keys to
              * expire. So after a given amount of microseconds return to the


### PR DESCRIPTION
Fixes #15411

## The problem

activeExpireCycle() decides whether to keep scanning a database using only the staleness observed in a ~20 key window around the persistent db->expires_cursor. That local estimate can be arbitrarily biased. A long running client SCAN lazily expires every key it visits (expireIfNeeded() in scanCallback()), and since db->keys and db->expires hash the same keys, dictScan's reverse binary iteration visits them in the same relative order in both tables, regardless of table size. The slow moving expires cursor therefore keeps sampling regions the much faster SCAN front has just cleaned: every SLOW cycle sees few expired keys in its window, exits after a single window, and the cursor advances only a few hundred keys per second while logically expired keys accumulate unreclaimed in the rest of the keyspace. The feedback is self reinforcing, and it also pins stat_expired_stale_perc near the acceptable threshold while true staleness grows, so neither the repeat decision nor the estimator ever notices the backlog. The main thread stays mostly idle the whole time (expired_time_cap_reached_count does not move).

## The fix

Each cycle takes a small position independent random sample of the expires table (a fair random slot plus kvstoreDictGetSomeKeys(), the same primitive eviction sampling uses) and counts how many sampled keys are already logically expired. That estimate is ORed into the repeat decision, so a clean neighborhood around the cursor can no longer stop the cycle while the random sample says the keyspace is stale, and it is fed into stat_expired_stale_perc so the INFO stat reflects global staleness instead of the cursor's local view.

The probe only inspects keys and never deletes them: reclamation stays with the cursor driven scan, which preserves its full coverage guarantee. Every degradation path (skipped migrating slot, empty sample, nothing stale) falls back to the previous behavior, and total work remains bounded by the existing per cycle time caps.

Note: the FAST cycle stale percentage trigger that could partially mitigate this is currently dead code due to a unit mismatch (#15410, addressed separately in #15412). This change deliberately does not touch it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core background expiration pacing and global stale-key metrics; behavior is additive with fallbacks when the probe is empty, but mis-estimation could increase expire-cycle CPU under load.
> 
> **Overview**
> Fixes **active expire cycle starvation** when a concurrent client `SCAN` lazily expires keys along the same traversal order as `db->expires_cursor`, so the cursor’s local window looks clean while stale keys pile up elsewhere.
> 
> Each slow/fast cycle now runs **`expiresStalenessProbe`**: a fair random slot sample (via `kvstoreGetFairRandomDictIndex` / `kvstoreDictGetSomeKeys`) that only **counts** logically expired keys—no deletes. Those counts feed **`stat_expired_stale_perc`** and the **`repeat`** decision is extended so high staleness in the **random probe** keeps scanning even when the cursor neighborhood looks fine. Migrating slots are skipped via **`expiryRandomSamplingShouldSkipDictIndex`**, matching existing expire sampling behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d87c11ee0c7e9f9deac27f1b82e48a7292a2fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->