### PR TITLE
Fix client replication compression test

### DIFF
--- a/tests/integration/replication-buffer.tcl
+++ b/tests/integration/replication-buffer.tcl
@@ -196,7 +196,7 @@ start_server {} {
 
         # revert the config
         if {$::compression} {
-            $replica2 config set repl-rdb-channel yes
+            $replica2 config set repl-rdb-channel $rdbchannel
         }
     }
 
@@ -208,6 +208,8 @@ start_server {} {
     }
 
     test "Replica could use replication buffer (beyond backlog config) for partial resynchronization rdbchannel=$rdbchannel" {
+        set old_sync_partial [s sync_partial_ok]
+
         # replica1 disconnects with master
         $replica1 replicaof [srv -1 host] [srv -1 port]
         # Write a mass of data that exceeds repl-backlog-size
@@ -223,7 +225,7 @@ start_server {} {
         # replica2 still waits for bgsave ending
         assert {[s rdb_bgsave_in_progress] eq {1} && [lindex [$replica2 role] 3] eq {sync}}
         # master accepted replica1 partial resync
-        assert_equal [s sync_partial_ok] {1}
+        assert_equal [s sync_partial_ok] [expr $old_sync_partial + 1]
         assert_equal [$master debug digest] [$replica1 debug digest]
     }
 


### PR DESCRIPTION
Fix Daily CI after https://github.com/redis/redis/pull/15366 

Failed Daily: https://github.com/redis/redis/actions/runs/29790168282/job/88510026649
with error:

```
*** [err]: Replica could use replication buffer (beyond backlog config) for partial resynchronization rdbchannel=yes in tests/integration/replication-buffer.tcl
Expected '2' to be equal to '1' (context: type eval line 17 cmd {assert_equal [s sync_partial_ok] {1}} proc ::test)
```

Fixed couple of things:
- a test had disabled dual channel rdb replication for compression, but was incorrectly enabling it when the config was initially disabled
- fix counting of partial resynchronizations. This is somewhat temporary fix, as one of the tests expects a single successful partial resynchronization, but in the case of compression it is possible for another PSYNC to have succeed in a previous test breaking the assertion `assert_equal [s sync_partial_ok] {1}` Root cause of why the previous test does not reject the PSYNC is still under investigation and since it's not trivial I decided to add this fix, so as to fix the Daily CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in integration TCL with no production code or runtime behavior impact.
> 
> **Overview**
> Fixes **Daily CI** failures in `tests/integration/replication-buffer.tcl` tied to dual-channel RDB replication and compression runs.
> 
> When compression is enabled, the backlog test temporarily sets `repl-rdb-channel` on replica2 to `no` but now **restores** `$rdbchannel` instead of hard-coding `yes`, so teardown matches the test matrix for both `yes` and `no`.
> 
> The partial-resync test no longer assumes `sync_partial_ok` is exactly `1`; it records the counter before reconnect and asserts it **increments by one**, so an extra successful PSYNC from an earlier step (seen with compression) does not fail the assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7780389898a0b8060d830afb876fa344d934d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->