### PR TITLE
Update RedisBloom to v8.4.8

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.4.5
+MODULE_VERSION = v8.4.8
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 


### PR DESCRIPTION
## Summary

Bumps the RedisBloom pin on `8.4` from `v8.4.5` to `v8.4.8`.

| Module | From | To |
|---|---|---|
| RedisBloom | `v8.4.5` | `v8.4.8` |

## RedisBloom changes ([v8.4.5...v8.4.8](https://github.com/RedisBloom/RedisBloom/compare/v8.4.5...v8.4.8))

- MOD-16050 — Replicate `CF.LOADCHUNK` data chunks to prevent silent Cuckoo Filter data loss on failover ([#1020](https://github.com/RedisBloom/RedisBloom/pull/1020))
- MOD-13409 — Harden RDB loading, including validation of crafted module payloads ([#1039](https://github.com/RedisBloom/RedisBloom/pull/1039))

## Test plan

- [x] Confirmed `v8.4.8` exists in RedisBloom
- [x] Validated `modules/redisbloom/Makefile` pins `MODULE_VERSION` to `v8.4.8`
- [ ] Redis core CI passes with the updated module pin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Module upgrade touches replication and persistence parsing; failures could affect Bloom/Cuckoo data durability or availability on load, though scope is limited to the RedisBloom pin.
> 
> **Overview**
> Bumps the RedisBloom build pin from **v8.4.5** to **v8.4.8** by updating `MODULE_VERSION` in `modules/redisbloom/Makefile`, so `get_source` clones and builds the newer upstream tag.
> 
> That range pulls in upstream fixes for **Cuckoo Filter replication** (`CF.LOADCHUNK` chunks replicated to avoid data loss on failover) and **stricter RDB load validation** for crafted module payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f168a96ee97bf52ca928bbab34c28a13e0d596a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->