### PR TITLE
Fix meaningless assertions

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1927,8 +1927,9 @@ void unlinkClient(client *c) {
 
     /* Remove from the list of pending writes if needed. */
     if (c->flags & CLIENT_PENDING_WRITE) {
-        serverAssert(&c->clients_pending_write_node.next != NULL || 
-                     &c->clients_pending_write_node.prev != NULL);
+        serverAssert(listNextNode(&c->clients_pending_write_node) != NULL ||
+                     listPrevNode(&c->clients_pending_write_node) != NULL ||
+                     listFirst(server.clients_pending_write) == &c->clients_pending_write_node);
         listUnlinkNode(server.clients_pending_write, &c->clients_pending_write_node);
         c->flags &= ~CLIENT_PENDING_WRITE;
     }


### PR DESCRIPTION
`&c->clients_pending_write_node.next` and `&c->clients_pending_write_node.prev` always are not NULL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-only assertion change in client teardown; no behavior change beyond catching invalid `CLIENT_PENDING_WRITE` state in development builds.
> 
> **Overview**
> **Fixes a meaningless `serverAssert` when unlinking a client from `clients_pending_write`.**
> 
> The old check took the address of `next`/`prev` on the embedded list node, which is always non-null, so it never validated list membership. The assertion now requires the node to be linked: it has a `next` or `prev` neighbor, or it is the head of `server.clients_pending_write`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c0ad218d6d114c0481ab9b856f16725dcce261c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->