### PR TITLE
Fix quadratic search of slot duplicates in hotkeys command

### DIFF
--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -437,6 +437,7 @@ void hotkeysCommand(client *c) {
                 /* Sort the slots array */
                 qsort(temp_slots, slots_count, sizeof(int), slotCompare);
 
+                /* Check for duplicates */
                 for (int i = 1; i < slots_count; ++i) {
                     if (temp_slots[i] == temp_slots[i-1]) {
                         addReplyError(c, "duplicate slot number");

--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -431,20 +431,19 @@ void hotkeysCommand(client *c) {
                         return;
                     }
 
-                    /* Check for duplicate slot */
-                    for (int k = 0; k < i; k++) {
-                        if (temp_slots[k] == slot_val) {
-                            addReplyError(c, "duplicate slot number");
-                            zfree(temp_slots);
-                            return;
-                        }
-                    }
-
                     temp_slots[i] = (int)slot_val;
                 }
 
                 /* Sort the slots array */
                 qsort(temp_slots, slots_count, sizeof(int), slotCompare);
+
+                for (int i = 1; i < slots_count; ++i) {
+                    if (temp_slots[i] == temp_slots[i-1]) {
+                        addReplyError(c, "duplicate slot number");
+                        zfree(temp_slots);
+                        return;
+                    }
+                }
 
                 /* Build slotRangeArray from sorted slots */
                 for (int i = 0; i < slots_count; i++) {


### PR DESCRIPTION
When parsing the `SLOTS` param of `HOTKEYS START` we were doing a linear search on all the slots up until the currently iterated one to search for duplicates, leading to O(n^2) overall time for parsing the `SLOTS` which can theoretically be up to 16k 

Since we are already sorting the parsed slots at the end we can just defer the duplicate search after the sort in linear time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of SLOTS validation in hotkeys command parsing with no security or data-path changes.
> 
> **Overview**
> **HOTKEYS START** `SLOTS` parsing no longer checks for duplicate slot numbers while building the temporary list (which was O(n²) for up to ~16k slots).
> 
> Duplicate detection now runs **after** `qsort` on `temp_slots`, comparing adjacent entries in a single linear pass. Users still get the same `duplicate slot number` error; only parse-time complexity improves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1752ce802a1f2353bb7f9e5a36a1709bb516a948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->