### PR TITLE
Skip the stale Unix socket test under Valgrind

### DIFF
--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -31,6 +31,8 @@ start_server {tags {"unixsocket external:skip"}} {
         assert_equal PONG [exec {*}[rediscli_unixsocket [srv unixsocket]] PING]
     }
 
+    # SIGKILL prevents Valgrind from writing its leak summary, causing the test
+    # harness to report an error even when no memory error occurred.
     if {!$::valgrind} {
     test {A stale Unix socket is replaced and accepts connections} {
         set stale_socket [file normalize [tmpfile stale.sock]]

--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -31,6 +31,7 @@ start_server {tags {"unixsocket external:skip"}} {
         assert_equal PONG [exec {*}[rediscli_unixsocket [srv unixsocket]] PING]
     }
 
+    if {!$::valgrind} {
     test {A stale Unix socket is replaced and accepts connections} {
         set stale_socket [file normalize [tmpfile stale.sock]]
 
@@ -51,6 +52,7 @@ start_server {tags {"unixsocket external:skip"}} {
         start_server [list overrides [list unixsocket $stale_socket]] {
             assert_equal PONG [exec {*}[rediscli_unixsocket $stale_socket] PING]
         }
+    }
     }
 }
 


### PR DESCRIPTION
## Issue

The stale Unix socket test uses `SIGKILL` to stop a Redis server without removing its socket. Under Valgrind, `SIGKILL` prevents the leak summary from being written, so the test harness reports a Valgrind error even though no memory error occurred.

## Change

Wrap the stale Unix socket test with `if {!$::valgrind}` so it does not run under Valgrind.

This matches the existing handling for a test that kills the Redis main process in `tests/integration/replication.tcl:903`.

## Test

Daily CI with param:`--single unit/networking` : https://github.com/vitahlin/redis/actions/runs/30755211136

introduced from https://github.com/redis/redis/pull/15537

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only guard with no production code changes; reduces false Valgrind failures in CI.
> 
> **Overview**
> The **stale Unix socket** integration test (`SIGKILL` leaves a socket path, then a new server replaces it) is now **skipped when tests run under Valgrind** via `if {!$::valgrind}`.
> 
> A short comment documents that **SIGKILL** stops Valgrind from writing its leak summary, which made the harness fail without a real memory error. This follows the same pattern used elsewhere (e.g. replication tests that kill the main process).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527dc099cb3d0f5e28e75a93758c94c87d33026b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->