### PR TITLE
Fix report actual listener bind addresses in INFO SERVER

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -196,7 +196,7 @@ sds getListensInfoString(sds info) {
 
         info = sdscatfmt(info, "listener%i:name=%s", j, listener->ct->get_type(NULL));
         for (int i = 0; i < listener->count; i++) {
-            info = sdscatfmt(info, ",bind=%s", listener->bindaddr[i]);
+            info = sdscatfmt(info, ",bind=%s", listener->bindaddr_actual[i]);
         }
 
         if (listener->port)

--- a/src/connection.h
+++ b/src/connection.h
@@ -119,6 +119,10 @@ struct connListener {
     int fd[CONFIG_BINDADDR_MAX];
     int count;
     char **bindaddr;
+    /* bindaddr is the configured list of addresses to try. bindaddr_actual[i]
+     * is the actual address used by fd[i], keeping successful fds and bind
+     * addresses aligned after failed optional binds are skipped. */
+    char *bindaddr_actual[CONFIG_BINDADDR_MAX];
     int bindaddr_count;
     int port;
     ConnectionType *ct;

--- a/src/server.c
+++ b/src/server.c
@@ -2789,10 +2789,11 @@ void closeListener(connListener *sfd) {
     int j;
 
     for (j = 0; j < sfd->count; j++) {
-        if (sfd->fd[j] == -1) continue;
-
-        aeDeleteFileEvent(server.el, sfd->fd[j], AE_READABLE);
-        close(sfd->fd[j]);
+        if (sfd->fd[j] != -1) {
+            aeDeleteFileEvent(server.el, sfd->fd[j], AE_READABLE);
+            close(sfd->fd[j]);
+        }
+        sfd->bindaddr_actual[j] = NULL;
     }
 
     sfd->count = 0;
@@ -2870,6 +2871,7 @@ int listenToPort(connListener *sfd) {
         if (server.socket_mark_id > 0) anetSetSockMarkId(NULL, sfd->fd[sfd->count], server.socket_mark_id);
         anetNonBlock(NULL,sfd->fd[sfd->count]);
         anetCloexec(sfd->fd[sfd->count]);
+        sfd->bindaddr_actual[sfd->count] = addr;
         sfd->count++;
     }
     return C_OK;

--- a/src/unix.c
+++ b/src/unix.c
@@ -68,7 +68,9 @@ static int connUnixListen(connListener *listener) {
         }
         anetNonBlock(NULL, fd);
         anetCloexec(fd);
-        listener->fd[listener->count++] = fd;
+        listener->fd[listener->count] = fd;
+        listener->bindaddr_actual[listener->count] = addr;
+        listener->count++;
     }
 
     return C_OK;

--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -51,6 +51,41 @@ test {CONFIG SET bind address} {
     }
 } {} {external:skip}
 
+start_server {args {--bind -203.0.113.1 127.0.0.1} tags {external:skip}} {
+    test {INFO SERVER reports the bind address of successfully created listeners} {
+        set info [r INFO SERVER]
+        set pattern {^listener[0-9]+:name=tcp[^\r\n]*}
+        assert {[regexp -line $pattern $info listener]}
+        assert_match {*,bind=127.0.0.1,*} $listener
+        assert_no_match {*,bind=-203.0.113.1,*} $listener
+
+        if {$::tls} {
+            set pattern {^listener[0-9]+:name=tls[^\r\n]*}
+            assert {[regexp -line $pattern $info listener]}
+            assert_match {*,bind=127.0.0.1,*} $listener
+            assert_no_match {*,bind=-203.0.113.1,*} $listener
+        }
+    }
+}
+
+start_server {tags {external:skip}} {
+    test {INFO SERVER reports the bind address of successfully recreated listeners} {
+        r CONFIG SET bind "-203.0.113.1 127.0.0.1"
+        set info [r INFO SERVER]
+        set pattern {^listener[0-9]+:name=tcp[^\r\n]*}
+        assert {[regexp -line $pattern $info listener]}
+        assert_match {*,bind=127.0.0.1,*} $listener
+        assert_no_match {*,bind=-203.0.113.1,*} $listener
+
+        if {$::tls} {
+            set pattern {^listener[0-9]+:name=tls[^\r\n]*}
+            assert {[regexp -line $pattern $info listener]}
+            assert_match {*,bind=127.0.0.1,*} $listener
+            assert_no_match {*,bind=-203.0.113.1,*} $listener
+        }
+    }
+}
+
 # Attempt to connect to host using a client bound to bindaddr,
 # and return a non-zero value if successful within specified
 # millisecond timeout, or zero otherwise.


### PR DESCRIPTION

## Issue

`INFO SERVER` builds listener bind fields by iterating over the number of successfully created listener fds, but it read addresses from the configured bind address array using the same index. When an optional bind address fails and is skipped, later successful fds no longer align with the original bind address indexes, so `INFO SERVER` can report an address that is not actually listening.

For example, with an optional unavailable address before a valid address:

```sh
redis-server --bind -203.0.113.1 127.0.0.1 --port 6389
```

`INFO SERVER` could report the skipped optional address instead of the actual listener address.

## Change

Track the actual bind address associated with each successfully created listener fd.

`INFO SERVER` now reports bind addresses from the fd-aligned listener state instead of assuming successful fd indexes match configured bind address indexes. The same mapping is maintained for TCP, TLS, and Unix listeners, and cleared when listeners are closed.

## Test

CI with command `--single unit/networking`: https://github.com/vitahlin/redis/actions/runs/28917469164/job/85787358538

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only fix to INFO output and listener bookkeeping; binding and accept behavior are unchanged aside from aligned metadata.
> 
> **Overview**
> Fixes **incorrect `bind=` values in `INFO SERVER`** when some configured bind addresses fail and are skipped (e.g. optional `-203.0.113.1` before `127.0.0.1`).
> 
> Each successful listener fd now stores its real bind address in a new **`bindaddr_actual[]`** field on `connListener`, set during TCP/TLS setup in `server.c` and Unix setup in `unix.c`, and cleared in `closeListener`. `getListensInfoString` reads from that fd-aligned list instead of indexing into the configured `bindaddr` array.
> 
> Adds **networking tests** that assert INFO shows only the address that actually listened, including after `CONFIG SET bind`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6241eb427ec2c11f4bbc88d8737e32daf9afbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->