### PR TITLE
Fix key-spec numkeys overflow

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3307,6 +3307,16 @@ int getKeysUsingKeySpecs(struct redisCommand *cmd, robj **argv, int argc, int se
             }
 
             first += spec->fk.keynum.firstkey;
+            if (numkeys < 1 || step <= 0 || first < 0 || first >= argc)
+                goto invalid_spec;
+
+            /* Validate the key count before using it to calculate the last key
+             * index. Besides rejecting counts that don't fit in argv, this
+             * keeps the arithmetic below within the range of long. */
+            long max_numkeys = 1 + (argc - 1 - first) / step;
+            if (numkeys > max_numkeys)
+                goto invalid_spec;
+
             last = first + ((long)numkeys - 1) * step;
         } else {
             /* unknown spec */

--- a/tests/unit/auth.tcl
+++ b/tests/unit/auth.tcl
@@ -35,6 +35,11 @@ start_server {tags {"auth external:skip"} overrides {requirepass foobar}} {
         set _ $err
     } {NOAUTH*}
 
+    test {Oversized key count is safely handled before authentication} {
+        catch {r zunion 9223372036854775807 ""} err
+        set _ $err
+    } {NOAUTH*}
+
     test {AUTH succeeds when the right password is given} {
         r auth foobar
     } {OK}

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -159,6 +159,7 @@ start_server {tags {"introspection"}} {
 
     test {COMMAND GETKEYSANDFLAGS invalid args} {
         assert_error "ERR Invalid arguments*" {r command getkeysandflags ZINTERSTORE zz 1443677133621497600 asdf}
+        assert_error "ERR Invalid arguments*" {r command getkeysandflags ZUNION 9223372036854775807 ""}
     }
 
     test {COMMAND GETKEYSANDFLAGS MSETEX} {


### PR DESCRIPTION
## Summary

- reject invalid `KSPEC_FK_KEYNUM` counts before calculating the last key index
- bound user-controlled key counts by the arguments available to the command
- preserve both generic key-introspection errors and pre-auth `NOAUTH` behavior

## Root cause

`getKeysUsingKeySpecs()` calculated `first + (numkeys - 1) * step` before checking the result against `argc`. A parsed `LLONG_MAX` key count could therefore overflow signed `long` arithmetic before the malformed request was rejected.

This was found while running the recent-command fuzzing campaign in [aviggiano/redis#205](https://github.com/aviggiano/redis/pull/205); its PR-triggered UBSan corpus replay confirmed the deterministic `ZUNION` reproducer.

Fixes #15549

## Testing

- normal Redis build
- `./runtest --single unit/introspection-2 --single unit/auth`
- UBSan-instrumented build and the same focused suites
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared command key-introspection used by ACL, cluster, and COMMAND APIs; the change is narrow validation logic with focused regression tests rather than command semantics changes.
> 
> **Overview**
> Fixes **signed `long` overflow** when commands such as **`ZUNION`** use a **`KSPEC_FK_KEYNUM`** key spec: the server used to compute the last key index from a parsed `numkeys` (e.g. `LLONG_MAX`) before checking it against `argc`, which could trigger UBSan and undefined behavior during key introspection (ACL, cluster slot extraction, `COMMAND GETKEYS*`, etc.).
> 
> **`getKeysUsingKeySpecs()`** in `db.c` now rejects invalid specs earlier—`numkeys < 1`, bad `step`/`first`, and **`numkeys` above what `argv` can actually supply**—so `last = first + (numkeys - 1) * step` stays in range and malformed requests still surface as **invalid arguments** (or **`NOAUTH`** when auth runs first).
> 
> Tests add **`ZUNION` with `9223372036854775807`** under **`requirepass`** (expect **`NOAUTH`**, not a crash) and the same case for **`COMMAND GETKEYSANDFLAGS`** (expect **`ERR Invalid arguments*`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e074006f2599638388835358837258aeb38bcae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->