### PR TITLE
Update RedisBloom to v8.6.5

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.6.2
+MODULE_VERSION = v8.6.5
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 


### PR DESCRIPTION
## Summary

Bumps the RedisBloom pin on `8.6` from `v8.6.2` to `v8.6.5`.

| Module | From | To |
|---|---|---|
| RedisBloom | `v8.6.2` | `v8.6.5` |

## RedisBloom changes ([v8.6.2...v8.6.5](https://github.com/RedisBloom/RedisBloom/compare/v8.6.2...v8.6.5))

- MOD-16050 — Replicate `CF.LOADCHUNK` data chunks to prevent silent Cuckoo Filter data loss on failover ([#1021](https://github.com/RedisBloom/RedisBloom/pull/1021))
- MOD-13409 — Harden RDB loading, including validation of crafted module payloads ([#1046](https://github.com/RedisBloom/RedisBloom/pull/1046))

## Test plan

- [x] Confirmed `v8.6.5` exists in RedisBloom
- [x] Validated `modules/redisbloom/Makefile` pins `MODULE_VERSION` to `v8.6.5`
- [ ] Redis core CI passes with the updated module pin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upstream changes affect replication and persistence loading for Bloom/Cuckoo data; risk is confined to the version pin but runtime behavior shifts on upgrade.
> 
> **Overview**
> **Bumps the RedisBloom build pin** from `v8.6.2` to `v8.6.5` in `modules/redisbloom/Makefile` (`MODULE_VERSION` only).
> 
> That upstream release brings **replication for `CF.LOADCHUNK`** so Cuckoo Filter chunks aren’t lost on failover, plus **stricter RDB load validation** for crafted module payloads. No other files in this repo change—consumers get the new `.so` when rebuilt against this pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3b8bc5313ae85c85c145a131e65eaa16e1cc43b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->