### PR TITLE
Fix replica SIGABRT crash on BGSAVE failure

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -450,7 +450,7 @@ static int scriptVerifyWriteCommandAllow(scriptRunCtx *run_ctx, char **err) {
         return C_ERR;
     }
 
-    if (deny_write_type != DISK_ERROR_TYPE_NONE) {
+    if (deny_write_type != DISK_ERROR_TYPE_NONE && !mustObeyClient(run_ctx->original_client)) {
         *err = writeCommandsGetDiskErrorMessage(deny_write_type);
         return C_ERR;
     }

--- a/src/server.c
+++ b/src/server.c
@@ -5261,12 +5261,7 @@ error:
  * DISK_ERROR_TYPE_RDB:     Don't accept writes: RDB errors.
  */
 int writeCommandsDeniedByDiskError(void) {
-    if (server.stop_writes_on_bgsave_err &&
-        server.saveparamslen > 0 &&
-        server.lastbgsave_status == C_ERR)
-    {
-        return DISK_ERROR_TYPE_RDB;
-    } else if (server.aof_state != AOF_OFF) {
+    if (server.aof_state != AOF_OFF) {
         if (server.aof_last_write_status == C_ERR) {
             return DISK_ERROR_TYPE_AOF;
         }
@@ -5277,6 +5272,13 @@ int writeCommandsDeniedByDiskError(void) {
             atomicGet(server.aof_bio_fsync_errno,server.aof_last_write_errno);
             return DISK_ERROR_TYPE_AOF;
         }
+    }
+
+    if (server.stop_writes_on_bgsave_err &&
+        server.saveparamslen > 0 &&
+        server.lastbgsave_status == C_ERR)
+    {
+        return DISK_ERROR_TYPE_RDB;
     }
 
     return DISK_ERROR_TYPE_NONE;

--- a/src/server.c
+++ b/src/server.c
@@ -4689,7 +4689,11 @@ int processCommand(client *c) {
         (is_write_command || c->cmd->proc == pingCommand))
     {
         if (obey_client) {
-            if (!server.repl_ignore_disk_write_error && c->cmd->proc != pingCommand) {
+            if (deny_write_type == DISK_ERROR_TYPE_RDB) {
+                /* A failed BGSAVE shouldn't cause a replica to panic or drop
+                 * master commands, since it doesn't affect command persistence 
+                 * directly like an AOF error does. */
+            } else if (!server.repl_ignore_disk_write_error && c->cmd->proc != pingCommand) {
                 serverPanic("Replica was unable to write command to disk.");
             } else {
                 static mstime_t last_log_time_ms = 0;

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -431,6 +431,51 @@ start_server {} {
         # server is writable again
         r set x y
     } {OK}
+
+    test "failed bgsave does not prevent master writes on replica" {
+        start_server {} {
+            set replica [srv 0 client]
+            set replica_host [srv 0 host]
+            set replica_port [srv 0 port]
+            
+            start_server {} {
+                set master [srv 0 client]
+                $replica replicaof [srv 0 host] [srv 0 port]
+                wait_for_sync $replica
+
+                # Make sure the replica saves an RDB on shutdown
+                $replica config set save "900 1"
+
+                $replica config set rdb-key-save-delay 10000000
+                populate 1000 "" 100
+                $master set x x
+                
+                # Wait for sync so that x is on replica
+                wait_for_condition 50 100 {
+                    [$replica get x] eq "x"
+                } else {
+                    fail "Replica didn't sync"
+                }
+
+                $replica bgsave
+                set pid1 [get_child_pid -1]
+                catch {exec kill -9 $pid1}
+                waitForBgsave $replica
+
+                # Ensure replica doesn't crash on subsequent writes from master
+                $master set y y
+                wait_for_condition 50 100 {
+                    [$replica get y] eq "y"
+                } else {
+                    fail "Replica didn't apply write after failed bgsave"
+                }
+
+                $replica config set rdb-key-save-delay 0
+                $replica bgsave
+                waitForBgsave $replica
+            }
+        }
+    }
 }
 
 start_server {overrides {save "900 1"}} {


### PR DESCRIPTION
Fixes #15501.

When a replica's background save (BGSAVE) fails, it shouldn't crash or deny writes from the master, because an RDB failure does not compromise the ability to apply master commands to the in-memory dataset.

Previously, `writeCommandsDeniedByDiskError` lumped together both AOF disk write errors (which *should* panic a replica) and RDB snapshot errors (which should not). This caused replicas to panic with `Replica was unable to write command to disk` when receiving master commands if their periodic BGSAVE had failed (e.g. due to memory limits causing `fork()` to return `EAGAIN`).

This PR:
1. Skips the panic in `processCommand` when the disk error type is `DISK_ERROR_TYPE_RDB` and the command is from the master.
2. Skips the error in `scriptVerifyCommandAcceptance` for propagated scripts when the error is a disk error.
3. Adds a regression test that deliberately fails a BGSAVE on a replica and asserts it successfully processes subsequent writes from the master without crashing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replication command acceptance and disk-error classification at the boundary between RDB and AOF; incorrect handling could allow writes when AOF is broken or still panic on benign BGSAVE failures.
> 
> **Overview**
> Fixes replicas **SIGABRT** / write denial when periodic **BGSAVE** fails but the in-memory dataset is still healthy. Failed RDB snapshots no longer block or panic on commands from the master (or propagated scripts), while **AOF** persistence failures keep the stricter behavior.
> 
> **`writeCommandsDeniedByDiskError`** now evaluates **AOF** write/fsync errors before **RDB** (`lastbgsave_status`), so AOF problems still win when both conditions exist.
> 
> In **`processCommand`**, master/AOF clients (`obey_client`) skip the replica panic and warning path when the error is **`DISK_ERROR_TYPE_RDB`**; AOF errors still honor **`repl-ignore-disk-write-error`** (panic vs throttled log).
> 
> **`scriptVerifyWriteCommandAllow`** skips the disk-error rejection when **`mustObeyClient`** applies (replication-driven scripts), matching ordinary replicated writes.
> 
> Adds an integration test that kills a replica BGSAVE and asserts subsequent master writes replicate without crashing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b75094e70efbd4d9ecc750b27f8fc27bbc997f37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->