### PR TITLE
Fix vector sets VREM crash caused by bad HNSW entry point replacement

### DIFF
--- a/modules/vector-sets/hnsw.c
+++ b/modules/vector-sets/hnsw.c
@@ -1929,21 +1929,25 @@ void hnsw_unlink_node(HNSW *index, hnswNode *node) {
         index->enter_point = NULL;
         index->max_level = 0;
 
-        /* Step 1: Try to find a replacement by scanning levels
-         * from top to bottom. Under normal conditions, if there is
-         * any other node at the same level, we have a link. Anyway
-         * we descend levels to find any neighbor at the higher level
-         * possible. */
-        for (int level = node->level; level >= 0; level--) {
-            if (node->layers[level].num_links > 0) {
-                index->enter_point = node->layers[level].links[0];
-                break;
-            }
-        }
+        /* Step 1: Try to find a replacement among the links of the
+         * deleted node at its top layer. Links at a given layer only
+         * connect nodes of that level or higher, and no node can be
+         * taller than the entry point, so any link found here is
+         * guaranteed to be of the same level as the deleted node.
+         *
+         * Note that we can't just descend to lower layers looking for
+         * some link: a node found there may be shorter than other
+         * nodes elsewhere in the graph. With max_level set too low,
+         * the reconnection performed when deleting one of the taller
+         * nodes would call search_layer() with a layer greater than
+         * the level of the entry point itself, accessing layers past
+         * the end of the node allocation. */
+        if (node->layers[node->level].num_links > 0)
+            index->enter_point = node->layers[node->level].links[0];
 
-        /* Step 2: If no links were found at any level, do a full scan.
-         * This should never happen in practice if the HNSW is not
-         * empty. */
+        /* Step 2: If the deleted node top layer has no links (it can
+         * remain empty after deletions of other nodes), do a full
+         * scan to find the tallest node remaining in the graph. */
         if (!index->enter_point) {
             uint32_t new_max_level = 0;
             hnswNode *current = index->head;

--- a/modules/vector-sets/tests/entry_point_deletion.py
+++ b/modules/vector-sets/tests/entry_point_deletion.py
@@ -1,0 +1,85 @@
+from test import TestCase, generate_random_vector
+import struct
+import random
+
+"""
+Regression test for the entry point replacement bug of issue #15424.
+
+When the deleted node was the entry point, the replacement used to be
+picked from the deleted node links, descending from the top layer until
+some layer with links was found. If the upper layers of the entry point
+were left without links (a state that small sets under insertion and
+deletion churn can reach), the replacement could be a node of lower
+level than the tallest node still in the graph, leaving
+index->max_level too low. From there, deleting one of the taller nodes
+made hnsw_reconnect_nodes() search a layer above the entry point level,
+reading past the end of the entry point allocation and possibly
+crashing the server inside select_neighbors() (see the issue for the
+production stack trace).
+
+The buggy state needs a rare combination of deletion order and node
+levels (levels are drawn server side, so no fixed command sequence can
+reproduce it deterministically). This test churns many small sets with
+a low M (sparse upper layers erode much faster) and, instead of
+waiting for the eventual crash, checks after every single VREM the
+invariant that the bug breaks: the max-level reported by VINFO must
+always match the level of the tallest element, known from VLINKS at
+insertion time. Any run of the buggy code that enters the bad state
+fails here immediately, long before the crash; with the fix the
+invariant holds on every deletion.
+"""
+
+class EntryPointDeletion(TestCase):
+    def getname(self):
+        return "Entry point deletion keeps max-level correct (issue #15424)"
+
+    def estimated_runtime(self):
+        return 15
+
+    def max_level(self):
+        info = self.redis.execute_command('VINFO', self.test_key)
+        if not isinstance(info, dict):
+            info = {info[i]: info[i+1] for i in range(0, len(info), 2)}
+        info = {k.decode() if isinstance(k, bytes) else k: v
+                for k, v in info.items()}
+        return int(info['max-level'])
+
+    def test(self):
+        random.seed(42)
+        dim = 8
+        num_sets = 60
+        set_size = 80
+
+        for s in range(num_sets):
+            self.redis.delete(self.test_key)
+            levels = {}
+            for i in range(set_size):
+                name = f"item:{i}"
+                vec = generate_random_vector(dim)
+                vec_bytes = struct.pack(f'{dim}f', *vec)
+                self.redis.execute_command('VADD', self.test_key, 'FP32',
+                                           vec_bytes, name, 'M', '4')
+                # The number of layers reported by VLINKS is level+1.
+                links = self.redis.execute_command('VLINKS', self.test_key,
+                                                   name)
+                levels[name] = len(links) - 1
+
+            # Drain the set in insertion order, checking after every
+            # deletion that the graph max level still matches the
+            # tallest element left.
+            for i in range(set_size):
+                name = f"item:{i}"
+                assert self.redis.execute_command('VREM', self.test_key,
+                                                  name) == 1
+                del levels[name]
+                if not levels:
+                    break
+                reported = self.max_level()
+                expected = max(levels.values())
+                assert reported == expected, \
+                    f"set {s}: after deleting {name} VINFO reports " \
+                    f"max-level {reported} but the tallest element " \
+                    f"has level {expected}: the entry point was " \
+                    f"replaced by a node below the graph max level"
+
+        assert self.redis.ping()


### PR DESCRIPTION
Reopens #15487 — I deleted my fork while cleaning up my repositories and GitHub closed the PR along with it. The branch and content are identical.

Fixes #15424

### Problem

When `hnsw_delete_node()` deletes the current entry point, the replacement is
picked from the deleted node's own links, descending from its top layer until
some layer with links is found, and `index->max_level` is set to the
replacement's level. Links at layer N only connect nodes of level >= N, so a
replacement taken from the top layer is guaranteed to have the same level as
the deleted entry point — but one taken from a lower layer is not: taller
nodes may still exist elsewhere in the graph, leaving `max_level` lower than
the tallest node.

Small sets under add/delete churn reach this state easily: an upper layer
holds only one or two nodes, so the entry point's top layers routinely end up
with no links (e.g. when its only upper-layer neighbor is deleted and the
reconnection step finds no other node at that layer to relink).

Once `max_level` is too low, a later `VREM` of one of the still-taller nodes
runs `hnsw_reconnect_nodes()` for `layer > max_level`. The broader-graph
search in step 6 starts from `index->enter_point`, whose `level < layer`, and
`search_layer()` dereferences `entry_point->layers[layer]` — past the end of
the node allocation, since `layers[]` is a flexible array member sized
level+1. When the out-of-bounds memory happens to be zeroed, the garbage
layer looks full (`num_links (0) >= max_links (0)`), so `select_neighbors()`
(called with `aggressive >= 1`, which skips the `worst_distance` guard) takes
the link-replacement path and dereferences the NULL `links` array: SIGSEGV
with fault address 0, matching the reported stack

    select_neighbors
    hnsw_reconnect_nodes
    VREM_RedisCommand

Since VREM is propagated verbatim, the replica applies the same delete on a
similarly shaped graph and can go down right after the master, which matches
the report (both nodes of a shard lost on one VREM). The same path is also
reachable through VADD of an existing element, which deletes and reinserts
the node.

### Fix

Take the replacement only from the deleted node's top layer, where the same
level is guaranteed. If the top layer has no links, fall back to the full
scan for the tallest remaining node (the scan already existed as the
fallback for the all-layers-empty case). This restores the invariant that
the entry point is always one of the tallest nodes of the graph, which is
what `hnsw_reconnect_nodes()` and the insert/search descend loops rely on.

An entry point deletion with a bare top layer is the rare case (and frequent
only on small graphs), and node deletion is already dominated by the
reconnection work, so the extra full scans are not a concern.

### Why the fix is correct

Links at layer N only connect nodes of level >= N, and no node can be
taller than the entry point, so a link taken from the deleted entry point's
top layer has exactly the old max level. A link taken from any lower layer
carries no such guarantee, which is the whole bug. When the top layer is
empty the tallest remaining node genuinely has to be searched for, and the
full scan already existed as the fallback. Every other writer of
`enter_point`/`max_level` (insert of a taller node, first node, serialized
load) already maintains the invariant; deletion was the only breaker.

### Verification

The bad state needs a rare combination of deletion order and node levels,
and node levels are drawn from the server-side RNG, so there is no fixed
command sequence that reproduces it deterministically. What I have:

- Pre-fix, ASAN build (`make SANITIZER=address`), draining ~80-element
  M=4 sets FIFO while checking `VINFO max-level` against the known level
  of the tallest element after every VREM: one run hit a stale max-level
  (max-level lower than the tallest element, exactly the broken invariant)
  and then a server crash on VREM a few hundred sets later. Across ~6,800
  drained sets total the state was entered twice — consistent with the
  reporter only seeing it in production at 100K-set scale after weeks of
  churn, and with `hnsw_deserialize_index()` already treating
  "link to a node whose level is below the layer" as corruption while the
  runtime path could create the equivalent state.
- Post-fix, same ASAN build: the invariant held on every deletion in all
  runs, the new test and the full vector sets suite (`test.py`, with
  replica, 42/42) pass, and no sanitizer reports were produced.
- New test `tests/entry_point_deletion.py` encodes the invariant check, so
  any future regression that re-enters the state fails immediately and
  deterministically, long before a crash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core HNSW deletion invariants on a path that already caused production crashes (VREM/replication); the fix is narrowly scoped but touches graph metadata used by all search and reconnect logic.
> 
> **Overview**
> Fixes **#15424**, where deleting the HNSW entry point during **VREM** (or VADD update) could leave `index->max_level` below the tallest node still in the graph, then crash in `hnsw_reconnect_nodes()` via out-of-bounds layer access and **SIGSEGV** in `select_neighbors()`.
> 
> **`hnsw_unlink_node()`** no longer walks down the deleted entry point’s layers to pick the first link it finds. It now chooses a replacement only from links on the deleted node’s **top layer** (same level as the old entry point), or runs the existing **full scan** for the tallest remaining node when that top layer has no links.
> 
> Adds **`tests/entry_point_deletion.py`**, which churns small vector sets and asserts after every **VREM** that **VINFO** `max-level` matches the tallest element’s level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 948476fbd67f3bfd9bd1cbddd51bd77bf004c469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->