### PR TITLE
Enhance the module modernization tests:

### DIFF
--- a/.github/workflows/modules-daily.yml
+++ b/.github/workflows/modules-daily.yml
@@ -1,0 +1,167 @@
+name: Modules Daily
+
+# Verifies the from-source modules flow documented in modules/README.md on
+# every OS the bundled modules support (the same list the modules' own
+# nightlies build against), each inside a clean stock container image — no
+# prebuilt/docker-file images. The steps mirror the manual verbatim:
+#
+#   make modules-update            clone every module pinned in modules.yaml
+#   make bootstrap                 install per-module build/test prereqs
+#   make LTO=0                     build Redis + all modules (see LTO note)
+#   ./src/redis-server redis-full.conf   then `redis-cli MODULE LIST`
+#   make test all                  every module's suite
+#
+# The "install manual prerequisites" step deliberately installs only what a
+# user needs before the manual's first command can run at all (git, make,
+# CA certs — plus awk/find on minimal images and bash on alpine, where the
+# module orchestration scripts need it). Compilers and per-module toolchains
+# must come from `make bootstrap`; if they don't, the manual is broken on
+# that OS and this workflow exists to catch exactly that.
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+    inputs:
+      skiptests:
+        description: "set to 'modules' to skip the heavy 'make test all' step"
+        default: ''
+      use_repo:
+        description: 'repo owner and name'
+        default: 'redis/redis'
+      use_git_ref:
+        description: 'git branch or sha to use'
+        default: 'unstable'
+
+jobs:
+
+  test-modules:
+    name: test-modules-${{ matrix.arch }}-${{ matrix.osnick }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'redis/redis'
+    timeout-minutes: 300
+    # Mapping form with an explicit PATH: a module bootstrap can append to
+    # $GITHUB_PATH (redisearch's uv installer does), and when the runner
+    # rebuilds the container exec PATH from an image with no PATH in its
+    # Config.Env, later steps lose /usr/bin and die with 'exec: "sh":
+    # executable file not found' (seen on rocky10). Pinning PATH here keeps
+    # step exec sane regardless of what bootstrap appends.
+    container:
+      image: ${{ matrix.image }}
+      env:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    env:
+      # GCC 12 (bookworm) has false positives inside its own avx512fintrin.h
+      # (_mm256_undefined_pd self-init, GCC PR105593, fixed in GCC 13) which
+      # VectorSimilarity's unconditional -Werror turns fatal on x86_64. The
+      # headers trip BOTH the -Wuninitialized and -Wmaybe-uninitialized
+      # variants depending on the intrinsic, so both must be non-fatal.
+      # -Wmaybe-uninitialized is GCC-only, and clang (the LTO=1 compiler)
+      # + -Werror turns the unknown option itself into an error, so
+      # -Wno-unknown-warning-option keeps the trio clang-safe; GCC treats
+      # that one as an ignorable note. Verified on both compilers.
+      # Job-level (not build-step-level) because redisearch's `make test`
+      # re-drives its cmake build with BUILD_TESTS=1 (GCC, no LTO), so the
+      # flags must reach that rebuild too. Redis core is pure C and ignores
+      # CXXFLAGS.
+      CXXFLAGS: -Wno-error=uninitialized -Wno-error=maybe-uninitialized -Wno-unknown-warning-option
+    strategy:
+      fail-fast: false
+      # Both architectures the bundled modules support, mirroring their own
+      # nightlies. The OS list is the intersection the pinned module versions
+      # actually support: redisearch v8.9.82 dropped amazonlinux2, bullseye
+      # and mariner2 (upstream #9015 "Remove unsupported platforms"), so they
+      # are deliberately absent. The include entries augment each generated
+      # arch×osnick combo with its image and package family; every listed
+      # image publishes a multi-arch manifest.
+      matrix:
+        arch: [x64, arm64]
+        osnick: [focal, jammy, noble, resolute, bookworm, trixie,
+                 alma8, alma9, alma10, rocky8, rocky9, rocky10,
+                 amazonlinux2023, azurelinux3, alpine]
+        include:
+          - { osnick: focal,           image: 'ubuntu:20.04',                                family: apt  }
+          - { osnick: jammy,           image: 'ubuntu:22.04',                                family: apt  }
+          - { osnick: noble,           image: 'ubuntu:24.04',                                family: apt  }
+          - { osnick: resolute,        image: 'ubuntu:26.04',                                family: apt  }
+          - { osnick: bookworm,        image: 'debian:bookworm',                             family: apt  }
+          - { osnick: trixie,          image: 'debian:trixie',                               family: apt  }
+          - { osnick: alma8,           image: 'almalinux:8',                                 family: dnf  }
+          - { osnick: alma9,           image: 'almalinux:9',                                 family: dnf  }
+          - { osnick: alma10,          image: 'almalinux:10',                                family: dnf  }
+          - { osnick: rocky8,          image: 'rockylinux:8',                                family: dnf  }
+          - { osnick: rocky9,          image: 'rockylinux:9',                                family: dnf  }
+          - { osnick: rocky10,         image: 'quay.io/rockylinux/rockylinux:10',            family: dnf  }
+          - { osnick: amazonlinux2023, image: 'amazonlinux:2023',                            family: dnf  }
+          - { osnick: azurelinux3,     image: 'mcr.microsoft.com/azurelinux/base/core:3.0',  family: tdnf }
+          - { osnick: alpine,          image: 'alpine:3.23',                                 family: apk  }
+    steps:
+    - name: install manual prerequisites
+      run: |
+        # openssl dev headers (libssl-dev / openssl-devel / openssl-dev) +
+        # the openssl CLI: the bundle builds redis-server with BUILD_TLS=yes
+        # so redisearch's TLS tests (test_with_tls) can start a TLS server;
+        # the CLI is used to generate the test certificates at test time.
+        case '${{ matrix.family }}' in
+          apt)  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git make ca-certificates libssl-dev openssl ;;
+          dnf)  dnf install -y git make gawk findutils ca-certificates openssl-devel openssl ;;
+          tdnf)
+            # packages.microsoft.com mirrors intermittently fail the
+            # repogpgcheck plugin's metadata-signature fetch (404); retry,
+            # falling back to package-level GPG verification only. Track
+            # success explicitly so an all-retries-failed loop (last command
+            # is `sleep`) doesn't leave the step passing with packages missing.
+            ok=
+            for _ in 1 2 3; do
+              tdnf install -y git make gawk findutils ca-certificates tar openssl-devel openssl && { ok=1; break; }
+              tdnf --disableplugin=tdnfrepogpgcheck install -y git make gawk findutils ca-certificates tar openssl-devel openssl && { ok=1; break; }
+              sleep 10
+            done
+            [ -n "$ok" ] || { echo "ERROR: tdnf prerequisite install failed after retries" >&2; exit 1; } ;;
+          apk)  apk add git make bash ca-certificates openssl-dev openssl ;;
+        esac
+        # The modules' bootstrap tooling (redistimeseries .install/lib/
+        # setup-python.sh) skips its uv/venv/pip setup when /.dockerenv
+        # exists, assuming the module repo's own Dockerfile flow that
+        # prebuilds /opt/.venv. Container jobs always have /.dockerenv and
+        # we don't use those Dockerfiles, so drop the marker or the test
+        # harness (RLTest) never gets installed.
+        rm -f /.dockerenv
+    # Plain `git clone` instead of actions/checkout: keeps the jobs free of
+    # node-based actions (which need a new-enough glibc inside the container),
+    # and a real git checkout is what the manual assumes anyway.
+    - name: checkout
+      run: |
+        git config --global --add safe.directory "$(pwd)"
+        git init .
+        git remote add origin "https://github.com/${{ github.event.inputs.use_repo || 'redis/redis' }}.git"
+        git fetch --depth 1 origin "${{ github.event.inputs.use_git_ref || 'unstable' }}"
+        git checkout FETCH_HEAD
+    - name: make modules-update
+      run: make modules-update
+    - name: make bootstrap
+      run: make bootstrap
+    # Default build (LTO=1 for redisearch via its build_env): the pinned
+    # redisearch branch carries the bootstrap fixes that provision the
+    # matched clang/lld toolchain, so no LTO=0 escape hatch is needed.
+    # BUILD_TLS=yes builds redis-server with TLS (README's documented full
+    # build) so redisearch's TLS test suite can start a TLS server. Same
+    # parallel form the README documents for tarball builds.
+    - name: make -j "$(nproc)" all BUILD_TLS=yes
+      run: make -j "$(nproc)" all BUILD_TLS=yes
+    - name: run server with redis-full.conf, verify MODULE LIST
+      run: |
+        ./src/redis-server redis-full.conf --daemonize no &
+        i=0
+        until ./src/redis-cli ping 2>/dev/null | grep -q PONG; do
+          i=$((i+1)); [ "$i" -gt 60 ] && echo 'redis-server did not come up' && exit 1
+          sleep 1
+        done
+        ./src/redis-cli MODULE LIST | tee module-list.txt
+        for m in bf search ReJSON timeseries; do
+          grep -qx "$m" module-list.txt || { echo "MISSING MODULE: $m"; exit 1; }
+        done
+        ./src/redis-cli shutdown nosave || true
+    - name: make test all
+      if: ${{ !contains(github.event.inputs.skiptests, 'modules') }}
+      run: make test all

