### PR TITLE
Fix signed integer overflows in Key-spec numkeys validation

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3287,6 +3287,13 @@ int getKeysUsingKeySpecs(struct redisCommand *cmd, robj **argv, int argc, int se
             }
 
             first += spec->fk.keynum.firstkey;
+            if (numkeys > 0) {
+                if (first >= argc) goto invalid_spec;
+                int available = argc - first;
+                if (step > 0 && numkeys > (available / step) + 1) {
+                    goto invalid_spec;
+                }
+            }
             last = first + ((long)numkeys - 1) * step;
         } else {
             /* unknown spec */


### PR DESCRIPTION
Fixes #15549.

Validates that `numkeys`, `first`, and `step` describe a range contained by the supplied arguments in `getKeysUsingKeySpecs` before performing `((long)numkeys - 1) * step` to avoid arithmetic overflow on large `numkeys` inputs.