### PR TITLE
Fix VRANDMEMBER null pointer dereferences (#15567)

### DIFF
--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -1644,15 +1644,18 @@ int VRANDMEMBER_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
         abs_count = set_size;
 
     /* Prepare reply. */
-    RedisModule_ReplyWithArray(ctx, abs_count);
+    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+    long long replied = 0;
 
     if (allow_duplicates) {
         /* Simple case: With duplicates, just pick random nodes
          * abs_count times. */
         for (long long i = 0; i < abs_count; i++) {
             hnswNode *random_node = hnsw_random_node(vset->hnsw,0);
+            if (!random_node) break;
             struct vsetNodeVal *nv = random_node->value;
             RedisModule_ReplyWithString(ctx, nv->item);
+            replied++;
         }
     } else {
         /* Case where count is positive: we need unique elements.
@@ -1667,9 +1670,9 @@ int VRANDMEMBER_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
         if (use_dict) {
             RedisModuleDict *returned = RedisModule_CreateDict(ctx);
 
-            long long returned_count = 0;
-            while (returned_count < abs_count) {
+            while (replied < abs_count) {
                 hnswNode *random_node = hnsw_random_node(vset->hnsw, 0);
+                if (!random_node) break;
                 struct vsetNodeVal *nv = random_node->value;
 
                 /* Check if we've already returned this element. */
@@ -1677,7 +1680,7 @@ int VRANDMEMBER_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
                     /* Mark as returned and add to results. */
                     RedisModule_DictSet(returned, nv->item, (void*)1);
                     RedisModule_ReplyWithString(ctx, nv->item);
-                    returned_count++;
+                    replied++;
                 }
             }
             RedisModule_FreeDict(ctx, returned);
@@ -1694,19 +1697,23 @@ int VRANDMEMBER_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
             hnswNode *start_node = hnsw_random_node(vset->hnsw, 0);
             hnswNode *current = start_node;
 
-            long long returned_count = 0;
-            while (returned_count < abs_count) {
+            int wrapped = 0;
+            while (replied < abs_count) {
                 if (current == NULL) {
+                    if (wrapped) break; /* Avoid infinite loop if head is also NULL */
                     /* Restart from head if we hit the end. */
                     current = vset->hnsw->head;
+                    wrapped = 1;
+                    if (current == NULL) break;
                 }
                 struct vsetNodeVal *nv = current->value;
                 RedisModule_ReplyWithString(ctx, nv->item);
-                returned_count++;
+                replied++;
                 current = current->next;
             }
         }
     }
+    RedisModule_ReplySetArrayLength(ctx, replied);
     return REDISMODULE_OK;
 }
 


### PR DESCRIPTION
Fixes #15567.

Guards against `hnsw_random_node()` returning NULL in `VRANDMEMBER_RedisCommand` array return paths, using postponed array length to return gracefully if the graph is empty despite `set_size > 0`. Also adds a guard to avoid an infinite loop if the head node is NULL during linear scans.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized defensive fixes in VRANDMEMBER array paths; behavior change is returning shorter arrays instead of crashing when the graph is empty or inconsistent.
> 
> **Overview**
> **VRANDMEMBER** with a `COUNT` now uses a **postponed array length** and tracks how many elements were actually emitted, so the reply stays valid when fewer members are returned than requested.
> 
> The command **stops safely** when `hnsw_random_node()` returns NULL in the duplicate, dict-based unique, and related paths—avoiding null pointer dereferences when the HNSW graph has no usable nodes even if `node_count` is non-zero.
> 
> For **large unique samples** that walk the level-0 linked list, a **wrap guard** breaks out if `head` is NULL after restarting from the end, preventing an infinite loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb961cb82bfda5ad76132e425afe5feca096baca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->