### PR TITLE
Skip unready fds in select event backend

### DIFF
--- a/src/ae_select.c
+++ b/src/ae_select.c
@@ -74,6 +74,7 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
                 mask |= AE_READABLE;
             if (fe->mask & AE_WRITABLE && FD_ISSET(j,&state->_wfds))
                 mask |= AE_WRITABLE;
+            if (mask == AE_NONE) continue;
             eventLoop->fired[numevents].fd = j;
             eventLoop->fired[numevents].mask = mask;
             numevents++;


### PR DESCRIPTION

## Issue

After `select()` returns, the select backend loops over all registered fds to find the ones that are ready. It already skips fds that are not registered, but it did not skip registered fds that were not ready in the current `select()` result.

Those fds have a computed mask of `AE_NONE`. They do not trigger any read/write callback, but adding them to `eventLoop->fired` still makes `aeProcessEvents()` count them as processed events.

## Change

Skip fds whose computed mask is `AE_NONE` before adding them to `eventLoop->fired`.

This makes the select backend only report fds that are actually ready.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line guard in the select polling path only; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes the **select**-based event loop backend so it no longer enqueues registered file descriptors that `select()` did not mark ready.
> 
> After `select()` returns, the backend already ignored unregistered fds but still appended registered fds whose read/write bits were not set, with mask `AE_NONE`. Those entries did not run callbacks but still increased `numevents`, so `aeProcessEvents()` could treat them as handled events. A single **`continue`** when `mask == AE_NONE` aligns behavior with backends like epoll, which only report actually-ready fds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53dfd2a45a929742d1346a4df455f2d134e5db84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->