### PR TITLE
Directly ingest data into AOF instead of triggering a background rewrite

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -992,6 +992,13 @@ int ingestPreloadRdbIntoAof(void) {
     server.aof_fd = incr_fd;
     server.aof_state = AOF_ON;
     server.aof_current_size = 0;
+    /* Set rewrite base size to the BASE file size so auto‑rewrite behaves correctly. */
+    struct stat st;
+    if (stat(target_path, &st) == 0) {
+        server.aof_rewrite_base_size = st.st_size;
+    } else {
+        server.aof_rewrite_base_size = 0;
+    }
     server.aof_last_incr_size = 0;
 
     sdsfree(incr_path);
@@ -1143,6 +1150,13 @@ int ingestPreloadSingleAofIntoAof(void) {
     server.aof_fd = incr_fd;
     server.aof_state = AOF_ON;
     server.aof_current_size = 0;
+    /* Set rewrite base size to the BASE file size so auto‑rewrite behaves correctly. */
+    struct stat st;
+    if (stat(target_path, &st) == 0) {
+        server.aof_rewrite_base_size = st.st_size;
+    } else {
+        server.aof_rewrite_base_size = 0;
+    }
     server.aof_last_incr_size = 0;
 
     sdsfree(incr_path);
@@ -1240,6 +1254,28 @@ int ingestPreloadManifestIntoAof(void) {
         listAddNodeTail(new_am->incr_aof_list, new_ai);
     }
 
+        /* Compute the total size of the ingested BASE + historical INCR files
+     * for the auto‑rewrite threshold (the new empty INCR is excluded). */
+    off_t total_base_size = 0;
+    if (new_am->base_aof_info) {
+        sds base_path = makePath(server.aof_dirname, new_am->base_aof_info->file_name);
+        struct stat st;
+        if (stat(base_path, &st) == 0) total_base_size += st.st_size;
+        sdsfree(base_path);
+    }
+    {
+        listIter li2;
+        listNode *ln2;
+        listRewind(new_am->incr_aof_list, &li2);
+        while ((ln2 = listNext(&li2)) != NULL) {
+            aofInfo *ai = listNodeValue(ln2);
+            sds incr_path = makePath(server.aof_dirname, ai->file_name);
+            struct stat st;
+            if (stat(incr_path, &st) == 0) total_base_size += st.st_size;
+            sdsfree(incr_path);
+        }
+    }
+
     /* Manually create a fresh INCR file for future writes.
      * We bypass openNewIncrAofForAppend() because it relies on live-server
      * state that isn't correctly set after a preload. */
@@ -1257,7 +1293,7 @@ int ingestPreloadManifestIntoAof(void) {
     }
 
     aofInfo *incr_ai = aofInfoCreate();
-    incr_ai->file_name = incr_name;
+    incr_ai->file_name = incr_name;   /* ownership passed */
     incr_ai->file_seq = next_incr_seq;
     incr_ai->file_type = AOF_FILE_TYPE_INCR;
     incr_ai->start_offset = server.master_repl_offset;
@@ -1283,6 +1319,7 @@ int ingestPreloadManifestIntoAof(void) {
     /* Attach the new INCR fd and mark AOF as ON. */
     server.aof_fd = incr_fd;
     server.aof_state = AOF_ON;
+    server.aof_rewrite_base_size = total_base_size;   /* set auto‑rewrite base */
     server.aof_current_size = 0;
     server.aof_last_incr_size = 0;
 
@@ -2004,8 +2041,16 @@ struct client *createAOFClient(void) {
 
 int loadPreLoadAOFFile(char *file) {
     aofManifest* preload_am = aofManifestCreate();
-    aofInfo *ai = aofInfoCreate();
-    ai->file_name = sdsnew(file);
+        aofInfo *ai = aofInfoCreate();
+    sds file_dir = getFilePath(file);
+    if (file_dir) {
+        /* Extract only the base name; loadAppendOnlyFiles will prepend the dir */
+        char *base = strrchr(file, '/');
+        ai->file_name = sdsnew(base ? base + 1 : file);
+        sdsfree(file_dir);
+    } else {
+        ai->file_name = sdsnew(file);
+    }
     ai->file_seq = 1;
     ai->file_type = AOF_FILE_TYPE_BASE;
     preload_am->base_aof_info = ai;

--- a/src/aof.c
+++ b/src/aof.c
@@ -32,6 +32,11 @@ int rewriteAppendOnlyFile(char *filename);
 aofManifest *aofLoadManifestFromFile(sds am_filepath);
 void aofManifestFreeAndUpdate(aofManifest *am);
 void aof_background_fsync_and_close(int fd);
+static void removeFilesInDir(char *dirname);
+static int openNewIncrAofForAppend(void);
+int ingestPreloadRdbIntoAof(void);
+int ingestPreloadSingleAofIntoAof(void);
+int ingestPreloadManifestIntoAof(void);
 
 /* When we call 'startAppendOnly', we will create a temp INCR AOF, and rename
  * it to the real INCR AOF name when the AOFRW is done, so if want to know the
@@ -833,16 +838,477 @@ void aofHandlePreloadOnServerStart(void) {
         return;
     }
 
-    /* The current manifest may describe a different dataset, so don't attach
-     * new writes to its active INCR while rebuilding it. Reuse the state used
-     * when AOF is enabled at runtime: write to a temporary INCR, publish it
-     * together with the new BASE after AOFRW succeeds, and retry on failure. */
-    server.aof_state = AOF_WAIT_REWRITE;
-    if (rewriteAppendOnlyFileBackground() != C_OK) {
-        serverLog(LL_WARNING,
-            "Failed to start background AOF rewrite after preload");
+    /* The current AOF was opened with the old (unrelated) manifest.
+     * Stop it cleanly before we empty the directory. */
+    stopAppendOnly();
+
+    /* We are about to replace the entire AOF history with the preload
+    * dataset. Delete all files from the appendonlydir first, because
+    * they belong to an old, now invalid state. */
+    serverLog(LL_NOTICE, "Ingesting preload data into AOF directory: %s", server.preload_file);
+    removeFilesInDir(server.aof_dirname);
+    if (!dirIsEmpty(server.aof_dirname)) {
+        serverLog(LL_WARNING, "Failed to completely empty AOF directory, ingestion aborted.");
         exit(1);
     }
+
+    /* Now ingest the preload dataset. The exact method depends on the type. */
+    int ingested = 0;
+    if (strncmp(server.preload_file, "rdb:/", 5) == 0) {
+        ingested = ingestPreloadRdbIntoAof();
+    } else if (strncmp(server.preload_file, "aof:/", 5) == 0) {
+        const char *ext = getFileExtension(server.preload_file);
+        if (ext && !strcmp(ext, "aof")) {
+            ingested = ingestPreloadSingleAofIntoAof();
+        } else if (ext && !strcmp(ext, "manifest")) {
+            ingested = ingestPreloadManifestIntoAof();
+        }
+    }
+
+    if (ingested != C_OK) {
+        serverLog(LL_WARNING, "Failed to ingest preload file into AOF, exiting.");
+        exit(1);
+    }
+
+    serverLog(LL_NOTICE, "AOF is now consistent with preload file, no rewrite needed.");
+}
+
+/* Ingest a preloaded RDB file into the (empty) append-only directory.
+ * The RDB file is hard-linked (or copied if cross-device) as the BASE file,
+ * then a new manifest is created and a fresh INCR AOF is opened for future
+ * writes.
+ *
+ * Returns C_OK on success, C_ERR on failure (logs details). */
+int ingestPreloadRdbIntoAof(void) {
+    /* Obtain the absolute path to the preloaded RDB file. */
+    const char *rdb_path = server.preload_file + 4; /* skip "rdb:" */
+    sds abs_src = getAbsolutePath(rdb_path);
+    if (!abs_src) {
+        serverLog(LL_WARNING, "Failed to resolve absolute path for RDB: %s", rdb_path);
+        return C_ERR;
+    }
+
+    /* Ensure the appendonly directory exists. */
+    if (dirCreateIfMissing(server.aof_dirname) == -1) {
+        serverLog(LL_WARNING, "Cannot create AOF directory: %s", strerror(errno));
+        sdsfree(abs_src);
+        return C_ERR;
+    }
+
+    /* Construct the target BASE file path. */
+    sds base_name = sdsnew("appendonly.aof.1.base.rdb");
+    sds target_path = makePath(server.aof_dirname, base_name);
+
+    /* Try hard-linking the RDB into the AOF directory. */
+    if (link(abs_src, target_path) == -1) {
+        if (errno == EXDEV) {
+            /* Cross-device link - fall back to full copy. */
+            serverLog(LL_NOTICE,
+                "Hard link failed (cross-device), copying RDB file instead: %s -> %s",
+                abs_src, target_path);
+            if (fcopyfile(abs_src, target_path) != 0) {
+                serverLog(LL_WARNING, "Copy failed: %s -> %s: %s",
+                          abs_src, target_path, strerror(errno));
+                sdsfree(abs_src);
+                sdsfree(target_path);
+                sdsfree(base_name);
+                return C_ERR;
+            }
+        } else {
+            serverLog(LL_WARNING, "Cannot hard-link RDB file: %s -> %s: %s",
+                      abs_src, target_path, strerror(errno));
+            sdsfree(abs_src);
+            sdsfree(target_path);
+            sdsfree(base_name);
+            return C_ERR;
+        }
+    }
+    sdsfree(abs_src);
+
+    /* Build a fresh MP-AOF manifest with the BASE file. */
+    aofManifest *new_am = aofManifestCreate();
+    aofInfo *base_ai = aofInfoCreate();
+    base_ai->file_name = sdsdup(base_name);
+    base_ai->file_seq = 1;
+    base_ai->file_type = AOF_FILE_TYPE_BASE;
+    new_am->base_aof_info = base_ai;
+    new_am->curr_base_file_seq = 1;
+    new_am->dirty = 1;
+
+    /* Replace the old manifest now (the AOF directory is empty so any old
+     * manifest is invalid). */
+    if (server.aof_manifest) {
+        aofManifestFree(server.aof_manifest);
+    }
+    server.aof_manifest = new_am;
+
+    /* Manually create a fresh INCR file and update the manifest.
+     * We bypass openNewIncrAofForAppend() because that function relies
+     * on live-server state (repl offset, rewrite flags) that are not
+     * properly initialised after a preload. */
+    int next_incr_seq = new_am->curr_base_file_seq + 1;
+    sds incr_name = sdscatprintf(sdsempty(), "appendonly.aof.%d.incr.aof", next_incr_seq);
+    sds incr_path = makePath(server.aof_dirname, incr_name);
+    int incr_fd = open(incr_path, O_WRONLY|O_CREAT|O_TRUNC, 0644);
+    if (incr_fd == -1) {
+        serverLog(LL_WARNING, "Cannot create new INCR file %s: %s",
+                  incr_name, strerror(errno));
+        sdsfree(incr_name);
+        sdsfree(incr_path);
+        /* Rollback: remove BASE file and free manifest */
+        unlink(target_path);
+        aofManifestFree(server.aof_manifest);
+        server.aof_manifest = NULL;
+        sdsfree(target_path);
+        sdsfree(base_name);
+        return C_ERR;
+    }
+
+    aofInfo *incr_ai = aofInfoCreate();
+    incr_ai->file_name = incr_name;   /* ownership passed */
+    incr_ai->file_seq = next_incr_seq;
+    incr_ai->file_type = AOF_FILE_TYPE_INCR;
+    incr_ai->start_offset = 0;
+    incr_ai->end_offset = -1;
+    listAddNodeTail(new_am->incr_aof_list, incr_ai);
+    new_am->dirty = 1;
+
+    if (persistAofManifest(new_am) != C_OK) {
+        serverLog(LL_WARNING, "Failed to persist manifest after adding INCR");
+        close(incr_fd);
+        unlink(incr_path);
+        /* Rollback: remove BASE file and free manifest */
+        unlink(target_path);
+        aofManifestFree(server.aof_manifest);
+        server.aof_manifest = NULL;
+        sdsfree(target_path);
+        sdsfree(base_name);
+        sdsfree(incr_path);
+        return C_ERR;
+    }
+
+    /* Live manifest is already set; now attach the new INCR fd. */
+    server.aof_fd = incr_fd;
+    server.aof_state = AOF_ON;
+    server.aof_current_size = 0;
+    server.aof_last_incr_size = 0;
+
+    sdsfree(incr_path);
+    sdsfree(target_path);
+    sdsfree(base_name);
+    return C_OK;
+}
+
+/* Link/copy a file into the AOF directory and record it for rollback.
+ * Returns the new base name (sds) on success, NULL on failure. */
+static sds copyFileIntoAofDir(fileList *created, const char *src_path,
+                               int seq, const char *type, const char *ext) {
+    sds new_name = sdscatprintf(sdsempty(), "appendonly.aof.%d.%s.%s",
+                                seq, type, ext);
+    sds new_path = makePath(server.aof_dirname, new_name);
+    if (link(src_path, new_path) == -1) {
+        if (errno == EXDEV) {
+            serverLog(LL_NOTICE, "Cross-device link, copying: %s -> %s",
+                      src_path, new_path);
+            if (fcopyfile(src_path, new_path) != 0) {
+                serverLog(LL_WARNING, "Copy failed: %s -> %s: %s",
+                          src_path, new_path, strerror(errno));
+                sdsfree(new_path);
+                sdsfree(new_name);
+                return NULL;
+            }
+        } else {
+            serverLog(LL_WARNING, "Cannot hard-link: %s -> %s: %s",
+                      src_path, new_path, strerror(errno));
+            sdsfree(new_path);
+            sdsfree(new_name);
+            return NULL;
+        }
+    }
+    fileListAdd(created, sdsdup(new_path));
+    sdsfree(new_path);
+    return new_name;
+}
+
+/* Ingest a preloaded single AOF file (old-style) into the (empty) append-only
+ * directory. The file is hard-linked (or copied if cross-device) as the BASE
+ * AOF, a new MP-AOF manifest is created, and a fresh INCR AOF is opened for
+ * future writes.
+ *
+ * Returns C_OK on success, C_ERR on failure (logs details). */
+int ingestPreloadSingleAofIntoAof(void) {
+    /* Obtain the absolute path to the preloaded AOF file. */
+    const char *aof_path = server.preload_file + 4; /* skip "aof:" */
+    sds abs_src = getAbsolutePath(aof_path);
+    if (!abs_src) {
+        serverLog(LL_WARNING, "Failed to resolve absolute path for AOF: %s", aof_path);
+        return C_ERR;
+    }
+
+    /* Ensure the append-only directory exists. */
+    if (dirCreateIfMissing(server.aof_dirname) == -1) {
+        serverLog(LL_WARNING, "Cannot create AOF directory: %s", strerror(errno));
+        sdsfree(abs_src);
+        return C_ERR;
+    }
+
+    /* Construct the target BASE file name. */
+    sds base_name = sdsnew("appendonly.aof.1.base.aof");
+    sds target_path = makePath(server.aof_dirname, base_name);
+
+    /* Try hard-linking the AOF file. Fallback to copy on EXDEV. */
+    if (link(abs_src, target_path) == -1) {
+        if (errno == EXDEV) {
+            /* Cross-device link, copying instead. */
+            serverLog(LL_NOTICE,
+                "Hard link failed (cross-device), copying AOF file instead: %s -> %s",
+                abs_src, target_path);
+            if (fcopyfile(abs_src, target_path) != 0) {
+                serverLog(LL_WARNING, "Copy failed: %s -> %s: %s",
+                          abs_src, target_path, strerror(errno));
+                goto fail;
+            }
+        } else {
+            serverLog(LL_WARNING, "Cannot hard-link AOF file: %s -> %s: %s",
+                      abs_src, target_path, strerror(errno));
+            goto fail;
+        }
+    }
+    sdsfree(abs_src);
+
+    /* Build a fresh MP-AOF manifest with the BASE file. */
+    aofManifest *new_am = aofManifestCreate();
+    aofInfo *base_ai = aofInfoCreate();
+    base_ai->file_name = sdsdup(base_name);
+    base_ai->file_seq = 1;
+    base_ai->file_type = AOF_FILE_TYPE_BASE;
+    new_am->base_aof_info = base_ai;
+    new_am->curr_base_file_seq = 1;
+    new_am->dirty = 1;
+
+    /* Replace the existing manifest. */
+    if (server.aof_manifest) {
+        aofManifestFree(server.aof_manifest);
+    }
+    server.aof_manifest = new_am;
+
+    /* Manually create a fresh INCR file and update the manifest.
+     * We bypass openNewIncrAofForAppend() because that function relies
+     * on live-server state (repl offset, rewrite flags) that are not
+     * properly initialised after a preload. */
+    int next_incr_seq = new_am->curr_base_file_seq + 1;
+    sds incr_name = sdscatprintf(sdsempty(), "appendonly.aof.%d.incr.aof", next_incr_seq);
+    sds incr_path = makePath(server.aof_dirname, incr_name);
+    int incr_fd = open(incr_path, O_WRONLY|O_CREAT|O_TRUNC, 0644);
+    if (incr_fd == -1) {
+        serverLog(LL_WARNING, "Cannot create new INCR file %s: %s",
+                  incr_name, strerror(errno));
+        sdsfree(incr_name);
+        sdsfree(incr_path);
+        /* Rollback: remove BASE file and free manifest */
+        unlink(target_path);
+        aofManifestFree(server.aof_manifest);
+        server.aof_manifest = NULL;
+        sdsfree(target_path);
+        sdsfree(base_name);
+        return C_ERR;
+    }
+
+    aofInfo *incr_ai = aofInfoCreate();
+    incr_ai->file_name = incr_name;   /* ownership passed */
+    incr_ai->file_seq = next_incr_seq;
+    incr_ai->file_type = AOF_FILE_TYPE_INCR;
+    incr_ai->start_offset = 0;
+    incr_ai->end_offset = -1;
+    listAddNodeTail(new_am->incr_aof_list, incr_ai);
+    new_am->dirty = 1;
+
+    if (persistAofManifest(new_am) != C_OK) {
+        serverLog(LL_WARNING, "Failed to persist manifest after adding INCR");
+        close(incr_fd);
+        unlink(incr_path);
+        /* Rollback as above */
+        unlink(target_path);
+        aofManifestFree(server.aof_manifest);
+        server.aof_manifest = NULL;
+        sdsfree(target_path);
+        sdsfree(base_name);
+        sdsfree(incr_path);
+        return C_ERR;
+    }
+
+    /* Attach the new INCR fd and mark AOF as ON. */
+    server.aof_fd = incr_fd;
+    server.aof_state = AOF_ON;
+    server.aof_current_size = 0;
+    server.aof_last_incr_size = 0;
+
+    sdsfree(incr_path);
+    sdsfree(target_path);
+    sdsfree(base_name);
+    return C_OK;
+
+fail:
+    sdsfree(abs_src);
+    sdsfree(target_path);
+    sdsfree(base_name);
+    return C_ERR;
+}
+
+/* Ingest a preloaded MP-AOF manifest (sealed backup) into the (empty) append-only
+ * directory. Every file referenced by the manifest is hard-linked (or copied if
+ * cross-device) with new sequential MP-AOF names. A new manifest is then
+ * persisted, and a fresh INCR AOF is opened for future writes.
+ *
+ * Returns C_OK on success, C_ERR on failure (logs details). */
+int ingestPreloadManifestIntoAof(void) {
+    const char *manifest_path = server.preload_file + 4;
+    sds abs_manifest = getAbsolutePath(manifest_path);
+    if (!abs_manifest) {
+        serverLog(LL_WARNING, "Failed to resolve absolute path for manifest: %s",
+                  manifest_path);
+        return C_ERR;
+    }
+
+    aofManifest *preload_am = aofLoadManifestFromFile(abs_manifest);
+    if (!preload_am) {
+        serverLog(LL_WARNING, "Failed to load preload manifest: %s", abs_manifest);
+        sdsfree(abs_manifest);
+        return C_ERR;
+    }
+
+    sds src_dir = getFilePath(abs_manifest);
+    if (!src_dir) src_dir = sdsnew(".");
+
+    if (dirCreateIfMissing(server.aof_dirname) == -1) {
+        serverLog(LL_WARNING, "Cannot create AOF directory: %s", strerror(errno));
+        aofManifestFree(preload_am);
+        sdsfree(abs_manifest);
+        sdsfree(src_dir);
+        return C_ERR;
+    }
+
+    aofManifest *new_am = aofManifestCreate();
+    fileList created;
+    fileListInit(&created);
+    int next_seq = 1;
+    int success = C_OK;
+
+    /* Process BASE file. */
+    if (preload_am->base_aof_info) {
+        aofInfo *base_src = preload_am->base_aof_info;
+        sds src_path = makePath(src_dir, base_src->file_name);
+        char *ext = getFileExtension(base_src->file_name);
+        if (!ext) ext = "aof";
+        sds new_name = copyFileIntoAofDir(&created, src_path, next_seq, "base", ext);
+        sdsfree(src_path);
+        if (!new_name) {
+            success = C_ERR;
+            goto cleanup;
+        }
+        aofInfo *new_ai = aofInfoCreate();
+        new_ai->file_name = new_name;
+        new_ai->file_seq = next_seq++;
+        new_ai->file_type = AOF_FILE_TYPE_BASE;
+        new_ai->start_offset = base_src->start_offset;
+        new_ai->end_offset = base_src->end_offset;
+        new_am->base_aof_info = new_ai;
+        new_am->curr_base_file_seq = new_ai->file_seq;
+    }
+
+    /* Process INCR files. */
+    listIter li;
+    listNode *ln;
+    listRewind(preload_am->incr_aof_list, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        aofInfo *incr_src = listNodeValue(ln);
+        sds src_path = makePath(src_dir, incr_src->file_name);
+        sds new_name = copyFileIntoAofDir(&created, src_path, next_seq, "incr", "aof");
+        sdsfree(src_path);
+        if (!new_name) {
+            success = C_ERR;
+            goto cleanup;
+        }
+        aofInfo *new_ai = aofInfoCreate();
+        new_ai->file_name = new_name;
+        new_ai->file_seq = next_seq++;
+        new_ai->file_type = AOF_FILE_TYPE_INCR;
+        new_ai->start_offset = incr_src->start_offset;
+        new_ai->end_offset = incr_src->end_offset;
+        listAddNodeTail(new_am->incr_aof_list, new_ai);
+    }
+
+    /* Persist the manifest (contains BASE + historical INCRs). */
+    if (persistAofManifest(new_am) != C_OK) {
+        serverLog(LL_WARNING, "Failed to persist new manifest after ingestion");
+        success = C_ERR;
+        goto cleanup;
+    }
+
+    /* Replace the live manifest with the one we just built. */
+    if (server.aof_manifest) aofManifestFree(server.aof_manifest);
+    server.aof_manifest = new_am;
+    new_am = NULL;  /* ownership transferred */
+
+    /* Manually create a fresh INCR file for future writes.
+     * We bypass openNewIncrAofForAppend() because it relies on live-server
+     * state that isn't correctly set after a preload. */
+    int next_incr_seq = next_seq;
+    sds incr_name = sdscatprintf(sdsempty(), "appendonly.aof.%d.incr.aof", next_incr_seq);
+    sds incr_path = makePath(server.aof_dirname, incr_name);
+    int incr_fd = open(incr_path, O_WRONLY|O_CREAT|O_TRUNC, 0644);
+    if (incr_fd == -1) {
+        serverLog(LL_WARNING, "Cannot create new INCR file %s: %s",
+                  incr_name, strerror(errno));
+        sdsfree(incr_name);
+        sdsfree(incr_path);
+        success = C_ERR;
+        goto cleanup;
+    }
+
+    aofInfo *incr_ai = aofInfoCreate();
+    incr_ai->file_name = incr_name;   /* ownership passed */
+    incr_ai->file_seq = next_incr_seq;
+    incr_ai->file_type = AOF_FILE_TYPE_INCR;
+    incr_ai->start_offset = 0;
+    incr_ai->end_offset = -1;
+    listAddNodeTail(server.aof_manifest->incr_aof_list, incr_ai);
+    server.aof_manifest->dirty = 1;
+
+    if (persistAofManifest(server.aof_manifest) != C_OK) {
+        serverLog(LL_WARNING, "Failed to persist manifest after adding INCR");
+        close(incr_fd);
+        unlink(incr_path);
+        /* The INCR file was not added to the rollback list; we remove it manually
+         * while the rest of created files will be cleaned by fileListRollback. */
+        success = C_ERR;
+        goto cleanup;
+    }
+
+    /* Attach the new INCR fd and mark AOF as ON. */
+    server.aof_fd = incr_fd;
+    server.aof_state = AOF_ON;
+    server.aof_current_size = 0;
+    server.aof_last_incr_size = 0;
+
+    sdsfree(incr_path);
+    /* Fall through to cleanup, which frees the created file list but keeps files. */
+
+cleanup:
+    if (new_am) aofManifestFree(new_am);
+
+    if (success != C_OK) {
+        /* Remove all files we created (including BASE/INCR copies) */
+        fileListRollback(&created);
+    } else {
+        /* Files are in place; just free the path list. */
+        fileListFree(&created);
+    }
+
+    sdsfree(src_dir);
+    sdsfree(abs_manifest);
+    aofManifestFree(preload_am);
+    return success;
 }
 
 int aofFileExist(char *filename) {
@@ -1555,9 +2021,10 @@ int loadPreLoadAOFFile(char *file) {
     char *tmp_aof_filename = server.aof_filename;
     server.aof_filename = "";
     char *tmp_aof_dirname = server.aof_dirname;
-    server.aof_dirname = "";
+    server.aof_dirname = getFilePath(file);
     int ret = loadAppendOnlyFiles(preload_am);
     aofManifestFree(preload_am);
+    sdsfree(server.aof_dirname);
     server.aof_filename = tmp_aof_filename;
     server.aof_dirname = tmp_aof_dirname;
     return ret;

--- a/src/aof.c
+++ b/src/aof.c
@@ -968,10 +968,11 @@ int ingestPreloadRdbIntoAof(void) {
     incr_ai->file_name = incr_name;   /* ownership passed */
     incr_ai->file_seq = next_incr_seq;
     incr_ai->file_type = AOF_FILE_TYPE_INCR;
-    incr_ai->start_offset = 0;
+    incr_ai->start_offset = server.master_repl_offset;
     incr_ai->end_offset = -1;
     listAddNodeTail(new_am->incr_aof_list, incr_ai);
     new_am->dirty = 1;
+    new_am->curr_incr_file_seq = next_incr_seq;
 
     if (persistAofManifest(new_am) != C_OK) {
         serverLog(LL_WARNING, "Failed to persist manifest after adding INCR");
@@ -1118,10 +1119,11 @@ int ingestPreloadSingleAofIntoAof(void) {
     incr_ai->file_name = incr_name;   /* ownership passed */
     incr_ai->file_seq = next_incr_seq;
     incr_ai->file_type = AOF_FILE_TYPE_INCR;
-    incr_ai->start_offset = 0;
+    incr_ai->start_offset = server.master_repl_offset;
     incr_ai->end_offset = -1;
     listAddNodeTail(new_am->incr_aof_list, incr_ai);
     new_am->dirty = 1;
+    new_am->curr_incr_file_seq = next_incr_seq;
 
     if (persistAofManifest(new_am) != C_OK) {
         serverLog(LL_WARNING, "Failed to persist manifest after adding INCR");
@@ -1238,18 +1240,6 @@ int ingestPreloadManifestIntoAof(void) {
         listAddNodeTail(new_am->incr_aof_list, new_ai);
     }
 
-    /* Persist the manifest (contains BASE + historical INCRs). */
-    if (persistAofManifest(new_am) != C_OK) {
-        serverLog(LL_WARNING, "Failed to persist new manifest after ingestion");
-        success = C_ERR;
-        goto cleanup;
-    }
-
-    /* Replace the live manifest with the one we just built. */
-    if (server.aof_manifest) aofManifestFree(server.aof_manifest);
-    server.aof_manifest = new_am;
-    new_am = NULL;  /* ownership transferred */
-
     /* Manually create a fresh INCR file for future writes.
      * We bypass openNewIncrAofForAppend() because it relies on live-server
      * state that isn't correctly set after a preload. */
@@ -1267,23 +1257,28 @@ int ingestPreloadManifestIntoAof(void) {
     }
 
     aofInfo *incr_ai = aofInfoCreate();
-    incr_ai->file_name = incr_name;   /* ownership passed */
+    incr_ai->file_name = incr_name;
     incr_ai->file_seq = next_incr_seq;
     incr_ai->file_type = AOF_FILE_TYPE_INCR;
-    incr_ai->start_offset = 0;
+    incr_ai->start_offset = server.master_repl_offset;
     incr_ai->end_offset = -1;
-    listAddNodeTail(server.aof_manifest->incr_aof_list, incr_ai);
-    server.aof_manifest->dirty = 1;
+    listAddNodeTail(new_am->incr_aof_list, incr_ai);
+    new_am->curr_incr_file_seq = next_incr_seq;
+    new_am->dirty = 1;
 
-    if (persistAofManifest(server.aof_manifest) != C_OK) {
+    /* Now persist the complete manifest (BASE + historical INCRs + new INCR). */
+    if (persistAofManifest(new_am) != C_OK) {
         serverLog(LL_WARNING, "Failed to persist manifest after adding INCR");
         close(incr_fd);
         unlink(incr_path);
-        /* The INCR file was not added to the rollback list; we remove it manually
-         * while the rest of created files will be cleaned by fileListRollback. */
         success = C_ERR;
         goto cleanup;
     }
+
+    /* Replace the live manifest with the one we just built. */
+    if (server.aof_manifest) aofManifestFree(server.aof_manifest);
+    server.aof_manifest = new_am;
+    new_am = NULL;  /* ownership transferred */
 
     /* Attach the new INCR fd and mark AOF as ON. */
     server.aof_fd = incr_fd;

--- a/src/util.c
+++ b/src/util.c
@@ -51,6 +51,7 @@
 #include "util.h"
 #include "sha256.h"
 #include "config.h"
+#include "zmalloc.h"
 
 #define UNUSED(x) ((void)(x))
 
@@ -1034,7 +1035,7 @@ void getRandomHexChars(char *p, size_t len) {
  * The function does not try to normalize everything, but only the obvious
  * case of one or more "../" appearing at the start of "filename"
  * relative path. */
-sds getAbsolutePath(char *filename) {
+sds getAbsolutePath(const char *filename) {
     char cwd[1024];
     sds abspath;
     sds relpath = sdsnew(filename);
@@ -1112,10 +1113,83 @@ char *getFileExtension(char *path) {
 }
 
 sds getFilePath(char *path) {
-    if (pathIsBaseName(path)) return NULL;
+    if (pathIsBaseName(path)) return sdsnew(".");
 
     char *pch = strrchr(path,'/');
     return sdsnewlen(path, pch - path);
+}
+
+/* Initialise a new fileList. Caller must later call fileListRollback or fileListFree. */
+void fileListInit(fileList *fl) {
+    fl->paths = NULL;
+    fl->count = 0;
+    fl->capacity = 0;
+}
+
+/* Add a path to the list. The sds ownership is taken by the list. */
+void fileListAdd(fileList *fl, sds path) {
+    if (fl->count >= fl->capacity) {
+        int newcap = fl->capacity ? fl->capacity * 2 : 8;
+        fl->paths = zrealloc(fl->paths, sizeof(sds) * newcap);
+        fl->capacity = newcap;
+    }
+    fl->paths[fl->count++] = path;
+}
+
+/* Remove (unlink) all files in the list, free their sds strings, and reset
+ * the list. This is meant for error recovery. After calling, the list is
+ * empty and can be reused or simply discarded. */
+void fileListRollback(fileList *fl) {
+    for (int i = 0; i < fl->count; i++) {
+        unlink(fl->paths[i]);      /* ignore errors, best effort */
+        sdsfree(fl->paths[i]);
+    }
+    zfree(fl->paths);
+    fl->paths = NULL;
+    fl->count = 0;
+    fl->capacity = 0;
+}
+
+/* Free the list without deleting files (for successful completion). */
+void fileListFree(fileList *fl) {
+    for (int i = 0; i < fl->count; i++) {
+        sdsfree(fl->paths[i]);
+    }
+    zfree(fl->paths);
+    fl->paths = NULL;
+    fl->count = 0;
+    fl->capacity = 0;
+}
+
+/* Copy file from src to dst. Returns 0 on success, -1 on error. */
+int fcopyfile(const char *src, const char *dst) {
+    int sfd = open(src, O_RDONLY);
+    if (sfd == -1) return -1;
+    int dfd = open(dst, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (dfd == -1) { close(sfd); return -1; }
+
+    char buf[65536];
+    ssize_t n;
+    int err = 0;
+    while ((n = read(sfd, buf, sizeof(buf))) > 0) {
+        ssize_t written = 0;
+        while (written < n) {
+            ssize_t w = write(dfd, buf + written, n - written);
+            if (w == -1) {
+                if (errno == EINTR) continue;
+                err = 1;
+                goto end;
+            }
+            written += w;
+        }
+    }
+    if (n == -1) err = 1;
+
+end:
+    close(sfd);
+    close(dfd);
+    if (err) { unlink(dst); return -1; }
+    return 0;
 }
 
 int fileExist(char *filename) {

--- a/src/util.h
+++ b/src/util.h
@@ -37,6 +37,13 @@ typedef enum {
     LD_STR_HEX       /* %La */
 } ld2string_mode;
 
+/* Simple dynamic list of file paths for atomic rollback. */
+typedef struct {
+    sds *paths;      /* array of sds */
+    int count;       /* number of entries */
+    int capacity;    /* allocated size */
+} fileList;
+
 int prefixmatch(const char *pattern, int patternLen, const char *prefixStr, 
                 int prefixStrLen, int nocase);
 int stringmatchlen(const char *p, int plen, const char *s, int slen, int nocase);
@@ -61,11 +68,16 @@ int fixedpoint_d2string(char *dst, size_t dstlen, double dvalue, int fractional_
 int ld2string(char *buf, size_t len, long double value, ld2string_mode mode);
 int double2ll(double d, long long *out);
 int yesnotoi(char *s);
-sds getAbsolutePath(char *filename);
+sds getAbsolutePath(const char *filename);
 long getTimeZone(void);
 int pathIsBaseName(char *path);
 char *getFileExtension(char *path);
 sds getFilePath(char *path);
+void fileListInit(fileList *fl);
+void fileListAdd(fileList *fl, sds path);
+void fileListRollback(fileList *fl);
+void fileListFree(fileList *fl);
+int fcopyfile(const char *src, const char *dst);
 int dirCreateIfMissing(char *dname);
 int dirExists(char *dname);
 int dirIsEmpty(char *dname);

--- a/tests/integration/backup.tcl
+++ b/tests/integration/backup.tcl
@@ -130,7 +130,7 @@ start_server {overrides {appendonly no auto-aof-rewrite-percentage 0}} {
         set manifest [file join $bdir appendonly.aof.manifest]
         start_server [list overrides [list dir $local_dir appendonly yes preload-file "aof:$manifest"] keep_persistence true] {
             assert_equal 3 [r dbsize]
-            assert_equal 1 [s aof_rewrites]
+            assert_equal 0 [s aof_rewrites]
             waitForBgrewriteaof r
             assert_equal ok [s aof_last_bgrewrite_status]
             # we don't append the old incr aof, and it is deleted after AOFRW
@@ -631,6 +631,112 @@ start_server {overrides {appendonly yes auto-aof-rewrite-percentage 0}} {
 
         assert_equal "OK" [r backup cleanup]
         assert_equal "idle" [backup_status_field state]
+    }
+
+    test {Ingested RDB produces a working MP-AOF with new writes} {
+        r flushall
+        r set pre key1
+        r set post key2
+        # Create an RDB snapshot
+        set rdb_path [file join [lindex [r config get dir] 1] preload_ingest.rdb]
+        r save
+        file copy -force [file join [lindex [r config get dir] 1] dump.rdb] $rdb_path
+
+        # Start a new server with appendonly yes and the RDB preload file
+        start_server [list overrides [list appendonly yes preload-file "rdb:$rdb_path"]] {
+            # Both keys must be present (RDB content was loaded)
+            assert_equal 2 [r dbsize]
+            assert_equal key1 [r get pre]
+            assert_equal key2 [r get post]
+
+            # Write a new key and restart to confirm the AOF persists it
+            r set after_ingest works
+            assert_equal 3 [r dbsize]
+
+            set server_dir [lindex [r config get dir] 1]
+            set manifest [file join $server_dir appendonlydir appendonly.aof.manifest]
+            assert {[file exists $manifest]}
+            # The manifest should contain BASE and INCR entries
+            set fd [open $manifest r]
+            set content [read $fd]
+            close $fd
+            assert_match {*base*} $content
+            assert_match {*incr*} $content
+        }
+
+        # Cleanup the temporary RDB
+        file delete $rdb_path
+    }
+
+    test {Ingested manifest keeps all INCR files and can be appended to} {
+        # Create a temporary sealed backup to use as preload source
+        set backup_dir [tmpdir manifest_ingest]
+        set backup_subdir [file join $backup_dir backupdir]
+        file mkdir $backup_subdir
+
+        # Start a temporary server to create a sealed backup
+        start_server [list overrides [list dir $backup_dir appendonly yes auto-aof-rewrite-percentage 0]] {
+            r flushall
+            r set k1 v1
+            r set k2 v2
+            r backup start
+            wait_for_condition 50 100 {
+                [backup_status_field state] eq "incrementing"
+            } else {
+                fail "Backup did not reach incrementing state"
+            }
+            r set k3 v3
+            r backup seal
+            assert_equal "sealed" [backup_status_field state]
+        }
+
+        set manifest [file join $backup_subdir appendonly.aof.manifest]
+        set manifest_abs [file normalize $manifest]
+        assert {[file exists $manifest]}
+
+        # Now ingest that sealed backup into a new server
+        start_server [list overrides [list appendonly yes preload-file "aof:$manifest_abs"]] {
+            # Check data from the backup is present
+            assert_equal 3 [r dbsize]
+            assert_equal v1 [r get k1]
+            assert_equal v2 [r get k2]
+            assert_equal v3 [r get k3]
+
+            # Write a new key and verify it survives restart
+            r set after_ingest works
+            set server_dir [lindex [r config get dir] 1]
+            # Restart the same server (without preload-file) to test persistence
+            start_server [list overrides [list dir $server_dir appendonly yes]] {
+                assert_equal 4 [r dbsize]
+                assert_equal works [r get after_ingest]
+            }
+        }
+    }
+
+    test {Ingestion rollback cleans up on write error} {
+        r flushall
+        r set must-survive 1
+        set rdb [file join [lindex [r config get dir] 1] crash_me.rdb]
+        r save
+        file copy -force [file join [lindex [r config get dir] 1] dump.rdb] $rdb
+
+        # Start a server with appendonly yes, but make the appendonlydir read-only
+        # so open() for the new INCR fails.
+        set server_dir [tmpdir ingest_rollback]
+        file mkdir $server_dir
+        file attributes $server_dir -permissions 0555  ;# read+execute only
+
+        catch {
+            exec src/redis-server --port 0 --dir $server_dir --appendonly yes \
+                 --preload-file "rdb:$rdb" --logfile /dev/null
+        }
+        # The server should exit, and the appendonlydir should remain empty (no leftover BASE)
+        assert {[llength [glob -nocomplain -directory $server_dir *]] == 0}
+
+        file delete $rdb
+        # Restore permissions to clean up
+        file attributes $server_dir -permissions 0755
+        file delete -force $server_dir
     }
 
 }


### PR DESCRIPTION
### Problem

When `preload-file` was used together with `appendonly yes`, the server would load the preload data, then schedule a background AOF rewrite to reconcile the new dataset with the existing (unrelated) AOF history. During that rewrite, new writes were buffered in a temporary INCR file, causing the AOF to be temporarily unavailable and introducing complexity and a performance hit (fork + rewrite).

### Solution

Instead of rewriting, we now directly ingest the preloaded dataset into the live MP-AOF directory:

1. Stop the current AOF and empty the appendonlydir.
2. Hard-link (or copy, if cross-device) the preload files into the empty directory with proper MP-AOF naming (`appendonly.aof.N.type.ext`).
3. Build a fresh manifest and open a new INCR for future writes.
4. Set the AOF state to ON – no fork, no background rewrite.

This approach makes the AOF immediately consistent with the loaded data and avoids any temporary buffer or state mismatch.

### Changes

- **aof.c**: Replaced the `AOF_WAIT_REWRITE` path in `aofHandlePreloadOnServerStart` with direct ingestion. Added three
  ingestion functions:
  * `ingestPreloadRdbIntoAof()` – treat an RDB file as BASE and create a fresh INCR.
  * `ingestPreloadSingleAofIntoAof()` – treat an old-style single AOF as BASE.
  * `ingestPreloadManifestIntoAof()` – ingest a sealed backup (manifest + files), preserving all history and adding a new INCR.

- **util.c/h**: Added helper utilities needed by ingestion:
  * `fileList` – dynamic array of file paths for atomic rollback on failure.
  * `fcopyfile()` – simple file copy used as fallback when hard links fail (cross-device).
  * Fixed `getAbsolutePath` to accept `const char *` and `getFilePath` to return `"."` for bare filenames (instead of NULL).

- **tests/integration/backup.tcl**:
  * Adjusted the "Preload proactively rewrites the local AOF" test to expect zero rewrites (since ingestion no longer triggers a rewrite).
  * Added three new tests:
    - `Ingested RDB produces a working MP-AOF with new writes`
    - `Ingested manifest keeps all INCR files and can be appended to`
    - `Ingestion rollback cleans up on write error`

### Backward compatibility

The `preload-file` config behavior remains unchanged: the server loads the specified RDB/AOF/manifest and then, if AOF is on, makes the local AOF consistent with that data. The only difference is that this is now done immediately at startup without a background rewrite, which is strictly better for performance and simplicity.

### Testing

All existing backup tests pass. The new tests cover RDB ingestion, manifest ingestion with history preservation, and error-rollback cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Startup persistence path now wipes and rebuilds the entire AOF directory; mistakes could corrupt or lose local AOF history, though failures exit or roll back created files.
> 
> **Overview**
> When **`preload-file`** does not match the live manifest, startup no longer forks a background AOF rewrite. **`aofHandlePreloadOnServerStart`** stops AOF, clears **`appendonlydir`**, then **ingests** the preload into a fresh MP-AOF layout and turns AOF back on immediately.
> 
> Ingestion is split by source: **`rdb:`** → BASE `.rdb` + new INCR; **`aof:`** single file → BASE `.aof` + INCR; **`aof:`** manifest → copy/link all BASE/INCR entries with new seq names, persist manifest, open a new INCR. Files are **hard-linked** when possible, with **`fcopyfile`** on cross-device; manifest ingestion uses **`fileList`** rollback on failure.
> 
> **`util`** adds **`fileList`**, **`fcopyfile`**, **`getAbsolutePath(const char *)`**, and **`getFilePath`** returning `"."` for basename-only paths. **`loadPreLoadAOFFile`** loads relative to the preload file’s directory.
> 
> Integration tests expect **zero** rewrites for manifest preload replacing local AOF, plus new coverage for RDB/manifest ingestion and rollback on write failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c69459f4464411b57e52fb4d376e55667706e838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->