### PR TITLE
kk

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -8,7 +8,7 @@
  * Licensed under your choice of (a) the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).
- */
+ */ 
 
 #include "server.h"
 #include "cluster.h"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment-only whitespace in a non-security-critical file; no executable code affected.
> 
> **Overview**
> Adds a trailing space after the closing `*/` on the license block comment at the top of `acl.c`. No ACL logic, APIs, or runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d852e688487474dbaeb12cc227106c493477297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->