### PR TITLE
Fix x86-64 detection in CRC optimizations

### DIFF
--- a/src/crccombine.c
+++ b/src/crccombine.c
@@ -38,7 +38,9 @@
   madler@alumni.caltech.edu
 */
 
-#define STATIC_ASSERT(VVV) do {int test = 1 / (VVV);test++;} while (0)
+#ifndef static_assert
+#define static_assert(expr, lit) extern char __static_assert_failure[(expr) ? 1 : -1]
+#endif
 
 #if !((defined(__i386__) || defined(__X86_64__) || defined(__x86_64__)))
 
@@ -115,6 +117,11 @@ uint64_t gf2_matrix_times_switch(uint64_t *mat, uint64_t vec) {
 
 #else
 
+static_assert(sizeof(uint64_t) == 8,
+              "CRC vector implementation requires uint64_t to be 8 bytes");
+static_assert(sizeof(long long unsigned int) == 8,
+              "CRC vector implementation requires unsigned long long to be 8 bytes");
+
 /*
 	Warning: here there be dragons involving vector math, and macros to save us
 	from repeating the same information over and over.
@@ -158,8 +165,6 @@ uint64_t gf2_matrix_times_vec2(uint64_t *mat, uint64_t vec) {
 	DO_CHUNK16();
 	DO_CHUNK16();
 
-	STATIC_ASSERT(sizeof(uint64_t) == 8);
-	STATIC_ASSERT(sizeof(long long unsigned int) == 8);
 	return sum[0] ^ sum[1];
 }
 

--- a/src/crccombine.c
+++ b/src/crccombine.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <strings.h>
-#if defined(__i386__) || defined(__X86_64__)
+#if defined(__i386__) || defined(__x86_64__)
 #include <immintrin.h>
 #endif
 #include "crccombine.h"
@@ -40,7 +40,7 @@
 
 #define STATIC_ASSERT(VVV) do {int test = 1 / (VVV);test++;} while (0)
 
-#if !((defined(__i386__) || defined(__X86_64__)))
+#if !((defined(__i386__) || defined(__x86_64__)))
 
 /* This cuts 40% of the time vs bit-by-bit. */
 

--- a/src/crccombine.c
+++ b/src/crccombine.c
@@ -40,7 +40,7 @@
 
 #define STATIC_ASSERT(VVV) do {int test = 1 / (VVV);test++;} while (0)
 
-#if !((defined(__i386__) || defined(__x86_64__)))
+#if !((defined(__i386__) || defined(__X86_64__) || defined(__x86_64__)))
 
 /* This cuts 40% of the time vs bit-by-bit. */
 

--- a/src/crccombine.c
+++ b/src/crccombine.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <strings.h>
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(__X86_64__) || defined(__x86_64__)
 #include <immintrin.h>
 #endif
 #include "crccombine.h"

--- a/src/crcspeed.c
+++ b/src/crcspeed.c
@@ -157,7 +157,7 @@ void crcspeed16big_init(crcfn16 fn, uint16_t big_table[8][256]) {
  * reasonable for Intel CPUs made since 2010. Please adjust as necessary if
  * or when your CPU has more load / execute units. We've written benchmark code
  * to help you tune your platform, see crc64Test. */
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(__X86_64__) || defined(__x86_64__)
 static size_t CRC64_TRI_CUTOFF = (2*1024);
 static size_t CRC64_DUAL_CUTOFF = (128);
 #else

--- a/src/crcspeed.c
+++ b/src/crcspeed.c
@@ -157,7 +157,7 @@ void crcspeed16big_init(crcfn16 fn, uint16_t big_table[8][256]) {
  * reasonable for Intel CPUs made since 2010. Please adjust as necessary if
  * or when your CPU has more load / execute units. We've written benchmark code
  * to help you tune your platform, see crc64Test. */
-#if defined(__i386__) || defined(__X86_64__)
+#if defined(__i386__) || defined(__x86_64__)
 static size_t CRC64_TRI_CUTOFF = (2*1024);
 static size_t CRC64_DUAL_CUTOFF = (128);
 #else


### PR DESCRIPTION
## Issue

GCC and Clang define `__x86_64__` for x86-64 targets, but the CRC implementation checked the undefined `__X86_64__` macro.

## Test

<img width="1122" height="188" alt="CleanShot 2026-07-25 at 00 58 00@2x" src="https://github.com/user-attachments/assets/f59090f5-79aa-43e6-b911-5cf12c3cddea" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted preprocessor and assert changes in CRC performance code; behavior change is enabling already-intended optimizations on x86-64, with low risk outside that platform.
> 
> **Overview**
> Fixes **x86-64 platform detection** so GCC/Clang builds actually take the fast CRC paths. Preprocessor checks in `crccombine.c` and `crcspeed.c` now include **`__x86_64__`** (in addition to `__i386__` and `__X86_64__`), which was missing before and left typical 64-bit Linux/macOS builds on the slower non-vector combine path and non-x86 parallel CRC cutoffs.
> 
> In **`crccombine.c`**, the custom `STATIC_ASSERT` macro is replaced with a portable **`static_assert`** fallback, and the **8-byte `uint64_t` / `unsigned long long` checks** are moved to compile time at the start of the x86 vector branch instead of inside `gf2_matrix_times_vec2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf5cea1a01f7a773f7f1c02b22374bbe0e0188e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->