### PR TITLE
Handle active-defrag thresholds where upper <= lower

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -2604,7 +2604,9 @@ rdb-save-incremental-fsync yes
 # Minimum amount of fragmentation waste to start active defrag
 # active-defrag-ignore-bytes 100mb
 
-# Minimum percentage of fragmentation to start active defrag
+# Minimum percentage of fragmentation to start active defrag.
+# This value should be less than active-defrag-threshold-upper. Otherwise,
+# active defrag will use the maximum CPU effort once this threshold is reached.
 # active-defrag-threshold-lower 10
 
 # Maximum percentage of fragmentation at which we use maximum effort

--- a/src/config.c
+++ b/src/config.c
@@ -2554,7 +2554,6 @@ static int isValidArraySparseKmin(long long val, const char **err) {
     return 1;
 }
 
-/* Validate active-defrag-threshold-lower: must be < upper */
 static int isValidActiveDefragThresholdLower(long long val, const char **err) {
     if (val >= server.active_defrag_threshold_upper) {
         *err = "active-defrag-threshold-lower must be less than active-defrag-threshold-upper";
@@ -2563,7 +2562,6 @@ static int isValidActiveDefragThresholdLower(long long val, const char **err) {
     return 1;
 }
 
-/* Validate active-defrag-threshold-upper: must be > lower */
 static int isValidActiveDefragThresholdUpper(long long val, const char **err) {
     if (val <= server.active_defrag_threshold_lower) {
         *err = "active-defrag-threshold-upper must be greater than active-defrag-threshold-lower";

--- a/src/config.c
+++ b/src/config.c
@@ -3343,7 +3343,7 @@ standardConfig static_configs[] = {
     createIntConfig("cluster-migration-barrier", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_migration_barrier, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("active-defrag-cycle-min", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_min, 1, INTEGER_CONFIG, NULL, updateDefragConfiguration), /* Default: 1% CPU min (at lower threshold) */
     createIntConfig("active-defrag-cycle-max", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_max, 25, INTEGER_CONFIG, NULL, updateDefragConfiguration), /* Default: 25% CPU max (at upper threshold) */
-    createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, INTEGER_CONFIG, isValidActiveDefragThresholdLower, updateDefragConfiguration), /* Default: don't defrag when fragmentation is below 10% */
+    createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, INTEGER_CONFIG, isValidActiveDefragThresholdLower, NULL), /* Default: don't defrag when fragmentation is below 10% */
     createIntConfig("active-defrag-threshold-upper", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_upper, 100, INTEGER_CONFIG, isValidActiveDefragThresholdUpper, updateDefragConfiguration), /* Default: maximum defrag force at 100% fragmentation */
     createIntConfig("lfu-log-factor", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_log_factor, 10, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("lfu-decay-time", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_decay_time, 1, INTEGER_CONFIG, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -2554,24 +2554,6 @@ static int isValidArraySparseKmin(long long val, const char **err) {
     return 1;
 }
 
-/* Keep accepting equal or reversed thresholds for backward compatibility.
- * These validators only log a warning; computeDefragCycles() handles them safely. */
-static int isValidActiveDefragThresholdLower(long long val, const char **err) {
-    UNUSED(err);
-    if (val >= server.active_defrag_threshold_upper) {
-        serverLog(LL_WARNING, "WARNING: active-defrag-threshold-lower should be less than active-defrag-threshold-upper");
-    }
-    return 1;
-}
-
-static int isValidActiveDefragThresholdUpper(long long val, const char **err) {
-    UNUSED(err);
-    if (val <= server.active_defrag_threshold_lower) {
-        serverLog(LL_WARNING, "WARNING: active-defrag-threshold-upper should be greater than active-defrag-threshold-lower");
-    }
-    return 1;
-}
-
 static int updateLocaleCollate(const char **err) {
     const char *s = setlocale(LC_COLLATE, server.locale_collate);
     if (s == NULL) {
@@ -3343,8 +3325,8 @@ standardConfig static_configs[] = {
     createIntConfig("cluster-migration-barrier", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_migration_barrier, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("active-defrag-cycle-min", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_min, 1, INTEGER_CONFIG, NULL, updateDefragConfiguration), /* Default: 1% CPU min (at lower threshold) */
     createIntConfig("active-defrag-cycle-max", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_max, 25, INTEGER_CONFIG, NULL, updateDefragConfiguration), /* Default: 25% CPU max (at upper threshold) */
-    createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, INTEGER_CONFIG, isValidActiveDefragThresholdLower, NULL), /* Default: don't defrag when fragmentation is below 10% */
-    createIntConfig("active-defrag-threshold-upper", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_upper, 100, INTEGER_CONFIG, isValidActiveDefragThresholdUpper, updateDefragConfiguration), /* Default: maximum defrag force at 100% fragmentation */
+    createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, INTEGER_CONFIG, NULL, NULL), /* Default: don't defrag when fragmentation is below 10% */
+    createIntConfig("active-defrag-threshold-upper", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_upper, 100, INTEGER_CONFIG, NULL, updateDefragConfiguration), /* Default: maximum defrag force at 100% fragmentation */
     createIntConfig("lfu-log-factor", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_log_factor, 10, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("lfu-decay-time", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_decay_time, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("replica-priority", "slave-priority", MODIFIABLE_CONFIG, 0, INT_MAX, server.slave_priority, 100, INTEGER_CONFIG, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -2554,18 +2554,20 @@ static int isValidArraySparseKmin(long long val, const char **err) {
     return 1;
 }
 
+/* Keep accepting equal or reversed thresholds for backward compatibility.
+ * These validators only log a warning; computeDefragCycles() handles them safely. */
 static int isValidActiveDefragThresholdLower(long long val, const char **err) {
+    UNUSED(err);
     if (val >= server.active_defrag_threshold_upper) {
-        *err = "active-defrag-threshold-lower must be less than active-defrag-threshold-upper";
-        return 0;
+        serverLog(LL_WARNING, "WARNING: active-defrag-threshold-lower should be less than active-defrag-threshold-upper");
     }
     return 1;
 }
 
 static int isValidActiveDefragThresholdUpper(long long val, const char **err) {
+    UNUSED(err);
     if (val <= server.active_defrag_threshold_lower) {
-        *err = "active-defrag-threshold-upper must be greater than active-defrag-threshold-lower";
-        return 0;
+        serverLog(LL_WARNING, "WARNING: active-defrag-threshold-upper should be greater than active-defrag-threshold-lower");
     }
     return 1;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -3343,7 +3343,7 @@ standardConfig static_configs[] = {
     createIntConfig("cluster-migration-barrier", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_migration_barrier, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("active-defrag-cycle-min", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_min, 1, INTEGER_CONFIG, NULL, updateDefragConfiguration), /* Default: 1% CPU min (at lower threshold) */
     createIntConfig("active-defrag-cycle-max", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_max, 25, INTEGER_CONFIG, NULL, updateDefragConfiguration), /* Default: 25% CPU max (at upper threshold) */
-    createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, INTEGER_CONFIG, isValidActiveDefragThresholdLower, NULL), /* Default: don't defrag when fragmentation is below 10% */
+    createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, INTEGER_CONFIG, isValidActiveDefragThresholdLower, updateDefragConfiguration), /* Default: don't defrag when fragmentation is below 10% */
     createIntConfig("active-defrag-threshold-upper", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_upper, 100, INTEGER_CONFIG, isValidActiveDefragThresholdUpper, updateDefragConfiguration), /* Default: maximum defrag force at 100% fragmentation */
     createIntConfig("lfu-log-factor", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_log_factor, 10, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("lfu-decay-time", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_decay_time, 1, INTEGER_CONFIG, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -2554,6 +2554,24 @@ static int isValidArraySparseKmin(long long val, const char **err) {
     return 1;
 }
 
+/* Validate active-defrag-threshold-lower: must be < upper */
+static int isValidActiveDefragThresholdLower(long long val, const char **err) {
+    if (val >= server.active_defrag_threshold_upper) {
+        *err = "active-defrag-threshold-lower must be less than active-defrag-threshold-upper";
+        return 0;
+    }
+    return 1;
+}
+
+/* Validate active-defrag-threshold-upper: must be > lower */
+static int isValidActiveDefragThresholdUpper(long long val, const char **err) {
+    if (val <= server.active_defrag_threshold_lower) {
+        *err = "active-defrag-threshold-upper must be greater than active-defrag-threshold-lower";
+        return 0;
+    }
+    return 1;
+}
+
 static int updateLocaleCollate(const char **err) {
     const char *s = setlocale(LC_COLLATE, server.locale_collate);
     if (s == NULL) {
@@ -3325,8 +3343,8 @@ standardConfig static_configs[] = {
     createIntConfig("cluster-migration-barrier", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_migration_barrier, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("active-defrag-cycle-min", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_min, 1, INTEGER_CONFIG, NULL, updateDefragConfiguration), /* Default: 1% CPU min (at lower threshold) */
     createIntConfig("active-defrag-cycle-max", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_max, 25, INTEGER_CONFIG, NULL, updateDefragConfiguration), /* Default: 25% CPU max (at upper threshold) */
-    createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, INTEGER_CONFIG, NULL, NULL), /* Default: don't defrag when fragmentation is below 10% */
-    createIntConfig("active-defrag-threshold-upper", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_upper, 100, INTEGER_CONFIG, NULL, updateDefragConfiguration), /* Default: maximum defrag force at 100% fragmentation */
+    createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, INTEGER_CONFIG, isValidActiveDefragThresholdLower, NULL), /* Default: don't defrag when fragmentation is below 10% */
+    createIntConfig("active-defrag-threshold-upper", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_upper, 100, INTEGER_CONFIG, isValidActiveDefragThresholdUpper, updateDefragConfiguration), /* Default: maximum defrag force at 100% fragmentation */
     createIntConfig("lfu-log-factor", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_log_factor, 10, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("lfu-decay-time", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_decay_time, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("replica-priority", "slave-priority", MODIFIABLE_CONFIG, 0, INT_MAX, server.slave_priority, 100, INTEGER_CONFIG, NULL, NULL),

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1471,10 +1471,12 @@ void computeDefragCycles(void) {
     /* Calculate the adaptive aggressiveness of the defrag based on the current
      * fragmentation and configurations. */
     int cpu_pct;
-    /* Equal or reversed thresholds are allowed for backward compatibility.
-     * Since there is no valid range to INTERPOLATE, use the minimum effort. */
+    /* If upper is not greater than lower, reaching the lower threshold also
+     * means reaching the upper threshold, so use the maximum effort. This may
+     * cause an immediate jump to maximum effort, but only for an invalid
+     * threshold configuration. */
     if (server.active_defrag_threshold_upper <= server.active_defrag_threshold_lower) {
-        cpu_pct = server.active_defrag_cycle_min;
+        cpu_pct = server.active_defrag_cycle_max;
     } else {
         cpu_pct = INTERPOLATE(frag_pct,
                 server.active_defrag_threshold_lower,

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1471,6 +1471,8 @@ void computeDefragCycles(void) {
     /* Calculate the adaptive aggressiveness of the defrag based on the current
      * fragmentation and configurations. */
     int cpu_pct;
+    /* Equal or reversed thresholds are allowed for backward compatibility.
+     * Since there is no valid range to INTERPOLATE, use the minimum effort. */
     if (server.active_defrag_threshold_upper <= server.active_defrag_threshold_lower) {
         cpu_pct = server.active_defrag_cycle_min;
     } else {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1470,11 +1470,16 @@ void computeDefragCycles(void) {
 
     /* Calculate the adaptive aggressiveness of the defrag based on the current
      * fragmentation and configurations. */
-    int cpu_pct = INTERPOLATE(frag_pct,
-            server.active_defrag_threshold_lower,
-            server.active_defrag_threshold_upper,
-            server.active_defrag_cycle_min,
-            server.active_defrag_cycle_max);
+    int cpu_pct;
+    if (server.active_defrag_threshold_upper <= server.active_defrag_threshold_lower) {
+        cpu_pct = server.active_defrag_cycle_min;
+    } else {
+        cpu_pct = INTERPOLATE(frag_pct,
+                server.active_defrag_threshold_lower,
+                server.active_defrag_threshold_upper,
+                server.active_defrag_cycle_min,
+                server.active_defrag_cycle_max);
+    }
     cpu_pct *= defrag.decay_rate;
     cpu_pct = LIMIT(cpu_pct,
             server.active_defrag_cycle_min,

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1471,11 +1471,11 @@ void computeDefragCycles(void) {
     /* Calculate the adaptive aggressiveness of the defrag based on the current
      * fragmentation and configurations. */
     int cpu_pct;
-    /* If upper is not greater than lower, reaching the lower threshold also
-     * means reaching the upper threshold, so use the maximum effort. This may
-     * cause an immediate jump to maximum effort, but only for an invalid
-     * threshold configuration. */
     if (server.active_defrag_threshold_upper <= server.active_defrag_threshold_lower) {
+        /* If upper is not greater than lower, reaching the lower threshold also
+         * means reaching the upper threshold, so use the maximum effort. This may
+         * cause an immediate jump to maximum effort, but only for an invalid
+         * threshold configuration. */
         cpu_pct = server.active_defrag_cycle_max;
     } else {
         cpu_pct = INTERPOLATE(frag_pct,

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -67,7 +67,11 @@ run_solo {defrag} {
             catch {r config set activedefrag yes}
 
             # The final PING verifies that the server stayed alive.
-            after 100
+            wait_for_condition 50 100 {
+                [s total_active_defrag_time] ne 0
+            } else {
+                fail "defrag not started."
+            }
             assert_equal PONG [r ping]
         }
     } {} {defrag external:skip tsan:skip standalone}

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -59,13 +59,11 @@ run_solo {defrag} {
             r config set hz 100
             r config set activedefrag no
             r config set active-defrag-ignore-bytes 1
-            # Catch the validation error so this UBSAN regression test can continue.
-            catch {r config set active-defrag-threshold-lower 20 active-defrag-threshold-upper 20}
+            r config set active-defrag-threshold-lower 20 active-defrag-threshold-upper 20
 
             # DEBUG_DEFRAG=force reports 99% fragmentation and SIZE_MAX
-            # fragmented bytes, guaranteeing that computeDefragCycles()
-            # reaches the interpolation with a zero denominator if the invalid
-            # thresholds above are accepted.
+            # fragmented bytes, guaranteeing that computeDefragCycles() handles
+            # the equal thresholds without reaching the interpolation.
             catch {r config set activedefrag yes}
 
             # The final PING verifies that the server stayed alive.

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -67,10 +67,12 @@ run_solo {defrag} {
             catch {r config set activedefrag yes}
 
             # The final PING verifies that the server stayed alive.
-            wait_for_condition 50 100 {
-                [s total_active_defrag_time] ne 0
-            } else {
-                fail "defrag not started."
+            if {[r config get activedefrag] eq "activedefrag yes"} {
+                wait_for_condition 50 100 {
+                    [s total_active_defrag_time] ne 0
+                } else {
+                    fail "defrag not started."
+                }
             }
             assert_equal PONG [r ping]
         }

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -53,31 +53,31 @@ start_server {tags {"memefficiency external:skip"}} {
     }
 }
 
-run_solo {defrag} {
-    test "Active defrag handles equal fragmentation thresholds" {
-        start_server {tags {"defrag"} overrides {save ""}} {
-            r config set hz 100
-            r config set activedefrag no
-            r config set active-defrag-ignore-bytes 1
-            r config set active-defrag-threshold-lower 1 active-defrag-threshold-upper 1
+test "Active defrag handles equal fragmentation thresholds" {
+    start_server {tags {"defrag"} overrides {save ""}} {
+        r config set hz 100
+        r config set activedefrag no
+        r config set active-defrag-ignore-bytes 1
+        r config set active-defrag-threshold-lower 1 active-defrag-threshold-upper 1
 
-            # DEBUG_DEFRAG=force reports 99% fragmentation and SIZE_MAX
-            # fragmented bytes, guaranteeing that computeDefragCycles() handles
-            # the equal thresholds without reaching the interpolation.
-            catch {r config set activedefrag yes}
+        # DEBUG_DEFRAG=force reports 99% fragmentation and SIZE_MAX
+        # fragmented bytes, guaranteeing that computeDefragCycles() handles
+        # the equal thresholds without reaching the interpolation.
+        catch {r config set activedefrag yes}
 
-            # The final PING verifies that the server stayed alive.
-            if {[r config get activedefrag] eq "activedefrag yes"} {
-                wait_for_condition 50 100 {
-                    [s total_active_defrag_time] ne 0
-                } else {
-                    fail "defrag not started."
-                }
+        # The final PING verifies that the server stayed alive.
+        if {[r config get activedefrag] eq "activedefrag yes"} {
+            wait_for_condition 50 100 {
+                [s total_active_defrag_time] ne 0
+            } else {
+                fail "defrag not started."
             }
-            assert_equal PONG [r ping]
         }
-    } {} {defrag external:skip tsan:skip standalone}
+        assert_equal PONG [r ping]
+    }
+} {} {defrag external:skip tsan:skip standalone}
 
+run_solo {defrag} {
     proc wait_for_defrag_stop {maxtries delay {expect_frag 0}} {
         wait_for_condition $maxtries $delay {
             [s active_defrag_running] eq 0 && ($expect_frag == 0 || [s allocator_frag_ratio] <= $expect_frag)

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -60,6 +60,8 @@ test "Active defrag handles equal fragmentation thresholds" {
         r config set active-defrag-ignore-bytes 1
         r config set active-defrag-threshold-lower 1 active-defrag-threshold-upper 1
 
+        r set defrag-test-key defrag-test-value
+
         # DEBUG_DEFRAG=force reports 99% fragmentation and SIZE_MAX
         # fragmented bytes, guaranteeing that computeDefragCycles() handles
         # the equal thresholds without reaching the interpolation.
@@ -68,7 +70,7 @@ test "Active defrag handles equal fragmentation thresholds" {
         # The final PING verifies that the server stayed alive.
         if {[r config get activedefrag] eq "activedefrag yes"} {
             wait_for_condition 50 100 {
-                [s total_active_defrag_time] ne 0
+                [s active_defrag_key_hits] + [s active_defrag_key_misses] > 0
             } else {
                 fail "defrag not started."
             }

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -59,7 +59,7 @@ run_solo {defrag} {
             r config set hz 100
             r config set activedefrag no
             r config set active-defrag-ignore-bytes 1
-            r config set active-defrag-threshold-lower 20 active-defrag-threshold-upper 20
+            r config set active-defrag-threshold-lower 1 active-defrag-threshold-upper 1
 
             # DEBUG_DEFRAG=force reports 99% fragmentation and SIZE_MAX
             # fragmented bytes, guaranteeing that computeDefragCycles() handles

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -54,6 +54,26 @@ start_server {tags {"memefficiency external:skip"}} {
 }
 
 run_solo {defrag} {
+    test "Active defrag handles equal fragmentation thresholds" {
+        start_server {tags {"defrag"} overrides {save ""}} {
+            r config set hz 100
+            r config set activedefrag no
+            r config set active-defrag-ignore-bytes 1
+            # Catch the validation error so this UBSAN regression test can continue.
+            catch {r config set active-defrag-threshold-lower 20 active-defrag-threshold-upper 20}
+
+            # DEBUG_DEFRAG=force reports 99% fragmentation and SIZE_MAX
+            # fragmented bytes, guaranteeing that computeDefragCycles()
+            # reaches the interpolation with a zero denominator if the invalid
+            # thresholds above are accepted.
+            r config set activedefrag yes
+
+            # The final PING verifies that the server stayed alive.
+            after 100
+            assert_equal PONG [r ping]
+        }
+    } {} {defrag external:skip tsan:skip standalone}
+
     proc wait_for_defrag_stop {maxtries delay {expect_frag 0}} {
         wait_for_condition $maxtries $delay {
             [s active_defrag_running] eq 0 && ($expect_frag == 0 || [s allocator_frag_ratio] <= $expect_frag)

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -60,7 +60,12 @@ test "Active defrag handles equal fragmentation thresholds" {
         r config set active-defrag-ignore-bytes 1
         r config set active-defrag-threshold-lower 1 active-defrag-threshold-upper 1
 
-        r set defrag-test-key defrag-test-value
+        # Leave allocated regions between freed regions so jemalloc reports
+        # fragmentation while retaining keys for active defrag to scan.
+        populate 1000 defrag-test-key 1024
+        for {set j 0} {$j < 1000} {incr j 2} {
+            r del defrag-test-key$j
+        }
 
         # DEBUG_DEFRAG=force reports 99% fragmentation and SIZE_MAX
         # fragmented bytes, guaranteeing that computeDefragCycles() handles

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -66,7 +66,7 @@ run_solo {defrag} {
             # fragmented bytes, guaranteeing that computeDefragCycles()
             # reaches the interpolation with a zero denominator if the invalid
             # thresholds above are accepted.
-            r config set activedefrag yes
+            catch {r config set activedefrag yes}
 
             # The final PING verifies that the server stayed alive.
             after 100


### PR DESCRIPTION

## Issue

`computeDefragCycles()` uses the difference between `active-defrag-threshold-upper` and `active-defrag-threshold-lower` as a divisor.

Equal thresholds cause a division-by-zero UBSAN error.

## Change

Allow equal or reversed thresholds for backward compatibility and log a warning.

When `active_defrag_threshold_upper <= active_defrag_threshold_lower`, `computeDefragCycles()` uses `active_defrag_cycle_max`. This avoids division by zero without rejecting existing configurations.

## Test

```sh
make SANITIZER=undefined DEBUG_DEFRAG=force             
./runtest --single unit/memefficiency --only "Active defrag handles equal fragmentation thresholds"
```

Before fix:
<img width="2242" height="862" alt="CleanShot 2026-07-22 at 19 03 42@2x" src="https://github.com/user-attachments/assets/18dc1618-1cdc-4137-b13b-a7136891e58b" />

After fix:
<img width="1644" height="626" alt="CleanShot 2026-07-22 at 19 05 49@2x" src="https://github.com/user-attachments/assets/fdbe39ca-2970-4cfc-86b8-03383254ffe0" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to defrag scheduling math with a targeted test; no auth, persistence, or replication impact.
> 
> **Overview**
> Fixes **undefined behavior** when `active-defrag-threshold-upper` is not greater than `active-defrag-threshold-lower`: `computeDefragCycles()` no longer runs `INTERPOLATE()` with a zero-width range (which triggered UBSAN division-by-zero).
> 
> When upper ≤ lower, defrag CPU effort is set directly to **`active-defrag-cycle-max`** instead of interpolating between thresholds, so misconfigured or equal thresholds still allow active defrag to run without crashing.
> 
> **`redis.conf`** comments now state that the lower threshold should stay below the upper one, and that equal/reversed settings imply maximum effort once the lower bound is hit.
> 
> Adds **`unit/memefficiency`** coverage that enables defrag with both thresholds at `1`, forces high fragmentation via `DEBUG_DEFRAG`, and asserts the server stays up and defrag activity occurs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a61043781a041a6743d97a64fe301bdcf6b1103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->