### PR TITLE
Fix redis.conf and README for repl compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1237,7 +1237,7 @@ If TLS is built, running the tests with TLS enabled (you will need `tcl-tls` ins
 ./runtest --tls
 ```
 
-Redis suppports compression of replication stream via zstd as of 8.10. To build with compression support use the following flag:
+Redis supports compression of replication stream via zstd as of 8.10. To build with compression support use the following flag:
 
 ```sh
 make BUILD_COMPRESSION=yes

--- a/README.md
+++ b/README.md
@@ -1237,6 +1237,12 @@ If TLS is built, running the tests with TLS enabled (you will need `tcl-tls` ins
 ./runtest --tls
 ```
 
+Redis suppports compression of replication stream via zstd as of 8.10. To build with compression support use the following flag:
+
+```sh
+make BUILD_COMPRESSION=yes
+```
+
 ### Fixing build problems with dependencies or cached build options
 
 Redis has some dependencies which are included in the `deps` directory. `make` does not automatically rebuild dependencies even if something in the source code of dependencies changes.

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Tested with the following Docker image:
    ```sh
    apt-get update
    apt-get install -y sudo
-   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool
+   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool libzstd-dev
    ```
 
 2. Use GCC 11 as the default compiler
@@ -339,7 +339,7 @@ Tested with the following Docker image:
    ```sh
    apt-get update
    apt-get install -y sudo
-   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git cmake python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool
+   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git cmake python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool libzstd-dev
    ```
 
 2. Install CMake
@@ -430,7 +430,7 @@ Tested with the following Docker image:
    ```sh
    apt-get update
    apt-get install -y sudo
-   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git cmake python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool
+   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git cmake python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool libzstd-dev
    ```
 
 2. Install the LLVM 21 toolchain
@@ -511,7 +511,7 @@ Tested with the following Docker image:
    ```sh
    apt-get update
    apt-get install -y sudo
-   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev libcrypt-dev make git python3 python3-pip python3-venv python3-dev unzip rsync clang lld llvm automake autoconf libtool
+   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev libcrypt-dev make git python3 python3-pip python3-venv python3-dev unzip rsync clang lld llvm automake autoconf libtool libzstd-dev
    ```
 
 2. Install CMake
@@ -594,7 +594,7 @@ Tested with the following Docker images:
    ```sh
    apt-get update
    apt-get install -y sudo
-   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git cmake python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool
+   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git cmake python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool libzstd-dev
    ```
 
 2. Install the LLVM 21 toolchain
@@ -701,7 +701,7 @@ Tested with the following Docker images:
    Update your package lists and install the necessary development tools and libraries:
 
    ```sh
-   dnf install -y pkg-config wget gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ git make openssl openssl-devel python3.11 python3.11-pip python3.11-devel unzip rsync clang lld llvm libtool automake autoconf jq systemd-devel
+   dnf install -y pkg-config wget gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ git make openssl openssl-devel python3.11 python3.11-pip python3.11-devel unzip rsync clang lld llvm libtool automake autoconf jq systemd-devel libzstd-devel
    ```
 
    `clang` on these releases is already LLVM 21, matching the Rust toolchain installed in the "Install the Rust toolchain" step below; `lld` and `llvm` supply the linker and the `llvm-ar`/`llvm-ranlib` archiver that RediSearch's default cross-language (C/Rust) LTO build uses.
@@ -820,7 +820,7 @@ Tested with the following Docker images:
    Update your package lists and install the necessary development tools and libraries:
 
    ```sh
-   dnf install -y pkg-config xz wget which gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ git make openssl openssl-devel python3 python3-pip python3-devel unzip rsync clang lld llvm libtool automake autoconf jq systemd-devel
+   dnf install -y pkg-config xz wget which gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ git make openssl openssl-devel python3 python3-pip python3-devel unzip rsync clang lld llvm libtool automake autoconf jq systemd-devel libzstd-devel
    ```
 
    `clang` on these releases is already LLVM 21, matching the Rust toolchain installed in the "Install the Rust toolchain" step below; `lld` and `llvm` supply the linker and the `llvm-ar`/`llvm-ranlib` archiver that RediSearch's default cross-language (C/Rust) LTO build uses.
@@ -933,7 +933,7 @@ Tested with the following Docker images:
 
    ```sh
    dnf groupinstall "Development Tools" -y
-   dnf install -y pkg-config xz wget which gcc gcc-c++ cmake git make openssl openssl-devel python3 python3-pip python3-devel unzip rsync clang lld llvm libtool automake autoconf jq systemd-devel
+   dnf install -y pkg-config xz wget which gcc gcc-c++ cmake git make openssl openssl-devel python3 python3-pip python3-devel unzip rsync clang lld llvm libtool automake autoconf jq systemd-devel libzstd-devel
    ```
 
    On AlmaLinux/Rocky 10.1 the `clang`, `lld`, and `llvm` packages above are LLVM 21, which matches the LLVM version of the Rust toolchain installed in the "Install the Rust toolchain" step below. `RediSearch`'s cross-language (C/Rust) LTO needs this match, and `llvm` provides the `llvm-ar`/`llvm-ranlib` archiver the LTO build uses, so no separate LLVM toolchain is required.
@@ -1005,7 +1005,7 @@ Tested with the following Docker image:
      openssl openssl-dev cmake bash git wget curl xz unzip tar rsync which \
      libtool automake autoconf libffi-dev libgcc ncurses-dev xsimd \
      cargo clang21 clang21-static clang21-libclang llvm21-dev lld21 \
-     python3 py3-pip python3-dev
+     python3 py3-pip python3-dev zstd-dev
    ```
 
    Install the Python packages required by the `RedisJSON` module build:
@@ -1103,6 +1103,7 @@ The following instructions apply to both Intel and Apple Silicon (ARM) Macs.
    brew install automake
    brew install libtool
    brew install wget
+   brew install zstd
    ```
 
 3. Install Rust
@@ -1237,7 +1238,7 @@ If TLS is built, running the tests with TLS enabled (you will need `tcl-tls` ins
 ./runtest --tls
 ```
 
-Redis supports compression of replication stream via zstd as of 8.10. To build with compression support use the following flag:
+Redis supports compression of replication stream via zstd as of 8.10. To build with compression support you have to install zstd development libraries (e.g libzstd-dev on Debian/Ubuntu) and use the following flag when invoking the make command:
 
 ```sh
 make BUILD_COMPRESSION=yes

--- a/redis.conf
+++ b/redis.conf
@@ -839,15 +839,18 @@ replica-priority 100
 # By default min-replicas-to-write is set to 0 (feature disabled) and
 # min-replicas-max-lag is set to 10.
 
+# Compression related configs. Compression is disabled by default, unless redis
+# is build with BUILD_COMPRESSION=yes, hence why the configs are commented out.
+#
 # Enable client compression for replication at specified level when connecting to
 # master 0-22 (0 for disabled compression). Currently only zstd compression lib
 # is supported hence the compression values 1-22 are related to it.
 # NOTE: This setting only works when io-threads > 1
-repl-compression 0
-
+# repl-compression 0
+#
 # When compression is enabled specify maximum latency in ms before the
 # compressed data is flushed and send to the socket.
-repl-compression-max-latency 100
+# repl-compression-max-latency 100
 
 # A Redis master is able to list the address and port of the attached
 # replicas in different ways. For example the "INFO replication" section


### PR DESCRIPTION
Followup https://github.com/redis/redis/pull/15366

Comment out repl-compression related configs in redis.conf as redis is build with repl compression disabled by default.

Add a comment about how to build redis with repl compression support in the README


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and sample configuration only; no runtime or build logic changes in this diff.
> 
> **Overview**
> Aligns **sample config and build docs** with replication zstd compression being **off unless** Redis is built with `BUILD_COMPRESSION=yes`.
> 
> In **`redis.conf`**, `repl-compression` and `repl-compression-max-latency` are **commented out** and a short note explains that compression-related settings stay disabled by default for that reason.
> 
> The **README** adds **zstd dev packages** (`libzstd-dev`, `libzstd-devel`, `zstd-dev`, Homebrew `zstd`) to every OS-specific dependency install block, and documents building with **`make BUILD_COMPRESSION=yes`** after the zstd 8.10 replication-compression note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 790d847e24c9a0689586e106a1c1d0cb97f18fc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->