### PR TITLE
Fix unloadable RDB when XSETID lowers entries_added

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3810,8 +3810,33 @@ void xsetidCommand(client *c) {
     }
 
     s->last_id = id;
-    if (entries_added != -1)
+    if (entries_added != -1) {
+        uint64_t prev_entries_added = s->entries_added;
         s->entries_added = entries_added;
+        /* Lowering entries_added may leave a consumer group's entries_read
+         * greater than the stream's entries_added. That breaks the lag
+         * calculation (XINFO GROUPS would report a negative lag) and, on
+         * builds that validate this invariant, produces an RDB/RESTORE
+         * payload that fails to load. Clamp each group's counter down, just
+         * like XGROUP CREATE/SETID does when entries_read is set too high.
+         * Only needed when entries_added is actually lowered; otherwise the
+         * entries_read <= entries_added invariant already holds and the loop
+         * would be a no-op. */
+        if (s->entries_added < prev_entries_added && s->cgroups) {
+            raxIterator ri;
+            raxStart(&ri, s->cgroups);
+            raxSeek(&ri, "^", NULL, 0);
+            while (raxNext(&ri)) {
+                streamCG *cg = ri.data;
+                if (cg->entries_read != SCG_INVALID_ENTRIES_READ &&
+                    (uint64_t)cg->entries_read > s->entries_added)
+                {
+                    cg->entries_read = s->entries_added;
+                }
+            }
+            raxStop(&ri);
+        }
+    }
     if (!streamIDEqZero(&max_xdel_id))
         s->max_deleted_entry_id = max_xdel_id;
     addReply(c,shared.ok);

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -4841,31 +4841,34 @@ start_server {tags {"stream external:skip needs:debug"}} {
     # negative lag, and the resulting RDB fails to load ("Stream cgroup
     # entries_read inconsistent with entries_added"). XGROUP CREATE/SETID
     # already clamp entries_read; XSETID must clamp it too.
-    test "XSETID ENTRIESADDED clamps group entries_read and never yields negative lag" {
-        r DEL mystream
-        for {set i 1} {$i <= 10} {incr i} { r XADD mystream * f v$i }
-        r XGROUP CREATE mystream grp 0
-        r XREADGROUP GROUP grp c COUNT 10 STREAMS mystream >
-        set top [dict get [r XINFO STREAM mystream] last-generated-id]
+    proc setup_xsetid_shrunk_stream {key} {
+        r DEL $key
+        for {set i 1} {$i <= 10} {incr i} { r XADD $key * f v$i }
+        r XGROUP CREATE $key grp 0
+        r XREADGROUP GROUP grp c COUNT 10 STREAMS $key >
+        set top [dict get [r XINFO STREAM $key] last-generated-id]
 
         # Shrink the stream so entries_added can be lowered below entries_read.
-        r XTRIM mystream MAXLEN 2
-        r XSETID mystream $top ENTRIESADDED 2
+        r XTRIM $key MAXLEN 2
+        r XSETID $key $top ENTRIESADDED 2
+    }
+
+    test "XSETID ENTRIESADDED clamps group entries_read and never yields negative lag" {
+        setup_xsetid_shrunk_stream mystream
 
         set ginfo [lindex [r XINFO GROUPS mystream] 0]
         assert_equal [dict get $ginfo entries-read] 2
-        assert {[dict get $ginfo lag] >= 0}
         assert_equal [dict get $ginfo lag] 0
     }
 
     test "XSETID inconsistency does not produce an unloadable RDB" {
-        # Reuse the state from the previous test; a reload must succeed and
-        # keep the counters consistent.
+        setup_xsetid_shrunk_stream mystream
+
         r DEBUG RELOAD
         assert_equal [r XLEN mystream] 2
         set ginfo [lindex [r XINFO GROUPS mystream] 0]
-        assert {[dict get $ginfo lag] >= 0}
         assert_equal [dict get $ginfo entries-read] 2
+        assert_equal [dict get $ginfo lag] 0
     }
 
     test "XSETID raising entries_added leaves group entries_read untouched" {

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -4841,28 +4841,20 @@ start_server {tags {"stream external:skip needs:debug"}} {
     # negative lag, and the resulting RDB fails to load ("Stream cgroup
     # entries_read inconsistent with entries_added"). XGROUP CREATE/SETID
     # already clamp entries_read; XSETID must clamp it too.
-    proc setup_xsetid_shrunk_stream {key} {
-        r DEL $key
-        for {set i 1} {$i <= 10} {incr i} { r XADD $key * f v$i }
-        r XGROUP CREATE $key grp 0
-        r XREADGROUP GROUP grp c COUNT 10 STREAMS $key >
-        set top [dict get [r XINFO STREAM $key] last-generated-id]
+    test "XSETID ENTRIESADDED clamps group entries_read and keeps the RDB loadable" {
+        r DEL mystream
+        for {set i 1} {$i <= 10} {incr i} { r XADD mystream * f v$i }
+        r XGROUP CREATE mystream grp 0
+        r XREADGROUP GROUP grp c COUNT 10 STREAMS mystream >
+        set top [dict get [r XINFO STREAM mystream] last-generated-id]
 
         # Shrink the stream so entries_added can be lowered below entries_read.
-        r XTRIM $key MAXLEN 2
-        r XSETID $key $top ENTRIESADDED 2
-    }
-
-    test "XSETID ENTRIESADDED clamps group entries_read and never yields negative lag" {
-        setup_xsetid_shrunk_stream mystream
+        r XTRIM mystream MAXLEN 2
+        r XSETID mystream $top ENTRIESADDED 2
 
         set ginfo [lindex [r XINFO GROUPS mystream] 0]
         assert_equal [dict get $ginfo entries-read] 2
         assert_equal [dict get $ginfo lag] 0
-    }
-
-    test "XSETID inconsistency does not produce an unloadable RDB" {
-        setup_xsetid_shrunk_stream mystream
 
         r DEBUG RELOAD
         assert_equal [r XLEN mystream] 2

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -4835,3 +4835,48 @@ start_server {tags {"repl external:skip" "stream"}} {
     }
 }
 
+start_server {tags {"stream external:skip needs:debug"}} {
+    # XSETID ... ENTRIESADDED must not leave a consumer group's entries_read
+    # greater than the stream's entries_added. Otherwise XINFO GROUPS reports a
+    # negative lag, and the resulting RDB fails to load ("Stream cgroup
+    # entries_read inconsistent with entries_added"). XGROUP CREATE/SETID
+    # already clamp entries_read; XSETID must clamp it too.
+    test "XSETID ENTRIESADDED clamps group entries_read and never yields negative lag" {
+        r DEL mystream
+        for {set i 1} {$i <= 10} {incr i} { r XADD mystream * f v$i }
+        r XGROUP CREATE mystream grp 0
+        r XREADGROUP GROUP grp c COUNT 10 STREAMS mystream >
+        set top [dict get [r XINFO STREAM mystream] last-generated-id]
+
+        # Shrink the stream so entries_added can be lowered below entries_read.
+        r XTRIM mystream MAXLEN 2
+        r XSETID mystream $top ENTRIESADDED 2
+
+        set ginfo [lindex [r XINFO GROUPS mystream] 0]
+        assert_equal [dict get $ginfo entries-read] 2
+        assert {[dict get $ginfo lag] >= 0}
+        assert_equal [dict get $ginfo lag] 0
+    }
+
+    test "XSETID inconsistency does not produce an unloadable RDB" {
+        # Reuse the state from the previous test; a reload must succeed and
+        # keep the counters consistent.
+        r DEBUG RELOAD
+        assert_equal [r XLEN mystream] 2
+        set ginfo [lindex [r XINFO GROUPS mystream] 0]
+        assert {[dict get $ginfo lag] >= 0}
+        assert_equal [dict get $ginfo entries-read] 2
+    }
+
+    test "XSETID raising entries_added leaves group entries_read untouched" {
+        r DEL s2
+        for {set i 1} {$i <= 5} {incr i} { r XADD s2 * f v$i }
+        r XGROUP CREATE s2 g 0
+        r XREADGROUP GROUP g c COUNT 3 STREAMS s2 >
+        set top [dict get [r XINFO STREAM s2] last-generated-id]
+        r XSETID s2 $top ENTRIESADDED 100
+        set ginfo [lindex [r XINFO GROUPS s2] 0]
+        assert_equal [dict get $ginfo entries-read] 3
+        assert_equal [dict get $ginfo lag] 97
+    }
+}


### PR DESCRIPTION
Fixes #15488
Introduced by https://github.com/redis/redis/pull/15308

## Problem

`XSETID key <id> ENTRIESADDED n` lowers a stream's `entries_added` counter,
validating only `n >= stream length`. It never reconciles `n` with the consumer
groups' `entries_read`, so after `XTRIM` a group can end up with
`entries_read > entries_added`.

That violates the `entries_read <= entries_added` invariant and causes:

1. `XINFO GROUPS` reporting a **negative `lag`** (`lag = entries_added - entries_read`).
2. An **RDB that saves fine but fails to load** — the loader's consistency
   check in `rdb.c` rejects it (*"Stream cgroup entries_read inconsistent with
   entries_added"*), so the primary can't restart, replicas can't full-sync and
   backups can't be restored.

The same invariant is already enforced elsewhere: `XGROUP CREATE` and
`XGROUP SETID` clamp `entries_read` down to `entries_added`, and the RDB loader
rejects payloads that break it. Only `XSETID` was missing the guard.

## Fix

When `XSETID` lowers `entries_added`, clamp every consumer group's
`entries_read` down to the new `entries_added` (skipping groups whose counter is
`SCG_INVALID_ENTRIES_READ`), exactly as `XGROUP CREATE`/`SETID` already do.

## Reproduction

```
XADD st * f v        # x10
XGROUP CREATE st g 0
XREADGROUP GROUP g c COUNT 10 STREAMS st >
XTRIM st MAXLEN 2
XSETID st <last-generated-id> ENTRIESADDED 2
XINFO GROUPS st      # lag => -8   (before the fix)
SAVE                 # OK, but restart fails to load the dump before the fix
```

## Tests

Added three cases to `tests/unit/type/stream-cgroups.tcl`:

- `XSETID ENTRIESADDED` clamps `entries_read` and never yields a negative lag.
- The resulting state survives `DEBUG RELOAD` (no unloadable RDB).
- `XSETID` **raising** `entries_added` leaves a group's `entries_read` untouched
  (no over-eager clamping).

Verified the new tests fail without the fix and pass with it; the full
`unit/type/stream-cgroups` suite is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stream metadata and consumer-group counters on a rarely used admin path; behavior aligns with existing XGROUP clamping but incorrect iteration could affect lag and persistence.
> 
> **Overview**
> **Fixes inconsistent stream cgroup state** when `XSETID ... ENTRIESADDED` lowers the stream’s `entries_added` below a consumer group’s `entries_read` (e.g. after `XTRIM`), which could yield negative `XINFO GROUPS` lag and RDB loads that fail validation.
> 
> On a **lower** of `entries_added`, `XSETID` now walks all consumer groups and clamps `entries_read` down to the new `entries_added` (skipping `SCG_INVALID_ENTRIES_READ`), matching behavior already used in `XGROUP CREATE`/`SETID`. Raising `entries_added` does not change group counters.
> 
> Adds stream-cgroup tests for clamping/lag, `DEBUG RELOAD` survivability, and the no-clamp path when `entries_added` is increased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98ca48e9bdf374dbed7262af8b270a5d2a2d0fe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->