### PR TITLE
Fix flaky XADD IDMP FLUSHALL test

### DIFF
--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -1077,11 +1077,11 @@ start_server {
 
         $db0 XADD mystream IDMP p1 "init" * field "init"
         $db0 XCFGSET mystream IDMP-DURATION 2
-        set id0 [$db0 XADD mystream IDMP p1 "req-1" * field "v1"]
+        $db0 XADD mystream IDMP p1 "req-1" * field "v1"
 
         $db1 XADD mystream IDMP p2 "init" * field "init"
         $db1 XCFGSET mystream IDMP-DURATION 2
-        set id1 [$db1 XADD mystream IDMP p2 "req-1" * field "v1"]
+        $db1 XADD mystream IDMP p2 "req-1" * field "v1"
 
         assert_equal 1 [dict get [$db0 XINFO STREAM mystream] pids-tracked]
         assert_equal 1 [dict get [$db1 XINFO STREAM mystream] pids-tracked]
@@ -1094,13 +1094,15 @@ start_server {
         $db1 XCFGSET mystream IDMP-DURATION 2
 
         set len0_before [$db0 XLEN mystream]
-        set id0_new [$db0 XADD mystream IDMP p1 "req-1" * field "v2"]
-        assert_equal [expr {$len0_before + 1}] [$db0 XLEN mystream] \
+        $db0 XADD mystream IDMP p1 "req-1" * field "v2"
+        set len0_after [$db0 XLEN mystream]
+        assert_equal [expr {$len0_before + 1}] $len0_after \
             "DB0: XADD after FLUSHALL should create a new entry, not deduplicate"
 
         set len1_before [$db1 XLEN mystream]
-        set id1_new [$db1 XADD mystream IDMP p2 "req-1" * field "v2"]
-        assert_equal [expr {$len1_before + 1}] [$db1 XLEN mystream] \
+        $db1 XADD mystream IDMP p2 "req-1" * field "v2"
+        set len1_after [$db1 XLEN mystream]
+        assert_equal [expr {$len1_before + 1}] $len1_after \
             "DB1: XADD after FLUSHALL should create a new entry, not deduplicate"
 
         wait_for_condition 50 100 {
@@ -1116,7 +1118,7 @@ start_server {
 
         $db0 close
         $db1 close
-        assert {$id0 ne $id0_new}
+        assert_equal {2 2} [list $len0_after $len1_after]
     } {} {singledb:skip}
 
     test {XADD IDMP tracking survives RENAME} {


### PR DESCRIPTION
The `XADD IDMP tracking cleared after FLUSHALL across all databases` test ends with:

```tcl
assert {$id0 ne $id0_new}
```

This compares auto-generated stream entry IDs (`<ms>-<seq>`) captured before and after a `FLUSHALL`. When both `XADD`s land in the same millisecond the IDs collide, so the assertion fails even though IDMP dedup tracking was correctly cleared.

The actual invariant — that the post-FLUSHALL `XADD` creates a new entry rather than being deduplicated — is already asserted inline via `XLEN` growth. This replaces the timing-dependent ID comparison with a deterministic final-length assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Tcl integration test assertions change; no server or IDMP implementation code is modified.
> 
> **Overview**
> Fixes flakiness in **`XADD IDMP tracking cleared after FLUSHALL across all databases`** by dropping comparisons of auto-generated stream IDs captured before and after `FLUSHALL`.
> 
> The test already checked that post-`FLUSHALL` `XADD` calls append new entries (via **`XLEN`** growth on DB 0 and DB 1). The final **`assert {$id0 ne $id0_new}`** could fail when both writes shared the same millisecond and got identical IDs, even when IDMP dedup state was cleared correctly.
> 
> The change stops storing those IDs, records **`len0_after`** / **`len1_after`** after the critical `XADD`s, and ends with **`assert_equal {2 2}`** on both lengths instead of the ID inequality check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d85b35141d2a055e9291e983cc535cfa38c87d8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->