### PR TITLE
Update Redis modules(json & bloom) to version v8.9.90

### DIFF
--- a/modules/modules.yaml
+++ b/modules/modules.yaml
@@ -64,7 +64,7 @@
 modules:
   - name: redisbloom
     repo: https://github.com/redisbloom/redisbloom
-    ref: v8.9.81
+    ref: v8.9.90
     target_module: redisbloom.so
     loadmodule: ./modules/redisbloom/redisbloom.so
   - name: redisearch
@@ -75,7 +75,7 @@ modules:
     build_env: LTO=1 REDISEARCH_GENERATE_HEADERS=0 INLINE_LSE_ATOMICS=0
   - name: redisjson
     repo: https://github.com/redisjson/redisjson
-    ref: v8.9.81
+    ref: v8.9.90
     target_module: rejson.so
     loadmodule: ./modules/redisjson/rejson.so
   - name: redistimeseries


### PR DESCRIPTION
## Changelog

### RedisJSON [v8.9.81...v8.9.90](https://github.com/RedisJSON/RedisJSON/compare/v8.9.81...v8.9.90)
- MOD-16300 perf(json_path): materialize filter literals once per query ([#1615](https://github.com/RedisJSON/RedisJSON/pull/1615))
- MOD-16608 Bump ijson (reduce object memory) ([#1617](https://github.com/RedisJSON/RedisJSON/pull/1617))
- MOD-16274 | MOD-16275 add size/sizeof and empty operators on object ([#1618](https://github.com/RedisJSON/RedisJSON/pull/1618))
- MOD-16685 Add RedisJSON API to open from RedisModuleKey ([#1619](https://github.com/RedisJSON/RedisJSON/pull/1619)/[#1620](https://github.com/RedisJSON/RedisJSON/pull/1620))

### RedisBloom [v8.9.81...v8.9.90](https://github.com/RedisBloom/RedisBloom/compare/v8.9.81...v8.9.90)
- No functional changes — version bump only ([#1033](https://github.com/RedisBloom/RedisBloom/pull/1033))

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Manifest-only version pin bumps with no config or load-path changes; risk is limited to upstream module behavior in the new tags.
> 
> **Overview**
> Bumps the bundled **RedisBloom** and **RedisJSON** upstream pins in `modules/modules.yaml` from **v8.9.81** to **v8.9.90**. RediSearch and RedisTimeSeries stay on **v8.9.82**; `loadmodule` paths and build settings are unchanged.
> 
> After merge, refresh local clones with `make modules-update redisbloom redisjson` (or a full modules update) so builds, Docker image prep, and release tarballs pull the new tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561e54e7ba4ba2e3d28c89d84d7d40c867e19cb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
