### PR TITLE
Update RedisBloom to v8.2.15

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.2.12
+MODULE_VERSION = v8.2.15
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 


### PR DESCRIPTION
## Summary

Bumps the RedisBloom pin on `8.2` from `v8.2.12` to `v8.2.15`.

| Module | From | To |
|---|---|---|
| RedisBloom | `v8.2.12` | `v8.2.15` |

## RedisBloom changes ([v8.2.12...v8.2.15](https://github.com/RedisBloom/RedisBloom/compare/v8.2.12...v8.2.15))

- MOD-16050 — Replicate `CF.LOADCHUNK` data chunks to prevent silent Cuckoo Filter data loss on failover ([#1019](https://github.com/RedisBloom/RedisBloom/pull/1019))
- MOD-13409 — Harden RDB loading, including validation of crafted module payloads ([#1041](https://github.com/RedisBloom/RedisBloom/pull/1041))

## Test plan

- [x] Confirmed `v8.2.15` exists in RedisBloom
- [x] Validated `modules/redisbloom/Makefile` pins `MODULE_VERSION` to `v8.2.15`
- [ ] Redis core CI passes with the updated module pin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upstream changes affect replication and persistence loading for Bloom/Cuckoo data; risk is moderate but bounded to the RedisBloom module pin, not core Redis.
> 
> **Overview**
> Bumps the RedisBloom build pin from **v8.2.12** to **v8.2.15** via `MODULE_VERSION` in `modules/redisbloom/Makefile`, so CI and packaging pull the newer upstream release.
> 
> That release includes replication fixes for **`CF.LOADCHUNK`** (avoiding Cuckoo Filter data loss on failover) and **stricter RDB load validation** for crafted module payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a95ebed62695eb2958f03fec5f762f630330c589. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->