### PR TITLE
Speed up XAUTOCLAIM by replacing per-entry lookups with a single forward scan

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4852,28 +4852,26 @@ void xautoclaimCommand(client *c) {
     void *endidptr = addReplyDeferredLen(c); /* reply[0] */
     void *arraylenptr = addReplyDeferredLen(c); /* reply[1] */
 
+    /* Open a single stream iterator and merge-join it forward across all PEL
+     * entries. The stream's entry data is never mutated during a single
+     * XAUTOCLAIM (only the group/consumer PEL and NACKs are), so this iterator
+     * stays valid for the whole command. */
+    streamID maxid = {UINT64_MAX, UINT64_MAX};
+    streamID entry_id, last_id, last_master = {0,0};
+    int64_t entry_numfields;
+    int have_entry = 0; /* 1 if entry_id is valid and its fields are unread. */
+    int have_last = 0; /* Node last-ID cache, persists across xautoclaimAdvance(). */
+    streamIterator si;
+    streamIteratorStart(&si,s,&startid,&maxid,0);
+
     unsigned char startkey[sizeof(streamID)];
     streamEncodeID(startkey,&startid);
     raxIterator ri;
     raxStart(&ri,group->pel);
     raxSeek(&ri,">=",startkey,sizeof(startkey));
     size_t arraylen = 0;
-    mstime_t now = commandTimeSnapshot();
     int deleted_id_num = 0;
-
-    /* Open a single stream iterator and merge-join it forward across all PEL
-     * entries. The stream's entry data is never mutated during a single
-     * XAUTOCLAIM (only the group/consumer PEL and NACKs are), so this iterator
-     * stays valid for the whole command. */
-    streamID maxid = {UINT64_MAX, UINT64_MAX};
-    streamIterator si;
-    streamIteratorStart(&si,s,&startid,&maxid,0);
-    streamID entry_id;
-    int64_t entry_numfields;
-    int have_entry = 0; /* 1 if entry_id is valid and its fields are unread. */
-    /* Node last-ID cache, persists across xautoclaimAdvance() calls. */
-    streamID last_id, last_master = {0,0};
-    int have_last = 0;
+    mstime_t now = commandTimeSnapshot();
     while (attempts-- && count && raxNext(&ri)) {
         streamNACK *nack = ri.data;
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4717,8 +4717,9 @@ cleanup:
  * entry's fields have been consumed, so the next streamIteratorGetID() call
  * yields the following entry.
  *
- * Returns 1 with 'si' positioned on *entry_id (>= *target, fields intact), or
- * 0 at EOF. */
+ * Returns 1 if *target exists, positioning 'si' on it (fields intact). Returns
+ * 0 otherwise; if we stopped on a later entry it is left unconsumed
+ * (*have_entry stays 1) for the next call to reuse. */
 static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
                              streamID *entry_id, int64_t *entry_numfields,
                              int *have_entry)
@@ -4741,15 +4742,17 @@ static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
         if (!*have_entry) {
             *have_entry = streamIteratorGetID(si,entry_id,entry_numfields);
             if (!*have_entry) return 0; /* EOF */
-            /* Count node boundaries crossed while scanning forward; once we
-             * cross more than STREAM_XAC_MAX_NODE_SCAN without reaching the
-             * target (sparse PEL), seek directly instead. */
+            /* After crossing more than STREAM_XAC_MAX_NODE_SCAN nodes without
+             * reaching the target (sparse PEL), seek directly instead. But skip
+             * the re-seek if the current entry already reached the target,
+             * since it would only rediscover the same entry. */
             if (!have_master) {
                 prev_master = si->master_id;
                 have_master = 1;
             } else if (streamCompareID(&si->master_id,&prev_master) != 0) {
                 prev_master = si->master_id;
-                if (++node_scan > STREAM_XAC_MAX_NODE_SCAN) {
+                if (++node_scan > STREAM_XAC_MAX_NODE_SCAN &&
+                    streamCompareID(entry_id,target) < 0) {
                     streamIteratorStop(si);
                     streamIteratorStart(si,s,target,&maxid,0);
                     node_scan = 0;
@@ -4759,7 +4762,9 @@ static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
                 }
             }
         }
-        if (streamCompareID(entry_id,target) >= 0) return 1;
+        int cmp = streamCompareID(entry_id,target);
+        if (cmp == 0) return 1;  /* Found target. */
+        if (cmp > 0) return 0;   /* Past target: not found, leave entry for reuse. */
     }
 }
 
