### PR TITLE
redis-benchmark: keep contended request counters off read-mostly cache lines

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -67,10 +67,15 @@ static struct config {
     int numclients;
     redisAtomic int liveclients;
     int requests;
-    redisAtomic int requests_issued;
+    /* Every client thread does an RFO on these counters for each request
+     * issued and each reply consumed. Keep them on a dedicated cache line
+     * so the resulting coherence traffic does not keep invalidating the
+     * read-mostly fields (requests, pipeline) that the same hot paths
+     * read on every operation. */
+    redisAtomic int requests_issued __attribute__((aligned(CACHE_LINE_SIZE)));
     redisAtomic int requests_finished;
     redisAtomic int previous_requests_finished;
-    int last_printed_bytes;
+    int last_printed_bytes __attribute__((aligned(CACHE_LINE_SIZE)));
     long long previous_tick;
     int keysize;
     int datasize;


### PR DESCRIPTION
`requests_issued` and `requests_finished` take a cache-line RFO from every client thread on every request issued and every reply consumed. They currently share a cache line with `requests`, and depending on build layout, `pipeline` as well, which are fields that are read only after init but read by those same hot paths on every operation:

```
/* pahole -C config, x86-64 gcc -O3, before */
/* --- cacheline 2 boundary (128 bytes) --- */
int          requests;                    /*  128  4 */
_Atomic int  requests_issued;             /*  132  4 */
_Atomic int  requests_finished;           /*  136  4 */
_Atomic int  previous_requests_finished;  /*  140  4 */
...
int          pipeline;                    /*  180  4 */
```

Each counter increment invalidates that line in every other worker's cache, so the read-mostly stop bounds are re-fetched millions of times per second despite never changing. At 2.4M rps that is  approx 5M invalidations/sec against fields every thread reads per operation. Since redis-benchmark is the measuring instrument, its own coherence traffic is instrument error. That is, it grows with `--threads` and matters most exactly when server latency is lowest.

This patch places the three counters on a dedicated cache line, using the same `CACHE_LINE_SIZE` idiom already in the tree (`zmalloc.c` `used_memory`, `server.h` `IOThread`). After:

```
/* --- cacheline 3 boundary (192 bytes) --- */
_Atomic int  requests_issued;             /*  192  4 */
_Atomic int  requests_finished;           /*  196  4 */
_Atomic int  previous_requests_finished;  /*  200  4 */
/* requests and pipeline no longer share a line with any write-hot field */
```

Scope note: this removes the false-sharing component. The counters themselves still ping pong between writers; eliminating that would need per thread counters and a change to the stop condition, which is out of scope here.

Found by a static cache layout analyzer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only struct layout and comments; no protocol, server, or behavioral changes beyond reduced measurement noise.
> 
> **Overview**
> **redis-benchmark** layout change: per-thread atomic **`requests_issued`** / **`requests_finished`** traffic no longer shares cache lines with read-mostly **`requests`** and **`pipeline`**, which every client hits on each send/receive.
> 
> The patch adds a short comment and applies **`CACHE_LINE_SIZE`** alignment (same pattern as elsewhere in the tree) so write-heavy counters sit on their own line and stop invalidating neighbors during high **`--threads`** runs. **`last_printed_bytes`** is also aligned to avoid mixing with other hot fields. Logic and stop conditions are unchanged; only struct padding/layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee79f93dc56e586fae809365cfce7e4ce0e2bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->