### PR TITLE
Report replication compression context memory in INFO

### DIFF
--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -553,6 +553,25 @@ int clientHasPendingCompressedData(client *c) {
            state->output.written > state->output.consumed;
 }
 
+/* Return the size in bytes of the underlying zstd streaming context (CCtx/DCtx)
+ * currently allocated for this client's compression state, or 0 if none exists.
+ * This memory is allocated by libzstd via libc malloc, not zmalloc, so it is
+ * NOT tracked by zmalloc/used_memory and must never be folded into
+ * clientCompressionMemoryUsage(). Context allocation inside libzstd is lazy, so
+ * the reported size can still be small until the first compress/decompress
+ * call has run. */
+size_t clientCompressionCtxMemoryUsage(client *c) {
+    compressionState *st = c->compression_state;
+    if (!st) return 0;
+
+    if (st->dir == COMPRESS && st->ctx.zstdCCtx)
+        return ZSTD_sizeof_CStream(st->ctx.zstdCCtx);
+    if (st->dir == DECOMPRESS && st->ctx.zstdDCtx)
+        return ZSTD_sizeof_DStream(st->ctx.zstdDCtx);
+
+    return 0;
+}
+
 /* Add the client to its event loop's pending decompression list so its buffered
  * compressed/decompressed data can be drained from beforeSleep even when no
  * socket read event fires. No-op if already present. */
@@ -815,6 +834,11 @@ int clientHasPendingCompressionFlush(client *c) {
 }
 
 int clientHasPendingCompressedData(client *c) {
+    UNUSED(c);
+    return 0;
+}
+
+size_t clientCompressionCtxMemoryUsage(client *c) {
     UNUSED(c);
     return 0;
 }