--- a/.github/workflows/modules-daily.yml
+++ b/.github/workflows/modules-daily.yml
@@ -167,31 +167,60 @@ jobs:
     - name: make test all
       if: ${{ github.event.inputs.run_tests == 'true' }}
       run: make test all
-    # Package/deploy smoke: verify `make tarball` produces a self-contained
-    # bundle and `make deploy` installs a runnable server + modules.
-    #   tarball: TARBALL_SKIP_MODULES_UPDATE=1 — modules already cloned above.
-    #   deploy : reuses the already-built tree, copies binaries + .so into
-    #            $PREFIX and rewrites redis-full.conf's loadmodule paths to
-    #            the installed absolute paths; we then run the deployed server.
-    # ponytail: deploy smokes the current build, not a from-tarball rebuild —
-    # a full rebuild-from-tarball would double build time for little added
-    # signal here; add it if the tarball's bundled sources ever drift.
+    # Package/deploy smoke — mirrors PR TalBarYakar/redis#4's
+    # phase_package_deploy_smoke exactly:
+    #   1. make tarball, extract, assert the bundled redis.conf carries the
+    #      exact relative loadmodule line for every module.
+    #   2. make deploy FROM the extracted tarball, then assert deploy
+    #      rewrote redis.conf's loadmodule lines to the absolute $PREFIX paths.
+    #   3. run the deployed redis-server with that redis.conf, verify each
+    #      module both loads (MODULE LIST + server log) and answers a command.
     - name: make tarball, deploy, smoke test
