### PR TITLE
Fix parallel builds with `make -j`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ install:
 # line (e.g. `make clean DEPS=1`) propagate to the per-module clean via
 # the shell environment.
 clean:
-	@scripts/clean.sh $(CLEAN_ARGS)
+	+@scripts/clean.sh $(CLEAN_ARGS)
 
 # ----------------------------------------------------------------------------
 # Module / build / test orchestration. Recipes are thin wrappers around
@@ -106,11 +106,11 @@ clean:
 
 # build [<name> ...|all|.|redis|core|none] — Redis core + selected modules.
 build:
-	@scripts/build.sh $(BUILD_ARGS)
+	+@scripts/build.sh $(BUILD_ARGS)
 
 # bootstrap [<name> ...|all|.] — install per-module build/test prereqs.
 bootstrap:
-	@scripts/bootstrap.sh $(BOOTSTRAP_ARGS)
+	+@scripts/bootstrap.sh $(BOOTSTRAP_ARGS)
 
 # deploy [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]
 #   Install Redis core + selected modules (default: every cloned module),
@@ -128,12 +128,12 @@ run:
 
 # test [redis|all|<module> [<test_name>]] [TEST=<name>] — see scripts/test.sh.
 test:
-	@TEST='$(TEST)' scripts/test.sh $(TEST_ARGS)
+	+@TEST='$(TEST)' scripts/test.sh $(TEST_ARGS)
 
 # modules-update [<name> ...|all|.] [MODULES_UPDATE_SHALLOW=1]
 #   Idempotent clone/refresh per modules.yaml.
 modules-update:
-	@MODULES_UPDATE_SHALLOW='$(MODULES_UPDATE_SHALLOW)' scripts/modules-update.sh $(MODULES_ARGS)
+	+@MODULES_UPDATE_SHALLOW='$(MODULES_UPDATE_SHALLOW)' scripts/modules-update.sh $(MODULES_ARGS)
 
 # modules-shallow <name> [<name> ...] — re-clone selected modules with --depth 1.
 modules-shallow:


### PR DESCRIPTION
After #15253 parallel builds started to warn:

```
  ~/..../redis$ make -j
  ==> Building main Redis (src/)
  make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
  make[1]: Entering directory '~/..../redis/src'
      CC Makefile.dep
  make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
  ....
```

and use only a single process when building, ignoring the `-j` flag.

Fix this by invoking build scripts with `+` prefix to let `make` know we spawn sub-make, so it keeps the jobserver pipe fd open for the script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ca8c7c13eed2c8fe53b5bc43be736a11f71fde5a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->