### PR TITLE
update TLS.md to reflect current TLS support

### DIFF
--- a/TLS.md
+++ b/TLS.md
@@ -68,11 +68,10 @@ Connections
 All socket operations now go through a connection abstraction layer that hides
 I/O and read/write event handling from the caller.
 
-**Multi-threading I/O is not currently supported for TLS**, as a TLS connection
-needs to do its own manipulation of AE events which is not thread safe. The
-solution is probably to manage independent AE loops for I/O threads and longer
-term association of connections with threads. This may potentially improve
-overall performance as well.
+Multi-threading I/O is supported for TLS since Redis 8.0. TLS connections are assigned to I/O
+threads like plain TCP connections, and each I/O thread's event loop drains any
+connection-level pending data (typical for TLS) via the connection abstraction
+layer.
 
 Sync IO for TLS is currently implemented in a hackish way, i.e. making the
 socket blocking and configuring socket-level timeout.  This means the timeout
@@ -81,16 +80,6 @@ However I believe that getting rid of syncio completely in favor of pure async
 work is probably a better move than trying to fix that. For replication it would
 probably not be so hard. For cluster keys migration it might be more difficult,
 but there are probably other good reasons to improve that part anyway.
-
-To-Do List
-----------
-
-- [ ] redis-benchmark support. The current implementation is a mix of using
-  hiredis for parsing and basic networking (establishing connections), but
-  directly manipulating sockets for most actions. This will need to be cleaned
-  up for proper TLS support. The best approach is probably to migrate to hiredis
-  async mode.
-- [ ] redis-cli `--slave` and `--rdb` support.
 
 Multi-port
 ----------

--- a/TLS.md
+++ b/TLS.md
@@ -68,10 +68,10 @@ Connections
 All socket operations now go through a connection abstraction layer that hides
 I/O and read/write event handling from the caller.
 
-Multi-threading I/O is supported for TLS since Redis 8.0. TLS connections are assigned to I/O
-threads like plain TCP connections, and each I/O thread's event loop drains any
-connection-level pending data (typical for TLS) via the connection abstraction
-layer.
+Multi-threading I/O is supported for TLS since Redis 8.0. TLS connections are
+assigned to I/O threads like plain TCP connections, and each I/O thread's
+event loop drains any connection-level pending data (typical for TLS) via the
+connection abstraction layer.
 
 Sync IO for TLS is currently implemented in a hackish way, i.e. making the
 socket blocking and configuring socket-level timeout.  This means the timeout


### PR DESCRIPTION
## Description

`TLS.md` has drifted out of date. This PR updates it to match the current state of the code:

1. **Multi-threading I/O.** The doc claimed multi-threaded I/O is not supported
   for TLS. This has been supported since Redis 8.0(async I/O threads
introduced in #13695)

2. **To-Do List removed.** Both remaining items were completed long ago:
   - redis-benchmark TLS support — done in #7959
   - redis-cli `--slave` / `--rdb` support — done in #7456

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to TLS.md with no runtime or security behavior changes.
> 
> **Overview**
> **`TLS.md`** is brought in line with current behavior: the **Connections** section no longer says TLS lacks multi-threaded I/O and instead states that **TLS multi-threading I/O is supported since Redis 8.0**, with TLS connections assigned to I/O threads like TCP and pending TLS data drained via the connection layer.
> 
> The obsolete **To-Do List** section is removed entirely (redis-benchmark TLS and redis-cli `--slave` / `--rdb` items that are already implemented). No code changes—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2539aa71350d5b76ac074dbcc7842ba66b9b067a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->