+      env:
+        DEPLOY_PREFIX: /tmp/redis-deploy
+        DEPLOY_RUN_LOG: /tmp/redis-deploy-run.log
       run: |
-        make tarball TAG=HEAD OUT_PATH=/tmp/redis-bundle.tar.gz TARBALL_SKIP_MODULES_UPDATE=1
-        tar tzf /tmp/redis-bundle.tar.gz | grep -q 'modules/redisearch/src/' || { echo 'tarball missing module sources'; exit 1; }
-        make deploy PREFIX=/tmp/redis-deploy
-        /tmp/redis-deploy/bin/redis-server redis-full.conf --daemonize no &
+        make tarball TAG=HEAD
+        rm -rf /tmp/redis-tarball-check && mkdir -p /tmp/redis-tarball-check
+        tar -xf /tmp/redis-HEAD.tar.gz -C /tmp/redis-tarball-check
+        EXTRACTED=/tmp/redis-tarball-check/redis-HEAD
+        for line in \
+          "loadmodule ./modules/redisbloom/redisbloom.so" \
+          "loadmodule ./modules/redisearch/redisearch.so" \
+          "loadmodule ./modules/redisjson/rejson.so" \
+          "loadmodule ./modules/redistimeseries/redistimeseries.so"; do
+          grep -qxF "$line" "$EXTRACTED/redis.conf" || { echo "ERROR: missing tarball redis.conf line: $line" >&2; exit 1; }
+        done
+        mkdir -p "$DEPLOY_PREFIX"
+        ( cd "$EXTRACTED" && make deploy PREFIX="$DEPLOY_PREFIX" )
+        for so in redisbloom.so redisearch.so rejson.so redistimeseries.so; do
+          line="loadmodule $DEPLOY_PREFIX/lib/redis/modules/$so"
+          grep -qxF "$line" "$EXTRACTED/redis.conf" || { echo "ERROR: deployed redis.conf missing absolute line: $line" >&2; exit 1; }
+        done
+        cp "$EXTRACTED/redis.conf" "$DEPLOY_PREFIX/redis.conf"
+        "$DEPLOY_PREFIX/bin/redis-server" "$DEPLOY_PREFIX/redis.conf" --appendonly no >"$DEPLOY_RUN_LOG" 2>&1 &
+        cli="$DEPLOY_PREFIX/bin/redis-cli"
         i=0
