### PR TITLE
Server: support Linux abstract sockets for unixsocket via the @ prefix

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -155,6 +155,17 @@ tcp-backlog 511
 #
 # unixsocket /run/redis.sock
 # unixsocketperm 700
+#
+# On Linux, a unixsocket value starting with '@' names a socket in the abstract
+# namespace (the socat/systemd convention): it has no filesystem presence, needs
+# no cleanup, and unixsocketperm does not apply.
+#
+# SECURITY: because an abstract socket has no filesystem presence, it is not
+# protected by file permissions -- any process in the same network namespace may
+# connect. Use requirepass/ACLs, or confine the server in its own network
+# namespace, where a pathname socket would have relied on unixsocketperm.
+#
+# unixsocket @redis
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout 0

--- a/src/anet.c
+++ b/src/anet.c
@@ -25,6 +25,7 @@
 #include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stddef.h>
 
 #include "anet.h"
 #include "config.h"
@@ -471,6 +472,54 @@ int anetTcpNonBlockBestEffortBindConnect(char *err, const char *addr, int port,
             ANET_CONNECT_NONBLOCK|ANET_CONNECT_BE_BINDING);
 }
 
+/* Fill in a sockaddr_un for `path` and return the address length to use with
+ * bind()/connect(). On Linux, a leading '@' maps to the abstract socket
+ * namespace, following the convention established by socat and systemd:
+ * sun_path[0] becomes a NUL byte and the returned length covers EXACTLY the
+ * NUL plus the name. The exact length matters: for pathname sockets trailing
+ * padding is ignored, but for abstract sockets every byte up to the given
+ * length is part of the name, so passing sizeof(sa) would quietly create or
+ * dial a different (NUL-padded) name. */
+/* Is `path` an abstract-namespace name? Only ever true on Linux: elsewhere '@' is an ordinary
+ * pathname byte and must keep behaving like one (including unlink/chmod lifecycle). */
+static int anetUnixIsAbstract(const char *path) {
+#ifdef __linux__
+    return path[0] == '@';
+#else
+    (void)path;
+    return 0;
+#endif
+}
+
+/* Returns 0 (with err set) if the name does not fit -- the caller must fail the operation. This is the
+ * SINGLE length authority: the two forms have different budgets (an abstract name spends one sun_path
+ * byte on the leading NUL but none on the '@', and needs no trailing NUL; a pathname needs its
+ * terminator), so any '@'-inclusive check in a caller is wrong for one form or the other. The bound
+ * matters most on the CONNECT path, which historically relied on strlcpy's implicit truncation and so
+ * never length-checked; an unchecked memcpy here would be a stack buffer overflow on an oversized
+ * name. */
+static socklen_t anetUnixAddr(char *err, struct sockaddr_un *sa, const char *path) {
+    memset(sa,0,sizeof(*sa));
+    sa->sun_family = AF_LOCAL;
+    if (anetUnixIsAbstract(path)) {
+        size_t namelen = strlen(path+1);
+        if (namelen > sizeof(sa->sun_path)-1) {
+            anetSetError(err,"abstract socket name too long (%zu), must be at most %zu",
+                namelen, sizeof(sa->sun_path)-1);
+            return 0;
+        }
+        memcpy(sa->sun_path+1,path+1,namelen);
+        return offsetof(struct sockaddr_un,sun_path) + 1 + namelen;
+    }
+    if (strlen(path) > sizeof(sa->sun_path)-1) {
+        anetSetError(err,"unix socket path too long (%zu), must be under %zu",
+            strlen(path), sizeof(sa->sun_path));
+        return 0;
+    }
+    redis_strlcpy(sa->sun_path,path,sizeof(sa->sun_path));
+    return sizeof(*sa);
+}
+
 int anetUnixGenericConnect(char *err, const char *path, int flags)
 {
     int s;
@@ -479,15 +528,18 @@ int anetUnixGenericConnect(char *err, const char *path, int flags)
     if ((s = anetCreateSocket(err,AF_LOCAL)) == ANET_ERR)
         return ANET_ERR;
 
-    sa.sun_family = AF_LOCAL;
-    redis_strlcpy(sa.sun_path,path,sizeof(sa.sun_path));
+    socklen_t len = anetUnixAddr(err,&sa,path);
+    if (len == 0) {
+        close(s);
+        return ANET_ERR;
+    }
     if (flags & ANET_CONNECT_NONBLOCK) {
         if (anetNonBlock(err,s) != ANET_OK) {
             close(s);
             return ANET_ERR;
         }
     }
-    if (connect(s,(struct sockaddr*)&sa,sizeof(sa)) == -1) {
+    if (connect(s,(struct sockaddr*)&sa,len) == -1) {
         if (errno == EINPROGRESS &&
             flags & ANET_CONNECT_NONBLOCK)
             return s;
@@ -512,7 +564,10 @@ static int anetListen(char *err, int s, struct sockaddr *sa, socklen_t len, int 
         return ANET_ERR;
     }
 
-    if (sa->sa_family == AF_LOCAL && perm)
+    /* Abstract-namespace sockets (sun_path[0] == NUL) have no filesystem
+     * presence, so there is nothing to chmod and permissions do not apply. */
+    if (sa->sa_family == AF_LOCAL && perm &&
+        ((struct sockaddr_un *) sa)->sun_path[0] != '\0')
         chmod(((struct sockaddr_un *) sa)->sun_path, perm);
 
     if (listen(s, backlog) == -1) {
@@ -587,19 +642,18 @@ int anetTcp6Server(char *err, int port, char *bindaddr, int backlog)
 int anetUnixServer(char *err, char *path, mode_t perm, int backlog)
 {
     int s;
+    socklen_t len;
     struct sockaddr_un sa;
 
-    if (strlen(path) > sizeof(sa.sun_path)-1) {
-        anetSetError(err,"unix socket path too long (%zu), must be under %zu", strlen(path), sizeof(sa.sun_path));
-        return ANET_ERR;
-    }
     if ((s = anetCreateSocket(err,AF_LOCAL)) == ANET_ERR)
         return ANET_ERR;
 
-    memset(&sa,0,sizeof(sa));
-    sa.sun_family = AF_LOCAL;
-    redis_strlcpy(sa.sun_path,path,sizeof(sa.sun_path));
-    if (anetListen(err,s,(struct sockaddr*)&sa,sizeof(sa),backlog,perm) == ANET_ERR)
+    len = anetUnixAddr(err,&sa,path);
+    if (len == 0) {
+        close(s);
+        return ANET_ERR;
+    }
+    if (anetListen(err,s,(struct sockaddr*)&sa,len,backlog,perm) == ANET_ERR)
         return ANET_ERR;
     return s;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -4958,7 +4958,11 @@ void closeListeningSockets(int unlink_unix_socket) {
 
     if (server.cluster_enabled)
         for (j = 0; j < server.clistener.count; j++) close(server.clistener.fd[j]);
-    if (unlink_unix_socket && server.unixsocket) {
+    int unixsocket_abstract = 0;
+#ifdef __linux__
+    unixsocket_abstract = server.unixsocket && server.unixsocket[0] == '@';
+#endif
+    if (unlink_unix_socket && server.unixsocket && !unixsocket_abstract) {
         serverLog(LL_NOTICE,"Removing the unix socket file.");
         if (unlink(server.unixsocket) != 0)
             serverLog(LL_WARNING,"Error removing the unix socket file: %s",strerror(errno));

--- a/src/unix.c
+++ b/src/unix.c
@@ -68,8 +68,14 @@ static int connUnixListen(connListener *listener) {
             return C_ERR;
         }
 
-        /* Remove the old path before binding the new Unix socket. */
-        if (unlink(addr) == -1 && errno != ENOENT) {
+        /* Remove the old path before binding the new Unix socket. Abstract-
+         * namespace names ('@' prefix) have no filesystem presence: nothing to
+         * remove, and they vanish with their listener. */
+        int abstract = 0;
+#ifdef __linux__
+        abstract = addr[0] == '@';
+#endif
+        if (!abstract && unlink(addr) == -1 && errno != ENOENT) {
             serverLog(LL_WARNING, "Failed removing the old Unix socket %s: %s", addr, strerror(errno));
             return C_ERR;
         }

--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -484,3 +484,31 @@ test {Pending command pool expansion and shrinking} {
         $rd2 close
     }
 }
+
+# Abstract-namespace Unix sockets are Linux-only ('@' prefix; see anetUnixAddr).
+if {[get_system_name] eq "linux"} {
+    test {Abstract Unix socket (@name) accepts connections and has no filesystem presence} {
+        set abs_name "@redis-test-abs-[pid]"
+        start_server [list overrides [list unixsocket $abs_name] tags {"unixsocket external:skip"}] {
+            assert_equal PONG [exec {*}[rediscli_unixsocket $abs_name] PING]
+            # The whole point of the abstract namespace: nothing on the filesystem, nothing to clean up.
+            assert_equal 0 [file exists $abs_name]
+        }
+    }
+
+    test {A second server does not replace an active abstract socket} {
+        set abs_name "@redis-test-abs2-[pid]"
+        start_server [list overrides [list unixsocket $abs_name] tags {"unixsocket external:skip"}] {
+            set second_port [find_available_port $::baseport $::portcount]
+            assert_equal 1 [catch {
+                exec src/redis-server [srv config_file] \
+                    --port $second_port --tls-port 0 \
+                    --unixsocket $abs_name
+            } second_error]
+            assert_match {*Unix socket * is already in use*} $second_error
+
+            # The failed second startup must not disturb the original listener.
+            assert_equal PONG [exec {*}[rediscli_unixsocket $abs_name] PING]
+        }
+    }
+}


### PR DESCRIPTION
Support Linux abstract sockets for unixsocket via the @ prefix

This is the server half of #15577

Note tests are dependent on the client half, https://github.com/redis/redis/pull/15572

The server's Unix-socket bind (anetUnixServer) copies the path with redis_strlcpy and binds with sizeof(sockaddr_un), so the abstract namespace -- whose addresses begin with a NUL byte -- has never been reachable. This maps a leading '@' to the abstract namespace, following the convention established by socat and systemd, on Linux only.

One shared helper (anetUnixAddr) builds the address for both anetUnixServer and anetUnixGenericConnect, so the "is this socket already in use" probe in connUnixListen keeps working for abstract names too. The subtle half is the address length: for pathname sockets trailing padding is ignored, but for abstract sockets every byte up to the given length is part of the name, so the address must be bound and dialed with EXACTLY offsetof(sun_path) + 1 + strlen(name).

Lifecycle differences handled where they arise rather than special-cased later:
 - no chmod: abstract sockets have no filesystem presence, so unixsocketperm cannot apply (anetListen skips it when sun_path[0] is NUL);
 - no unlink, before bind (connUnixListen) or at shutdown (server.c): there is no file, and the name vanishes with the listener.

redis.conf documents the form. Client-side support for the same convention (redis-cli/redis-benchmark via hiredis) is the sibling branch marc/uds-abstract-sockets; the two compose but do not depend on each other.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes low-level Unix socket bind/connect behavior and listen/shutdown lifecycle; abstract sockets weaken filesystem-based access control compared to pathname sockets with `unixsocketperm`.
> 
> **Overview**
> Adds **Linux abstract Unix domain sockets** for `unixsocket` when the configured name starts with `@` (socat/systemd convention), so listeners need no filesystem socket file or cleanup.
> 
> **`anetUnixAddr`** centralizes sockaddr construction and exact `socklen_t` for bind/connect (critical for abstract names, where padding would change the socket identity). Connect/bind now enforce name length limits that pathname sockets previously lacked on the connect path.
> 
> **Lifecycle:** `unixsocketperm` / `chmod` are skipped for abstract sockets; **`unlink` is not run** before bind (`unix.c`) or on shutdown (`server.c`). **`redis.conf`** documents behavior and security (no file permissions—rely on ACLs/network namespace). Linux integration tests cover PING, no filesystem entry, and collision detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a46b37648c0cfca387a1b3b753d55ee3531c58a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->