### PR TITLE
Fix AOF rewrite crash on module types with a NULL aof_rewrite callback

### DIFF
--- a/modules/vector-sets/tests/aof_rewrite.py
+++ b/modules/vector-sets/tests/aof_rewrite.py
@@ -1,0 +1,50 @@
+from test import TestCase
+import time
+
+class AOFRewriteWithoutCallback(TestCase):
+    def getname(self):
+        return "AOF rewrite of a vector set without aof_rewrite fails gracefully"
+
+    def _wait_rewrite_done(self, timeout=30):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            info = self.redis.info('persistence')
+            if (info.get('aof_rewrite_in_progress') == 0 and
+                info.get('aof_rewrite_scheduled') == 0):
+                return info
+            time.sleep(0.1)
+        raise AssertionError("AOF rewrite did not complete in time")
+
+    def test(self):
+        # Vector Sets register their module data type with a NULL aof_rewrite
+        # callback. A pure AOF rewrite (no RDB preamble) used to dereference
+        # that NULL pointer and crash the rewrite child process (#15387).
+        original_appendonly = self.redis.config_get('appendonly')['appendonly']
+        original_preamble = \
+            self.redis.config_get('aof-use-rdb-preamble')['aof-use-rdb-preamble']
+        try:
+            # Enable AOF with the RDB preamble still on, so the initial
+            # rewrite triggered by enabling it succeeds.
+            self.redis.config_set('appendonly', 'yes')
+            info = self._wait_rewrite_done()
+            assert info['aof_last_bgrewrite_status'] == 'ok', \
+                "Initial AOF rewrite with RDB preamble should succeed"
+
+            self.redis.config_set('aof-use-rdb-preamble', 'no')
+            self.redis.execute_command('VADD', self.test_key,
+                                       'VALUES', 3, 1, 2, 3, 'elem1')
+
+            self.redis.execute_command('BGREWRITEAOF')
+            info = self._wait_rewrite_done()
+
+            # The rewrite must fail with an error instead of crashing the
+            # rewrite child, and the server must stay fully functional.
+            assert info['aof_last_bgrewrite_status'] == 'err', \
+                "AOF rewrite of a type without aof_rewrite should fail"
+            assert self.redis.ping(), "Server should still be responsive"
+            assert self.redis.execute_command('TYPE', self.test_key) == \
+                b'vectorset', "Vector set should still be intact"
+        finally:
+            self.redis.delete(self.test_key)
+            self.redis.config_set('aof-use-rdb-preamble', original_preamble)
+            self.redis.config_set('appendonly', original_appendonly)

