### PR TITLE
Fix ACL key checks for SORT

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1752,6 +1752,7 @@ int sortGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *
                  * ones are provided. This is same behavior as SORT. */
                 found_store = 1;
                 keys[num] = i+1; /* <store-key> */
+                i++; /* Skip the store argument so it isn't re-parsed as an option keyword. */
                 break;
             }
         }

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -476,6 +476,24 @@ start_server {tags {"acl"}} {
         assert_match "*Unknown subcommand or wrong number of arguments*" $e
     }
 
+    test {SORT duplicate STORE is checked against the last key} {
+        # Duplicate STORE uses last-wins semantics, so ACL must validate the
+        # last key. The earlier STORE argument can look like an option keyword
+        # (BY/GET/LIMIT) and must be skipped so a permitted first key doesn't
+        # mask a forbidden last key. (Backport smoke test for redis/redis#15478;
+        # 6.2 has no ACL DRYRUN, so we exercise the real command path.)
+        r ACL setuser command-test reset on nopass +@all ~read* ~by ~get ~limit
+        r AUTH command-test ""
+
+        assert_equal {0} [r SORT read STORE by STORE read2]
+        assert_error {*NOPERM*key*} {r SORT read STORE by STORE write2}
+        assert_error {*NOPERM*key*} {r SORT read STORE get STORE write2}
+        assert_error {*NOPERM*key*} {r SORT read STORE limit STORE write2}
+
+        r AUTH default ""
+        r ACL deluser command-test
+    }
+
     test {Delete a user that the client doesn't use} {
         r ACL setuser not_used on >passwd
         assert {[r ACL deluser not_used] == 1}


### PR DESCRIPTION
Based on https://github.com/redis/redis/pull/15478

## Problem

Sort command resolved ACL keys from a keyspec that didn't match the key the command actually operates on, allowing a permission bypass:

- **`SORT`**: `STORE` also uses last-wins semantics. The `STORE` keyspec is already `unknown`, so ACL falls back to `sortGetKeys()` — but that parser didn't skip the `STORE` argument. An earlier `STORE` value that looks like an option keyword (`BY`/`GET`/`LIMIT`) derailed the scan, so a permitted (or non-existent) first key masked a forbidden last key that the write actually landed on.

## Solution

- **`SORT`**: no keyspec change needed — the `STORE` keyspec is already `unknown`, so ACL already delegates to `sortGetKeys()`. Fixed the parser to skip the `STORE` argument (`i++`) so it isn't re-parsed as an option keyword; the last `STORE` still wins.

## Note

Since `GEORADIUS/GEORADIUSBYMEMBER` and `XREAD/XREADGROUP` are the last wins, there is no need for any further fixes for them.