-        until /tmp/redis-deploy/bin/redis-cli ping 2>/dev/null | grep -q PONG; do
-          i=$((i+1)); [ "$i" -gt 60 ] && echo 'deployed redis-server did not come up' && exit 1
+        until "$cli" PING 2>/dev/null | grep -q PONG; do
+          i=$((i+1)); [ "$i" -gt 120 ] && { tail -80 "$DEPLOY_RUN_LOG"; echo 'deployed redis-server did not become ready' >&2; exit 1; }
           sleep 1
         done
-        /tmp/redis-deploy/bin/redis-cli MODULE LIST | tee deploy-module-list.txt
-        for m in bf search ReJSON timeseries; do
-          grep -qx "$m" deploy-module-list.txt || { echo "MISSING MODULE (deploy): $m"; exit 1; }
+        for needle in timeseries bf ReJSON search; do
+          "$cli" MODULE LIST | grep -qi "$needle" || { "$cli" MODULE LIST; echo "ERROR: module '$needle' was not loaded" >&2; exit 1; }
         done
-        /tmp/redis-deploy/bin/redis-cli shutdown nosave || true
+        "$cli" TS.CREATE ts
+        "$cli" TS.ADD ts '*' 1
+        "$cli" TS.INFO ts
+        "$cli" BF.ADD bf x
+        "$cli" BF.EXISTS bf x
+        "$cli" JSON.SET j '$' '{"a":1}'
+        "$cli" JSON.GET j
+        "$cli" FT.CREATE idx ON HASH SCHEMA t TEXT
+        "$cli" FT._LIST
+        for module_name in bf search ReJSON timeseries; do
+          grep -q "Module '$module_name' loaded" "$DEPLOY_RUN_LOG" || { tail -80 "$DEPLOY_RUN_LOG"; echo "ERROR: deployed server log did not show module '$module_name' loading" >&2; exit 1; }
+        done
+        "$cli" SHUTDOWN NOSAVE || true
 
   # Same from-source flow as test-modules, on native macOS. macOS can't run
   # inside a container and current runners are arm64-only, so it can't join
@@ -246,18 +275,48 @@ jobs:
       if: ${{ github.event.inputs.run_tests == 'true' }}
       run: make test all
     - name: make tarball, deploy, smoke test
+      env:
+        DEPLOY_PREFIX: /tmp/redis-deploy
+        DEPLOY_RUN_LOG: /tmp/redis-deploy-run.log
       run: |
-        make tarball TAG=HEAD OUT_PATH=/tmp/redis-bundle.tar.gz TARBALL_SKIP_MODULES_UPDATE=1
-        tar tzf /tmp/redis-bundle.tar.gz | grep -q 'modules/redisearch/src/' || { echo 'tarball missing module sources'; exit 1; }
-        make deploy PREFIX=/tmp/redis-deploy
-        /tmp/redis-deploy/bin/redis-server redis-full.conf --daemonize no &
+        make tarball TAG=HEAD
+        rm -rf /tmp/redis-tarball-check && mkdir -p /tmp/redis-tarball-check
+        tar -xf /tmp/redis-HEAD.tar.gz -C /tmp/redis-tarball-check
+        EXTRACTED=/tmp/redis-tarball-check/redis-HEAD
+        for line in \
+          "loadmodule ./modules/redisbloom/redisbloom.so" \
+          "loadmodule ./modules/redisearch/redisearch.so" \
+          "loadmodule ./modules/redisjson/rejson.so" \
+          "loadmodule ./modules/redistimeseries/redistimeseries.so"; do
+          grep -qxF "$line" "$EXTRACTED/redis.conf" || { echo "ERROR: missing tarball redis.conf line: $line" >&2; exit 1; }
+        done
+        mkdir -p "$DEPLOY_PREFIX"
+        ( cd "$EXTRACTED" && make deploy PREFIX="$DEPLOY_PREFIX" )
+        for so in redisbloom.so redisearch.so rejson.so redistimeseries.so; do
+          line="loadmodule $DEPLOY_PREFIX/lib/redis/modules/$so"
+          grep -qxF "$line" "$EXTRACTED/redis.conf" || { echo "ERROR: deployed redis.conf missing absolute line: $line" >&2; exit 1; }
+        done
+        cp "$EXTRACTED/redis.conf" "$DEPLOY_PREFIX/redis.conf"
+        "$DEPLOY_PREFIX/bin/redis-server" "$DEPLOY_PREFIX/redis.conf" --appendonly no >"$DEPLOY_RUN_LOG" 2>&1 &
+        cli="$DEPLOY_PREFIX/bin/redis-cli"
         i=0
