### PR TITLE
Fix contradictory macOS libtool note in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1083,7 +1083,7 @@ The following instructions apply to both Intel and Apple Silicon (ARM) Macs.
 > **Note**: Three RediSearch-specific build constraints apply on macOS and are handled in the steps below:
 > - The cross-language LTO that RediSearch enables by default requires Linux; its build script aborts on macOS with `Error: LTO is only supported on Linux`. Step 6 sets `LTO=0` to disable it.
 > - RediSearch's Rust workspace uses edition 2024 and features stabilized in Rust 1.94, so the Rust toolchain in step 3 is pinned to `1.94.0`. Older Rust fails with `feature edition2024 is required`.
-> - RediSearch's CMake build calls `libtool -static` (BSD libtool syntax). Step 6's `PATH` does **not** prepend `$HOMEBREW_PREFIX/opt/libtool/libexec/gnubin`, so macOS's `/usr/bin/libtool` is used for that step.
+> - RediSearch's CMake build calls `libtool -static` (BSD libtool syntax). Step 6's `PATH` prepends `$HOMEBREW_PREFIX/opt/libtool/libexec/gnubin`, so Homebrew's GNU `libtool` is used for that step instead of macOS's `/usr/bin/libtool`.
 
 1. Install Homebrew
 


### PR DESCRIPTION
## Description

Fixes #15344.

The macOS build instructions in `README.md` contain a contradiction. The RediSearch note states:

> Step 6's `PATH` does **not** prepend `$HOMEBREW_PREFIX/opt/libtool/libexec/gnubin`, so macOS's `/usr/bin/libtool` is used for that step.

But Step 6's actual build command **does** prepend that directory:

```sh
PATH="$HOMEBREW_PREFIX/opt/libtool/libexec/gnubin:..."
```

Both cannot be correct. Since the build command was tested and confirmed working, the note text is stale. This change corrects the note to match the actual (tested) behavior: the `PATH` prepends the gnubin directory so Homebrew's GNU `libtool` is used instead of macOS's `/usr/bin/libtool`.

Documentation-only change; no code or build files touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only wording fix; no code, build scripts, or runtime behavior changes.
> 
> **Overview**
> Fixes contradictory macOS build documentation in `README.md` (issue #15344).
> 
> The third RediSearch note bullet previously claimed Step 6’s `PATH` does **not** prepend `$HOMEBREW_PREFIX/opt/libtool/libexec/gnubin`, implying `/usr/bin/libtool` is used. Step 6’s build command actually prepends that directory. The note now states that `PATH` **does** prepend gnubin so Homebrew’s GNU `libtool` is used for RediSearch’s `libtool -static` CMake step, matching the documented command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cee2717b2e49edb61c3e5a798ed949fe07e39f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->