### PR TITLE
Disable defrag during AOF RDB preamble loading to fix template defrag

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1866,12 +1866,11 @@ int loadSingleAppendOnlyFile(char *filename) {
         if (fseek(fp,0,SEEK_SET) == -1) goto readerr;
         rioInitWithFile(&rdb,fp);
 
-        /* Active defrag doesn't run during regular RDB loading. Disable it
+        /* Active defrag doesn't run during regular RDB loading. Pause it
          * while loading an RDB preamble from AOF as well. */
-        int orig_active_defrag = server.active_defrag_enabled;
-        server.active_defrag_enabled = 0;
+        server.active_defrag_paused++;
         int rdb_ret = rdbLoadRio(&rdb,RDBFLAGS_AOF_PREAMBLE,NULL);
-        server.active_defrag_enabled = orig_active_defrag;
+        server.active_defrag_paused--;
 
         if (rdb_ret != C_OK) {
             if (old_style)

--- a/src/aof.c
+++ b/src/aof.c
@@ -1865,7 +1865,15 @@ int loadSingleAppendOnlyFile(char *filename) {
 
         if (fseek(fp,0,SEEK_SET) == -1) goto readerr;
         rioInitWithFile(&rdb,fp);
-        if (rdbLoadRio(&rdb,RDBFLAGS_AOF_PREAMBLE,NULL) != C_OK) {
+
+        /* Active defrag doesn't run during regular RDB loading. Disable it
+         * while loading an RDB preamble from AOF as well. */
+        int orig_active_defrag = server.active_defrag_enabled;
+        server.active_defrag_enabled = 0;
+        int rdb_ret = rdbLoadRio(&rdb,RDBFLAGS_AOF_PREAMBLE,NULL);
+        server.active_defrag_enabled = orig_active_defrag;
+
+        if (rdb_ret != C_OK) {
             if (old_style)
                 serverLog(LL_WARNING, "Error reading the RDB preamble of the AOF file %s, AOF loading aborted", filename);
             else

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1710,7 +1710,7 @@ static doneStatus defragStageHashTemplates(void *ctx, monotime endtime) {
 
         hashTemplateDefrag(tmpl);
 
-        if (++iterations > 64) {
+        if (++iterations > 8) {
             iterations = 0;
             if (getMonotonicUs() >= endtime) return DEFRAG_NOT_DONE;
         }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1710,7 +1710,7 @@ static doneStatus defragStageHashTemplates(void *ctx, monotime endtime) {
 
         hashTemplateDefrag(tmpl);
 
-        if (++iterations > 8) {
+        if (++iterations > 64) {
             iterations = 0;
             if (getMonotonicUs() >= endtime) return DEFRAG_NOT_DONE;
         }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -2029,6 +2029,8 @@ static int activeDefragTimeProc(struct aeEventLoop *eventLoop, long long id, voi
  * actions. This interface allows defrag to continue running, avoiding a single long defrag step
  * after the long operation completes. */
 void defragWhileBlocked(void) {
+    if (server.active_defrag_paused) return;
+
     /* This is called infrequently, while timers are not active. We might need to start defrag. */
     if (!defragIsRunning()) activeDefragCycle();
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2759,8 +2759,7 @@ static robj *rdbFinalizeTmplLp(unsigned char *lp, hashTemplate *tmpl) {
  * were parsed but no template built yet - the caller builds it only after the
  * values load cleanly, so a bad value can't leave an orphan template behind. */
 typedef struct {
-    uint64_t tmpl_id;          /* Valid when tmpl_resolved is set. */
-    int tmpl_resolved;         /* Registry hit; tmpl_id has a hold ref. */
+    hashTemplate *tmpl;        /* Set if resolved from the registry, else NULL. */
     sds *fields;               /* Set if parsed but not yet a template, else NULL. */
     uint64_t field_count;      /* Number of entries in 'fields'. */
     unsigned char *fields_lp;  /* Optional listpack blob for a fast blob->template lookup. */
@@ -2791,9 +2790,7 @@ static int rdbLoadTemplateFields(rio *rdb, int deep, rdbTmplFields *out) {
         hashTemplate *tmpl = hashTemplateGetByFieldsLp(blob);
         if (tmpl != NULL) {
             zfree(blob);
-            hashTemplateIncrHoldRef(tmpl);
-            out->tmpl_id = tmpl->id;
-            out->tmpl_resolved = 1;
+            out->tmpl = tmpl;
             out->field_count = tmpl->field_count;
             return C_OK;
         }
@@ -2868,11 +2865,7 @@ static int rdbLoadTemplateFields(rio *rdb, int deep, rdbTmplFields *out) {
  * create one now, attaching the parsed blob if present. Either way the parsed
  * fields and blob in 'out' are consumed: freed, or handed to the template. */
 static hashTemplate *rdbCreateTemplateFromFields(rdbTmplFields *out) {
-    if (out->tmpl_resolved) {  /* registry hit */
-        hashTemplate *tmpl = hashTemplateGetById(out->tmpl_id);
-        serverAssert(tmpl != NULL); /* held by rdbLoadTemplateFields */
-        return tmpl;
-    }
+    if (out->tmpl != NULL) return out->tmpl; /* registry hit */
     hashTemplate *tmpl = hashTemplateGetOrCreate(out->fields, out->field_count);
     rdbFreeSdsArray(out->fields, out->field_count);
     out->fields = NULL;
@@ -2888,14 +2881,8 @@ static hashTemplate *rdbCreateTemplateFromFields(rdbTmplFields *out) {
 static void rdbDiscardTemplateFields(rdbTmplFields *out) {
     if (out->fields) rdbFreeSdsArray(out->fields, out->field_count);
     if (out->fields_lp) zfree(out->fields_lp);
-    if (out->tmpl_resolved) {
-        hashTemplate *tmpl = hashTemplateGetById(out->tmpl_id);
-        serverAssert(tmpl != NULL);
-        hashTemplateDecrHoldRef(tmpl);
-    }
     out->fields = NULL;
     out->fields_lp = NULL;
-    out->tmpl_resolved = 0;
 }
 
 /* Load a Redis object of the specified type from the specified file.
@@ -3280,7 +3267,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             return NULL;
         }
         o = rdbFinalizeTmplLp(lp, rdbCreateTemplateFromFields(&tf));
-        rdbDiscardTemplateFields(&tf);
 
         if (hashTypeLength(o, 0) > server.hash_max_listpack_entries)
             hashTypeConvert(NULL, o, OBJ_ENCODING_TMPL_ARRAY);
@@ -3331,7 +3317,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
         }
         hashTemplate *tmpl = rdbCreateTemplateFromFields(&tf);
         o = createHashObjectFromTemplate(tmpl, values, 1);
-        rdbDiscardTemplateFields(&tf);
         zfree(values);
     } else if (rdbtype == RDB_TYPE_HASH_TMPL_ARRAY_REF) {
         /* REF form is RDB-file only (needs the template section), never a DUMP payload. */
@@ -3340,25 +3325,19 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             return NULL;
         }
         /* TMPL_ARRAY REF form: [template_id][value1][value2]... */
-        uint64_t rdb_tmpl_id;
-        if ((rdb_tmpl_id = rdbLoadLen(rdb, NULL)) == RDB_LENERR)
+        uint64_t template_id;
+        if ((template_id = rdbLoadLen(rdb, NULL)) == RDB_LENERR)
             return NULL;
 
-        hashTemplate *tmpl = rdbGetHashTemplateById(rdb_tmpl_id);
+        hashTemplate *tmpl = rdbGetHashTemplateById(template_id);
         if (tmpl == NULL) {
-            rdbReportCorruptRDB("Invalid hash template ID %llu", (unsigned long long)rdb_tmpl_id);
+            rdbReportCorruptRDB("Invalid hash template ID %lu", (unsigned long)template_id);
             return NULL;
         }
-        uint64_t registry_tmpl_id = tmpl->id;
         unsigned long long field_count = tmpl->field_count;
 
         sds *values = rdbLoadSdsArray(rdb, field_count, "template-array");
         if (values == NULL) return NULL;
-
-        /* rdbLoadSdsArray() above may yield and defrag during AOF load can 
-         * relocate tmpl. Look it up again. */
-        tmpl = hashTemplateGetById(registry_tmpl_id);
-        serverAssert(tmpl != NULL);
         o = createHashObjectFromTemplate(tmpl, values, 1);
         zfree(values);
     } else if (rdbtype == RDB_TYPE_HASH_METADATA || rdbtype == RDB_TYPE_HASH_METADATA_PRE_GA) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1309,7 +1309,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
                 if (fields_lp) {
                     /* Get listpack blob and skip caching in fork. */
                     int cache = (server.in_fork_child == CHILD_TYPE_NONE);
-                    unsigned char *blob = hashTemplateGetFieldsLp(tmpl, cache);
+                    unsigned char *blob = hashTemplateGetFieldsLp(tmpl, &cache);
                     n = rdbSaveRawString(rdb, blob, lpBytes(blob));
                     if (!cache) lpFree(blob);
                     if (n == -1) return -1;
@@ -2759,7 +2759,8 @@ static robj *rdbFinalizeTmplLp(unsigned char *lp, hashTemplate *tmpl) {
  * were parsed but no template built yet - the caller builds it only after the
  * values load cleanly, so a bad value can't leave an orphan template behind. */
 typedef struct {
-    hashTemplate *tmpl;        /* Set if resolved from the registry, else NULL. */
+    uint64_t tmpl_id;          /* Valid when tmpl_resolved is set. */
+    int tmpl_resolved;         /* Registry hit; tmpl_id has a hold ref. */
     sds *fields;               /* Set if parsed but not yet a template, else NULL. */
     uint64_t field_count;      /* Number of entries in 'fields'. */
     unsigned char *fields_lp;  /* Optional listpack blob for a fast blob->template lookup. */
@@ -2790,7 +2791,9 @@ static int rdbLoadTemplateFields(rio *rdb, int deep, rdbTmplFields *out) {
         hashTemplate *tmpl = hashTemplateGetByFieldsLp(blob);
         if (tmpl != NULL) {
             zfree(blob);
-            out->tmpl = tmpl;
+            hashTemplateIncrHoldRef(tmpl);
+            out->tmpl_id = tmpl->id;
+            out->tmpl_resolved = 1;
             out->field_count = tmpl->field_count;
             return C_OK;
         }
@@ -2865,12 +2868,17 @@ static int rdbLoadTemplateFields(rio *rdb, int deep, rdbTmplFields *out) {
  * create one now, attaching the parsed blob if present. Either way the parsed
  * fields and blob in 'out' are consumed: freed, or handed to the template. */
 static hashTemplate *rdbCreateTemplateFromFields(rdbTmplFields *out) {
-    if (out->tmpl != NULL) return out->tmpl; /* registry hit */
+    if (out->tmpl_resolved) {  /* registry hit */
+        hashTemplate *tmpl = hashTemplateGetById(out->tmpl_id);
+        serverAssert(tmpl != NULL); /* held by rdbLoadTemplateFields */
+        return tmpl;
+    }
     hashTemplate *tmpl = hashTemplateGetOrCreate(out->fields, out->field_count);
     rdbFreeSdsArray(out->fields, out->field_count);
     out->fields = NULL;
     if (out->fields_lp != NULL) {
-        hashTemplateIndexFieldsLp(tmpl, out->fields_lp); /* transfers ownership */
+        if (!hashTemplateIndexFieldsLp(tmpl, out->fields_lp))
+            lpFree(out->fields_lp);
         out->fields_lp = NULL;
     }
     return tmpl;
@@ -2880,8 +2888,14 @@ static hashTemplate *rdbCreateTemplateFromFields(rdbTmplFields *out) {
 static void rdbDiscardTemplateFields(rdbTmplFields *out) {
     if (out->fields) rdbFreeSdsArray(out->fields, out->field_count);
     if (out->fields_lp) zfree(out->fields_lp);
+    if (out->tmpl_resolved) {
+        hashTemplate *tmpl = hashTemplateGetById(out->tmpl_id);
+        serverAssert(tmpl != NULL);
+        hashTemplateDecrHoldRef(tmpl);
+    }
     out->fields = NULL;
     out->fields_lp = NULL;
+    out->tmpl_resolved = 0;
 }
 
 /* Load a Redis object of the specified type from the specified file.
@@ -3266,6 +3280,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             return NULL;
         }
         o = rdbFinalizeTmplLp(lp, rdbCreateTemplateFromFields(&tf));
+        rdbDiscardTemplateFields(&tf);
 
         if (hashTypeLength(o, 0) > server.hash_max_listpack_entries)
             hashTypeConvert(NULL, o, OBJ_ENCODING_TMPL_ARRAY);
@@ -3316,6 +3331,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
         }
         hashTemplate *tmpl = rdbCreateTemplateFromFields(&tf);
         o = createHashObjectFromTemplate(tmpl, values, 1);
+        rdbDiscardTemplateFields(&tf);
         zfree(values);
     } else if (rdbtype == RDB_TYPE_HASH_TMPL_ARRAY_REF) {
         /* REF form is RDB-file only (needs the template section), never a DUMP payload. */
@@ -3324,19 +3340,25 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
             return NULL;
         }
         /* TMPL_ARRAY REF form: [template_id][value1][value2]... */
-        uint64_t template_id;
-        if ((template_id = rdbLoadLen(rdb, NULL)) == RDB_LENERR)
+        uint64_t rdb_tmpl_id;
+        if ((rdb_tmpl_id = rdbLoadLen(rdb, NULL)) == RDB_LENERR)
             return NULL;
 
-        hashTemplate *tmpl = rdbGetHashTemplateById(template_id);
+        hashTemplate *tmpl = rdbGetHashTemplateById(rdb_tmpl_id);
         if (tmpl == NULL) {
-            rdbReportCorruptRDB("Invalid hash template ID %lu", (unsigned long)template_id);
+            rdbReportCorruptRDB("Invalid hash template ID %llu", (unsigned long long)rdb_tmpl_id);
             return NULL;
         }
+        uint64_t registry_tmpl_id = tmpl->id;
         unsigned long long field_count = tmpl->field_count;
 
         sds *values = rdbLoadSdsArray(rdb, field_count, "template-array");
         if (values == NULL) return NULL;
+
+        /* rdbLoadSdsArray() above may yield and defrag during AOF load can 
+         * relocate tmpl. Look it up again. */
+        tmpl = hashTemplateGetById(registry_tmpl_id);
+        serverAssert(tmpl != NULL);
         o = createHashObjectFromTemplate(tmpl, values, 1);
         zfree(values);
     } else if (rdbtype == RDB_TYPE_HASH_METADATA || rdbtype == RDB_TYPE_HASH_METADATA_PRE_GA) {

--- a/src/server.h
+++ b/src/server.h
@@ -2275,6 +2275,7 @@ struct redisServer {
     int allow_access_expired;       /* If > 0, allow access to logically expired keys */
     int allow_access_trimmed;       /* If > 0, allow access to logically trimmed keys */
     int active_defrag_enabled;
+    int active_defrag_paused;
     int sanitize_dump_payload;      /* Enables deep sanitization for ziplist and listpack in RDB and RESTORE. */
     int skip_checksum_validation;   /* Disable checksum validation for RDB and RESTORE payload. */
     int allow_keymeta_registration; /* Allow keymeta class registration outside server startup (for testing). */

--- a/src/server.h
+++ b/src/server.h
@@ -3991,6 +3991,7 @@ typedef struct hashTemplateRegistry {
     size_t by_id_chunks;        /* How many chunks are currently allocated. */
     size_t by_id_next;          /* The next id that has never been used. */
     size_t total_key_refs;      /* Sum of key_refcount across all templates. */
+    size_t fields_lp_cache_bytes; /* Total lpBytes() of cached fields listpack blobs. */
     size_t total_mem_size;      /* Sum of every live template's mem_size, plus any
                                  * attached fields_lp blobs. */
 } hashTemplateRegistry;
@@ -4095,8 +4096,8 @@ hashTemplate *hashTypeGetTemplate(robj *o);
 void hashTemplateIncrKeyRef(hashTemplate *tmpl);
 void hashTemplateIncrHoldRef(hashTemplate *tmpl);
 void hashTemplateDecrHoldRef(hashTemplate *tmpl);
-unsigned char *hashTemplateGetFieldsLp(hashTemplate *tmpl, int cache);
-void hashTemplateIndexFieldsLp(hashTemplate *tmpl, unsigned char *fields_lp);
+unsigned char *hashTemplateGetFieldsLp(hashTemplate *tmpl, int *cache);
+int hashTemplateIndexFieldsLp(hashTemplate *tmpl, unsigned char *fields_lp);
 void hashTemplatesCron(void);
 robj *createHashObjectFromTemplate(hashTemplate *tmpl, sds *values, int take);
 int hashTemplateValidateFields(sds *fields, unsigned long long field_count);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -512,18 +512,33 @@ int hashTemplateDefragByIdChunk(unsigned long chunk_idx) {
     return 1;
 }
 
+/* HIMPORT SET propagation usually sends RESTORE commands with the same few
+ * field sets. ASM may send RESTORE commands with thousands of different field
+ * sets because keys arrive in arbitrary order. The cache holds at most one blob
+ * per template, so its size is naturally bounded by the template count. The
+ * explicit cap only protects against misuse that creates an excessive number
+ * of templates. */
+#define HASH_TMPL_FIELDS_LP_CACHE_MAX_BYTES (16 * 1024 * 1024)
+
 /* Cache 'fields_lp' as tmpl's fields-listpack (blob -> template), taking
- * ownership. Last one wins: a stale blob already attached is dropped. */
-void hashTemplateIndexFieldsLp(hashTemplate *tmpl, unsigned char *fields_lp) {
-    if (tmpl->fields_lp) {
-        dictDelete(htemplates->by_fields_lp, tmpl->fields_lp);
-        htemplates->total_mem_size -= lpBytes(tmpl->fields_lp);
-        lpFree(tmpl->fields_lp);
-    }
+ * ownership on success. Returns 0 without consuming fields_lp if tmpl is already
+ * indexed or the cache is full. */
+int hashTemplateIndexFieldsLp(hashTemplate *tmpl, unsigned char *fields_lp) {
+    if (tmpl->fields_lp) return 0;
+
+    size_t cached_bytes = htemplates->fields_lp_cache_bytes;
+    serverAssert(cached_bytes <= HASH_TMPL_FIELDS_LP_CACHE_MAX_BYTES);
+
+    size_t bytes = lpBytes(fields_lp);
+    if (bytes > HASH_TMPL_FIELDS_LP_CACHE_MAX_BYTES - cached_bytes)
+        return 0;
+
     tmpl->fields_lp = fields_lp;
     tmpl->fields_lp_last_used = server.mstime;
-    dictAdd(htemplates->by_fields_lp, fields_lp, tmpl);
-    htemplates->total_mem_size += lpBytes(fields_lp);
+    serverAssert(dictAdd(htemplates->by_fields_lp, fields_lp, tmpl) == DICT_OK);
+    htemplates->fields_lp_cache_bytes += bytes;
+    htemplates->total_mem_size += bytes;
+    return 1;
 }
 
 /* Build a fresh fields listpack (caller owns it). */
@@ -540,14 +555,15 @@ static unsigned char *hashTemplateBuildFieldsLp(hashTemplate *tmpl) {
     return lp;
 }
 
-/* Return tmpl's fields listpack, building it on first use. 'cache' also adds the
- * blob to the by_fields_lp lookup (used on RESTORE) */
-unsigned char *hashTemplateGetFieldsLp(hashTemplate *tmpl, int cache) {
-    if (!cache) return hashTemplateBuildFieldsLp(tmpl);
+/* Return tmpl's fields listpack, building it on first use. '*cache' requests
+ * indexing the blob for RESTORE lookup and is cleared if the cache is full,
+ * in which case the caller owns the returned blob. */
+unsigned char *hashTemplateGetFieldsLp(hashTemplate *tmpl, int *cache) {
+    if (!*cache) return hashTemplateBuildFieldsLp(tmpl);
     tmpl->fields_lp_last_used = server.mstime;
     if (tmpl->fields_lp) return tmpl->fields_lp;
     unsigned char *lp = hashTemplateBuildFieldsLp(tmpl);
-    hashTemplateIndexFieldsLp(tmpl, lp);
+    if (!hashTemplateIndexFieldsLp(tmpl, lp)) *cache = 0;
     return lp;
 }
 
@@ -601,16 +617,25 @@ static int templateFieldsKeyCompare(dictCmpCache *cache,
     return 1;
 }
 
+/* Drop tmpl's cached fields listpack. */
+static void hashTemplateDropFieldsLp(hashTemplate *tmpl) {
+    if (tmpl->fields_lp == NULL) return;
+
+    unsigned char *lp = tmpl->fields_lp;
+    size_t bytes = lpBytes(lp);
+    serverAssert(dictDelete(htemplates->by_fields_lp, lp) == DICT_OK);
+    serverAssert(htemplates->fields_lp_cache_bytes >= bytes);
+    htemplates->fields_lp_cache_bytes -= bytes;
+    htemplates->total_mem_size -= bytes;
+    lpFree(lp);
+    tmpl->fields_lp = NULL;
+}
+
 static void templateFieldsKeyDestructor(dict *d, void *key) {
     UNUSED(d);
     hashTemplate *tmpl = key;
     tmplIdRecycle(tmpl->id);
-    /* Drop the lazy fields-listpack blob and its by_fields_lp index entry. */
-    if (tmpl->fields_lp) {
-        dictDelete(htemplates->by_fields_lp, tmpl->fields_lp);
-        htemplates->total_mem_size -= lpBytes(tmpl->fields_lp);
-        lpFree(tmpl->fields_lp);
-    }
+    hashTemplateDropFieldsLp(tmpl);
     for (unsigned long long i = 0; i < tmpl->field_count; i++)
         sdsfree(tmpl->fields[i]);
     zfree(tmpl->fields);
@@ -862,12 +887,7 @@ static void hashTemplatesCleanupFieldsLpCron(void) {
 
         for (int i = 0; i < ctx.collected; i++) {
             hashTemplate *tmpl = ctx.tmpls[i];
-            if (tmpl->fields_lp == NULL) continue;
-
-            dictDelete(d, tmpl->fields_lp);
-            htemplates->total_mem_size -= lpBytes(tmpl->fields_lp);
-            lpFree(tmpl->fields_lp);
-            tmpl->fields_lp = NULL;
+            hashTemplateDropFieldsLp(tmpl);
         }
 
         if (cursor == 0) break; /* completed a full sweep */
@@ -3161,7 +3181,7 @@ void hashTypeConvert(redisDb *db, robj *o, int enc) {
  *   - Disassemble: at end of load, turn every template still below the threshold
  *     key count back into a plain LISTPACK/HT hash.
  *
- * Why the reverse map (template -> list of the hash kvobjs using it): to undo a
+ * Why the reverse map (template ID -> list of the hash keys using it): to undo a
  * few-key template at end of load we need its keys, but a template doesn't know
  * who points at it. Building the list as we go lets us disassemble without
  * scanning the whole keyspace. A template that reaches the threshold "graduates"
@@ -3171,8 +3191,8 @@ void hashTypeConvert(redisDb *db, robj *o, int enc) {
  * small early sample won't start it. See rdbLoadTemplateCtxShouldStopCreating(). */
 #define MIN_REVERSE_LOOKUP 1000
 struct rdbLoadTemplateCtx {
-    dict *reverse_lookup;   /* hashTemplate* -> list of hash kvobj* (few-key
-                             * templates only; entries leave on graduation). */
+    dict *reverse_lookup;   /* template ID -> list of rdbLoadTemplateCtxKvRef*
+                             * (few-key templates only; entries leave on graduation). */
     size_t disassembly_threshold; /* Keep templates with >= this many keys. */
     size_t number_of_templates;   /* Templates created this load (monotonic). */
     int stop_creating;        /* One-way latch: stop creating new templates. */
@@ -3195,8 +3215,7 @@ static void rdbLoadTemplateCtxListValDestructor(dict *d, void *val) {
     listRelease(val);
 }
 
-/* Keys are template pointers, values are lists of hash kvobjs freed when the 
- * entry is dropped/released. */
+/* Keys are stable template IDs; values are lists of rdbLoadTemplateCtxKvRef*. */
 static dictType rdbLoadTemplateCtxReverseDictType = {
     .hashFunction = dictPtrHash,
     .valDestructor = rdbLoadTemplateCtxListValDestructor,
@@ -3221,19 +3240,20 @@ void rdbLoadTemplateCtxRecord(rdbLoadTemplateCtx *ctx, robj *kv, redisDb *db) {
         kv->encoding != OBJ_ENCODING_TMPL_ARRAY) return;
 
     hashTemplate *tmpl = hashTypeGetTemplate(kv);
+    void *id_key = (void *)(uintptr_t)tmpl->id;
     if (tmpl->key_refcount == ctx->disassembly_threshold) {
         /* This key graduates tmpl: drop the tracking list so it survives. */
-        dictDelete(ctx->reverse_lookup, tmpl);
+        dictDelete(ctx->reverse_lookup, id_key);
         return;
     }
     if (tmpl->key_refcount > ctx->disassembly_threshold) return; /* already graduated */
 
-    dictEntry *de = dictFind(ctx->reverse_lookup, tmpl);
+    dictEntry *de = dictFind(ctx->reverse_lookup, id_key);
     list *l;
     if (de == NULL) {
         l = listCreate();
         listSetFreeMethod(l, rdbLoadTemplateCtxKvRefListFree);
-        dictAdd(ctx->reverse_lookup, tmpl, l);
+        dictAdd(ctx->reverse_lookup, id_key, l);
     } else {
         l = dictGetVal(de);
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3181,7 +3181,7 @@ void hashTypeConvert(redisDb *db, robj *o, int enc) {
  *   - Disassemble: at end of load, turn every template still below the threshold
  *     key count back into a plain LISTPACK/HT hash.
  *
- * Why the reverse map (template ID -> list of the hash keys using it): to undo a
+ * Why the reverse map (template -> list of the hash kvobjs using it): to undo a
  * few-key template at end of load we need its keys, but a template doesn't know
  * who points at it. Building the list as we go lets us disassemble without
  * scanning the whole keyspace. A template that reaches the threshold "graduates"
@@ -3191,8 +3191,8 @@ void hashTypeConvert(redisDb *db, robj *o, int enc) {
  * small early sample won't start it. See rdbLoadTemplateCtxShouldStopCreating(). */
 #define MIN_REVERSE_LOOKUP 1000
 struct rdbLoadTemplateCtx {
-    dict *reverse_lookup;   /* template ID -> list of rdbLoadTemplateCtxKvRef*
-                             * (few-key templates only; entries leave on graduation). */
+    dict *reverse_lookup;   /* hashTemplate* -> list of hash kvobj* (few-key
+                             * templates only; entries leave on graduation). */
     size_t disassembly_threshold; /* Keep templates with >= this many keys. */
     size_t number_of_templates;   /* Templates created this load (monotonic). */
     int stop_creating;        /* One-way latch: stop creating new templates. */
@@ -3215,7 +3215,8 @@ static void rdbLoadTemplateCtxListValDestructor(dict *d, void *val) {
     listRelease(val);
 }
 
-/* Keys are stable template IDs; values are lists of rdbLoadTemplateCtxKvRef*. */
+/* Keys are template pointers, values are lists of hash kvobjs freed when the 
+ * entry is dropped/released. */
 static dictType rdbLoadTemplateCtxReverseDictType = {
     .hashFunction = dictPtrHash,
     .valDestructor = rdbLoadTemplateCtxListValDestructor,
@@ -3240,20 +3241,19 @@ void rdbLoadTemplateCtxRecord(rdbLoadTemplateCtx *ctx, robj *kv, redisDb *db) {
         kv->encoding != OBJ_ENCODING_TMPL_ARRAY) return;
 
     hashTemplate *tmpl = hashTypeGetTemplate(kv);
-    void *id_key = (void *)(uintptr_t)tmpl->id;
     if (tmpl->key_refcount == ctx->disassembly_threshold) {
         /* This key graduates tmpl: drop the tracking list so it survives. */
-        dictDelete(ctx->reverse_lookup, id_key);
+        dictDelete(ctx->reverse_lookup, tmpl);
         return;
     }
     if (tmpl->key_refcount > ctx->disassembly_threshold) return; /* already graduated */
 
-    dictEntry *de = dictFind(ctx->reverse_lookup, id_key);
+    dictEntry *de = dictFind(ctx->reverse_lookup, tmpl);
     list *l;
     if (de == NULL) {
         l = listCreate();
         listSetFreeMethod(l, rdbLoadTemplateCtxKvRefListFree);
-        dictAdd(ctx->reverse_lookup, id_key, l);
+        dictAdd(ctx->reverse_lookup, tmpl, l);
     } else {
         l = dictGetVal(de);
     }

--- a/tests/unit/type/hash-templates.tcl
+++ b/tests/unit/type/hash-templates.tcl
@@ -1452,6 +1452,16 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"}
         } else {
             fail "serialization cache ($mem_with_cache bytes) was not reclaimed"
         }
+
+        # A blob just below the 16 MB cap does not fit beside the small one.
+        r config set hash-max-listpack-value 17mb
+        r himport prepare bigfs [string repeat x [expr {16 * 1024 * 1024 - 8192}]]
+        r himport set bigkey bigfs v
+
+        r dump k
+        set mem_before [s used_memory_hash_templates]
+        r restore bigcopy 0 [r dump bigkey]
+        assert_equal $mem_before [s used_memory_hash_templates]
     }
 }
 


### PR DESCRIPTION
Normally, defrag does not run while loading an RDB. However, it can run when the RDB is loaded as an AOF base file, since this happens in the AOF loading context. This may relocate hash templates while RDB parsing code still holds temporary pointers to them. This PR disables defrag while loading the AOF base RDB and restores it before replaying the AOF incr files.

Additional changes: 
- Check budget more frequently during template defrag.
- Cap the field listpack cache to prevent memory spikes if misuse creates a very large number of templates.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes loading and active-defrag interaction with hash templates—areas where pointer invalidation bugs are serious—but the scope is narrow and covered by new cache-cap tests.
> 
> **Overview**
> **Pauses active defrag while loading an AOF base/RDB preamble**, matching standalone RDB load, so `defragWhileBlocked` cannot relocate hash templates while RDB parsing still holds pointers to them. Adds `server.active_defrag_paused` around `rdbLoadRio` in AOF loading.
> 
> **Tightens hash-template defrag** by checking the time budget every 8 templates instead of 64.
> 
> **Caps the hash-template fields listpack cache at 16 MB** (`fields_lp_cache_bytes` on the registry). `hashTemplateIndexFieldsLp` now returns success/failure, skips indexing when the template already has a blob or the cap would be exceeded, and no longer replaces an existing cached blob. Callers (`hashTemplateGetFieldsLp`, RDB save/load) free blobs when caching is declined; reclaim paths use `hashTemplateDropFieldsLp`.
> 
> Tests cover RESTORE when a near-cap blob cannot be cached.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e724a5399fbe1ca9fa4ad26066bd33fb8d7d0725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->