### PR TITLE
Fix timeout issue for replication-buffer test with TLS

### DIFF
--- a/tests/integration/replication-buffer.tcl
+++ b/tests/integration/replication-buffer.tcl
@@ -156,12 +156,15 @@ start_server {} {
 
     # Executing 'debug digest' on master which has many keys costs much time
     # (especially in valgrind), this causes that replica1 and replica2 disconnect
-    # with master.
-    $master config set repl-timeout 1000
-    $replica1 config set repl-timeout 1000
+    # with master. Under TLS (especially rdbchannel=no) the large populate below
+    # can take >16 minutes, so keep repl-timeout well above that: if replica2
+    # times out while stuck in the delayed RDB transfer, the master trims the
+    # backlog and the later histlen / PSYNC assertions fail.
+    $master config set repl-timeout 10000
+    $replica1 config set repl-timeout 10000
     $replica1 config set repl-rdb-channel $rdbchannel
     $replica1 config set client-output-buffer-limit "replica 1024 0 0"
-    $replica2 config set repl-timeout 1000
+    $replica2 config set repl-timeout 10000
     $replica2 config set client-output-buffer-limit "replica 1024 0 0"
     $replica2 config set repl-rdb-channel $rdbchannel
 
@@ -169,8 +172,13 @@ start_server {} {
     wait_for_sync $replica1
 
     test "Replication backlog size can outgrow the backlog limit config rdbchannel=$rdbchannel" {
-        # Generating RDB will take 1000 seconds
-        $master config set rdb-key-save-delay 1000000
+        # Generating RDB will take many hours: the delay is per-key
+        # (~1000 keys in the DB), so replica2's full-sync bgsave cannot
+        # complete within any test run. This keeps replica2 stuck holding the
+        # replication buffer for the whole test, which the backlog assertions
+        # below (and in the following test) rely on. If replica2 ever caught
+        # up, the master would trim the backlog and those asserts would fail.
+        $master config set rdb-key-save-delay 100000000
         populate 1000 master 10000
 
         # When compression is enabled the repl buffer may be consumed by the


### PR DESCRIPTION
Fix flaky Daily CI jobs related to TLS - specifically integration/replication-buffer

Tests rely on one of the replicas being stuck in rdb download. Sometimes TLS tests run slow when the GH runners are loaded (I presume), which broke the test because either that slow replica caught up or it was disconnected prematurely because of low repl-timout config. Increased `repl-timeout` and the `rdb-key-save-delay` for that replica in order for it to be deterministically slow even in the slowest of test environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing and config tweaks in integration tests; no production replication or server logic changes.
> 
> **Overview**
> Stabilizes the **replication backlog** integration group in `tests/integration/replication-buffer.tcl` when Daily CI runs with TLS or on slow runners.
> 
> **`repl-timeout`** is raised from **1000** to **10000** on the master, replica1, and replica2 so a replica stuck in a delayed RDB full sync does not drop before the large `populate` finishes (TLS can push that past ~16 minutes). Early disconnect would trim the backlog and break later **histlen** / **PSYNC** assertions.
> 
> **`rdb-key-save-delay`** is increased from **1000000** to **100000000** so replica2’s per-key delayed bgsave stays effectively unfinishable for the whole test, preserving the “slow replica holds the replication buffer” setup the backlog tests depend on. Comments are updated to document both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d01b2873488b7fe3cac2ca51f891a86b57fbaf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->