### PR TITLE
Update RedisBloom to v8.8.2

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.8.0
+MODULE_VERSION = v8.8.2
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 


### PR DESCRIPTION
## Summary

Bumps the RedisBloom pin on `8.8` from `v8.8.0` to `v8.8.2`.

| Module | From | To |
|---|---|---|
| RedisBloom | `v8.8.0` | `v8.8.2` |

## RedisBloom changes ([v8.8.0...v8.8.2](https://github.com/RedisBloom/RedisBloom/compare/v8.8.0...v8.8.2))

- MOD-13409 — Harden RDB loading, including validation of crafted module payloads ([#1044](https://github.com/RedisBloom/RedisBloom/pull/1044))

## Test plan

- [x] Confirmed `v8.8.2` exists in RedisBloom
- [x] Validated `modules/redisbloom/Makefile` pins `MODULE_VERSION` to `v8.8.2`
- [ ] Redis core CI passes with the updated module pin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Makefile version pin with no local logic changes; upstream change targets safer RDB deserialization, which is a security hardening rather than new surface area in this repo.
> 
> **Overview**
> Bumps the **RedisBloom** build pin from `v8.8.0` to **`v8.8.2`** in `modules/redisbloom/Makefile` (`MODULE_VERSION` only).
> 
> Upstream **v8.8.1–v8.8.2** includes **MOD-13409**: hardened **RDB loading** and validation of crafted module payloads ([#1044](https://github.com/RedisBloom/RedisBloom/pull/1044)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2c922a9e347aa5906289c42ace9ee797c7342b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->