### PR TITLE
fix(active-defrag): prevent division-by-zero when thresholds are equal

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1470,6 +1470,15 @@ void computeDefragCycles(void) {
 
     /* Calculate the adaptive aggressiveness of the defrag based on the current
      * fragmentation and configurations. */
+    /* Guard against division-by-zero when thresholds are equal or reversed */
+    if (server.active_defrag_threshold_upper <= server.active_defrag_threshold_lower) {
+        serverLog(LL_WARNING,
+            "Active defrag: upper threshold (%d) <= lower threshold (%d), using max cycle",
+            server.active_defrag_threshold_upper,
+            server.active_defrag_threshold_lower);
+        server.active_defrag_running = server.active_defrag_cycle_max;
+        return;
+    }
     int cpu_pct = INTERPOLATE(frag_pct,
             server.active_defrag_threshold_lower,
             server.active_defrag_threshold_upper,


### PR DESCRIPTION
## What does this PR do?

`computeDefragCycles()` uses the difference between `active-defrag-threshold-upper` and `active-defrag-threshold-lower` as a divisor in the INTERPOLATE macro. Equal thresholds cause a division-by-zero UBSAN error.

### Issue

```c
#define INTERPOLATE(x, x1, x2, y1, y2) ( (y1) + ((x)-(x1)) * ((y2)-(y1)) / ((x2)-(x1)) )
```

When `threshold_upper == threshold_lower`, `(x2)-(x1)` equals zero, causing undefined behavior.

### Fix

Check if `threshold_upper <= threshold_lower` before interpolation. If so, log a warning and use `active_defrag_cycle_max` directly to avoid the division.

This maintains backward compatibility with existing configurations while preventing UBsan errors.

Fixes #15513

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in active defrag cycle calculation; avoids UBSAN on misconfiguration without altering normal threshold behavior.
> 
> **Overview**
> **Active defrag** no longer divides by zero when `active-defrag-threshold-upper` is less than or equal to `active-defrag-threshold-lower`.
> 
> In `computeDefragCycles()`, a check runs before the `INTERPOLATE` call that maps fragmentation to CPU cycle percent. If the upper threshold is not above the lower one, the server logs a warning, sets `active_defrag_running` to `active_defrag_cycle_max`, and returns instead of evaluating `INTERPOLATE` (whose divisor is `upper - lower`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a331cd6df9fc6508756da9dfe47692e0889fd3eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->