-        until /tmp/redis-deploy/bin/redis-cli ping 2>/dev/null | grep -q PONG; do
-          i=$((i+1)); [ "$i" -gt 60 ] && echo 'deployed redis-server did not come up' && exit 1
+        until "$cli" PING 2>/dev/null | grep -q PONG; do
+          i=$((i+1)); [ "$i" -gt 120 ] && { tail -80 "$DEPLOY_RUN_LOG"; echo 'deployed redis-server did not become ready' >&2; exit 1; }
           sleep 1
         done
-        /tmp/redis-deploy/bin/redis-cli MODULE LIST | tee deploy-module-list.txt
-        for m in bf search ReJSON timeseries; do
-          grep -qx "$m" deploy-module-list.txt || { echo "MISSING MODULE (deploy): $m"; exit 1; }
+        for needle in timeseries bf ReJSON search; do
+          "$cli" MODULE LIST | grep -qi "$needle" || { "$cli" MODULE LIST; echo "ERROR: module '$needle' was not loaded" >&2; exit 1; }
         done
-        /tmp/redis-deploy/bin/redis-cli shutdown nosave || true
+        "$cli" TS.CREATE ts
+        "$cli" TS.ADD ts '*' 1
+        "$cli" TS.INFO ts
+        "$cli" BF.ADD bf x
+        "$cli" BF.EXISTS bf x
+        "$cli" JSON.SET j '$' '{"a":1}'
+        "$cli" JSON.GET j
+        "$cli" FT.CREATE idx ON HASH SCHEMA t TEXT
+        "$cli" FT._LIST
+        for module_name in bf search ReJSON timeseries; do
+          grep -q "Module '$module_name' loaded" "$DEPLOY_RUN_LOG" || { tail -80 "$DEPLOY_RUN_LOG"; echo "ERROR: deployed server log did not show module '$module_name' loading" >&2; exit 1; }
+        done
+        "$cli" SHUTDOWN NOSAVE || true

--- a/.github/workflows/modules-daily.yml
+++ b/.github/workflows/modules-daily.yml
@@ -23,9 +23,10 @@ on:
     - cron: '30 1 * * *'
   workflow_dispatch:
     inputs:
-      skiptests:
-        description: "set to 'modules' to skip the heavy 'make test all' step"
-        default: ''
+      run_tests:
+        description: "run the heavy 'make test all' step (off by default; never runs on schedule)"
+        type: boolean
+        default: false
       use_repo:
         description: 'repo owner and name'
         default: 'redis/redis'
@@ -164,7 +165,7 @@ jobs:
         done
         ./src/redis-cli shutdown nosave || true
     - name: make test all
-      if: ${{ !contains(github.event.inputs.skiptests, 'modules') }}
+      if: ${{ github.event.inputs.run_tests == 'true' }}
       run: make test all
     # Package/deploy smoke: verify `make tarball` produces a self-contained
     # bundle and `make deploy` installs a runnable server + modules.
@@ -242,7 +243,7 @@ jobs:
         done
         ./src/redis-cli shutdown nosave || true
     - name: make test all
-      if: ${{ !contains(github.event.inputs.skiptests, 'modules') }}
+      if: ${{ github.event.inputs.run_tests == 'true' }}
       run: make test all
     - name: make tarball, deploy, smoke test
       run: |

--- a/.github/workflows/modules-daily.yml
+++ b/.github/workflows/modules-daily.yml
@@ -66,6 +66,10 @@ jobs:
       # flags must reach that rebuild too. Redis core is pure C and ignores
       # CXXFLAGS.
       CXXFLAGS: -Wno-error=uninitialized -Wno-error=maybe-uninitialized -Wno-unknown-warning-option
+      # Shared across the split tarball/deploy/run steps (same runner FS).
+      EXTRACTED: /tmp/redis-tarball-check/redis-HEAD
+      DEPLOY_PREFIX: /tmp/redis-deploy
+      DEPLOY_RUN_LOG: /tmp/redis-deploy-run.log
     strategy:
       fail-fast: false
       # Both architectures the bundled modules support, mirroring their own
@@ -168,22 +172,16 @@ jobs:
       if: ${{ github.event.inputs.run_tests == 'true' }}
       run: make test all
     # Package/deploy smoke — mirrors PR TalBarYakar/redis#4's
