### PR TITLE
Reject invalid flags for string module configs

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -14360,7 +14360,7 @@ unsigned int maskModuleEnumConfigFlags(unsigned int flags) {
  * * EALREADY: The provided configuration name is already used. */
 int RM_RegisterStringConfig(RedisModuleCtx *ctx, const char *name, const char *default_val, unsigned int flags, RedisModuleConfigGetStringFunc getfn, RedisModuleConfigSetStringFunc setfn, RedisModuleConfigApplyFunc applyfn, void *privdata) {
     RedisModule *module = ctx->module;
-    if (moduleConfigValidityCheck(module, name, flags, NUMERIC_CONFIG)) {
+    if (moduleConfigValidityCheck(module, name, flags, STRING_CONFIG)) {
         return REDISMODULE_ERR;
     }
     

--- a/tests/modules/moduleconfigs.c
+++ b/tests/modules/moduleconfigs.c
@@ -1,4 +1,5 @@
 #include "redismodule.h"
+#include <errno.h>
 #include <string.h>
 #include <strings.h>
 #include <assert.h>
@@ -203,6 +204,28 @@ void cleanup(RedisModuleCtx *ctx) {
     }
 }
 
+int verifyInvalidStringConfigFlags(RedisModuleCtx *ctx) {
+    errno = 0;
+    if (RedisModule_RegisterStringConfig(ctx, "memory-string", "secret password", REDISMODULE_CONFIG_MEMORY,
+                                         getStringConfigCommand, setStringConfigCommand, NULL, NULL) != REDISMODULE_ERR ||
+        errno != EINVAL)
+    {
+        RedisModule_Log(ctx, "warning", "String config with REDISMODULE_CONFIG_MEMORY was not rejected with EINVAL");
+        return REDISMODULE_ERR;
+    }
+
+    errno = 0;
+    if (RedisModule_RegisterStringConfig(ctx, "bitflags-string", "secret password", REDISMODULE_CONFIG_BITFLAGS,
+                                         getStringConfigCommand, setStringConfigCommand, NULL, NULL) != REDISMODULE_ERR ||
+        errno != EINVAL)
+    {
+        RedisModule_Log(ctx, "warning", "String config with REDISMODULE_CONFIG_BITFLAGS was not rejected with EINVAL");
+        return REDISMODULE_ERR;
+    }
+
+    return REDISMODULE_OK;
+}
+
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
@@ -210,6 +233,11 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_Init(ctx, "moduleconfigs", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR) {
         RedisModule_Log(ctx, "warning", "Failed to init module");
         return REDISMODULE_ERR;
+    }
+
+    size_t len;
+    if (argc && !strcasecmp(RedisModule_StringPtrLen(argv[0], &len), "invalid-flags")) {
+        return verifyInvalidStringConfigFlags(ctx);
     }
 
     if (RedisModule_RegisterBoolConfig(ctx, "mutable_bool", 1, REDISMODULE_CONFIG_DEFAULT, getBoolConfigCommand, setBoolConfigCommand, boolApplyFunc, &mutable_bool_val) == REDISMODULE_ERR) {
@@ -276,7 +304,6 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     }
 
     RedisModule_Log(ctx, "debug", "Registered configuration");
-    size_t len;
     if (argc && !strcasecmp(RedisModule_StringPtrLen(argv[0], &len), "noload")) {
         return REDISMODULE_OK;
     } else if (argc && !strcasecmp(RedisModule_StringPtrLen(argv[0], &len), "override-default")) {

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -2,6 +2,11 @@ set testmodule [file normalize tests/modules/moduleconfigs.so]
 set testmoduletwo [file normalize tests/modules/moduleconfigstwo.so]
 
 start_server {tags {"modules external:skip"}} {
+    test {String config registration rejects invalid type-specific flags} {
+        r module load $testmodule invalid-flags
+        r module unload moduleconfigs
+    }
+
     r module load $testmodule
     test {Config get commands work} {
         # Make sure config get module config works
@@ -383,4 +388,3 @@ start_server {tags {"modules external:skip"}} {
         r module unload moduleconfigs
     }
 }
-


### PR DESCRIPTION

## Issue

`RM_RegisterStringConfig()` passed `NUMERIC_CONFIG` into module config validation, so string configs could incorrectly accept numeric-only flags such as `REDISMODULE_CONFIG_MEMORY` instead of returning `REDISMODULE_ERR` with `errno == EINVAL`.

## Change

Use `STRING_CONFIG` when validating string config registration.

Add module API coverage that loads `moduleconfigs` in an `invalid-flags` mode and verifies string configs reject type-specific flags that do not apply to strings.

## Test

CI with command `--single unit/moduleapi/moduleconfigs`: https://github.com/vitahlin/redis/actions/runs/28933035991/job/85836553702


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line validation fix in module config registration plus test coverage; no runtime behavior change for correctly registered string configs.
> 
> **Overview**
> Fixes **`RM_RegisterStringConfig`** so registration validation uses **`STRING_CONFIG`** instead of **`NUMERIC_CONFIG`**, so numeric-only flags (e.g. **`REDISMODULE_CONFIG_MEMORY`**) are rejected with **`REDISMODULE_ERR`** and **`errno == EINVAL`** instead of being accepted for string configs.
> 
> Adds **`invalid-flags`** load mode on the **`moduleconfigs`** test module and a unit test that verifies **`REDISMODULE_CONFIG_MEMORY`** and **`REDISMODULE_CONFIG_BITFLAGS`** are rejected for string registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ca38f6e2718ca1f62dff0a007b81a7a6e0be325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->