### PR TITLE
Fix signed overflow in BITFIELD i64 checks

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -622,7 +622,7 @@ int checkSignedBitfieldOverflow(int64_t value, int64_t incr, uint64_t bits, int 
      * happens. 'uint64_t' cast is there just to prevent undefined behavior on
      * overflow */
     int64_t maxincr = (uint64_t)max-value;
-    int64_t minincr = min-value;
+    int64_t minincr = (int64_t)((uint64_t)min - (uint64_t)value);
 
     if (value > max || (bits != 64 && incr > maxincr) || (value >= 0 && incr > 0 && incr > maxincr))
     {

--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -8,6 +8,15 @@ start_server {tags {"bitops"}} {
         set results
     } {0 -100 101}
 
+    test {BITFIELD i64 SET no signed overflow on positive value} {
+        r del bits
+        # Regression test for https://github.com/redis/redis/issues/15545
+        # checkSignedBitfieldOverflow() computed INT64_MIN minus a positive value
+        # for i64 SET operations, which is undefined signed overflow.
+        # This test verifies that a deterministic positive i64 SET works.
+        set results [r bitfield bits set i64 0 42 get i64 0]
+    } {0 42}
+
     test {BITFIELD unsigned SET and GET basics} {
         r del bits
         set results {}


### PR DESCRIPTION
`checkSignedBitfieldOverflow()` computed `INT64_MIN - value` for
i64 SET operations, which is undefined signed overflow when `value` is
positive. Use unsigned arithmetic for the subtraction, matching the
existing upper-threshold handling (`maxincr` already uses
`(uint64_t)max-value`).

Also adds a deterministic positive i64 SET regression test.

Fixes #15545

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-expression fix in overflow math plus a regression test; behavior change is making i64 overflow checks well-defined, with low blast radius outside BITFIELD signed operations.
> 
> **Overview**
> Fixes **undefined signed integer overflow** in `checkSignedBitfieldOverflow()` when validating **BITFIELD** signed **SET**/**INCRBY** paths (notably **i64** with a positive stored value).
> 
> The lower-bound margin `minincr` is now computed as `(int64_t)((uint64_t)min - (uint64_t)value)`, matching the existing unsigned-style `maxincr` calculation instead of `min - value` (which can be `INT64_MIN - positive`).
> 
> Adds a unit regression test that **SET i64** to a positive value and **GET** returns deterministically (issue #15545).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d17d19bdf817f6010ef01d43ed4ad7ad79675d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->