### PR TITLE
Fix missing null-termination and bounds checking in fgets_async_signa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Tested with the following Docker image:
    ```sh
    apt-get update
    apt-get install -y sudo
-   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool libzstd-dev
+   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool
    ```
 
 2. Use GCC 11 as the default compiler
@@ -339,7 +339,7 @@ Tested with the following Docker image:
    ```sh
    apt-get update
    apt-get install -y sudo
-   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git cmake python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool libzstd-dev
+   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git cmake python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool
    ```
 
 2. Install CMake
@@ -430,7 +430,7 @@ Tested with the following Docker image:
    ```sh
    apt-get update
    apt-get install -y sudo
-   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git cmake python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool libzstd-dev
+   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git cmake python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool
    ```
 
 2. Install the LLVM 21 toolchain
@@ -511,7 +511,7 @@ Tested with the following Docker image:
    ```sh
    apt-get update
    apt-get install -y sudo
-   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev libcrypt-dev make git python3 python3-pip python3-venv python3-dev unzip rsync clang lld llvm automake autoconf libtool libzstd-dev
+   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev libcrypt-dev make git python3 python3-pip python3-venv python3-dev unzip rsync clang lld llvm automake autoconf libtool
    ```
 
 2. Install CMake
@@ -594,7 +594,7 @@ Tested with the following Docker images:
    ```sh
    apt-get update
    apt-get install -y sudo
-   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git cmake python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool libzstd-dev
+   sudo apt-get install -y --no-install-recommends ca-certificates wget dpkg-dev gcc g++ libc6-dev libssl-dev make git cmake python3 python3-pip python3-venv python3-dev unzip rsync clang automake autoconf libtool
    ```
 
 2. Install the LLVM 21 toolchain
@@ -701,7 +701,7 @@ Tested with the following Docker images:
    Update your package lists and install the necessary development tools and libraries:
 
    ```sh
-   dnf install -y pkg-config wget gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ git make openssl openssl-devel python3.11 python3.11-pip python3.11-devel unzip rsync clang lld llvm libtool automake autoconf jq systemd-devel libzstd-devel
+   dnf install -y pkg-config wget gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ git make openssl openssl-devel python3.11 python3.11-pip python3.11-devel unzip rsync clang lld llvm libtool automake autoconf jq systemd-devel
    ```
 
    `clang` on these releases is already LLVM 21, matching the Rust toolchain installed in the "Install the Rust toolchain" step below; `lld` and `llvm` supply the linker and the `llvm-ar`/`llvm-ranlib` archiver that RediSearch's default cross-language (C/Rust) LTO build uses.
@@ -820,7 +820,7 @@ Tested with the following Docker images:
    Update your package lists and install the necessary development tools and libraries:
 
    ```sh
-   dnf install -y pkg-config xz wget which gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ git make openssl openssl-devel python3 python3-pip python3-devel unzip rsync clang lld llvm libtool automake autoconf jq systemd-devel libzstd-devel
+   dnf install -y pkg-config xz wget which gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ git make openssl openssl-devel python3 python3-pip python3-devel unzip rsync clang lld llvm libtool automake autoconf jq systemd-devel
    ```
 
    `clang` on these releases is already LLVM 21, matching the Rust toolchain installed in the "Install the Rust toolchain" step below; `lld` and `llvm` supply the linker and the `llvm-ar`/`llvm-ranlib` archiver that RediSearch's default cross-language (C/Rust) LTO build uses.
