### PR TITLE
Fix signed overflow in BITFIELD i64 checks

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -619,10 +619,10 @@ int checkSignedBitfieldOverflow(int64_t value, int64_t incr, uint64_t bits, int 
 
     /* Note that maxincr and minincr could overflow, but we use the values
      * only after checking 'value' range, so when we use it no overflow
-     * happens. 'uint64_t' cast is there just to prevent undefined behavior on
+     * happens. 'uint64_t' casts are there just to prevent undefined behavior on
      * overflow */
     int64_t maxincr = (uint64_t)max-value;
-    int64_t minincr = min-value;
+    int64_t minincr = (uint64_t)min-value;
 
     if (value > max || (bits != 64 && incr > maxincr) || (value >= 0 && incr > 0 && incr > maxincr))
     {

--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -8,6 +8,11 @@ start_server {tags {"bitops"}} {
         set results
     } {0 -100 101}
 
+    test {BITFIELD signed i64 SET handles positive values} {
+        r del bits
+        r bitfield bits set i64 0 32 get i64 0
+    } {0 32}
+
     test {BITFIELD unsigned SET and GET basics} {
         r del bits
         set results {}


### PR DESCRIPTION
Fixes #15550

## Overview

Fixes undefined behavior in `checkSignedBitfieldOverflow()` when computing the lower increment bound for signed `BITFIELD` operations. `minincr` is now derived via `(uint64_t)min - value`, matching the existing `maxincr` pattern, so eager `min - value` on positive values no longer triggers signed-overflow UB under UBSan while overflow/wrap/sat semantics stay the same.
