### PR TITLE
Prevent duplicate redis instances from replacing active Unix sockets

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -499,8 +499,7 @@ int anetUnixGenericConnect(char *err, const char *path, int flags)
     return s;
 }
 
-int anetUnixNonBlockConnect(char *err, const char *path)
-{
+int anetUnixNonBlockConnect(char *err, const char *path) {
     return anetUnixGenericConnect(err,path,ANET_CONNECT_NONBLOCK);
 }
 

--- a/src/anet.c
+++ b/src/anet.c
@@ -492,10 +492,8 @@ int anetUnixGenericConnect(char *err, const char *path, int flags)
             flags & ANET_CONNECT_NONBLOCK)
             return s;
 
-        int connect_errno = errno;
         anetSetError(err, "connect: %s", strerror(errno));
         close(s);
-        errno = connect_errno;
         return ANET_ERR;
     }
     return s;

--- a/src/anet.c
+++ b/src/anet.c
@@ -492,8 +492,10 @@ int anetUnixGenericConnect(char *err, const char *path, int flags)
             flags & ANET_CONNECT_NONBLOCK)
             return s;
 
+        int connect_errno = errno;
         anetSetError(err, "connect: %s", strerror(errno));
         close(s);
+        errno = connect_errno;
         return ANET_ERR;
     }
     return s;

--- a/src/anet.c
+++ b/src/anet.c
@@ -499,6 +499,11 @@ int anetUnixGenericConnect(char *err, const char *path, int flags)
     return s;
 }
 
