### PR TITLE
Fix write handler removal in iothread when sending client to main

### DIFF
--- a/src/iothread.c
+++ b/src/iothread.c
@@ -776,6 +776,7 @@ int processClientsFromMainThread(IOThread *t) {
          * thread event loop doesn't keep firing writable (EPOLLOUT) on an idle
          * client. */
         if (!(c->io_flags & CLIENT_IO_CLOSE_ASAP) && !clientHasPendingReplies(c)) {
+            serverAssert(connHasEventLoop(c->conn));
             connSetWriteHandler(c->conn, NULL);
         }
     }

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -120,7 +120,6 @@ void enqueuePendingClientsToMainThread(client *c, int unbind) {
         sendPendingClientsToMainThreadIfNeeded(t, 1);
         /* Disable read and write to avoid race when main thread processes. */
         c->io_flags &= ~(CLIENT_IO_READ_ENABLED | CLIENT_IO_WRITE_ENABLED);
-        connSetWriteHandler(c->conn, NULL);
         /* Remove the client from IO thread, add it to main thread's pending list. */
         listUnlinkNode(t->clients, c->io_thread_client_list_node);
         listLinkNodeTail(t->pending_clients_to_main_thread, c->io_thread_client_list_node);
@@ -772,6 +771,14 @@ int processClientsFromMainThread(IOThread *t) {
             if (!(c->io_flags & CLIENT_IO_CLOSE_ASAP) && clientHasPendingReplies(c)) {
                 connSetWriteHandler(c->conn, sendReplyToClient);
             }
+        }
+        /* If everything has been flushed, drop any stale write handler so the IO
+         * thread event loop doesn't keep firing writable (EPOLLOUT) on an idle
+         * client. writeToClient(c, 0) above returns early when writing is disabled
+         * and never removes the handler, so we clear it here once there are no
+         * pending replies left. */
+        if (!(c->io_flags & CLIENT_IO_CLOSE_ASAP) && !clientHasPendingReplies(c)) {
+            connSetWriteHandler(c->conn, NULL);
         }
     }
     /* All clients must are processed. */

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -774,9 +774,7 @@ int processClientsFromMainThread(IOThread *t) {
         }
         /* If everything has been flushed, drop any stale write handler so the IO
          * thread event loop doesn't keep firing writable (EPOLLOUT) on an idle
-         * client. writeToClient(c, 0) above returns early when writing is disabled
-         * and never removes the handler, so we clear it here once there are no
-         * pending replies left. */
+         * client. */
         if (!(c->io_flags & CLIENT_IO_CLOSE_ASAP) && !clientHasPendingReplies(c)) {
             connSetWriteHandler(c->conn, NULL);
         }


### PR DESCRIPTION
Continuation of https://github.com/redis/redis/pull/15329 which broke TLS.

Removing the write handler unconditionally inside `enqueuePendingClientsToMainThread` was incorrect as the `unbind` flag may be raised which both removes the event loop and the write handler from the connection.

TLS expect the event loop to be bound when (un)setting the write handler and asserts if not, which was caught by the dailies.

**NOTE** the root cause of the issue was not fully understood in the #15329 PR. It's important to note that if IO thread's cron sends replica client to main thread while it has a write handler installed and then when replica is back in IO thread the `processClientsFromMainThread` does call `writeToClient(c, 0)` which may indeed flush out all the replies and send back the replica client to main thread. At this point if all traffic has stopped the write handler busy-loops in the IO thread's event loop. Note that the replica client is periodically send to IO thread because the REPLCONF ACK messages send from the replica node trigger a read. This read though is processed inside the event loop before the write event, and since IO-thread sends the clients back to main thread for processing inside the read handler this prevents the subsequently triggered write handler to clear itself from the connection. It's the nature of the `REPLCONF ACK` command that does not return a reply that introduces the bug.

Fixing the issue via removing the write handle inside `processClientsFromMainThread` when there are no more pending replies. This serves the same purpose as the original fix, but is easier to follow and reason about in the code.

Thanks to @ShooterIT and @sundb for helping pin point the exact issue. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches threaded client I/O handoff and event-loop write registration on replication paths; incorrect handler lifetime could affect CPU usage or TLS connections, but the change is narrow and localized to iothread.c.
> 
> **Overview**
> Replaces the **#15329** approach of unconditionally clearing the write handler when handing a client from an IO thread to the main thread. That path could run after `unbind` had already torn down the connection’s event loop, which **broke TLS** (setting a write handler without a bound loop triggers assertions).
> 
> The fix **drops the write-handler clear from `enqueuePendingClientsToMainThread`** and instead, in **`processClientsFromMainThread`**, after `writeToClient` when there are **no pending replies**, explicitly calls `connSetWriteHandler(..., NULL)` while the connection is still bound to the IO thread event loop.
> 
> This targets replica clients that keep a writable (**EPOLLOUT**) handler after all output is flushed—e.g. when periodic **`REPLCONF ACK`** reads hand the client to the main thread before the write callback can remove itself, since ACK produces no reply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e2e1ff65f3a3acec4234aaedd87f2d6c9d9cf47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->