### PR TITLE
Feed replicas mid command-stream under heavy write load

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2936,6 +2936,9 @@ int handleClientsWithPendingWrites(void) {
             installClientWriteHandler(c);
         }
     }
+    /* Record the flushed offset so flushSlavesOutputBuffersIfNeeded() only
+     * fires when a single event loop accumulates more than the threshold. */
+    server.repl_last_flush_offset = server.master_repl_offset;
     return processed;
 }
 
@@ -5429,6 +5432,33 @@ void flushSlavesOutputBuffers(void) {
         {
             writeToClient(slave,0);
         }
+    }
+    /* Record the flushed offset for flushSlavesOutputBuffersIfNeeded(). */
+    server.repl_last_flush_offset = server.master_repl_offset;
+}
+
+/* Send pending data to replicas once ~1MB has built up, instead of waiting
+ * for beforeSleep, so a busy loop keeps feeding replicas as it goes rather
+ * than in one burst at the end.
+ *
+ * Normally we write to replicas only once per event loop, at beforeSleep.
+ * If one loop produces 10MB, the replica socket stays empty during the
+ * loop, then at beforeSleep we try to send all 10MB at once. The socket
+ * buffer only fits ~4MB, so 4MB is sent and 6MB waits, with a write handler
+ * installed for the rest. But that handler runs about once per loop and only
+ * sends another ~4MB, while every loop adds 10MB more, so the buffer keeps
+ * growing. It eventually hits the replica client-output-buffer-limit, the
+ * master drops the replica, and it has to full sync. Sending every ~1MB
+ * during the loop feeds the replica as data is produced, so the buffer stays
+ * small and the replica keeps up. */
+#define REPL_FLUSH_THRESHOLD (1024*1024)
+void flushSlavesOutputBuffersIfNeeded(void) {
+    /* Only with io threads off. When on, replicas are written from a separate 
+     * thread in parallel, so they keep up on their own even under load. */
+    if (server.io_threads_num <= 1 && listLength(server.slaves) &&
+        server.master_repl_offset - server.repl_last_flush_offset > REPL_FLUSH_THRESHOLD)
+    {
+        flushSlavesOutputBuffers();
     }
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -2691,6 +2691,8 @@ void readSyncBulkPayload(connection *conn) {
      * we are starting a new history. */
     memcpy(server.replid,server.master->replid,sizeof(server.replid));
     server.master_repl_offset = server.master->reploff;
+    /* The offset jumped, reset the flush marker */
+    server.repl_last_flush_offset = server.master_repl_offset;
     clearReplicationId2();
 
     /* Let's create the replication backlog if needed. Slaves need to

--- a/src/server.c
+++ b/src/server.c
@@ -2477,6 +2477,7 @@ void initServerConfig(void) {
     server.repl_down_since = 0; /* Never connected, repl is down since EVER. */
     server.repl_up_since = 0;
     server.master_repl_offset = 0;
+    server.repl_last_flush_offset = 0;
     server.fsynced_reploff_pending = 0;
     server.repl_stream_lastio = server.unixtime;
     server.repl_total_sync_attempts = 0;
@@ -3875,6 +3876,9 @@ void postExecutionUnitOperations(void) {
     /* If we are at the top-most call() and not inside a an active module
      * context (e.g. within a module timer) we can propagate what we accumulated. */
     propagatePendingCommands();
+
+    /* Feed replicas mid command-stream if enough has accumulated. */
+    flushSlavesOutputBuffersIfNeeded();
 
     /* Module subsystem post-execution-unit logic */
     modulePostExecutionUnitOperations();

--- a/src/server.h
+++ b/src/server.h
@@ -2382,6 +2382,7 @@ struct redisServer {
     int repl_ping_slave_period;     /* Master pings the slave every N seconds */
     replBacklog *repl_backlog;      /* Replication backlog for partial syncs */
     long long repl_backlog_size;    /* Backlog circular buffer size */
+    long long repl_last_flush_offset;  /* master_repl_offset at the last replica flush */
     long long repl_full_sync_buffer_limit; /* Accumulated repl data limit during rdb channel replication */
     replDataBuf repl_full_sync_buffer;  /* Accumulated replication data for rdb channel replication */
     time_t repl_backlog_time_limit; /* Time without slaves after the backlog
@@ -3313,6 +3314,7 @@ int getClientType(client *c);
 int getClientTypeByName(char *name);
 char *getClientTypeName(int class);
 void flushSlavesOutputBuffers(void);
+void flushSlavesOutputBuffersIfNeeded(void);
 void disconnectSlaves(void);
 void evictClients(void);
 int listenToPort(connListener *fds);


### PR DESCRIPTION
Send pending data to replicas once ~1MB has built up, instead of waiting for beforeSleep, so a busy loop keeps feeding replicas as it goes rather than in one burst at the end.

Normally we write to replicas only once per event loop, at beforeSleep. If one loop produces 10MB, the replica socket stays empty during the loop, then at beforeSleep we try to send all 10MB at once. The socket buffer only fits ~4MB, so 4MB is sent and 6MB waits, with a write handler installed for the rest. But that handler runs about once per loop and only sends another ~4MB, while every loop adds 10MB more, so the buffer keeps growing. It eventually hits the replica client-output-buffer-limit, the master drops the replica, and it has to full sync. Sending every ~1MB during the loop feeds the replica as data is produced, so the buffer stays small and the replica keeps up.

If io threads are enabled, this is not necessary. When on, replicas are written from a separate thread in parallel, so they keep up on their own even under load.

This scenario could be tested with a command like: 

```
memtier_benchmark --ratio 1:0 --data-size 500 --pipeline 50 --threads 8 --clients 50
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot replication write path during command execution, but reuses existing flush logic and is gated on io_threads_num <= 1.
> 
> **Overview**
> Under heavy write load with **IO threads disabled**, replica output used to flush only at **beforeSleep**, so one event loop could queue far more replication data than the socket could drain. Replica **client output buffers** could grow until the master disconnected them and forced a **full resync**.
> 
> This change tracks **`repl_last_flush_offset`** and calls **`flushSlavesOutputBuffersIfNeeded()`** from **`postExecutionUnitOperations()`** when **`master_repl_offset`** has advanced more than **~1MB** since the last flush. The marker is updated whenever **`flushSlavesOutputBuffers()`** runs (including the existing **beforeSleep** path) and is reset after a **full resync** when the replication offset jumps. The incremental flush is **skipped when IO threads are enabled**, since replicas are already written from a separate thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb4919ff53236e53568113de432b1d15e817bc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->