### PR TITLE
MOD-16885: Update RediSearch module to v8.9.90

### DIFF
--- a/modules/modules.yaml
+++ b/modules/modules.yaml
@@ -69,7 +69,7 @@ modules:
     loadmodule: ./modules/redisbloom/redisbloom.so
   - name: redisearch
     repo: https://github.com/redisearch/redisearch
-    ref: v8.9.82
+    ref: v8.9.90
     target_module: search-community/redisearch.so
     loadmodule: ./modules/redisearch/redisearch.so
     build_env: LTO=1 REDISEARCH_GENERATE_HEADERS=0 INLINE_LSE_ATOMICS=0


### PR DESCRIPTION
Updates the bundled RediSearch pin from `v8.9.82` to `v8.9.90`.

Current Redis `unstable` now uses `modules/modules.yaml` as the single source of truth for bundled module refs, so this PR updates the `redisearch` manifest entry instead of `modules/redisearch/Makefile` (which no longer exists).

Validation:
- `scripts/lib/manifest.sh ref redisearch` -> `v8.9.90`
- `scripts/lib/manifest.sh ref-kind redisearch` -> `tag`
- Verified `v8.9.90` resolves through `https://github.com/redisearch/redisearch` to `6fab39bbb5ce12b66ce012d0c761dae21a61b54f`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only version bump with no Redis core or build-flag changes; risk is limited to whatever changed in the RediSearch release between tags.
> 
> **Overview**
> Bumps the bundled **RediSearch** upstream pin from `v8.9.82` to **`v8.9.90`** in `modules/modules.yaml`, which is now the single source of truth for module refs on `unstable`.
> 
> No repo URLs, build artifacts, `loadmodule` paths, or `build_env` change—only the `redisearch` `ref` field. Refresh with `make modules-update redisearch` (or a full modules update) to pull the new tag into `modules/redisearch/src/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ed2d96462d54665049136865ce10f27f8dd426f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->