### PR TITLE
Update RedisTimeSeries module to v8.9.91

### DIFF
--- a/modules/modules.yaml
+++ b/modules/modules.yaml
@@ -80,6 +80,6 @@ modules:
     loadmodule: ./modules/redisjson/rejson.so
   - name: redistimeseries
     repo: https://github.com/redistimeseries/redistimeseries
-    ref: v8.9.90
+    ref: v8.9.91
     target_module: redistimeseries.so
     loadmodule: ./modules/redistimeseries/redistimeseries.so


### PR DESCRIPTION
Bumps the bundled **RedisTimeSeries** pin in `modules/modules.yaml` from **v8.9.90** to **v8.9.91**. Manifest-only change; `loadmodule` path, `target_module`, and build settings are unchanged. RediSearch/RedisJSON/RedisBloom are untouched here.

## Changelog

### RedisTimeSeries [v8.9.90...v8.9.91](https://github.com/RedisTimeSeries/RedisTimeSeries/compare/v8.9.90...v8.9.91)

This tag is a single, self-contained change — it bumps the vendored **LibMR** submodule to master, which brings one upstream fix:

- **MOD-16951** — Gate inter-shard TLS on `tls-cluster` for the native cluster view. Fixes an inter-shard cluster-bus handshake that attempted a **TLS connection to a peer's plaintext port**, breaking multi-shard command fan-out (e.g. `TS.MRANGE`) on TLS-enabled clusters. LibMR bumped [`a6d14e8...bd964f6`](https://github.com/RedisGears/LibMR/compare/a6d14e8...bd964f6) via LibMR [#111](https://github.com/RedisGears/LibMR/pull/111); packaged in RedisTimeSeries [#2122](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2122).

No command surface, RDB/AOF format, or replication behavior changes vs. v8.9.90.

## How to refresh locally

```
make modules-update redistimeseries
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only version bump with a targeted upstream cluster/TLS fix; no local build or load paths change.
> 
> **Overview**
> **Bumps the bundled RedisTimeSeries pin** in `modules/modules.yaml` from `v8.9.90` to `v8.9.91`. Only the `ref` field changes; `repo`, `target_module`, and `loadmodule` stay the same.
> 
> The new tag pulls in an updated **LibMR** with a fix for **TLS-enabled native clusters**: inter-shard traffic now respects `tls-cluster`, avoiding TLS handshakes to plaintext cluster-bus ports that broke multi-shard fan-out (e.g. `TS.MRANGE`). Other bundled modules remain on v8.9.90.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c2c193a0e9437867fbba26f02f89dded189376b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->