### PR TITLE
Update RedisTimeSeries to version 8.10.0

### DIFF
--- a/modules/modules.yaml
+++ b/modules/modules.yaml
@@ -80,6 +80,6 @@ modules:
     loadmodule: ./modules/redisjson/rejson.so
   - name: redistimeseries
     repo: https://github.com/redistimeseries/redistimeseries
-    ref: v8.9.91
+    ref: v8.10.0
     target_module: redistimeseries.so
     loadmodule: ./modules/redistimeseries/redistimeseries.so


### PR DESCRIPTION
<h2 dir="auto" style="box-sizing: border-box; margin-top: 0px !important; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Module Update</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This PR bumps the pinned<span> </span><strong style="box-sizing: border-box; font-weight: 600;">MODULE_VERSION</strong><span> </span>for<span> </span><strong style="box-sizing: border-box; font-weight: 600;">RedisTimeSeries</strong><span> </span>from<span> </span><strong style="box-sizing: border-box; font-weight: 600;">v8.9.91</strong><span> </span>to<span> </span><strong style="box-sizing: border-box; font-weight: 600;">v8.10.0</strong>. RedisBloom and RedisJSON are unchanged.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h2><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
Module | From | To
-- | -- | --
RedisTimeSeries | v8.9.91 | v8.10.0

</markdown-accessiblity-table><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; font-weight: 600;">Note:</strong><span> </span>this RedisTimeSeries range contains 10 relevant commits. The main changes are topology-change handling/tests, LibMR topology fixes, TLS cluster CI coverage, RDB test stability, and bootstrap list / dry-run support.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Module Changes</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><a href="https://github.com/RedisTimeSeries/RedisTimeSeries/compare/v8.9.91...v8.10.0" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">RedisTimeSeries range</a></p><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;">MOD-16382 — handle topology-change notifications, add<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">ts-topology-events</code><span> </span>config, update LibMR/RedisModulesSDK, and wire topology update handling (<a href="https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2104" data-hovercard-type="pull_request" data-hovercard-url="/RedisTimeSeries/RedisTimeSeries/pull/2104/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">#2104</a>)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">MOD-16382 — add consolidated topology-change flow tests for CLUSTERSET reconcile, reshard convergence, and cold multishard query behavior (<a href="https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2116" data-hovercard-type="pull_request" data-hovercard-url="/RedisTimeSeries/RedisTimeSeries/pull/2116/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">#2116</a>)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">MOD-16265 — make RDB dump/reload tests wait briefly for active background saves to finish, avoiding "Background save already in progress" flakes (<a href="https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2124" data-hovercard-type="pull_request" data-hovercard-url="/RedisTimeSeries/RedisTimeSeries/pull/2124/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">#2124</a>)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">MOD-16382 — revert the topology-change flow tests from<span> </span><a href="https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2116" data-hovercard-type="pull_request" data-hovercard-url="/RedisTimeSeries/RedisTimeSeries/pull/2116/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">#2116</a><span> </span>(<a href="https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2125" data-hovercard-type="pull_request" data-hovercard-url="/RedisTimeSeries/RedisTimeSeries/pull/2125/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">#2125</a>)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">MOD-17016 — disable topology-events handling under Redis Enterprise for now (<a href="https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2130" data-hovercard-type="pull_request" data-hovercard-url="/RedisTimeSeries/RedisTimeSeries/pull/2130/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">#2130</a>)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">MOD-17095 — add a TLS cluster test leg, TLS cert generation, install/build wiring, and LibMR updates (<a href="https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2126" data-hovercard-type="pull_request" data-hovercard-url="/RedisTimeSeries/RedisTimeSeries/pull/2126/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">#2126</a>)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">MOD-16382 — add replacement topology-events flow tests, shared test helpers, LibMR update, and fix a UAF around unblocked-client query params (<a href="https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2121" data-hovercard-type="pull_request" data-hovercard-url="/RedisTimeSeries/RedisTimeSeries/pull/2121/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">#2121</a>)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">MOD-16382 — add regression coverage that obsolete short-form CLUSTERSET cannot discard topology installed by topology events; pins LibMR with the fix (<a href="https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2131" data-hovercard-type="pull_request" data-hovercard-url="/RedisTimeSeries/RedisTimeSeries/pull/2131/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">#2131</a>)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">No MOD ticket in commit title — enhance bootstrap/install scripts with dependency listing, dry-run support, retry handling, Python setup, and root-without-sudo support (<a href="https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2128" data-hovercard-type="pull_request" data-hovercard-url="/RedisTimeSeries/RedisTimeSeries/pull/2128/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">#2128</a>)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">MOD-16399 — bump LibMR to skip rebuilds for unchanged long-form CLUSTERSET topologies and add no-op CLUSTERSET regression coverage (<a href="https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2088" data-hovercard-type="pull_request" data-hovercard-url="/RedisTimeSeries/RedisTimeSeries/pull/2088/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(9, 105, 218); text-decoration: underline; text-underline-offset: 0.2rem;">#2088</a>)</li></ul><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Excluded Commits</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; font-weight: 600;">0 commits excluded</strong></p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">All 10 listed commits are part of the requested RedisTimeSeries update set.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Verification</h2><ul class="contains-task-list" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Incomplete task" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span>CI passes for RedisTimeSeries at the new pinned version</li><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Incomplete task" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">make all</code><span> </span>builds RedisTimeSeries cleanly against unstable</li><li class="task-list-item enabled hovered" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 1; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Incomplete task" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span>Module tests run under<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">make test</code></li></ul>Module Update
This PR bumps the pinned MODULE_VERSION for RedisTimeSeries from v8.9.91 to v8.10.0. RedisBloom and RedisJSON are unchanged.

