### PR TITLE
Add REDISMODULE_NODE_PORT_TLS flag to RM_GetClusterNodeInfo()

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -72,6 +72,10 @@ int getSlotOrReply(client *c, robj *o) {
     return (int) slot;
 }
 
+int clusterDefaultClientPortIsTLS(void) {
+    return server.tls_cluster;
+}
+
 ConnectionType *connTypeOfCluster(void) {
     if (server.tls_cluster) {
         return connectionTypeTls();

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -886,12 +886,12 @@ void clusterCommandMyShardId(client *c) {
  * a Lua script or RM_call, there is no connection in the fake client, so we use
  * server.current_client here to get the real client if available. And if it is not
  * available (modules may call commands without a real client), we return the default
- * info, which is determined by server.tls_cluster. */
+ * info, which is determined by clusterDefaultClientPortIsTLS(). */
 static int shouldReturnTlsInfo(void) {
     if (server.current_client && server.current_client->conn) {
         return connIsTLS(server.current_client->conn);
     } else {
-        return server.tls_cluster;
+        return clusterDefaultClientPortIsTLS();
     }
 }
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -120,6 +120,7 @@ void clusterCommandMyShardId(client *c);
 sds clusterGenNodeDescription(client *c, clusterNode *node, int tls_primary);
 
 int clusterNodeCoversSlot(clusterNode *n, int slot);
+int clusterDefaultClientPortIsTLS(void);
 int getNodeDefaultClientPort(clusterNode *n);
 int clusterNodeIsMyself(clusterNode *n);
 clusterNode *getMyClusterNode(void);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -100,10 +100,6 @@ void freeClusterLink(clusterLink *link);
 int verifyClusterNodeId(const char *name, int length);
 static void updateShardId(clusterNode *node, const char *shard_id);
 
-int clusterDefaultClientPortIsTLS(void) {
-    return server.tls_cluster;
-}
-
 int getNodeDefaultClientPort(clusterNode *n) {
     return clusterDefaultClientPortIsTLS() ? n->tls_port : n->tcp_port;
 }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -100,8 +100,12 @@ void freeClusterLink(clusterLink *link);
 int verifyClusterNodeId(const char *name, int length);
 static void updateShardId(clusterNode *node, const char *shard_id);
 
+int clusterDefaultClientPortIsTLS(void) {
+    return server.tls_cluster;
+}
+
 int getNodeDefaultClientPort(clusterNode *n) {
-    return server.tls_cluster ? n->tls_port : n->tcp_port;
+    return clusterDefaultClientPortIsTLS() ? n->tls_port : n->tcp_port;
 }
 
 static inline int getNodeDefaultReplicationPort(clusterNode *n) {
@@ -113,7 +117,7 @@ int clusterNodeClientPort(clusterNode *n, int use_tls) {
 }
 
 static inline int defaultClientPort(void) {
-    return server.tls_cluster ? server.tls_port : server.port;
+    return clusterDefaultClientPortIsTLS() ? server.tls_port : server.port;
 }
 
 #define isSlotUnclaimed(slot) \
@@ -497,7 +501,7 @@ int clusterLoadConfig(char *filename) {
         /* If neither TCP or TLS port is found in aux field, it is considered
          * an old version of nodes.conf file.*/
         if (!aux_tcp_port && !aux_tls_port) {
-            if (server.tls_cluster) {
+            if (clusterDefaultClientPortIsTLS()) {
                 n->tls_port = atoi(port);
             } else {
                 n->tcp_port = atoi(port);
@@ -2048,7 +2052,7 @@ int clusterStartHandshake(char *ip, int port, int cport) {
      * handshake. */
     n = createClusterNode(NULL,CLUSTER_NODE_HANDSHAKE|CLUSTER_NODE_MEET);
     memcpy(n->ip,norm_ip,sizeof(n->ip));
-    if (server.tls_cluster) {
+    if (clusterDefaultClientPortIsTLS()) {
         n->tls_port = port;
     } else {
         n->tcp_port = port;
@@ -2059,7 +2063,7 @@ int clusterStartHandshake(char *ip, int port, int cport) {
 }
 
 static void getClientPortFromClusterMsg(clusterMsg *hdr, int *tls_port, int *tcp_port) {
-    if (server.tls_cluster) {
+    if (clusterDefaultClientPortIsTLS()) {
         *tls_port = ntohs(hdr->port);
         *tcp_port = ntohs(hdr->pport);
     } else {
@@ -2069,7 +2073,7 @@ static void getClientPortFromClusterMsg(clusterMsg *hdr, int *tls_port, int *tcp
 }
 
 static void getClientPortFromGossip(clusterMsgDataGossip *g, int *tls_port, int *tcp_port) {
-    if (server.tls_cluster) {
+    if (clusterDefaultClientPortIsTLS()) {
         *tls_port = ntohs(g->port);
         *tcp_port = ntohs(g->pport);
     } else {
@@ -2208,8 +2212,8 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
                 !(flags & CLUSTER_NODE_NOADDR) &&
                 !(flags & (CLUSTER_NODE_FAIL|CLUSTER_NODE_PFAIL)) &&
                 (strcasecmp(node->ip,g->ip) ||
-                 node->tls_port != (server.tls_cluster ? ntohs(g->port) : ntohs(g->pport)) ||
-                 node->tcp_port != (server.tls_cluster ? ntohs(g->pport) : ntohs(g->port)) ||
+                 node->tls_port != msg_tls_port ||
+                 node->tcp_port != msg_tcp_port ||
                  node->cport != ntohs(g->cport)))
             {
                 if (node->link) freeClusterLink(node->link);
@@ -3683,7 +3687,7 @@ static void clusterBuildMessageHdr(clusterMsg *hdr, int type, size_t msglen) {
     memset(hdr->slaveof,0,CLUSTER_NAMELEN);
     if (myself->slaveof != NULL)
         memcpy(hdr->slaveof,myself->slaveof->name, CLUSTER_NAMELEN);
-    if (server.tls_cluster) {
+    if (clusterDefaultClientPortIsTLS()) {
         hdr->port = htons(announced_tls_port);
         hdr->pport = htons(announced_tcp_port);
     } else {
@@ -3723,7 +3727,7 @@ void clusterSetGossipEntry(clusterMsg *hdr, int i, clusterNode *n) {
     gossip->ping_sent = htonl(n->ping_sent/1000);
     gossip->pong_received = htonl(n->pong_received/1000);
     memcpy(gossip->ip,n->ip,sizeof(n->ip));
-    if (server.tls_cluster) {
+    if (clusterDefaultClientPortIsTLS()) {
         gossip->port = htons(n->tls_port);
         gossip->pport = htons(n->tcp_port);
     } else {

--- a/src/module.c
+++ b/src/module.c
@@ -10030,7 +10030,7 @@ int RM_GetClusterNodeInfo(RedisModuleCtx *ctx, const char *id, char *ip, char *m
         if (clusterNodeTimedOut(node)) *flags |= REDISMODULE_NODE_PFAIL;
         if (clusterNodeIsFailing(node)) *flags |= REDISMODULE_NODE_FAIL;
         if (clusterNodeIsNoFailover(node)) *flags |= REDISMODULE_NODE_NOFAILOVER;
-        if (server.tls_cluster) *flags |= REDISMODULE_NODE_PORT_TLS;
+        if (clusterDefaultClientPortIsTLS()) *flags |= REDISMODULE_NODE_PORT_TLS;
     }
     return REDISMODULE_OK;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -9996,6 +9996,7 @@ size_t RM_GetClusterSize(void) {
  * * REDISMODULE_NODE_PFAIL:        We see the node as failing
  * * REDISMODULE_NODE_FAIL:         The cluster agrees the node is failing
  * * REDISMODULE_NODE_NOFAILOVER:   The slave is configured to never failover
+ * * REDISMODULE_NODE_PORT_TLS:     The returned port is a TLS port
  */
 int RM_GetClusterNodeInfo(RedisModuleCtx *ctx, const char *id, char *ip, char *master_id, int *port, int *flags) {
     UNUSED(ctx);
@@ -10029,6 +10030,7 @@ int RM_GetClusterNodeInfo(RedisModuleCtx *ctx, const char *id, char *ip, char *m
         if (clusterNodeTimedOut(node)) *flags |= REDISMODULE_NODE_PFAIL;
         if (clusterNodeIsFailing(node)) *flags |= REDISMODULE_NODE_FAIL;
         if (clusterNodeIsNoFailover(node)) *flags |= REDISMODULE_NODE_NOFAILOVER;
+        if (server.tls_cluster) *flags |= REDISMODULE_NODE_PORT_TLS;
     }
     return REDISMODULE_OK;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -9996,7 +9996,7 @@ size_t RM_GetClusterSize(void) {
  * * REDISMODULE_NODE_PFAIL:        We see the node as failing
  * * REDISMODULE_NODE_FAIL:         The cluster agrees the node is failing
  * * REDISMODULE_NODE_NOFAILOVER:   The slave is configured to never failover
- * * REDISMODULE_NODE_PORT_TLS:     The returned port is a TLS port
+ * * REDISMODULE_NODE_PORT_TLS:     The returned port is a TLS port (added in Redis 8.12)
  */
 int RM_GetClusterNodeInfo(RedisModuleCtx *ctx, const char *id, char *ip, char *master_id, int *port, int *flags) {
     UNUSED(ctx);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -292,6 +292,7 @@ This flag should not be used directly by the module.
 #define REDISMODULE_NODE_PFAIL      (1<<3)
 #define REDISMODULE_NODE_FAIL       (1<<4)
 #define REDISMODULE_NODE_NOFAILOVER (1<<5)
+#define REDISMODULE_NODE_PORT_TLS   (1<<6)
 
 #define REDISMODULE_CLUSTER_FLAG_NONE 0
 #define REDISMODULE_CLUSTER_FLAG_NO_FAILOVER (1<<1)

--- a/tests/modules/basics.c
+++ b/tests/modules/basics.c
@@ -109,6 +109,25 @@ int TestGetResp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return REDISMODULE_OK;
 }
 
+int TestGetClusterNodeInfo(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+
+    if (argc != 1) return RedisModule_WrongArity(ctx);
+
+    int port, flags;
+    const char *id = RedisModule_GetMyClusterID();
+    if (id == NULL ||
+        RedisModule_GetClusterNodeInfo(ctx, id, NULL, NULL, &port, &flags) == REDISMODULE_ERR)
+    {
+        return RedisModule_ReplyWithError(ctx, "ERR cluster node info unavailable");
+    }
+
+    RedisModule_ReplyWithArray(ctx, 2);
+    RedisModule_ReplyWithLongLong(ctx, port);
+    RedisModule_ReplyWithLongLong(ctx, flags);
+    return REDISMODULE_OK;
+}
+
 int TestCallRespAutoMode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
@@ -1035,6 +1054,10 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     if (RedisModule_CreateCommand(ctx,"test.candebug",
         TestCanDebug,"readonly",1,1,1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"test.getclusternodeinfo",
+        TestGetClusterNodeInfo,"readonly",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     RedisModule_SubscribeToKeyspaceEvents(ctx,

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -224,6 +224,16 @@ start_cluster 3 0 [list tags {external:skip cluster modules} config_lines $modul
         assert_equal {PONG} [$node2 PING]
         assert_equal {PONG} [$node3 PING]
     }
+
+    test "RedisModule_GetClusterNodeInfo reports whether the returned port uses TLS" {
+        set info [$node1 test.getclusternodeinfo]
+        set port [lindex $info 0]
+        set flags [lindex $info 1]
+        set tls_port_flag [expr {1 << 6}]
+
+        assert_equal [srv 0 port] $port
+        assert_equal $::tls [expr {($flags & $tls_port_flag) != 0}]
+    }
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Add `REDISMODULE_NODE_PORT_TLS` to the flags returned by `RedisModule_GetClusterNodeInfo`.
- Set the flag when the returned client port is the node's TLS port.
- Document the new flag in the module API implementation.
- Add module API coverage that verifies both the returned port and flag in TCP and TLS test modes.

## Why

`RedisModule_GetClusterNodeInfo` returns the default client port selected by the cluster TLS configuration, but modules currently cannot determine whether that port expects TLS. Exposing this through the existing flags output lets modules connect to cluster nodes using the correct transport without changing the API signature.

## Validation

- `make BUILD_TLS=yes`
- `./runtest-moduleapi --single unit/moduleapi/cluster --baseport 31000` (full module API suite passed)
- `tclsh8.6 tests/test_helper.tcl --single unit/moduleapi/cluster --tls --baseport 32000` (focused TLS cluster module test passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a new module flag and a small refactor around existing TLS cluster port selection; no auth or data-path behavior change beyond clearer module metadata.
> 
> **Overview**
> Modules can now tell whether **`RedisModule_GetClusterNodeInfo`** returned a TLS or plain TCP client port via a new **`REDISMODULE_NODE_PORT_TLS`** flag (bit 6), without changing the API signature.
> 
> Cluster code centralizes the “default client port is TLS” decision in **`clusterDefaultClientPortIsTLS()`**, replacing scattered **`server.tls_cluster`** checks in port selection, gossip/bus encoding, and **`shouldReturnTlsInfo()`**. Gossip-driven node address updates now compare against parsed TLS/TCP ports from the message instead of re-deriving them inline.
> 
> Module API tests add **`test.getclusternodeinfo`** and a cluster TCL case that asserts the returned port matches the server and the TLS flag aligns with **`$::tls`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3752eed3ec133ad4453a350ebf33218e2bef935b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->