### PR TITLE
Update RedisTimeSeries module to v8.9.90

### DIFF
--- a/modules/modules.yaml
+++ b/modules/modules.yaml
@@ -80,6 +80,6 @@ modules:
     loadmodule: ./modules/redisjson/rejson.so
   - name: redistimeseries
     repo: https://github.com/redistimeseries/redistimeseries
-    ref: v8.9.82
+    ref: v8.9.90
     target_module: redistimeseries.so
     loadmodule: ./modules/redistimeseries/redistimeseries.so


### PR DESCRIPTION
Bumps the bundled **RedisTimeSeries** pin in `modules/modules.yaml` from **v8.9.82** to **v8.9.90**. Manifest-only change; `loadmodule` path and build settings unchanged. RediSearch/RedisJSON/RedisBloom are untouched here.

## Changelog

### RedisTimeSeries [v8.9.82...v8.9.90](https://github.com/RedisTimeSeries/RedisTimeSeries/compare/v8.9.82...v8.9.90)
- MOD-16382 Handle cluster topology-change notifications — auto-refresh the cluster view on the topology-change event (replaces manual `TIMESERIES.REFRESHCLUSTER`) ([#2104](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2104))
- MOD-16370 Introduce `TS.QUERYLABELS` — return the list of labels and label-values for a filter ([#2090](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2090))
- MOD-16172 Support `EXCLUDEEMPTY` in `TS.MRANGE` / `TS.MREVRANGE` ([#2072](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2072))
- MOD-16873 `TS.INCRBY` replicate the master timestamp when the given timestamp is lower ([#2109](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2109))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only version bump; runtime risk is limited to upstream RedisTimeSeries behavior between v8.9.82 and v8.9.90 after rebuild/redeploy.
> 
> **Overview**
> Updates the **RedisTimeSeries** pin in `modules/modules.yaml` from **v8.9.82** to **v8.9.90**. No changes to `loadmodule`, `target_module`, or other bundled modules—operators refresh sources with `make modules-update redistimeseries`.
> 
> The new tag brings cluster topology auto-refresh on topology-change events, **`TS.QUERYLABELS`**, **`EXCLUDEEMPTY`** on **`TS.MRANGE`** / **`TS.MREVRANGE`**, and corrected replication behavior for **`TS.INCRBY`** when the supplied timestamp is lower than the master’s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c4cf4fdb2d5263dc98d12b4910e99eb247de30b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->