### PR TITLE
Fix relative expiration overflow

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -256,11 +256,14 @@ static int getExpireMillisecondsOrReply(client *c, robj *expire, int relative_tt
     if (unit == UNIT_SECONDS) *milliseconds *= 1000;
 
     if (relative_ttl) {
-        *milliseconds += commandTimeSnapshot();
+        if (add_overflow_ll(*milliseconds, commandTimeSnapshot(), milliseconds)) {
+            addReplyErrorExpireTime(c);
+            return C_ERR;
+        }
     }
 
     if (*milliseconds <= 0) {
-        /* Overflow detected. */
+        /* The resulting absolute timestamp must be positive. */
         addReplyErrorExpireTime(c);
         return C_ERR;
     }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -265,6 +265,17 @@ start_server {tags {"expire"}} {
         set e
     } {ERR invalid expire time in 'getex' command}
 
+    test {GETEX rejects relative expires that overflow the absolute timestamp} {
+        r set foo old px 100000
+        set expire_at [r pexpiretime foo]
+
+        assert_error "ERR invalid expire time in 'getex' command" {
+            r getex foo EX 9223372036854775
+        }
+        assert_equal old [r get foo]
+        assert_equal $expire_at [r pexpiretime foo]
+    }
+
     test {EXPIRE with big integer overflows when converted to milliseconds} {
         r set foo bar
 

--- a/tests/unit/type/increx.tcl
+++ b/tests/unit/type/increx.tcl
@@ -416,6 +416,23 @@ start_server {tags {"increx"}} {
         assert_error "*invalid expire time*" {r increx mykey BYINT 1 EX -1}
     }
 
+    test {INCREX - relative expiration overflow has no side effects} {
+        r set mykey 10 px 100000
+        set expire_at [r pexpiretime mykey]
+
+        assert_error "ERR invalid expire time in 'increx' command" {
+            r increx mykey BYINT 1 PX 9223372036854775807
+        }
+        assert_equal 10 [r get mykey]
+        assert_equal $expire_at [r pexpiretime mykey]
+
+        r del newkey
+        assert_error "ERR invalid expire time in 'increx' command" {
+            r increx newkey PX 9223372036854775807
+        }
+        assert_equal 0 [r exists newkey]
+    }
+
     # ---------------------------------------------------------------------
     # Type check
     # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- reject relative `EX`/`PX` values when converting them to an absolute timestamp would overflow
- preserve the existing key value and expiration when validation fails
- cover the shared expiration helper and the exact `INCREX ... PX LLONG_MAX` reproducer

## Root cause

`getExpireMillisecondsOrReply()` added `commandTimeSnapshot()` to a signed `long long` and only checked the wrapped result afterward. The fix uses `add_overflow_ll()` before accepting the absolute timestamp.

This was found while running the recent-command fuzzing campaign in [aviggiano/redis#205](https://github.com/aviggiano/redis/pull/205); its PR-triggered UBSan job preserved the deterministic reproducer.

Fixes #15548

## Testing

- normal Redis build
- `./runtest --single unit/expire --single unit/type/string --single unit/type/increx --clients 3`
- UBSan-instrumented build and focused GETEX/INCREX replay
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core TTL validation used by several string commands; the change is small and well-tested but affects expiration handling on edge-case inputs (UBSan-reported overflow).
> 
> **Overview**
> Fixes **signed overflow** when relative `EX`/`PX` values are turned into absolute millisecond expirations in `getExpireMillisecondsOrReply()`: addition to `commandTimeSnapshot()` now goes through `add_overflow_ll()` instead of unchecked `+=`, and failures return the usual invalid-expire error.
> 
> That helper backs **SET**, **GETEX**, **MSETEX**, and **INCREX**, so the behavior change is shared across those commands. On rejection, keys keep their **value and existing TTL** (no partial updates).
> 
> Tests add **GETEX** overflow coverage and **INCREX** cases for `PX LLONG_MAX` on existing and missing keys, asserting no side effects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fdef1e448355d3d8b85d9706e085a63ae6cde65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->