### PR TITLE
Close socket when blocking connect wait fails

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -350,6 +350,7 @@ static int connSocketBlockingConnect(connection *conn, const char *addr, int por
     }
 
     if ((aeWait(fd, AE_WRITABLE, timeout) & AE_WRITABLE) == 0) {
+        close(fd);
         conn->state = CONN_STATE_ERROR;
         conn->last_errno = ETIMEDOUT;
         return C_ERR;


### PR DESCRIPTION

## Issue

`connSocketBlockingConnect()` creates a socket in a local variable and only assigns it to `conn->fd` after `aeWait()` succeeds. 
If the aeWait fails, `connClose()` cannot close the socket because `conn->fd` remains `-1`, causing a file descriptor leak.

## Change

Close the local socket before returning `C_ERR`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line resource cleanup on an error path in blocking TCP connect; no behavior change on success paths.
> 
> **Overview**
> Fixes a **file descriptor leak** in `connSocketBlockingConnect()` when the writable wait times out or otherwise fails.
> 
> The socket is created in a local `fd` and only assigned to `conn->fd` after `aeWait()` succeeds. On failure, the connection error path left `conn->fd` at `-1`, so `connClose()` could not release the socket. The change **closes the local `fd`** before returning `C_ERR` with `ETIMEDOUT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 594a2289d43b74afae5418c8e6778d5c2e5aaded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->