@@ -4884,8 +4889,7 @@ void xautoclaimCommand(client *c) {
         /* Merge-join: advance the shared iterator to the first stream entry
          * with ID >= this PEL id, reusing it both to check existence and (for
          * non-JUSTID) to emit its fields. */
-        int have = xautoclaimAdvance(&si,s,&id,&entry_id,&entry_numfields,&have_entry);
-        int found = have && streamCompareID(&entry_id,&id) == 0;
+        int found = xautoclaimAdvance(&si,s,&id,&entry_id,&entry_numfields,&have_entry);
 
         /* Item must exist for us to transfer it to another consumer. */
         if (!found) {

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4704,21 +4704,18 @@ cleanup:
     if (ids != static_ids) zfree(ids);
 }
 
-/* Upper bound on how many stream entries XAUTOCLAIM's merge-join iterator will
- * scan forward while looking for the next pending entry before it gives up and
- * seeks directly to the target. Roughly one macro-node worth of entries: for a
- * dense/contiguous PEL each resume is O(1); for a sparse PEL this cap keeps the
- * worst case no worse than the per-entry seek baseline. */
+/* Max entries the XAUTOCLAIM merge-join iterator scans forward before giving up
+ * and seeking directly to the target, bounding the sparse-PEL worst case. */
 #define STREAM_XAC_MAX_SCAN 128
 
 /* Advance the shared stream iterator 'si' forward to the first entry whose ID
  * is >= *target, implementing the merge-join used by xautoclaimCommand.
  *
- * Iterator carry-over state between calls:
- *  - *have_entry == 1: 'si' is positioned on *entry_id / *entry_numfields with
- *    the current entry's fields NOT yet consumed.
- *  - *have_entry == 0: the previous entry's fields have been consumed, so the
- *    next streamIteratorGetID() yields the following entry.
+ * The '*have_entry' flag carries the iterator state across calls. If it is 1
+ * then 'si' is positioned on *entry_id / *entry_numfields and the current
+ * entry's fields have NOT yet been consumed. If it is 0 then the previous
+ * entry's fields have been consumed, so the next streamIteratorGetID() call
+ * yields the following entry.
  *
  * Returns 1 with 'si' positioned on *entry_id (>= *target, fields intact), or
  * 0 at EOF. */
@@ -4728,29 +4725,28 @@ static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
     streamID maxid = {UINT64_MAX, UINT64_MAX};
     int steps = 0;
     while (1) {
-        if (*have_entry && streamCompareID(entry_id, target) < 0) {
+        if (*have_entry && streamCompareID(entry_id,target) < 0) {
             /* Skip an intervening / already-processed entry: consume its
              * fields so lp_ele lands where the next GetID expects it. */
             int64_t nf = *entry_numfields;
             while (nf--) {
                 unsigned char *f, *v;
                 int64_t fl, vl;
-                streamIteratorGetField(si, &f, &v, &fl, &vl);
+                streamIteratorGetField(si,&f,&v,&fl,&vl);
             }
             *have_entry = 0;
         }
         if (!*have_entry) {
-            /* Bounded fallback: if we have scanned too far without reaching the
-             * target (sparse PEL), stop the forward scan and seek directly, so
-             * the worst case stays ~= the baseline per-entry seek. */
+            /* If we have scanned too far without reaching the target (sparse
+             * PEL), stop the forward scan and seek directly to the target. */
             if (steps++ > STREAM_XAC_MAX_SCAN) {
                 streamIteratorStop(si);
-                streamIteratorStart(si, s, target, &maxid, 0);
+                streamIteratorStart(si,s,target,&maxid,0);
             }
-            *have_entry = streamIteratorGetID(si, entry_id, entry_numfields);
+            *have_entry = streamIteratorGetID(si,entry_id,entry_numfields);
             if (!*have_entry) return 0; /* EOF */
         }
-        if (streamCompareID(entry_id, target) >= 0) return 1;
+        if (streamCompareID(entry_id,target) >= 0) return 1;
     }
 }
 
@@ -4856,18 +4852,16 @@ void xautoclaimCommand(client *c) {
     mstime_t now = commandTimeSnapshot();
     int deleted_id_num = 0;
 
-    /* Open a single stream iterator once and advance it forward (merge-join)
-     * across all PEL entries, instead of re-seeking per entry. The stream's
-     * entry data is never mutated during a single XAUTOCLAIM (only the
-     * group/consumer PEL and NACKs are), so this iterator stays valid for the
-     * whole command. */
+    /* Open a single stream iterator and merge-join it forward across all PEL
+     * entries. The stream's entry data is never mutated during a single
+     * XAUTOCLAIM (only the group/consumer PEL and NACKs are), so this iterator
+     * stays valid for the whole command. */
     streamID maxid = {UINT64_MAX, UINT64_MAX};
     streamIterator si;
     streamIteratorStart(&si,s,&startid,&maxid,0);
-    streamID entry_id;           /* Stream entry the shared iterator is on. */
-    int64_t entry_numfields;     /* Field count for that entry. */
-    int have_entry = 0;          /* 1 if entry_id is valid and fields unread. */
-
+    streamID entry_id;
+    int64_t entry_numfields;
+    int have_entry = 0; /* 1 if entry_id is valid and its fields are unread. */
     while (attempts-- && count && raxNext(&ri)) {
         streamNACK *nack = ri.data;
 
@@ -4877,8 +4871,7 @@ void xautoclaimCommand(client *c) {
         /* Merge-join: advance the shared iterator to the first stream entry
          * with ID >= this PEL id, reusing it both to check existence and (for
          * non-JUSTID) to emit its fields. */
-        int have = xautoclaimAdvance(&si,s,&id,&entry_id,&entry_numfields,
-                                     &have_entry);
+        int have = xautoclaimAdvance(&si,s,&id,&entry_id,&entry_numfields,&have_entry);
         int found = have && streamCompareID(&entry_id,&id) == 0;
 
         /* Item must exist for us to transfer it to another consumer. */
@@ -4908,7 +4901,6 @@ void xautoclaimCommand(client *c) {
             count--; /* Count is a limit of the command response size. */
             continue;
         }
-        serverAssert(streamCompareID(&id,&entry_id) == 0);
 
         if (nack->consumer && minidle) {
             mstime_t this_idle = now - nack->delivery_time;
@@ -4942,9 +4934,6 @@ void xautoclaimCommand(client *c) {
         if (justid) {
             addReplyStreamID(c,&id);
         } else {
-            /* Emit the raw entry (ID + field/value pairs) straight from the
-             * iterator we already positioned, mirroring the min_idle_time==-1
-             * RAWENTRIES shape of streamReplyWithRange. */
             addReplyArrayLen(c,2);
             addReplyStreamID(c,&id);
             addReplyArrayLen(c,entry_numfields*2);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4704,6 +4704,55 @@ cleanup:
     if (ids != static_ids) zfree(ids);
 }
 
+/* Upper bound on how many stream entries XAUTOCLAIM's merge-join iterator will
+ * scan forward while looking for the next pending entry before it gives up and
+ * seeks directly to the target. Roughly one macro-node worth of entries: for a
+ * dense/contiguous PEL each resume is O(1); for a sparse PEL this cap keeps the
+ * worst case no worse than the per-entry seek baseline. */
+#define STREAM_XAC_MAX_SCAN 128
+
+/* Advance the shared stream iterator 'si' forward to the first entry whose ID
+ * is >= *target, implementing the merge-join used by xautoclaimCommand.
+ *
+ * Iterator carry-over state between calls:
+ *  - *have_id == 1: 'si' is positioned on *cur_id / *cur_nf with the current
+ *    entry's fields NOT yet consumed.
+ *  - *have_id == 0: the previous entry's fields have been consumed, so the next
+ *    streamIteratorGetID() yields the following entry.
+ *
+ * Returns 1 with 'si' positioned on *cur_id (>= *target, fields intact), or 0
+ * at EOF. */
+static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
+                             streamID *cur_id, int64_t *cur_nf, int *have_id) {
+    streamID maxid = {UINT64_MAX, UINT64_MAX};
+    int steps = 0;
+    while (1) {
+        if (*have_id && streamCompareID(cur_id, target) < 0) {
+            /* Skip an intervening / already-processed entry: consume its
+             * fields so lp_ele lands where the next GetID expects it. */
+            int64_t nf = *cur_nf;
+            while (nf--) {
+                unsigned char *f, *v;
+                int64_t fl, vl;
+                streamIteratorGetField(si, &f, &v, &fl, &vl);
+            }
+            *have_id = 0;
+        }
+        if (!*have_id) {
+            /* Bounded fallback: if we have scanned too far without reaching the
+             * target (sparse PEL), stop the forward scan and seek directly, so
+             * the worst case stays ~= the baseline per-entry seek. */
+            if (steps++ > STREAM_XAC_MAX_SCAN) {
+                streamIteratorStop(si);
+                streamIteratorStart(si, s, target, &maxid, 0);
+            }
+            *have_id = streamIteratorGetID(si, cur_id, cur_nf);
+            if (!*have_id) return 0; /* EOF */
+        }
+        if (streamCompareID(cur_id, target) >= 0) return 1;
+    }
+}
+
 /* XAUTOCLAIM <key> <group> <consumer> <min-idle-time> <start> [COUNT <count>] [JUSTID]
  *
  * Changes ownership of one or multiple messages in the Pending Entries List
@@ -4805,25 +4854,36 @@ void xautoclaimCommand(client *c) {
     size_t arraylen = 0;
     mstime_t now = commandTimeSnapshot();
     int deleted_id_num = 0;
+
+    /* Open a single stream iterator once and advance it forward (merge-join)
+     * across all PEL entries, instead of re-seeking per entry. The stream's
+     * entry data is never mutated during a single XAUTOCLAIM (only the
+     * group/consumer PEL and NACKs are), so this iterator stays valid for the
+     * whole command. */
+    streamID maxid = {UINT64_MAX, UINT64_MAX};
+    streamIterator si;
+    streamIteratorStart(&si,s,&startid,&maxid,0);
+    streamID cur_id;
+    int64_t cur_nf;
+    int have_id = 0;
+
     while (attempts-- && count && raxNext(&ri)) {
         streamNACK *nack = ri.data;
 
         streamID id;
         streamDecodeID(ri.key, &id);
 
-        /* Position a single stream iterator on this entry and reuse it both to
-         * check existence and (for non-JUSTID) to emit its fields. This avoids
-         * the second seek that a follow-up streamReplyWithRange would perform
-         * for the same ID. */
-        streamIterator si;
-        streamID myid;
-        int64_t numfields;
-        streamIteratorStart(&si,s,&id,&id,0);
-        int found = streamIteratorGetID(&si,&myid,&numfields);
+        /* Merge-join: advance the shared iterator to the first stream entry
+         * with ID >= this PEL id, reusing it both to check existence and (for
+         * non-JUSTID) to emit its fields. */
+        int have = xautoclaimAdvance(&si,s,&id,&cur_id,&cur_nf,&have_id);
+        int found = have && streamCompareID(&cur_id,&id) == 0;
 
         /* Item must exist for us to transfer it to another consumer. */
         if (!found) {
-            streamIteratorStop(&si);
+            /* Leave the iterator positioned as-is: cur_id (if any) is > id and
+             * may match a later PEL id, so we must not consume it here. The
+             * cleanup below only touches the PEL rax, so 'si' stays valid. */
             /* Propagate this change (we are going to delete the NACK). */
             if (nack->consumer) {
                 robj *idstr = createObjectFromStreamID(&id);
@@ -4849,12 +4909,13 @@ void xautoclaimCommand(client *c) {
             count--; /* Count is a limit of the command response size. */
             continue;
         }
-        serverAssert(streamCompareID(&id,&myid) == 0);
+        serverAssert(streamCompareID(&id,&cur_id) == 0);
 
         if (nack->consumer && minidle) {
             mstime_t this_idle = now - nack->delivery_time;
             if (this_idle < minidle) {
-                streamIteratorStop(&si);
+                /* Leave the iterator's fields unconsumed; the next
+                 * xautoclaimAdvance sees cur_id < next target and skips them. */
                 continue;
             }
         }
@@ -4884,22 +4945,25 @@ void xautoclaimCommand(client *c) {
         /* Send the reply for this entry. */
         if (justid) {
             addReplyStreamID(c,&id);
+            /* Leave have_id set: the fields are skipped lazily on the next
+             * xautoclaimAdvance. */
         } else {
             /* Emit the raw entry (ID + field/value pairs) straight from the
              * iterator we already positioned, mirroring the min_idle_time==-1
              * RAWENTRIES shape of streamReplyWithRange. */
             addReplyArrayLen(c,2);
             addReplyStreamID(c,&id);
-            addReplyArrayLen(c,numfields*2);
-            while (numfields--) {
+            addReplyArrayLen(c,cur_nf*2);
+            int64_t nf = cur_nf;
+            while (nf--) {
                 unsigned char *field, *value;
                 int64_t field_len, value_len;
                 streamIteratorGetField(&si,&field,&value,&field_len,&value_len);
                 addReplyBulkCBuffer(c,field,field_len);
                 addReplyBulkCBuffer(c,value,value_len);
             }
+            have_id = 0; /* Fields consumed; next GetID yields the following entry. */
         }
-        streamIteratorStop(&si);
         arraylen++;
         count--;
 
@@ -4911,6 +4975,8 @@ void xautoclaimCommand(client *c) {
         decrRefCount(idstr);
         server.dirty++;
     }
+
+    streamIteratorStop(&si);
 
     /* We need to return the next entry as a cursor for the next XAUTOCLAIM call */
     raxNext(&ri);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4811,8 +4811,19 @@ void xautoclaimCommand(client *c) {
         streamID id;
         streamDecodeID(ri.key, &id);
 
+        /* Position a single stream iterator on this entry and reuse it both to
+         * check existence and (for non-JUSTID) to emit its fields. This avoids
+         * the second seek that a follow-up streamReplyWithRange would perform
+         * for the same ID. */
+        streamIterator si;
+        streamID myid;
+        int64_t numfields;
+        streamIteratorStart(&si,s,&id,&id,0);
+        int found = streamIteratorGetID(&si,&myid,&numfields);
+
         /* Item must exist for us to transfer it to another consumer. */
-        if (!streamEntryExists(s,&id)) {
+        if (!found) {
+            streamIteratorStop(&si);
             /* Propagate this change (we are going to delete the NACK). */
             if (nack->consumer) {
                 robj *idstr = createObjectFromStreamID(&id);
@@ -4838,11 +4849,14 @@ void xautoclaimCommand(client *c) {
             count--; /* Count is a limit of the command response size. */
             continue;
         }
+        serverAssert(streamCompareID(&id,&myid) == 0);
 
         if (nack->consumer && minidle) {
             mstime_t this_idle = now - nack->delivery_time;
-            if (this_idle < minidle)
+            if (this_idle < minidle) {
+                streamIteratorStop(&si);
                 continue;
+            }
         }
 
         if (nack->consumer != consumer) {
@@ -4871,12 +4885,21 @@ void xautoclaimCommand(client *c) {
         if (justid) {
             addReplyStreamID(c,&id);
         } else {
-            streamReplyRangeArgs rawargs = {
-                .start = &id, .end = &id, .count = 1,
-                .min_idle_time = -1, .flags = STREAM_RWR_RAWENTRIES,
-            };
-            serverAssert(streamReplyWithRange(c,o->ptr,&rawargs) == 1);
+            /* Emit the raw entry (ID + field/value pairs) straight from the
+             * iterator we already positioned, mirroring the min_idle_time==-1
+             * RAWENTRIES shape of streamReplyWithRange. */
+            addReplyArrayLen(c,2);
+            addReplyStreamID(c,&id);
+            addReplyArrayLen(c,numfields*2);
+            while (numfields--) {
+                unsigned char *field, *value;
+                int64_t field_len, value_len;
+                streamIteratorGetField(&si,&field,&value,&field_len,&value_len);
+                addReplyBulkCBuffer(c,field,field_len);
+                addReplyBulkCBuffer(c,value,value_len);
+            }
         }
+        streamIteratorStop(&si);
         arraylen++;
         count--;
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4870,8 +4870,8 @@ void xautoclaimCommand(client *c) {
     raxStart(&ri,group->pel);
     raxSeek(&ri,">=",startkey,sizeof(startkey));
     size_t arraylen = 0;
-    int deleted_id_num = 0;
     mstime_t now = commandTimeSnapshot();
+    int deleted_id_num = 0;
     while (attempts-- && count && raxNext(&ri)) {
         streamNACK *nack = ri.data;
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4704,10 +4704,6 @@ cleanup:
     if (ids != static_ids) zfree(ids);
 }
 
-/* Max macro-nodes the XAUTOCLAIM merge-join scans forward before seeking
- * directly to the target, bounding the sparse-PEL worst case. */
-#define STREAM_XAC_MAX_NODE_SCAN 2
-
 /* Advance the shared stream iterator 'si' forward to the first entry whose ID
  * is >= *target, implementing the merge-join used by xautoclaimCommand.
  *
@@ -4717,6 +4713,10 @@ cleanup:
  * entry's fields have been consumed, so the next streamIteratorGetID() call
  * yields the following entry.
  *
+ * When the target is past the last ID of the current listpack node (sparse
+ * PEL), the iterator seeks directly to *target instead of scanning every
+ * intervening entry.
+ *
  * Returns 1 if *target exists, positioning 'si' on it (fields intact). Returns
  * 0 otherwise; if we stopped on a later entry it is left unconsumed
  * (*have_entry stays 1) for the next call to reuse. */
@@ -4725,46 +4725,41 @@ static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
                              int *have_entry)
 {
     streamID maxid = {UINT64_MAX, UINT64_MAX};
-    int node_scan = 0;
-    int have_master = *have_entry;
-    streamID prev_master = have_master ? si->master_id : (streamID){0,0};
     while (1) {
-        if (*have_entry && streamCompareID(entry_id,target) < 0) {
-            /* Skip an intervening / already-processed entry: advance past its
-             * fields without decoding them, mirroring streamIteratorGetID()'s
-             * discard logic. */
-            int64_t to_skip = (si->entry_flags & STREAM_ITEM_FLAG_SAMEFIELDS) ?
-                              *entry_numfields : *entry_numfields*2;
-            while (to_skip-- > 0)
-                si->lp_ele = lpNext(si->lp,si->lp_ele);
+        if (*have_entry) {
+            int cmp = streamCompareID(entry_id,target);
+            if (cmp == 0) return 1;  /* Found target. */
+            if (cmp > 0) return 0;   /* Past target: not found, leave entry for reuse. */
+            /* entry_id < target. If the target is past this listpack's last ID,
+             * seek directly instead of walking intervening entries. */
+            streamID last_id;
+            if (lpGetEdgeStreamID(si->lp, 0, &si->master_id, &last_id) &&
+                streamCompareID(target, &last_id) > 0)
+            {
+                streamIteratorStop(si);
+                streamIteratorStart(si,s,target,&maxid,0);
+            } else {
+                /* Target may still be in this node: skip this entry's fields
+                 * without decoding them, mirroring streamIteratorGetID(). */
+                int64_t to_skip = (si->entry_flags & STREAM_ITEM_FLAG_SAMEFIELDS) ?
+                                  *entry_numfields : *entry_numfields*2;
+                while (to_skip-- > 0)
+                    si->lp_ele = lpNext(si->lp,si->lp_ele);
+            }
             *have_entry = 0;
-        }
-        if (!*have_entry) {
-            *have_entry = streamIteratorGetID(si,entry_id,entry_numfields);
-            if (!*have_entry) return 0; /* EOF */
-            /* After crossing more than STREAM_XAC_MAX_NODE_SCAN nodes without
-             * reaching the target (sparse PEL), seek directly instead. But skip
-             * the re-seek if the current entry already reached the target,
-             * since it would only rediscover the same entry. */
-            if (!have_master) {
-                prev_master = si->master_id;
-                have_master = 1;
-            } else if (streamCompareID(&si->master_id,&prev_master) != 0) {
-                prev_master = si->master_id;
-                if (++node_scan > STREAM_XAC_MAX_NODE_SCAN &&
-                    streamCompareID(entry_id,target) < 0) {
-                    streamIteratorStop(si);
-                    streamIteratorStart(si,s,target,&maxid,0);
-                    node_scan = 0;
-                    have_master = 0; /* re-prime prev_master on next GetID */
-                    *have_entry = 0;
-                    continue;
-                }
+        } else if (si->lp) {
+            /* Fields already consumed; still jump past this node if needed. */
+            streamID last_id;
+            if (lpGetEdgeStreamID(si->lp, 0, &si->master_id, &last_id) &&
+                streamCompareID(target, &last_id) > 0)
+            {
+                streamIteratorStop(si);
+                streamIteratorStart(si,s,target,&maxid,0);
             }
         }
-        int cmp = streamCompareID(entry_id,target);
-        if (cmp == 0) return 1;  /* Found target. */
-        if (cmp > 0) return 0;   /* Past target: not found, leave entry for reuse. */
+
+        *have_entry = streamIteratorGetID(si,entry_id,entry_numfields);
+        if (!*have_entry) return 0; /* EOF */
     }
 }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4704,37 +4704,33 @@ cleanup:
     if (ids != static_ids) zfree(ids);
 }
 
-/* Advance the shared stream iterator 'si' forward to the first entry whose ID
- * is >= *target, implementing the merge-join used by xautoclaimCommand.
+/* Advance the stream iterator 'si' to the first entry whose ID is greater than
+ * or equal to 'target'. This implements the merge join used by
+ * xautoclaimCommand().
  *
- * The '*have_entry' flag carries the iterator state across calls. If it is 1
- * then 'si' is positioned on *entry_id / *entry_numfields and the current
- * entry's fields have NOT yet been consumed. If it is 0 then the previous
- * entry's fields have been consumed, so the next streamIteratorGetID() call
- * yields the following entry.
+ * If 'have_entry' is set, 'entry_id' and 'entry_numfields' describe the
+ * current entry and its fields have not been consumed. Otherwise, the next
+ * call to streamIteratorGetID() returns the following entry.
  *
- * When the target is past the last ID of the current listpack node (sparse
- * PEL), the iterator seeks directly to *target instead of scanning every
- * intervening entry. The node last-ID is cached and refreshed only when the
- * current listpack (master_id) changes.
+ * If 'target' is past the current listpack, seek directly to it instead of
+ * scanning the intervening entries. The last ID of the current listpack is
+ * cached in 'last_id', 'last_master', and 'have_last' across calls.
  *
- * Returns 1 if *target exists, positioning 'si' on it (fields intact). Returns
- * 0 otherwise; if we stopped on a later entry it is left unconsumed
- * (*have_entry stays 1) for the next call to reuse. */
+ * Return 1 if 'target' exists, leaving its fields unconsumed. Otherwise return
+ * 0. If a later entry was found, it is also left unconsumed for the next call. */
 static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
                              streamID *entry_id, int64_t *entry_numfields,
-                             int *have_entry)
+                             int *have_entry, streamID *last_id,
+                             streamID *last_master, int *have_last)
 {
     streamID maxid = {UINT64_MAX, UINT64_MAX};
-    streamID last_id, last_master = {0,0};
-    int have_last = 0;
     while (1) {
-        /* Cache this listpack's last ID once per node. */
-        if (si->lp && (!have_last || streamCompareID(&si->master_id,&last_master) != 0)) {
-            have_last = lpGetEdgeStreamID(si->lp,0,&si->master_id,&last_id);
-            last_master = si->master_id;
+        /* Cache this listpack's last ID once per node (persists across calls). */
+        if (si->lp && (!*have_last || streamCompareID(&si->master_id,last_master) != 0)) {
+            *have_last = lpGetEdgeStreamID(si->lp,0,&si->master_id,last_id);
+            *last_master = si->master_id;
         }
-        int past_node = have_last && streamCompareID(target,&last_id) > 0;
+        int past_node = *have_last && streamCompareID(target,last_id) > 0;
 
         if (*have_entry) {
             int cmp = streamCompareID(entry_id,target);
@@ -4755,7 +4751,7 @@ static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
         if (past_node) {
             streamIteratorStop(si);
             streamIteratorStart(si,s,target,&maxid,0);
-            have_last = 0;
+            *have_last = 0;
         }
 
         *have_entry = streamIteratorGetID(si,entry_id,entry_numfields);
@@ -4875,6 +4871,9 @@ void xautoclaimCommand(client *c) {
     streamID entry_id;
     int64_t entry_numfields;
     int have_entry = 0; /* 1 if entry_id is valid and its fields are unread. */
+    /* Node last-ID cache, persists across xautoclaimAdvance() calls. */
+    streamID last_id, last_master = {0,0};
+    int have_last = 0;
     while (attempts-- && count && raxNext(&ri)) {
         streamNACK *nack = ri.data;
 
@@ -4884,7 +4883,8 @@ void xautoclaimCommand(client *c) {
         /* Merge-join: advance the shared iterator to the first stream entry
          * with ID >= this PEL id, reusing it both to check existence and (for
          * non-JUSTID) to emit its fields. */
-        int found = xautoclaimAdvance(&si,s,&id,&entry_id,&entry_numfields,&have_entry);
+        int found = xautoclaimAdvance(&si,s,&id,&entry_id,&entry_numfields,&have_entry,
+                                      &last_id,&last_master,&have_last);
 
         /* Item must exist for us to transfer it to another consumer. */
         if (!found) {

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4730,34 +4730,29 @@ static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
     int have_last = 0;
     while (1) {
         /* Cache this listpack's last ID once per node. */
-        if (si->lp &&
-            (!have_last || streamCompareID(&si->master_id,&last_master) != 0))
-        {
+        if (si->lp && (!have_last || streamCompareID(&si->master_id,&last_master) != 0)) {
             have_last = lpGetEdgeStreamID(si->lp,0,&si->master_id,&last_id);
             last_master = si->master_id;
         }
+        int past_node = have_last && streamCompareID(target,&last_id) > 0;
 
         if (*have_entry) {
             int cmp = streamCompareID(entry_id,target);
             if (cmp == 0) return 1;  /* Found target. */
             if (cmp > 0) return 0;   /* Past target: not found, leave entry for reuse. */
-            /* entry_id < target. If the target is past this listpack's last ID,
-             * seek directly instead of walking intervening entries. */
-            if (have_last && streamCompareID(target,&last_id) > 0) {
-                streamIteratorStop(si);
-                streamIteratorStart(si,s,target,&maxid,0);
-                have_last = 0; /* invalidate; next GetID may land on a new node */
-            } else {
-                /* Target may still be in this node: skip this entry's fields
-                 * without decoding them, mirroring streamIteratorGetID(). */
+            /* entry_id < target. Skip fields only if we stay in this node;
+             * a seek below abandons the listpack cursor entirely. */
+            if (!past_node) {
                 int64_t to_skip = (si->entry_flags & STREAM_ITEM_FLAG_SAMEFIELDS) ?
                                   *entry_numfields : *entry_numfields*2;
                 while (to_skip-- > 0)
                     si->lp_ele = lpNext(si->lp,si->lp_ele);
             }
             *have_entry = 0;
-        } else if (si->lp && have_last && streamCompareID(target,&last_id) > 0) {
-            /* Fields already consumed; still jump past this node if needed. */
+        }
+
+        /* Sparse PEL: jump past this node instead of walking intervening entries. */
+        if (past_node) {
             streamIteratorStop(si);
             streamIteratorStart(si,s,target,&maxid,0);
             have_last = 0;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4704,9 +4704,9 @@ cleanup:
     if (ids != static_ids) zfree(ids);
 }
 
-/* Max entries the XAUTOCLAIM merge-join iterator scans forward before giving up
- * and seeking directly to the target, bounding the sparse-PEL worst case. */
-#define STREAM_XAC_MAX_SCAN 128
+/* Max macro-nodes the XAUTOCLAIM merge-join scans forward before seeking
+ * directly to the target, bounding the sparse-PEL worst case. */
+#define STREAM_XAC_MAX_NODE_SCAN 2
 
 /* Advance the shared stream iterator 'si' forward to the first entry whose ID
  * is >= *target, implementing the merge-join used by xautoclaimCommand.
@@ -4723,28 +4723,40 @@ static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
                              streamID *entry_id, int64_t *entry_numfields,
                              int *have_entry) {
     streamID maxid = {UINT64_MAX, UINT64_MAX};
-    int steps = 0;
+    int node_scan = 0;
+    int have_master = *have_entry;
+    streamID prev_master = have_master ? si->master_id : (streamID){0,0};
     while (1) {
         if (*have_entry && streamCompareID(entry_id,target) < 0) {
-            /* Skip an intervening / already-processed entry: consume its
-             * fields so lp_ele lands where the next GetID expects it. */
-            int64_t nf = *entry_numfields;
-            while (nf--) {
-                unsigned char *f, *v;
-                int64_t fl, vl;
-                streamIteratorGetField(si,&f,&v,&fl,&vl);
-            }
+            /* Skip an intervening / already-processed entry: advance past its
+             * fields without decoding them, mirroring streamIteratorGetID()'s
+             * discard logic. */
+            int64_t to_skip = (si->entry_flags & STREAM_ITEM_FLAG_SAMEFIELDS) ?
+                              *entry_numfields : *entry_numfields*2;
+            while (to_skip-- > 0)
+                si->lp_ele = lpNext(si->lp,si->lp_ele);
             *have_entry = 0;
         }
         if (!*have_entry) {
-            /* If we have scanned too far without reaching the target (sparse
-             * PEL), stop the forward scan and seek directly to the target. */
-            if (steps++ > STREAM_XAC_MAX_SCAN) {
-                streamIteratorStop(si);
-                streamIteratorStart(si,s,target,&maxid,0);
-            }
             *have_entry = streamIteratorGetID(si,entry_id,entry_numfields);
             if (!*have_entry) return 0; /* EOF */
+            /* Count node boundaries crossed while scanning forward; once we
+             * cross more than STREAM_XAC_MAX_NODE_SCAN without reaching the
+             * target (sparse PEL), seek directly instead. */
+            if (!have_master) {
+                prev_master = si->master_id;
+                have_master = 1;
+            } else if (streamCompareID(&si->master_id,&prev_master) != 0) {
+                prev_master = si->master_id;
+                if (++node_scan > STREAM_XAC_MAX_NODE_SCAN) {
+                    streamIteratorStop(si);
+                    streamIteratorStart(si,s,target,&maxid,0);
+                    node_scan = 0;
+                    have_master = 0; /* re-prime prev_master on next GetID */
+                    *have_entry = 0;
+                    continue;
+                }
+            }
         }
         if (streamCompareID(entry_id,target) >= 0) return 1;
     }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4715,7 +4715,8 @@ cleanup:
  *
  * When the target is past the last ID of the current listpack node (sparse
  * PEL), the iterator seeks directly to *target instead of scanning every
- * intervening entry.
+ * intervening entry. The node last-ID is cached and refreshed only when the
+ * current listpack (master_id) changes.
  *
  * Returns 1 if *target exists, positioning 'si' on it (fields intact). Returns
  * 0 otherwise; if we stopped on a later entry it is left unconsumed
@@ -4725,19 +4726,27 @@ static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
                              int *have_entry)
 {
     streamID maxid = {UINT64_MAX, UINT64_MAX};
+    streamID last_id, last_master = {0,0};
+    int have_last = 0;
     while (1) {
+        /* Cache this listpack's last ID once per node. */
+        if (si->lp &&
+            (!have_last || streamCompareID(&si->master_id,&last_master) != 0))
+        {
+            have_last = lpGetEdgeStreamID(si->lp,0,&si->master_id,&last_id);
+            last_master = si->master_id;
+        }
+
         if (*have_entry) {
             int cmp = streamCompareID(entry_id,target);
             if (cmp == 0) return 1;  /* Found target. */
             if (cmp > 0) return 0;   /* Past target: not found, leave entry for reuse. */
             /* entry_id < target. If the target is past this listpack's last ID,
              * seek directly instead of walking intervening entries. */
-            streamID last_id;
-            if (lpGetEdgeStreamID(si->lp, 0, &si->master_id, &last_id) &&
-                streamCompareID(target, &last_id) > 0)
-            {
+            if (have_last && streamCompareID(target,&last_id) > 0) {
                 streamIteratorStop(si);
                 streamIteratorStart(si,s,target,&maxid,0);
+                have_last = 0; /* invalidate; next GetID may land on a new node */
             } else {
                 /* Target may still be in this node: skip this entry's fields
                  * without decoding them, mirroring streamIteratorGetID(). */
@@ -4747,15 +4756,11 @@ static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
                     si->lp_ele = lpNext(si->lp,si->lp_ele);
             }
             *have_entry = 0;
-        } else if (si->lp) {
+        } else if (si->lp && have_last && streamCompareID(target,&last_id) > 0) {
             /* Fields already consumed; still jump past this node if needed. */
-            streamID last_id;
-            if (lpGetEdgeStreamID(si->lp, 0, &si->master_id, &last_id) &&
-                streamCompareID(target, &last_id) > 0)
-            {
-                streamIteratorStop(si);
-                streamIteratorStart(si,s,target,&maxid,0);
-            }
+            streamIteratorStop(si);
+            streamIteratorStart(si,s,target,&maxid,0);
+            have_last = 0;
         }
 
         *have_entry = streamIteratorGetID(si,entry_id,entry_numfields);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4715,30 +4715,31 @@ cleanup:
  * is >= *target, implementing the merge-join used by xautoclaimCommand.
  *
  * Iterator carry-over state between calls:
- *  - *have_id == 1: 'si' is positioned on *cur_id / *cur_nf with the current
- *    entry's fields NOT yet consumed.
- *  - *have_id == 0: the previous entry's fields have been consumed, so the next
- *    streamIteratorGetID() yields the following entry.
+ *  - *have_entry == 1: 'si' is positioned on *entry_id / *entry_numfields with
+ *    the current entry's fields NOT yet consumed.
+ *  - *have_entry == 0: the previous entry's fields have been consumed, so the
+ *    next streamIteratorGetID() yields the following entry.
  *
- * Returns 1 with 'si' positioned on *cur_id (>= *target, fields intact), or 0
- * at EOF. */
+ * Returns 1 with 'si' positioned on *entry_id (>= *target, fields intact), or
+ * 0 at EOF. */
 static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
-                             streamID *cur_id, int64_t *cur_nf, int *have_id) {
+                             streamID *entry_id, int64_t *entry_numfields,
+                             int *have_entry) {
     streamID maxid = {UINT64_MAX, UINT64_MAX};
     int steps = 0;
     while (1) {
-        if (*have_id && streamCompareID(cur_id, target) < 0) {
+        if (*have_entry && streamCompareID(entry_id, target) < 0) {
             /* Skip an intervening / already-processed entry: consume its
              * fields so lp_ele lands where the next GetID expects it. */
-            int64_t nf = *cur_nf;
+            int64_t nf = *entry_numfields;
             while (nf--) {
                 unsigned char *f, *v;
                 int64_t fl, vl;
                 streamIteratorGetField(si, &f, &v, &fl, &vl);
             }
-            *have_id = 0;
+            *have_entry = 0;
         }
-        if (!*have_id) {
+        if (!*have_entry) {
             /* Bounded fallback: if we have scanned too far without reaching the
              * target (sparse PEL), stop the forward scan and seek directly, so
              * the worst case stays ~= the baseline per-entry seek. */
@@ -4746,10 +4747,10 @@ static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
                 streamIteratorStop(si);
                 streamIteratorStart(si, s, target, &maxid, 0);
             }
-            *have_id = streamIteratorGetID(si, cur_id, cur_nf);
-            if (!*have_id) return 0; /* EOF */
+            *have_entry = streamIteratorGetID(si, entry_id, entry_numfields);
+            if (!*have_entry) return 0; /* EOF */
         }
-        if (streamCompareID(cur_id, target) >= 0) return 1;
+        if (streamCompareID(entry_id, target) >= 0) return 1;
     }
 }
 
@@ -4863,9 +4864,9 @@ void xautoclaimCommand(client *c) {
     streamID maxid = {UINT64_MAX, UINT64_MAX};
     streamIterator si;
     streamIteratorStart(&si,s,&startid,&maxid,0);
-    streamID cur_id;
-    int64_t cur_nf;
-    int have_id = 0;
+    streamID entry_id;           /* Stream entry the shared iterator is on. */
+    int64_t entry_numfields;     /* Field count for that entry. */
+    int have_entry = 0;          /* 1 if entry_id is valid and fields unread. */
 
     while (attempts-- && count && raxNext(&ri)) {
         streamNACK *nack = ri.data;
@@ -4876,14 +4877,12 @@ void xautoclaimCommand(client *c) {
         /* Merge-join: advance the shared iterator to the first stream entry
          * with ID >= this PEL id, reusing it both to check existence and (for
          * non-JUSTID) to emit its fields. */
-        int have = xautoclaimAdvance(&si,s,&id,&cur_id,&cur_nf,&have_id);
-        int found = have && streamCompareID(&cur_id,&id) == 0;
+        int have = xautoclaimAdvance(&si,s,&id,&entry_id,&entry_numfields,
+                                     &have_entry);
+        int found = have && streamCompareID(&entry_id,&id) == 0;
 
         /* Item must exist for us to transfer it to another consumer. */
         if (!found) {
-            /* Leave the iterator positioned as-is: cur_id (if any) is > id and
-             * may match a later PEL id, so we must not consume it here. The
-             * cleanup below only touches the PEL rax, so 'si' stays valid. */
             /* Propagate this change (we are going to delete the NACK). */
             if (nack->consumer) {
                 robj *idstr = createObjectFromStreamID(&id);
@@ -4909,15 +4908,12 @@ void xautoclaimCommand(client *c) {
             count--; /* Count is a limit of the command response size. */
             continue;
         }
-        serverAssert(streamCompareID(&id,&cur_id) == 0);
+        serverAssert(streamCompareID(&id,&entry_id) == 0);
 
         if (nack->consumer && minidle) {
             mstime_t this_idle = now - nack->delivery_time;
-            if (this_idle < minidle) {
-                /* Leave the iterator's fields unconsumed; the next
-                 * xautoclaimAdvance sees cur_id < next target and skips them. */
+            if (this_idle < minidle)
                 continue;
-            }
         }
 
         if (nack->consumer != consumer) {
@@ -4945,16 +4941,14 @@ void xautoclaimCommand(client *c) {
         /* Send the reply for this entry. */
         if (justid) {
             addReplyStreamID(c,&id);
-            /* Leave have_id set: the fields are skipped lazily on the next
-             * xautoclaimAdvance. */
         } else {
             /* Emit the raw entry (ID + field/value pairs) straight from the
              * iterator we already positioned, mirroring the min_idle_time==-1
              * RAWENTRIES shape of streamReplyWithRange. */
             addReplyArrayLen(c,2);
             addReplyStreamID(c,&id);
-            addReplyArrayLen(c,cur_nf*2);
-            int64_t nf = cur_nf;
+            addReplyArrayLen(c,entry_numfields*2);
+            int64_t nf = entry_numfields;
             while (nf--) {
                 unsigned char *field, *value;
                 int64_t field_len, value_len;
@@ -4962,7 +4956,7 @@ void xautoclaimCommand(client *c) {
                 addReplyBulkCBuffer(c,field,field_len);
                 addReplyBulkCBuffer(c,value,value_len);
             }
-            have_id = 0; /* Fields consumed; next GetID yields the following entry. */
+            have_entry = 0; /* Fields consumed; next GetID yields the next entry. */
         }
         arraylen++;
         count--;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4721,7 +4721,8 @@ cleanup:
  * 0 at EOF. */
 static int xautoclaimAdvance(streamIterator *si, stream *s, streamID *target,
                              streamID *entry_id, int64_t *entry_numfields,
-                             int *have_entry) {
+                             int *have_entry)
+{
     streamID maxid = {UINT64_MAX, UINT64_MAX};
     int node_scan = 0;
     int have_master = *have_entry;


### PR DESCRIPTION
**Summary**

Optimizes `XAUTOCLAIM` by replacing the per-entry existence check and per-entry range reply with a single shared stream iterator that is merge-joined forward across the group's Pending Entries List (PEL). Previously each candidate PEL id triggered an independent lookup (`streamEntryExists`) and, for non-`JUSTID` replies, a second independent seek (`streamReplyWithRange`), re-walking the stream from scratch for every message. Since PEL ids and stream entries are both iterated in sorted order, a single forward pass is sufficient.

**Changes**

- **New `xautoclaimAdvance()` merge-join helper**: Advances one shared `streamIterator` forward to the first entry whose ID is `>= target`. It carries iterator state across calls via a `have_entry` flag so the current entry's fields are only consumed once we know we don't need them, letting the same iterator both check existence and emit fields. Skipped/intervening entries have their fields drained (respecting `STREAM_ITEM_FLAG_SAMEFIELDS`) so `lp_ele` stays correctly positioned for the next `streamIteratorGetID()`.
- **`xautoclaimCommand` — single iterator for the whole command**: Opens one `streamIterator` at `startid` up front and reuses it for every PEL entry in the scan loop, replacing the previous `streamEntryExists(s,&id)` call. The stream's entry data is never mutated during a single `XAUTOCLAIM` (only the group/consumer PEL and NACKs change), so the iterator stays valid for the entire command and is stopped once at the end.
- **`xautoclaimCommand` — inline field emission**: For non-`JUSTID` claims, the reply is now built directly from the shared iterator's fields (`streamIteratorGetField`) instead of calling `streamReplyWithRange` with a single-id range, which would open and seek a fresh iterator per entry.
- **Bounded sparse-PEL worst case (per-listpack-node)**: `xautoclaimAdvance()` caches the current listpack node's last ID via `lpGetEdgeStreamID()` (refreshed only when the node/`master_id` changes). If the target PEL id lies past that last ID (a sparse PEL over a dense stream), the iterator is stopped and re-seeked directly to the target instead of walking every intervening entry — bounding the linear forward walk to within a single listpack node.

**Benefits**

- **One pass instead of N lookups**: Turns the per-entry `streamEntryExists` + `streamReplyWithRange` pattern (each of which re-seeks into the stream) into a single amortized forward scan across the PEL, exploiting the shared sorted order of PEL ids and stream entries.
- **Fewer iterator setups/teardowns**: A single `streamIteratorStart`/`streamIteratorStop` pair per command instead of one (or two) per claimed message.
- **Bounded worst case**: The per-node last-ID check lets a sparse PEL skip whole listpack nodes via a direct re-seek, preventing the forward merge-join from degrading into a full stream walk.
- **Zero behavioral change**: The reply shape (ids for `JUSTID`, `[id, [field, value, ...]]` otherwise), NACK/consumer transfer, deleted-id handling, and cursor semantics are all preserved; this is purely an internal traversal optimization.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core stream command traversal and reply assembly; behavior is intended to be identical but iterator edge cases (sparse PEL, SAMEFIELDS skipping) warrant careful review.
> 
> **Overview**
> **XAUTOCLAIM** no longer does a separate stream seek per PEL id. One forward `streamIterator` opened at `startid` is merge-joined with the sorted group PEL for the whole command.
> 
> New **`xautoclaimAdvance()`** moves that iterator to the first entry with ID `>=` each PEL id, reusing buffered entry state so existence checks and (when not `JUSTID`) reply building share the same position. Intervening entries are skipped by draining fields; when the target id is past the current listpack node’s last id, the iterator re-seeks to the target instead of walking the whole node—so sparse PELs over dense streams don’t devolve into a full stream walk.
> 
> Non-`JUSTID` replies are emitted inline via `streamIteratorGetField` instead of **`streamReplyWithRange`** on a one-id range (which started a fresh iterator each time). **`streamEntryExists`** is removed from the hot loop. Reply shape, claiming, deleted-id handling, and cursor behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c9bc4e218afe18ff07ebed5e8f1f9bd55a5766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->