### PR TITLE
rax: fix random walk from inlined leaves

### DIFF
--- a/src/rax.c
+++ b/src/rax.c
@@ -2276,17 +2276,25 @@ int raxRandomWalk(raxIterator *it, size_t steps) {
 
     raxNode *n = it->node;
     while(steps > 0 || (!n->iskey && it->leaf_slot_idx < 0)) {
+        /* A fixed-length inlined value is a virtual leaf: logically it has no
+         * children, even though it->node points to the leaf parent whose slots
+         * contain values. Move back to that parent before selecting the next
+         * edge. Otherwise the value slots could be interpreted as raxNode
+         * pointers when the walk continues from an already-positioned leaf. */
+        if (it->leaf_slot_idx >= 0) {
+            it->leaf_slot_idx = -1;
+            int todel = n->iscompr ? n->size : 1;
+            raxIteratorDelChars(it,todel);
+            continue;
+        }
+
         int numchildren = n->iscompr ? 1 : n->size;
         int r = rand() % (numchildren+(n != it->rt->head));
 
         if (r == numchildren) {
-            /* Go up: if parked on a virtual leaf, exit it (the leaf parent
-             * stays as n). Otherwise pop the real parent. Either way, the
-             * edge to strip is owned by the resulting `n`. */
-            if (it->leaf_slot_idx >= 0)
-                it->leaf_slot_idx = -1;
-            else
-                n = raxStackPop(&it->stack);
+            /* Go up to the real parent. The virtual-leaf case was normalized
+             * at the beginning of the loop. */
+            n = raxStackPop(&it->stack);
             int todel = n->iscompr ? n->size : 1;
             raxIteratorDelChars(it,todel);
         } else {
@@ -2864,6 +2872,31 @@ int raxTest(int argc, char **argv, int flags) {
             assert(yielded == 3);
             raxStop(&ri);
         }
+
+        raxFree(r);
+    }
+
+    TEST("inline-leaf: random walk from a virtual leaf") {
+        /* A single fixed-length key is stored as an iscompr=1 leaf parent at
+         * the root. Seeking positions the iterator on its virtual leaf. A
+         * subsequent random walk must first move back to the leaf parent;
+         * treating its value slot as a child raxNode would crash. Multiple
+         * steps exercise leaving and re-entering the same virtual leaf. */
+        rax *r = raxNewEx(0, NULL, 8);
+        unsigned char key[8] = {'A','A','A','A','A','A','A','A'};
+        void *value = (void*)(uintptr_t)1;
+        assert(raxInsert(r, key, sizeof(key), value, NULL) == 1);
+
+        raxIterator ri;
+        raxStart(&ri, r);
+        assert(raxSeek(&ri, "^", NULL, 0) == 1);
+        assert(ri.leaf_slot_idx == 0);
+        assert(raxRandomWalk(&ri, 8) == 1);
+        assert(ri.key_len == sizeof(key));
+        assert(memcmp(ri.key, key, sizeof(key)) == 0);
+        assert(ri.data == value);
+        assert(ri.leaf_slot_idx == 0);
+        raxStop(&ri);
 
         raxFree(r);
     }


### PR DESCRIPTION
### Summary

Fix a crash in `raxRandomWalk()` when a fixed-length rax iterator is
already positioned on an inlined virtual leaf.

This fixes a regression introduced by #15256.

### Root cause

Fixed-length rax trees store values directly in slots in the leaf
parent that normally hold child pointers.

When the iterator was already positioned on a virtual leaf,
`raxRandomWalk()` used the physical leaf parent's child count and could
interpret an inlined value as a `raxNode *`.

For a single-key fixed-length tree, this caused a deterministic invalid
read and `SIGSEGV`.

### Fix

Normalize the virtual-leaf state at the beginning of each random-walk
loop iteration by logically moving back to the leaf parent before
selecting the next edge.

Add a regression test that performs multiple random-walk steps starting
from an inlined virtual leaf.

### Tests

- `make -C src redis-server -j4 REDIS_CFLAGS=-DREDIS_TEST`
- `./src/redis-server test rax`
- `valgrind --error-exitcode=99 --leak-check=full ./src/redis-server test rax --valgrind`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized iterator fix in `rax.c` with a targeted test; behavior change only affects fixed-length rax random walks that start on virtual leaves.
> 
> **Overview**
> Fixes a **SIGSEGV in `raxRandomWalk()`** when the iterator is already on a fixed-length **inlined virtual leaf** (regression from leaf-inlining).
> 
> Each random-walk loop iteration now **clears `leaf_slot_idx` and trims the iterator key** back to the leaf parent before choosing the next edge or going up, so inlined value slots are never treated as `raxNode *` children. The special “go up” branch for virtual leaves at walk time is removed because that state is normalized up front.
> 
> Adds a regression test that seeks to the only key in an 8-byte fixed-length tree and runs multiple random-walk steps from that virtual leaf.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caeb68ac1d6e28ea354dc6a749dd7c98e939ba99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->