--- a/src/aof.c
+++ b/src/aof.c
@@ -2501,8 +2501,7 @@ int rewriteModuleObject(rio *r, robj *key, robj *o, int dbid) {
     if (mt->aof_rewrite == NULL) {
         serverLog(LL_WARNING,
             "Can't rewrite the append only file: the module data type '%s' "
-            "does not implement the aof_rewrite callback. Enable "
-            "aof-use-rdb-preamble to rewrite the AOF for this data type.",
+            "does not implement the aof_rewrite callback.",
             mt->entity.name);
         return 0;
     }

--- a/src/aof.c
+++ b/src/aof.c
@@ -2495,6 +2495,20 @@ int rewriteModuleObject(rio *r, robj *key, robj *o, int dbid) {
     RedisModuleIO io;
     moduleValue *mv = o->ptr;
     moduleType *mt = mv->type;
+    /* The aof_rewrite callback is optional for a module data type. Calling it
+     * when it is NULL would crash the child process performing the AOF
+     * rewrite, so fail the rewrite with a clear error instead. Data of such a
+     * type is still persisted through the RDB preamble (aof-use-rdb-preamble
+     * yes, the default) and through the verbatim commands already appended to
+     * the incremental AOF; only rewriting the base file is not possible. */
+    if (mt->aof_rewrite == NULL) {
+        serverLog(LL_WARNING,
+            "Can't rewrite the append only file: the module data type '%s' "
+            "does not implement the aof_rewrite callback. Enable "
+            "aof-use-rdb-preamble to rewrite the AOF for this data type.",
+            mt->entity.name);
+        return 0;
+    }
     moduleInitIOContext(&io, &mt->entity, r, key, dbid);
     mt->aof_rewrite(&io,key,mv->value);
     if (io.ctx) {

--- a/src/aof.c
+++ b/src/aof.c
@@ -2497,10 +2497,7 @@ int rewriteModuleObject(rio *r, robj *key, robj *o, int dbid) {
     moduleType *mt = mv->type;
     /* The aof_rewrite callback is optional for a module data type. Calling it
      * when it is NULL would crash the child process performing the AOF
-     * rewrite, so fail the rewrite with a clear error instead. Data of such a
-     * type is still persisted through the RDB preamble (aof-use-rdb-preamble
-     * yes, the default) and through the verbatim commands already appended to
-     * the incremental AOF; only rewriting the base file is not possible. */
+     * rewrite, so fail the rewrite with a clear error instead. */
     if (mt->aof_rewrite == NULL) {
         serverLog(LL_WARNING,
             "Can't rewrite the append only file: the module data type '%s' "

--- a/src/aof.c
+++ b/src/aof.c
@@ -2501,7 +2501,8 @@ int rewriteModuleObject(rio *r, robj *key, robj *o, int dbid) {
     if (mt->aof_rewrite == NULL) {
         serverLog(LL_WARNING,
             "Can't rewrite the append only file: the module data type '%s' "
-            "does not implement the aof_rewrite callback.",
+            "does not implement the aof_rewrite callback. Enable "
+            "aof-use-rdb-preamble to rewrite the AOF for this data type.",
             mt->entity.name);
         return 0;
     }

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -913,4 +913,33 @@ tags {"aof external:skip"} {
             assert {[$client get foo] eq "6"}
         }
     }
+
+    start_server {overrides {appendonly yes aof-use-rdb-preamble no auto-aof-rewrite-percentage 0}} {
+        # Vector Sets are the module type used to exercise this path. They can be
+        # excluded from the build (SKIP_VEC_SETS=yes, e.g. 32-bit builds), so run
+        # this test only when the VADD command is available.
+        if {[server_has_command vadd]} {
+            test "AOF rewrite of a module type without aof_rewrite fails gracefully" {
+                # Vector Sets register their module data type with a NULL
+                # aof_rewrite callback. A pure AOF rewrite (no RDB preamble) used
+                # to dereference that NULL pointer and crash the rewrite child
+                # process (#15387).
+                r VADD vk VALUES 3 1 2 3 elem1
+                assert_equal "vectorset" [r type vk]
+
+                set loglines [count_log_lines 0]
+                r bgrewriteaof
+                waitForBgrewriteaof r
+
+                # The server must stay up and the child must not die by signal.
+                assert_equal {PONG} [r ping]
+                assert_equal 1 [is_alive [srv pid]]
+                assert_equal 0 [count_log_message 0 "terminated by signal"]
+
+                # Instead, the rewrite fails with a clear, actionable error.
+                assert_equal "err" [status r aof_last_bgrewrite_status]
+                verify_log_message 0 "*does not implement the aof_rewrite callback*" $loglines
+            }
+        }
+    }
 }

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -913,33 +913,4 @@ tags {"aof external:skip"} {
             assert {[$client get foo] eq "6"}
         }
     }
-
-    start_server {overrides {appendonly yes aof-use-rdb-preamble no auto-aof-rewrite-percentage 0}} {
-        # Vector Sets are the module type used to exercise this path. They can be
-        # excluded from the build (SKIP_VEC_SETS=yes, e.g. 32-bit builds), so run
-        # this test only when the VADD command is available.
-        if {[server_has_command vadd]} {
-            test "AOF rewrite of a module type without aof_rewrite fails gracefully" {
-                # Vector Sets register their module data type with a NULL
-                # aof_rewrite callback. A pure AOF rewrite (no RDB preamble) used
-                # to dereference that NULL pointer and crash the rewrite child
-                # process (#15387).
-                r VADD vk VALUES 3 1 2 3 elem1
-                assert_equal "vectorset" [r type vk]
-
-                set loglines [count_log_lines 0]
-                r bgrewriteaof
-                waitForBgrewriteaof r
-
-                # The server must stay up and the child must not die by signal.
-                assert_equal {PONG} [r ping]
-                assert_equal 1 [is_alive [srv pid]]
-                assert_equal 0 [count_log_message 0 "terminated by signal"]
-
-                # Instead, the rewrite fails with a clear, actionable error.
-                assert_equal "err" [status r aof_last_bgrewrite_status]
-                verify_log_message 0 "*does not implement the aof_rewrite callback*" $loglines
-            }
-        }
-    }
 }


### PR DESCRIPTION
Fixes #15387.

## Problem

The `aof_rewrite` method is optional for a module data type. The built-in
Vector Set type registers its type with `aof_rewrite = NULL`
(`modules/vector-sets/vset.c`). During a *pure* AOF rewrite
(`aof-use-rdb-preamble no`), `rewriteModuleObject()` in `src/aof.c` invoked
that callback unconditionally:

```c
mt->aof_rewrite(&io, key, mv->value);   // mt->aof_rewrite == NULL
```
so a database containing a Vector Set key crashed the AOF rewrite child
process with a NULL-pointer dereference (SIGSEGV). The parent process
survives, but aof_last_bgrewrite_status becomes err and AOF
compaction/rewrite stays broken. An authenticated client that can run
VADD and trigger BGREWRITEAOF can keep the AOF rewrite failing.

## Fix

Guard the call in rewriteModuleObject(): if aof_rewrite is NULL, log a
clear, actionable error and fail the rewrite (exactly as the code already
does for other rewrite errors) instead of dereferencing the NULL pointer.
The guard applies to any module type, not just Vector Sets.

This does not lose data. A type without an aof_rewrite callback is still
persisted through the RDB preamble (aof-use-rdb-preamble yes, the default)
and through the verbatim commands already appended to the incremental AOF.
Only rewriting the AOF base file in pure-AOF mode is not possible, and the
log message now says so and points to aof-use-rdb-preamble.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence rewrite paths for all module types in pure-AOF mode; behavior change is intentional failure instead of crash, with low data-loss risk when RDB preamble or incremental AOF is used.
> 
> **Overview**
> Fixes a **SIGSEGV in the AOF rewrite child** when a pure AOF rewrite (`aof-use-rdb-preamble no`) encounters module keys whose type omits the optional `aof_rewrite` callback (e.g. Vector Sets).
> 
> `rewriteModuleObject()` now **checks for a NULL `aof_rewrite`**, logs a warning that names the module type and suggests enabling `aof-use-rdb-preamble`, and **fails the rewrite** like other rewrite errors instead of calling through NULL.
> 
> A **vector-sets integration test** enables AOF, turns off the RDB preamble, adds a vector set key, runs `BGREWRITEAOF`, and asserts `aof_last_bgrewrite_status` is `err` while the server and key remain usable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d94dbcf4faf5b69d459c271d9fbed97a86ae327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->