### PR TITLE
Fix LFU counters when switching maxmemory-policy at runtime

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2596,15 +2596,18 @@ static int updateReplBacklogSize(const char **err) {
 /* When switching maxmemory-policy at runtime, re-seed key access metadata so
  * the lru field encoding matches the new policy. Keys stored under a non-LFU
  * policy keep an LRU-encoded lru field; under LFU that is treated as frequency
- * 0 and can be preferred for eviction. The reverse (LFU -> idle-based) matters
- * for multi-arg CONFIG SET rollback and for LFU -> LRU/LRM: apply re-seeds LFU,
+ * 0 and can be preferred for eviction. The reverse (LFU -> non-LFU) matters for
+ * multi-arg CONFIG SET rollback and for LFU -> LRU/LRM: apply re-seeds LFU,
  * then a later failure restores the old non-LFU policy and must re-seed LRU
  * clocks so eviction does not interpret LFU counters as idle time. LRM scores
  * with estimateObjectIdleTime on the same field. See #15375.
  *
- * Only reseed when the LFU encoding bit flips. Switches within the same
- * encoding (allkeys-lru <-> volatile-lru, allkeys-lfu <-> volatile-lfu,
- * allkeys-lrm <-> volatile-lrm, lru <-> lrm) must not rewrite every key. */
+ * Always reseed when the LFU encoding bit flips, including LFU -> noeviction /
+ * random / volatile-ttl. Skipping those left LFU-encoded values on keys while
+ * prev_maxmemory_lfu claimed non-LFU, so a later switch to LRU/LRM saw no bit
+ * flip and treated LFU counters as idle clocks. Same-encoding switches
+ * (allkeys-lru <-> volatile-lru, allkeys-lfu <-> volatile-lfu, lru <-> lrm)
+ * do not rewrite every key. */
 static int prev_maxmemory_lfu = -1;
 
 /* loadServerConfig only sets maxmemory-policy and never runs apply. Seed the
@@ -2618,9 +2621,6 @@ static void seedMaxmemoryPolicyBaseline(void) {
 static int updateMaxmemoryPolicy(const char **err) {
     UNUSED(err);
     int lfu = server.maxmemory_policy & MAXMEMORY_FLAG_LFU ? 1 : 0;
-    /* LRU and LRM both score keys via estimateObjectIdleTime on lru. */
-    int idle_based = server.maxmemory_policy &
-                     (MAXMEMORY_FLAG_LRU|MAXMEMORY_FLAG_LRM) ? 1 : 0;
 
     /* Defensive: if baseline was never seeded, keys already match the live
      * policy encoding from createObject / initObjectLRUOrLFU. */
@@ -2631,13 +2631,6 @@ static int updateMaxmemoryPolicy(const char **err) {
 
     if (prev_maxmemory_lfu == lfu)
         return 1;
-
-    /* Leaving LFU for random / noeviction / volatile-ttl: field unused for
-     * eviction scoring, skip the keyspace walk. */
-    if (!lfu && !idle_based) {
-        prev_maxmemory_lfu = lfu;
-        return 1;
-    }
 
     for (int j = 0; j < server.dbnum; j++) {
         redisDb *db = server.db + j;

--- a/src/config.c
+++ b/src/config.c
@@ -2588,6 +2588,31 @@ static int updateReplBacklogSize(const char **err) {
     return 1;
 }
 
+/* When switching into an LFU policy at runtime, re-seed every object's LFU
+ * counter. Otherwise keys that were stored under LRU/noeviction keep their
+ * old lru field encoding, which OBJECT FREQ and eviction treat as frequency
+ * 0 and can preferentially evict. See #15375. */
+static int updateMaxmemoryPolicy(const char **err) {
+    UNUSED(err);
+    if (!(server.maxmemory_policy & MAXMEMORY_FLAG_LFU))
+        return 1;
+
+    for (int j = 0; j < server.dbnum; j++) {
+        redisDb *db = server.db + j;
+        if (!kvstoreSize(db->keys)) continue;
+
+        dictEntry *de;
+        kvstoreIterator kvs_it;
+        kvstoreIteratorInit(&kvs_it, db->keys);
+        while ((de = kvstoreIteratorNext(&kvs_it)) != NULL) {
+            kvobj *kv = dictGetKV(de);
+            kv->lru = (LFUGetTimeInMinutes() << 8) | LFU_INIT_VAL;
+        }
+        kvstoreIteratorReset(&kvs_it);
+    }
+    return 1;
+}
+
 static int updateMaxmemory(const char **err) {
     UNUSED(err);
     if (server.maxmemory) {
@@ -3270,7 +3295,7 @@ standardConfig static_configs[] = {
     createEnumConfig("syslog-facility", NULL, IMMUTABLE_CONFIG, syslog_facility_enum, server.syslog_facility, LOG_LOCAL0, NULL, NULL),
     createEnumConfig("repl-diskless-load", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG | DENY_LOADING_CONFIG, repl_diskless_load_enum, server.repl_diskless_load, REPL_DISKLESS_LOAD_DISABLED, NULL, NULL),
     createEnumConfig("loglevel", NULL, MODIFIABLE_CONFIG, loglevel_enum, server.verbosity, LL_NOTICE, NULL, NULL),
-    createEnumConfig("maxmemory-policy", NULL, MODIFIABLE_CONFIG, maxmemory_policy_enum, server.maxmemory_policy, MAXMEMORY_NO_EVICTION, NULL, NULL),
+    createEnumConfig("maxmemory-policy", NULL, MODIFIABLE_CONFIG, maxmemory_policy_enum, server.maxmemory_policy, MAXMEMORY_NO_EVICTION, NULL, updateMaxmemoryPolicy),
     createEnumConfig("appendfsync", NULL, MODIFIABLE_CONFIG, aof_fsync_enum, server.aof_fsync, AOF_FSYNC_EVERYSEC, NULL, updateAppendFsync),
     createEnumConfig("oom-score-adj", NULL, MODIFIABLE_CONFIG, oom_score_adj_enum, server.oom_score_adj, OOM_SCORE_ADJ_NO, NULL, updateOOMScoreAdj),
     createEnumConfig("acl-pubsub-default", NULL, MODIFIABLE_CONFIG, acl_pubsub_default_enum, server.acl_pubsub_default, 0, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -2594,15 +2594,35 @@ static int updateReplBacklogSize(const char **err) {
  * 0 and can be preferred for eviction. The reverse (LFU -> LRU) matters for
  * multi-arg CONFIG SET rollback: apply re-seeds LFU, then a later failure
  * restores the old non-LFU policy and must re-seed LRU clocks so eviction does
- * not interpret LFU counters as idle time. See #15375. */
+ * not interpret LFU counters as idle time. See #15375.
+ *
+ * Only reseed when the LFU encoding bit flips. Switches within the same
+ * encoding (allkeys-lru <-> volatile-lru, allkeys-lfu <-> volatile-lfu) must
+ * not rewrite every key's lru field. */
 static int updateMaxmemoryPolicy(const char **err) {
     UNUSED(err);
-    int lfu = server.maxmemory_policy & MAXMEMORY_FLAG_LFU;
-    int lru = server.maxmemory_policy & MAXMEMORY_FLAG_LRU;
+    /* -1: not yet initialized (startup config apply / first CONFIG SET). */
+    static int prev_lfu = -1;
+    int lfu = server.maxmemory_policy & MAXMEMORY_FLAG_LFU ? 1 : 0;
+    int lru = server.maxmemory_policy & MAXMEMORY_FLAG_LRU ? 1 : 0;
 
-    /* Random / noeviction do not use the lru field for eviction. */
-    if (!lfu && !lru)
+    /* Encoding unchanged after we have a baseline. */
+    if (prev_lfu == lfu && prev_lfu != -1)
         return 1;
+
+    /* First call while non-LFU (typical startup / noeviction default): just
+     * record baseline. First call into LFU still reseeds so keys created under
+     * the default non-LFU policy before any apply get correct counters. */
+    if (prev_lfu == -1 && !lfu) {
+        prev_lfu = 0;
+        return 1;
+    }
+
+    /* Leaving LFU for random/noeviction: field unused for eviction, skip walk. */
+    if (!lfu && !lru) {
+        prev_lfu = lfu;
+        return 1;
+    }
 
     for (int j = 0; j < server.dbnum; j++) {
         redisDb *db = server.db + j;
@@ -2620,6 +2640,7 @@ static int updateMaxmemoryPolicy(const char **err) {
         }
         kvstoreIteratorReset(&kvs_it);
     }
+    prev_lfu = lfu;
     return 1;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -2640,19 +2640,15 @@ static int updateMaxmemoryPolicy(const char **err) {
         /* LFU bit unchanged. Reopen idle import only when *entering* an
          * idle-scoring policy from a non-scoring one (LFU -> noeviction ->
          * LRU), once per leave-LFU cycle. Same-encoding LRU <-> LRU must not
-         * reopen or IDLETIME is rewritten. */
+         * reopen or IDLETIME is rewritten.
+         *
+         * Do not clear lru_field_may_be_lfu merely because the initial window
+         * expired while still on idle scoring: untouched keys may still be
+         * LFU-encoded, and a later non-scoring -> LRU hop needs one reopen. */
         if (!lfu && lru_field_may_be_lfu && idle_scoring && !prev_idle_scoring)
         {
             server.lru_import_until = mstime() + MAXMEMORY_POLICY_IMPORT_MS;
-            /* One reopen only; do not keep reopening on later non-scoring
-             * hops after keys have had a chance to convert. */
-            lru_field_may_be_lfu = 0;
-        } else if (!lfu && lru_field_may_be_lfu && idle_scoring &&
-                   prev_idle_scoring && server.lru_import_until &&
-                   mstime() >= server.lru_import_until)
-        {
-            /* Already on idle scoring and the initial window expired: residue
-             * flag is no longer needed. */
+            /* One reopen only; further non-scoring hops do not reopen. */
             lru_field_may_be_lfu = 0;
         }
         prev_idle_scoring = idle_scoring;

--- a/src/config.c
+++ b/src/config.c
@@ -2597,17 +2597,20 @@ static int updateReplBacklogSize(const char **err) {
  * still hold the previous encoding of the shared lru field. Walking the whole
  * keyspace on CONFIG SET is not acceptable on large instances.
  *
- * Lazy convert instead:
- * - non-LFU -> LFU: short import window; LFUDecrAndReturn / OBJECT FREQ convert
- *   on first LFU use (heuristic: lru still looks like an LRU clock).
- * - LFU -> non-LFU: no time window; estimateObjectIdleTime converts when the
- *   field still looks like LFU encoding (warm LFU ldt, or idle impossible for
- *   process uptime). Already-correct LRU clocks are left alone.
- * Same-encoding switches (allkeys-lru <-> volatile-lru, LFU <-> LFU) are no-ops.
- * See #15375. */
-#define MAXMEMORY_POLICY_IMPORT_MS 60000 /* 60s lazy LFU import window */
+ * Lazy convert on short import windows instead:
+ * - non-LFU -> LFU: lfu_import_until; LFUDecrAndReturn / OBJECT FREQ convert
+ * - LFU -> non-LFU: lru_import_until; estimateObjectIdleTime / OBJECT IDLETIME
+ *   convert. Also set lru_field_may_be_lfu so LFU->noeviction->LRU after the
+ *   window expires can reopen import (encoding bit alone would not flip).
+ * Same-encoding switches (allkeys-lru <-> volatile-lru, LFU <-> LFU) are no-ops
+ * unless reopening a dirty idle import. See #15375. */
+#define MAXMEMORY_POLICY_IMPORT_MS 60000 /* 60s lazy convert window */
 
 static int prev_maxmemory_lfu = -1;
+static int prev_idle_scoring = -1;
+/* Keys may still hold LFU-encoded lru after leaving LFU (until imported or
+ * rewritten by access under a non-LFU policy). */
+static int lru_field_may_be_lfu = 0;
 
 /* loadServerConfig only sets maxmemory-policy and never runs apply. Seed the
  * LFU-bit baseline from the live (default or conf-file) policy so the first
@@ -2615,32 +2618,52 @@ static int prev_maxmemory_lfu = -1;
  * defaults (initConfigValues) and again after config load. */
 static void seedMaxmemoryPolicyBaseline(void) {
     prev_maxmemory_lfu = server.maxmemory_policy & MAXMEMORY_FLAG_LFU ? 1 : 0;
+    prev_idle_scoring = server.maxmemory_policy &
+        (MAXMEMORY_FLAG_LRU|MAXMEMORY_FLAG_LRM) ? 1 : 0;
 }
 
 static int updateMaxmemoryPolicy(const char **err) {
     UNUSED(err);
     int lfu = server.maxmemory_policy & MAXMEMORY_FLAG_LFU ? 1 : 0;
+    int idle_scoring = server.maxmemory_policy &
+        (MAXMEMORY_FLAG_LRU|MAXMEMORY_FLAG_LRM) ? 1 : 0;
 
     /* Defensive: if baseline was never seeded, keys already match the live
      * policy encoding from createObject / initObjectLRUOrLFU. */
     if (prev_maxmemory_lfu == -1) {
         prev_maxmemory_lfu = lfu;
+        prev_idle_scoring = idle_scoring;
         return 1;
     }
 
-    if (prev_maxmemory_lfu == lfu)
+    if (prev_maxmemory_lfu == lfu) {
+        /* LFU bit unchanged. Reopen idle import only when *entering* an
+         * idle-scoring policy from a non-scoring one (LFU -> noeviction ->
+         * LRU). Same-encoding LRU <-> LRU must not reopen or IDLETIME is
+         * rewritten. */
+        if (!lfu && lru_field_may_be_lfu && idle_scoring && !prev_idle_scoring)
+        {
+            server.lru_import_until = mstime() + MAXMEMORY_POLICY_IMPORT_MS;
+        }
+        prev_idle_scoring = idle_scoring;
         return 1;
+    }
 
-    /* Encoding flipped: no keyspace walk. Open the LFU import window only when
-     * entering LFU; clear it when leaving so a bounce cannot keep converting
-     * under the wrong policy. LFU->idle convert is heuristic (no deadline). */
+    /* Encoding flipped: enable lazy per-object convert, no keyspace walk.
+     * Clear the opposite window so a quick bounce cannot rewrite under the
+     * wrong active policy. */
     if (lfu) {
         server.lfu_import_until = mstime() + MAXMEMORY_POLICY_IMPORT_MS;
+        server.lru_import_until = 0;
+        lru_field_may_be_lfu = 0;
     } else {
+        server.lru_import_until = mstime() + MAXMEMORY_POLICY_IMPORT_MS;
         server.lfu_import_until = 0;
+        lru_field_may_be_lfu = 1;
     }
 
     prev_maxmemory_lfu = lfu;
+    prev_idle_scoring = idle_scoring;
     return 1;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -2593,21 +2593,17 @@ static int updateReplBacklogSize(const char **err) {
     return 1;
 }
 
-/* When switching maxmemory-policy at runtime, re-seed key access metadata so
- * the lru field encoding matches the new policy. Keys stored under a non-LFU
- * policy keep an LRU-encoded lru field; under LFU that is treated as frequency
- * 0 and can be preferred for eviction. The reverse (LFU -> non-LFU) matters for
- * multi-arg CONFIG SET rollback and for LFU -> LRU/LRM: apply re-seeds LFU,
- * then a later failure restores the old non-LFU policy and must re-seed LRU
- * clocks so eviction does not interpret LFU counters as idle time. LRM scores
- * with estimateObjectIdleTime on the same field. See #15375.
+/* When maxmemory-policy flips between LFU and non-LFU encodings, existing keys
+ * still hold the previous encoding of the shared lru field. Walking the whole
+ * keyspace on CONFIG SET is not acceptable on large instances.
  *
- * Always reseed when the LFU encoding bit flips, including LFU -> noeviction /
- * random / volatile-ttl. Skipping those left LFU-encoded values on keys while
- * prev_maxmemory_lfu claimed non-LFU, so a later switch to LRU/LRM saw no bit
- * flip and treated LFU counters as idle clocks. Same-encoding switches
- * (allkeys-lru <-> volatile-lru, allkeys-lfu <-> volatile-lfu, lru <-> lrm)
- * do not rewrite every key. */
+ * Instead open a short lazy-import window. On first use of each object as LFU
+ * (LFUDecrAndReturn / eviction samples / OBJECT FREQ) or as idle time
+ * (estimateObjectIdleTime / OBJECT IDLETIME), convert that object only.
+ * Same-encoding switches (allkeys-lru <-> volatile-lru, LFU <-> LFU) are no-ops.
+ * See #15375. */
+#define MAXMEMORY_POLICY_IMPORT_MS 60000 /* 60s lazy convert window */
+
 static int prev_maxmemory_lfu = -1;
 
 /* loadServerConfig only sets maxmemory-policy and never runs apply. Seed the
@@ -2632,22 +2628,12 @@ static int updateMaxmemoryPolicy(const char **err) {
     if (prev_maxmemory_lfu == lfu)
         return 1;
 
-    for (int j = 0; j < server.dbnum; j++) {
-        redisDb *db = server.db + j;
-        if (!kvstoreSize(db->keys)) continue;
+    /* Encoding flipped: enable lazy per-object convert, no keyspace walk. */
+    if (lfu)
+        server.lfu_import_until = mstime() + MAXMEMORY_POLICY_IMPORT_MS;
+    else
+        server.lru_import_until = mstime() + MAXMEMORY_POLICY_IMPORT_MS;
 
-        dictEntry *de;
-        kvstoreIterator kvs_it;
-        kvstoreIteratorInit(&kvs_it, db->keys);
-        while ((de = kvstoreIteratorNext(&kvs_it)) != NULL) {
-            kvobj *kv = dictGetKV(de);
-            if (lfu)
-                kv->lru = (LFUGetTimeInMinutes() << 8) | LFU_INIT_VAL;
-            else
-                kv->lru = LRU_CLOCK();
-        }
-        kvstoreIteratorReset(&kvs_it);
-    }
     prev_maxmemory_lfu = lfu;
     return 1;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -2588,13 +2588,20 @@ static int updateReplBacklogSize(const char **err) {
     return 1;
 }
 
-/* When switching into an LFU policy at runtime, re-seed every object's LFU
- * counter. Otherwise keys that were stored under LRU/noeviction keep their
- * old lru field encoding, which OBJECT FREQ and eviction treat as frequency
- * 0 and can preferentially evict. See #15375. */
+/* When switching maxmemory-policy at runtime, re-seed key access metadata so
+ * the lru field encoding matches the new policy. Keys stored under a non-LFU
+ * policy keep an LRU-encoded lru field; under LFU that is treated as frequency
+ * 0 and can be preferred for eviction. The reverse (LFU -> LRU) matters for
+ * multi-arg CONFIG SET rollback: apply re-seeds LFU, then a later failure
+ * restores the old non-LFU policy and must re-seed LRU clocks so eviction does
+ * not interpret LFU counters as idle time. See #15375. */
 static int updateMaxmemoryPolicy(const char **err) {
     UNUSED(err);
-    if (!(server.maxmemory_policy & MAXMEMORY_FLAG_LFU))
+    int lfu = server.maxmemory_policy & MAXMEMORY_FLAG_LFU;
+    int lru = server.maxmemory_policy & MAXMEMORY_FLAG_LRU;
+
+    /* Random / noeviction do not use the lru field for eviction. */
+    if (!lfu && !lru)
         return 1;
 
     for (int j = 0; j < server.dbnum; j++) {
@@ -2606,7 +2613,10 @@ static int updateMaxmemoryPolicy(const char **err) {
         kvstoreIteratorInit(&kvs_it, db->keys);
         while ((de = kvstoreIteratorNext(&kvs_it)) != NULL) {
             kvobj *kv = dictGetKV(de);
-            kv->lru = (LFUGetTimeInMinutes() << 8) | LFU_INIT_VAL;
+            if (lfu)
+                kv->lru = (LFUGetTimeInMinutes() << 8) | LFU_INIT_VAL;
+            else
+                kv->lru = LRU_CLOCK();
         }
         kvstoreIteratorReset(&kvs_it);
     }

--- a/src/config.c
+++ b/src/config.c
@@ -652,6 +652,9 @@ loaderr:
     exit(1);
 }
 
+/* Forward decl: defined with updateMaxmemoryPolicy; called after config load. */
+static void seedMaxmemoryPolicyBaseline(void);
+
 /* Load the server configuration from the specified filename.
  * The function appends the additional configuration directives stored
  * in the 'options' string to the config file before loading.
@@ -731,6 +734,8 @@ void loadServerConfig(char *filename, char config_from_stdin, char *options) {
     }
     loadServerConfigFromString(config);
     sdsfree(config);
+    /* Conf may have set maxmemory-policy without apply; refresh LFU baseline. */
+    seedMaxmemoryPolicyBaseline();
 }
 
 static int performInterfaceSet(standardConfig *config, sds value, const char **errstr) {
@@ -2591,36 +2596,46 @@ static int updateReplBacklogSize(const char **err) {
 /* When switching maxmemory-policy at runtime, re-seed key access metadata so
  * the lru field encoding matches the new policy. Keys stored under a non-LFU
  * policy keep an LRU-encoded lru field; under LFU that is treated as frequency
- * 0 and can be preferred for eviction. The reverse (LFU -> LRU) matters for
- * multi-arg CONFIG SET rollback: apply re-seeds LFU, then a later failure
- * restores the old non-LFU policy and must re-seed LRU clocks so eviction does
- * not interpret LFU counters as idle time. See #15375.
+ * 0 and can be preferred for eviction. The reverse (LFU -> idle-based) matters
+ * for multi-arg CONFIG SET rollback and for LFU -> LRU/LRM: apply re-seeds LFU,
+ * then a later failure restores the old non-LFU policy and must re-seed LRU
+ * clocks so eviction does not interpret LFU counters as idle time. LRM scores
+ * with estimateObjectIdleTime on the same field. See #15375.
  *
  * Only reseed when the LFU encoding bit flips. Switches within the same
- * encoding (allkeys-lru <-> volatile-lru, allkeys-lfu <-> volatile-lfu) must
- * not rewrite every key's lru field. */
+ * encoding (allkeys-lru <-> volatile-lru, allkeys-lfu <-> volatile-lfu,
+ * allkeys-lrm <-> volatile-lrm, lru <-> lrm) must not rewrite every key. */
+static int prev_maxmemory_lfu = -1;
+
+/* loadServerConfig only sets maxmemory-policy and never runs apply. Seed the
+ * LFU-bit baseline from the live (default or conf-file) policy so the first
+ * CONFIG SET between LFU variants is not treated as "enter LFU". Called after
+ * defaults (initConfigValues) and again after config load. */
+static void seedMaxmemoryPolicyBaseline(void) {
+    prev_maxmemory_lfu = server.maxmemory_policy & MAXMEMORY_FLAG_LFU ? 1 : 0;
+}
+
 static int updateMaxmemoryPolicy(const char **err) {
     UNUSED(err);
-    /* -1: not yet initialized (startup config apply / first CONFIG SET). */
-    static int prev_lfu = -1;
     int lfu = server.maxmemory_policy & MAXMEMORY_FLAG_LFU ? 1 : 0;
-    int lru = server.maxmemory_policy & MAXMEMORY_FLAG_LRU ? 1 : 0;
+    /* LRU and LRM both score keys via estimateObjectIdleTime on lru. */
+    int idle_based = server.maxmemory_policy &
+                     (MAXMEMORY_FLAG_LRU|MAXMEMORY_FLAG_LRM) ? 1 : 0;
 
-    /* Encoding unchanged after we have a baseline. */
-    if (prev_lfu == lfu && prev_lfu != -1)
-        return 1;
-
-    /* First call while non-LFU (typical startup / noeviction default): just
-     * record baseline. First call into LFU still reseeds so keys created under
-     * the default non-LFU policy before any apply get correct counters. */
-    if (prev_lfu == -1 && !lfu) {
-        prev_lfu = 0;
+    /* Defensive: if baseline was never seeded, keys already match the live
+     * policy encoding from createObject / initObjectLRUOrLFU. */
+    if (prev_maxmemory_lfu == -1) {
+        prev_maxmemory_lfu = lfu;
         return 1;
     }
 
-    /* Leaving LFU for random/noeviction: field unused for eviction, skip walk. */
-    if (!lfu && !lru) {
-        prev_lfu = lfu;
+    if (prev_maxmemory_lfu == lfu)
+        return 1;
+
+    /* Leaving LFU for random / noeviction / volatile-ttl: field unused for
+     * eviction scoring, skip the keyspace walk. */
+    if (!lfu && !idle_based) {
+        prev_maxmemory_lfu = lfu;
         return 1;
     }
 
@@ -2640,7 +2655,7 @@ static int updateMaxmemoryPolicy(const char **err) {
         }
         kvstoreIteratorReset(&kvs_it);
     }
-    prev_lfu = lfu;
+    prev_maxmemory_lfu = lfu;
     return 1;
 }
 
@@ -3512,6 +3527,8 @@ void initConfigValues(void) {
             serverAssert(ret);
         }
     }
+    /* Defaults are live; seed before any client keys or CONFIG SET. */
+    seedMaxmemoryPolicyBaseline();
 }
 
 /* Remove a config by name from the configs dict. */

--- a/src/config.c
+++ b/src/config.c
@@ -2628,11 +2628,16 @@ static int updateMaxmemoryPolicy(const char **err) {
     if (prev_maxmemory_lfu == lfu)
         return 1;
 
-    /* Encoding flipped: enable lazy per-object convert, no keyspace walk. */
-    if (lfu)
+    /* Encoding flipped: enable lazy per-object convert, no keyspace walk.
+     * Clear the opposite window so a quick LFU<->non-LFU bounce cannot leave
+     * a stale deadline that rewrites keys under the wrong active policy. */
+    if (lfu) {
         server.lfu_import_until = mstime() + MAXMEMORY_POLICY_IMPORT_MS;
-    else
+        server.lru_import_until = 0;
+    } else {
         server.lru_import_until = mstime() + MAXMEMORY_POLICY_IMPORT_MS;
+        server.lfu_import_until = 0;
+    }
 
     prev_maxmemory_lfu = lfu;
     return 1;

--- a/src/config.c
+++ b/src/config.c
@@ -2639,11 +2639,21 @@ static int updateMaxmemoryPolicy(const char **err) {
     if (prev_maxmemory_lfu == lfu) {
         /* LFU bit unchanged. Reopen idle import only when *entering* an
          * idle-scoring policy from a non-scoring one (LFU -> noeviction ->
-         * LRU). Same-encoding LRU <-> LRU must not reopen or IDLETIME is
-         * rewritten. */
+         * LRU), once per leave-LFU cycle. Same-encoding LRU <-> LRU must not
+         * reopen or IDLETIME is rewritten. */
         if (!lfu && lru_field_may_be_lfu && idle_scoring && !prev_idle_scoring)
         {
             server.lru_import_until = mstime() + MAXMEMORY_POLICY_IMPORT_MS;
+            /* One reopen only; do not keep reopening on later non-scoring
+             * hops after keys have had a chance to convert. */
+            lru_field_may_be_lfu = 0;
+        } else if (!lfu && lru_field_may_be_lfu && idle_scoring &&
+                   prev_idle_scoring && server.lru_import_until &&
+                   mstime() >= server.lru_import_until)
+        {
+            /* Already on idle scoring and the initial window expired: residue
+             * flag is no longer needed. */
+            lru_field_may_be_lfu = 0;
         }
         prev_idle_scoring = idle_scoring;
         return 1;

--- a/src/config.c
+++ b/src/config.c
@@ -2597,12 +2597,15 @@ static int updateReplBacklogSize(const char **err) {
  * still hold the previous encoding of the shared lru field. Walking the whole
  * keyspace on CONFIG SET is not acceptable on large instances.
  *
- * Instead open a short lazy-import window. On first use of each object as LFU
- * (LFUDecrAndReturn / eviction samples / OBJECT FREQ) or as idle time
- * (estimateObjectIdleTime / OBJECT IDLETIME), convert that object only.
+ * Lazy convert instead:
+ * - non-LFU -> LFU: short import window; LFUDecrAndReturn / OBJECT FREQ convert
+ *   on first LFU use (heuristic: lru still looks like an LRU clock).
+ * - LFU -> non-LFU: no time window; estimateObjectIdleTime converts when the
+ *   field still looks like LFU encoding (warm LFU ldt, or idle impossible for
+ *   process uptime). Already-correct LRU clocks are left alone.
  * Same-encoding switches (allkeys-lru <-> volatile-lru, LFU <-> LFU) are no-ops.
  * See #15375. */
-#define MAXMEMORY_POLICY_IMPORT_MS 60000 /* 60s lazy convert window */
+#define MAXMEMORY_POLICY_IMPORT_MS 60000 /* 60s lazy LFU import window */
 
 static int prev_maxmemory_lfu = -1;
 
@@ -2628,14 +2631,12 @@ static int updateMaxmemoryPolicy(const char **err) {
     if (prev_maxmemory_lfu == lfu)
         return 1;
 
-    /* Encoding flipped: enable lazy per-object convert, no keyspace walk.
-     * Clear the opposite window so a quick LFU<->non-LFU bounce cannot leave
-     * a stale deadline that rewrites keys under the wrong active policy. */
+    /* Encoding flipped: no keyspace walk. Open the LFU import window only when
+     * entering LFU; clear it when leaving so a bounce cannot keep converting
+     * under the wrong policy. LFU->idle convert is heuristic (no deadline). */
     if (lfu) {
         server.lfu_import_until = mstime() + MAXMEMORY_POLICY_IMPORT_MS;
-        server.lru_import_until = 0;
     } else {
-        server.lru_import_until = mstime() + MAXMEMORY_POLICY_IMPORT_MS;
         server.lfu_import_until = 0;
     }
 

--- a/src/evict.c
+++ b/src/evict.c
@@ -88,17 +88,17 @@ static time_t serverUptimeSeconds(void) {
 }
 
 /* True if o->lru still looks like residual LFU encoding rather than an idle
- * clock. Used only inside the LFU->non-LFU import window. */
+ * clock. Used only inside the LFU->non-LFU import window.
+ *
+ * Do NOT use LFUTimeElapsed(o->lru>>8): after keys are rewritten to a normal
+ * LRU clock that shift is not an LFU ldt, yet the 24h check often still
+ * passes and would wipe real idle on every OBJECT IDLETIME / eviction sample.
+ * Residual LFU almost always yields an idle outside process uptime when read
+ * as an LRU clock; plausible idles are left alone (access under non-LFU also
+ * rewrites the field via lookupKey). */
 static int objectLruLooksLikeResidualLFU(robj *o) {
-    unsigned long ldt = o->lru >> 8;
-    /* Warm LFU last-decay time (within 24h of the LFU minute clock). */
-    if (LFUTimeElapsed(ldt) <= 60*24)
-        return 1;
-
-    /* Stale LFU: as an LRU clock the idle is almost never within process
-     * uptime, so treat impossible idles as residual LFU. Valid RESTORE /
-     * module IDLETIME values stay within uptime and are left alone. */
-    if (objectLruFieldIdleMs(o) / 1000 > (unsigned long long)serverUptimeSeconds() + 60)
+    if (objectLruFieldIdleMs(o) / 1000 >
+        (unsigned long long)serverUptimeSeconds() + 60)
         return 1;
     return 0;
 }

--- a/src/evict.c
+++ b/src/evict.c
@@ -73,25 +73,23 @@ unsigned int LRU_CLOCK(void) {
     return lruclock;
 }
 
-/* Return 1 if o->lru still looks like LFU encoding (ldt<<8|counter) rather
- * than an LRU/LRM clock. Used to lazily re-encode after leaving an LFU policy
- * without a keyspace walk or a time-bounded import window. */
-static int objectLruLooksLikeLFU(robj *o) {
+/* True if o->lru still looks like residual LFU encoding rather than an idle
+ * clock. Used only inside the LFU->non-LFU import window. */
+static int objectLruLooksLikeResidualLFU(robj *o) {
     unsigned long ldt = o->lru >> 8;
-    /* Warm/recent LFU last-decay time (within 24h of the LFU minute clock). */
+    /* Warm LFU last-decay time (within 24h of the LFU minute clock). */
     if (LFUTimeElapsed(ldt) <= 60*24)
         return 1;
 
-    /* Stale LFU: LFUTimeElapsed can exceed 24h. As an LRU clock, that field
-     * almost never yields an idle time within process uptime, so treat
-     * impossible idles as residual LFU encoding. */
-    unsigned int clock = LRU_CLOCK();
+    /* Stale LFU: as an LRU clock the idle is almost never within process
+     * uptime, so treat impossible idles as residual LFU. Valid RESTORE /
+     * module IDLETIME values stay within uptime and are left alone. */
+    unsigned long long lruclock = LRU_CLOCK();
     unsigned long long idle_ms;
-    if (clock >= o->lru)
-        idle_ms = (unsigned long long)(clock - o->lru) * LRU_CLOCK_RESOLUTION;
+    if (lruclock >= o->lru)
+        idle_ms = (lruclock - o->lru) * LRU_CLOCK_RESOLUTION;
     else
-        idle_ms = (unsigned long long)(clock + (LRU_CLOCK_MAX - o->lru)) *
-                    LRU_CLOCK_RESOLUTION;
+        idle_ms = (lruclock + (LRU_CLOCK_MAX - o->lru)) * LRU_CLOCK_RESOLUTION;
     time_t uptime = server.unixtime - server.stat_starttime;
     if (uptime < 0) uptime = 0;
     if (idle_ms / 1000 > (unsigned long long)uptime + 60)
@@ -103,12 +101,14 @@ static int objectLruLooksLikeLFU(robj *o) {
  * requested, using an approximated LRU algorithm. */
 unsigned long long estimateObjectIdleTime(robj *o) {
     /* After LFU -> non-LFU policy switch, lru may still hold LFU encoding.
-     * Convert lazily on first idle-time use (no keyspace walk, no expiry
-     * window). Only under a non-LFU policy so DEBUG OBJECT / idle paths cannot
-     * rewrite keys after a bounce back to LFU. Already-converted LRU clocks
-     * fail objectLruLooksLikeLFU and are left alone. */
+     * Convert lazily during the short import window only (no keyspace walk).
+     * Must not run outside the window: permanent heuristics rewrite legitimate
+     * RESTORE IDLETIME / module setlru clocks to a fresh LRU_CLOCK (idle 0).
+     * Only under a non-LFU policy so DEBUG OBJECT cannot rewrite after bounce
+     * back to LFU. */
     if (!(server.maxmemory_policy & MAXMEMORY_FLAG_LFU) &&
-        objectLruLooksLikeLFU(o))
+        server.lru_import_until && mstime() < server.lru_import_until &&
+        objectLruLooksLikeResidualLFU(o))
     {
         o->lru = LRU_CLOCK();
     }

--- a/src/evict.c
+++ b/src/evict.c
@@ -73,6 +73,20 @@ unsigned int LRU_CLOCK(void) {
     return lruclock;
 }
 
+/* Idle time in ms if o->lru is interpreted as an LRU/LRM clock. */
+static unsigned long long objectLruFieldIdleMs(robj *o) {
+    unsigned long long lruclock = LRU_CLOCK();
+    if (lruclock >= o->lru)
+        return (lruclock - o->lru) * LRU_CLOCK_RESOLUTION;
+    return (lruclock + (LRU_CLOCK_MAX - o->lru)) * LRU_CLOCK_RESOLUTION;
+}
+
+/* Process uptime in seconds (non-negative). */
+static time_t serverUptimeSeconds(void) {
+    time_t uptime = server.unixtime - server.stat_starttime;
+    return uptime < 0 ? 0 : uptime;
+}
+
 /* True if o->lru still looks like residual LFU encoding rather than an idle
  * clock. Used only inside the LFU->non-LFU import window. */
 static int objectLruLooksLikeResidualLFU(robj *o) {
@@ -84,15 +98,19 @@ static int objectLruLooksLikeResidualLFU(robj *o) {
     /* Stale LFU: as an LRU clock the idle is almost never within process
      * uptime, so treat impossible idles as residual LFU. Valid RESTORE /
      * module IDLETIME values stay within uptime and are left alone. */
-    unsigned long long lruclock = LRU_CLOCK();
-    unsigned long long idle_ms;
-    if (lruclock >= o->lru)
-        idle_ms = (lruclock - o->lru) * LRU_CLOCK_RESOLUTION;
-    else
-        idle_ms = (lruclock + (LRU_CLOCK_MAX - o->lru)) * LRU_CLOCK_RESOLUTION;
-    time_t uptime = server.unixtime - server.stat_starttime;
-    if (uptime < 0) uptime = 0;
-    if (idle_ms / 1000 > (unsigned long long)uptime + 60)
+    if (objectLruFieldIdleMs(o) / 1000 > (unsigned long long)serverUptimeSeconds() + 60)
+        return 1;
+    return 0;
+}
+
+/* True if o->lru still looks like a residual LRU/LRM clock rather than LFU
+ * encoding. Used only inside the non-LFU->LFU import window.
+ * LFUTimeElapsed(ldt) > 60 alone misses LRU clocks whose high bits land
+ * near the LFU minute clock; those would keep garbage low-8 frequency. */
+static int objectLruLooksLikeResidualLRU(robj *o) {
+    /* Plausible idle under the current process → residual LRU clock. */
+    if (objectLruFieldIdleMs(o) / 1000 <=
+        (unsigned long long)serverUptimeSeconds() + 60)
         return 1;
     return 0;
 }
@@ -339,15 +357,15 @@ uint8_t LFULogIncr(uint8_t counter) {
  * counter of the scanned objects if needed. */
 unsigned long LFUDecrAndReturn(robj *o) {
     /* After non-LFU -> LFU policy switch, lru may still hold an LRU clock.
-     * Convert lazily on first LFU use, and only while an LFU policy is active. */
+     * Convert lazily on first LFU use during the import window, only while
+     * an LFU policy is active. Detect residual LRU by plausible idle vs
+     * process uptime (not only LFUTimeElapsed > 60). */
     if ((server.maxmemory_policy & MAXMEMORY_FLAG_LFU) &&
-        server.lfu_import_until && mstime() < server.lfu_import_until)
+        server.lfu_import_until && mstime() < server.lfu_import_until &&
+        objectLruLooksLikeResidualLRU(o))
     {
-        unsigned long ldt = o->lru >> 8;
-        if (LFUTimeElapsed(ldt) > 60) {
-            o->lru = (LFUGetTimeInMinutes() << 8) | LFU_INIT_VAL;
-            return LFU_INIT_VAL;
-        }
+        o->lru = (LFUGetTimeInMinutes() << 8) | LFU_INIT_VAL;
+        return LFU_INIT_VAL;
     }
     unsigned long ldt = o->lru >> 8;
     unsigned long counter = o->lru & 255;

--- a/src/evict.c
+++ b/src/evict.c
@@ -73,20 +73,44 @@ unsigned int LRU_CLOCK(void) {
     return lruclock;
 }
 
+/* Return 1 if o->lru still looks like LFU encoding (ldt<<8|counter) rather
+ * than an LRU/LRM clock. Used to lazily re-encode after leaving an LFU policy
+ * without a keyspace walk or a time-bounded import window. */
+static int objectLruLooksLikeLFU(robj *o) {
+    unsigned long ldt = o->lru >> 8;
+    /* Warm/recent LFU last-decay time (within 24h of the LFU minute clock). */
+    if (LFUTimeElapsed(ldt) <= 60*24)
+        return 1;
+
+    /* Stale LFU: LFUTimeElapsed can exceed 24h. As an LRU clock, that field
+     * almost never yields an idle time within process uptime, so treat
+     * impossible idles as residual LFU encoding. */
+    unsigned int clock = LRU_CLOCK();
+    unsigned long long idle_ms;
+    if (clock >= o->lru)
+        idle_ms = (unsigned long long)(clock - o->lru) * LRU_CLOCK_RESOLUTION;
+    else
+        idle_ms = (unsigned long long)(clock + (LRU_CLOCK_MAX - o->lru)) *
+                    LRU_CLOCK_RESOLUTION;
+    time_t uptime = server.unixtime - server.stat_starttime;
+    if (uptime < 0) uptime = 0;
+    if (idle_ms / 1000 > (unsigned long long)uptime + 60)
+        return 1;
+    return 0;
+}
+
 /* Given an object returns the min number of milliseconds the object was never
  * requested, using an approximated LRU algorithm. */
 unsigned long long estimateObjectIdleTime(robj *o) {
     /* After LFU -> non-LFU policy switch, lru may still hold LFU encoding.
-     * Convert lazily (no keyspace walk on CONFIG SET). Only while an idle-based
-     * (non-LFU) policy is active, so a stale lru_import_until cannot rewrite
-     * keys after a quick bounce back to LFU. */
+     * Convert lazily on first idle-time use (no keyspace walk, no expiry
+     * window). Only under a non-LFU policy so DEBUG OBJECT / idle paths cannot
+     * rewrite keys after a bounce back to LFU. Already-converted LRU clocks
+     * fail objectLruLooksLikeLFU and are left alone. */
     if (!(server.maxmemory_policy & MAXMEMORY_FLAG_LFU) &&
-        server.lru_import_until && mstime() < server.lru_import_until)
+        objectLruLooksLikeLFU(o))
     {
-        unsigned long ldt = o->lru >> 8;
-        if (LFUTimeElapsed(ldt) <= 60*24) {
-            o->lru = LRU_CLOCK();
-        }
+        o->lru = LRU_CLOCK();
     }
     unsigned long long lruclock = LRU_CLOCK();
     if (lruclock >= o->lru) {

--- a/src/evict.c
+++ b/src/evict.c
@@ -77,9 +77,12 @@ unsigned int LRU_CLOCK(void) {
  * requested, using an approximated LRU algorithm. */
 unsigned long long estimateObjectIdleTime(robj *o) {
     /* After LFU -> non-LFU policy switch, lru may still hold LFU encoding.
-     * Convert lazily (no keyspace walk on CONFIG SET). LFU LDTs sit near the
-     * LFU minute clock; LRU clocks usually do not. */
-    if (server.lru_import_until && mstime() < server.lru_import_until) {
+     * Convert lazily (no keyspace walk on CONFIG SET). Only while an idle-based
+     * (non-LFU) policy is active, so a stale lru_import_until cannot rewrite
+     * keys after a quick bounce back to LFU. */
+    if (!(server.maxmemory_policy & MAXMEMORY_FLAG_LFU) &&
+        server.lru_import_until && mstime() < server.lru_import_until)
+    {
         unsigned long ldt = o->lru >> 8;
         if (LFUTimeElapsed(ldt) <= 60*24) {
             o->lru = LRU_CLOCK();
@@ -312,9 +315,10 @@ uint8_t LFULogIncr(uint8_t counter) {
  * counter of the scanned objects if needed. */
 unsigned long LFUDecrAndReturn(robj *o) {
     /* After non-LFU -> LFU policy switch, lru may still hold an LRU clock.
-     * Convert lazily on first LFU use. LRU clocks decoded as LFU almost always
-     * have an LDT far from the LFU minute clock (elapsed >> 60). */
-    if (server.lfu_import_until && mstime() < server.lfu_import_until) {
+     * Convert lazily on first LFU use, and only while an LFU policy is active. */
+    if ((server.maxmemory_policy & MAXMEMORY_FLAG_LFU) &&
+        server.lfu_import_until && mstime() < server.lfu_import_until)
+    {
         unsigned long ldt = o->lru >> 8;
         if (LFUTimeElapsed(ldt) > 60) {
             o->lru = (LFUGetTimeInMinutes() << 8) | LFU_INIT_VAL;

--- a/src/evict.c
+++ b/src/evict.c
@@ -45,6 +45,9 @@ struct evictionPoolEntry {
 
 static struct evictionPoolEntry *EvictionPoolLRU;
 
+/* Forward decl: used by estimateObjectIdleTime before its definition. */
+unsigned long LFUTimeElapsed(unsigned long ldt);
+
 /* ----------------------------------------------------------------------------
  * Implementation of eviction, aging and LRU
  * --------------------------------------------------------------------------*/
@@ -73,6 +76,15 @@ unsigned int LRU_CLOCK(void) {
 /* Given an object returns the min number of milliseconds the object was never
  * requested, using an approximated LRU algorithm. */
 unsigned long long estimateObjectIdleTime(robj *o) {
+    /* After LFU -> non-LFU policy switch, lru may still hold LFU encoding.
+     * Convert lazily (no keyspace walk on CONFIG SET). LFU LDTs sit near the
+     * LFU minute clock; LRU clocks usually do not. */
+    if (server.lru_import_until && mstime() < server.lru_import_until) {
+        unsigned long ldt = o->lru >> 8;
+        if (LFUTimeElapsed(ldt) <= 60*24) {
+            o->lru = LRU_CLOCK();
+        }
+    }
     unsigned long long lruclock = LRU_CLOCK();
     if (lruclock >= o->lru) {
         return (lruclock - o->lru) * LRU_CLOCK_RESOLUTION;
@@ -299,6 +311,16 @@ uint8_t LFULogIncr(uint8_t counter) {
  * to fit: as we check for the candidate, we incrementally decrement the
  * counter of the scanned objects if needed. */
 unsigned long LFUDecrAndReturn(robj *o) {
+    /* After non-LFU -> LFU policy switch, lru may still hold an LRU clock.
+     * Convert lazily on first LFU use. LRU clocks decoded as LFU almost always
+     * have an LDT far from the LFU minute clock (elapsed >> 60). */
+    if (server.lfu_import_until && mstime() < server.lfu_import_until) {
+        unsigned long ldt = o->lru >> 8;
+        if (LFUTimeElapsed(ldt) > 60) {
+            o->lru = (LFUGetTimeInMinutes() << 8) | LFU_INIT_VAL;
+            return LFU_INIT_VAL;
+        }
+    }
     unsigned long ldt = o->lru >> 8;
     unsigned long counter = o->lru & 255;
     unsigned long num_periods = server.lfu_decay_time ? LFUTimeElapsed(ldt) / server.lfu_decay_time : 0;

--- a/src/server.h
+++ b/src/server.h
@@ -2479,7 +2479,6 @@ struct redisServer {
      * the previous encoding. Do not walk the keyspace; instead convert each
      * object lazily on first LFU/LRU use until this deadline (mstime). */
     mstime_t lfu_import_until;      /* non-LFU -> LFU lazy convert window end */
-    mstime_t lru_import_until;      /* LFU -> non-LFU lazy convert window end */
     long long proto_max_bulk_len;   /* Protocol bulk length maximum size. */
     int oom_score_adj_values[CONFIG_OOM_COUNT];   /* Linux oom_score_adj configuration */
     int oom_score_adj;                            /* If true, oom_score_adj is managed */

--- a/src/server.h
+++ b/src/server.h
@@ -2479,6 +2479,7 @@ struct redisServer {
      * the previous encoding. Do not walk the keyspace; instead convert each
      * object lazily on first LFU/LRU use until this deadline (mstime). */
     mstime_t lfu_import_until;      /* non-LFU -> LFU lazy convert window end */
+    mstime_t lru_import_until;      /* LFU -> non-LFU lazy convert window end */
     long long proto_max_bulk_len;   /* Protocol bulk length maximum size. */
     int oom_score_adj_values[CONFIG_OOM_COUNT];   /* Linux oom_score_adj configuration */
     int oom_score_adj;                            /* If true, oom_score_adj is managed */

--- a/src/server.h
+++ b/src/server.h
@@ -2475,6 +2475,11 @@ struct redisServer {
     int maxmemory_eviction_tenacity;/* Aggressiveness of eviction processing */
     int lfu_log_factor;             /* LFU logarithmic counter factor. */
     int lfu_decay_time;             /* LFU counter decay factor. */
+    /* After CONFIG SET flips the LFU encoding bit, existing keys still hold
+     * the previous encoding. Do not walk the keyspace; instead convert each
+     * object lazily on first LFU/LRU use until this deadline (mstime). */
+    mstime_t lfu_import_until;      /* non-LFU -> LFU lazy convert window end */
+    mstime_t lru_import_until;      /* LFU -> non-LFU lazy convert window end */
     long long proto_max_bulk_len;   /* Protocol bulk length maximum size. */
     int oom_score_adj_values[CONFIG_OOM_COUNT];   /* Linux oom_score_adj configuration */
     int oom_score_adj;                            /* If true, oom_score_adj is managed */

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -828,8 +828,8 @@ start_server {tags {"maxmemory" "external:skip"}} {
         assert_lessthan_equal [r object idletime midttl] 1
     }
 
-    # Quick LFU -> LRU -> LFU must not leave a stale lru_import window that
-    # rewrites LFU keys when idle-time is computed under LFU (DEBUG OBJECT).
+    # Quick LFU -> LRU -> LFU must not rewrite LFU keys when idle-time is
+    # computed under LFU (DEBUG OBJECT uses estimateObjectIdleTime).
     test {LFU: bounce LFU to LRU to LFU keeps FREQ after DEBUG OBJECT} {
         r flushdb
         r config set maxmemory 0

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -828,6 +828,25 @@ start_server {tags {"maxmemory" "external:skip"}} {
         assert_lessthan_equal [r object idletime midttl] 1
     }
 
+    # Quick LFU -> LRU -> LFU must not leave a stale lru_import window that
+    # rewrites LFU keys when idle-time is computed under LFU (DEBUG OBJECT).
+    test {LFU: bounce LFU to LRU to LFU keeps FREQ after DEBUG OBJECT} {
+        r flushdb
+        r config set maxmemory 0
+        r config set maxmemory-policy allkeys-lfu
+        r set bouncekey value-bounce
+        for {set i 0} {$i < 200} {incr i} {
+            r get bouncekey
+        }
+        set before [r object freq bouncekey]
+        assert_morethan $before 5
+        r config set maxmemory-policy allkeys-lru
+        r config set maxmemory-policy allkeys-lfu
+        # Uses estimateObjectIdleTime; must not convert under LFU.
+        catch {r debug object bouncekey}
+        assert_equal $before [r object freq bouncekey]
+    }
+
 }
 
 # Conf-file LFU never runs apply at load; baseline must come from the live

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -793,6 +793,41 @@ start_server {tags {"maxmemory" "external:skip"}} {
         assert_lessthan_equal [r object idletime vlrmkey] 1
     }
 
+    # Intermediate non-scoring policies must still reseed off LFU encoding so a
+    # later switch to LRU/LRM does not treat LFU counters as idle clocks.
+    test {LFU: via noeviction then allkeys-lru has fresh IDLETIME} {
+        r flushdb
+        r config set maxmemory 0
+        r config set maxmemory-policy allkeys-lfu
+        r set midkey value-mid
+        assert_equal 5 [r object freq midkey]
+        r config set maxmemory-policy noeviction
+        r config set maxmemory-policy allkeys-lru
+        assert_lessthan_equal [r object idletime midkey] 1
+    }
+
+    test {LFU: via allkeys-random then allkeys-lrm has fresh IDLETIME} {
+        r flushdb
+        r config set maxmemory 0
+        r config set maxmemory-policy allkeys-lfu
+        r set midlrm value-midlrm
+        assert_equal 5 [r object freq midlrm]
+        r config set maxmemory-policy allkeys-random
+        r config set maxmemory-policy allkeys-lrm
+        assert_lessthan_equal [r object idletime midlrm] 1
+    }
+
+    test {LFU: via volatile-ttl then volatile-lru has fresh IDLETIME} {
+        r flushdb
+        r config set maxmemory 0
+        r config set maxmemory-policy allkeys-lfu
+        r set midttl value-midttl
+        assert_equal 5 [r object freq midttl]
+        r config set maxmemory-policy volatile-ttl
+        r config set maxmemory-policy volatile-lru
+        assert_lessthan_equal [r object idletime midttl] 1
+    }
+
 }
 
 # Conf-file LFU never runs apply at load; baseline must come from the live

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -739,4 +739,37 @@ start_server {tags {"maxmemory" "external:skip"}} {
         # Fresh LRU clock: idle time should be ~0 right after reseed.
         assert_lessthan_equal [r object idletime baz] 1
     }
+
+    # Same-encoding policy switches must not rewrite every key's lru field.
+    test {LRU: CONFIG SET allkeys-lru to volatile-lru preserves IDLETIME} {
+        r flushdb
+        r config set maxmemory 0
+        r config set maxmemory-policy allkeys-lru
+        r set idlekey value-idle
+        after 1100
+        set before [r object idletime idlekey]
+        assert_morethan_equal $before 1
+        r config set maxmemory-policy volatile-lru
+        set after_idle [r object idletime idlekey]
+        # Allow 1s of clock skew between samples; must not reset to a fresh clock (~0).
+        assert_morethan_equal $after_idle 1
+        assert {$after_idle >= $before - 1}
+    }
+
+    test {LFU: CONFIG SET allkeys-lfu to volatile-lfu preserves FREQ} {
+        r flushdb
+        r config set maxmemory 0
+        r config set maxmemory-policy allkeys-lfu
+        r set hotkey value-hot
+        # Bump frequency above the LFU_INIT_VAL reseed (5).
+        for {set i 0} {$i < 200} {incr i} {
+            r get hotkey
+        }
+        set before [r object freq hotkey]
+        assert_morethan $before 5
+        r config set maxmemory-policy volatile-lfu
+        assert_equal $before [r object freq hotkey]
+    }
+
+
 }

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -705,4 +705,25 @@ start_server {tags {"maxmemory" "external:skip"}} {
             assert {$write_survived > $read_survived}
         }
     }
+
+    # Regression for #15375: switching to LFU at runtime must re-seed LFU
+    # counters for keys created under a non-LFU policy. Otherwise OBJECT FREQ
+    # reports 0 and eviction prefers those keys incorrectly.
+    test {LFU: CONFIG SET to allkeys-lfu reseeds FREQ for existing keys} {
+        r flushdb
+        r config set maxmemory 0
+        r config set maxmemory-policy noeviction
+        r set foo value-foo
+        r config set maxmemory-policy allkeys-lfu
+        assert_equal 5 [r object freq foo]
+    }
+
+    test {LFU: CONFIG SET to volatile-lfu reseeds FREQ for existing keys} {
+        r flushdb
+        r config set maxmemory 0
+        r config set maxmemory-policy allkeys-lru
+        r set bar value-bar
+        r config set maxmemory-policy volatile-lfu
+        assert_equal 5 [r object freq bar]
+    }
 }

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -726,4 +726,17 @@ start_server {tags {"maxmemory" "external:skip"}} {
         r config set maxmemory-policy volatile-lfu
         assert_equal 5 [r object freq bar]
     }
+
+    # Leaving LFU (including CONFIG SET rollback of a failed multi-arg batch)
+    # must re-seed LRU clocks so LFU counters are not read as idle time.
+    test {LFU: CONFIG SET back to allkeys-lru reseeds IDLETIME for existing keys} {
+        r flushdb
+        r config set maxmemory 0
+        r config set maxmemory-policy allkeys-lfu
+        r set baz value-baz
+        assert_equal 5 [r object freq baz]
+        r config set maxmemory-policy allkeys-lru
+        # Fresh LRU clock: idle time should be ~0 right after reseed.
+        assert_lessthan_equal [r object idletime baz] 1
+    }
 }

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -771,5 +771,41 @@ start_server {tags {"maxmemory" "external:skip"}} {
         assert_equal $before [r object freq hotkey]
     }
 
+    # Leaving LFU for LRM must reseed idle clocks: LRM scores with
+    # estimateObjectIdleTime on the shared lru field (same as LRU).
+    test {LFU: CONFIG SET allkeys-lfu to allkeys-lrm reseeds IDLETIME} {
+        r flushdb
+        r config set maxmemory 0
+        r config set maxmemory-policy allkeys-lfu
+        r set lrmkey value-lrm
+        assert_equal 5 [r object freq lrmkey]
+        r config set maxmemory-policy allkeys-lrm
+        assert_lessthan_equal [r object idletime lrmkey] 1
+    }
 
+    test {LFU: CONFIG SET allkeys-lfu to volatile-lrm reseeds IDLETIME} {
+        r flushdb
+        r config set maxmemory 0
+        r config set maxmemory-policy allkeys-lfu
+        r set vlrmkey value-vlrm
+        assert_equal 5 [r object freq vlrmkey]
+        r config set maxmemory-policy volatile-lrm
+        assert_lessthan_equal [r object idletime vlrmkey] 1
+    }
+
+}
+
+# Conf-file LFU never runs apply at load; baseline must come from the live
+# policy so the first CONFIG SET between LFU variants preserves FREQ.
+start_server {tags {"maxmemory" "external:skip"} overrides {maxmemory-policy allkeys-lfu maxmemory 0}} {
+    test {LFU: conf-file allkeys-lfu then CONFIG SET volatile-lfu preserves FREQ} {
+        r set confkey value-conf
+        for {set i 0} {$i < 200} {incr i} {
+            r get confkey
+        }
+        set before [r object freq confkey]
+        assert_morethan $before 5
+        r config set maxmemory-policy volatile-lfu
+        assert_equal $before [r object freq confkey]
+    }
 }


### PR DESCRIPTION
## Summary

When `CONFIG SET maxmemory-policy` switches into an LFU policy (`allkeys-lfu` / `volatile-lfu`), existing keys still carry an LRU-encoded `lru` field. `OBJECT FREQ` and the LFU eviction path then treat that value as frequency **0**, so those keys are preferred for eviction incorrectly.

This PR hooks an apply callback on `maxmemory-policy` that re-seeds every key's LFU counter to `LFU_INIT_VAL` (5) with the current LFU minute clock when entering an LFU policy, matching how new objects are initialized under LFU.

Fixes #15375

## Reproduction (also covered by the new unit tests)

```
> SET foo value-foo
OK
> CONFIG SET maxmemory-policy allkeys-lfu
OK
> OBJECT FREQ foo
(integer) 0   # wrong; should be 5
```

## Red / green

Built `redis-server` and verified with `redis-cli` on a local instance:

- Without fix: `OBJECT FREQ foo` -> **0** after policy switch
- With fix: `OBJECT FREQ foo` -> **5** (`LFU_INIT_VAL`)

New tests in `tests/unit/maxmemory.tcl`:
- `LFU: CONFIG SET to allkeys-lfu reseeds FREQ for existing keys`
- `LFU: CONFIG SET to volatile-lfu reseeds FREQ for existing keys`

## Notes

- Only runs the full key walk when the **new** policy has `MAXMEMORY_FLAG_LFU` (no-op for non-LFU targets).
- Switching LFU -> LFU re-seeds again; that is intentional and cheap relative to correctness.
- The existing `OBJECT FREQ` error text already warned that runtime policy switches need time to adjust; this makes the LFU direction correct immediately.

## Prior art

- Issue #15375 (open, no competing PR on the issue timeline)
- No open PR for re-seeding LFU on `maxmemory-policy` change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eviction and OBJECT FREQ/IDLETIME semantics on policy switches via heuristic encoding detection; wrong heuristics could mis-rank keys until keys are touched or windows expire, but scope is bounded and avoids blocking CONFIG SET on large DBs.
> 
> **Overview**
> Fixes **#15375** by handling mismatched encodings in the shared `lru` field when **`CONFIG SET maxmemory-policy`** crosses LFU vs LRU/LRM, without scanning the keyspace on large instances.
> 
> **`updateMaxmemoryPolicy`** (new apply hook on `maxmemory-policy`) opens **60s import windows** (`lfu_import_until` / `lru_import_until`) when the LFU encoding bit flips, clears the opposite window on quick bounces, and tracks baseline via **`seedMaxmemoryPolicyBaseline`** after defaults and config load so conf-file LFU and same-encoding switches (e.g. allkeys-lru ↔ volatile-lru) do not mass-rewrite keys.
> 
> **Lazy per-key conversion** in **`LFUDecrAndReturn`** (OBJECT FREQ / LFU eviction) and **`estimateObjectIdleTime`** (OBJECT IDLETIME / LRU/LRM eviction), gated by uptime heuristics so legitimate clocks are not reset outside the window; **`lru_field_may_be_lfu`** allows one idle-import reopen after LFU → noeviction → LRU.
> 
> Extensive **`tests/unit/maxmemory.tcl`** coverage for FREQ/IDLETIME reseeding, preserved counters on same-encoding changes, multi-hop policy paths, and conf-file LFU baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 421b5c8768d2d983bdf8695d450848e45b11780f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->