### PR TITLE
Wake blocked list clients when SORT STORE overwrites a key

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -781,6 +781,16 @@ void setKeyByLink(client *c, redisDb *db, robj *key, robj **valref, int flags, d
         notifyKeyspaceEvent(NOTIFY_OVERWRITTEN, "overwritten", key, db->id);
         if (oldtype != newtype)
             notifyKeyspaceEvent(NOTIFY_TYPE_CHANGED, "type_changed", key, db->id);
+
+        /* Overwriting a key with a list must wake blocked clients. Same
+         * type: only "grew" waiters (e.g. BLMOVEM EXACTLY). Type changed:
+         * treat as a fresh list (wakes BLPOP/BLMOVE/modules). */
+        if (newtype == OBJ_LIST) {
+            if (oldtype == OBJ_LIST)
+                signalKeyAsReadyNonEmptyList(db, key);
+            else
+                signalKeyAsReady(db, key, OBJ_LIST);
+        }
     } else {
         /* Add the new key to the database */
         dbAddByLink(db, key, valref, link);

--- a/tests/unit/type/list-4.tcl
+++ b/tests/unit/type/list-4.tcl
@@ -231,6 +231,20 @@ foreach {type large} [array get largevalue] {
         $rd close
     }
 
+    test {BLMOVEM EXACTLY is woken by SORT STORE overwriting the source} {
+        r del src{t} dst{t} feed{t}
+        r rpush src{t} 1
+        r rpush feed{t} 3 1 2
+        set rd [redis_deferring_client]
+        $rd blmovem src{t} dst{t} left right 0 exactly 3 bulk
+        wait_for_blocked_client
+        r sort feed{t} store src{t}   ;# src overwritten -> 1 2 3, reaches 3
+        assert_equal {1 2 3} [$rd read]
+        assert_equal {1 2 3} [r lrange dst{t} 0 -1]
+        assert_equal 0 [r exists src{t}]
+        $rd close
+    }
+
     test {BLMOVEM times out with null array} {
         r del src{t} dst{t}
         set rd [redis_deferring_client]

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1298,6 +1298,20 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         $rd close
         set _ $res
     } {foo{t} aguacate}
+
+    test "$pop when existing key is overwritten by SORT..STORE" {
+        set rd [redis_deferring_client]
+        r del owfoo{t} ownotfoo{t}
+
+        bpop_command $rd $pop owfoo{t} 0
+        wait_for_blocked_client
+        r set owfoo{t} placeholder        ;# wrong type: client stays blocked
+        r rpush ownotfoo{t} 3 1 2
+        r sort ownotfoo{t} store owfoo{t} ;# owfoo{t} overwritten -> list [1 2 3]
+        set res [$rd read]
+        assert_equal {owfoo{t} 1} $res
+        $rd close
+    }
 }
 
     test "BLPOP: timeout value out of range" {


### PR DESCRIPTION
Fixes: #15452
Introduced by #15405

BLPOP/BLMOVE/BLMOVEM EXACTLY clients blocked on a key stayed asleep when `SORT ... STORE` turned that key into a list by overwriting it, because the overwrite path never signaled blocked clients at all.

Inside `setKeyByLink()`: when a key is overwritten with a list, wake waiters. If it was already a list, only wake "grew" waiters (e.g. BLMOVEM EXACTLY). If the type changed into a list, treat it like a fresh key so plain BLPOP/BLMOVE and modules get woken too.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core key-set/overwrite paths and blocking-list wakeup semantics; behavior change is narrow but affects all overwrites that end as OBJ_LIST.
> 
> **Overview**
> Fixes blocked **BLPOP** / **BLMOVE** / **BLMOVEM EXACTLY** clients that stayed blocked when **`SORT … STORE`** (or similar overwrites via `setKeyByLink`) replaced a key with a list without signaling readiness.
> 
> In **`setKeyByLink()`**, after an overwrite whose new value is a list: if the key was already a list, call **`signalKeyAsReadyNonEmptyList`** (for “list grew” waiters like BLMOVEM EXACTLY); if the type changed to a list, call **`signalKeyAsReady`** so plain blocking list ops and modules wake as on a new list.
> 
> Regression tests cover **BLMOVEM EXACTLY** woken by **`SORT … STORE`** on the source and **BLPOP** when a non-list key is overwritten into a list via **`SORT … STORE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06c5eda77546c81955cd2c30e3082b88a87ba87b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->