### PR TITLE
MOD-17163 Cluster: notify modules when node's own ip/port changes

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -86,6 +86,7 @@ void clusterCron(void);
 void clusterBeforeSleep(void);
 void clusterClaimUnassignedSlots(void);
 int verifyClusterConfigWithData(void);
+void clusterNotifyTopologyChange(uint64_t change_flags);
 
 int clusterSendModuleMessageToTarget(const char *target, uint64_t module_id, uint8_t type, const char *payload, uint32_t len);
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -852,13 +852,10 @@ void clusterUpdateMyselfFlags(void) {
 * The option can be set at runtime via CONFIG SET. */
 void clusterUpdateMyselfAnnouncedPorts(void) {
     if (!myself) return;
-    int old_tcp_port = myself->tcp_port;
-    int old_tls_port = myself->tls_port;
+    int old_client_port = getNodeDefaultClientPort(myself);
 
     deriveAnnouncedPorts(&myself->tcp_port,&myself->tls_port,&myself->cport);
-    if (myself->tcp_port != old_tcp_port ||
-        myself->tls_port != old_tls_port)
-    {
+    if (getNodeDefaultClientPort(myself) != old_client_port) {
         clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE);
     }
 }
@@ -2312,10 +2309,10 @@ int nodeUpdateAddressIfNeeded(clusterNode *node, clusterLink *link,
     if (node->tcp_port == tcp_port && node->cport == cport && node->tls_port == tls_port &&
         strcmp(ip,node->ip) == 0) return 0;
 
-    /* The cluster bus port is only used for internal node-to-node communication,
-     * so changing it alone is not a module-visible topology change. */
-    int topology_changed = node->tcp_port != tcp_port ||
-                           node->tls_port != tls_port ||
+    /* Inactive and cluster bus ports are not exposed by the module cluster
+     * APIs, so changing them alone is not a module-visible topology change. */
+    int topology_changed = getNodeDefaultClientPort(node) !=
+                           (server.tls_cluster ? tls_port : tcp_port) ||
                            strcmp(ip,node->ip) != 0;
 
     /* IP / port is different, update it. */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -852,10 +852,11 @@ void clusterUpdateMyselfFlags(void) {
 * The option can be set at runtime via CONFIG SET. */
 void clusterUpdateMyselfAnnouncedPorts(void) {
     if (!myself) return;
-    int old_client_port = getNodeDefaultClientPort(myself);
+    int old_tcp_port = myself->tcp_port;
+    int old_tls_port = myself->tls_port;
 
     deriveAnnouncedPorts(&myself->tcp_port,&myself->tls_port,&myself->cport);
-    if (getNodeDefaultClientPort(myself) != old_client_port) {
+    if (myself->tcp_port != old_tcp_port || myself->tls_port != old_tls_port) {
         clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE);
     }
 }
@@ -2309,10 +2310,11 @@ int nodeUpdateAddressIfNeeded(clusterNode *node, clusterLink *link,
     if (node->tcp_port == tcp_port && node->cport == cport && node->tls_port == tls_port &&
         strcmp(ip,node->ip) == 0) return 0;
 
-    /* Inactive and cluster bus ports are not exposed by the module cluster
-     * APIs, so changing them alone is not a module-visible topology change. */
-    int topology_changed = getNodeDefaultClientPort(node) !=
-                           (server.tls_cluster ? tls_port : tcp_port) ||
+    /* Both client ports are part of the announced node configuration and may
+     * be relevant to modules. The cluster bus port is internal, so changing it
+     * alone is not a module-visible topology change. */
+    int topology_changed = node->tcp_port != tcp_port ||
+                           node->tls_port != tls_port ||
                            strcmp(ip,node->ip) != 0;
 
     /* IP / port is different, update it. */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2312,6 +2312,12 @@ int nodeUpdateAddressIfNeeded(clusterNode *node, clusterLink *link,
     if (node->tcp_port == tcp_port && node->cport == cport && node->tls_port == tls_port &&
         strcmp(ip,node->ip) == 0) return 0;
 
+    /* The cluster bus port is only used for internal node-to-node communication,
+     * so changing it alone is not a module-visible topology change. */
+    int topology_changed = node->tcp_port != tcp_port ||
+                           node->tls_port != tls_port ||
+                           strcmp(ip,node->ip) != 0;
+
     /* IP / port is different, update it. */
     memcpy(node->ip,ip,sizeof(ip));
     node->tcp_port = tcp_port;
@@ -2327,8 +2333,8 @@ int nodeUpdateAddressIfNeeded(clusterNode *node, clusterLink *link,
     if (nodeIsSlave(myself) && myself->slaveof == node)
         replicationSetMaster(node->ip, getNodeDefaultReplicationPort(node));
 
-    /* A node moving to a different address is a topology change. */
-    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE);
+    if (topology_changed)
+        clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE);
     return 1;
 }
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -854,12 +854,10 @@ void clusterUpdateMyselfAnnouncedPorts(void) {
     if (!myself) return;
     int old_tcp_port = myself->tcp_port;
     int old_tls_port = myself->tls_port;
-    int old_cport = myself->cport;
 
     deriveAnnouncedPorts(&myself->tcp_port,&myself->tls_port,&myself->cport);
     if (myself->tcp_port != old_tcp_port ||
-        myself->tls_port != old_tls_port ||
-        myself->cport != old_cport)
+        myself->tls_port != old_tls_port)
     {
         clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE);
     }
@@ -5233,7 +5231,7 @@ void clusterCloseAllSlots(void) {
  * from the next clusterBeforeSleep(). Called by topology mutation paths and
  * config-driven endpoint updates. */
 void clusterNotifyTopologyChange(uint64_t change_flags) {
-    if (!server.cluster_enabled || !server.cluster) return;
+    if (!server.cluster_enabled) return;
     server.cluster->topology_change_flags |= change_flags;
     clusterDoBeforeSleep(CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE);
 }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -48,7 +48,6 @@ void clusterSendFail(char *nodename);
 void clusterSendFailoverAuthIfNeeded(clusterNode *node, clusterMsg *request);
 void clusterUpdateState(void);
 static void clusterFireTopologyChangeEventIfNeeded(void);
-static void clusterNotifyTopologyChange(uint64_t change_flags);
 int clusterNodeCoversSlot(clusterNode *n, int slot);
 list *clusterGetNodesInMyShard(clusterNode *node);
 int clusterNodeAddSlave(clusterNode *master, clusterNode *slave);
@@ -5221,7 +5220,8 @@ void clusterCloseAllSlots(void) {
  * REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_* bits) and request it to be fired
  * from the next clusterBeforeSleep(). Called from every slot/role mutation and
  * on the cluster's OK/FAIL transition. */
-static void clusterNotifyTopologyChange(uint64_t change_flags) {
+void clusterNotifyTopologyChange(uint64_t change_flags) {
+    if (!server.cluster_enabled || !server.cluster) return;
     server.cluster->topology_change_flags |= change_flags;
     clusterDoBeforeSleep(CLUSTER_TODO_FIRE_TOPOLOGY_CHANGE);
 }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -852,7 +852,17 @@ void clusterUpdateMyselfFlags(void) {
 * The option can be set at runtime via CONFIG SET. */
 void clusterUpdateMyselfAnnouncedPorts(void) {
     if (!myself) return;
+    int old_tcp_port = myself->tcp_port;
+    int old_tls_port = myself->tls_port;
+    int old_cport = myself->cport;
+
     deriveAnnouncedPorts(&myself->tcp_port,&myself->tls_port,&myself->cport);
+    if (myself->tcp_port != old_tcp_port ||
+        myself->tls_port != old_tls_port ||
+        myself->cport != old_cport)
+    {
+        clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE);
+    }
 }
 
 /* We want to take myself->ip in sync with the cluster-announce-ip option.
@@ -880,6 +890,7 @@ void clusterUpdateMyselfIp(void) {
         } else {
             myself->ip[0] = '\0'; /* Force autodetection. */
         }
+        clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE);
     }
 }
 
