### PR TITLE
Update RedisBloom to v8.9.91

### DIFF
--- a/modules/modules.yaml
+++ b/modules/modules.yaml
@@ -64,7 +64,7 @@
 modules:
   - name: redisbloom
     repo: https://github.com/redisbloom/redisbloom
-    ref: v8.9.90
+    ref: v8.9.91
     target_module: redisbloom.so
     loadmodule: ./modules/redisbloom/redisbloom.so
   - name: redisearch


### PR DESCRIPTION
## Summary

Bumps the RedisBloom pin on `unstable` from `v8.9.90` to `v8.9.91`.

| Module | From | To |
|---|---|---|
| RedisBloom | `v8.9.90` | `v8.9.91` |

## RedisBloom changes ([v8.9.90...v8.9.91](https://github.com/RedisBloom/RedisBloom/compare/v8.9.90...v8.9.91))

- MOD-13409 — Harden RDB loading, including validation of crafted module payloads ([#1042](https://github.com/RedisBloom/RedisBloom/pull/1042))

## Test plan

- [x] Confirmed `v8.9.91` exists in RedisBloom
- [x] Validated `modules/modules.yaml` resolves RedisBloom to `v8.9.91`
- [ ] Redis core CI passes with the updated module pin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only version bump; risk is limited to RedisBloom module behavior at load time, with no Redis core code changes.
> 
> **Overview**
> Updates the bundled **RedisBloom** pin in `modules/modules.yaml` from `v8.9.90` to **`v8.9.91`**. Other module refs are unchanged.
> 
> The upstream release (**MOD-13409**) tightens **RDB load** handling and validates crafted module payloads, which is a security-oriented fix in the module binary rather than Redis core.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d4831c173cd0ec6cb7a22497325c7c1ac4ee41f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->