-    # phase_package_deploy_smoke exactly:
-    #   1. make tarball, extract, assert the bundled redis.conf carries the
-    #      exact relative loadmodule line for every module.
-    #   2. make deploy FROM the extracted tarball, then assert deploy
-    #      rewrote redis.conf's loadmodule lines to the absolute $PREFIX paths.
-    #   3. run the deployed redis-server with that redis.conf, verify each
-    #      module both loads (MODULE LIST + server log) and answers a command.
-    - name: make tarball, deploy, smoke test
-      env:
-        DEPLOY_PREFIX: /tmp/redis-deploy
-        DEPLOY_RUN_LOG: /tmp/redis-deploy-run.log
+    # phase_package_deploy_smoke, split into one step per phase for easier
+    # tracking in the Actions UI. The steps share the runner filesystem and
+    # the EXTRACTED/DEPLOY_* paths from the job env.
+    - name: make tarball
       run: |
         make tarball TAG=HEAD
         rm -rf /tmp/redis-tarball-check && mkdir -p /tmp/redis-tarball-check
         tar -xf /tmp/redis-HEAD.tar.gz -C /tmp/redis-tarball-check
-        EXTRACTED=/tmp/redis-tarball-check/redis-HEAD
+    - name: check tarball redis.conf loadmodule lines
+      run: |
         for line in \
           "loadmodule ./modules/redisbloom/redisbloom.so" \
           "loadmodule ./modules/redisearch/redisearch.so" \
@@ -191,6 +189,8 @@ jobs:
           "loadmodule ./modules/redistimeseries/redistimeseries.so"; do
           grep -qxF "$line" "$EXTRACTED/redis.conf" || { echo "ERROR: missing tarball redis.conf line: $line" >&2; exit 1; }
         done
+    - name: make deploy from tarball
+      run: |
         mkdir -p "$DEPLOY_PREFIX"
         ( cd "$EXTRACTED" && make deploy PREFIX="$DEPLOY_PREFIX" )
         for so in redisbloom.so redisearch.so rejson.so redistimeseries.so; do
@@ -198,6 +198,8 @@ jobs:
           grep -qxF "$line" "$EXTRACTED/redis.conf" || { echo "ERROR: deployed redis.conf missing absolute line: $line" >&2; exit 1; }
         done
         cp "$EXTRACTED/redis.conf" "$DEPLOY_PREFIX/redis.conf"
+    - name: run deployed server, verify modules
+      run: |
         "$DEPLOY_PREFIX/bin/redis-server" "$DEPLOY_PREFIX/redis.conf" --appendonly no >"$DEPLOY_RUN_LOG" 2>&1 &
         cli="$DEPLOY_PREFIX/bin/redis-cli"
         i=0
@@ -234,6 +236,10 @@ jobs:
     env:
       # make tarball needs GNU tar (gtar from Homebrew); tarball.sh honors TAR.
       TAR: gtar
+      # Shared across the split tarball/deploy/run steps (same runner FS).
+      EXTRACTED: /tmp/redis-tarball-check/redis-HEAD
+      DEPLOY_PREFIX: /tmp/redis-deploy
+      DEPLOY_RUN_LOG: /tmp/redis-deploy-run.log
     steps:
     - name: install manual prerequisites
       # git/make/clang ship with the Xcode command line tools; brew supplies
@@ -274,15 +280,13 @@ jobs:
     - name: make test all
       if: ${{ github.event.inputs.run_tests == 'true' }}
       run: make test all
-    - name: make tarball, deploy, smoke test
-      env:
-        DEPLOY_PREFIX: /tmp/redis-deploy
-        DEPLOY_RUN_LOG: /tmp/redis-deploy-run.log
+    - name: make tarball
       run: |
         make tarball TAG=HEAD
         rm -rf /tmp/redis-tarball-check && mkdir -p /tmp/redis-tarball-check
         tar -xf /tmp/redis-HEAD.tar.gz -C /tmp/redis-tarball-check
-        EXTRACTED=/tmp/redis-tarball-check/redis-HEAD
+    - name: check tarball redis.conf loadmodule lines
+      run: |
         for line in \
           "loadmodule ./modules/redisbloom/redisbloom.so" \
           "loadmodule ./modules/redisearch/redisearch.so" \
@@ -290,6 +294,8 @@ jobs:
           "loadmodule ./modules/redistimeseries/redistimeseries.so"; do
           grep -qxF "$line" "$EXTRACTED/redis.conf" || { echo "ERROR: missing tarball redis.conf line: $line" >&2; exit 1; }
         done
