### PR TITLE
Fix ACL key checks for SORT, GEORADIUS/GEORADIUSBYMEMBER, and XREAD/XREADGROUP

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -3549,7 +3549,7 @@ commandHistory GEORADIUS_History[] = {
 #ifndef SKIP_CMD_KEY_SPECS_TABLE
 /* GEORADIUS key specs */
 keySpec GEORADIUS_Keyspecs[3] = {
-{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}},{NULL,CMD_KEY_OW|CMD_KEY_UPDATE,KSPEC_BS_KEYWORD,.bs.keyword={"STORE",6},KSPEC_FK_RANGE,.fk.range={0,1,0}},{NULL,CMD_KEY_OW|CMD_KEY_UPDATE,KSPEC_BS_KEYWORD,.bs.keyword={"STOREDIST",6},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}},{"Incomplete because duplicate STORE options use last-wins; fall back to georadiusGetKeys",CMD_KEY_OW|CMD_KEY_UPDATE|CMD_KEY_INCOMPLETE,KSPEC_BS_KEYWORD,.bs.keyword={"STORE",6},KSPEC_FK_RANGE,.fk.range={0,1,0}},{"Incomplete because duplicate STOREDIST options use last-wins; fall back to georadiusGetKeys",CMD_KEY_OW|CMD_KEY_UPDATE|CMD_KEY_INCOMPLETE,KSPEC_BS_KEYWORD,.bs.keyword={"STOREDIST",6},KSPEC_FK_RANGE,.fk.range={0,1,0}}
 };
 #endif
 
@@ -3612,7 +3612,7 @@ commandHistory GEORADIUSBYMEMBER_History[] = {
 #ifndef SKIP_CMD_KEY_SPECS_TABLE
 /* GEORADIUSBYMEMBER key specs */
 keySpec GEORADIUSBYMEMBER_Keyspecs[3] = {
-{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}},{NULL,CMD_KEY_OW|CMD_KEY_UPDATE,KSPEC_BS_KEYWORD,.bs.keyword={"STORE",5},KSPEC_FK_RANGE,.fk.range={0,1,0}},{NULL,CMD_KEY_OW|CMD_KEY_UPDATE,KSPEC_BS_KEYWORD,.bs.keyword={"STOREDIST",5},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}},{"Incomplete because duplicate STORE options use last-wins; fall back to georadiusGetKeys",CMD_KEY_OW|CMD_KEY_UPDATE|CMD_KEY_INCOMPLETE,KSPEC_BS_KEYWORD,.bs.keyword={"STORE",5},KSPEC_FK_RANGE,.fk.range={0,1,0}},{"Incomplete because duplicate STOREDIST options use last-wins; fall back to georadiusGetKeys",CMD_KEY_OW|CMD_KEY_UPDATE|CMD_KEY_INCOMPLETE,KSPEC_BS_KEYWORD,.bs.keyword={"STOREDIST",5},KSPEC_FK_RANGE,.fk.range={0,1,0}}
 };
 #endif
 

