### PR TITLE
Fix use-after-free in handleClientsBlockedOnKey

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -625,15 +625,28 @@ static void handleClientsBlockedOnKey(readyList *rl) {
 
     if (de) {
         list *clients = dictGetVal(de);
+        /* Snapshot the client pointers and protect them to avoid use-after-free
+         * if a client gets evicted during command processing (nested eviction). */
+        long count = listLength(clients);
+        client **client_ptrs = zmalloc(sizeof(client*) * count);
         listNode *ln;
         listIter li;
-        listRewind(clients,&li);
+        listRewind(clients, &li);
+        long i = 0;
+        while ((ln = listNext(&li)) && i < count) {
+            client *receiver = listNodeValue(ln);
+            protectClient(receiver);
+            client_ptrs[i++] = receiver;
+        }
 
         /* Avoid processing more than the initial count so that we're not stuck
          * in an endless loop in case the reprocessing of the command blocks again. */
-        long count = listLength(clients);
-        while ((ln = listNext(&li)) && count--) {
-            client *receiver = listNodeValue(ln);
+        for (long j = 0; j < i; j++) {
+            client *receiver = client_ptrs[j];
+
+            /* Check if the client is still blocked on this key. */
+            if (dictFind(receiver->bstate.keys, rl->key) == NULL) continue;
+
             kvobj *o = lookupKeyReadWithFlags(rl->db, rl->key, LOOKUP_NOEFFECTS);
             /* 1. In case new key was added/touched we need to verify it satisfy the
              *    blocked type, since we might process the wrong key type.
@@ -662,6 +675,10 @@ static void handleClientsBlockedOnKey(readyList *rl) {
                     moduleUnblockClientOnKey(receiver, rl->key);
             }
         }
+        for (long j = 0; j < i; j++) {
+            unprotectClient(client_ptrs[j]);
+        }
+        zfree(client_ptrs);
     }
 }
 


### PR DESCRIPTION
Fixes #15562. This PR snapshots the client IDs before iterating over the blocked clients to avoid iterator invalidation upon nested client evictions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core blocking-key wakeup logic used by BLPOP-style commands; behavior is narrowly scoped but errors could affect client unblock ordering or safety under eviction.
> 
> **Overview**
> Fixes a **use-after-free** when waking clients blocked on a key (e.g. BLPOP) if command re-execution triggers **nested client eviction** while the server is still walking the per-key blocked-client list.
> 
> `handleClientsBlockedOnKey` now **snapshots** the initial client pointers into a temporary array, wraps each with **`protectClient` / `unprotectClient`**, and processes that snapshot instead of advancing a live list iterator. It also **skips** snapshot entries that are no longer blocked on the key before calling `unblockClientOnKey` / `moduleUnblockClientOnKey`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb074bc8c3cb40813f0ee2bd0ef74fb435deb818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->