### PR TITLE
Implement ARAGG and RANGE predicate for ARGREP

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -34,6 +34,102 @@ const char *COMMAND_GROUP_STR[] = {
 const char *commandGroupStr(int index) {
     return COMMAND_GROUP_STR[index];
 }
+/********** ARAGG ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* ARAGG history */
+#define ARAGG_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* ARAGG tips */
+#define ARAGG_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* ARAGG key specs */
+keySpec ARAGG_Keyspecs[1] = {
+{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+};
+#endif
+
+/* ARAGG predicate exact argument table */
+struct COMMAND_ARG ARAGG_predicate_exact_Subargs[] = {
+{MAKE_ARG("exact",ARG_TYPE_PURE_TOKEN,-1,"EXACT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("string",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* ARAGG predicate match argument table */
+struct COMMAND_ARG ARAGG_predicate_match_Subargs[] = {
+{MAKE_ARG("match",ARG_TYPE_PURE_TOKEN,-1,"MATCH",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("string",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* ARAGG predicate glob argument table */
+struct COMMAND_ARG ARAGG_predicate_glob_Subargs[] = {
+{MAKE_ARG("glob",ARG_TYPE_PURE_TOKEN,-1,"GLOB",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("pattern",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* ARAGG predicate re argument table */
+struct COMMAND_ARG ARAGG_predicate_re_Subargs[] = {
+{MAKE_ARG("re",ARG_TYPE_PURE_TOKEN,-1,"RE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("pattern",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* ARAGG predicate range argument table */
+struct COMMAND_ARG ARAGG_predicate_range_Subargs[] = {
+{MAKE_ARG("range",ARG_TYPE_PURE_TOKEN,-1,"RANGE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("min",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("max",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("exclusive",ARG_TYPE_PURE_TOKEN,-1,"EXCLUSIVE",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
+};
+
+/* ARAGG predicate argument table */
+struct COMMAND_ARG ARAGG_predicate_Subargs[] = {
+{MAKE_ARG("exact",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=ARAGG_predicate_exact_Subargs},
+{MAKE_ARG("match",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=ARAGG_predicate_match_Subargs},
+{MAKE_ARG("glob",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=ARAGG_predicate_glob_Subargs},
+{MAKE_ARG("re",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=ARAGG_predicate_re_Subargs},
+{MAKE_ARG("range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,4,NULL),.subargs=ARAGG_predicate_range_Subargs},
+};
+
+/* ARAGG options argument table */
+struct COMMAND_ARG ARAGG_options_Subargs[] = {
+{MAKE_ARG("and",ARG_TYPE_PURE_TOKEN,-1,"AND",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("or",ARG_TYPE_PURE_TOKEN,-1,"OR",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("limit",ARG_TYPE_INTEGER,-1,"LIMIT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("nocase",ARG_TYPE_PURE_TOKEN,-1,"NOCASE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* ARAGG aggregate operations argument table */
+struct COMMAND_ARG ARAGG_aggregate_operations_Subargs[] = {
+{MAKE_ARG("sum",ARG_TYPE_PURE_TOKEN,-1,"SUM",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("min",ARG_TYPE_PURE_TOKEN,-1,"MIN",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("max",ARG_TYPE_PURE_TOKEN,-1,"MAX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("count",ARG_TYPE_PURE_TOKEN,-1,"COUNT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("avg",ARG_TYPE_PURE_TOKEN,-1,"AVG",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("and",ARG_TYPE_PURE_TOKEN,-1,"AND",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("or",ARG_TYPE_PURE_TOKEN,-1,"OR",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("xor",ARG_TYPE_PURE_TOKEN,-1,"XOR",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* ARAGG aggregate argument table */
+struct COMMAND_ARG ARAGG_aggregate_Subargs[] = {
+{MAKE_ARG("aggregate",ARG_TYPE_PURE_TOKEN,-1,"AGGREGATE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("operations",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,8,NULL),.subargs=ARAGG_aggregate_operations_Subargs},
+};
+
+/* ARAGG argument table */
+struct COMMAND_ARG ARAGG_Args[] = {
+{MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("start",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("end",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("predicate",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,5,NULL),.subargs=ARAGG_predicate_Subargs},
+{MAKE_ARG("options",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,4,NULL),.subargs=ARAGG_options_Subargs},
+{MAKE_ARG("aggregate",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=ARAGG_aggregate_Subargs},
+};
+
 /********** ARCOUNT ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -208,12 +304,21 @@ struct COMMAND_ARG ARGREP_predicate_re_Subargs[] = {
 {MAKE_ARG("pattern",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
+/* ARGREP predicate range argument table */
+struct COMMAND_ARG ARGREP_predicate_range_Subargs[] = {
+{MAKE_ARG("range",ARG_TYPE_PURE_TOKEN,-1,"RANGE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("min",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("max",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("exclusive",ARG_TYPE_PURE_TOKEN,-1,"EXCLUSIVE",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
+};
+
 /* ARGREP predicate argument table */
 struct COMMAND_ARG ARGREP_predicate_Subargs[] = {
 {MAKE_ARG("exact",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=ARGREP_predicate_exact_Subargs},
 {MAKE_ARG("match",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=ARGREP_predicate_match_Subargs},
 {MAKE_ARG("glob",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=ARGREP_predicate_glob_Subargs},
 {MAKE_ARG("re",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=ARGREP_predicate_re_Subargs},
+{MAKE_ARG("range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,4,NULL),.subargs=ARGREP_predicate_range_Subargs},
 };
 
 /* ARGREP options argument table */
@@ -230,7 +335,7 @@ struct COMMAND_ARG ARGREP_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("start",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("end",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("predicate",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,4,NULL),.subargs=ARGREP_predicate_Subargs},
+{MAKE_ARG("predicate",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,5,NULL),.subargs=ARGREP_predicate_Subargs},
 {MAKE_ARG("options",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,5,NULL),.subargs=ARGREP_options_Subargs},
 };
 
@@ -12797,6 +12902,7 @@ struct COMMAND_ARG WATCH_Args[] = {
 /* Main command table */
 struct COMMAND_STRUCT redisCommandTable[] = {
 /* array */
+{MAKE_CMD("aragg","Compute one or more aggregates over array elements matching optional predicates.","O(P * C + A) where P is the number of visited positions, C is predicate evaluation cost, and A is aggregate computation.","8.10.0",CMD_DOC_NONE,NULL,NULL,"array",COMMAND_GROUP_ARRAY,ARAGG_History,0,ARAGG_Tips,0,araggCommand,-6,CMD_READONLY,ACL_CATEGORY_ARRAY,ARAGG_Keyspecs,1,NULL,6),.args=ARAGG_Args},
 {MAKE_CMD("arcount","Returns the number of non-empty elements in an array.","O(1)","8.8.0",CMD_DOC_NONE,NULL,NULL,"array",COMMAND_GROUP_ARRAY,ARCOUNT_History,0,ARCOUNT_Tips,0,arcountCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_ARRAY,ARCOUNT_Keyspecs,1,NULL,1),.args=ARCOUNT_Args},
 {MAKE_CMD("ardel","Deletes elements at the specified indices in an array.","O(N) where N is the number of indices to delete","8.8.0",CMD_DOC_NONE,NULL,NULL,"array",COMMAND_GROUP_ARRAY,ARDEL_History,0,ARDEL_Tips,0,ardelCommand,-3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_ARRAY,ARDEL_Keyspecs,1,NULL,2),.args=ARDEL_Args},
 {MAKE_CMD("ardelrange","Deletes elements in one or more ranges.","Proportional to the number of existing elements / slices touched, not to the numeric span of the requested ranges","8.8.0",CMD_DOC_NONE,NULL,NULL,"array",COMMAND_GROUP_ARRAY,ARDELRANGE_History,0,ARDELRANGE_Tips,0,ardelrangeCommand,-4,CMD_WRITE,ACL_CATEGORY_ARRAY,ARDELRANGE_Keyspecs,1,NULL,2),.args=ARDELRANGE_Args},

--- a/src/commands/aragg.json
+++ b/src/commands/aragg.json
@@ -1,11 +1,11 @@
 {
-    "ARGREP": {
-        "summary": "Searches array elements in a range using textual predicates.",
-        "complexity": "O(P * C) where P is the number of visited positions in touched slices and C is the cost of evaluating the predicates on one existing element.",
+    "ARAGG": {
+        "summary": "Compute one or more aggregates over array elements matching optional predicates.",
+        "complexity": "O(P * C + A) where P is the number of visited positions, C is predicate evaluation cost, and A is aggregate computation.",
         "group": "array",
-        "since": "8.8.0",
+        "since": "8.10.0",
         "arity": -6,
-        "function": "argrepCommand",
+        "function": "araggCommand",
         "command_flags": [
             "READONLY"
         ],
@@ -33,35 +33,24 @@
             }
         ],
         "reply_schema": {
-            "anyOf": [
-                {
-                    "description": "Array of matching indexes.",
-                    "type": "array",
-                    "items": {
+            "description": "Array of aggregate results in the same order as the requested operations. Each result is a number (integer or string), or Null if no matching element could be aggregated.",
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
                         "type": "integer",
-                        "description": "Index of a matching element"
+                        "description": "COUNT, AND, OR, XOR operations return an integer"
+                    },
+                    {
+                        "type": "string",
+                        "description": "SUM, MIN, MAX, AVG operations return a string representation of the number"
+                    },
+                    {
+                        "type": "null",
+                        "description": "Returned when no element matched or no numeric value could be aggregated"
                     }
-                },
-                {
-                    "description": "Array of [index, value] pairs. Returned in case `WITHVALUES` was used.",
-                    "type": "array",
-                    "items": {
-                        "type": "array",
-                        "minItems": 2,
-                        "maxItems": 2,
-                        "items": [
-                            {
-                                "type": "integer",
-                                "description": "Index of a matching element"
-                            },
-                            {
-                                "type": "string",
-                                "description": "Value at that index"
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
         },
         "arguments": [
             {
@@ -81,6 +70,7 @@
                 "name": "predicate",
                 "type": "oneof",
                 "multiple": true,
+                "optional": true,
                 "arguments": [
                     {
                         "name": "exact",
@@ -191,14 +181,67 @@
                         "token": "LIMIT"
                     },
                     {
-                        "name": "withvalues",
-                        "type": "pure-token",
-                        "token": "WITHVALUES"
-                    },
-                    {
                         "name": "nocase",
                         "type": "pure-token",
                         "token": "NOCASE"
+                    }
+                ]
+            },
+            {
+                "name": "aggregate",
+                "type": "block",
+                "arguments": [
+                    {
+                        "name": "aggregate",
+                        "type": "pure-token",
+                        "token": "AGGREGATE"
+                    },
+                    {
+                        "name": "operations",
+                        "type": "oneof",
+                        "multiple": true,
+                        "arguments": [
+                            {
+                                "name": "sum",
+                                "type": "pure-token",
+                                "token": "SUM"
+                            },
+                            {
+                                "name": "min",
+                                "type": "pure-token",
+                                "token": "MIN"
+                            },
+                            {
+                                "name": "max",
+                                "type": "pure-token",
+                                "token": "MAX"
+                            },
+                            {
+                                "name": "count",
+                                "type": "pure-token",
+                                "token": "COUNT"
+                            },
+                            {
+                                "name": "avg",
+                                "type": "pure-token",
+                                "token": "AVG"
+                            },
+                            {
+                                "name": "and",
+                                "type": "pure-token",
+                                "token": "AND"
+                            },
+                            {
+                                "name": "or",
+                                "type": "pure-token",
+                                "token": "OR"
+                            },
+                            {
+                                "name": "xor",
+                                "type": "pure-token",
+                                "token": "XOR"
+                            }
+                        ]
                     }
                 ]
             }

--- a/src/server.h
+++ b/src/server.h
@@ -4812,6 +4812,7 @@ void argetrangeCommand(client *c);
 void arscanCommand(client *c);
 void argrepCommand(client *c);
 void aropCommand(client *c);
+void araggCommand(client *c);
 void arinsertCommand(client *c);
 void arringCommand(client *c);
 void arnextCommand(client *c);

--- a/src/t_array.c
+++ b/src/t_array.c
@@ -893,6 +893,7 @@ void arscanCommand(client *c) {
 #define ARGREP_PRED_MATCH 2
 #define ARGREP_PRED_GLOB  3
 #define ARGREP_PRED_RE    4
+#define ARGREP_PRED_RANGE 5
 
 #define ARGREP_MAX_PREDICATES 250
 #define ARGREP_MAX_RE_LEN 2048
@@ -905,10 +906,14 @@ void arscanCommand(client *c) {
 #define ARGREP_BOUND_END   3
 
 typedef struct {
-    int type;               /* EXACT, MATCH, GLOB, or RE. */
+    int type;               /* EXACT, MATCH, GLOB, RE, or RANGE */
     sds pattern;            /* Pattern argument exactly as given by the user. */
-    regex_t regex;          /* Compiled regex for RE predicates. */
-    int regex_compiled;     /* Whether regex must be freed. */
+    regex_t regex;          /* Compiled regex for RE predicates */
+    int regex_compiled;     /* Whether regex must be freed */
+    /* For RANGE predicate */
+    long double min;
+    long double max;
+    int exclusive;
 } arGrepPredicate;
 
 typedef struct {
@@ -967,6 +972,7 @@ int arGrepPredicateType(const char *token) {
     if (!strcasecmp(token, "MATCH")) return ARGREP_PRED_MATCH;
     if (!strcasecmp(token, "GLOB")) return ARGREP_PRED_GLOB;
     if (!strcasecmp(token, "RE")) return ARGREP_PRED_RE;
+    if (!strcasecmp(token, "RANGE")) return ARGREP_PRED_RANGE;
     return 0;
 }
 
@@ -1047,11 +1053,18 @@ int arGrepCompileRegexesOrReply(client *c, arGrepPlan *plan) {
     return C_OK;
 }
 
-/* Parse predicates and global modifiers in a single pass. This makes the
+/* Used by: ARGREP and ARAGG
+ * Parse predicates and global modifiers in a single pass. This makes the
  * command more user-friendly because predicates and options can be mixed
  * freely. If the same global option appears multiple times, the last one
- * wins. */
-int arGrepParsePlanOrReply(client *c, arGrepPlan *plan, uint64_t *limit) {
+ * wins. For ARAGG - If stop_token is NULL the parser runs until the end
+ * of argv and requires at least one predicate.  If stop_token is not NULL
+ * parser stops immediately when it encounters that token, returns success
+ * and writes current argv index into *next_arg (if next_arg != NULL).
+ * Zero predicates are allowed when a stop_token is given (useful for
+ * optional filtering).*/
+int arGrepParsePlanOrReply(client *c, arGrepPlan *plan, uint64_t *limit,
+                           const char *stop_token, int *next_arg) {
     memset(plan, 0, sizeof(*plan));
     plan->combine = ARGREP_COMBINE_OR;
     *limit = UINT64_MAX;
@@ -1061,9 +1074,47 @@ int arGrepParsePlanOrReply(client *c, arGrepPlan *plan, uint64_t *limit) {
 
     for (int arg = 4; arg < c->argc; ) {
         sds token = c->argv[arg]->ptr;
+        /* ---------- Sentinel token check ---------- */
+        if (stop_token && !strcasecmp(token, stop_token)) {
+            if (next_arg) *next_arg = arg;
+            /* Compile any regexes we already collected */
+            return arGrepCompileRegexesOrReply(c, plan);
+        }
+
         int type = arGrepPredicateType(token);
 
         if (type != 0) {
+            if (type == ARGREP_PRED_RANGE) {
+                if (arg + 2 >= c->argc) {
+                    addReplyErrorObject(c, shared.syntaxerr);
+                    return C_ERR;
+                }
+                if (plan->num_preds >= ARGREP_MAX_PREDICATES) {
+                    addReplyErrorFormat(c, "too many predicates, maximum is %d",
+                                        ARGREP_MAX_PREDICATES);
+                    return C_ERR;
+                }
+
+                arGrepPredicate *pred = &plan->preds[plan->num_preds++];
+                pred->type = ARGREP_PRED_RANGE;
+
+                if (getLongDoubleFromObjectOrReply(c, c->argv[arg+1],
+                                                   &pred->min, NULL) != C_OK)
+                    return C_ERR;
+                if (getLongDoubleFromObjectOrReply(c, c->argv[arg+2],
+                                                   &pred->max, NULL) != C_OK)
+                    return C_ERR;
+                pred->exclusive = 0;
+                arg += 3;   /* consumed RANGE, min, max */
+
+                /* Optional EXCLUSIVE flag */
+                if (arg < c->argc && !strcasecmp(c->argv[arg]->ptr, "EXCLUSIVE")) {
+                    pred->exclusive = 1;
+                    arg++;
+                }
+                continue;   /* skip the normal pattern handling below */
+            }
+
             if (arg + 1 >= c->argc) {
                 addReplyErrorObject(c, shared.syntaxerr);
                 return C_ERR;
@@ -1132,7 +1183,8 @@ int arGrepParsePlanOrReply(client *c, arGrepPlan *plan, uint64_t *limit) {
         return C_ERR;
     }
 
-    if (plan->num_preds == 0) {
+    /* Only enforce "at least one predicate" when no stop_token was used. */
+    if (plan->num_preds == 0 && stop_token == NULL) {
         addReplyErrorObject(c, shared.syntaxerr);
         return C_ERR;
     }
@@ -1143,18 +1195,33 @@ int arGrepParsePlanOrReply(client *c, arGrepPlan *plan, uint64_t *limit) {
 /* Match one predicate against the decoded element bytes. */
 int arGrepMatchPredicate(arGrepPredicate *pred, const char *data, size_t len,
                          int nocase) {
-    size_t pattern_len = sdslen(pred->pattern);
 
     switch (pred->type) {
-    case ARGREP_PRED_EXACT:
+    case ARGREP_PRED_EXACT: {
+        size_t pattern_len = sdslen(pred->pattern);
         return arGrepBytesEqual(data, len, pred->pattern, pattern_len, nocase);
-    case ARGREP_PRED_MATCH:
+    }
+    case ARGREP_PRED_MATCH: {
+        size_t pattern_len = sdslen(pred->pattern);
         return arGrepBytesContains(data, len, pred->pattern, pattern_len,
                                    nocase);
-    case ARGREP_PRED_GLOB:
+    }
+    case ARGREP_PRED_GLOB: {
+        size_t pattern_len = sdslen(pred->pattern);
         return stringmatchlen(pred->pattern, pattern_len, data, len, nocase);
+    }
     case ARGREP_PRED_RE:
         return tre_regnexecb(&pred->regex, data, len, 0, NULL, 0) == REG_OK;
+    case ARGREP_PRED_RANGE: {
+        long double val;
+        if (!string2ld(data, len, &val)) return 0;
+        if (pred->exclusive) {
+            if (val <= pred->min || val >= pred->max) return 0;
+        } else {
+            if (val < pred->min || val > pred->max) return 0;
+        }
+        return 1;
+    }
     default:
         serverPanic("Unknown ARGREP predicate type");
     }
@@ -1162,6 +1229,7 @@ int arGrepMatchPredicate(arGrepPredicate *pred, const char *data, size_t len,
 
 /* Decode one array value and apply all the predicates to it. */
 int arGrepValueMatches(arGrepPlan *plan, void *v) {
+    if (plan->num_preds == 0) return 1;
     char buf[AR_INLINE_BUFSIZE];
     size_t len;
     const char *data = arDecode(v, buf, sizeof(buf), &len);
@@ -1203,7 +1271,7 @@ void argrepCommand(client *c) {
 
     arGrepPlan plan;
     uint64_t remaining;
-    if (arGrepParsePlanOrReply(c, &plan, &remaining) != C_OK) {
+    if (arGrepParsePlanOrReply(c, &plan, &remaining, NULL, NULL) != C_OK) {
         arGrepFreePlan(&plan);
         return;
     }
@@ -1466,6 +1534,323 @@ void aropCommand(client *c) {
             addReplyBulkCBuffer(c, buf, len);
         }
     }
+}
+
+/* ============================================================================
+ * ARAGG
+ * ============================================================================
+ * Aggregate array elements that match a set of predicates.
+ *
+ * Shares the predicate parser and matching engine with ARGREP, allowing
+ * multiple aggregate operations (SUM, MIN, MAX, COUNT, AVG, AND, OR, XOR)
+ * to be computed in a single scan.
+ * -------------------------------------------------------------------------- */
+
+/* ARAGG aggregate operation types */
+#define ARAGG_OP_SUM   1
+#define ARAGG_OP_MIN   2
+#define ARAGG_OP_MAX   3
+#define ARAGG_OP_COUNT 4
+#define ARAGG_OP_AVG   5
+#define ARAGG_OP_AND   6
+#define ARAGG_OP_OR    7
+#define ARAGG_OP_XOR   8
+
+
+/* Holds state for multiple concurrent aggregates */
+typedef struct {
+    int has_sum, has_min, has_max, has_count;
+    int has_bitwise_and, has_bitwise_or, has_bitwise_xor;
+    int has_avg;
+
+    long double sum;
+    long double min;
+    long double max;
+    long long count;
+    long long numeric_count;  /* Used for AVG denominator. */
+    int64_t bitwise_and;
+    int64_t bitwise_or;
+    int64_t bitwise_xor;
+    int has_numeric;          /* saw at least one numeric value (for SUM/MIN/MAX) */
+    int has_int;              /* saw at least one integer (for bitwise) */
+} arMultiAcc;
+
+/* Initialise the accumulator with the list of requested aggregate ops.
+ * ops is an array of int (ARAGG_OP_*), num_ops is its length. */
+static void arMultiAccInit(arMultiAcc *acc, int *ops, int num_ops) {
+    memset(acc, 0, sizeof(*acc));
+    for (int i = 0; i < num_ops; i++) {
+        switch (ops[i]) {
+        case ARAGG_OP_SUM:  acc->has_sum = 1; break;
+        case ARAGG_OP_MIN:  acc->has_min = 1; break;
+        case ARAGG_OP_MAX:  acc->has_max = 1; break;
+        case ARAGG_OP_COUNT: acc->has_count = 1; break;
+        case ARAGG_OP_AVG:  acc->has_avg = 1; break;
+        case ARAGG_OP_AND:  acc->has_bitwise_and = 1; break;
+        case ARAGG_OP_OR:   acc->has_bitwise_or = 1; break;
+        case ARAGG_OP_XOR:  acc->has_bitwise_xor = 1; break;
+        }
+    }
+    /* AVG implicitly needs SUM and COUNT */
+    if (acc->has_avg) {
+        acc->has_sum = 1;
+        acc->has_count = 1;
+    }
+}
+
+/* Accumulate one value into all requested aggregates. */
+static void arMultiAccAdd(arMultiAcc *acc, void *v) {
+    if (acc->has_count) acc->count++;
+
+    /* Try to convert the value to a number for numeric ops */
+    int need_numeric = acc->has_sum || acc->has_min || acc->has_max ||
+                       acc->has_bitwise_and || acc->has_bitwise_or ||
+                       acc->has_bitwise_xor;
+    if (!need_numeric) return;
+
+    long double num;
+    int64_t ival = 0;
+    int is_int = 0;
+
+    if (arIsInt(v)) {
+        ival = arToInt(v);
+        num = (long double)ival;
+        is_int = 1;
+    } else if (arIsFloat(v)) {
+        num = (long double)arToDouble(v);
+    } else {
+        const char *data;
+        size_t vlen;
+        char smallbuf[8];
+
+        if (arIsSmallStr(v)) {
+            vlen = arToSmallStr(v, smallbuf);
+            data = smallbuf;
+        } else {
+            data = arStringData(v);
+            vlen = arStringLen(v);
+        }
+
+        long long ll;
+        if (string2ll(data, vlen, &ll)) {
+            ival = ll;
+            num = (long double)ll;
+            is_int = 1;
+        } else {
+            long double ld;
+            if (string2ld(data, vlen, &ld)) {
+                num = ld;
+            } else {
+                return;  /* not a number */
+            }
+        }
+    }
+
+    if (!is_int && isnan(num)) return;
+
+    /* Numeric aggregates */
+    if (acc->has_sum || acc->has_min || acc->has_max) {
+        if (acc->has_avg) acc->numeric_count++;   /* count numeric values for AVG */
+        if (!acc->has_numeric) {
+            acc->sum = num;
+            if (acc->has_min) acc->min = num;
+            if (acc->has_max) acc->max = num;
+            acc->has_numeric = 1;
+        } else {
+            if (acc->has_sum) acc->sum += num;
+            if (acc->has_min && num < acc->min) acc->min = num;
+            if (acc->has_max && num > acc->max) acc->max = num;
+        }
+    }
+
+    /* Bitwise aggregates (require integer) */
+    if (acc->has_bitwise_and || acc->has_bitwise_or || acc->has_bitwise_xor) {
+        if (!is_int) {
+            /* Bitwise aggregates operate on integers. Truncate finite floating
+             * point values toward zero when possible. */
+            if (isnan(num)) return;
+            if (num < (long double)INT64_MIN || num > (long double)INT64_MAX) return;
+            ival = (int64_t)num;
+        }
+        if (!acc->has_int) {
+            if (acc->has_bitwise_and) acc->bitwise_and = ival;
+            if (acc->has_bitwise_or)  acc->bitwise_or = ival;
+            if (acc->has_bitwise_xor) acc->bitwise_xor = ival;
+            acc->has_int = 1;
+        } else {
+            if (acc->has_bitwise_and) acc->bitwise_and &= ival;
+            if (acc->has_bitwise_or)  acc->bitwise_or  |= ival;
+            if (acc->has_bitwise_xor) acc->bitwise_xor ^= ival;
+        }
+    }
+}
+
+/* Reply with the requested aggregates in order. */
+static void arMultiAccReply(client *c, arMultiAcc *acc, int *ops, int num_ops) {
+    addReplyArrayLen(c, num_ops);
+    for (int i = 0; i < num_ops; i++) {
+        switch (ops[i]) {
+        case ARAGG_OP_SUM:
+            if (!acc->has_numeric) addReplyNull(c);
+            else {
+                char buf[MAX_LONG_DOUBLE_CHARS+1];
+                int len = ld2string(buf, sizeof(buf), acc->sum, LD_STR_AUTO);
+                addReplyBulkCBuffer(c, buf, len);
+            }
+            break;
+        case ARAGG_OP_MIN:
+            if (!acc->has_numeric) addReplyNull(c);
+            else {
+                char buf[MAX_LONG_DOUBLE_CHARS+1];
+                int len = ld2string(buf, sizeof(buf), acc->min, LD_STR_AUTO);
+                addReplyBulkCBuffer(c, buf, len);
+            }
+            break;
+        case ARAGG_OP_MAX:
+            if (!acc->has_numeric) addReplyNull(c);
+            else {
+                char buf[MAX_LONG_DOUBLE_CHARS+1];
+                int len = ld2string(buf, sizeof(buf), acc->max, LD_STR_AUTO);
+                addReplyBulkCBuffer(c, buf, len);
+            }
+            break;
+        case ARAGG_OP_COUNT:
+            addReplyLongLong(c, acc->count);
+            break;
+        case ARAGG_OP_AVG:
+            if (!acc->has_numeric || acc->numeric_count == 0) addReplyNull(c);
+            else {
+                long double avg = acc->sum / (long double)acc->numeric_count;
+                char buf[MAX_LONG_DOUBLE_CHARS+1];
+                int len = ld2string(buf, sizeof(buf), avg, LD_STR_AUTO);
+                addReplyBulkCBuffer(c, buf, len);
+            }
+            break;
+        case ARAGG_OP_AND:
+            if (!acc->has_int) addReplyNull(c);
+            else addReplyLongLong(c, acc->bitwise_and);
+            break;
+        case ARAGG_OP_OR:
+            if (!acc->has_int) addReplyNull(c);
+            else addReplyLongLong(c, acc->bitwise_or);
+            break;
+        case ARAGG_OP_XOR:
+            if (!acc->has_int) addReplyNull(c);
+            else addReplyLongLong(c, acc->bitwise_xor);
+            break;
+        default:
+            addReplyNull(c);
+        }
+    }
+}
+
+/* ARAGG key start end
+ *        [EXACT string | MATCH string | GLOB pattern | RE pattern | RANGE min max [EXCLUSIVE]] ...
+ *        [AND | OR] [LIMIT count] [NOCASE]
+ *        AGGREGATE <op> [op ...]
+ *
+ * Compute one or more aggregates over elements that match the given predicates.
+ * Available operations: SUM, MIN, MAX, COUNT, AVG, AND, OR, XOR. */
+void araggCommand(client *c) {
+    arGrepBound start_bound, end_bound;
+    if (arGrepParseBoundOrReply(c, c->argv[2], &start_bound) != C_OK) return;
+    if (arGrepParseBoundOrReply(c, c->argv[3], &end_bound) != C_OK) return;
+
+    /* ---- Parse optional predicates + global options, stopping at "AGGREGATE" ---- */
+    arGrepPlan plan;
+    uint64_t limit;
+    int agg_idx = -1;   /* will be set to the index of "AGGREGATE" */
+    if (arGrepParsePlanOrReply(c, &plan, &limit, "AGGREGATE", &agg_idx) != C_OK) {
+        arGrepFreePlan(&plan);
+        return;
+    }
+    if (agg_idx == -1) {
+        arGrepFreePlan(&plan);
+        addReplyError(c, "AGGREGATE keyword required");
+        return;
+    }
+
+    /* ---- Parse aggregate operations (argv[agg_idx+1 .. argc-1]) ---- */
+    int first_op = agg_idx + 1;
+    if (first_op >= c->argc) {
+        arGrepFreePlan(&plan);
+        addReplyError(c, "AGGREGATE keyword requires at least one operation");
+        return;
+    }
+
+    int max_ops = c->argc - first_op;
+    int *ops = zcalloc(sizeof(int) * max_ops);
+    int num_ops = 0;
+    for (int i = first_op; i < c->argc; i++) {
+        const char *opstr = c->argv[i]->ptr;
+        int op = 0;
+        if (!strcasecmp(opstr, "SUM"))        op = ARAGG_OP_SUM;
+        else if (!strcasecmp(opstr, "MIN"))   op = ARAGG_OP_MIN;
+        else if (!strcasecmp(opstr, "MAX"))   op = ARAGG_OP_MAX;
+        else if (!strcasecmp(opstr, "COUNT")) op = ARAGG_OP_COUNT;
+        else if (!strcasecmp(opstr, "AVG"))   op = ARAGG_OP_AVG;
+        else if (!strcasecmp(opstr, "AND"))   op = ARAGG_OP_AND;
+        else if (!strcasecmp(opstr, "OR"))    op = ARAGG_OP_OR;
+        else if (!strcasecmp(opstr, "XOR"))   op = ARAGG_OP_XOR;
+        else {
+            zfree(ops);
+            arGrepFreePlan(&plan);
+            addReplyErrorFormat(c, "unknown aggregate operation: %s", opstr);
+            return;
+        }
+        ops[num_ops++] = op;
+    }
+
+    robj *o = lookupKeyRead(c->db, c->argv[1]);
+    if (o != NULL && checkType(c, o, OBJ_ARRAY)) {
+        zfree(ops);
+        arGrepFreePlan(&plan);
+        return;
+    }
+
+    if (o == NULL) {
+        arMultiAcc acc;
+        memset(&acc, 0, sizeof(acc));
+        arMultiAccReply(c, &acc, ops, num_ops);
+        zfree(ops);
+        arGrepFreePlan(&plan);
+        return;
+    }
+
+    redisArray *ar = o->ptr;
+    uint64_t ar_len = arLen(ar);
+    if (ar_len == 0 || arCount(ar) == 0) {
+        arMultiAcc acc;
+        memset(&acc, 0, sizeof(acc));
+        arMultiAccReply(c, &acc, ops, num_ops);
+        zfree(ops);
+        arGrepFreePlan(&plan);
+        return;
+    }
+
+    /* ---- Iterate over the range and accumulate ---- */
+    uint64_t max_index = ar_len - 1;
+    uint64_t start = arGrepResolveBound(&start_bound, max_index);
+    uint64_t end   = arGrepResolveBound(&end_bound,   max_index);
+
+    arScanIter it;
+    arScanIterInit(ar, start, end, &it);
+    uint64_t idx;
+    void *v;
+
+    arMultiAcc acc;
+    arMultiAccInit(&acc, ops, num_ops);
+
+    while (limit > 0 && arScanIterNext(&it, &idx, &v)) {
+        if (!arGrepValueMatches(&plan, v)) continue;
+        arMultiAccAdd(&acc, v);
+        limit--;
+    }
+
+    arMultiAccReply(c, &acc, ops, num_ops);
+
+    zfree(ops);
+    arGrepFreePlan(&plan);
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/t_array.c
+++ b/src/t_array.c
@@ -880,30 +880,33 @@ void arscanCommand(client *c) {
 }
 
 /* ============================================================================
- * ARGREP
+ * ARRAY PREDICATE ENGINE
  * ============================================================================
  *
- * Search existing array elements in a range using textual predicates.
- * Like ARSCAN, the work is bound by the visited slices, not by the raw
- * numeric span alone: dense slices scan the touched dense window, while
- * sparse slices only scan stored entries inside the covered offsets.
+ * Shared predicate definitions, parsing, compilation, matching, and plan
+ * management used by ARGREP (element search) and ARAGG (element aggregation).
+ *
+ * A predicate plan describes one or more predicates that an array element
+ * must satisfy, together with global options such as AND/OR combine mode,
+ * case‑insensitivity, and a response limit.
+ *
+ * Bounds are also parsed here because they are reused by both callers.
  * -------------------------------------------------------------------------- */
+#define ARPRED_EXACT 1
+#define ARPRED_MATCH 2
+#define ARPRED_GLOB   3
+#define ARPRED_RE     4
+#define ARPRED_RANGE  5
 
-#define ARGREP_PRED_EXACT 1
-#define ARGREP_PRED_MATCH 2
-#define ARGREP_PRED_GLOB  3
-#define ARGREP_PRED_RE    4
-#define ARGREP_PRED_RANGE 5
+#define ARPRED_MAX_PREDICATES 250
+#define ARPRED_MAX_RE_LEN     2048
 
-#define ARGREP_MAX_PREDICATES 250
-#define ARGREP_MAX_RE_LEN 2048
+#define ARPRED_COMBINE_OR  1
+#define ARPRED_COMBINE_AND 2
 
-#define ARGREP_COMBINE_OR  1
-#define ARGREP_COMBINE_AND 2
-
-#define ARGREP_BOUND_INDEX 1
-#define ARGREP_BOUND_START 2
-#define ARGREP_BOUND_END   3
+#define ARBOUND_INDEX 1
+#define ARBOUND_START 2
+#define ARBOUND_END   3
 
 typedef struct {
     int type;               /* EXACT, MATCH, GLOB, RE, or RANGE */
@@ -914,36 +917,36 @@ typedef struct {
     long double min;
     long double max;
     int exclusive;
-} arGrepPredicate;
+} arPredicate;
 
 typedef struct {
     int type;               /* Numeric index, logical start, or logical end. */
     uint64_t index;         /* Used only for numeric bounds. */
-} arGrepBound;
+} arPredicateBound;
 
 typedef struct {
-    arGrepPredicate *preds; /* All predicates to apply to each element. */
+    arPredicate *preds;     /* All predicates to apply to each element. */
     int num_preds;          /* Number of predicates stored in preds[]. */
     int combine;            /* OR by default, AND if requested. */
     int withvalues;         /* Reply with [idx value ...] instead of [idx ...]. */
     int nocase;             /* Apply case-insensitive matching globally. */
-} arGrepPlan;
+} arPredicatePlan;
 
 /* Lowercase only ASCII letters. This keeps MATCH/EXACT deterministic and
  * locale-independent even on arbitrary binary payloads. */
-static inline unsigned char arGrepLowerAscii(unsigned char c) {
+static inline unsigned char arPredicateLowerAscii(unsigned char c) {
     return (c >= 'A' && c <= 'Z') ? (unsigned char)(c + ('a' - 'A')) : c;
 }
 
 /* Compare two byte strings, optionally ignoring ASCII case. */
-int arGrepBytesEqual(const char *a, size_t alen, const char *b, size_t blen,
+int arPredicateBytesEqual(const char *a, size_t alen, const char *b, size_t blen,
                      int nocase) {
     if (alen != blen) return 0;
     if (!nocase) return memcmp(a, b, alen) == 0;
 
     for (size_t i = 0; i < alen; i++) {
-        if (arGrepLowerAscii((unsigned char)a[i]) !=
-            arGrepLowerAscii((unsigned char)b[i])) {
+        if (arPredicateLowerAscii((unsigned char)a[i]) !=
+            arPredicateLowerAscii((unsigned char)b[i])) {
             return 0;
         }
     }
@@ -951,14 +954,14 @@ int arGrepBytesEqual(const char *a, size_t alen, const char *b, size_t blen,
 }
 
 /* Find a needle inside a byte string, optionally ignoring ASCII case. */
-int arGrepBytesContains(const char *haystack, size_t haystack_len,
+int arPredicateBytesContains(const char *haystack, size_t haystack_len,
                         const char *needle, size_t needle_len, int nocase) {
     if (needle_len == 0) return 1;
     if (needle_len > haystack_len) return 0;
 
     size_t last = haystack_len - needle_len;
     for (size_t i = 0; i <= last; i++) {
-        if (arGrepBytesEqual(haystack + i, needle_len, needle, needle_len,
+        if (arPredicateBytesEqual(haystack + i, needle_len, needle, needle_len,
                              nocase)) {
             return 1;
         }
@@ -967,17 +970,17 @@ int arGrepBytesContains(const char *haystack, size_t haystack_len,
 }
 
 /* Return the predicate type for a keyword, or 0 if it is not one. */
-int arGrepPredicateType(const char *token) {
-    if (!strcasecmp(token, "EXACT")) return ARGREP_PRED_EXACT;
-    if (!strcasecmp(token, "MATCH")) return ARGREP_PRED_MATCH;
-    if (!strcasecmp(token, "GLOB")) return ARGREP_PRED_GLOB;
-    if (!strcasecmp(token, "RE")) return ARGREP_PRED_RE;
-    if (!strcasecmp(token, "RANGE")) return ARGREP_PRED_RANGE;
+int arPredicateType(const char *token) {
+    if (!strcasecmp(token, "EXACT")) return ARPRED_EXACT;
+    if (!strcasecmp(token, "MATCH")) return ARPRED_MATCH;
+    if (!strcasecmp(token, "GLOB"))  return ARPRED_GLOB;
+    if (!strcasecmp(token, "RE"))    return ARPRED_RE;
+    if (!strcasecmp(token, "RANGE")) return ARPRED_RANGE;
     return 0;
 }
 
-/* Free any compiled regex state created while parsing ARGREP. */
-void arGrepFreePlan(arGrepPlan *plan) {
+/* Free any compiled regex state created while parsing. */
+void arFreePredicatePlan(arPredicatePlan *plan) {
     if (plan->preds == NULL) return;
 
     for (int i = 0; i < plan->num_preds; i++) {
@@ -988,18 +991,18 @@ void arGrepFreePlan(arGrepPlan *plan) {
     plan->preds = NULL;
 }
 
-/* Parse a bound argument. ARGREP accepts the special tokens "-" and "+"
+/* Parse a bound argument. ARGREP/ARAGG accepts the special tokens "-" and "+"
  * in addition to normal array indexes. */
-int arGrepParseBoundOrReply(client *c, robj *arg, arGrepBound *bound) {
+int arParsePredicateBoundOrReply(client *c, robj *arg, arPredicateBound *bound) {
     if (arg->encoding != OBJ_ENCODING_INT) {
         sds token = arg->ptr;
         if (sdslen(token) == 1 && token[0] == '-') {
-            bound->type = ARGREP_BOUND_START;
+            bound->type = ARBOUND_START;
             bound->index = 0;
             return C_OK;
         }
         if (sdslen(token) == 1 && token[0] == '+') {
-            bound->type = ARGREP_BOUND_END;
+            bound->type = ARBOUND_END;
             bound->index = 0;
             return C_OK;
         }
@@ -1009,23 +1012,23 @@ int arGrepParseBoundOrReply(client *c, robj *arg, arGrepBound *bound) {
         addReplyError(c, "invalid array index");
         return C_ERR;
     }
-    bound->type = ARGREP_BOUND_INDEX;
+    bound->type = ARBOUND_INDEX;
     return C_OK;
 }
 
 /* Resolve a parsed bound against the current array length. */
-uint64_t arGrepResolveBound(arGrepBound *bound, uint64_t max_index) {
-    if (bound->type == ARGREP_BOUND_START) return 0;
-    if (bound->type == ARGREP_BOUND_END) return max_index;
+uint64_t arResolvePredicateBound(arPredicateBound *bound, uint64_t max_index) {
+    if (bound->type == ARBOUND_START) return 0;
+    if (bound->type == ARBOUND_END) return max_index;
     return bound->index;
 }
 
 /* Compile all RE predicates after the whole command is parsed, so NOCASE is
  * already known and affects every regex consistently. */
-int arGrepCompileRegexesOrReply(client *c, arGrepPlan *plan) {
+int arCompilePredicateRegexesOrReply(client *c, arPredicatePlan *plan) {
     for (int i = 0; i < plan->num_preds; i++) {
-        arGrepPredicate *pred = &plan->preds[i];
-        if (pred->type != ARGREP_PRED_RE) continue;
+        arPredicate *pred = &plan->preds[i];
+        if (pred->type != ARPRED_RE) continue;
 
         if (sdslen(pred->pattern) == 0) {
             addReplyError(c, "regular expression is empty");
@@ -1054,19 +1057,20 @@ int arGrepCompileRegexesOrReply(client *c, arGrepPlan *plan) {
 }
 
 /* Used by: ARGREP and ARAGG
- * Parse predicates and global modifiers in a single pass. This makes the
- * command more user-friendly because predicates and options can be mixed
- * freely. If the same global option appears multiple times, the last one
- * wins. For ARAGG - If stop_token is NULL the parser runs until the end
- * of argv and requires at least one predicate.  If stop_token is not NULL
- * parser stops immediately when it encounters that token, returns success
- * and writes current argv index into *next_arg (if next_arg != NULL).
- * Zero predicates are allowed when a stop_token is given (useful for
- * optional filtering).*/
-int arGrepParsePlanOrReply(client *c, arGrepPlan *plan, uint64_t *limit,
-                           const char *stop_token, int *next_arg) {
+ * Parse predicates and global modifiers in a single pass. Options and
+ * predicates may be freely interleaved; the last occurrence of a global
+ * option wins.
+ *
+ * If stop_token is not NULL, parsing stops when that token is encountered
+ * and the current argv index is written into *next_arg (if next_arg != NULL).
+ * In that case zero predicates are allowed (optional filtering).
+ *
+ * If stop_token is NULL, at least one predicate must be supplied. */
+int arParsePredicatePlanOrReply(client *c, arPredicatePlan *plan, uint64_t *limit,
+                           const char *stop_token, int *next_arg,
+                           int allow_withvalues) {
     memset(plan, 0, sizeof(*plan));
-    plan->combine = ARGREP_COMBINE_OR;
+    plan->combine = ARPRED_COMBINE_OR;
     *limit = UINT64_MAX;
 
     int max_preds = c->argc - 4;
@@ -1074,29 +1078,29 @@ int arGrepParsePlanOrReply(client *c, arGrepPlan *plan, uint64_t *limit,
 
     for (int arg = 4; arg < c->argc; ) {
         sds token = c->argv[arg]->ptr;
-        /* ---------- Sentinel token check ---------- */
+        /* Sentinel token check (used by ARAGG to stop before AGGREGATE) */
         if (stop_token && !strcasecmp(token, stop_token)) {
             if (next_arg) *next_arg = arg;
             /* Compile any regexes we already collected */
-            return arGrepCompileRegexesOrReply(c, plan);
+            return arCompilePredicateRegexesOrReply(c, plan);
         }
 
-        int type = arGrepPredicateType(token);
+        int type = arPredicateType(token);
 
         if (type != 0) {
-            if (type == ARGREP_PRED_RANGE) {
+            if (type == ARPRED_RANGE) {
                 if (arg + 2 >= c->argc) {
                     addReplyErrorObject(c, shared.syntaxerr);
                     return C_ERR;
                 }
-                if (plan->num_preds >= ARGREP_MAX_PREDICATES) {
+                if (plan->num_preds >= ARPRED_MAX_PREDICATES) {
                     addReplyErrorFormat(c, "too many predicates, maximum is %d",
-                                        ARGREP_MAX_PREDICATES);
+                                        ARPRED_MAX_PREDICATES);
                     return C_ERR;
                 }
 
-                arGrepPredicate *pred = &plan->preds[plan->num_preds++];
-                pred->type = ARGREP_PRED_RANGE;
+                arPredicate *pred = &plan->preds[plan->num_preds++];
+                pred->type = ARPRED_RANGE;
 
                 if (getLongDoubleFromObjectOrReply(c, c->argv[arg+1],
                                                    &pred->min, NULL) != C_OK)
@@ -1119,20 +1123,20 @@ int arGrepParsePlanOrReply(client *c, arGrepPlan *plan, uint64_t *limit,
                 addReplyErrorObject(c, shared.syntaxerr);
                 return C_ERR;
             }
-            if (plan->num_preds >= ARGREP_MAX_PREDICATES) {
+            if (plan->num_preds >= ARPRED_MAX_PREDICATES) {
                 addReplyErrorFormat(c, "too many predicates, maximum is %d",
-                                    ARGREP_MAX_PREDICATES);
+                                    ARPRED_MAX_PREDICATES);
                 return C_ERR;
             }
 
-            arGrepPredicate *pred = &plan->preds[plan->num_preds++];
+            arPredicate *pred = &plan->preds[plan->num_preds++];
             pred->type = type;
             pred->pattern = c->argv[arg + 1]->ptr;
-            if (type == ARGREP_PRED_RE &&
-                sdslen(pred->pattern) > ARGREP_MAX_RE_LEN) {
+            if (type == ARPRED_RE &&
+                sdslen(pred->pattern) > ARPRED_MAX_RE_LEN) {
                 addReplyErrorFormat(c,
                     "regular expression is too long, maximum is %d bytes",
-                    ARGREP_MAX_RE_LEN);
+                    ARPRED_MAX_RE_LEN);
                 return C_ERR;
             }
             arg += 2;
@@ -1161,6 +1165,10 @@ int arGrepParsePlanOrReply(client *c, arGrepPlan *plan, uint64_t *limit,
         }
 
         if (!strcasecmp(token, "WITHVALUES")) {
+            if (!allow_withvalues) {
+                addReplyError(c, "WITHVALUES is not supported in ARAGG command");
+                return C_ERR;
+            }
             plan->withvalues = 1;
             arg++;
             continue;
@@ -1174,7 +1182,7 @@ int arGrepParsePlanOrReply(client *c, arGrepPlan *plan, uint64_t *limit,
 
         if (!strcasecmp(token, "AND") || !strcasecmp(token, "OR")) {
             plan->combine = !strcasecmp(token, "AND") ?
-                ARGREP_COMBINE_AND : ARGREP_COMBINE_OR;
+                ARPRED_COMBINE_AND : ARPRED_COMBINE_OR;
             arg++;
             continue;
         }
@@ -1189,30 +1197,30 @@ int arGrepParsePlanOrReply(client *c, arGrepPlan *plan, uint64_t *limit,
         return C_ERR;
     }
 
-    return arGrepCompileRegexesOrReply(c, plan);
+    return arCompilePredicateRegexesOrReply(c, plan);
 }
 
 /* Match one predicate against the decoded element bytes. */
-int arGrepMatchPredicate(arGrepPredicate *pred, const char *data, size_t len,
+int arPredicateMatch(arPredicate *pred, const char *data, size_t len,
                          int nocase) {
 
     switch (pred->type) {
-    case ARGREP_PRED_EXACT: {
+    case ARPRED_EXACT: {
         size_t pattern_len = sdslen(pred->pattern);
-        return arGrepBytesEqual(data, len, pred->pattern, pattern_len, nocase);
+        return arPredicateBytesEqual(data, len, pred->pattern, pattern_len, nocase);
     }
-    case ARGREP_PRED_MATCH: {
+    case ARPRED_MATCH: {
         size_t pattern_len = sdslen(pred->pattern);
-        return arGrepBytesContains(data, len, pred->pattern, pattern_len,
+        return arPredicateBytesContains(data, len, pred->pattern, pattern_len,
                                    nocase);
     }
-    case ARGREP_PRED_GLOB: {
+    case ARPRED_GLOB: {
         size_t pattern_len = sdslen(pred->pattern);
         return stringmatchlen(pred->pattern, pattern_len, data, len, nocase);
     }
-    case ARGREP_PRED_RE:
+    case ARPRED_RE:
         return tre_regnexecb(&pred->regex, data, len, 0, NULL, 0) == REG_OK;
-    case ARGREP_PRED_RANGE: {
+    case ARPRED_RANGE: {
         long double val;
         if (!string2ld(data, len, &val)) return 0;
         if (pred->exclusive) {
@@ -1223,20 +1231,20 @@ int arGrepMatchPredicate(arGrepPredicate *pred, const char *data, size_t len,
         return 1;
     }
     default:
-        serverPanic("Unknown ARGREP predicate type");
+        serverPanic("Unknown ARRAY predicate type");
     }
 }
 
 /* Decode one array value and apply all the predicates to it. */
-int arGrepValueMatches(arGrepPlan *plan, void *v) {
+int arPredicateValueMatches(arPredicatePlan *plan, void *v) {
     if (plan->num_preds == 0) return 1;
     char buf[AR_INLINE_BUFSIZE];
     size_t len;
     const char *data = arDecode(v, buf, sizeof(buf), &len);
 
-    if (plan->combine == ARGREP_COMBINE_AND) {
+    if (plan->combine == ARPRED_COMBINE_AND) {
         for (int i = 0; i < plan->num_preds; i++) {
-            if (!arGrepMatchPredicate(&plan->preds[i], data, len,
+            if (!arPredicateMatch(&plan->preds[i], data, len,
                                       plan->nocase)) {
                 return 0;
             }
@@ -1245,11 +1253,22 @@ int arGrepValueMatches(arGrepPlan *plan, void *v) {
     }
 
     for (int i = 0; i < plan->num_preds; i++) {
-        if (arGrepMatchPredicate(&plan->preds[i], data, len, plan->nocase))
+        if (arPredicateMatch(&plan->preds[i], data, len, plan->nocase))
             return 1;
     }
     return 0;
 }
+
+
+/* ============================================================================
+ * ARGREP
+ * ============================================================================
+ *
+ * Search existing array elements in a range using textual predicates.
+ * Like ARSCAN, the work is bound by the visited slices, not by the raw
+ * numeric span alone: dense slices scan the touched dense window, while
+ * sparse slices only scan stored entries inside the covered offsets.
+ * -------------------------------------------------------------------------- */
 
 /* ARGREP key start end
  *        (EXACT string | MATCH string | GLOB pattern | RE pattern) ...
@@ -1265,24 +1284,24 @@ int arGrepValueMatches(arGrepPlan *plan, void *v) {
  * "-" and "+" mean the logical start and end of the array. WITHVALUES changes
  * the reply from [idx ...] to [idx value ...]. */
 void argrepCommand(client *c) {
-    arGrepBound start_bound, end_bound;
-    if (arGrepParseBoundOrReply(c, c->argv[2], &start_bound) != C_OK) return;
-    if (arGrepParseBoundOrReply(c, c->argv[3], &end_bound) != C_OK) return;
+    arPredicateBound start_bound, end_bound;
+    if (arParsePredicateBoundOrReply(c, c->argv[2], &start_bound) != C_OK) return;
+    if (arParsePredicateBoundOrReply(c, c->argv[3], &end_bound) != C_OK) return;
 
-    arGrepPlan plan;
+    arPredicatePlan plan;
     uint64_t remaining;
-    if (arGrepParsePlanOrReply(c, &plan, &remaining, NULL, NULL) != C_OK) {
-        arGrepFreePlan(&plan);
+    if (arParsePredicatePlanOrReply(c, &plan, &remaining, NULL, NULL, 1) != C_OK) {
+        arFreePredicatePlan(&plan);
         return;
     }
 
     robj *o = lookupKeyRead(c->db, c->argv[1]);
     if (o != NULL && checkType(c, o, OBJ_ARRAY)) {
-        arGrepFreePlan(&plan);
+        arFreePredicatePlan(&plan);
         return;
     }
     if (o == NULL) {
-        arGrepFreePlan(&plan);
+        arFreePredicatePlan(&plan);
         addReplyArrayLen(c, 0);
         return;
     }
@@ -1290,7 +1309,7 @@ void argrepCommand(client *c) {
     redisArray *ar = o->ptr;
     uint64_t ar_len = arLen(ar);
     if (ar_len == 0 || arCount(ar) == 0) {
-        arGrepFreePlan(&plan);
+        arFreePredicatePlan(&plan);
         addReplyArrayLen(c, 0);
         return;
     }
@@ -1298,15 +1317,15 @@ void argrepCommand(client *c) {
     void *replylen = addReplyDeferredLen(c);
     uint64_t count = 0;
     uint64_t max_index = ar_len - 1;
-    uint64_t start = arGrepResolveBound(&start_bound, max_index);
-    uint64_t end = arGrepResolveBound(&end_bound, max_index);
+    uint64_t start = arResolvePredicateBound(&start_bound, max_index);
+    uint64_t end = arResolvePredicateBound(&end_bound, max_index);
     arScanIter it;
     uint64_t idx;
     void *v;
 
     arScanIterInit(ar, start, end, &it);
     while (remaining && arScanIterNext(&it, &idx, &v)) {
-        if (!arGrepValueMatches(&plan, v)) continue;
+        if (!arPredicateValueMatches(&plan, v)) continue;
         /* With WITHVALUES, reply nested [idx, value] pairs. */
         if (plan.withvalues) addReplyArrayLen(c, 2);
         addReplyUnsignedLongLong(c, idx);
@@ -1316,7 +1335,7 @@ void argrepCommand(client *c) {
     }
 
     setDeferredArrayLen(c, replylen, count);
-    arGrepFreePlan(&plan);
+    arFreePredicatePlan(&plan);
 }
 
 /* ============================================================================
@@ -1556,7 +1575,6 @@ void aropCommand(client *c) {
 #define ARAGG_OP_OR    7
 #define ARAGG_OP_XOR   8
 
-
 /* Holds state for multiple concurrent aggregates */
 typedef struct {
     int has_sum, has_min, has_max, has_count;
@@ -1752,20 +1770,20 @@ static void arMultiAccReply(client *c, arMultiAcc *acc, int *ops, int num_ops) {
  * Compute one or more aggregates over elements that match the given predicates.
  * Available operations: SUM, MIN, MAX, COUNT, AVG, AND, OR, XOR. */
 void araggCommand(client *c) {
-    arGrepBound start_bound, end_bound;
-    if (arGrepParseBoundOrReply(c, c->argv[2], &start_bound) != C_OK) return;
-    if (arGrepParseBoundOrReply(c, c->argv[3], &end_bound) != C_OK) return;
+    arPredicateBound start_bound, end_bound;
+    if (arParsePredicateBoundOrReply(c, c->argv[2], &start_bound) != C_OK) return;
+    if (arParsePredicateBoundOrReply(c, c->argv[3], &end_bound) != C_OK) return;
 
     /* ---- Parse optional predicates + global options, stopping at "AGGREGATE" ---- */
-    arGrepPlan plan;
+    arPredicatePlan plan;
     uint64_t limit;
     int agg_idx = -1;   /* will be set to the index of "AGGREGATE" */
-    if (arGrepParsePlanOrReply(c, &plan, &limit, "AGGREGATE", &agg_idx) != C_OK) {
-        arGrepFreePlan(&plan);
+    if (arParsePredicatePlanOrReply(c, &plan, &limit, "AGGREGATE", &agg_idx, 0) != C_OK) {
+        arFreePredicatePlan(&plan);
         return;
     }
     if (agg_idx == -1) {
-        arGrepFreePlan(&plan);
+        arFreePredicatePlan(&plan);
         addReplyError(c, "AGGREGATE keyword required");
         return;
     }
@@ -1773,7 +1791,7 @@ void araggCommand(client *c) {
     /* ---- Parse aggregate operations (argv[agg_idx+1 .. argc-1]) ---- */
     int first_op = agg_idx + 1;
     if (first_op >= c->argc) {
-        arGrepFreePlan(&plan);
+        arFreePredicatePlan(&plan);
         addReplyError(c, "AGGREGATE keyword requires at least one operation");
         return;
     }
@@ -1794,7 +1812,7 @@ void araggCommand(client *c) {
         else if (!strcasecmp(opstr, "XOR"))   op = ARAGG_OP_XOR;
         else {
             zfree(ops);
-            arGrepFreePlan(&plan);
+            arFreePredicatePlan(&plan);
             addReplyErrorFormat(c, "unknown aggregate operation: %s", opstr);
             return;
         }
@@ -1804,7 +1822,7 @@ void araggCommand(client *c) {
     robj *o = lookupKeyRead(c->db, c->argv[1]);
     if (o != NULL && checkType(c, o, OBJ_ARRAY)) {
         zfree(ops);
-        arGrepFreePlan(&plan);
+        arFreePredicatePlan(&plan);
         return;
     }
 
@@ -1813,7 +1831,7 @@ void araggCommand(client *c) {
         memset(&acc, 0, sizeof(acc));
         arMultiAccReply(c, &acc, ops, num_ops);
         zfree(ops);
-        arGrepFreePlan(&plan);
+        arFreePredicatePlan(&plan);
         return;
     }
 
@@ -1824,14 +1842,14 @@ void araggCommand(client *c) {
         memset(&acc, 0, sizeof(acc));
         arMultiAccReply(c, &acc, ops, num_ops);
         zfree(ops);
-        arGrepFreePlan(&plan);
+        arFreePredicatePlan(&plan);
         return;
     }
 
     /* ---- Iterate over the range and accumulate ---- */
     uint64_t max_index = ar_len - 1;
-    uint64_t start = arGrepResolveBound(&start_bound, max_index);
-    uint64_t end   = arGrepResolveBound(&end_bound,   max_index);
+    uint64_t start = arResolvePredicateBound(&start_bound, max_index);
+    uint64_t end   = arResolvePredicateBound(&end_bound,   max_index);
 
     arScanIter it;
     arScanIterInit(ar, start, end, &it);
@@ -1842,7 +1860,7 @@ void araggCommand(client *c) {
     arMultiAccInit(&acc, ops, num_ops);
 
     while (limit > 0 && arScanIterNext(&it, &idx, &v)) {
-        if (!arGrepValueMatches(&plan, v)) continue;
+        if (!arPredicateValueMatches(&plan, v)) continue;
         arMultiAccAdd(&acc, v);
         limit--;
     }
@@ -1850,7 +1868,7 @@ void araggCommand(client *c) {
     arMultiAccReply(c, &acc, ops, num_ops);
 
     zfree(ops);
-    arGrepFreePlan(&plan);
+    arFreePredicatePlan(&plan);
 }
 
 /* ----------------------------------------------------------------------------

--- a/tests/unit/type/array.tcl
+++ b/tests/unit/type/array.tcl
@@ -380,6 +380,78 @@ start_server {
         assert_error {*invalid regular expression*} [list r argrep myarray - + RE $invalid NOCASE]
     }
 
+     test {ARGREP RANGE inclusive} {
+        r del myarray
+        r armset myarray 0 5 1 10 2 15 3 20 4 foo 5 25
+
+        assert_equal {1 2 3} [r argrep myarray - + RANGE 10 20]
+    }
+
+    test {ARGREP RANGE exclusive} {
+        r del myarray
+        r armset myarray 0 10 1 15 2 20
+
+        assert_equal {1} [r argrep myarray - + RANGE 10 20 EXCLUSIVE]
+    }
+
+    test {ARGREP RANGE with non-numeric values} {
+        r del myarray
+        r armset myarray 0 hello 1 5 2 world 3 10
+
+        assert_equal {1 3} [r argrep myarray - + RANGE 0 100]
+    }
+
+    test {ARGREP RANGE with WITHVALUES and reverse} {
+        r del myarray
+        r armset myarray 0 5 1 10 2 15
+
+        assert_equal {{2 15} {1 10}} [r argrep myarray 2 0 RANGE 10 20 WITHVALUES]
+    }
+
+    test {ARGREP RANGE combined with AND} {
+        r del myarray
+        r armset myarray 0 10 1 20 2 30
+
+        assert_equal {0} [r argrep myarray - + MATCH 10 RANGE 0 100 AND]
+    }
+
+    test {ARGREP RANGE combined with OR} {
+        r del myarray
+        r armset myarray 0 "foo" 1 10 2 20
+
+        assert_equal {0 2} [r argrep myarray - + MATCH foo RANGE 15 25 OR]
+    }
+
+    test {ARGREP RANGE with LIMIT} {
+        r del myarray
+        r armset myarray 0 10 1 20 2 30
+
+        assert_equal {0 1} [r argrep myarray - + RANGE 0 100 LIMIT 2]
+    }
+
+    test {ARGREP RANGE error cases} {
+        r del myarray
+        r arset myarray 0 5
+
+        # not enough arguments caught by arity
+        catch {r argrep myarray - + RANGE} err
+        assert_match "*wrong number*" $err
+
+        # invalid numeric values
+        assert_error "*not a valid float*" {r argrep myarray - + RANGE not-a-number 10}
+        assert_error "*not a valid float*" {r argrep myarray - + RANGE 10 not-a-number}
+
+        # unknown token after a valid predicate triggers syntax error
+        assert_error "*syntax error*" {r argrep myarray - + RANGE 10 20 FOO}
+    }
+
+    test {ARGREP still works after adding RANGE} {
+        r del myarray
+        r armset myarray 0 alpha 1 beta 2 alphabet
+
+        assert_equal {0 2} [r argrep myarray - + MATCH alpha]
+    }
+
     test {ARSET contiguous write basics} {
         r del myarray
         assert_equal 3 [r arset myarray 0 a b c]
@@ -532,6 +604,201 @@ start_server {
         assert_equal 1 [r arop myarray 0 2 AND]
         assert_equal 7 [r arop myarray 0 2 OR]
         assert_equal 5 [r arop myarray 0 2 XOR]
+    }
+
+    # ARAGG tests
+    test {ARAGG COUNT all elements} {
+        r del myarray
+        r armset myarray 0 a 1 b 2 c
+
+        assert_equal 3 [r aragg myarray - + AGGREGATE COUNT]
+    }
+
+    test {ARAGG COUNT with predicate} {
+        r del myarray
+        r armset myarray 0 apple 1 banana 2 apricot
+
+        assert_equal 1 [r aragg myarray - + MATCH ban AGGREGATE COUNT]
+    }
+
+    test {ARAGG SUM} {
+        r del myarray
+        r armset myarray 0 10 1 20.5 2 30
+
+        # 10 + 20.5 + 30 = 60.5, Redis returns string
+        set res [r aragg myarray - + AGGREGATE SUM]
+        assert_equal "60.5" $res
+    }
+
+    test {ARAGG MIN and MAX} {
+        r del myarray
+        r armset myarray 0 100 1 5 2 20.5
+
+        assert_equal "5" [r aragg myarray - + AGGREGATE MIN]
+        assert_equal "100" [r aragg myarray - + AGGREGATE MAX]
+    }
+
+    test {ARAGG AVG} {
+        r del myarray
+        r armset myarray 0 10 1 20 2 "hello" 3 30
+
+        # numeric: 10,20,30 -> sum=60, numeric_count=3, avg=20
+        set res [r aragg myarray - + AGGREGATE AVG]
+        assert_equal "20" $res
+    }
+
+    test {ARAGG bitwise operations} {
+        r del myarray
+        # 7 (0b0111), 3 (0b0011), 1 (0b0001)
+        r armset myarray 0 7 1 3 2 1
+
+        assert_equal 1 [r aragg myarray - + AGGREGATE AND]
+        assert_equal 7 [r aragg myarray - + AGGREGATE OR]
+        assert_equal 5 [r aragg myarray - + AGGREGATE XOR]
+    }
+
+    test {ARAGG bitwise truncates floats} {
+        r del myarray
+        r armset myarray 0 7.9 1 3.2 2 1.8
+
+        assert_equal 1 [r aragg myarray - + AGGREGATE AND]
+        assert_equal 7 [r aragg myarray - + AGGREGATE OR]
+        assert_equal 5 [r aragg myarray - + AGGREGATE XOR]
+    }
+
+    #  ARAGG – multiple operations
+    test {ARAGG multiple aggregates in one call} {
+        r del myarray
+        r armset myarray 0 10 1 20 2 30
+
+        set res [r aragg myarray - + AGGREGATE SUM MIN MAX COUNT AVG]
+        assert_equal {60 10 30 3 20} $res
+    }
+
+    test {ARAGG mixed numeric and bitwise} {
+        r del myarray
+        r armset myarray 0 5 1 3 2 1
+
+        set res [r aragg myarray - + AGGREGATE SUM AND OR]
+        assert_equal {9 1 7} $res
+    }
+
+    #  ARAGG – predicates and options
+    test {ARAGG with RANGE filter} {
+        r del myarray
+        r armset myarray 0 5 1 10 2 15 3 20
+
+        assert_equal 3 [r aragg myarray - + RANGE 10 20 AGGREGATE COUNT]
+    }
+
+    test {ARAGG with MATCH and NOCASE} {
+        r del myarray
+        r armset myarray 0 Alpha 1 beta 2 ALPHA
+
+        assert_equal 2 [r aragg myarray - + MATCH alpha NOCASE AGGREGATE COUNT]
+    }
+
+    test {ARAGG with AND combination} {
+        r del myarray
+        r armset myarray 0 12 1 123 2 34
+
+        assert_equal 1 [r aragg myarray - + MATCH 12 RANGE 0 100 AND AGGREGATE COUNT]
+    }
+
+    test {ARAGG with OR combination} {
+        r del myarray
+        r armset myarray 0 "foo" 1 10 2 20
+
+        assert_equal 2 [r aragg myarray - + MATCH foo RANGE 15 25 OR AGGREGATE COUNT]
+    }
+
+    test {ARAGG with LIMIT} {
+        r del myarray
+        r armset myarray 0 10 1 20 2 30 3 40
+
+        # only first 2 matching elements are considered
+        set res [r aragg myarray - + LIMIT 2 AGGREGATE SUM]
+        assert_equal "30" $res
+    }
+
+    test {ARAGG with GLOB predicate} {
+        r del myarray
+        r armset myarray 0 "apple" 1 "application" 2 "banana"
+
+        assert_equal 2 [r aragg myarray - + GLOB app* AGGREGATE COUNT]
+    }
+
+    #ARAGG – edge cases and errors    
+    test {ARAGG missing key returns nulls/0} {
+        r del nonexistent
+        set res [r aragg nonexistent - + AGGREGATE SUM COUNT AVG]
+        assert_equal {{} 0 {}} $res
+    }
+
+    test {ARAGG empty array returns nulls/0} {
+        r del myarray
+        r arset myarray 0 a
+        r ardel myarray 0
+        set res [r aragg myarray - + AGGREGATE SUM COUNT]
+        assert_equal {{} 0} $res
+    }
+
+    test {ARAGG AGGREGATE keyword missing} {
+        r del myarray
+        assert_error {*AGGREGATE keyword required*} {r aragg myarray - + MATCH foo}
+    }
+
+    test {ARAGG no operation after AGGREGATE} {
+        r del myarray
+        assert_error {*requires at least one operation*} {r aragg myarray - + MATCH foo AGGREGATE}
+    }
+
+    test {ARAGG unknown operation} {
+        r del myarray
+        assert_error {*unknown aggregate operation: FOO*} {r aragg myarray - + AGGREGATE FOO}
+    }
+
+    test {ARAGG type error on key} {
+        r set mystring hello
+        assert_error {*WRONGTYPE*} {r aragg mystring - + AGGREGATE COUNT}
+    }
+
+    test {ARAGG ignores NaN for numeric aggregates} {
+        r del myarray
+        r armset myarray 0 10 1 "not a number" 2 20
+
+        set res [r aragg myarray - + AGGREGATE SUM COUNT AVG]
+        # count includes non-numeric, sum=30, numeric_count=2 => avg=15
+        assert_equal {30 3 15} $res
+    }
+
+    test {ARAGG non-numeric string ignored by bitwise} {
+        r del myarray
+        r armset myarray 0 7 1 "hello" 2 3
+
+        set res [r aragg myarray - + AGGREGATE AND]
+        # only 7 and 3: 7&3=3
+        assert_equal 3 $res
+    }
+
+    test {ARAGG with invalid regex} {
+        r del myarray
+        assert_error {*invalid regular expression*} {r aragg myarray - + RE {(} AGGREGATE COUNT}
+    }
+
+    test {ARAGG respects start/end bounds} {
+        r del myarray
+        r armset myarray 0 10 1 20 2 30 3 40
+
+        assert_equal 1 [r aragg myarray 1 1 AGGREGATE COUNT]
+    }
+
+    test {ARAGG does not interfere with ARGREP} {
+        r del myarray
+        r armset myarray 0 10 1 20
+
+        assert_equal 2 [r aragg myarray - + AGGREGATE COUNT]
+        assert_equal {0 1} [r argrep myarray - + RANGE 0 100]
     }
 
     # ARINFO tests


### PR DESCRIPTION
**This PR addresses #15211 - but `ARQUERY` is not added because its functionality would remain same as `ARGREP`, so I am unsure whether to add it or not (happy to change my decision if maintainers push me)**

- **Implements `ARAGG` - Array Aggregate command in similar fashion as `AROP`.**

- **Enhances `ARGREP` to include `RANGE` predicate.**

## Changes

  1. Changes to `ARGREP` to add `RANGE` is minimal. (`t_array.c`)
  2. `ARAGG` is implemented in similar way to `AROP`. (`t_array.c`)
  3.  Predicate logic is now shared between `ARGREP` and `ARAGG`. (`t_array.c`)
  4. Tests covering `ARGREP` with `RANGE` predicate and `ARAGG` command.
  
## ARGREP – now with RANGE predicate
```
ARGREP key start end
  [EXACT string | MATCH string | GLOB pattern | RE pattern | RANGE min max [EXCLUSIVE]] ...
  [AND | OR] [LIMIT count] [WITHVALUES] [NOCASE]
```
  
## ARAGG – compute aggregates with optional predicates
```
ARAGG key start end
  [EXACT string | MATCH string | GLOB pattern | RE pattern | RANGE min max [EXCLUSIVE]] ...
  [AND | OR] [LIMIT count] [NOCASE]
  AGGREGATE op [op ...]
```

## Examples

```
127.0.0.1:6379> DEL temps
(integer) 1
127.0.0.1:6379> ARMSET temps 0 20.1 1 45.0 2 29.9 3 35.2
(integer) 4
127.0.0.1:6379> ARGREP temps - + RANGE 30 40
1) (integer) 3

127.0.0.1:6379> DEL temps
(integer) 1
127.0.0.1:6379> ARMSET temps 0 5 1 10 2 15 3 20 4 25
(integer) 5
127.0.0.1:6379> ARGREP temps - + RANGE 10 20 EXCLUSIVE
1) (integer) 2

127.0.0.1:6379> DEL readings
(integer) 1
127.0.0.1:6379> ARMSET readings 5 "failover-55"
(integer) 1
127.0.0.1:6379> ARGREP readings - + MATCH "fail" WITHVALUES
1) 1) (integer) 5
   2) "failover-55"
   
127.0.0.1:6379> DEL temps
(integer) 1
127.0.0.1:6379> ARMSET temps 0 20.1 1 5.0 2 35.2
(integer) 3
127.0.0.1:6379> ARAGG temps - + AGGREGATE MIN MAX AVG
1) "5"
2) "35.2"
3) "20.1"

127.0.0.1:6379> DEL errors
(integer) 1
127.0.0.1:6379> ARMSET errors 0 "timeout-120" 1 "timeout-150" 2 "timeout-180"
(integer) 3
127.0.0.1:6379> ARAGG errors - + MATCH "timeout" AGGREGATE COUNT
1) (integer) 3
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public commands and shared parser changes affect ARGREP and ARAGG behavior; readonly-only but regex/RANGE parsing and aggregate edge cases need careful review.
> 
> **Overview**
> Introduces **`ARAGG`** (8.10.0): a readonly array command that scans an index range, optionally filters elements with the same predicates as **`ARGREP`** (EXACT, MATCH, GLOB, RE, **RANGE**), then returns **SUM, MIN, MAX, COUNT, AVG, AND, OR, XOR** in one pass via a required **`AGGREGATE`** clause. Predicates are optional for `ARAGG`; **`WITHVALUES`** is rejected there.
> 
> **`ARGREP`** gains a **`RANGE min max [EXCLUSIVE]`** predicate (numeric element values, inclusive or exclusive bounds). Command metadata is updated in `commands/aragg.json`, `commands/argrep.json`, and generated `commands.def`.
> 
> **`t_array.c`** refactors ARGREP-specific predicate code into a shared **array predicate engine** (`arPredicate*`, `arParsePredicatePlanOrReply` with optional stop-at-`AGGREGATE` and optional zero predicates). **`araggCommand`** implements multi-accumulator logic similar in spirit to **`AROP`**, honoring **LIMIT** on matched elements. Unit tests in `tests/unit/type/array.tcl` cover RANGE on ARGREP and broad ARAGG behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f68b8e608a24efc82a98963af57b00234e4508c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->