--- a/src/client_comp.h
+++ b/src/client_comp.h
@@ -39,6 +39,12 @@ int clientReadBufAndDecompress(struct client *c, char *input_buf, size_t input_l
 int clientHasPendingCompressionFlush(struct client *c);
 int clientHasPendingCompressedData(struct client *c);
 
+/* Size in bytes of the underlying zstd streaming context (CCtx/DCtx) allocated
+ * for the client's compression state, or 0 if none exists. This memory is
+ * allocated by libzstd via libc malloc, not zmalloc, so it is not tracked by
+ * used_memory/zmalloc accounting. */
+size_t clientCompressionCtxMemoryUsage(struct client *c);
+
 /* Client-level compression API. These are the networking-facing wrappers that
  * apply the client's compressor around the client's connection.
  *

--- a/src/object.c
+++ b/src/object.c
@@ -1489,6 +1489,20 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
     mh->cluster_links = server.stat_cluster_links_memory;
     mem_total += mh->cluster_links;
 
+    /* Replication (de)compression contexts (zstd). These are allocated by
+     * libzstd via libc malloc, so they are not part of zmalloc_used_memory()
+     * and must NOT be added to mem_total, or dataset/dataset_perc would be
+     * miscalculated. Reported for visibility only. */
+    {
+        listNode *ln;
+        listIter li;
+        listRewind(server.clients, &li);
+        while ((ln = listNext(&li))) {
+            client *c = listNodeValue(ln);
+            mh->replication_compression_ctx += clientCompressionCtxMemoryUsage(c);
+        }
+    }
+
     mem = 0;
     if (server.aof_state != AOF_OFF) {
         mem += sdsZmallocSize(server.aof_buf);
@@ -1844,7 +1858,7 @@ NULL
     } else if (!strcasecmp(c->argv[1]->ptr,"stats") && c->argc == 2) {
         struct redisMemOverhead *mh = getMemoryOverheadData();
 
-        addReplyMapLen(c,36+mh->num_dbs);
+        addReplyMapLen(c,37+mh->num_dbs);
 
         addReplyBulkCString(c,"peak.allocated");
         addReplyLongLong(c,mh->peak_allocated);
@@ -1875,6 +1889,9 @@ NULL
 
         addReplyBulkCString(c,"cluster.links");
         addReplyLongLong(c,mh->cluster_links);
+
+        addReplyBulkCString(c,"replication.compression.ctx");
+        addReplyLongLong(c,mh->replication_compression_ctx);
 
         addReplyBulkCString(c,"aof.buffer");
         addReplyLongLong(c,mh->aof_buffer);

--- a/src/server.c
+++ b/src/server.c
@@ -6577,6 +6577,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "mem_cluster_slot_migration_input_buffer:%zu\r\n", mh->asm_import_input_buffer,
             "mem_cluster_slot_migration_input_buffer_peak:%zu\r\n", asmGetPeakSyncBufferSize(),
             "mem_cluster_links:%zu\r\n", mh->cluster_links,
+            "mem_replication_compression_ctx:%zu\r\n", mh->replication_compression_ctx,
             "mem_aof_buffer:%zu\r\n", mh->aof_buffer,
             "mem_allocator:%s\r\n", ZMALLOC_LIB,
             "mem_overhead_db_hashtable_rehashing:%zu\r\n", mh->overhead_db_hashtable_rehashing,

--- a/src/server.h
+++ b/src/server.h
@@ -1862,6 +1862,9 @@ struct redisMemOverhead {
     size_t clients_normal_shared;
     size_t clients_normal_unshared;
     size_t cluster_links;
+    size_t replication_compression_ctx; /* zstd (de)compression contexts. Not part of
+                                         * overhead_total: libzstd allocates them via
+                                         * libc malloc so they are not in used_memory. */
     size_t aof_buffer;
     size_t eval_caches;
     size_t functions_caches;

--- a/tests/integration/replication-buffer.tcl
+++ b/tests/integration/replication-buffer.tcl
@@ -389,3 +389,43 @@ test "Replica client-output-buffer size is limited to backlog_limit/16 when no r
 }
 }
 
+if {$::compression} {
+    start_server {tags {"repl external:skip"}} {
+        start_server {} {
+            r config set save ""
+
+            set replica [srv -1 client]
+            $replica replicaof [srv 0 host] [srv 0 port]
+            wait_for_sync $replica
+
+            test "mem_replication_compression_ctx reports zstd context memory" {
+                # zstd allocates the context workspace lazily, and small commands
+                # alone don't grow it past the initial few KB, so push large
+                # values too.
+                for {set i 0} {$i < 200} {incr i} {
+                    r set k$i v$i
+                }
+                set big [string repeat "y" 65536]
+                for {set i 0} {$i < 20} {incr i} {
+                    r set big$i $big
+                }
+                wait_for_ofs_sync r $replica
+
+                # At zstd level 1 the CStream workspace measures ~1.3MB once allocated.
+                wait_for_condition 50 100 {
+                    [s mem_replication_compression_ctx] >= 512*1024
+                } else {
+                    fail "master mem_replication_compression_ctx too low: [s mem_replication_compression_ctx]"
+                }
+
+                # The replica only holds a DStream, which is much smaller.
+                wait_for_condition 50 100 {
+                    [s -1 mem_replication_compression_ctx] > 0
+                } else {
+                    fail "replica mem_replication_compression_ctx not reported: [s -1 mem_replication_compression_ctx]"
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Follow-up to #15498, split out of #15499 per the discussion there.

## The problem

The zstd contexts backing replication compression are allocated by libzstd through libc malloc, so zmalloc never sees them and they don't appear in `used_memory`. They aren't small either. Measured with `ZSTD_sizeof_CStream()` once the workspace is actually allocated:

| level | context size per link |
|---|--:|
| 1 | 1.3 MB |
| 3 | 3.6 MB |
| 12 | 46.9 MB |
| 22 | 874 MB |

On a master with a single compressed replica at level 12 this reads as an unexplained gap between `used_memory` and RSS, which is easy to misdiagnose as fragmentation.

## The fix

`clientCompressionCtxMemoryUsage()` queries the live size through `ZSTD_sizeof_CStream()` / `ZSTD_sizeof_DStream()`, and the sum over all clients is exposed as `mem_replication_compression_ctx` in `INFO memory` and `replication.compression.ctx` in `MEMORY STATS`.

Two things worth calling out:

**It is deliberately excluded from `mem_total`.** `overhead_total` feeds `dataset = zmalloc_used - mem_total`, so adding memory that isn't in `used_memory` would push `dataset` to 0 on any instance whose dataset is smaller than the contexts, and skew `dataset_perc` with it. Reporting it as its own field keeps the existing accounting intact.

**`ZSTD_sizeof_*` rather than `ZSTD_create*_advanced()` with a zmalloc-backed `customMem`.** The latter would put the contexts under `used_memory` and `maxmemory` properly, but those creators are `ZSTDLIB_STATIC_API` and zstd.h says that tier must never be used with a dynamically-linked libzstd, which is how we link it. That route needs a static-linking decision first; `ZSTD_sizeof_*` are stable `ZSTDLIB_API` and safe as we build today.

## Testing

New test in `replication-buffer.tcl` under the `--compression` run mode. It fails before the fix (field absent) and passes with it:

```
[ok]: mem_replication_compression_ctx reports zstd context memory (38 ms)
```

`./runtest --single integration/replication-buffer` passes both with `--compression --config repl-compression 1 --config io-threads 4` and in the default build.

End-to-end against a live master/replica pair, level 1, after pushing large-value traffic:

```
master   mem_replication_compression_ctx:1369625
replica  mem_replication_compression_ctx:1013552
```

The master figure was stable across repeated samples. The workspace grows with the data actually compressed — small commands alone leave it at ~26KB, which is why the test pushes large values before asserting.

`dataset` stays intact with the contexts reported, as intended:

```
used_memory:2157216
overhead.total:1730879
dataset.bytes:450865
mem_replication_compression_ctx:26460
```

`MEMORY STATS` parses correctly under both RESP2 and RESP3 with the added field. Compiles clean with and without `BUILD_COMPRESSION=yes`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only observability over existing compression state; no change to replication, accounting totals, or maxmemory behavior.
> 
> **Overview**
> Adds **visibility** for libzstd replication compress/decompress stream memory that sits outside `used_memory` because libzstd allocates via libc `malloc`.
> 
> Introduces `clientCompressionCtxMemoryUsage()` (using `ZSTD_sizeof_CStream` / `ZSTD_sizeof_DStream`, with a no-op stub when compression is disabled). The sum over all clients is exposed as **`mem_replication_compression_ctx`** in `INFO memory` and **`replication.compression.ctx`** in `MEMORY STATS`. That total is **not** folded into `overhead_total` / `mem_total`, so **`dataset`** and **`dataset_perc`** stay unchanged.
> 
> Includes an integration test under `--compression` that drives replication with large values and asserts the new metrics are non-trivial on master and replica.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526fb5e1224aa2f3c3863336f64452a67c4e0a3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->