+    - name: make deploy from tarball
+      run: |
         mkdir -p "$DEPLOY_PREFIX"
         ( cd "$EXTRACTED" && make deploy PREFIX="$DEPLOY_PREFIX" )
         for so in redisbloom.so redisearch.so rejson.so redistimeseries.so; do
@@ -297,6 +303,8 @@ jobs:
           grep -qxF "$line" "$EXTRACTED/redis.conf" || { echo "ERROR: deployed redis.conf missing absolute line: $line" >&2; exit 1; }
         done
         cp "$EXTRACTED/redis.conf" "$DEPLOY_PREFIX/redis.conf"
+    - name: run deployed server, verify modules
+      run: |
         "$DEPLOY_PREFIX/bin/redis-server" "$DEPLOY_PREFIX/redis.conf" --appendonly no >"$DEPLOY_RUN_LOG" 2>&1 &
         cli="$DEPLOY_PREFIX/bin/redis-cli"
         i=0

--- a/.github/workflows/modules-daily.yml
+++ b/.github/workflows/modules-daily.yml
@@ -118,7 +118,8 @@ jobs:
               sleep 10
             done
             [ -n "$ok" ] || { echo "ERROR: tdnf prerequisite install failed after retries" >&2; exit 1; } ;;
-          apk)  apk add git make bash ca-certificates openssl-dev openssl ;;
+          # tar: alpine's default is busybox tar; `make tarball` needs GNU tar.
+          apk)  apk add git make bash ca-certificates openssl-dev openssl tar ;;
         esac
         # The modules' bootstrap tooling (redistimeseries .install/lib/
         # setup-python.sh) skips its uv/venv/pip setup when /.dockerenv
@@ -165,3 +166,97 @@ jobs:
     - name: make test all
       if: ${{ !contains(github.event.inputs.skiptests, 'modules') }}
       run: make test all
