### PR TITLE
Reject duplicate HNSW node IDs on Vector Set load

### DIFF
--- a/modules/vector-sets/hnsw.c
+++ b/modules/vector-sets/hnsw.c
@@ -2747,7 +2747,15 @@ int hnsw_deserialize_index(HNSW *index, uint64_t salt0, uint64_t salt1) {
     if (table == NULL) return 0;
     memset(table,0,sizeof(hnswNode*) * table_size);
 
-    /* First pass: populate the ID -> pointer hash table. */
+    /* First pass: populate the ID -> pointer hash table.
+     *
+     * Duplicate node IDs are rejected here as a corruption: a well-formed
+     * serialization always assigns a unique ID to each node. If duplicates
+     * were accepted, the reciprocal-links check below could pass at the ID
+     * level while the resolved pointer graph is actually non-reciprocal
+     * (link resolution stops at the first node with a matching ID). Such a
+     * graph leaves dangling links after a node is deleted, leading to a
+     * use-after-free on later access. */
     hnswNode *node = index->head;
     while(node) {
         uint64_t bucket = hnsw_hash_node_id(node->id) & (table_size-1);
@@ -2756,6 +2764,7 @@ int hnsw_deserialize_index(HNSW *index, uint64_t salt0, uint64_t salt1) {
                 table[bucket] = node;
                 break;
             }
+            if (table[bucket]->id == node->id) goto corrupted;
             bucket = (bucket+1) & (table_size-1);
         }
         node = node->next;

--- a/modules/vector-sets/tests/restore_dup_hnsw_id.py
+++ b/modules/vector-sets/tests/restore_dup_hnsw_id.py
@@ -1,0 +1,130 @@
+from test import TestCase
+import struct
+import redis
+
+
+def enc_len(value):
+    """Encode a length using the RDB length encoding."""
+    if value < 64:
+        return bytes([value])
+    if value < (1 << 14):
+        return bytes([0x40 | (value >> 8), value & 0xff])
+    if value <= 0xffffffff:
+        return b"\x80" + struct.pack("!I", value)
+    return b"\x81" + struct.pack("!Q", value)
+
+
+def load_len(buf, pos):
+    """Decode a length previously encoded with enc_len()."""
+    b = buf[pos]
+    pos += 1
+    typ = (b & 0xC0) >> 6
+    if typ == 0:
+        return b & 0x3f, pos
+    if typ == 1:
+        return ((b & 0x3f) << 8) | buf[pos], pos + 1
+    if b == 0x80:
+        return struct.unpack("!I", buf[pos:pos + 4])[0], pos + 4
+    if b == 0x81:
+        return struct.unpack("!Q", buf[pos:pos + 8])[0], pos + 8
+    raise ValueError("unexpected encoded length")
+
+
+def module_uint(value):
+    return enc_len(2) + enc_len(value)
+
+
+def module_string(data):
+    return enc_len(5) + enc_len(len(data)) + data
+
+
+def serialized_node(element, node_id, links):
+    """Serialize a single level-0 HNSW node the way VectorSetRdbSave() does."""
+    m = 16
+    params = [
+        node_id,
+        (1 << 24),       # version=1, level=0
+        len(links),
+        m * 2,           # layer-0 max_links
+    ]
+    params.extend(links)
+    params.append(0)             # worst_idx=0, worst_distance=0
+    params.append(0x3f800000)    # l2=1.0, qrange=0
+
+    out = module_string(element.encode())
+    out += module_string(struct.pack("<ff", 1.0, 0.0))
+    out += module_uint(len(params))
+    for param in params:
+        out += module_uint(param)
+    return out
+
+
+def build_dup_id_payload(module_id, rdb_version):
+    """Craft a Vector Set DUMP payload with two nodes sharing HNSW ID 1.
+
+    The duplicate ID lets the reciprocal-links check pass at the ID level
+    while the resolved pointer graph is non-reciprocal (a -> c, c -> b),
+    which used to leave a dangling link after VREM and crash on VLINKS.
+    """
+    body = bytearray([7]) + enc_len(module_id)  # RDB_TYPE_MODULE_2 + module id
+    body += module_uint(2)          # vector dimension
+    body += module_uint(3)          # elements
+    body += module_uint(16 << 8)    # quant_type=f32, M=16
+    body += module_uint(0)          # save_flags
+
+    body += serialized_node("a", 1, [2])
+    body += serialized_node("b", 1, [])
+    body += serialized_node("c", 2, [1])
+
+    body += enc_len(0)                          # module EOF opcode
+    body += struct.pack("<H", rdb_version)      # DUMP footer version
+    body += b"\x00" * 8                         # zero checksum: accepted by RESTORE
+    return bytes(body)
+
+
+class RestoreDuplicateHNSWID(TestCase):
+    def getname(self):
+        return "RESTORE rejects duplicate HNSW node IDs"
+
+    def test(self):
+        seed_key = f"{self.test_key}:seed"
+        bad_key = f"{self.test_key}:bad"
+        self.redis.delete(seed_key, bad_key)
+
+        # Seed a real Vector Set so we can learn the module id from its DUMP.
+        self.redis.execute_command(
+            'VADD', seed_key, 'VALUES', '2', '1', '0', 'seed', 'NOQUANT', 'M', '16')
+
+        seed_dump = self.redis.execute_command('DUMP', seed_key)
+        assert seed_dump and seed_dump[0] == 7, "unexpected DUMP payload for Vector Set"
+        module_id, _ = load_len(seed_dump, 1)
+        # Reuse the server's own RDB version from the seed DUMP footer so the
+        # crafted payload always clears the version check and reaches the
+        # module loader (the code path under test), regardless of the current
+        # RDB version.
+        rdb_version = struct.unpack("<H", seed_dump[-10:-8])[0]
+
+        # Positive control: a genuine Vector Set must still round-trip.
+        self.redis.execute_command('RESTORE', bad_key, '0', seed_dump, 'REPLACE')
+        assert self.redis.execute_command('VCARD', bad_key) == 1, \
+            "valid Vector Set failed to RESTORE"
+        self.redis.delete(bad_key)
+
+        # The crafted payload with duplicate HNSW IDs must be rejected.
+        payload = build_dup_id_payload(module_id, rdb_version)
+        rejected = False
+        try:
+            self.redis.execute_command('RESTORE', bad_key, '0', payload, 'REPLACE')
+        except redis.exceptions.ResponseError:
+            rejected = True
+        assert rejected, "RESTORE accepted a Vector Set with duplicate HNSW node IDs"
+
+        # The server must still be alive and functional (no use-after-free).
+        assert self.redis.execute_command('PING'), "server did not survive the payload"
+        assert self.redis.execute_command('EXISTS', bad_key) == 0, \
+            "rejected payload must not create the key"
+        self.redis.execute_command(
+            'VADD', bad_key, 'VALUES', '2', '1', '0', 'ok', 'NOQUANT', 'M', '16')
+        assert self.redis.execute_command('VCARD', bad_key) == 1
+
+        self.redis.delete(seed_key, bad_key)


### PR DESCRIPTION
## Problem

Fixes #15385.

A Vector Set RDB/RESTORE (or replication) payload can carry multiple serialized HNSW nodes that share the same internal node ID. `hnsw_deserialize_index()` builds an ID → pointer table and validates that links are reciprocal, but the reciprocal check operates purely at the **ID level**: it hashes each sorted `(A, B, level)` triple into a 128-bit accumulator and only guarantees that every ID pair appears an even number of times.

Link resolution, however, resolves each linked ID to the **first** node in the table with that ID. With two nodes sharing an ID, the accumulator can be zero while the resolved *pointer* graph is non-reciprocal. For the payload in the issue:

```
a: id=1, links to id=2
b: id=1, no links
c: id=2, links to id=1
```

`c -> id=1` resolves to `b` while `a -> id=2` resolves to `c`, so the pointer graph is `a -> c`, `c -> b`. The accumulator still sees the pair `{1,2}` twice and accepts the graph. `VREM ... c` then only unlinks the neighbors `c` actually points to, leaving `a`'s link dangling at the freed node, and a later `VLINKS ... a` dereferences it and crashes the server (SIGSEGV). An authenticated client with `RESTORE` + Vector Set access, or anyone able to feed a crafted replication/RDB payload, can turn this into a DoS.

## Fix

Reject duplicate node IDs in the first pass of `hnsw_deserialize_index()`, where the ID → pointer table is built. A well-formed serialization always assigns a unique ID to each node, so duplicate IDs are always a corruption of the on-disk/replicated format. Rejecting them restores the invariant that ID-level reciprocity implies pointer-level reciprocity.

The check reuses the existing `corrupted:` error path (which already handles unresolved links, self-links, duplicate links, and non-reciprocal graphs), so a rejected payload is cleaned up exactly like every other corruption case: `RESTORE` returns `Bad data format`, no key is created, and the server stays up. The reciprocity salt is runtime-random (`RedisModule_GetRandomBytes`), not attacker-controlled, so the duplicate-ID path was the only way to defeat the reciprocity check.

## Testing

- New regression test `modules/vector-sets/tests/restore_dup_hnsw_id.py` crafts the duplicate-ID payload and asserts `RESTORE` rejects it and the server survives, with a positive control that a genuine Vector Set still round-trips through DUMP/RESTORE.
- Verified the test **fails on unpatched** `unstable` (RESTORE accepts the payload; `VLINKS` crashes the server) and **passes with the fix**.
- Full vector-set suite: 41/41 pass, including HNSW Persistence (DEBUG RELOAD of 5000 nodes) and the replication round-trip, confirming legitimate data is never falsely rejected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Fixes a security-sensitive deserialization bug that allowed authenticated RESTORE or crafted replication payloads to crash Redis via memory corruption; the change is small and aligned with existing corruption handling.
> 
> **Overview**
> **HNSW index load** now treats duplicate internal node IDs as corruption during `hnsw_deserialize_index()`’s ID→pointer table build, jumping to the existing `corrupted` path so **RESTORE/RDB/replication** fails instead of building an inconsistent graph.
> 
> Crafted payloads could reuse the same ID on multiple nodes so reciprocity checks passed on **IDs** while link resolution picked the **first** matching node, leaving dangling pointers after deletes and a **use-after-free** (server crash).
> 
> A new regression test **`restore_dup_hnsw_id.py`** builds a malicious Vector Set DUMP with duplicate IDs, asserts **RESTORE** is rejected, and confirms the server stays healthy with a valid DUMP round-trip control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a829c929dc59d6efb86f1b6bcc7d94f81f5e3f20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->