### PR TITLE
Pass generic HOST triplet to jemalloc configure when cross-compiling

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -140,7 +140,13 @@ lua: .make-prerequisites
 JEMALLOC_CFLAGS=$(ENABLE_LTO) $(CFLAGS)
 JEMALLOC_LDFLAGS=$(ENABLE_LTO) $(LDFLAGS)
 
-ifneq ($(DEB_HOST_GNU_TYPE),)
+# Pass a host triplet to jemalloc's configure when cross-compiling, so that its
+# configure script does not try to run target binaries on the build machine.
+# DEB_HOST_GNU_TYPE is set automatically in Debian packaging environments; HOST
+# is a generic override for other cross-compilation setups (e.g. Yocto/Poky).
+ifneq ($(HOST),)
+JEMALLOC_CONFIGURE_OPTS += --host=$(HOST)
+else ifneq ($(DEB_HOST_GNU_TYPE),)
 JEMALLOC_CONFIGURE_OPTS += --host=$(DEB_HOST_GNU_TYPE)
 endif
 


### PR DESCRIPTION
## Description

Fixes #15395.

`deps/Makefile` only passes `--host` to jemalloc's `configure` when `DEB_HOST_GNU_TYPE` is set, which is specific to Debian packaging environments. When cross-compiling with other toolchains (e.g. Yocto/Poky), the user sets `CC` to a cross-compiler but `--host` stays unset. jemalloc's configure then detects the *build* host, attempts to run target binaries, and fails:

```
checking whether we are cross compiling... configure: error: cannot run C compiled programs.
If you meant to cross compile, use `--host'.
```

which cascades into `fatal error: jemalloc/jemalloc.h: No such file or directory` for the main build.

## Change

Honor a generic `HOST` variable that can be passed on the make command line, keeping `DEB_HOST_GNU_TYPE` as a fallback:

```make
ifneq ($(HOST),)
JEMALLOC_CONFIGURE_OPTS += --host=$(HOST)
else ifneq ($(DEB_HOST_GNU_TYPE),)
JEMALLOC_CONFIGURE_OPTS += --host=$(DEB_HOST_GNU_TYPE)
endif
```

Users can then cross-compile with:

```
make HOST=aarch64-poky-linux CC=aarch64-poky-linux-gcc ...
```

`HOST` propagates automatically to the recursive `deps` sub-make.

## Scope

This PR intentionally addresses **only** the jemalloc `--host` half of the issue (the root cause of the build failure). The `tests/modules/Makefile` `CC` override mentioned in the issue only affects the test module build and is left untouched to keep this change minimal and low-risk.

## Testing

- Native build on macOS (Apple clang 17, Command Line Tools): `make -j4` completes successfully — `HOST` is empty on native builds so behavior is unchanged.
- On native builds `JEMALLOC_CONFIGURE_OPTS` is identical to before this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Makefile conditional for dependency configure; native and Debian builds behave as before when `HOST` is unset.
> 
> **Overview**
> **Cross-compiling Redis** now works when the build sets a generic `HOST` triplet (e.g. Yocto/Poky), not only when Debian’s `DEB_HOST_GNU_TYPE` is present.
> 
> `deps/Makefile` passes `--host=$(HOST)` to jemalloc’s `configure` when `HOST` is set, and still falls back to `--host=$(DEB_HOST_GNU_TYPE)` in Debian packaging. Native builds are unchanged because neither variable is set. This stops jemalloc from treating the build machine as the target and failing with “cannot run C compiled programs,” which previously blocked building `libjemalloc.a` and caused missing `jemalloc/jemalloc.h` errors downstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23ba24fffa8a52dfe56600b36ef81667e9d75d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->