### PR TITLE
Fix recursive crash in signal handler when child process crashes

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2471,6 +2471,10 @@ void killThreads(void) {
 void doFastMemoryTest(void) {
 #if defined(HAVE_PROC_MAPS)
     if (server.memcheck_enabled) {
+        /* Skip the memory test for child processes to avoid killing threads
+         * that don't exist and causing a recursive crash. */
+        if (server.pid != getpid()) return;
+
         /* Test memory */
         serverLogRaw(LL_WARNING|LL_RAW, "\n------ FAST MEMORY TEST ------\n");
         killThreads();

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -92,6 +92,28 @@ if {!$::valgrind} {
         }
     }
 
+    # test crash report generated when child process crashes
+    set server_path [tmpdir server2_child.log]
+    start_server [list overrides [list dir $server_path]] {
+        test "Crash report generated without recursive crash when child process crashes" {
+            r config set rdb-key-save-delay 10000000
+            r debug populate 1000
+            r bgsave
+            wait_for_condition 50 100 {
+                [s rdb_bgsave_in_progress] == 1
+            } else {
+                fail "bgsave did not start"
+            }
+            set child_pid [get_child_pid 0]
+            assert {$child_pid > 0}
+            exec kill -SIGSEGV $child_pid
+            wait_for_log_messages 0 [list "*REDIS BUG REPORT END*"] 0 200 100
+            assert_equal [count_log_message 0 "Crashed running signal handler"] 0
+            assert_equal [count_log_message 0 "crashed by signal"] 1
+            assert_equal "PONG" [r ping]
+        }
+    }
+
     # test DEBUG SIGALRM being non-fatal
     set server_path [tmpdir server3.log]
     start_server [list overrides [list dir $server_path]] {


### PR DESCRIPTION
Fixes the recursive crash scenario reported in #15559.

When a child process (such as an RDB background save or AOF rewrite) crashes and enters the crash signal handler, `printCrashReport()` calls `killThreads()` to forcefully terminate worker threads.

Because child processes created via `fork()` do not have those threads, calling `pthread_cancel()` on the parent's thread IDs causes the signal handler itself to crash recursively, which prints:
```
Crashed running signal handler. Providing reduced version of recursive crash report.
```
and ends up truncating the actual crash report.

This change checks `server.pid != getpid()` in `killThreads()` so child processes skip thread killing and can cleanly log their full crash reports.

---

> [!NOTE]
> **Low Risk**
> Single guard in crash-only thread-kill path plus a regression test; main-process crash behavior is unchanged when `server.pid == getpid()`.
> 
> **Overview**
> Prevents **recursive crashes inside the crash signal handler** when a **forked child** (e.g. RDB `BGSAVE`) dies with a fatal signal.
> 
> `killThreads()` now returns immediately when `server.pid != getpid()`, so children no longer call `pthread_cancel` on the parent’s thread IDs during `printCrashReport()` / fast memory check. That avoids a second fault in the handler and the truncated *“Crashed running signal handler”* report.
> 
> An integration test in `logging.tcl` SIGSEGVs a `BGSAVE` child, expects a complete bug report (no recursive handler message, single *crashed by signal*), and confirms the parent still answers `PING`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Crash-only path guarded by PID check plus a regression test; normal server and main-process crash handling are unchanged.
> 
> **Overview**
> Forked children (e.g. **BGSAVE**) no longer run the fast memory test path that calls **`killThreads()`** during **`printCrashReport()`**, which previously tried to cancel the parent’s pthread IDs and could fault again inside the signal handler.
> 
> **`doFastMemoryTest()`** now returns immediately when **`server.pid != getpid()`**, so only the main process still kills worker threads before the Linux anonymous-map memtest. Parent crash behavior is unchanged when PIDs match.
> 
> An integration test in **`logging.tcl`** SIGSEGVs a slow **BGSAVE** child and checks for a full bug report (no *Crashed running signal handler*, a single *crashed by signal*), with the parent still responding to **PING**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 818b7b16e7e7dcfb655a419a55d72a02fe4b90c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->