### PR TITLE
Fix heap use-after-free in handleClientsBlockedOnKey (Issue #15562)

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -625,14 +625,13 @@ static void handleClientsBlockedOnKey(readyList *rl) {
 
     if (de) {
         list *clients = dictGetVal(de);
-        listNode *ln;
-        listIter li;
-        listRewind(clients,&li);
 
         /* Avoid processing more than the initial count so that we're not stuck
          * in an endless loop in case the reprocessing of the command blocks again. */
         long count = listLength(clients);
-        while ((ln = listNext(&li)) && count--) {
+        while (count--) {
+            listNode *ln = listFirst(clients);
+            if (ln == NULL) break;
             client *receiver = listNodeValue(ln);
             kvobj *o = lookupKeyReadWithFlags(rl->db, rl->key, LOOKUP_NOEFFECTS);
             /* 1. In case new key was added/touched we need to verify it satisfy the
@@ -660,6 +659,12 @@ static void handleClientsBlockedOnKey(readyList *rl) {
                      * (RM_SignalKeyAsReady, key (re)creation, deletion/swap),
                      * not by plain writes to a pre-existing key. */
                     moduleUnblockClientOnKey(receiver, rl->key);
+            }
+            
+            /* If the client is still in the list, we need to rotate it to the tail
+             * to process the next client. */
+            if (listFirst(clients) == ln) {
+                listRotateHeadToTail(clients);
             }
         }
     }


### PR DESCRIPTION
Fixes #15562.

In `handleClientsBlockedOnKey`, we iterate over `rl->db->blocking_keys` to serve blocked clients. Re-executing a client's command upon unblocking might push memory usage over `maxmemory`, triggering client eviction. 

If memory eviction frees another blocked client in the same list, the node is removed. However, since the current iteration relies on the vulnerable standard `listIter` iterator which caches a `next` pointer, this leads to a heap use-after-free and a server crash when the loop proceeds to the freed node.

This PR solves the UAF by replacing the vulnerable iterator with an idiomatic list rotation pattern (`listRotateHeadToTail`) to safely step through the list. This pattern ensures we always operate on valid `listFirst` elements and never persist pointers across command re-evaluations, cleanly adapting to any dynamic modifications (evictions or standard unblocking) during the loop.

Passed local aggressive tests running the PoC in a loop alongside `make test` for list operations without issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core blocking/unblocking for list/stream/zset waiters; logic is localized but incorrect rotation could affect FIFO wake order or skip clients.
> 
> **Overview**
> Fixes a **heap use-after-free** in `handleClientsBlockedOnKey` when re-serving blocked clients (e.g. BLPOP) on a ready key.
> 
> The loop no longer uses `listIter`/`listNext`, which could keep a stale `next` pointer if unblocking or **maxmemory eviction** removes another client from the same `blocking_keys` list mid-iteration. It now walks the list with **`listFirst`** and, when the head node is unchanged after handling, **`listRotateHeadToTail`** so each pass only uses the current head and stays safe under list mutations—matching the rotation pattern used elsewhere in the server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a19759bbbc80199f5a7614d2f57e32d53e318ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->