### PR TITLE
deps/xxhash: drop clean rules for non-vendored tests/ dir

### DIFF
--- a/deps/xxhash/Makefile
+++ b/deps/xxhash/Makefile
@@ -186,9 +186,6 @@ clean:
 	$(RM) xxhsum.wasm xxhsum.js xxhsum.html
 	$(RM) xxh32sum$(EXT) xxh64sum$(EXT) xxh128sum$(EXT) xxh3sum$(EXT)
 	$(RM) fuzzer
-	$(MAKE) -C tests clean
-	$(MAKE) -C tests/bench clean
-	$(MAKE) -C tests/collisions clean
 	@echo cleaning completed
 
 


### PR DESCRIPTION
Fixes #15484

### Root Cause

The vendored copy of the `xxhash` library in `deps/xxhash` ships the upstream `Makefile`, but Redis deliberately does not vendor the upstream `tests/` directory in order to keep the codebase lightweight. As a result, the `clean` target in `deps/xxhash/Makefile` recurses into `tests/`, `tests/bench/`, and `tests/collisions/`, which do not exist.

When `make clean` / `make distclean` is run (or an internal rebuild is triggered by `make all`), this produces noisy errors in the build logs:

```
make[4]: *** tests: No such file or directory.  Stop.
make[3]: *** [Makefile:189: clean] Error 2
```

The error is swallowed by `|| true` in `deps/Makefile`, but it still pollutes CI/CD and local build logs.

### Solution

Since Redis never vendors the `tests/` tree, these recursive `clean` calls can never do anything useful. Following review feedback, this PR simply removes the three lines instead of guarding them, which keeps the `Makefile` clean and eliminates the error at the source.

### Verification

- Ran `make distclean` under `deps/xxhash`; the `tests: No such file or directory` error no longer appears.
- Confirmed the object/library `clean` behavior for the vendored xxhash build is unchanged.