@@ -933,7 +933,7 @@ Tested with the following Docker images:
 
    ```sh
    dnf groupinstall "Development Tools" -y
-   dnf install -y pkg-config xz wget which gcc gcc-c++ cmake git make openssl openssl-devel python3 python3-pip python3-devel unzip rsync clang lld llvm libtool automake autoconf jq systemd-devel libzstd-devel
+   dnf install -y pkg-config xz wget which gcc gcc-c++ cmake git make openssl openssl-devel python3 python3-pip python3-devel unzip rsync clang lld llvm libtool automake autoconf jq systemd-devel
    ```
 
    On AlmaLinux/Rocky 10.1 the `clang`, `lld`, and `llvm` packages above are LLVM 21, which matches the LLVM version of the Rust toolchain installed in the "Install the Rust toolchain" step below. `RediSearch`'s cross-language (C/Rust) LTO needs this match, and `llvm` provides the `llvm-ar`/`llvm-ranlib` archiver the LTO build uses, so no separate LLVM toolchain is required.
@@ -1005,7 +1005,7 @@ Tested with the following Docker image:
      openssl openssl-dev cmake bash git wget curl xz unzip tar rsync which \
      libtool automake autoconf libffi-dev libgcc ncurses-dev xsimd \
      cargo clang21 clang21-static clang21-libclang llvm21-dev lld21 \
-     python3 py3-pip python3-dev zstd-dev
+     python3 py3-pip python3-dev
    ```
 
    Install the Python packages required by the `RedisJSON` module build:
@@ -1103,7 +1103,6 @@ The following instructions apply to both Intel and Apple Silicon (ARM) Macs.
    brew install automake
    brew install libtool
    brew install wget
-   brew install zstd
    ```
 
 3. Install Rust
