### PR TITLE
Add alloc_size callback to get module allocation size in O(1)

### DIFF
--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -2294,6 +2294,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         .rdb_load = VectorSetRdbLoad,
         .rdb_save = VectorSetRdbSave,
         .aof_rewrite = NULL,
+        .alloc_size = NULL,
         .mem_usage = VectorSetMemUsage,
         .free = VectorSetFree,
         .digest = VectorSetDigest

--- a/src/module.c
+++ b/src/module.c
@@ -4525,6 +4525,10 @@ int RM_SetAbsExpire(RedisModuleKey *key, mstime_t expire) {
  * * **defrag**: A callback function pointer for active defragmentation (optional).
  *   If the metadata contains pointers, this callback should defragment them.
  *
+ * * **alloc_size**: A callback function pointer for kvobjAllocSize() (optional).
+ *   Should return the allocated memory of the module value in O(1).
+ *   Unlike mem_usage, this callback must not perform sampling or traversal.
+ *
  * * **mem_usage**: A callback function pointer for MEMORY USAGE command (optional).
  *   Should return the memory used by the metadata in bytes.
  *
@@ -7438,6 +7442,7 @@ robj *moduleTypeDupOrReply(client *c, robj *fromkey, robj *tokey, int todb, robj
  *
  *             // Optional fields
  *             .digest = myType_DigestCallBack,
+ *             .alloc_size = myType_AllocSizeCallBack,
  *             .mem_usage = myType_MemUsageCallBack,
  *             .aux_load = myType_AuxRDBLoadCallBack,
  *             .aux_save = myType_AuxRDBSaveCallBack,
@@ -7562,6 +7567,9 @@ moduleType *RM_CreateDataType(RedisModuleCtx *ctx, const char *name, int encver,
         struct {
             moduleTypeAuxSaveFunc aux_save2;
         } v5;
+        struct {
+            moduleTypeAllocSizeFunc alloc_size;
+        } v6;
     } *tms = (struct typemethods*) typemethods_ptr;
 
     moduleType *mt = zcalloc(sizeof(*mt));
@@ -7592,6 +7600,9 @@ moduleType *RM_CreateDataType(RedisModuleCtx *ctx, const char *name, int encver,
     }
     if (tms->version >= 5) {
         mt->aux_save2 = tms->v5.aux_save2;
+    }
+    if (tms->version >= 6) {
+        mt->alloc_size = tms->v6.alloc_size;
     }
     memcpy(mt->entity.name,name,sizeof(mt->entity.name));
     listAddNodeTail(ctx->module->types,mt);
@@ -13197,6 +13208,20 @@ size_t moduleGetFreeEffort(robj *key, robj *val, int dbid) {
     }  
 
     return effort;
+}
+
+/* Return the allocated memory of the module value.
+ * Calls the alloc_size callback if provided.
+ * Returns 0 by default.
+ */
+size_t moduleGetAllocSize(robj *o) {
+    moduleValue *mv = o->ptr;
+    moduleType *mt = mv->type;
+
+    if (mt->alloc_size)
+        return mt->alloc_size(mv->value);
+
+    return 0;
 }
 
 /* Return the memory usage of the module, it will automatically choose to call 

--- a/src/modules/hellotype.c
+++ b/src/modules/hellotype.c
@@ -278,6 +278,10 @@ void HelloTypeAofRewrite(RedisModuleIO *aof, RedisModuleString *key, void *value
     }
 }
 
+size_t HelloTypeAllocSize(const void *value) {
+    return HelloTypeMemUsage(value);
+}
+
 /* The goal of this function is to return the amount of memory used by
  * the HelloType value. */
 size_t HelloTypeMemUsage(const void *value) {
@@ -314,6 +318,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         .rdb_load = HelloTypeRdbLoad,
         .rdb_save = HelloTypeRdbSave,
         .aof_rewrite = HelloTypeAofRewrite,
+        .alloc_size = HelloTypeAllocSize,
         .mem_usage = HelloTypeMemUsage,
         .free = HelloTypeFree,
         .digest = HelloTypeDigest

--- a/src/object.c
+++ b/src/object.c
@@ -1368,7 +1368,7 @@ size_t kvobjAllocSize(kvobj *o) {
         redisArray *ar = o->ptr;
         asize += ar->alloc_size;
     } else if (o->type == OBJ_MODULE) {
-        /* TODO: Provide moduleGetAllocSize() module API for O(1) allocation size retrieval */
+        asize += moduleGetAllocSize(o);
     }
     return asize;
 }

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -44,7 +44,7 @@ typedef long long ustime_t;
 
 /* Version of the RedisModuleTypeMethods structure. Once the RedisModuleTypeMethods 
  * structure is changed, this version number needs to be changed synchronistically. */
-#define REDISMODULE_TYPE_METHOD_VERSION 5
+#define REDISMODULE_TYPE_METHOD_VERSION 6
 
 /* Version of the RedisModuleKeyMetaClassConfig structure. Once the RedisModuleKeyMetaClassConfig 
  * structure is changed, this version number needs to be changed synchronistically. */
@@ -1005,6 +1005,7 @@ typedef void (*RedisModuleTypeSaveFunc)(RedisModuleIO *rdb, void *value);
 typedef int (*RedisModuleTypeAuxLoadFunc)(RedisModuleIO *rdb, int encver, int when);
 typedef void (*RedisModuleTypeAuxSaveFunc)(RedisModuleIO *rdb, int when);
 typedef void (*RedisModuleTypeRewriteFunc)(RedisModuleIO *aof, RedisModuleString *key, void *value);
+typedef size_t (*RedisModuleTypeAllocSizeFunc)(const void *value);
 typedef size_t (*RedisModuleTypeMemUsageFunc)(const void *value);
 typedef size_t (*RedisModuleTypeMemUsageFunc2)(RedisModuleKeyOptCtx *ctx, const void *value, size_t sample_size);
 typedef void (*RedisModuleTypeDigestFunc)(RedisModuleDigest *digest, void *value);
@@ -1067,6 +1068,7 @@ typedef struct RedisModuleTypeMethods {
     RedisModuleTypeUnlinkFunc2 unlink2;
     RedisModuleTypeCopyFunc2 copy2;
     RedisModuleTypeAuxSaveFunc aux_save2;
+    RedisModuleTypeAllocSizeFunc alloc_size;
 } RedisModuleTypeMethods;
 
 /* Key metadata class configuration structure.

--- a/src/server.h
+++ b/src/server.h
@@ -936,6 +936,7 @@ typedef int (*moduleTypeAuxLoadFunc)(struct RedisModuleIO *rdb, int encver, int 
 typedef void (*moduleTypeAuxSaveFunc)(struct RedisModuleIO *rdb, int when);
 typedef void (*moduleTypeRewriteFunc)(struct RedisModuleIO *io, struct redisObject *key, void *value);
 typedef void (*moduleTypeDigestFunc)(struct RedisModuleDigest *digest, void *value);
+typedef size_t (*moduleTypeAllocSizeFunc)(const void *value);
 typedef size_t (*moduleTypeMemUsageFunc)(const void *value);
 typedef void (*moduleTypeFreeFunc)(void *value);
 typedef size_t (*moduleTypeFreeEffortFunc)(struct redisObject *key, const void *value);
@@ -963,6 +964,7 @@ typedef struct RedisModuleType {
     moduleTypeLoadFunc rdb_load;
     moduleTypeSaveFunc rdb_save;
     moduleTypeRewriteFunc aof_rewrite;
+    moduleTypeAllocSizeFunc alloc_size;
     moduleTypeMemUsageFunc mem_usage;
     moduleTypeDigestFunc digest;
     moduleTypeFreeFunc free;
@@ -3190,6 +3192,7 @@ int moduleClientIsBlockedOnKeys(client *c);
 void moduleNotifyUserChanged(client *c);
 void moduleNotifyKeyUnlink(robj *key, kvobj *kv, int dbid, int flags);
 size_t moduleGetFreeEffort(robj *key, robj *val, int dbid);
+size_t moduleGetAllocSize(robj *o);
 size_t moduleGetMemUsage(robj *key, robj *val, size_t sample_size, int dbid);
 robj *moduleTypeDupOrReply(client *c, robj *fromkey, robj *tokey, int todb, robj *value);
 int moduleDefragValue(robj *key, robj *obj, int dbid);


### PR DESCRIPTION
## Summary

This PR introduces an optional `alloc_size` callback to `RedisModuleTypeMethods` to support O(1) allocation size accounting for module data types.

`kvobjAllocSize()` currently accounts for all built-in object types but leaves `OBJ_MODULE` unimplemented with a TODO. This change adds a dedicated callback and helper to allow modules to report their allocated size without requiring key context or sampling.

## Changes

- Add `RedisModuleTypeAllocSizeFunc` and `moduleTypeAllocSizeFunc`.
- Add an optional `alloc_size` callback to `RedisModuleTypeMethods` and `moduleType`.
- Add `moduleGetAllocSize()` to dispatch the callback, returning `0` if it is not implemented.
- Use `moduleGetAllocSize()` in `kvobjAllocSize()` for `OBJ_MODULE`.
- Bump `REDISMODULE_TYPE_METHOD_VERSION` from 5 to 6.
- Update the `hellotype` example module to implement the new callback.
- Update module API documentation for the new callback.

## Why a new callback?

The existing `mem_usage`/`mem_usage2` callbacks are intended for the `MEMORY USAGE` command and may perform sampling or use key-specific context.

The new `alloc_size` callback is intended specifically for internal allocation accounting and is expected to return the allocated size in O(1) without traversal or sampling.

For simple modules, `alloc_size` can simply reuse the existing `mem_usage` implementation, as demonstrated by `hellotype`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive module API with backward-compatible default (0); touches memory accounting paths but not auth, persistence, or command behavior.
> 
> **Overview**
> Adds an optional **`alloc_size`** hook on **`RedisModuleTypeMethods`** (API version **6**) so module types can report allocated value size in **O(1)** for internal accounting, separate from **`mem_usage`** / **`mem_usage2`** used by **`MEMORY USAGE`** (which may sample or need key context).
> 
> The core wires **`moduleGetAllocSize()`** through type registration and **`kvobjAllocSize()`** now includes **`OBJ_MODULE`** values via that callback (default **0** when unset). **`hellotype`** registers a sample implementation; **vector-sets** leaves **`alloc_size`** as **`NULL`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 044e7a54dc8e852dcdbe626ad9b1b343d32a214b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->