### PR TITLE
add cve reachability

### DIFF
--- a/.github/scripts/cve-2026-28390-report.sh
+++ b/.github/scripts/cve-2026-28390-report.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+evidence_dir="${1:?evidence directory is required}"
+metadata_dir="${evidence_dir}/metadata"
+codeql_dir="${evidence_dir}/codeql"
+
+count_csv_rows() {
+  python3 - "$1" <<'PY'
+import csv
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+if not path.is_file():
+    print(0)
+    raise SystemExit
+with path.open(newline="", encoding="utf-8") as stream:
+    rows = csv.reader(stream)
+    next(rows, None)
+    print(sum(1 for _ in rows))
+PY
+}
+
+count_csv_rows_matching() {
+  python3 - "$1" "$2" <<'PY'
+import csv
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+pattern = re.compile(sys.argv[2])
+if not path.is_file():
+    print(0)
+    raise SystemExit
+with path.open(newline="", encoding="utf-8") as stream:
+    rows = csv.reader(stream)
+    next(rows, None)
+    print(sum(1 for row in rows if pattern.search("\t".join(row))))
+PY
+}
+
+direct="$(count_csv_rows "${codeql_dir}/FindCmsDecryptCalls.csv")"
+references="$(count_csv_rows "${codeql_dir}/FindCmsDecryptReferences.csv")"
+cms_api="$(count_csv_rows "${codeql_dir}/FindCmsApiUsage.csv")"
+dynamic_query="$(count_csv_rows "${codeql_dir}/FindDynamicCmsLookup.csv")"
+dynamic_decrypt="$(count_csv_rows_matching "${codeql_dir}/FindDynamicCmsLookup.csv" 'CMS_decrypt')"
+binary_decrypt=0
+binary_cms=0
+if [[ -f "${evidence_dir}/binary/filtered-symbols.txt" ]]; then
+  binary_decrypt="$(grep -c 'CMS_decrypt' "${evidence_dir}/binary/filtered-symbols.txt" || true)"
+  binary_cms="$(grep -cE 'CMS_|SMIME_|d2i_CMS_|i2d_CMS_' "${evidence_dir}/binary/filtered-symbols.txt" || true)"
+fi
+
+if (( direct > 0 || references > 0 || dynamic_decrypt > 0 || binary_decrypt > 0 )); then
+  status="potentially_reachable"
+elif (( cms_api > 0 || binary_cms > 0 )); then
+  status="cms_usage_detected"
+else
+  status="no_reachable_reference_identified"
+fi
+
+redis_version="$(tr '\n' ' ' < "${metadata_dir}/redis-version.txt" | sed 's/[[:space:]]*$//')"
+codeql_version="$(head -n 1 "${metadata_dir}/codeql-version.txt")"
+binary_sha256="$(awk '{print $1}' "${metadata_dir}/binary-sha256.txt")"
+resolved_commit="$(tr -d '\n' < "${metadata_dir}/source-commit.txt")"
+extracted_source_files="$(
+  tr -d '\n' < "${metadata_dir}/extracted-source-file-count.txt"
+)"
+
+jq -n \
+  --arg cve "CVE-2026-28390" \
+  --arg vulnerable_function "CMS_decrypt" \
+  --arg repository "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+  --arg requested_ref "${REQUESTED_REF}" \
+  --arg resolved_commit "${resolved_commit}" \
+  --argjson build_tls "${BUILD_TLS}" \
+  --arg redis_version "${redis_version}" \
+  --arg binary_sha256 "${binary_sha256}" \
+  --arg codeql_version "${codeql_version}" \
+  --arg workflow_run_id "${GITHUB_RUN_ID}" \
+  --arg analysis_timestamp_utc "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  --arg status "${status}" \
+  --argjson direct_call_matches "${direct}" \
+  --argjson function_reference_matches "${references}" \
+  --argjson cms_api_matches "${cms_api}" \
+  --argjson dynamic_query_matches "${dynamic_query}" \
+  --argjson dynamic_lookup_matches "${dynamic_decrypt}" \
+  --argjson binary_symbol_matches "${binary_cms}" \
+  --argjson binary_cms_decrypt_matches "${binary_decrypt}" \
+  --argjson extracted_source_files "${extracted_source_files}" \
+  '{
+    cve: $cve,
+    vulnerable_function: $vulnerable_function,
+    repository: $repository,
+    requested_ref: $requested_ref,
+    resolved_commit: $resolved_commit,
+    build_tls: $build_tls,
+    redis_version: $redis_version,
+    binary_sha256: $binary_sha256,
+    codeql_version: $codeql_version,
+    workflow_run_id: $workflow_run_id,
+    analysis_timestamp_utc: $analysis_timestamp_utc,
+    status: $status,
+    direct_call_matches: $direct_call_matches,
+    function_reference_matches: $function_reference_matches,
+    cms_api_matches: $cms_api_matches,
+    dynamic_query_matches: $dynamic_query_matches,
+    dynamic_lookup_matches: $dynamic_lookup_matches,
+    binary_symbol_matches: $binary_symbol_matches,
+    binary_cms_decrypt_matches: $binary_cms_decrypt_matches,
+    extracted_source_files: $extracted_source_files
+  }' > "${metadata_dir}/analysis.json"
+
+source_matches="$(wc -l < "${evidence_dir}/source/source-search.txt")"
+binary_filtered_matches="$(wc -l < "${evidence_dir}/binary/filtered-symbols.txt")"
+
+cat > "${evidence_dir}/report.md" <<EOF
+# CVE-2026-28390 Redis reachability report
+
+## Executive Summary
+
+Analysis status: **${status}**
+
+## Analysis subject
+
+- Repository: \`${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}\`
+- Requested Redis ref: \`${REQUESTED_REF}\`
+- Resolved commit: \`${resolved_commit}\`
+- Redis version: \`${redis_version}\`
+- TLS build: \`${BUILD_TLS}\`
+- CodeQL CLI: \`${codeql_version}\`
+- Compiled source files observed by CodeQL: ${extracted_source_files}
+- Binary SHA-256: \`${binary_sha256}\`
+
+## CodeQL queries and match counts
+
+| Query | Purpose | Matches |
+|---|---|---:|
+| FindCmsDecryptCalls | Direct, statically resolved \`CMS_decrypt\` calls | ${direct} |
+| FindCmsDecryptReferences | Non-call \`FunctionAccess\` references, including function-pointer values | ${references} |
+| FindCmsApiUsage | Direct \`CMS_*\`, \`d2i_CMS_*\`, \`i2d_CMS_*\`, and \`SMIME_*\` calls | ${cms_api} |
+| FindDynamicCmsLookup | Relevant literals plus \`dlopen\`/\`dlsym\` review locations | ${dynamic_query} |
+
+Of the dynamic-query rows, ${dynamic_decrypt} contain the exact symbol name \`CMS_decrypt\`.
+
+## Independent source and binary evidence
+
+- Source search rows: ${source_matches}
+- Filtered binary symbol/string rows: ${binary_filtered_matches}
+- Exact \`CMS_decrypt\` binary rows: ${binary_decrypt}
+- Complete outputs from \`readelf\`, \`nm\`, \`objdump\`, \`strings\`, \`ldd\`, \`file\`, and \`sha256sum\` are included in the artifact.
+
+## Technical interpretation
+
+EOF
+
+case "${status}" in
+  no_reachable_reference_identified)
+    cat >> "${evidence_dir}/report.md" <<'EOF'
+The analyzed Redis source revision was compiled under CodeQL instrumentation with the TLS setting recorded above. The analysis identified no direct call, function reference, CMS/S-MIME API usage, dynamic symbol lookup, or binary symbol reference involving OpenSSL `CMS_decrypt()`. Based on the analyzed source revision, build configuration, and resulting Redis executable, no reachable reference to the vulnerable function was identified.
+EOF
+    ;;
+  cms_usage_detected)
+    cat >> "${evidence_dir}/report.md" <<'EOF'
+CMS or S/MIME usage was detected, but the evidence did not identify a direct call, function reference, dynamic lookup, or binary reference to `CMS_decrypt()`. Review the included rows before making a deployment-specific conclusion.
+EOF
+    ;;
+  potentially_reachable)
+    cat >> "${evidence_dir}/report.md" <<'EOF'
+At least one direct call, function reference, exact dynamic-symbol candidate, or binary reference involving `CMS_decrypt()` was detected. Treat the analyzed build as potentially reaching the vulnerable function until the evidence is reviewed.
+EOF
+    ;;
+esac
+
+cat >> "${evidence_dir}/report.md" <<'EOF'
+
+## Limits and module scope
+
+`FunctionAccess` identifies statically resolved function values but does not prove the target of a function pointer after arbitrary reassignment. The dynamic query finds exact relevant literals and direct literal arguments to `dlsym`; it is not a general interprocedural string-flow proof. Generic `dlopen` and `dlsym` calls are included for manual review. Absence of a match is evidence, not mathematical proof of non-exploitability.
+
+The standard Redis core build does not automatically incorporate arbitrary external Redis modules. A static analysis of Redis core cannot cover third-party modules loaded separately at runtime.
+
+This conclusion applies only to the analyzed Redis core build and does not automatically cover separately loaded Redis modules, a different vendor build, another architecture, or additional processes contained in the production container image.
+
+## Recommended customer statement
+
+Use the status-specific technical interpretation above together with the exact source commit, build configuration, binary hash, and production image provenance. Do not generalize this result to a vendor binary unless its source revision and build inputs are known to match.
+EOF
+
+printf '%s\n' "${status}" > "${metadata_dir}/status.txt"

--- a/.github/workflows/cve-2026-28390-reachability.yml
+++ b/.github/workflows/cve-2026-28390-reachability.yml
@@ -1,0 +1,385 @@
+---
+# yamllint disable rule:line-length
+name: CVE-2026-28390 Redis reachability
+
+'on':
+  workflow_dispatch:
+    inputs:
+      redis_ref:
+        description: Redis Git tag, branch or commit to analyze
+        required: true
+        default: unstable
+      build_tls:
+        description: Build Redis with TLS support
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Redis core
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    env:
+      DATABASE_PATH: ${{ runner.temp }}/redis-codeql-db
+      EVIDENCE_DIR: ${{ github.workspace }}/evidence
+      QUERY_PACK: ${{ github.workspace }}/analysis-tooling/codeql/redis-cms-reachability
+      REDIS_SOURCE: ${{ github.workspace }}/redis-source
+      REQUESTED_REF: ${{ inputs.redis_ref }}
+      BUILD_TLS: ${{ inputs.build_tls }}
+
+    steps:
+      - name: Check out analysis tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: analysis-tooling
+          persist-credentials: false
+
+      - name: Prepare inconclusive evidence
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          mkdir -p \
+            "${EVIDENCE_DIR}/metadata" \
+            "${EVIDENCE_DIR}/codeql" \
+            "${EVIDENCE_DIR}/source" \
+            "${EVIDENCE_DIR}/binary" \
+            "${EVIDENCE_DIR}/query-pack"
+          cp -a "${QUERY_PACK}/." "${EVIDENCE_DIR}/query-pack/"
+
+          jq -n \
+            --arg cve "CVE-2026-28390" \
+            --arg vulnerable_function "CMS_decrypt" \
+            --arg repository "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --arg requested_ref "${REQUESTED_REF}" \
+            --argjson build_tls "${BUILD_TLS}" \
+            --arg workflow_run_id "${GITHUB_RUN_ID}" \
+            '{
+              cve: $cve,
+              vulnerable_function: $vulnerable_function,
+              repository: $repository,
+              requested_ref: $requested_ref,
+              resolved_commit: "",
+              build_tls: $build_tls,
+              redis_version: "",
+              binary_sha256: "",
+              codeql_version: "",
+              workflow_run_id: $workflow_run_id,
+              analysis_timestamp_utc: "",
+              status: "analysis_inconclusive",
+              direct_call_matches: 0,
+              function_reference_matches: 0,
+              cms_api_matches: 0,
+              dynamic_query_matches: 0,
+              dynamic_lookup_matches: 0,
+              binary_symbol_matches: 0,
+              binary_cms_decrypt_matches: 0,
+              extracted_source_files: 0
+            }' > "${EVIDENCE_DIR}/metadata/analysis.json"
+
+          cat > "${EVIDENCE_DIR}/report.md" <<'EOF'
+          # CVE-2026-28390 Redis reachability report
+
+          Analysis status: **analysis_inconclusive**
+
+          The workflow did not complete every required build, CodeQL, and binary inspection step. Inspect the workflow log and the partial evidence artifact.
+          EOF
+
+      - name: Check out requested Redis ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.redis_ref }}
+          path: redis-source
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Record source identity
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          git -C "${REDIS_SOURCE}" rev-parse HEAD > "${EVIDENCE_DIR}/metadata/source-commit.txt"
+          git -C "${REDIS_SOURCE}" status --short --branch > "${EVIDENCE_DIR}/metadata/repository-status.txt"
+          git -C "${REDIS_SOURCE}" remote get-url origin > "${EVIDENCE_DIR}/metadata/source-remote.txt"
+
+          jq \
+            --arg resolved_commit "$(cat "${EVIDENCE_DIR}/metadata/source-commit.txt")" \
+            '.resolved_commit = $resolved_commit' \
+            "${EVIDENCE_DIR}/metadata/analysis.json" \
+            > "${RUNNER_TEMP}/analysis.json"
+          mv "${RUNNER_TEMP}/analysis.json" "${EVIDENCE_DIR}/metadata/analysis.json"
+
+      - name: Install build and inspection dependencies
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            curl \
+            file \
+            jq \
+            libssl-dev \
+            pkg-config \
+            python3 \
+            tcl \
+            zstd \
+            binutils
+
+          {
+            uname -a
+            printf '\nCompiler:\n'
+            gcc --version
+            printf '\nOpenSSL:\n'
+            openssl version -a
+            printf '\nOS release:\n'
+            cat /etc/os-release
+          } > "${EVIDENCE_DIR}/metadata/environment.txt"
+
+      - name: Install current stable official CodeQL bundle
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          release_json="${RUNNER_TEMP}/codeql-releases.json"
+          archive="${RUNNER_TEMP}/codeql-bundle-linux64.tar.zst"
+          install_root="${RUNNER_TEMP}/codeql-home"
+
+          curl --fail --location --silent --show-error \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/github/codeql-action/releases?per_page=100" \
+            --output "${release_json}"
+
+          bundle_url="$(
+            jq -r '
+              map(select(.draft == false and .prerelease == false and (.tag_name | startswith("codeql-bundle-v"))))
+              | first
+              | .assets[]
+              | select(.name == "codeql-bundle-linux64.tar.zst")
+              | .browser_download_url
+            ' "${release_json}"
+          )"
+          bundle_tag="$(
+            jq -r '
+              map(select(.draft == false and .prerelease == false and (.tag_name | startswith("codeql-bundle-v"))))
+              | first
+              | .tag_name
+            ' "${release_json}"
+          )"
+
+          [[ "${bundle_tag}" =~ ^codeql-bundle-v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "${bundle_url}" == "https://github.com/github/codeql-action/releases/download/${bundle_tag}/codeql-bundle-linux64.tar.zst" ]]
+
+          curl --fail --location --silent --show-error \
+            --retry 3 \
+            --output "${archive}" \
+            "${bundle_url}"
+          sha256sum "${archive}" > "${EVIDENCE_DIR}/metadata/codeql-bundle-sha256.txt"
+          printf '%s\n' "${bundle_tag}" > "${EVIDENCE_DIR}/metadata/codeql-bundle-release.txt"
+          printf '%s\n' "${bundle_url}" > "${EVIDENCE_DIR}/metadata/codeql-bundle-url.txt"
+
+          mkdir -p "${install_root}"
+          tar --use-compress-program=unzstd -xf "${archive}" -C "${install_root}"
+          "${install_root}/codeql/codeql" version \
+            | tee "${EVIDENCE_DIR}/metadata/codeql-version.txt"
+          printf '%s\n' "${install_root}/codeql" >> "${GITHUB_PATH}"
+
+      - name: Install and compile custom query pack
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          codeql pack install "${QUERY_PACK}"
+          codeql pack ls "${QUERY_PACK}" \
+            | tee "${EVIDENCE_DIR}/metadata/codeql-pack.txt"
+          while IFS= read -r query; do
+            codeql query compile "${query}"
+          done < <(find "${QUERY_PACK}" -type f -name '*.ql' -print | sort)
+          cp -a "${QUERY_PACK}/." "${EVIDENCE_DIR}/query-pack/"
+
+      - name: Create CodeQL database from observed Redis build
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          cd "${REDIS_SOURCE}"
+          make distclean || true
+
+          if [[ "${BUILD_TLS}" == "true" ]]; then
+            build_command="make BUILD_TLS=yes -j1"
+          else
+            build_command="make -j1"
+          fi
+          printf '%s\n' "${build_command}" > "${EVIDENCE_DIR}/metadata/build-command.txt"
+
+          codeql database create "${DATABASE_PATH}" \
+            --language=c-cpp \
+            --source-root="${REDIS_SOURCE}" \
+            --command="${build_command}" \
+            --overwrite
+
+          test -x "${REDIS_SOURCE}/src/redis-server"
+          "${REDIS_SOURCE}/src/redis-server" --version \
+            | tee "${EVIDENCE_DIR}/metadata/redis-version.txt"
+
+          sanity_bqrs="${EVIDENCE_DIR}/codeql/ExtractionSanity.bqrs"
+          sanity_csv="${EVIDENCE_DIR}/metadata/extraction-sanity.csv"
+          codeql query run \
+            --database="${DATABASE_PATH}" \
+            --output="${sanity_bqrs}" \
+            "${QUERY_PACK}/support/ExtractionSanity.ql"
+          codeql bqrs decode \
+            --format=csv \
+            --no-titles \
+            --output="${sanity_csv}" \
+            "${sanity_bqrs}"
+          compiled_source_files="$(
+            python3 - "${sanity_csv}" <<'PY'
+          import csv
+          import sys
+
+          with open(sys.argv[1], newline="", encoding="utf-8") as stream:
+              row = next(csv.reader(stream), [])
+          print(row[0] if row else "0")
+          PY
+          )"
+          [[ "${compiled_source_files}" =~ ^[0-9]+$ ]]
+          (( compiled_source_files > 0 ))
+          printf '%s\n' "${compiled_source_files}" \
+            > "${EVIDENCE_DIR}/metadata/extracted-source-file-count.txt"
+
+      - name: Run CodeQL suite and preserve BQRS and CSV
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          codeql database analyze "${DATABASE_PATH}" "${QUERY_PACK}/queries.qls" \
+            --format=sarif-latest \
+            --output="${EVIDENCE_DIR}/codeql/results.sarif" \
+            --rerun
+
+          while IFS= read -r query; do
+            query_name="$(basename "${query}" .ql)"
+            bqrs="${EVIDENCE_DIR}/codeql/${query_name}.bqrs"
+            csv="${EVIDENCE_DIR}/codeql/${query_name}.csv"
+            codeql query run \
+              --database="${DATABASE_PATH}" \
+              --output="${bqrs}" \
+              "${query}"
+            codeql bqrs decode \
+              --format=csv \
+              --output="${csv}" \
+              "${bqrs}"
+            codeql bqrs info "${bqrs}" \
+              > "${EVIDENCE_DIR}/codeql/${query_name}.bqrs-info.txt"
+          done < <(find "${QUERY_PACK}" -maxdepth 1 -type f -name '*.ql' -print | sort)
+
+          jq empty "${EVIDENCE_DIR}/codeql/results.sarif"
+
+      - name: Run independent source and module checks
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          search_roots=()
+          for candidate in src deps modules; do
+            if [[ -d "${REDIS_SOURCE}/${candidate}" ]]; then
+              search_roots+=("${REDIS_SOURCE}/${candidate}")
+            fi
+          done
+
+          if (( ${#search_roots[@]} > 0 )); then
+            grep -RInE \
+              --exclude-dir=.git \
+              'CMS_decrypt|CMS_|SMIME_|d2i_CMS_|i2d_CMS_|dlsym|dlopen' \
+              "${search_roots[@]}" \
+              > "${EVIDENCE_DIR}/source/source-search.txt" 2>/dev/null || true
+          else
+            : > "${EVIDENCE_DIR}/source/source-search.txt"
+          fi
+
+          {
+            printf 'Build command: '
+            cat "${EVIDENCE_DIR}/metadata/build-command.txt"
+            printf '\nRedis module-related build/source references:\n'
+            grep -RInE \
+              --exclude-dir=.git \
+              'REDISMODULE|MODULE_LOAD|loadmodule|MODULE LIST' \
+              "${REDIS_SOURCE}/Makefile" \
+              "${REDIS_SOURCE}/src" \
+              2>/dev/null || true
+            cat <<'EOF'
+
+          Scope assessment:
+          The standard Redis core build does not automatically include arbitrary external
+          Redis modules. Modules can be loaded separately at runtime through Redis
+          configuration or commands. Those third-party module binaries are outside this
+          Redis core database and must be analyzed independently.
+          EOF
+          } > "${EVIDENCE_DIR}/source/module-assessment.txt"
+
+      - name: Inspect the built redis-server binary
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          binary="${REDIS_SOURCE}/src/redis-server"
+          test -x "${binary}"
+
+          readelf --dyn-syms --wide "${binary}" > "${EVIDENCE_DIR}/binary/dynamic-symbols.txt"
+          nm -D --undefined-only "${binary}" > "${EVIDENCE_DIR}/binary/undefined-symbols.txt"
+          objdump -T "${binary}" > "${EVIDENCE_DIR}/binary/object-symbols.txt"
+          strings --all "${binary}" > "${EVIDENCE_DIR}/binary/strings.txt"
+          ldd "${binary}" > "${EVIDENCE_DIR}/binary/ldd.txt"
+          file "${binary}" > "${EVIDENCE_DIR}/binary/file.txt"
+          sha256sum "${binary}" \
+            | tee "${EVIDENCE_DIR}/metadata/binary-sha256.txt"
+
+          {
+            cat "${EVIDENCE_DIR}/binary/dynamic-symbols.txt"
+            cat "${EVIDENCE_DIR}/binary/undefined-symbols.txt"
+            cat "${EVIDENCE_DIR}/binary/object-symbols.txt"
+            cat "${EVIDENCE_DIR}/binary/strings.txt"
+          } | grep -E \
+            'CMS_decrypt|CMS_|SMIME_|d2i_CMS_|i2d_CMS_|dlopen|dlsym' \
+            > "${EVIDENCE_DIR}/binary/filtered-symbols.txt" || true
+
+      - name: Classify results and render report
+        if: always()
+        shell: bash
+        env:
+          PRIOR_JOB_STATUS: ${{ job.status }}
+        run: |
+          set -Eeuo pipefail
+          if [[ "${PRIOR_JOB_STATUS}" == "success" ]]; then
+            bash "${GITHUB_WORKSPACE}/analysis-tooling/.github/scripts/cve-2026-28390-report.sh" \
+              "${EVIDENCE_DIR}"
+          else
+            jq \
+              --arg timestamp "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+              '.analysis_timestamp_utc = $timestamp | .status = "analysis_inconclusive"' \
+              "${EVIDENCE_DIR}/metadata/analysis.json" \
+              > "${RUNNER_TEMP}/analysis.json"
+            mv "${RUNNER_TEMP}/analysis.json" "${EVIDENCE_DIR}/metadata/analysis.json"
+          fi
+          jq empty "${EVIDENCE_DIR}/metadata/analysis.json"
+          cat "${EVIDENCE_DIR}/report.md" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload analysis evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cve-2026-28390-evidence-${{ github.run_id }}
+          path: evidence/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce analysis result
+        if: always()
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          status="$(jq -r '.status' "${EVIDENCE_DIR}/metadata/analysis.json")"
+          printf 'Final analysis status: %s\n' "${status}"
+          if [[ "${status}" != "no_reachable_reference_identified" ]]; then
+            exit 1
+          fi

--- a/codeql/redis-cms-reachability/FindCmsApiUsage.ql
+++ b/codeql/redis-cms-reachability/FindCmsApiUsage.ql
@@ -1,0 +1,24 @@
+/**
+ * @name OpenSSL CMS and S/MIME API calls
+ * @description Finds direct calls to OpenSSL CMS, CMS serialization, and S/MIME APIs.
+ * @kind problem
+ * @problem.severity warning
+ * @precision high
+ * @id cpp/redis-cve-2026-28390-cms-api-call
+ * @tags security
+ */
+
+import cpp
+
+predicate isCmsOrSmimeApi(string name) {
+  name.regexpMatch("^(CMS_|d2i_CMS_|i2d_CMS_|SMIME_).*$")
+}
+
+from FunctionCall call, Function target
+where
+  call.getTarget() = target and
+  isCmsOrSmimeApi(target.getName())
+select call,
+  "Direct call to OpenSSL CMS/S/MIME API " + target.getQualifiedName() +
+    " from " + call.getEnclosingFunction().getQualifiedName() + " at " +
+    call.getLocation().toString() + "."

--- a/codeql/redis-cms-reachability/FindCmsDecryptCalls.ql
+++ b/codeql/redis-cms-reachability/FindCmsDecryptCalls.ql
@@ -1,0 +1,21 @@
+/**
+ * @name Direct calls to OpenSSL CMS_decrypt
+ * @description Finds statically resolved direct calls to the global OpenSSL CMS_decrypt function.
+ * @kind problem
+ * @problem.severity warning
+ * @precision very-high
+ * @id cpp/redis-cve-2026-28390-cms-decrypt-call
+ * @tags security
+ */
+
+import cpp
+
+from FunctionCall call, Function target
+where
+  call.getTarget() = target and
+  target.hasGlobalName("CMS_decrypt")
+select call,
+  "Direct call to OpenSSL CMS_decrypt from " +
+    call.getEnclosingFunction().getQualifiedName() + " at " +
+    call.getLocation().toString() + "; resolved target: " +
+    target.getQualifiedName() + "."

--- a/codeql/redis-cms-reachability/FindCmsDecryptReferences.ql
+++ b/codeql/redis-cms-reachability/FindCmsDecryptReferences.ql
@@ -1,0 +1,36 @@
+/**
+ * @name References to OpenSSL CMS_decrypt
+ * @description Finds non-call function accesses to CMS_decrypt, including uses as a function pointer value.
+ * @kind problem
+ * @problem.severity warning
+ * @precision very-high
+ * @id cpp/redis-cve-2026-28390-cms-decrypt-reference
+ * @tags security
+ */
+
+import cpp
+
+string enclosingFunctionName(Expr expression) {
+  exists(Function function |
+    function = expression.getEnclosingFunction() and
+    result = function.getQualifiedName()
+  )
+  or
+  not exists(expression.getEnclosingFunction()) and result = "<global scope>"
+}
+
+/*
+ * FunctionAccess excludes the ordinary callee expression of a FunctionCall.
+ * It therefore complements FindCmsDecryptCalls and detects statically resolved
+ * uses such as "&CMS_decrypt" or assignment to a function pointer. It does not
+ * prove where an arbitrarily reassigned function pointer is later invoked.
+ */
+from FunctionAccess access, Function target
+where
+  access.getTarget() = target and
+  target.hasGlobalName("CMS_decrypt")
+select access,
+  "Non-call reference to OpenSSL CMS_decrypt from " +
+    enclosingFunctionName(access) + " at " +
+    access.getLocation().toString() + "; resolved target: " +
+    target.getQualifiedName() + "."

--- a/codeql/redis-cms-reachability/FindDynamicCmsLookup.ql
+++ b/codeql/redis-cms-reachability/FindDynamicCmsLookup.ql
@@ -1,0 +1,58 @@
+/**
+ * @name Potential dynamic lookup of OpenSSL CMS and S/MIME symbols
+ * @description Finds relevant symbol string literals, direct dlsym uses of those literals, and dynamic-loader calls for review.
+ * @kind problem
+ * @problem.severity warning
+ * @precision high
+ * @id cpp/redis-cve-2026-28390-dynamic-cms-lookup
+ * @tags security
+ */
+
+import cpp
+
+string enclosingFunctionName(Expr expression) {
+  exists(Function function |
+    function = expression.getEnclosingFunction() and
+    result = function.getQualifiedName()
+  )
+  or
+  not exists(expression.getEnclosingFunction()) and result = "<global scope>"
+}
+
+predicate isCmsOrSmimeSymbol(string value) {
+  value.regexpMatch("^(CMS_decrypt|CMS_.*|d2i_CMS_.*|i2d_CMS_.*|SMIME_.*)$")
+}
+
+predicate evidence(Expr location, string kind, string symbol) {
+  exists(StringLiteral literal |
+    location = literal and
+    isCmsOrSmimeSymbol(literal.getValue()) and
+    symbol = literal.getValue() and
+    kind = "CMS/S-MIME symbol string literal"
+  )
+  or
+  exists(FunctionCall call, Function target, StringLiteral literal |
+    location = call and
+    call.getTarget() = target and
+    target.hasGlobalName("dlsym") and
+    call.getNumberOfArguments() > 1 and
+    call.getArgument(1).getUnconverted() = literal and
+    isCmsOrSmimeSymbol(literal.getValue()) and
+    symbol = literal.getValue() and
+    kind = "Direct dlsym lookup of CMS/S-MIME symbol"
+  )
+  or
+  exists(FunctionCall call, Function target |
+    location = call and
+    call.getTarget() = target and
+    (target.hasGlobalName("dlopen") or target.hasGlobalName("dlsym")) and
+    symbol = target.getName() and
+    kind = "Dynamic-loader API call requiring manual review"
+  )
+}
+
+from Expr location, string kind, string symbol
+where evidence(location, kind, symbol)
+select location,
+  kind + ": " + symbol + " in " + enclosingFunctionName(location) + " at " +
+    location.getLocation().toString() + "."

--- a/codeql/redis-cms-reachability/qlpack.yml
+++ b/codeql/redis-cms-reachability/qlpack.yml
@@ -1,0 +1,6 @@
+---
+name: jkleinlercher/redis-cms-reachability
+version: 0.0.1
+dependencies:
+  codeql/cpp-all: "*"
+extractor: cpp

--- a/codeql/redis-cms-reachability/queries.qls
+++ b/codeql/redis-cms-reachability/queries.qls
@@ -1,0 +1,6 @@
+---
+- description: CVE-2026-28390 Redis CMS reachability queries
+- query: FindCmsDecryptCalls.ql
+- query: FindCmsDecryptReferences.ql
+- query: FindCmsApiUsage.ql
+- query: FindDynamicCmsLookup.ql

--- a/codeql/redis-cms-reachability/support/ExtractionSanity.ql
+++ b/codeql/redis-cms-reachability/support/ExtractionSanity.ql
@@ -1,0 +1,7 @@
+import cpp
+
+from int compiledSourceFileCount
+where
+  compiledSourceFileCount =
+    count(File file | file.compiledAsC() or file.compiledAsCpp())
+select compiledSourceFileCount

--- a/docs/security/CVE-2026-28390-reachability.md
+++ b/docs/security/CVE-2026-28390-reachability.md
@@ -1,0 +1,77 @@
+# CVE-2026-28390: Redis code-reachability analysis
+
+## Purpose
+
+This repository contains a manually triggered, reproducible evidence workflow for determining whether a selected Redis core build refers to the OpenSSL function `CMS_decrypt()`. CVE-2026-28390 concerns that function; the workflow does not modify Redis application code.
+
+A package or container scanner can establish that an OpenSSL library is present. Presence alone does not establish that Redis imports or calls the affected function:
+
+1. **Library presence** says that an OpenSSL package or shared object is available.
+2. **Binary reference** says that the built executable imports, exports, or embeds a relevant symbol or string.
+3. **Code reachability evidence** says that source expressions resolve to the affected API or preserve it as a callable function value.
+
+The workflow combines all three views where applicable: CodeQL AST queries, an independent source search, and ELF/binary inspection.
+
+## Running the workflow
+
+Open **Actions → CVE-2026-28390 Redis reachability → Run workflow**. Supply the exact Redis tag, branch, or commit corresponding to the build under review. Prefer an immutable commit SHA. Enable `build_tls` if the production build includes Redis TLS support.
+
+Using GitHub CLI:
+
+```bash
+gh workflow run cve-2026-28390-reachability.yml \
+  --repo jkleinlercher/redis \
+  -f redis_ref='<REDIS_TAG_OR_COMMIT>' \
+  -f build_tls=true
+```
+
+The workflow accepts no free-form build command. This prevents a dispatch input from becoming shell code. It checks out the requested ref, records the resolved commit and dirty status, downloads the current stable official GitHub CodeQL bundle, records its version and archive digest, creates an explicit C/C++ database at `${RUNNER_TEMP}/redis-codeql-db`, and observes the serial Redis build.
+
+The current `.qls` query-suite format is used instead of the legacy `queries.xml` format. `queries.qls` selects all queries in the pack and is passed directly to `codeql database analyze`.
+An internal support query counts files actually observed as compiled C/C++ input. A zero count makes the run `analysis_inconclusive`; the support query is not part of the alert suite.
+
+## Queries
+
+- `FindCmsDecryptCalls.ql` uses `FunctionCall.getTarget()` and `hasGlobalName()` to find direct calls.
+- `FindCmsDecryptReferences.ql` uses `FunctionAccess`, whose current C/C++ model excludes ordinary direct-call callee expressions, to find function values and pointer references.
+- `FindCmsApiUsage.ql` uses `string.regexpMatch()` with anchored regular expressions for `CMS_*`, `d2i_CMS_*`, `i2d_CMS_*`, and `SMIME_*`. The expressions are regular expressions, not SQL wildcard patterns.
+- `FindDynamicCmsLookup.ql` identifies relevant `StringLiteral` values, direct literal arguments to `dlsym`, and `dlopen`/`dlsym` call sites for manual review.
+
+Each query is run individually to retain raw BQRS and decoded CSV evidence. The suite is also analyzed to produce SARIF.
+
+## Results and artifacts
+
+The workflow summary shows `evidence/report.md`. The workflow run also contains an artifact named `cve-2026-28390-evidence-<run id>` with:
+
+- machine-readable metadata in `metadata/analysis.json`;
+- CodeQL BQRS, CSV, and SARIF results;
+- repository, environment, Redis, CodeQL, and binary identity data;
+- independent source-search results;
+- complete and filtered `readelf`, `nm`, `objdump`, `strings`, `ldd`, and `file` output;
+- a human-readable report.
+
+Statuses mean:
+
+- `potentially_reachable`: an exact `CMS_decrypt` call, function reference, dynamic-symbol candidate, or binary reference exists.
+- `cms_usage_detected`: other CMS/S/MIME APIs or symbols exist without an exact `CMS_decrypt` reachability indicator.
+- `no_reachable_reference_identified`: none of the defined source, CodeQL, or binary indicators were found.
+- `analysis_inconclusive`: a build, extraction, query, database, binary, or inspection failure prevented a sound negative result.
+
+The job fails for `analysis_inconclusive`, `potentially_reachable`, and `cms_usage_detected`, after uploading evidence. A zero-result query is valid and does not by itself fail the job.
+
+## Limits and production correlation
+
+The analysis covers the selected Redis core source, runner architecture, build inputs, and generated `src/redis-server`. It does not automatically cover third-party Redis modules loaded at runtime, another vendor build, a different architecture, or other executables in a production image. Static function-value analysis also cannot prove every target after arbitrary pointer reassignment, and the dynamic-symbol query is deliberately not a general interprocedural string-flow analysis.
+
+For an Argo CD deployment, record separately:
+
+- application and environment;
+- image registry/repository and immutable image digest;
+- manifest or Helm revision;
+- Redis executable hash and version from the image;
+- vendor source tag/commit and build configuration, if available;
+- date and identity of the evidence workflow run.
+
+Do not start a cluster in this workflow. Correlate the production image digest outside it. The analyzed source ref must match the vendor build because compiler options, patches, linked libraries, bundled modules, and source changes can all change reachability and binary references.
+
+An absence of findings is scoped evidence, not a claim that exploitation is mathematically impossible.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CI scripts, CodeQL queries, and documentation; Redis runtime source is not modified.
> 
> **Overview**
> Adds a **manually triggered** GitHub Actions pipeline to produce reproducible evidence on whether a chosen Redis core build references OpenSSL **`CMS_decrypt`** (CVE-2026-28390), without changing Redis application code.
> 
> The workflow checks out a configurable **`redis_ref`** and optional **`build_tls`**, installs the stable CodeQL bundle, builds **`redis-server`** under CodeQL observation, runs a new **`codeql/redis-cms-reachability`** query pack (direct calls, function references, broader CMS/S-MIME API usage, dynamic `dlopen`/`dlsym` signals), plus grep-based source checks and **`readelf`/`nm`/`strings`** on the binary. **`cve-2026-28390-report.sh`** aggregates match counts into **`analysis.json`**, **`report.md`**, and a reachability status; evidence is uploaded as an artifact and summarized on the run. The job **exits non-zero** unless the status is **`no_reachable_reference_identified`** (inconclusive or any CMS/`CMS_decrypt` signal fails the gate). **`docs/security/CVE-2026-28390-reachability.md`** documents how to run it and how to interpret limits (modules, vendor builds, static analysis bounds).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edae216af7a3458f78217af405f083b4f814eb1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->