### PR TITLE
Fix cross-compilation with jemalloc and test modules

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -140,7 +140,9 @@ lua: .make-prerequisites
 JEMALLOC_CFLAGS=$(ENABLE_LTO) $(CFLAGS)
 JEMALLOC_LDFLAGS=$(ENABLE_LTO) $(LDFLAGS)
 
-ifneq ($(DEB_HOST_GNU_TYPE),)
+ifneq ($(HOST),)
+JEMALLOC_CONFIGURE_OPTS += --host=$(HOST)
+else ifneq ($(DEB_HOST_GNU_TYPE),)
 JEMALLOC_CONFIGURE_OPTS += --host=$(DEB_HOST_GNU_TYPE)
 endif
 

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -25,12 +25,16 @@ endif
 endif
 
 
-# This is a hack to override the default CC. When running with SANITIZER=memory
-# tough we want to keep the compiler as clang as MSan is not supported for gcc
+# This is a hack to override the default compiler. Preserve compilers supplied
+# by cross-compilation environments or on the make command line.
 ifeq ($(uname_S),Linux)
 ifneq ($(SANITIZER),memory)
-	LD = gcc
+ifeq ($(origin CC),default)
 	CC = gcc
+endif
+ifeq ($(origin LD),default)
+	LD = $(CC)
+endif
 endif
 endif
 


### PR DESCRIPTION
Fix two toolchain propagation problems affecting cross-compilation:

- Pass `HOST` to jemalloc's configure script through `--host`, while retaining `DEB_HOST_GNU_TYPE` as a fallback.
- Preserve `CC` and `LD` supplied by cross-compilation environments or on the make command line when building test modules.
- When only `CC` is supplied, use the same compiler driver for linking the test modules.

### Problem

Without `--host`, jemalloc's configure script attempts to run a binary produced by the target compiler. This fails when the target architecture differs from the build machine.

The test module Makefile also unconditionally selected `gcc` on Linux, overriding compilers supplied through the environment. This could silently produce host-architecture modules during a cross-build.

Default native Linux behavior remains unchanged: test modules still use `gcc` when no compiler is supplied.

MSan behaviour is also unchanged.

### Verification

- Reproduced the jemalloc configure failure before the change.
- Reproduced test modules being built with the host compiler despite a cross-compiler being supplied.
- Successfully completed a clean ARM64 Linux cross-build, including jemalloc, Redis binaries, and test modules.
- Confirmed the resulting Redis binaries and test modules were ARM64 Linux ELF files.
- Successfully completed a clean native macOS build.
- Ran `./runtest --single unit/moduleapi/basics` successfully.

Fixes #15395

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Makefile changes for cross-compilation; no runtime Redis, auth, or data-path behavior.
> 
> **Overview**
> Fixes **cross-compilation** for jemalloc and Redis test modules by propagating the target toolchain instead of assuming the build host.
> 
> In **`deps/Makefile`**, jemalloc’s `configure` now gets **`--host=$(HOST)`** when `HOST` is set, with **`DEB_HOST_GNU_TYPE`** unchanged as the fallback. That avoids configure trying to run a binary built for the target on the build machine.
> 
> In **`tests/modules/Makefile`**, Linux no longer always forces **`gcc`** for **`CC`** and a separate linker. **`CC`** and **`LD`** are only defaulted when Make’s own defaults apply, so env/command-line cross compilers are kept; if only **`CC`** is set, **`LD`** matches it. Native Linux (no compiler passed) still uses **`gcc`**; MSan/clang behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fd7fb2b0c1b5612f4527b845d8ffa00fda38b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->