### PR TITLE
Fix signed overflow in BITFIELD #offset parsing

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -727,7 +727,13 @@ int getBitOffsetFromArgument(client *c, robj *o, uint64_t *offset, int hash, int
     }
 
     /* Adjust the offset by 'bits' for #<offset> form. */
-    if (usehash) loffset *= bits;
+    if (usehash) {
+        if (loffset < 0 || loffset > LLONG_MAX / bits) {
+            addReplyError(c,err);
+            return C_ERR;
+        }
+        loffset *= bits;
+    }
 
     /* Limit offset to server.proto_max_bulk_len (512MB in bytes by default) */
     if (loffset < 0 || (!mustObeyClient(c) && (loffset >> 3) >= server.proto_max_bulk_len))

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -721,14 +721,14 @@ int getBitOffsetFromArgument(client *c, robj *o, uint64_t *offset, int hash, int
     /* Handle #<offset> form. */
     if (p[0] == '#' && hash && bits > 0) usehash = 1;
 
-    if (string2ll(p+usehash,plen-usehash,&loffset) == 0) {
+    if (string2ll(p+usehash,plen-usehash,&loffset) == 0 || loffset < 0) {
         addReplyError(c,err);
         return C_ERR;
     }
 
     /* Adjust the offset by 'bits' for #<offset> form. */
     if (usehash) {
-        if (loffset < 0 || loffset > LLONG_MAX / bits) {
+        if (loffset > LLONG_MAX / bits) {
             addReplyError(c,err);
             return C_ERR;
         }
@@ -736,7 +736,7 @@ int getBitOffsetFromArgument(client *c, robj *o, uint64_t *offset, int hash, int
     }
 
     /* Limit offset to server.proto_max_bulk_len (512MB in bytes by default) */
-    if (loffset < 0 || (!mustObeyClient(c) && (loffset >> 3) >= server.proto_max_bulk_len))
+    if (!mustObeyClient(c) && (loffset >> 3) >= server.proto_max_bulk_len)
     {
         addReplyError(c,err);
         return C_ERR;

--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -42,6 +42,15 @@ start_server {tags {"bitops"}} {
         r get bits
     } {ABC}
 
+    test {BITFIELD #<idx> form rejects offsets that overflow when scaled by type width} {
+        assert_error {*ERR bit offset is not an integer or out of range*} {
+            r bitfield_ro bits get i64 #144115188075855872
+        }
+        assert_error {*ERR bit offset is not an integer or out of range*} {
+            r bitfield bits get i64 #144115188075855872
+        }
+    }
+
     test {BITFIELD basic INCRBY form} {
         r del bits
         set results {}


### PR DESCRIPTION
`BITFIELD` and `BITFIELD_RO` support `#<offset>` syntax, where the parsed offset is multiplied by the bitfield width before use. For very large offsets, that multiplication could overflow `long long` before the existing range checks ran.

This PR fixes #15389 by rejecting `#<offset>` values that would overflow before applying the width multiplier, returning the existing `ERR bit offset is not an integer or out of range` error instead.

Tests:
- `./runtest --single unit/bitfield`
- Verified with a UBSAN build that both repro commands return an error and the server remains alive:
  - `BITFIELD_RO k GET i64 '#144115188075855872'`
  - `BITFIELD k GET i64 '#144115188075855872'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows command input validation on a shared bit-offset helper used by BITFIELD and related commands; behavior change is limited to previously unsafe huge # offsets.
> 
> **Overview**
> Fixes **signed overflow** when `BITFIELD` / `BITFIELD_RO` parse `#<index>` offsets: the index is multiplied by the field width in bits, and huge values could overflow `long long` before existing range checks ran.
> 
> `getBitOffsetFromArgument` now rejects negative parsed offsets up front and, for `#` form, refuses multiplication when `loffset > LLONG_MAX / bits`, returning the existing `ERR bit offset is not an integer or out of range`. Unit tests cover the `i64` repro for both `BITFIELD` and `BITFIELD_RO`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09e0466dccaaf3208f6ee2230cd73e0e87c8bc6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->