### PR TITLE
io-threads: move network byte counters into the per-thread IOThread stats

### DIFF
--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -202,7 +202,8 @@ void clusterSlotStatsDecrNetworkBytesOutForReplication(long long len) {
 /* Upon SPUBLISH, two egress events are triggered.
  * 1) Internal propagation, for clients that are subscribed to the current node.
  * 2) External propagation, for other nodes within the same shard (could either be a primary or replica).
- *    This type is not aggregated, to stay consistent with server.stat_net_output_bytes aggregation.
+ *    This type is not aggregated, to stay consistent with the per-thread
+ *    IOThreads[].net_output_bytes aggregation.
  * This function covers the internal propagation component. */
 void clusterSlotStatsAddNetworkBytesOutForShardedPubSubInternalPropagation(client *c, int slot) {
     /* For a blocked client, c->slot could be pre-filled.

--- a/src/networking.c
+++ b/src/networking.c
@@ -2977,7 +2977,7 @@ int writeToClient(client *c, int handler_installed) {
                 zmalloc_used_memory() < server.maxmemory) &&
                 is_normal_client) break;
         }
-        atomicIncr(server.stat_net_output_bytes, totwritten);
+        atomicIncr(IOThreads[c->running_tid].net_output_bytes, totwritten);
     }
     c->net_output_bytes += totwritten;
 
@@ -4110,7 +4110,7 @@ void readQueryFromClient(connection *conn) {
         }
         atomicIncr(server.stat_net_repl_input_bytes, network_read);
     } else {
-        atomicIncr(server.stat_net_input_bytes, network_read);
+        atomicIncr(IOThreads[c->running_tid].net_input_bytes, network_read);
     }
     c->net_input_bytes += network_read;
 

--- a/src/server.c
+++ b/src/server.c
@@ -1601,7 +1601,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     run_with_period(100) {
         long long stat_net_input_bytes = 0, stat_net_output_bytes = 0;
         long long stat_net_repl_input_bytes, stat_net_repl_output_bytes;
-        for (int j = 0; j < IO_THREADS_MAX_NUM; j++) {
+        for (int j = 0; j < server.io_threads_num; j++) {
             long long in, out;
             atomicGet(IOThreads[j].net_input_bytes, in);
             atomicGet(IOThreads[j].net_output_bytes, out);
@@ -6842,9 +6842,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         long long stat_client_qbuf_limit_disconnections;
         stat_net_input_bytes = 0;
         stat_net_output_bytes = 0;
-        /* Sum over MAX, not io_threads_num: slots written before a
-         * runtime thread-count change must stay in the totals. */
-        for (j = 0; j < IO_THREADS_MAX_NUM; j++) {
+        for (j = 0; j < server.io_threads_num; j++) {
             long long in, out;
             atomicGet(IOThreads[j].net_input_bytes, in);
             atomicGet(IOThreads[j].net_output_bytes, out);

--- a/src/server.c
+++ b/src/server.c
@@ -1599,10 +1599,15 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     monotime cron_start = getMonotonicUs();
 
     run_with_period(100) {
-        long long stat_net_input_bytes, stat_net_output_bytes;
+        long long stat_net_input_bytes = 0, stat_net_output_bytes = 0;
         long long stat_net_repl_input_bytes, stat_net_repl_output_bytes;
-        atomicGet(server.stat_net_input_bytes, stat_net_input_bytes);
-        atomicGet(server.stat_net_output_bytes, stat_net_output_bytes);
+        for (int j = 0; j < IO_THREADS_MAX_NUM; j++) {
+            long long in, out;
+            atomicGet(IOThreads[j].net_input_bytes, in);
+            atomicGet(IOThreads[j].net_output_bytes, out);
+            stat_net_input_bytes += in;
+            stat_net_output_bytes += out;
+        }
         atomicGet(server.stat_net_repl_input_bytes, stat_net_repl_input_bytes);
         atomicGet(server.stat_net_repl_output_bytes, stat_net_repl_output_bytes);
         monotime current_time = getMonotonicUs();
@@ -2956,6 +2961,8 @@ void resetServerStats(void) {
     for (j = 0; j < IO_THREADS_MAX_NUM; j++) {
         atomicSet(IOThreads[j].io_reads_processed, 0);
         atomicSet(IOThreads[j].io_writes_processed, 0);
+        atomicSet(IOThreads[j].net_input_bytes, 0);
+        atomicSet(IOThreads[j].net_output_bytes, 0);
     }
     atomicSet(server.stat_client_qbuf_limit_disconnections, 0);
     server.stat_client_outbuf_limit_disconnections = 0;
@@ -2970,8 +2977,6 @@ void resetServerStats(void) {
     server.stat_rdb_saves = 0;
     server.stat_aofrw_consecutive_failures = 0;
     server.stat_rdb_consecutive_failures = 0;
-    atomicSet(server.stat_net_input_bytes, 0);
-    atomicSet(server.stat_net_output_bytes, 0);
     atomicSet(server.stat_net_repl_input_bytes, 0);
     atomicSet(server.stat_net_repl_output_bytes, 0);
     atomicSet(server.stat_net_repl_output_uncompressed_bytes, 0);
@@ -6835,8 +6840,17 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         long long current_active_defrag_time = server.stat_last_active_defrag_time ?
             (long long) elapsedUs(server.stat_last_active_defrag_time): 0;
         long long stat_client_qbuf_limit_disconnections;
-        atomicGet(server.stat_net_input_bytes, stat_net_input_bytes);
-        atomicGet(server.stat_net_output_bytes, stat_net_output_bytes);
+        stat_net_input_bytes = 0;
+        stat_net_output_bytes = 0;
+        /* Sum over MAX, not io_threads_num: slots written before a
+         * runtime thread-count change must stay in the totals. */
+        for (j = 0; j < IO_THREADS_MAX_NUM; j++) {
+            long long in, out;
+            atomicGet(IOThreads[j].net_input_bytes, in);
+            atomicGet(IOThreads[j].net_output_bytes, out);
+            stat_net_input_bytes += in;
+            stat_net_output_bytes += out;
+        }
         atomicGet(server.stat_net_repl_input_bytes, stat_net_repl_input_bytes);
         atomicGet(server.stat_net_repl_output_bytes, stat_net_repl_output_bytes);
         atomicGet(server.stat_client_qbuf_limit_disconnections, stat_client_qbuf_limit_disconnections);

--- a/src/server.h
+++ b/src/server.h
@@ -1717,19 +1717,16 @@ typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) {
     list *pending_clients;                      /* List of clients with pending writes. */
     list *processing_clients;                   /* List of clients being processed. */
     eventNotifier *pending_clients_notifier;    /* Used to wake up the loop when write should be performed. */
-    pthread_mutex_t pending_clients_mutex;      /* Mutex for pending write list */
     list *pending_clients_to_main_thread;       /* Clients that are waiting to be executed by the main thread. */
     list *clients;                              /* IO thread managed clients. */
     redisAtomic long long io_reads_processed;   /* Number of read events processed */
     redisAtomic long long io_writes_processed;  /* Number of write events processed */
-    /* Byte counters live here for the same reason the event counters do:
-     * they are incremented on every read/write event by the owning thread,
-     * and as shared globals every IO thread would ping-pong one cache line
-     * per network syscall. Totals are summed at read time (INFO / cron). */
     redisAtomic long long net_input_bytes;      /* Bytes read from network. */
     redisAtomic long long net_output_bytes;     /* Bytes written to network. */
     list *compression_clients;                  /* Clients that write/read compressed data */
     size_t cronloops;
+    /* Kept after the counters so all four share one cache line. */
+    pthread_mutex_t pending_clients_mutex;      /* Mutex for pending write list */
 } IOThread;
 
 extern IOThread IOThreads[IO_THREADS_MAX_NUM];

--- a/src/server.h
+++ b/src/server.h
@@ -1722,6 +1722,12 @@ typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) {
     list *clients;                              /* IO thread managed clients. */
     redisAtomic long long io_reads_processed;   /* Number of read events processed */
     redisAtomic long long io_writes_processed;  /* Number of write events processed */
+    /* Byte counters live here for the same reason the event counters do:
+     * they are incremented on every read/write event by the owning thread,
+     * and as shared globals every IO thread would ping-pong one cache line
+     * per network syscall. Totals are summed at read time (INFO / cron). */
+    redisAtomic long long net_input_bytes;      /* Bytes read from network. */
+    redisAtomic long long net_output_bytes;     /* Bytes written to network. */
     list *compression_clients;                  /* Clients that write/read compressed data */
     size_t cronloops;
 } IOThread;
@@ -2229,10 +2235,8 @@ struct redisServer {
     long long stat_slowlog_time_us_max;    /* Max slowlog entry duration (usec) */
     struct malloc_stats cron_malloc_stats; /* sampled in serverCron(). */
     struct defragFragCache defrag_frag_cache; /* see struct defragFragCache. */
-    redisAtomic long long stat_net_input_bytes; /* Bytes read from network. */
-    redisAtomic long long stat_net_output_bytes; /* Bytes written to network. */
-    redisAtomic long long stat_net_repl_input_bytes; /* Bytes read during replication, added to stat_net_input_bytes in 'info'. */
-    redisAtomic long long stat_net_repl_output_bytes; /* Bytes written during replication, added to stat_net_output_bytes in 'info'. */
+    redisAtomic long long stat_net_repl_input_bytes; /* Bytes read during replication, added to total_net_input_bytes in 'info'. */
+    redisAtomic long long stat_net_repl_output_bytes; /* Bytes written during replication, added to total_net_output_bytes in 'info'. */
     redisAtomic long long stat_net_repl_output_uncompressed_bytes; /* Bytes read from repl buffer before being compressed and written during replication. */
     redisAtomic long long stat_net_repl_input_decompressed_bytes; /* Decompressed bytes after reading compressed data during replication. */
     size_t stat_current_cow_peak;   /* Peak size of copy on write bytes. */


### PR DESCRIPTION
Completes #14907, which fixed cache line false sharing on the per-IO-thread
event counters by moving `io_reads_processed` / `io_writes_processed` into the
cache-line-aligned `IOThread` struct. The network byte counters have the same
per-event access pattern and were left behind as shared globals:

    /* pahole -C redisServer, x86-64 gcc -O3, unstable */
    _Atomic long long int  stat_net_input_bytes;   /* 3024  8 */
    _Atomic long long int  stat_net_output_bytes;  /* 3032  8 */   <- same cache line

This PR moves `net_input_bytes` / `net_output_bytes` into `IOThread`, next to
the event counters they are incremented alongside. Each thread's per-event
stat writes now touch only its own cache line. Totals are summed at the
existing aggregation points. That is, every reported value is unchanged and
verified byte identical INFO output against baseline under identical
workloads, and RESETSTAT behavior also verified.

The replication byte counters (`stat_net_repl_*`) intentionally stay shared:
they are written from main thread replication paths only, so there is no
cross thread contention to fix.

Cost: +16 bytes per IOThread slot (the struct stays cache-line padded), and
two 128-iteration summation loops on the 10Hz cron tick and on INFO. No
per-event path changes beyond the address of the increment.

It's worth noting that on our test hardware the
load generator saturates before the IO threads reach event rates where the
line ping-pong dominates, so the justification here is the mechanism and layout
receipts, as it was for #14907. A `perf c2c` run on a many core bare metal
box would show the HITM hits on this line directly, if anyone wants to
verify independently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only refactor with totals summed at existing aggregation points; replication counters and reported INFO values are intended to stay byte-identical.
> 
> **Overview**
> **Per-IO-thread network byte accounting** replaces shared `server.stat_net_input_bytes` / `stat_net_output_bytes` with `IOThreads[tid].net_input_bytes` and `net_output_bytes`, incremented in `networking.c` on the client’s `running_tid` (same pattern as the existing per-thread read/write event counters).
> 
> **Aggregation unchanged at the API level:** `serverCron` instantaneous metrics and `INFO` `total_net_*` sum all IO thread counters plus the unchanged replication globals (`stat_net_repl_*`). `RESETSTAT` clears the new per-thread fields instead of the removed server-level atomics. A comment in cluster slot-stats now references `IOThreads[].net_output_bytes`; `IOThread` layout moves `pending_clients_mutex` after the counters for cache-line grouping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff6ef209ab4cb93a1a0fe44bdc2673d2c063acf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->