Changes
Module	From	To
RedisTimeSeries	v8.9.91	v8.10.0
Note: this RedisTimeSeries range contains 10 relevant commits. The main changes are topology-change handling/tests, LibMR topology fixes, TLS cluster CI coverage, RDB test stability, and bootstrap list / dry-run support.

Module Changes
[RedisTimeSeries range](https://github.com/RedisTimeSeries/RedisTimeSeries/compare/v8.9.91...v8.10.0)

MOD-16382 — handle topology-change notifications, add ts-topology-events config, update LibMR/RedisModulesSDK, and wire topology update handling (https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2104)
MOD-16382 — add consolidated topology-change flow tests for CLUSTERSET reconcile, reshard convergence, and cold multishard query behavior (https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2116)
MOD-16265 — make RDB dump/reload tests wait briefly for active background saves to finish, avoiding "Background save already in progress" flakes (https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2124)
MOD-16382 — revert the topology-change flow tests from https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2116 (https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2125)
MOD-17016 — disable topology-events handling under Redis Enterprise for now (https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2130)
MOD-17095 — add a TLS cluster test leg, TLS cert generation, install/build wiring, and LibMR updates (https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2126)
MOD-16382 — add replacement topology-events flow tests, shared test helpers, LibMR update, and fix a UAF around unblocked-client query params (https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2121)
MOD-16382 — add regression coverage that obsolete short-form CLUSTERSET cannot discard topology installed by topology events; pins LibMR with the fix (https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2131)
No MOD ticket in commit title — enhance bootstrap/install scripts with dependency listing, dry-run support, retry handling, Python setup, and root-without-sudo support (https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2128)
MOD-16399 — bump LibMR to skip rebuilds for unchanged long-form CLUSTERSET topologies and add no-op CLUSTERSET regression coverage (https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2088)
Excluded Commits
0 commits excluded

All 10 listed commits are part of the requested RedisTimeSeries update set.

Verification
 CI passes for RedisTimeSeries at the new pinned version
 make all builds RedisTimeSeries cleanly against unstable
 Module tests run under make test