### PR TITLE
Fix Vector Set RESTORE UAF from duplicate HNSW node IDs

### DIFF
--- a/modules/vector-sets/hnsw.c
+++ b/modules/vector-sets/hnsw.c
@@ -2593,6 +2593,15 @@ hnswNode *hnsw_insert_serialized(HNSW *index, void *vector, uint64_t *params, ui
     uint32_t version = (params[1] & 0xff000000) >> 24;  // Format version.
 
     if (version > HNSW_SERIALIZATION_VERSION) return NULL;
+    /* Serialized nodes always carry a real unique ID (>= 1). id==0 is the
+     * in-memory "auto-assign" sentinel used by hnsw_node_new(); accepting it
+     * here rewrites the ID and can collide with later nodes that claim that
+     * auto-assigned value, defeating ID uniqueness. */
+    if (id == 0) return NULL;
+    /* Levels above HNSW_MAX_LEVEL never occur in legitimate indexes
+     * (random_level() is capped). Reject them so untrusted RESTORE/RDB
+     * payloads cannot inflate max_level past structures sized for the cap. */
+    if (level > HNSW_MAX_LEVEL) return NULL;
     int has_worst_link_info = version > 0;
 
     /* Keep track of maximum ID seen while loading. */
@@ -2747,17 +2756,33 @@ int hnsw_deserialize_index(HNSW *index, uint64_t salt0, uint64_t salt1) {
     if (table == NULL) return 0;
     memset(table,0,sizeof(hnswNode*) * table_size);
 
-    /* First pass: populate the ID -> pointer hash table. */
+    /* First pass: populate the ID -> pointer hash table.
+     *
+     * Duplicate node IDs are rejected as corruption: a well-formed
+     * serialization always assigns a unique ID to each node. If duplicates
+     * were accepted, the reciprocal-links check below could pass at the ID
+     * level while the resolved pointer graph is non-reciprocal (link
+     * resolution stops at the first table entry with a matching ID). Such a
+     * graph can leave dangling neighbor pointers after a node is deleted,
+     * leading to a use-after-free on later access. */
     hnswNode *node = index->head;
     while(node) {
         uint64_t bucket = hnsw_hash_node_id(node->id) & (table_size-1);
+        int inserted = 0;
         for (uint64_t j = 0; j < table_size; j++) {
             if (table[bucket] == NULL) {
                 table[bucket] = node;
+                inserted = 1;
                 break;
             }
+            /* Same ID already mapped: reject before link resolution. */
+            if (table[bucket]->id == node->id) goto corrupted;
             bucket = (bucket+1) & (table_size-1);
         }
+        /* Table is sized ~2x node_count; failure to insert means the probe
+         * found neither an empty slot nor a duplicate — treat as corruption
+         * rather than silently dropping the node from the ID map. */
+        if (!inserted) goto corrupted;
         node = node->next;
     }
 

--- a/modules/vector-sets/tests/restore_dup_hnsw_id.py
+++ b/modules/vector-sets/tests/restore_dup_hnsw_id.py
@@ -1,0 +1,236 @@
+# Regression test for #15385:
+# RESTORE of a Vector Set whose HNSW serialization reuses the same node ID
+# must be rejected. Accepting the payload leaves a non-reciprocal pointer
+# graph after link resolution, and VREM + VLINKS can use-after-free / crash.
+#
+# Copyright (c) 2009-Present, Redis Ltd.
+# All rights reserved.
+#
+# Licensed under your choice of (a) the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+
+from test import TestCase
+import struct
+import redis
+
+
+def enc_len(value):
+    """Encode a length the way rdbSaveLen() does for small integers."""
+    if value < 64:
+        return bytes([value])
+    if value < (1 << 14):
+        return bytes([0x40 | (value >> 8), value & 0xff])
+    if value <= 0xffffffff:
+        return b"\x80" + struct.pack(">I", value)
+    return b"\x81" + struct.pack(">Q", value)
+
+
+def module_uint(value):
+    """RDB_MODULE_OPCODE_UINT + rdbSaveLen(value)."""
+    return enc_len(2) + enc_len(value)
+
+
+def module_string(data):
+    """RDB_MODULE_OPCODE_STRING + raw string (length-prefixed)."""
+    if isinstance(data, str):
+        data = data.encode()
+    return enc_len(5) + enc_len(len(data)) + data
+
+
+def serialized_node(element, node_id, links, vector, level=0):
+    """
+    Serialize one HNSW node the way VectorSetRdbSave() / hnsw_serialize_node()
+    would for FP32 (HNSW_QUANT_NONE).
+
+    params layout (version 1), per layer 0..level:
+      [id, version|level, (num_links, max_links, link_ids..., worst_pack)..., l2|range]
+
+    'links' is applied on layer 0 only; higher layers are empty (valid for
+    crafting illegal levels / isolated high-level nodes).
+    """
+    m = 16
+    params = [
+        node_id,
+        (1 << 24) | (level & 0xFF),  # version=1, level
+    ]
+    for i in range(level + 1):
+        layer_links = links if i == 0 else []
+        params.append(len(layer_links))
+        params.append(m * 2 if i == 0 else m)
+        params.extend(layer_links)
+        # worst_idx in low 32 bits, worst_distance bits in high 32
+        params.append(0)
+    # l2 = 1.0f in low 32 bits, quants_range = 0 in high 32
+    params.append(0x3F800000)
+
+    out = module_string(element)
+    out += module_string(struct.pack(f"<{len(vector)}f", *vector))
+    out += module_uint(len(params))
+    for param in params:
+        out += module_uint(param)
+    return out
+
+
+def build_vectorset_dump(nodes, module_id, dim=2, quant=0, M=16, rdb_version=14):
+    """
+    Build a RESTORE/DUMP payload for a Vector Set (RDB_TYPE_MODULE_2).
+
+    nodes: list of (element, node_id, links, vector_floats)
+           or (element, node_id, links, vector_floats, level)
+    A zero CRC footer is accepted by verifyDumpPayload().
+    """
+    body = bytearray([7])  # RDB_TYPE_MODULE_2
+    body += enc_len(module_id)
+    body += module_uint(dim)
+    body += module_uint(len(nodes))
+    hnsw_config = (quant & 0xFF) | ((M & 0xFFFF) << 8)
+    body += module_uint(hnsw_config)
+    body += module_uint(0)  # save_flags: no proj matrix, no attribs
+
+    for node in nodes:
+        if len(node) == 5:
+            element, node_id, links, vector, level = node
+        else:
+            element, node_id, links, vector = node
+            level = 0
+        body += serialized_node(element, node_id, links, vector, level=level)
+
+    body += enc_len(0)  # RDB_MODULE_OPCODE_EOF
+    body += struct.pack("<H", rdb_version)
+    body += b"\x00" * 8  # no checksum
+    return bytes(body)
+
+
+class RestoreDuplicateHNSWID(TestCase):
+    def getname(self):
+        return "RESTORE rejects corrupt Vector Set payloads"
+
+    def estimated_runtime(self):
+        return 0.5
+
+    def _live_module_id(self):
+        """Obtain the module type id Redis actually writes into DUMP."""
+        # Create a tiny legitimate vector set and read the DUMP header.
+        key = f"{self.test_key}:probe"
+        self.redis.delete(key)
+        self.redis.execute_command(
+            "VADD", key, "VALUES", 2, "1.0", "0.0", "probe-a"
+        )
+        dump = self.redis.execute_command("DUMP", key)
+        self.redis.delete(key)
+
+        # type(1) + module id as rdb length encoding
+        assert dump[0] == 7, f"expected RDB_TYPE_MODULE_2, got {dump[0]}"
+        b = dump[1]
+        typ = (b & 0xC0) >> 6
+        if typ == 0:
+            return b & 0x3F
+        if typ == 1:
+            return ((b & 0x3F) << 8) | dump[2]
+        if b == 0x80:
+            return struct.unpack(">I", dump[2:6])[0]
+        if b == 0x81:
+            return struct.unpack(">Q", dump[2:10])[0]
+        raise AssertionError(f"unexpected module id length encoding 0x{b:02x}")
+
+    def test(self):
+        module_id = self._live_module_id()
+
+        # Positive control: unique IDs + reciprocal links must RESTORE cleanly
+        # and remain usable.
+        valid_nodes = [
+            ("a", 1, [2], [1.0, 0.0]),
+            ("b", 2, [1, 3], [0.0, 1.0]),
+            ("c", 3, [2], [1.0, 1.0]),
+        ]
+        valid_payload = build_vectorset_dump(valid_nodes, module_id)
+        good_key = f"{self.test_key}:good"
+        self.redis.delete(good_key)
+        assert (
+            self.redis.execute_command("RESTORE", good_key, 0, valid_payload) == b"OK"
+        ), "valid Vector Set payload should RESTORE"
+        assert self.redis.execute_command("TYPE", good_key) == b"vectorset"
+        assert self.redis.execute_command("VCARD", good_key) == 3
+        # Round-trip through DUMP/RESTORE once more to ensure we did not
+        # break legitimate serialization.
+        dumped = self.redis.execute_command("DUMP", good_key)
+        self.redis.delete(good_key)
+        assert (
+            self.redis.execute_command("RESTORE", good_key, 0, dumped) == b"OK"
+        ), "legitimate DUMP should RESTORE after a round-trip"
+        assert self.redis.execute_command("VCARD", good_key) == 3
+        self.redis.delete(good_key)
+
+        # Malicious payload from #15385:
+        #   a: id=1 -> links to 2
+        #   b: id=1 (duplicate), no links
+        #   c: id=2 -> links to 1
+        # ID-level reciprocity sees pair {1,2} twice and would accept it;
+        # pointer resolution maps c->1 to the first id=1 node (a or b
+        # depending on insert order into the table), leaving a non-reciprocal
+        # graph. After the fix, RESTORE must refuse this as corruption.
+        malicious_nodes = [
+            ("a", 1, [2], [1.0, 0.0]),
+            ("b", 1, [], [0.0, 1.0]),
+            ("c", 2, [1], [1.0, 1.0]),
+        ]
+        malicious_payload = build_vectorset_dump(malicious_nodes, module_id)
+        bad_key = f"{self.test_key}:bad"
+        self.redis.delete(bad_key)
+
+        self._assert_restore_rejected(bad_key, malicious_payload)
+
+        # id==0 is the in-memory auto-assign sentinel in hnsw_node_new().
+        # Serialized payloads must never use it (legitimate nodes start at 1).
+        id0_nodes = [
+            ("a", 0, [2], [1.0, 0.0]),
+            ("b", 1, [], [0.0, 1.0]),
+            ("c", 2, [1], [1.0, 1.0]),
+        ]
+        self._assert_restore_rejected(
+            f"{self.test_key}:id0",
+            build_vectorset_dump(id0_nodes, module_id),
+        )
+
+        # Triple duplicate IDs with no links — still corruption.
+        triple = [
+            ("a", 5, [], [1.0, 0.0]),
+            ("b", 5, [], [0.0, 1.0]),
+            ("c", 5, [], [1.0, 1.0]),
+        ]
+        self._assert_restore_rejected(
+            f"{self.test_key}:triple",
+            build_vectorset_dump(triple, module_id),
+        )
+
+        # Level above HNSW_MAX_LEVEL (16) never occurs in legitimate data.
+        high_level = [
+            ("a", 1, [2], [1.0, 0.0], 32),
+            ("b", 2, [1], [0.0, 1.0], 0),
+        ]
+        self._assert_restore_rejected(
+            f"{self.test_key}:level",
+            build_vectorset_dump(high_level, module_id),
+        )
+
+        # Duplicate element names leave an orphan HNSW node if accepted.
+        dup_name = [
+            ("same", 1, [2], [1.0, 0.0]),
+            ("same", 2, [1], [0.0, 1.0]),
+        ]
+        self._assert_restore_rejected(
+            f"{self.test_key}:dupname",
+            build_vectorset_dump(dup_name, module_id),
+        )
+
+        assert self.redis.ping() is True, "server must stay up after rejecting payloads"
+
+    def _assert_restore_rejected(self, key, payload):
+        self.redis.delete(key)
+        try:
+            self.redis.execute_command("RESTORE", key, 0, payload)
+            assert False, f"RESTORE of corrupt payload should fail (key={key})"
+        except redis.exceptions.ResponseError as e:
+            assert "Bad data format" in str(e), f"unexpected error for {key}: {e}"
+        assert self.redis.exists(key) == 0, f"failed RESTORE must not create {key}"

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -2118,8 +2118,19 @@ void *VectorSetRdbLoad(RedisModuleIO *rdb, int encver) {
             RedisModule_Free(params);
             goto ioerr;
         }
+        /* Element names must be unique. DictSet is try-insert (not replace):
+         * a failed insert would leave an HNSW node with no name map entry,
+         * so VCARD (node_count) would disagree with the dict. Reject as
+         * corruption. Node is already linked into the HNSW list; free via
+         * object teardown on ioerr. Only free the temporary RDB buffers. */
+        if (RedisModule_DictSet(vset->dict,ele,node) != REDISMODULE_OK) {
+            RedisModule_LogIOError(rdb,"warning",
+                                       "Duplicate vector set element name");
+            RedisModule_Free(vector);
+            RedisModule_Free(params);
+            goto ioerr;
+        }
         if (nv->attrib) vset->numattribs++;
-        RedisModule_DictSet(vset->dict,ele,node);
         RedisModule_Free(vector);
         RedisModule_Free(params);
     }
@@ -2127,6 +2138,13 @@ void *VectorSetRdbLoad(RedisModuleIO *rdb, int encver) {
     uint64_t salt[2];
     RedisModule_GetRandomBytes((unsigned char*)salt,sizeof(salt));
     if (!hnsw_deserialize_index(vset->hnsw, salt[0], salt[1])) goto ioerr;
+
+    /* Final invariant: every HNSW node is reachable by name and vice versa. */
+    if (RedisModule_DictSize(vset->dict) != vset->hnsw->node_count) {
+        RedisModule_LogIOError(rdb,"warning",
+                                   "Vector set name map / graph size mismatch");
+        goto ioerr;
+    }
 
     return vset;
 


### PR DESCRIPTION
## Summary

Fixes #15385.

`RESTORE` (and RDB/replication load) of a Vector Set accepted payloads where multiple HNSW nodes shared the same internal node ID. Link reciprocity is checked at the **ID** level, but link resolution maps each ID to the **first** matching node pointer. That mismatch can leave a non-reciprocal pointer graph: after `VREM`, a neighbor still points at a freed node, and a later command such as `VLINKS` can use-after-free / crash the process.

### Root cause

In `hnsw_deserialize_index()`, the first pass builds an ID → pointer hash table without rejecting duplicates. A well-formed serialization always assigns unique IDs, so duplicates are always corruption of the on-disk/replicated format.

### Fix

1. **Primary (UAF):** while inserting into the ID table, if the same ID is already present, treat the payload as corrupted and fail load (`RESTORE` → `ERR Bad data format`, no key created).
2. **Same trust boundary (RESTORE/RDB):**
   - Reject serialized `id == 0` (in-memory auto-assign sentinel in `hnsw_node_new()`; legitimate nodes start at 1).
   - Reject `level > HNSW_MAX_LEVEL` (live inserts never exceed the cap).
   - Reject duplicate element names via `DictSet` try-insert failure (avoids orphan HNSW nodes and `VCARD` vs name-map skew).
   - Enforce `DictSize == node_count` after deserialize.
   - Fail closed if the ID table probe cannot insert a node.

### Compatibility

These checks do not break legitimate Vector Set dumps:

- Serialized node IDs are always the real ids written by `hnsw_serialize_node()` (≥ 1).
- `random_level()` is capped at `HNSW_MAX_LEVEL` (16); the level check is strict `>`.

## Test plan

- [x] Regression test `modules/vector-sets/tests/restore_dup_hnsw_id.py`:
  - Positive control: reciprocal unique-ID graph RESTORE + DUMP/RESTORE round-trip
  - #15385-style duplicate HNSW IDs rejected
  - Variants: `id == 0`, triple duplicate IDs, `level > 16`, duplicate element names
  - Asserts key not created and server stays up
- [x] Reproduced crash on unpatched tree; confirmed reject + liveness after fix
- [x] Full vector-set suite: **40/41 passed**, 1 skipped (replication; no local replica)

```text
# focused
cd modules/vector-sets && python3 -c 'from tests.restore_dup_hnsw_id import RestoreDuplicateHNSWID; t=RestoreDuplicateHNSWID(); assert t.run()'

# full module suite (needs redis-server with --enable-debug-command yes)
python3 test.py --primary-port 6379 --replica-port 6380
```

## Notes for reviewers

- The load-bearing UAF fix is the duplicate-ID check in `hnsw_deserialize_index()`. The other checks harden the same untrusted entrypoint and are small; happy to split if preferred.
- Ownership on the duplicate-name error path: the node is already linked into the HNSW list, so we only free temporary RDB buffers and rely on `vectorSetReleaseObject()` on `ioerr` (do **not** free `nv` twice).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes untrusted RESTORE/RDB deserialization and memory-safety invariants; incorrect rejection could break legitimate dumps, while the fix closes a process-crashing UAF path.
> 
> **Overview**
> Fixes **#15385**: corrupt Vector Set **RESTORE**/RDB loads could build an HNSW graph that passes ID-level reciprocity checks but resolves links to the wrong nodes, leading to **use-after-free** after `VREM` (e.g. `VLINKS` crash).
> 
> **HNSW deserialize (`hnsw.c`):** Reject duplicate node IDs when building the ID→pointer table (and fail if a node cannot be inserted). Reject serialized **`id == 0`** and **`level > HNSW_MAX_LEVEL`** in `hnsw_insert_serialized()`.
> 
> **Vector Set RDB load (`vset.c`):** Treat duplicate element names as corruption (`DictSet` try-insert failure). After `hnsw_deserialize_index()`, require **`DictSize == node_count`**.
> 
> **Tests:** New `restore_dup_hnsw_id.py` crafts module dumps for valid round-trip, duplicate HNSW IDs, `id==0`, high level, and duplicate names; asserts `RESTORE` fails with “Bad data format” and the server stays up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 011555cf7c05093086c1c28ca9f72534bff693f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->