### PR TITLE
Disabling copy avoidance in 'client eviction due to output buffer' test

### DIFF
--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -293,7 +293,7 @@ start_server {} {
         }
         $rr close
         r debug reply-copy-avoidance 1
-    }
+    } {OK} {needs:debug}
 
     foreach {no_evict} {on off} {
         test "client no-evict $no_evict" {

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -265,7 +265,8 @@ start_server {} {
 
     test "client evicted due to output buf" {
         r flushdb
-        r setrange k 15000 v
+        r debug reply-copy-avoidance 0
+        r setrange k 200000 v
         set rr [redis_deferring_client]
         $rr client setname test_client
         $rr flush
@@ -273,7 +274,7 @@ start_server {} {
         # Attempt a large response under eviction limit
         $rr get k
         $rr flush
-        assert {[string length [$rr read]] == 15001}
+        assert {[string length [$rr read]] == 200001}
         set mem [client_field test_client tot-mem]
         assert {$mem < $maxmemory_clients}
 
@@ -291,6 +292,7 @@ start_server {} {
             }
         }
         $rr close
+        r debug reply-copy-avoidance 1
     }
 
     foreach {no_evict} {on off} {

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -265,7 +265,7 @@ start_server {} {
 
     test "client evicted due to output buf" {
         r flushdb
-        r setrange k 200000 v
+        r setrange k 15000 v
         set rr [redis_deferring_client]
         $rr client setname test_client
         $rr flush
@@ -273,7 +273,7 @@ start_server {} {
         # Attempt a large response under eviction limit
         $rr get k
         $rr flush
-        assert {[string length [$rr read]] == 200001}
+        assert {[string length [$rr read]] == 15001}
         set mem [client_field test_client tot-mem]
         assert {$mem < $maxmemory_clients}
 


### PR DESCRIPTION
The 'client eviction due to output buffer' test was using a large key (200 KB) which was never really copied to the key output buffer thanks to copy avoidance. As a result, the test was increasing the output buffer on every get with very few data, taking it almost 12 seconds(!) to reach the limit and evict the client.
Disabling the copy avoidance logic using a debug command reduces the test running time to a few tens of milliseconds.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change gated on debug support; no production behavior modified.
> 
> **Overview**
> Fixes the **client evicted due to output buf** integration test so it actually fills the client output buffer instead of relying on copy avoidance for a 200 KB `GET` reply.
> 
> The test now runs `DEBUG REPLY-COPY-AVOIDANCE 0` before the eviction loop and restores `1` afterward, and is tagged with `{needs:debug}` (expected reply `OK` on the debug path). Runtime drops from on the order of ~12s to tens of milliseconds while still asserting eviction under `maxmemory-clients`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1799573e46df9bc6ac5aaa81196b814ffd551e17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->