--- a/src/commands.def
+++ b/src/commands.def
@@ -11495,7 +11495,7 @@ commandHistory XREAD_History[] = {
 #ifndef SKIP_CMD_KEY_SPECS_TABLE
 /* XREAD key specs */
 keySpec XREAD_Keyspecs[1] = {
-{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_KEYWORD,.bs.keyword={"STREAMS",1},KSPEC_FK_RANGE,.fk.range={-1,1,2}}
+{"Incomplete because a stream key named STREAMS (or options before it) can shift the STREAMS keyword; fall back to xreadGetKeys",CMD_KEY_RO|CMD_KEY_ACCESS|CMD_KEY_INCOMPLETE,KSPEC_BS_KEYWORD,.bs.keyword={"STREAMS",1},KSPEC_FK_RANGE,.fk.range={-1,1,2}}
 };
 #endif
 
@@ -11532,7 +11532,7 @@ commandHistory XREADGROUP_History[] = {
 #ifndef SKIP_CMD_KEY_SPECS_TABLE
 /* XREADGROUP key specs */
 keySpec XREADGROUP_Keyspecs[1] = {
-{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_KEYWORD,.bs.keyword={"STREAMS",4},KSPEC_FK_RANGE,.fk.range={-1,1,2}}
+{"Incomplete because a consumer/group named STREAMS (or options before GROUP) can shift the STREAMS keyword; fall back to xreadGetKeys",CMD_KEY_RO|CMD_KEY_ACCESS|CMD_KEY_INCOMPLETE,KSPEC_BS_KEYWORD,.bs.keyword={"STREAMS",4},KSPEC_FK_RANGE,.fk.range={-1,1,2}}
 };
 #endif
 

--- a/src/commands/georadius.json
+++ b/src/commands/georadius.json
@@ -49,9 +49,11 @@
                 }
             },
             {
+                "notes": "Incomplete because duplicate STORE options use last-wins; fall back to georadiusGetKeys",
                 "flags": [
                     "OW",
-                    "UPDATE"
+                    "UPDATE",
+                    "INCOMPLETE"
                 ],
                 "begin_search": {
                     "keyword": {
@@ -68,9 +70,11 @@
                 }
             },
             {
+                "notes": "Incomplete because duplicate STOREDIST options use last-wins; fall back to georadiusGetKeys",
                 "flags": [
                     "OW",
-                    "UPDATE"
+                    "UPDATE",
+                    "INCOMPLETE"
                 ],
                 "begin_search": {
                     "keyword": {

--- a/src/commands/georadiusbymember.json
+++ b/src/commands/georadiusbymember.json
@@ -49,9 +49,11 @@
                 }
             },
             {
+                "notes": "Incomplete because duplicate STORE options use last-wins; fall back to georadiusGetKeys",
                 "flags": [
                     "OW",
-                    "UPDATE"
+                    "UPDATE",
+                    "INCOMPLETE"
                 ],
                 "begin_search": {
                     "keyword": {
@@ -68,9 +70,11 @@
                 }
             },
             {
+                "notes": "Incomplete because duplicate STOREDIST options use last-wins; fall back to georadiusGetKeys",
                 "flags": [
                     "OW",
-                    "UPDATE"
+                    "UPDATE",
+                    "INCOMPLETE"
                 ],
                 "begin_search": {
                     "keyword": {

--- a/src/commands/xread.json
+++ b/src/commands/xread.json
@@ -21,9 +21,11 @@
         ],
         "key_specs": [
             {
+                "notes": "Incomplete because a stream key named STREAMS (or options before it) can shift the STREAMS keyword; fall back to xreadGetKeys",
                 "flags": [
                     "RO",
-                    "ACCESS"
+                    "ACCESS",
+                    "INCOMPLETE"
                 ],
                 "begin_search": {
                     "keyword": {

--- a/src/commands/xreadgroup.json
+++ b/src/commands/xreadgroup.json
@@ -26,9 +26,11 @@
         ],
         "key_specs": [
             {
+                "notes": "Incomplete because a consumer/group named STREAMS (or options before GROUP) can shift the STREAMS keyword; fall back to xreadGetKeys",
                 "flags": [
                     "RO",
-                    "ACCESS"
+                    "ACCESS",
+                    "INCOMPLETE"
                 ],
                 "begin_search": {
                     "keyword": {

--- a/src/db.c
+++ b/src/db.c
@@ -3774,8 +3774,10 @@ int migrateGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResul
  * GEORADIUS key x y radius unit [WITHDIST] [WITHHASH] [WITHCOORD] [ASC|DESC]
  *                             [COUNT count] [STORE key|STOREDIST key]
  * GEORADIUSBYMEMBER key member radius unit ... options ...
- * 
- * This command has a fully defined keyspec, so returning flags isn't needed. */
+ *
+ * STORE/STOREDIST keyspecs are marked incomplete because duplicate options
+ * use last-wins semantics (same as georadiusGeneric). ACL and other callers
+ * of getKeysFromCommandWithSpecs fall back here. */
 int georadiusGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
     int i, num;
     keyReference *keys;
@@ -3804,10 +3806,10 @@ int georadiusGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysRes
 
     /* Add all key positions to keys[] */
     keys[0].pos = 1;
-    keys[0].flags = 0;
-    if(num > 1) {
+    keys[0].flags = CMD_KEY_RO | CMD_KEY_ACCESS;
+    if (num > 1) {
          keys[1].pos = stored_key;
-         keys[1].flags = 0;
+         keys[1].flags = CMD_KEY_OW | CMD_KEY_UPDATE;
     }
     result->numkeys = num;
     return num;

--- a/src/db.c
+++ b/src/db.c
@@ -3681,12 +3681,13 @@ int sortGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *
                 i += skiplist[j].skip;
                 break;
             } else if (!strcasecmp(argv[i]->ptr,"store") && i+1 < argc) {
-                /* Note: we don't increment "num" here and continue the loop
-                 * to be sure to process the *last* "STORE" option if multiple
-                 * ones are provided. This is same behavior as SORT. */
+                /* Don't increment "num" so the *last* STORE option wins if
+                 * several are given (same behavior as SORT). Skip the store
+                 * argument (i++) so it isn't re-parsed as an option keyword. */
                 found_store = 1;
                 keys[num].pos = i+1; /* <store-key> */
                 keys[num].flags = CMD_KEY_OW | CMD_KEY_UPDATE;
+                i++;
                 break;
             }
         }
@@ -3818,7 +3819,8 @@ int georadiusGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysRes
 /* XREAD [BLOCK <milliseconds>] [COUNT <count>] [GROUP <groupname> <ttl>]
  *       STREAMS key_1 key_2 ... key_N ID_1 ID_2 ... ID_N
  *
- * This command has a fully defined keyspec, so returning flags isn't needed. */
+ * The keyspec is incomplete, so callers fall back to this function to parse
+ * the options and locate the real STREAMS token. */
 int xreadGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
     int i, num = 0;
     keyReference *keys;
@@ -3835,6 +3837,12 @@ int xreadGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult 
             i++; /* Skip option argument. */
         } else if (!strcasecmp(arg, "count")) {
             i++; /* Skip option argument. */
+        } else if (!strcasecmp(arg, "maxcount")) {
+            i++; /* Skip option argument. */
+        } else if (!strcasecmp(arg, "maxsize")) {
+            i++; /* Skip option argument. */
+        } else if (!strcasecmp(arg, "claim")) {
+            i++; /* Skip option argument (min-idle-time). */
         } else if (!strcasecmp(arg, "group")) {
             i += 2; /* Skip option argument. */
         } else if (!strcasecmp(arg, "noack")) {
@@ -3859,7 +3867,7 @@ int xreadGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult 
     keys = getKeysPrepareResult(result, num);
     for (i = streams_pos+1; i < argc-num; i++) {
         keys[i-streams_pos-1].pos = i;
-        keys[i-streams_pos-1].flags = 0; 
+        keys[i-streams_pos-1].flags = CMD_KEY_RO | CMD_KEY_ACCESS;
     } 
     result->numkeys = num;
     return num;

--- a/src/db.c
+++ b/src/db.c
@@ -3682,12 +3682,11 @@ int sortGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *
                 break;
             } else if (!strcasecmp(argv[i]->ptr,"store") && i+1 < argc) {
                 /* Don't increment "num" so the *last* STORE option wins if
-                 * several are given (same behavior as SORT). Skip the store
-                 * argument (i++) so it isn't re-parsed as an option keyword. */
+                 * several are given (same behavior as SORT). */
                 found_store = 1;
                 keys[num].pos = i+1; /* <store-key> */
                 keys[num].flags = CMD_KEY_OW | CMD_KEY_UPDATE;
-                i++;
+                i++; /* Skip the store argument so it isn't re-parsed as an option keyword. */
                 break;
             }
         }

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -397,6 +397,21 @@ start_server {tags {"acl external:skip"}} {
         assert_match {*has no permissions to access the 'write1' key*} [r ACL DRYRUN command-test GEORADIUS write1 longitude latitude radius M STORE write2]
     }
 
+    test {Test GEORADIUS duplicate STORE is checked against the last key} {
+        r ACL setuser command-test +@all %R~read* %W~write* %RW~rw*
+
+        # Duplicate STORE/STOREDIST uses last-wins semantics (same as
+        # georadiusGeneric), so ACL must validate the last key. Otherwise a
+        # permitted first key would mask a forbidden second key.
+        assert_equal "OK" [r ACL DRYRUN command-test GEORADIUS read longitude latitude radius M STORE read1 STORE write2]
+        assert_match {*has no permissions to access the 'read2' key*} [r ACL DRYRUN command-test GEORADIUS read longitude latitude radius M STORE write1 STORE read2]
+        assert_match {*has no permissions to access the 'read2' key*} [r ACL DRYRUN command-test GEORADIUS read longitude latitude radius M STOREDIST write1 STOREDIST read2]
+
+        assert_equal "OK" [r ACL DRYRUN command-test GEORADIUSBYMEMBER read member radius M STORE read1 STORE write2]
+        assert_match {*has no permissions to access the 'read2' key*} [r ACL DRYRUN command-test GEORADIUSBYMEMBER read member radius M STORE write1 STORE read2]
+        assert_match {*has no permissions to access the 'read2' key*} [r ACL DRYRUN command-test GEORADIUSBYMEMBER read member radius M STOREDIST write1 STOREDIST read2]
+    }
+
     # Existence test commands are not marked as access since they are the result
     # of a lot of write commands. We therefore make the claim they can be executed
     # when either READ or WRITE flags are provided.

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -412,6 +412,40 @@ start_server {tags {"acl external:skip"}} {
         assert_match {*has no permissions to access the 'read2' key*} [r ACL DRYRUN command-test GEORADIUSBYMEMBER read member radius M STOREDIST write1 STOREDIST read2]
     }
 
+    test {Test SORT duplicate STORE is checked against the last key} {
+        r ACL setuser command-test +@all %R~read* %W~write* %RW~rw*
+
+        # Duplicate STORE uses last-wins semantics, so ACL must validate the
+        # last key. The earlier STORE argument can look like an option keyword
+        # (BY/GET/LIMIT) and must be skipped so a permitted first key doesn't
+        # mask a forbidden last key.
+        assert_equal "OK" [r ACL DRYRUN command-test SORT read STORE by STORE write2]
+        assert_match {*has no permissions to access the 'read2' key*} [r ACL DRYRUN command-test SORT read STORE by STORE read2]
+        assert_match {*has no permissions to access the 'read2' key*} [r ACL DRYRUN command-test SORT read STORE get STORE read2]
+        assert_match {*has no permissions to access the 'read2' key*} [r ACL DRYRUN command-test SORT read STORE limit STORE read2]
+    }
+
+    test {Test XREADGROUP STREAMS keyword is not confused with the consumer name} {
+        r ACL setuser command-test +@all %R~read* %W~write* %RW~rw*
+
+        # A consumer literally named "STREAMS" must not be mistaken for the
+        # STREAMS option, otherwise ACL validates the wrong argument.
+        assert_equal "OK" [r ACL DRYRUN command-test XREADGROUP NOACK GROUP g STREAMS STREAMS read2 >]
+        assert_match {*has no permissions to access the 'write2' key*} [r ACL DRYRUN command-test XREADGROUP NOACK GROUP g STREAMS STREAMS write2 >]
+        assert_match {*has no permissions to access the 'write2' key*} [r ACL DRYRUN command-test XREADGROUP COUNT 1 GROUP g STREAMS STREAMS write2 >]
+
+        # Options carrying an argument must be skipped when locating STREAMS.
+        assert_match {*has no permissions to access the 'write2' key*} [r ACL DRYRUN command-test XREADGROUP GROUP g consumer MAXCOUNT 10 STREAMS write2 >]
+        assert_match {*has no permissions to access the 'write2' key*} [r ACL DRYRUN command-test XREADGROUP GROUP g consumer CLAIM 100 STREAMS write2 >]
+        assert_match {*has no permissions to access the 'write2' key*} [r ACL DRYRUN command-test XREAD MAXSIZE 5 STREAMS write2 $]
+        assert_match {*has no permissions to access the 'write2' key*} [r ACL DRYRUN command-test XREAD MAXCOUNT 5 STREAMS write2 $]
+        assert_equal "OK" [r ACL DRYRUN command-test XREADGROUP GROUP g consumer MAXCOUNT 10 STREAMS read2 >]
+
+        # Sanity: a normal consumer name still validates the real stream key.
+        assert_equal "OK" [r ACL DRYRUN command-test XREADGROUP GROUP g consumer STREAMS read2 >]
+        assert_match {*has no permissions to access the 'write2' key*} [r ACL DRYRUN command-test XREADGROUP GROUP g consumer STREAMS write2 >]
+    }
+
     # Existence test commands are not marked as access since they are the result
     # of a lot of write commands. We therefore make the claim they can be executed
     # when either READ or WRITE flags are provided.


### PR DESCRIPTION
## Problem

Several commands resolved ACL keys from a keyspec that didn't match the key the command actually operates on, allowing a permission bypass:

- **`GEORADIUS`/`GEORADIUSBYMEMBER`**: the `STORE`/`STOREDIST` keyspec matches the **first** occurrence of the keyword, but the command uses **last-wins** semantics and writes to the **last** key. So `GEORADIUS ... STORE <permitted> STORE <forbidden>` passed ACL while writing to the forbidden key (same for `STOREDIST` and both commands).

- **`SORT`**: `STORE` also uses last-wins semantics. The `STORE` keyspec is already `unknown`, so ACL falls back to `sortGetKeys()` — but that parser didn't skip the `STORE` argument. An earlier `STORE` value that looks like an option keyword (`BY`/`GET`/`LIMIT`) derailed the scan, so a permitted (or non-existent) first key masked a forbidden last key that the write actually landed on.

- **`XREAD`/`XREADGROUP`**: the stream keys are the args after the `STREAMS` keyword, whose position is found by a static keyspec. A consumer/group named `STREAMS`, or options before `GROUP`/`STREAMS`, could shift the real `STREAMS` token so ACL validated the wrong argument and the read hit a forbidden key.

## Solution

Make ACL resolve keys via each command's `getKeys` function, which returns the effective keys with proper flags:

- **`GEORADIUS`/`GEORADIUSBYMEMBER`**: mark the `STORE`/`STOREDIST` keyspecs `INCOMPLETE` so ACL falls back to `georadiusGetKeys()`, which returns the last key (`RO|ACCESS` source, `OW|UPDATE` store).
- **`SORT`**: no keyspec change needed — the `STORE` keyspec is already `unknown`, so ACL already delegates to `sortGetKeys()`. Fixed the parser to skip the `STORE` argument (`i++`) so it isn't re-parsed as an option keyword; the last `STORE` still wins.
- **`XREAD`/`XREADGROUP`**: mark the keyspecs `INCOMPLETE` and fall back to `xreadGetKeys()`, which now skips option arguments (`COUNT`, `MAXCOUNT`, `MAXSIZE`, `CLAIM`, `GROUP`, …) to locate the real `STREAMS` token and tags the resolved keys `RO|ACCESS`.

Adds `acl-v2` tests for duplicate `STORE`/`STOREDIST` (`GEORADIUS`/`GEORADIUSBYMEMBER`, `SORT`) and for the `XREAD`/`XREADGROUP` `STREAMS`-keyword confusion.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix for ACL permission bypass on geo, sort, and stream commands; behavior change is intentional and limited to key resolution for ACL and related getKeys callers.
> 
> **Overview**
> Fixes **ACL key checks** that could approve commands while touching keys the user was not allowed to access.
> 
> **GEORADIUS / GEORADIUSBYMEMBER** — `STORE` and `STOREDIST` keyspecs are marked **INCOMPLETE** so ACL uses `georadiusGetKeys()`, which applies **last-wins** for duplicate options and sets read vs overwrite flags on the geo key and store key.
> 
> **SORT** — `sortGetKeys()` now **skips the key argument** after `STORE` so a value like `BY`/`GET`/`LIMIT` is not scanned as an option; ACL still validates the **last** `STORE` key.
> 
> **XREAD / XREADGROUP** — stream keyspecs are **INCOMPLETE** so ACL uses `xreadGetKeys()`, which skips option arguments (`MAXCOUNT`, `MAXSIZE`, `CLAIM`, etc.) to find the real `STREAMS` token when a consumer/group is named `STREAMS`.
> 
> Adds **`acl-v2`** `ACL DRYRUN` coverage for duplicate `STORE`/`STOREDIST`, `SORT` duplicate `STORE`, and `XREAD`/`XREADGROUP` `STREAMS` confusion cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb2ad3b8cde4b5293c7afedf9c939de9d794ae68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->