### PR TITLE
Fix flaky cluster-topology-change test by waiting for ASM to finish

### DIFF
--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -68,6 +68,38 @@ proc wait_for_cluster_propagation {} {
     }
 }
 
+# Return 1 if all instances have no in-progress atomic slot migration (ASM)
+# task and no running slot trim.
+proc asm_all_instances_idle {total} {
+    for {set i 0} {$i < $total} {incr i} {
+        if {[CI $i cluster_slot_migration_active_tasks] != 0} { return 0 }
+        if {[CI $i cluster_slot_migration_active_trim_running] != 0} { return 0 }
+    }
+    return 1
+}
+
+# Wait for all atomic slot migration (ASM) tasks to complete in the cluster.
+# The cluster_state can be "ok" while an ASM task is still running (slots stay
+# covered throughout the migration), so callers that need the migration to be
+# fully settled must use this instead of relying on wait_for_cluster_state.
+proc wait_for_asm_done {} {
+    set total_instances [expr {$::cluster_master_nodes + $::cluster_replica_nodes}]
+
+    wait_for_condition 3000 10 {
+        [asm_all_instances_idle $total_instances] == 1
+    } else {
+        # Print the number of active tasks on each instance
+        for {set i 0} {$i < $total_instances} {incr i} {
+            set migration_count [CI $i cluster_slot_migration_active_tasks]
+            set trim_count [CI $i cluster_slot_migration_active_trim_running]
+            puts "Instance $i: migration_tasks=$migration_count, trim_tasks=$trim_count"
+        }
+        fail "ASM tasks did not complete on all instances"
+    }
+    # wait all nodes to reach the same cluster config after ASM
+    wait_for_cluster_propagation
+}
+
 # Wait for cluster size to be consistent across nodes.
 proc wait_for_cluster_size {cluster_size} {
     wait_for_condition 1000 50 {

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -99,34 +99,6 @@ proc populate_slot {num args} {
     R $idx deferred 0
 }
 
-# Return 1 if all instances are idle
-proc asm_all_instances_idle {total} {
-    for {set i 0} {$i < $total} {incr i} {
-        if {[CI $i cluster_slot_migration_active_tasks] != 0} { return 0 }
-        if {[CI $i cluster_slot_migration_active_trim_running] != 0} { return 0 }
-    }
-    return 1
-}
-
-# Wait for all ASM tasks to complete in the cluster
-proc wait_for_asm_done {} {
-    set total_instances [expr {$::cluster_master_nodes + $::cluster_replica_nodes}]
-
-    wait_for_condition 3000 10 {
-        [asm_all_instances_idle $total_instances] == 1
-    } else {
-        # Print the number of active tasks on each instance
-        for {set i 0} {$i < $total_instances} {incr i} {
-            set migration_count [CI $i cluster_slot_migration_active_tasks]
-            set trim_count [CI $i cluster_slot_migration_active_trim_running]
-            puts "Instance $i: migration_tasks=$migration_count, trim_tasks=$trim_count"
-        }
-        fail "ASM tasks did not complete on all instances"
-    }
-    # wait all nodes to reach the same cluster config after ASM
-    wait_for_cluster_propagation
-}
-
 proc failover_and_wait_for_done {node_id {failover_arg ""}} {
     set max_attempts 5
     for {set attempt 1} {$attempt <= $max_attempts} {incr attempt} {

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -85,9 +85,9 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
             }
         }
         # Migrate the slots back so the cluster layout is restored.
-        wait_for_cluster_propagation
+        wait_for_asm_done
         R 0 cluster migration import 0 100
-        wait_for_cluster_propagation
+        wait_for_asm_done
         wait_for_cluster_state ok
     }
 


### PR DESCRIPTION
`CLUSTER MIGRATION IMPORT` is async, and `cluster_state` stays `ok` throughout an atomic slot migration.
So `wait_for_cluster_state ok` doesn't guarantee the migration is done, the next test could run `DELSLOTSRANGE` on node 0 before the migrate-back settled, making the test flaky.

Fix by waiting for the ASM task to actually complete.
Moved the existing `wait_for_asm_done` helper into the shared `cluster_util.tcl` and used it in `cluster-topology-change.tcl` instead of `wait_for_cluster_propagation`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor and synchronization fixes; no production server or cluster behavior changes.
> 
> **Overview**
> Fixes flaky **`cluster-topology-change`** coverage around atomic slot migration by waiting for **ASM** (migration + trim) to finish, not just for cluster config gossip to converge.
> 
> **`asm_all_instances_idle`** and **`wait_for_asm_done`** move from `atomic-slot-migration.tcl` into shared **`cluster_util.tcl`** (with a note that **`cluster_state ok`** can still be true while ASM runs). **`atomic-slot-migration.tcl`** drops the duplicate procs and keeps using the shared helper.
> 
> In the topology-change ASM test, **`wait_for_cluster_propagation`** after **`CLUSTER MIGRATION IMPORT`** is replaced with **`wait_for_asm_done`** before the migrate-back and before **`wait_for_cluster_state ok`**, so later tests (e.g. **`DELSLOTSRANGE`**) do not run against a still-in-flight migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb71f6a36a8e105079ed3a11c17cf2534871441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->