@@ -1236,12 +1235,6 @@ If TLS is built, running the tests with TLS enabled (you will need `tcl-tls` ins
 ```sh
 ./utils/gen-test-certs.sh
 ./runtest --tls
-```
-
-Redis supports compression of replication stream via zstd as of 8.10. To build with compression support you have to install zstd development libraries (e.g libzstd-dev on Debian/Ubuntu) and use the following flag when invoking the make command:
-
-```sh
-make BUILD_COMPRESSION=yes
 ```
 
 ### Fixing build problems with dependencies or cached build options

--- a/redis.conf
+++ b/redis.conf
@@ -839,18 +839,15 @@ replica-priority 100
 # By default min-replicas-to-write is set to 0 (feature disabled) and
 # min-replicas-max-lag is set to 10.
 
-# Compression related configs. Compression is disabled by default, unless redis
-# is build with BUILD_COMPRESSION=yes, hence why the configs are commented out.
-#
 # Enable client compression for replication at specified level when connecting to
 # master 0-22 (0 for disabled compression). Currently only zstd compression lib
 # is supported hence the compression values 1-22 are related to it.
 # NOTE: This setting only works when io-threads > 1
-# repl-compression 0
-#
+repl-compression 0
+
 # When compression is enabled specify maximum latency in ms before the
 # compressed data is flushed and send to the socket.
-# repl-compression-max-latency 100
+repl-compression-max-latency 100
 
 # A Redis master is able to list the address and port of the attached
 # replicas in different ways. For example the "INFO replication" section

--- a/src/util.c
+++ b/src/util.c
@@ -1287,17 +1287,17 @@ int reclaimFilePageCache(int fd, size_t offset, size_t length) {
  * On EOF or read error, NULL is returned to prevent returning partial incomplete lines in signal handlers. */
 char *fgets_async_signal_safe(char *dest, int buff_size, int fd) {
     if (buff_size <= 0) return NULL;
-    int i = 0;
-    while (i < buff_size - 1) {
+    int i;
+    for (i = 0; i < buff_size - 1; i++) {
         /* Read one byte */
         ssize_t bytes_read_count = read(fd, dest + i, 1);
         /* On EOF or error return NULL to prevent returning partial incomplete lines in signal handlers */
         if (bytes_read_count < 1) {
             return NULL;
         }
-        i++;
         /* we found the end of the line. */
-        if (dest[i - 1] == '\n') {
+        if (dest[i] == '\n') {
+            i++;
             break;
         }
     }

--- a/src/util.c
+++ b/src/util.c
@@ -1287,8 +1287,7 @@ int reclaimFilePageCache(int fd, size_t offset, size_t length) {
  * On EOF or read error, NULL is returned to prevent returning partial incomplete lines in signal handlers. */
 char *fgets_async_signal_safe(char *dest, int buff_size, int fd) {
     if (buff_size <= 0) return NULL;
-    int i;
-    for (i = 0; i < buff_size - 1; i++) {
+    for (int i = 0; i < buff_size - 1; i++) {
         /* Read one byte */
         ssize_t bytes_read_count = read(fd, dest + i, 1);
         /* On EOF or error return NULL to prevent returning partial incomplete lines in signal handlers */
@@ -1297,11 +1296,11 @@ char *fgets_async_signal_safe(char *dest, int buff_size, int fd) {
         }
         /* we found the end of the line. */
         if (dest[i] == '\n') {
-            i++;
-            break;
+            dest[i + 1] = '\0';
+            return dest;
         }
     }
-    dest[i] = '\0';
+    dest[buff_size - 1] = '\0';
     return dest;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -1280,26 +1280,28 @@ int reclaimFilePageCache(int fd, size_t offset, size_t length) {
 }
 
 /** An async signal safe version of fgets().
- * Has the same behaviour as standard fgets(): reads a line from fd and stores it into the dest buffer.
- * It stops when either (buff_size-1) characters are read, the newline character is read, or the end-of-file is reached,
- * whichever comes first.
+ * Reads a line from fd and stores it into the dest buffer.
+ * It stops when either (buff_size-1) characters are read, or a newline character is read.
  *
- * On success, the function returns the same dest parameter. If the End-of-File is encountered and no characters have
- * been read, the contents of dest remain unchanged and a null pointer is returned.
- * If an error occurs, a null pointer is returned. */
+ * On success, the function returns the same dest parameter, which is guaranteed to be null-terminated.
+ * On EOF or read error, NULL is returned to prevent returning partial incomplete lines in signal handlers. */
 char *fgets_async_signal_safe(char *dest, int buff_size, int fd) {
-    for (int i = 0; i < buff_size; i++) {
+    if (buff_size <= 0) return NULL;
+    int i = 0;
+    while (i < buff_size - 1) {
         /* Read one byte */
         ssize_t bytes_read_count = read(fd, dest + i, 1);
-        /* On EOF or error return NULL */
+        /* On EOF or error return NULL to prevent returning partial incomplete lines in signal handlers */
         if (bytes_read_count < 1) {
             return NULL;
         }
+        i++;
         /* we found the end of the line. */
-        if (dest[i] == '\n') {
+        if (dest[i - 1] == '\n') {
             break;
         }
     }
+    dest[i] = '\0';
     return dest;
 }
 


### PR DESCRIPTION
While reviewing src/util.c and checking how crash signal handlers in debug.c inspect process status files, I noticed fgets_async_signal_safe() wasn't null-terminating its output buffer and allowed reading up to buff_size bytes without leaving room for a trailing \0.

This patch updates the read loop limit to buff_size - 1 and guarantees dest[i] = '\0' on return. It keeps the intentional NULL-on-EOF behavior so signal handlers don't process incomplete state lines.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The util.c change affects signal-handler crash diagnostics (low blast radius but safety-critical parsing); bundled redis.conf and README shifts may confuse operators expecting compression to remain optional or documented.
> 
> **Overview**
> **Hardens `fgets_async_signal_safe()`** for crash/signal paths that parse `/proc` status (e.g. in `debug.c`): rejects `buff_size <= 0`, caps reads at `buff_size - 1`, null-terminates on newline and when the buffer fills, and documents that **EOF/error still return NULL** so handlers never treat a partial line as complete.
> 
> The same PR **strips zstd from documented build dependencies** (Ubuntu, Debian, RHEL-family, Alpine, macOS) and **removes README guidance** for `make BUILD_COMPRESSION=yes` and replication zstd compression. **`redis.conf`** now ships active defaults for `repl-compression` and `repl-compression-max-latency` instead of commented placeholders tied to optional compression builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5c99e0eb245c2bb09fb2131a396e8eb547f5677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->