+    # Package/deploy smoke: verify `make tarball` produces a self-contained
+    # bundle and `make deploy` installs a runnable server + modules.
+    #   tarball: TARBALL_SKIP_MODULES_UPDATE=1 — modules already cloned above.
+    #   deploy : reuses the already-built tree, copies binaries + .so into
+    #            $PREFIX and rewrites redis-full.conf's loadmodule paths to
+    #            the installed absolute paths; we then run the deployed server.
+    # ponytail: deploy smokes the current build, not a from-tarball rebuild —
+    # a full rebuild-from-tarball would double build time for little added
+    # signal here; add it if the tarball's bundled sources ever drift.
+    - name: make tarball, deploy, smoke test
+      run: |
+        make tarball TAG=HEAD OUT_PATH=/tmp/redis-bundle.tar.gz TARBALL_SKIP_MODULES_UPDATE=1
+        tar tzf /tmp/redis-bundle.tar.gz | grep -q 'modules/redisearch/src/' || { echo 'tarball missing module sources'; exit 1; }
+        make deploy PREFIX=/tmp/redis-deploy
+        /tmp/redis-deploy/bin/redis-server redis-full.conf --daemonize no &
+        i=0
+        until /tmp/redis-deploy/bin/redis-cli ping 2>/dev/null | grep -q PONG; do
+          i=$((i+1)); [ "$i" -gt 60 ] && echo 'deployed redis-server did not come up' && exit 1
+          sleep 1
+        done
+        /tmp/redis-deploy/bin/redis-cli MODULE LIST | tee deploy-module-list.txt
+        for m in bf search ReJSON timeseries; do
+          grep -qx "$m" deploy-module-list.txt || { echo "MISSING MODULE (deploy): $m"; exit 1; }
+        done
+        /tmp/redis-deploy/bin/redis-cli shutdown nosave || true
+
+  # Same from-source flow as test-modules, on native macOS. macOS can't run
+  # inside a container and current runners are arm64-only, so it can't join
+  # the arch×osnick matrix above — it's the same steps as one matrix row,
+  # with the macOS-only prerequisites (Homebrew) as the sole difference.
+  test-modules-macos:
+    name: test-modules-macos
+    runs-on: macos-latest
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'redis/redis'
+    timeout-minutes: 300
+    env:
+      # make tarball needs GNU tar (gtar from Homebrew); tarball.sh honors TAR.
+      TAR: gtar
+    steps:
+    - name: install manual prerequisites
+      # git/make/clang ship with the Xcode command line tools; brew supplies
+      # only what the manual assumes present that macOS lacks: coreutils for
+      # nproc (used by the build step, same as the Linux rows), GNU tar for
+      # make tarball, and openssl for the BUILD_TLS=yes build.
+      run: |
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install coreutils gnu-tar openssl
+        # coreutils installs GNU tools g-prefixed; put the unprefixed names
+        # (nproc, …) on PATH so the build step matches the Linux rows verbatim.
+        echo "$(brew --prefix)/opt/coreutils/libexec/gnubin" >> "$GITHUB_PATH"
+    - name: checkout
+      run: |
+        git config --global --add safe.directory "$(pwd)"
+        git init .
+        git remote add origin "https://github.com/${{ github.event.inputs.use_repo || 'redis/redis' }}.git"
+        git fetch --depth 1 origin "${{ github.event.inputs.use_git_ref || 'unstable' }}"
+        git checkout FETCH_HEAD
+    - name: make modules-update
+      run: make modules-update
+    - name: make bootstrap
+      run: make bootstrap
+    - name: make -j "$(nproc)" all BUILD_TLS=yes
+      run: make -j "$(nproc)" all BUILD_TLS=yes
+    - name: run server with redis-full.conf, verify MODULE LIST
+      run: |
+        ./src/redis-server redis-full.conf --daemonize no &
+        i=0
+        until ./src/redis-cli ping 2>/dev/null | grep -q PONG; do
+          i=$((i+1)); [ "$i" -gt 60 ] && echo 'redis-server did not come up' && exit 1
+          sleep 1
+        done
+        ./src/redis-cli MODULE LIST | tee module-list.txt
+        for m in bf search ReJSON timeseries; do
+          grep -qx "$m" module-list.txt || { echo "MISSING MODULE: $m"; exit 1; }
+        done
+        ./src/redis-cli shutdown nosave || true
+    - name: make test all
+      if: ${{ !contains(github.event.inputs.skiptests, 'modules') }}
+      run: make test all
+    - name: make tarball, deploy, smoke test
+      run: |
+        make tarball TAG=HEAD OUT_PATH=/tmp/redis-bundle.tar.gz TARBALL_SKIP_MODULES_UPDATE=1
+        tar tzf /tmp/redis-bundle.tar.gz | grep -q 'modules/redisearch/src/' || { echo 'tarball missing module sources'; exit 1; }
+        make deploy PREFIX=/tmp/redis-deploy
+        /tmp/redis-deploy/bin/redis-server redis-full.conf --daemonize no &
+        i=0
+        until /tmp/redis-deploy/bin/redis-cli ping 2>/dev/null | grep -q PONG; do
+          i=$((i+1)); [ "$i" -gt 60 ] && echo 'deployed redis-server did not come up' && exit 1
+          sleep 1
+        done
+        /tmp/redis-deploy/bin/redis-cli MODULE LIST | tee deploy-module-list.txt
+        for m in bf search ReJSON timeseries; do
+          grep -qx "$m" deploy-module-list.txt || { echo "MISSING MODULE (deploy): $m"; exit 1; }
+        done
+        /tmp/redis-deploy/bin/redis-cli shutdown nosave || true


### PR DESCRIPTION
1. add tarball phase 
2. checks redis.conf contains 4 modules load module command
3. run make deploy with PREFIX 
4. run the server with redis.conf which his load modules commands suppose to contains the PREFIX in the path

make test optional , only for manual trigger (false by default)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions CI configuration; no runtime Redis or module code paths are modified.
> 
> **Overview**
> Introduces **Modules Daily** (`.github/workflows/modules-daily.yml`), a scheduled and manually dispatchable workflow that exercises the documented from-source modules flow across a large **arch × OS** matrix in stock container images, plus a parallel **macOS** job.
> 
> Beyond **modules-update**, **bootstrap**, **BUILD_TLS=yes** build, and in-tree **redis-full.conf** / **MODULE LIST** checks, it adds a **package/deploy smoke** path: **`make tarball`**, asserts the four relative **`loadmodule`** lines in the tarball **`redis.conf`**, runs **`make deploy`** with a **`PREFIX`**, verifies **`redis.conf`** is rewritten with absolute module paths, then starts the deployed server and smoke-tests Bloom, JSON, TimeSeries, and Search (including log checks for module load messages).
> 
> **`make test all`** is gated behind workflow_dispatch input **`run_tests`** (default **false**, not run on schedule). Prerequisite steps were extended where needed for tarball/TLS (e.g. GNU **tar** on Alpine, **openssl** packages, macOS **gtar**/**coreutils**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d652b57e65c18459d6e694bc290f9c51c11157. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->