### PR TITLE
Remove single-use dictForEach macro

### DIFF
--- a/src/dict.h
+++ b/src/dict.h
@@ -318,19 +318,6 @@ void dictSetUnsignedIntegerVal(dictEntry *de, uint64_t val);
 uint64_t dictIncrUnsignedIntegerVal(dictEntry *de, uint64_t val);
 uint64_t dictGetUnsignedIntegerVal(const dictEntry *de);
 
-#define dictForEach(d, ty, m, ...) do { \
-    dictIterator di; \
-    dictEntry *de; \
-    dictInitIterator(&di, d); \
-    while ((de = dictNext(&di)) != NULL) { \
-        ty *m = dictGetVal(de); \
-        do { \
-            __VA_ARGS__ \
-        } while(0); \
-    } \
-    dictResetIterator(&di); \
-} while(0);
-
 #ifdef REDIS_TEST
 int dictTest(int argc, char *argv[], int flags);
 #endif

--- a/src/module.c
+++ b/src/module.c
@@ -15571,22 +15571,32 @@ int moduleDefragValue(robj *key, robj *value, int dbid) {
 
 /* Call registered module API defrag start functions */
 void moduleDefragStart(void) {
-    dictForEach(modules, struct RedisModule, module, 
+    dictIterator di;
+    dictEntry *de;
+    dictInitIterator(&di, modules);
+    while ((de = dictNext(&di)) != NULL) {
+        struct RedisModule *module = dictGetVal(de);
         if (module->defrag_start_cb) {
             RedisModuleDefragCtx defrag_ctx = INIT_MODULE_DEFRAG_CTX(0, NULL, NULL, -1);
             module->defrag_start_cb(&defrag_ctx);
         }
-    );
+    }
+    dictResetIterator(&di);
 }
 
 /* Call registered module API defrag end functions */
 void moduleDefragEnd(void) {
-    dictForEach(modules, struct RedisModule, module, 
+    dictIterator di;
+    dictEntry *de;
+    dictInitIterator(&di, modules);
+    while ((de = dictNext(&di)) != NULL) {
+        struct RedisModule *module = dictGetVal(de);
         if (module->defrag_end_cb) {
             RedisModuleDefragCtx defrag_ctx = INIT_MODULE_DEFRAG_CTX(0, NULL, NULL, -1);
             module->defrag_end_cb(&defrag_ctx);
         }
-    );
+    }
+    dictResetIterator(&di);
 }
 
 /* Returns the name of the key currently being processed.


### PR DESCRIPTION
The `dictForEach` macro (in `dict.h`) was used in only two places, both in `module.c` (`moduleDefragStart`/`moduleDefragEnd`, iterating the `modules` dict). It diverged from the plain `dictInitIterator`/`dictNext`/`dictResetIterator` idiom used ~286 times elsewhere in the codebase, hid control flow inside a `__VA_ARGS__` body (awkward for debugging, breaks on a top-level comma), and carried a non-idiomatic trailing semicolon.

This PR inlines both call sites with the standard iteration pattern and removes the macro. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)