+int anetUnixNonBlockConnect(char *err, const char *path)
+{
+    return anetUnixGenericConnect(err,path,ANET_CONNECT_NONBLOCK);
+}
+
 static int anetListen(char *err, int s, struct sockaddr *sa, socklen_t len, int backlog, mode_t perm) {
     if (bind(s,sa,len) == -1) {
         anetSetError(err, "bind: %s", strerror(errno));

--- a/src/anet.h
+++ b/src/anet.h
@@ -33,6 +33,7 @@
 
 int anetTcpNonBlockConnect(char *err, const char *addr, int port);
 int anetTcpNonBlockBestEffortBindConnect(char *err, const char *addr, int port, const char *source_addr);
+int anetUnixNonBlockConnect(char *err, const char *path);
 int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len, int flags);
 int anetTcpServer(char *err, int port, char *bindaddr, int backlog);
 int anetTcp6Server(char *err, int port, char *bindaddr, int backlog);

--- a/src/connection.c
+++ b/src/connection.c
@@ -62,11 +62,12 @@ int connTypeInitialize(void) {
     /* currently socket connection type is necessary  */
     serverAssert(RedisRegisterConnectionTypeSocket() == C_OK);
 
-    /* currently unix socket connection type is necessary  */
-    serverAssert(RedisRegisterConnectionTypeUnix() == C_OK);
-
     /* may fail if without BUILD_TLS=yes */
     RedisRegisterConnectionTypeTLS();
+
+    /* Register the Unix connection type last so its listener is initialized
+     * only after the TCP and TLS listeners. */
+    serverAssert(RedisRegisterConnectionTypeUnix() == C_OK);
 
     return C_OK;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -3296,6 +3296,7 @@ void initListeners(void) {
 
     /* create all the configured listener, and add handler to start to accept */
     int listen_fds = 0;
+    int unix_socket_created = 0;
     for (int j = 0; j < CONN_TYPE_MAX; j++) {
         listener = &server.listeners[j];
         if (listener->ct == NULL)
@@ -3303,19 +3304,30 @@ void initListeners(void) {
 
         if (connListen(listener) == C_ERR) {
             serverLog(LL_WARNING, "Failed listening on port %u (%s), aborting.", listener->port, listener->ct->get_type(NULL));
-            exit(1);
+            goto listener_error;
         }
 
-        if (createSocketAcceptHandler(listener, connAcceptHandler(listener->ct)) != C_OK)
-            serverPanic("Unrecoverable error creating %s listener accept handler.", listener->ct->get_type(NULL));
+        if (!strcasecmp(listener->ct->get_type(NULL), CONN_TYPE_UNIX) && listener->count > 0)
+            unix_socket_created = 1;
 
-       listen_fds += listener->count;
+        if (createSocketAcceptHandler(listener, connAcceptHandler(listener->ct)) != C_OK) {
+            serverLog(LL_WARNING, "Failed creating %s listener accept handler, aborting.",
+                      listener->ct->get_type(NULL));
+            goto listener_error;
+        }
+
+        listen_fds += listener->count;
     }
 
     if (listen_fds == 0) {
         serverLog(LL_WARNING, "Configured to not listen anywhere, exiting.");
-        exit(1);
+        goto listener_error;
     }
+    return;
+
+listener_error:
+    closeListeningSockets(unix_socket_created);
+    exit(1);
 }
 
 /* Some steps in server initialization need to be done last (after modules

--- a/src/unix.c
+++ b/src/unix.c
@@ -62,8 +62,8 @@ static int connUnixListen(connListener *listener) {
 
         /* Make sure the path does not belong to an active listener. */
         fd = anetUnixNonBlockConnect(server.neterr, addr);
-        if (fd != ANET_ERR) {
-            close(fd);
+        if (fd != ANET_ERR || errno == EAGAIN) {
+            if (fd != ANET_ERR) close(fd);
             serverLog(LL_WARNING, "Unix socket %s is already in use", addr);
             return C_ERR;
         }

--- a/src/unix.c
+++ b/src/unix.c
@@ -60,11 +60,27 @@ static int connUnixListen(connListener *listener) {
     for (int j = 0; j < listener->bindaddr_count; j++) {
         char *addr = listener->bindaddr[j];
 
-        unlink(addr); /* don't care if this fails */
+        fd = anetUnixNonBlockConnect(server.neterr, addr);
+        if (fd != ANET_ERR) {
+            close(fd);
+            serverLog(LL_WARNING, "Unix socket %s is already in use", addr);
+            return C_ERR;
+        }
+        if (errno != ENOENT) {
+            if (errno != ECONNREFUSED) {
+                serverLog(LL_WARNING, "Failed probing Unix socket %s: %s", addr, server.neterr);
+                return C_ERR;
+            }
+            if (unlink(addr) == -1) {
+                serverLog(LL_WARNING, "Failed removing stale Unix socket %s: %s", addr, strerror(errno));
+                return C_ERR;
+            }
+        }
+
         fd = anetUnixServer(server.neterr, addr, *perm, server.tcp_backlog);
         if (fd == ANET_ERR) {
             serverLog(LL_WARNING, "Failed opening Unix socket: %s", server.neterr);
-            exit(1);
+            return C_ERR;
         }
         anetNonBlock(NULL, fd);
         anetCloexec(fd);

--- a/src/unix.c
+++ b/src/unix.c
@@ -60,8 +60,7 @@ static int connUnixListen(connListener *listener) {
     for (int j = 0; j < listener->bindaddr_count; j++) {
         char *addr = listener->bindaddr[j];
 
-        /* anetUnixServer unlinks the path before binding, so first make sure the
-         * path does not belong to an active listener. */
+        /* Make sure the path does not belong to an active listener. */
         fd = anetUnixNonBlockConnect(server.neterr, addr);
         if (fd != ANET_ERR) {
             close(fd);
@@ -69,18 +68,10 @@ static int connUnixListen(connListener *listener) {
             return C_ERR;
         }
 
-        /* ENOENT means the path is available. ECONNREFUSED means that a socket
-         * path exists without a listener and can be removed. For any other
-         * error, leave the path untouched since it may not be a stale socket. */
-        if (errno != ENOENT) {
-            if (errno != ECONNREFUSED) {
-                serverLog(LL_WARNING, "Failed probing Unix socket %s: %s", addr, server.neterr);
-                return C_ERR;
-            }
-            if (unlink(addr) == -1) {
-                serverLog(LL_WARNING, "Failed removing stale Unix socket %s: %s", addr, strerror(errno));
-                return C_ERR;
-            }
+        /* Remove the old path before binding the new Unix socket. */
+        if (unlink(addr) == -1 && errno != ENOENT) {
+            serverLog(LL_WARNING, "Failed removing the old Unix socket %s: %s", addr, strerror(errno));
+            return C_ERR;
         }
 
         fd = anetUnixServer(server.neterr, addr, *perm, server.tcp_backlog);

--- a/src/unix.c
+++ b/src/unix.c
@@ -60,12 +60,18 @@ static int connUnixListen(connListener *listener) {
     for (int j = 0; j < listener->bindaddr_count; j++) {
         char *addr = listener->bindaddr[j];
 
+        /* anetUnixServer unlinks the path before binding, so first make sure the
+         * path does not belong to an active listener. */
         fd = anetUnixNonBlockConnect(server.neterr, addr);
         if (fd != ANET_ERR) {
             close(fd);
             serverLog(LL_WARNING, "Unix socket %s is already in use", addr);
             return C_ERR;
         }
+
+        /* ENOENT means the path is available. ECONNREFUSED means that a socket
+         * path exists without a listener and can be removed. For any other
+         * error, leave the path untouched since it may not be a stale socket. */
         if (errno != ENOENT) {
             if (errno != ECONNREFUSED) {
                 serverLog(LL_WARNING, "Failed probing Unix socket %s: %s", addr, server.neterr);

--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -16,35 +16,19 @@ source tests/support/cli.tcl
 
 start_server {tags {"unixsocket external:skip"}} {
     test {A second server does not replace an active Unix socket} {
-        # Avoid a TCP port conflict so the second server reaches the Unix
-        # socket check, while reusing the socket owned by the outer server.
+        # Avoid TCP and TLS port conflicts so the second server reaches the
+        # Unix socket check while reusing the socket owned by the outer server.
         set second_port [find_available_port $::baseport $::portcount]
 
         assert_equal 1 [catch {
             exec src/redis-server [srv config_file] \
-                --port $second_port --unixsocket [srv unixsocket]
+                --port $second_port --tls-port 0 \
+                --unixsocket [srv unixsocket]
         } second_error]
         assert_match {*Unix socket * is already in use*} $second_error
 
         # The failed second startup must not disturb the original listener.
         assert_equal PONG [exec {*}[rediscli_unixsocket [srv unixsocket]] PING]
-    }
-
-    test {Failed listener initialization removes its newly created Unix socket} {
-        if {$::tls} {
-            # Disable the plain TCP listener and use a new Unix socket. The
-            # inherited TLS port is already owned by the outer server, so this
-            # startup fails only after successfully creating the Unix socket.
-            set failed_socket [file normalize [tmpfile failed-startup.sock]]
-
-            assert_equal 1 [catch {
-                exec src/redis-server [srv config_file] \
-                    --port 0 --unixsocket $failed_socket
-            }]
-
-            # Listener rollback must remove the socket created by this process.
-            assert_equal 0 [file exists $failed_socket]
-        }
     }
 
     test {A stale Unix socket is replaced and accepts connections} {

--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -14,6 +14,62 @@
 
 source tests/support/cli.tcl
 
+start_server {tags {"unixsocket external:skip"}} {
+    test {A second server does not replace an active Unix socket} {
+        # Avoid a TCP port conflict so the second server reaches the Unix
+        # socket check, while reusing the socket owned by the outer server.
+        set second_port [find_available_port $::baseport $::portcount]
+
+        assert_equal 1 [catch {
+            exec src/redis-server [srv config_file] \
+                --port $second_port --unixsocket [srv unixsocket]
+        } second_error]
+        assert_match {*Unix socket * is already in use*} $second_error
+
+        # The failed second startup must not disturb the original listener.
+        assert_equal PONG [exec {*}[rediscli_unixsocket [srv unixsocket]] PING]
+    }
+
+    test {Failed listener initialization removes its newly created Unix socket} {
+        if {$::tls} {
+            # Disable the plain TCP listener and use a new Unix socket. The
+            # inherited TLS port is already owned by the outer server, so this
+            # startup fails only after successfully creating the Unix socket.
+            set failed_socket [file normalize [tmpfile failed-startup.sock]]
+
+            assert_equal 1 [catch {
+                exec src/redis-server [srv config_file] \
+                    --port 0 --unixsocket $failed_socket
+            }]
+
+            # Listener rollback must remove the socket created by this process.
+            assert_equal 0 [file exists $failed_socket]
+        }
+    }
+
+    test {A stale Unix socket is replaced and accepts connections} {
+        set stale_socket [file normalize [tmpfile stale.sock]]
+
+        # SIGKILL bypasses normal shutdown cleanup, leaving the socket path
+        # behind with no process listening on it.
+        start_server [list overrides [list unixsocket $stale_socket]] {
+            set stale_pid [srv 0 pid]
+            exec kill -9 $stale_pid
+            wait_for_condition 500 10 {
+                ![is_alive $stale_pid]
+            } else {
+                fail "Server did not exit after SIGKILL"
+            }
+        }
+        assert_equal 1 [file exists $stale_socket]
+
+        # A new server should remove the stale path, bind it, and accept clients.
+        start_server [list overrides [list unixsocket $stale_socket]] {
+            assert_equal PONG [exec {*}[rediscli_unixsocket $stale_socket] PING]
+        }
+    }
+}
+
 test {CONFIG SET port number} {
     start_server {} {
         if {$::tls} { set port_cfg tls-port} else { set port_cfg port }


### PR DESCRIPTION
A second redis process using the same Unix socket path could unlink and replace
the socket of an already-running server before failing to initialize another
listener, such as a TLS listener. This left the original server running but made
its Unix socket unreachable.

This change probes an existing Unix socket before replacing it:

- If the connection succeeds, the socket is active and startup fails without
modifying it.
- If the connection fails, the old path is removed before binding the new Unix
socket. A missing path is ignored.

It also closes listeners created during partial initialization so that a failed
startup does not leave behind a newly created Unix socket.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server startup and Unix socket binding behavior on a critical client path; mistakes could block legitimate restarts or leave stale sockets, though behavior is covered by new tests.
> 
> **Overview**
> Stops a second Redis process from **unlinking and replacing** a Unix socket path that already belongs to a live server—a failure mode that could leave the first instance running but unreachable on that socket.
> 
> **Unix bind path:** Before removing the socket file, startup **probes** the path with a new non-blocking `anetUnixNonBlockConnect`. If connect succeeds (or errno is not the expected “nothing listening” case), bind aborts with *Unix socket … is already in use* without touching the path. Stale paths are still removed (`unlink`, ignoring `ENOENT`) before `anetUnixServer`. Unix listener setup now **returns errors** instead of `exit(1)` inside `unix.c`.
> 
> **Startup ordering and cleanup:** Unix connection type registration moves **after** TCP/TLS so Unix listeners come up last. Listener setup uses a shared **`listener_error`** path: on bind/accept-handler failure or “nowhere to listen”, **`closeListeningSockets`** runs (unlinking the Unix socket only if one was created in this attempt) before `exit(1)`.
> 
> **anet:** Failed Unix `connect` preserves **`errno`** for callers after `anetSetError`/`close`.
> 
> Integration tests cover blocking a second server on the same socket and reusing a path left after **SIGKILL**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f09db9fdfefb4df1e49bf2aa3cc2d74824cd4400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->