### PR TITLE
fix: compare expire stale fraction to percent threshold correctly

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -320,8 +320,11 @@ void activeExpireCycle(int type) {
          * for time limit, unless the percentage of estimated stale keys is
          * too high. Also never repeat a fast cycle for the same period
          * as the fast cycle total duration itself. */
+        /* stat_expired_stale_perc is a 0..1 fraction; config is a percent
+         * (ACTIVE_EXPIRE_CYCLE_ACCEPTABLE_STALE is 10 meaning 10%). Compare
+         * like units so a high stale estimate can still force a FAST cycle. */
         if (!timelimit_exit &&
-            server.stat_expired_stale_perc < config_cycle_acceptable_stale)
+            server.stat_expired_stale_perc * 100 < config_cycle_acceptable_stale)
             return;
 
         if (start < last_fast_cycle + (long long)config_cycle_fast_duration*2)


### PR DESCRIPTION
## Summary

`activeExpireCycle()` skips a FAST cycle when `stat_expired_stale_perc` is below `config_cycle_acceptable_stale`. The stat is a **0..1 fraction**, while the config is a **percent** (default 10 meaning 10%). Comparing them directly made the stale-percentage trigger dead code: even 100% stale (stat `1.0`) is still `< 10`.

## Change

Compare `stat_expired_stale_perc * 100` against the percent threshold so a high stale estimate can force a FAST cycle as intended.

## Evidence

From INFO (`server.c`):

```c
"expired_stale_perc:%.2f\r\n", server.stat_expired_stale_perc*100
```

so the runtime value is stored as a fraction and only scaled for display.

Fixes #15410

## Test plan

- [x] `make` builds `redis-server`
- [ ] Manual: with many logically expired keys and no prior time-limit exit, FAST cycles can still run when estimated stale % is high

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line comparison fix in active expiration scheduling with no API or persistence changes; behavior change only restores the intended FAST-cycle trigger when stale key share is high.
> 
> **Overview**
> Fixes a **unit mismatch** in `activeExpireCycle()` when deciding whether to run a **FAST** expire cycle after the previous cycle did not hit the time limit.
> 
> `server.stat_expired_stale_perc` is maintained as a **0..1 fraction** (see end-of-cycle update and INFO, which reports `* 100`), while `config_cycle_acceptable_stale` is a **percent** (default 10 = 10%). Comparing them directly meant the “high stale %” escape hatch almost never applied—even 100% stale (`1.0`) stayed below threshold `10`.
> 
> The gate now compares **`stat_expired_stale_perc * 100`** to the percent threshold so elevated stale estimates can **force extra FAST cycles** and reclaim logically expired keys as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77d9210c0aaef3ceeea4c1c4338376f6d795ce80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->