@@ -898,6 +909,7 @@ static void updateAnnouncedHostname(clusterNode *node, char *new) {
         sdsclear(node->hostname);
     }
     clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
+    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE);
 }
 
 static void updateAnnouncedHumanNodename(clusterNode *node, char *new) {
@@ -5218,8 +5230,8 @@ void clusterCloseAllSlots(void) {
 
 /* Record a pending RedisModuleEvent_ClusterTopologyChange (the change_flags are
  * REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_* bits) and request it to be fired
- * from the next clusterBeforeSleep(). Called from every slot/role mutation and
- * on the cluster's OK/FAIL transition. */
+ * from the next clusterBeforeSleep(). Called by topology mutation paths and
+ * config-driven endpoint updates. */
 void clusterNotifyTopologyChange(uint64_t change_flags) {
     if (!server.cluster_enabled || !server.cluster) return;
     server.cluster->topology_change_flags |= change_flags;

--- a/src/config.c
+++ b/src/config.c
@@ -2808,6 +2808,16 @@ static int applyTlsCfg(const char **err) {
     return 1;
 }
 
+static int applyTlsCluster(const char **err) {
+    if (!applyTlsCfg(err)) return 0;
+
+    /* tls-cluster selects which client port is advertised by the cluster.
+     * Modules cache that topology through the cluster module APIs, so notify
+     * them when the preferred port changes. */
+    clusterNotifyTopologyChange(REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE);
+    return 1;
+}
+
 static int applyTLSPort(const char **err) {
     ConnectionType *ct_tls = connectionTypeTls();
     /* Refuse if no TLS support compiled in */
@@ -3432,7 +3442,7 @@ standardConfig static_configs[] = {
     createIntConfig("tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.tls_port, 0, INTEGER_CONFIG, NULL, applyTLSPort), /* TCP port. */
     createIntConfig("tls-session-cache-size", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_size, 20*1024, INTEGER_CONFIG, NULL, applyTlsCfg),
     createIntConfig("tls-session-cache-timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_timeout, 300, INTEGER_CONFIG, NULL, applyTlsCfg),
-    createBoolConfig("tls-cluster", NULL, MODIFIABLE_CONFIG, server.tls_cluster, 0, NULL, applyTlsCfg),
+    createBoolConfig("tls-cluster", NULL, MODIFIABLE_CONFIG, server.tls_cluster, 0, NULL, applyTlsCluster),
     createBoolConfig("tls-replication", NULL, MODIFIABLE_CONFIG, server.tls_replication, 0, NULL, applyTlsCfg),
     createEnumConfig("tls-auth-clients", NULL, MODIFIABLE_CONFIG, tls_auth_clients_enum, server.tls_auth_clients, TLS_CLIENT_AUTH_YES, NULL, NULL),
     createEnumConfig("tls-auth-clients-user", NULL, MODIFIABLE_CONFIG, tls_client_auth_user_enum, server.tls_ctx_config.client_auth_user, TLS_CLIENT_FIELD_OFF, NULL, NULL),

--- a/src/module.c
+++ b/src/module.c
@@ -12978,7 +12978,7 @@ static uint64_t moduleEventVersions[] = {
  *         first becoming ready at startup).
  *     * `REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE`:
  *         A node joined or left the cluster, or an existing node's address
- *         (ip/port) changed.
+ *         (IP, hostname, or port) changed.
  *
  *     More than one bit may be set. Beyond the change reasons, the module reads
  *     whatever else it needs about the new topology via the cluster info APIs

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -176,6 +176,28 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
     }
 }
 
+start_cluster 2 2 [list tags {external:skip cluster modules} config_lines [list loadmodule $testmodule cluster-node-timeout 3000]] {
+    test "ClusterTopologyChange does not report NODE when only a peer cluster bus port changes" {
+        if {$::tls} {
+            set baseport [lindex [R 0 config get tls-port] 1]
+        } else {
+            set baseport [lindex [R 0 config get port] 1]
+        }
+        set count [expr [llength $::servers] + 1]
+        set newbus [find_available_port $baseport $count]
+
+        set before [dict get [topo_stats 1] node]
+        R 0 config set cluster-announce-bus-port $newbus
+
+        wait_for_condition 50 100 {
+            [string match "*@$newbus *" [R 1 cluster nodes]]
+        } else {
+            fail "Cluster announced bus port was not propagated via gossip"
+        }
+        assert_equal $before [dict get [topo_stats 1] node]
+    }
+}
+
 if {$::tls} {
     start_cluster 1 0 [list tags {external:skip cluster modules tls} config_lines [list loadmodule $testmodule]] {
         test "ClusterTopologyChange reports the NODE reason when local announced endpoints change" {

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -184,7 +184,6 @@ if {$::tls} {
                 {cluster-announce-hostname node.example.test ""}
                 {cluster-announce-port 32001 0}
                 {cluster-announce-tls-port 32002 0}
-                {cluster-announce-bus-port 32003 0}
             } {
                 lassign $change config value default
 
@@ -204,6 +203,15 @@ if {$::tls} {
                     fail "NODE change reason was not reported after resetting $config"
                 }
             }
+        }
+
+        test "ClusterTopologyChange does not report NODE for local cluster bus port changes" {
+            set before [dict get [topo_stats 0] node]
+            R 0 config set cluster-announce-bus-port 32003
+            assert_equal $before [dict get [topo_stats 0] node]
+
+            R 0 config set cluster-announce-bus-port 0
+            assert_equal $before [dict get [topo_stats 0] node]
         }
 
         test "ClusterTopologyChange reports the NODE reason when tls-cluster changes the preferred port" {

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -175,3 +175,29 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
         }
     }
 }
+
+if {$::tls} {
+    start_cluster 1 0 [list tags {external:skip cluster modules tls} config_lines [list loadmodule $testmodule]] {
+        test "ClusterTopologyChange reports the NODE reason when tls-cluster changes the preferred port" {
+            set tls_port [lindex [R 0 config get tls-port] 1]
+            set tcp_port [lindex [R 0 config get port] 1]
+            assert {$tls_port != $tcp_port}
+
+            set before [dict get [topo_stats 0] node]
+            R 0 config set tls-cluster no
+            wait_for_condition 50 100 {
+                [dict get [topo_stats 0] node] > $before
+            } else {
+                fail "NODE change reason was not reported when tls-cluster was disabled"
+            }
+
+            set before [dict get [topo_stats 0] node]
+            R 0 config set tls-cluster yes
+            wait_for_condition 50 100 {
+                [dict get [topo_stats 0] node] > $before
+            } else {
+                fail "NODE change reason was not reported when tls-cluster was enabled"
+            }
+        }
+    }
+}

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -13,8 +13,8 @@ proc topo_stats {node} {
 }
 
 # Returns whether node_id's persisted cluster entry contains the given port.
-# Persisting the config lets tests verify that an inactive TCP/TLS port was
-# learned even though module APIs intentionally hide it.
+# Persisting the config lets tests verify that an announced TCP/TLS port was
+# learned even when it is not the cluster's preferred client port.
 proc cluster_config_has_port {node node_id field port} {
     R $node cluster saveconfig
     set dir [lindex [R $node config get dir] 1]
@@ -221,52 +221,49 @@ start_cluster 2 2 [list tags {external:skip cluster modules} config_lines [list 
         assert_equal $before [dict get [topo_stats 1] node]
     }
 
-    test "ClusterTopologyChange does not report NODE when an inactive peer port changes" {
+    test "ClusterTopologyChange reports NODE when peer client ports change" {
         set node_id [R 0 cluster myid]
-        if {[lindex [R 0 config get tls-cluster] 1] eq "yes"} {
-            set config cluster-announce-port
-            set aux_field tcp-port
-            set default_port [lindex [R 0 config get port] 1]
-        } else {
-            set config cluster-announce-tls-port
-            set aux_field tls-port
-            set default_port [lindex [R 0 config get tls-port] 1]
-        }
-        set newport 32004
+        foreach change {
+            {cluster-announce-port tcp-port port 32004}
+            {cluster-announce-tls-port tls-port tls-port 32005}
+        } {
+            lassign $change config field default_config newport
+            set default_port [lindex [R 0 config get $default_config] 1]
 
-        set local_before [dict get [topo_stats 0] node]
-        set peer_before [dict get [topo_stats 1] node]
-        R 0 config set $config $newport
+            set local_before [dict get [topo_stats 0] node]
+            set peer_before [dict get [topo_stats 1] node]
+            R 0 config set $config $newport
 
-        wait_for_condition 50 100 {
-            [cluster_config_has_port 1 $node_id $aux_field $newport]
-        } else {
-            fail "Inactive announced port was not propagated via gossip"
-        }
-        assert_equal $peer_before [dict get [topo_stats 1] node]
-        assert_equal $local_before [dict get [topo_stats 0] node]
+            wait_for_condition 50 100 {
+                [cluster_config_has_port 1 $node_id $field $newport] &&
+                [dict get [topo_stats 1] node] > $peer_before
+            } else {
+                fail "NODE change reason was not reported after changing peer $config"
+            }
+            assert {[dict get [topo_stats 0] node] > $local_before}
 
-        R 0 config set $config 0
-        assert_equal $local_before [dict get [topo_stats 0] node]
-        wait_for_condition 50 100 {
-            [cluster_config_has_port 1 $node_id $aux_field $default_port]
-        } else {
-            fail "Reset inactive announced port was not propagated via gossip"
+            set local_before [dict get [topo_stats 0] node]
+            set peer_before [dict get [topo_stats 1] node]
+            R 0 config set $config 0
+
+            wait_for_condition 50 100 {
+                [cluster_config_has_port 1 $node_id $field $default_port] &&
+                [dict get [topo_stats 1] node] > $peer_before
+            } else {
+                fail "NODE change reason was not reported after resetting peer $config"
+            }
+            assert {[dict get [topo_stats 0] node] > $local_before}
         }
-        assert_equal $peer_before [dict get [topo_stats 1] node]
     }
 }
 
 start_cluster 1 0 [list tags {external:skip cluster modules} config_lines [list loadmodule $testmodule]] {
     test "ClusterTopologyChange reports the NODE reason when local announced endpoints change" {
-        if {[lindex [R 0 config get tls-cluster] 1] eq "yes"} {
-            set active_port_config cluster-announce-tls-port
-        } else {
-            set active_port_config cluster-announce-port
-        }
         foreach change {
             {cluster-announce-ip 127.0.0.2 ""}
             {cluster-announce-hostname node.example.test ""}
+            {cluster-announce-port 32001 0}
+            {cluster-announce-tls-port 32002 0}
         } {
             lassign $change config value default
 
@@ -286,37 +283,6 @@ start_cluster 1 0 [list tags {external:skip cluster modules} config_lines [list 
                 fail "NODE change reason was not reported after resetting $config"
             }
         }
-
-        set before [dict get [topo_stats 0] node]
-        R 0 config set $active_port_config 32001
-        wait_for_condition 50 100 {
-            [dict get [topo_stats 0] node] > $before
-        } else {
-            fail "NODE change reason was not reported after changing $active_port_config"
-        }
-
-        set before [dict get [topo_stats 0] node]
-        R 0 config set $active_port_config 0
-        wait_for_condition 50 100 {
-            [dict get [topo_stats 0] node] > $before
-        } else {
-            fail "NODE change reason was not reported after resetting $active_port_config"
-        }
-    }
-
-    test "ClusterTopologyChange does not report NODE for an inactive local port change" {
-        if {[lindex [R 0 config get tls-cluster] 1] eq "yes"} {
-            set inactive_port_config cluster-announce-port
-        } else {
-            set inactive_port_config cluster-announce-tls-port
-        }
-
-        set before [dict get [topo_stats 0] node]
-        R 0 config set $inactive_port_config 32002
-        assert_equal $before [dict get [topo_stats 0] node]
-
-        R 0 config set $inactive_port_config 0
-        assert_equal $before [dict get [topo_stats 0] node]
     }
 
     test "ClusterTopologyChange does not report NODE for local cluster bus port changes" {

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -178,6 +178,34 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
 
 if {$::tls} {
     start_cluster 1 0 [list tags {external:skip cluster modules tls} config_lines [list loadmodule $testmodule]] {
+        test "ClusterTopologyChange reports the NODE reason when local announced endpoints change" {
+            foreach change {
+                {cluster-announce-ip 127.0.0.2 ""}
+                {cluster-announce-hostname node.example.test ""}
+                {cluster-announce-port 32001 0}
+                {cluster-announce-tls-port 32002 0}
+                {cluster-announce-bus-port 32003 0}
+            } {
+                lassign $change config value default
+
+                set before [dict get [topo_stats 0] node]
+                R 0 config set $config $value
+                wait_for_condition 50 100 {
+                    [dict get [topo_stats 0] node] > $before
+                } else {
+                    fail "NODE change reason was not reported after changing $config"
+                }
+
+                set before [dict get [topo_stats 0] node]
+                R 0 config set $config $default
+                wait_for_condition 50 100 {
+                    [dict get [topo_stats 0] node] > $before
+                } else {
+                    fail "NODE change reason was not reported after resetting $config"
+                }
+            }
+        }
+
         test "ClusterTopologyChange reports the NODE reason when tls-cluster changes the preferred port" {
             set tls_port [lindex [R 0 config get tls-port] 1]
             set tcp_port [lindex [R 0 config get port] 1]

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -12,6 +12,30 @@ proc topo_stats {node} {
     R $node cluster_topology.stats
 }
 
+# Returns whether node_id's persisted cluster entry contains the given port.
+# Persisting the config lets tests verify that an inactive TCP/TLS port was
+# learned even though module APIs intentionally hide it.
+proc cluster_config_has_port {node node_id field port} {
+    R $node cluster saveconfig
+    set dir [lindex [R $node config get dir] 1]
+    set filename [lindex [R $node config get cluster-config-file] 1]
+    set fd [open [file join $dir $filename] r]
+    set contents [read $fd]
+    close $fd
+
+    foreach line [split $contents "\n"] {
+        if {[string match "$node_id *" $line]} {
+            # nodes.conf keeps TCP in the main address field for backward
+            # compatibility and stores TLS as an auxiliary field.
+            if {$field eq "tcp-port"} {
+                return [string match "$node_id *:$port@*" $line]
+            }
+            return [expr {[string first ",$field=$port" $line] != -1}]
+        }
+    }
+    return 0
+}
+
 start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list loadmodule $testmodule cluster-node-timeout 3000]] {
     test "ClusterTopologyChange notifies modules once the cluster becomes ready" {
         # cluster_setup has already waited for the cluster to be OK on every node.
@@ -196,46 +220,115 @@ start_cluster 2 2 [list tags {external:skip cluster modules} config_lines [list 
         }
         assert_equal $before [dict get [topo_stats 1] node]
     }
+
+    test "ClusterTopologyChange does not report NODE when an inactive peer port changes" {
+        set node_id [R 0 cluster myid]
+        if {[lindex [R 0 config get tls-cluster] 1] eq "yes"} {
+            set config cluster-announce-port
+            set aux_field tcp-port
+            set default_port [lindex [R 0 config get port] 1]
+        } else {
+            set config cluster-announce-tls-port
+            set aux_field tls-port
+            set default_port [lindex [R 0 config get tls-port] 1]
+        }
+        set newport 32004
+
+        set local_before [dict get [topo_stats 0] node]
+        set peer_before [dict get [topo_stats 1] node]
+        R 0 config set $config $newport
+
+        wait_for_condition 50 100 {
+            [cluster_config_has_port 1 $node_id $aux_field $newport]
+        } else {
+            fail "Inactive announced port was not propagated via gossip"
+        }
+        assert_equal $peer_before [dict get [topo_stats 1] node]
+        assert_equal $local_before [dict get [topo_stats 0] node]
+
+        R 0 config set $config 0
+        assert_equal $local_before [dict get [topo_stats 0] node]
+        wait_for_condition 50 100 {
+            [cluster_config_has_port 1 $node_id $aux_field $default_port]
+        } else {
+            fail "Reset inactive announced port was not propagated via gossip"
+        }
+        assert_equal $peer_before [dict get [topo_stats 1] node]
+    }
 }
 
-if {$::tls} {
-    start_cluster 1 0 [list tags {external:skip cluster modules tls} config_lines [list loadmodule $testmodule]] {
-        test "ClusterTopologyChange reports the NODE reason when local announced endpoints change" {
-            foreach change {
-                {cluster-announce-ip 127.0.0.2 ""}
-                {cluster-announce-hostname node.example.test ""}
-                {cluster-announce-port 32001 0}
-                {cluster-announce-tls-port 32002 0}
-            } {
-                lassign $change config value default
+start_cluster 1 0 [list tags {external:skip cluster modules} config_lines [list loadmodule $testmodule]] {
+    test "ClusterTopologyChange reports the NODE reason when local announced endpoints change" {
+        if {[lindex [R 0 config get tls-cluster] 1] eq "yes"} {
+            set active_port_config cluster-announce-tls-port
+        } else {
+            set active_port_config cluster-announce-port
+        }
+        foreach change {
+            {cluster-announce-ip 127.0.0.2 ""}
+            {cluster-announce-hostname node.example.test ""}
+        } {
+            lassign $change config value default
 
-                set before [dict get [topo_stats 0] node]
-                R 0 config set $config $value
-                wait_for_condition 50 100 {
-                    [dict get [topo_stats 0] node] > $before
-                } else {
-                    fail "NODE change reason was not reported after changing $config"
-                }
+            set before [dict get [topo_stats 0] node]
+            R 0 config set $config $value
+            wait_for_condition 50 100 {
+                [dict get [topo_stats 0] node] > $before
+            } else {
+                fail "NODE change reason was not reported after changing $config"
+            }
 
-                set before [dict get [topo_stats 0] node]
-                R 0 config set $config $default
-                wait_for_condition 50 100 {
-                    [dict get [topo_stats 0] node] > $before
-                } else {
-                    fail "NODE change reason was not reported after resetting $config"
-                }
+            set before [dict get [topo_stats 0] node]
+            R 0 config set $config $default
+            wait_for_condition 50 100 {
+                [dict get [topo_stats 0] node] > $before
+            } else {
+                fail "NODE change reason was not reported after resetting $config"
             }
         }
 
-        test "ClusterTopologyChange does not report NODE for local cluster bus port changes" {
-            set before [dict get [topo_stats 0] node]
-            R 0 config set cluster-announce-bus-port 32003
-            assert_equal $before [dict get [topo_stats 0] node]
-
-            R 0 config set cluster-announce-bus-port 0
-            assert_equal $before [dict get [topo_stats 0] node]
+        set before [dict get [topo_stats 0] node]
+        R 0 config set $active_port_config 32001
+        wait_for_condition 50 100 {
+            [dict get [topo_stats 0] node] > $before
+        } else {
+            fail "NODE change reason was not reported after changing $active_port_config"
         }
 
+        set before [dict get [topo_stats 0] node]
+        R 0 config set $active_port_config 0
+        wait_for_condition 50 100 {
+            [dict get [topo_stats 0] node] > $before
+        } else {
+            fail "NODE change reason was not reported after resetting $active_port_config"
+        }
+    }
+
+    test "ClusterTopologyChange does not report NODE for an inactive local port change" {
+        if {[lindex [R 0 config get tls-cluster] 1] eq "yes"} {
+            set inactive_port_config cluster-announce-port
+        } else {
+            set inactive_port_config cluster-announce-tls-port
+        }
+
+        set before [dict get [topo_stats 0] node]
+        R 0 config set $inactive_port_config 32002
+        assert_equal $before [dict get [topo_stats 0] node]
+
+        R 0 config set $inactive_port_config 0
+        assert_equal $before [dict get [topo_stats 0] node]
+    }
+
+    test "ClusterTopologyChange does not report NODE for local cluster bus port changes" {
+        set before [dict get [topo_stats 0] node]
+        R 0 config set cluster-announce-bus-port 32003
+        assert_equal $before [dict get [topo_stats 0] node]
+
+        R 0 config set cluster-announce-bus-port 0
+        assert_equal $before [dict get [topo_stats 0] node]
+    }
+
+    if {$::tls} {
         test "ClusterTopologyChange reports the NODE reason when tls-cluster changes the preferred port" {
             set tls_port [lindex [R 0 config get tls-port] 1]
             set tcp_port [lindex [R 0 config get port] 1]


### PR DESCRIPTION
## Summary

Notify modules via RM_ClusterTopologyChange() when node's own address/port changes 

- emit `RedisModuleEvent_ClusterTopologyChange` with the `NODE` reason after a successful `tls-cluster` change
- notify at the actual endpoint mutation sites when a node IP, hostname, or TCP/TLS client port changes
- notify when either announced TCP or TLS client port changes, even when it is not currently preferred
- exclude bus-port-only changes both locally and when learned from peer gossip
- add local and peer regressions in both TLS modes, including non-preferred client ports

## Why

Modules that cache cluster topology subscribe to `RedisModuleEvent_ClusterTopologyChange`. Runtime endpoint configuration currently updates the local node and module APIs immediately, but local modules may receive only the generic config event and keep stale topology until an unrelated cluster message arrives. A one-node cluster exposes the gap deterministically because there is no peer gossip.

The endpoint mutation paths cover:

- `tls-cluster`
- `cluster-announce-ip`
- `cluster-announce-hostname`
- `cluster-announce-port`
- `cluster-announce-tls-port`

They also naturally cover runtime `port` and `tls-port` changes that recalculate the same node fields. `cluster-announce-bus-port` is intentionally excluded because it is used for internal node communication, including when a peer learns a bus-port-only change through gossip. `cluster-announce-human-nodename` is excluded because it is a display label rather than a routing endpoint.

## Validation

- `make -j8 BUILD_TLS=yes`
- both-client-port A/B: against the active-only implementation, the updated tests failed for local and peer `cluster-announce-tls-port` changes; after the fix, both TCP and TLS port set/reset notifications pass in non-TLS and TLS modes\n- RedisTimeSeries endpoint regressions pass against the fixed Core binary: 3/3 non-TLS scenarios and 2/2 TLS scenarios
- local bus-port negative A/B: before excluding the bus port, its change incremented the NODE counter from 9 to 10; after the refinement, changing and resetting only `cluster-announce-bus-port` leaves the counter unchanged
- peer-gossip bus-port negative A/B: before filtering the existing peer path, node 1 learned the new bus port and its NODE counter incorrectly rose from 4 to 5; after the fix, the bus port propagates and the counter remains unchanged
- `tls-cluster yes -> no -> yes` passes
- RedisTimeSeries one-node regressions pass against the final branch for IP, hostname, TCP port, TLS port, and `tls-cluster` preferred-port transitions

Local macOS core test command:

`./runtest --tls --config tls-protocols TLSv1 --config tls-ciphers DEFAULT:@SECLEVEL=0 --single unit/cluster/cluster-topology-change`

The protocol override is only for the old Tcl-TLS bundled on the local runner.

Dependent RedisTimeSeries regression: https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2129

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when modules receive topology NODE events for runtime config and gossip; behavior is intentional but modules relying on the old semantics may need to refresh caches more often.
> 
> **Overview**
> Modules that cache cluster topology via `RedisModuleEvent_ClusterTopologyChange` now get the **NODE** reason when a node’s **public routing endpoint** changes at runtime, not only after slot/role changes or peer gossip.
> 
> **`clusterNotifyTopologyChange`** is exported and fires **NODE** when local **`cluster-announce-ip`**, hostname, or announced TCP/TLS ports actually change (including **`tls-cluster`** toggling the preferred client port). **`cluster-announce-bus-port`** and bus-only peer gossip updates are **excluded** so internal bus port changes do not look like client endpoint changes.
> 
> Docs clarify that **NODE** covers IP, hostname, and port. New cluster topology tests cover local/peer announce paths and negative cases for bus port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8be81e1c6f3d983dd81740f8cf6fbf9e78cd579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

