### PR TITLE
Use kvobj/robj declarations that match the expected object

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -2964,7 +2964,7 @@ int rewriteArrayObject(rio *r, robj *key, robj *o) {
     return 1;
 }
 
-int rewriteObject(rio *r, robj *key, robj *o, int dbid, long long expiretime) {
+int rewriteObject(rio *r, robj *key, kvobj *o, int dbid, long long expiretime) {
     /* Save the key and associated value */
     if (o->type == OBJ_STRING) {
         /* Emit a SET command */

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -797,8 +797,8 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
     if (checkType(c,o,OBJ_STRING)) return NULL;
 
     if (o == NULL) {
-        o = createObject(OBJ_STRING,sdsnewlen(NULL, byte+1));
-        dbAddByLink(c->db,c->argv[1],&o,&link);
+        robj *newo = createObject(OBJ_STRING,sdsnewlen(NULL, byte+1));
+        o = dbAddByLink(c->db,c->argv[1],&newo,&link);
         *strGrowSize = byte + 1;
         *strOldSize = 0;
     } else {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -113,8 +113,11 @@ void createDumpPayload(rio *payload, robj *o, robj *key, int dbid, int flags, si
     /* Save key metadata if present (TTL is handled separately via command
      * args). AOF RESTORE payloads omit it because AOF rewrite handles module
      * metadata separately through keyMetaOnAof(). */
-    if (!(flags & DUMP_PAYLOAD_SKIP_KEY_META) && getModuleMetaBits(o->metabits))
-        serverAssert(rdbSaveKeyMetadata(payload, key, o, dbid) != -1);
+    if (!(flags & DUMP_PAYLOAD_SKIP_KEY_META) && getModuleMetaBits(o->metabits)) {
+        /* Only a keyspace object can carry module metadata, so 'o' is a kvobj
+         * here. Callers such as createRawDumpPayload() may pass a plain robj. */
+        serverAssert(rdbSaveKeyMetadata(payload, key, (kvobj *) o, dbid) != -1);
+    }
     serverAssert(rdbSaveObjectType(payload,o));
     serverAssert(rdbSaveObject(payload,o,key,dbid));
 
@@ -497,7 +500,7 @@ void migrateCommand(client *c) {
     char *password = NULL;
     long timeout;
     long dbid;
-    robj **kvArray = NULL; /* Objects to migrate. */
+    kvobj **kvArray = NULL; /* Objects to migrate. */
     robj **keyArray = NULL; /* Key names. */
     robj **newargv = NULL; /* Used to rewrite the command as DEL ... keys ... */
     rio cmd, payload;

--- a/src/db.c
+++ b/src/db.c
@@ -636,7 +636,7 @@ static void dbSetValue(redisDb *db, robj *key, robj **valref, dictEntryLink link
     {
         /* Keep old object in the database. Just swap it's ptr, type and
          * encoding with the content of val. */
-        robj tmp = *old;
+        kvobj tmp = *old;
         old->type = val->type;
         old->encoding = val->encoding;
         old->ptr = val->ptr;
@@ -971,15 +971,17 @@ kvobj *dbUnshareStringValue(redisDb *db, robj *key, kvobj *kv) {
 
 /* Like dbUnshareStringValue(), but accepts a optional link,
  * which can be used if we already have one, thus saving the dbFind call. */
-kvobj *dbUnshareStringValueByLink(redisDb *db, robj *key, kvobj *o, dictEntryLink link) {
-    serverAssert(o->type == OBJ_STRING);
-    if (o->refcount != 1 || o->encoding != OBJ_ENCODING_RAW) {
-        robj *decoded = getDecodedObject(o);
-        o = createRawStringObject(decoded->ptr, sdslen(decoded->ptr));
+kvobj *dbUnshareStringValueByLink(redisDb *db, robj *key, kvobj *kv, dictEntryLink link) {
+    serverAssert(kv->type == OBJ_STRING);
+    if (kv->refcount != 1 || kv->encoding != OBJ_ENCODING_RAW) {
+        robj *decoded = getDecodedObject(kv);
+        robj *unshared = createRawStringObject(decoded->ptr, sdslen(decoded->ptr));
         decrRefCount(decoded);
-        dbReplaceValueWithLink(db, key, &o, link);
+        /* Puts 'unshared' in the keyspace, updating it to the stored kvobj. */
+        dbReplaceValueWithLink(db, key, &unshared, link);
+        kv = unshared;
     }
-    return o;
+    return kv;
 }
 
 /* Remove all keys from the database(s) structure. The dbarray argument

--- a/src/debug.c
+++ b/src/debug.c
@@ -743,7 +743,6 @@ NULL
         createDumpPayload(&payload, kv, c->argv[2], c->db->id, DUMP_PAYLOAD_SKIP_KEY_META, 0);
         addReplyBulkSds(c, payload.io.buffer.ptr);
     } else if (!strcasecmp(c->argv[1]->ptr,"sdslen") && c->argc == 3) {
-        robj *val;
         sds key;
         kvobj *kv;
 
@@ -751,24 +750,23 @@ NULL
             addReplyErrorObject(c,shared.nokeyerr);
             return;
         }
-        
-        val = kv;
+
         key = kvobjGetKey(kv);
-        if (kv->type != OBJ_STRING || !sdsEncodedObject(val)) {
+        if (kv->type != OBJ_STRING || !sdsEncodedObject(kv)) {
             addReplyError(c,"Not an sds encoded string.");
         } else {
             /* The key's allocation size reflects the entire robj allocation.  
              * For embedded values, report an allocation size of 0. */
-            size_t obj_alloc = zmalloc_usable_size(val);
-            size_t val_alloc = val->encoding == OBJ_ENCODING_RAW ? sdsAllocSize(val->ptr) : 0;
+            size_t obj_alloc = zmalloc_usable_size(kv);
+            size_t val_alloc = kv->encoding == OBJ_ENCODING_RAW ? sdsAllocSize(kv->ptr) : 0;
             addReplyStatusFormat(c,
                 "key_sds_len:%lld, key_sds_avail:%lld, key_zmalloc: %lld, "
                 "val_sds_len:%lld, val_sds_avail:%lld, val_zmalloc: %lld",
                 (long long) sdslen(key),
                 (long long) sdsavail(key),
                 (long long) obj_alloc,
-                (long long) sdslen(val->ptr),
-                (long long) sdsavail(val->ptr),
+                (long long) sdslen(kv->ptr),
+                (long long) sdsavail(kv->ptr),
                 (long long) val_alloc);
         }
     } else if (!strcasecmp(c->argv[1]->ptr,"listpack") && c->argc == 3) {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1095,7 +1095,7 @@ void defragModule(defragKeysCtx *ctx, redisDb *db, kvobj *kv) {
  * Returns NULL if the allocation wasn't moved.
  * When it returns a non-null value, the old pointer was already released
  * (unless without_free is set) and should NOT be accessed. */
-robj *activeDefragKvobj(kvobj* kv, int without_free) {
+kvobj *activeDefragKvobj(kvobj* kv, int without_free) {
     void *alloc, *newalloc;
     kvobj *kvNew = NULL;
     /* Use LONG_MIN as sentinel to detect if we have an EMBSTR string */

--- a/src/gcra.c
+++ b/src/gcra.c
@@ -275,7 +275,7 @@ void gcraSetValueCommand(client *c) {
     addReply(c, shared.ok);
 }
 
-robj *gcraDup(robj *o) {
+robj *gcraDup(kvobj *o) {
     long long val;
     getLongLongFromGCRAObject(o, &val);
     return createGCRAObject(val);

--- a/src/geo.c
+++ b/src/geo.c
@@ -942,7 +942,7 @@ void geoposCommand(client *c) {
     int j;
 
     /* Look up the requested zset */
-    robj *zobj = lookupKeyRead(c->db, c->argv[1]);
+    kvobj *zobj = lookupKeyRead(c->db, c->argv[1]);
     if (checkType(c, zobj, OBJ_ZSET)) return;
 
     /* Report elements one after the other, using a null bulk reply for

--- a/src/module.c
+++ b/src/module.c
@@ -795,7 +795,7 @@ static void moduleFreeListIterator(void *data) {
 int moduleDelKeyIfEmpty(RedisModuleKey *key) {
     if (!(key->mode & REDISMODULE_WRITE) || key->kv == NULL) return 0;
     int isempty;
-    robj *o = key->kv;
+    kvobj *o = key->kv;
 
     switch(o->type) {
     case OBJ_LIST: isempty = listTypeLength(o) == 0; break;

--- a/src/object.c
+++ b/src/object.c
@@ -662,7 +662,7 @@ void decrRefCount(robj *o) {
         
         if (o->iskvobj) {
             /* eval real allocation pointer */
-            alloc = kvobjGetAllocPtr(o);
+            alloc = kvobjGetAllocPtr((kvobj *)o);
             /* if kvobj has metadata attached. */
             if (getModuleMetaBits(o->metabits))
                 keyMetaOnFree((kvobj *)o);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1686,7 +1686,7 @@ size_t rdbSavedObjectLen(robj *o, robj *key, int dbid) {
 /* Save a key-value pair, with expire time, type, key, value.
  * On error -1 is returned.
  * On success if the key was actually saved 1 is returned. */
-int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime, int dbid) {
+int rdbSaveKeyValuePair(rio *rdb, robj *key, kvobj *val, long long expiretime, int dbid) {
     int savelru = server.maxmemory_policy & MAXMEMORY_FLAG_LRU;
     int savelfu = server.maxmemory_policy & MAXMEMORY_FLAG_LFU;
 

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -164,7 +164,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid);
 size_t rdbSavedObjectLen(robj *o, robj *key, int dbid);
 robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error);
 void backgroundSaveDoneHandler(int exitcode, int bysignal);
-int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime, int dbid);
+int rdbSaveKeyValuePair(rio *rdb, robj *key, kvobj *val, long long expiretime, int dbid);
 ssize_t rdbSaveSingleModuleAux(rio *rdb, int when, moduleType *mt);
 robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename, int null_on_error);
 int rdbResolveKeyType(rio *rdb, int *type, int dbid, KeyMetaSpec *keymeta);

--- a/src/server.h
+++ b/src/server.h
@@ -3515,10 +3515,10 @@ void listTypeReplace(listTypeEntry *entry, robj *value);
 int listTypeEqual(listTypeEntry *entry, robj *o, size_t object_len,
                   long long *cached_longval, int *cached_valid);
 void listTypeDelete(listTypeIterator *iter, listTypeEntry *entry);
-robj *listTypeDup(robj *o);
+robj *listTypeDup(kvobj *o);
 void listTypeDelRange(robj *o, long start, long stop);
 void popGenericCommand(client *c, int where);
-void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, size_t oldsize, int signal, int *deleted);
+void listElementsRemoved(client *c, robj *key, int where, kvobj *o, long count, size_t oldsize, int signal, int *deleted);
 typedef enum {
     LIST_CONV_AUTO,
     LIST_CONV_GROWING,
@@ -3654,7 +3654,7 @@ int aofDelHistoryFiles(void);
 int aofRewriteLimited(void);
 void updateCurIncrAofEndOffset(void);
 void updateReplOffsetAndResetEndOffset(void);
-int rewriteObject(rio *r, robj *key, robj *o, int dbid, long long expiretime);
+int rewriteObject(rio *r, robj *key, kvobj *o, int dbid, long long expiretime);
 
 /* Child info */
 void openChildInfoPipe(void);
@@ -3787,7 +3787,7 @@ unsigned long zslGetRank(zskiplist *zsl, double score, sds o);
 int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, double *newscore);
 long zsetRank(robj *zobj, sds ele, int reverse, double *score);
 int zsetDel(robj *zobj, sds ele);
-robj *zsetDup(robj *o);
+robj *zsetDup(kvobj *o);
 void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey, long count, int use_nested_array, int reply_nil_when_empty, int *deleted);
 sds lpGetObject(unsigned char *sptr);
 int zslValueGteMin(double value, zrangespec *spec);
@@ -3803,7 +3803,7 @@ int zslLexValueGteMin(sds value, zlexrangespec *spec);
 int zslLexValueLteMax(sds value, zlexrangespec *spec);
 
 /* gcra related */
-robj *gcraDup(robj *o);
+robj *gcraDup(kvobj *o);
 
 /* Core functions */
 int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *level);
@@ -3931,7 +3931,7 @@ unsigned long setTypeSize(const robj *subject);
 size_t setTypeAllocSize(const robj *o);
 void setTypeConvert(robj *subject, int enc);
 int setTypeConvertAndExpand(robj *setobj, int enc, unsigned long cap, int panic);
-robj *setTypeDup(robj *o);
+robj *setTypeDup(kvobj *o);
 
 /* Data structure for OBJ_ENCODING_LISTPACK_EX for hash. It contains listpack
  * and metadata fields for hash field expiration.*/
@@ -4119,7 +4119,7 @@ void listpackExAddNew(robj *o, char *field, size_t flen,
                       char *value, size_t vlen, uint64_t expireAt);
 
 /* Array data type. */
-robj *arrayTypeDup(robj *o);
+robj *arrayTypeDup(kvobj *o);
 
 /* Pub / Sub */
 int pubsubUnsubscribeAllChannels(client *c, int notify);
@@ -4281,7 +4281,7 @@ kvobj *dbAdd(redisDb *db, robj *key, robj **valref);
 kvobj *dbAddByLink(redisDb *db, robj *key, robj **valref, dictEntryLink *link);
 kvobj *dbAddInternal(redisDb *db, robj *key, robj **valref, dictEntryLink *link, const KeyMetaSpec *m);
 kvobj *dbAddRDBLoad(redisDb *db, sds key, robj **valref, const KeyMetaSpec *keyMetaSpec);
-void dbReplaceValue(redisDb *db, robj *key, kvobj **ioKeyVal, int updateKeySizes);
+void dbReplaceValue(redisDb *db, robj *key, robj **valref, int updateKeySizes);
 void dbReplaceValueWithLink(redisDb *db, robj *key, robj **val, dictEntryLink link);
 
 #define SETKEY_KEEPTTL 1

--- a/src/sort.c
+++ b/src/sort.c
@@ -44,6 +44,9 @@ robj *lookupKeyByPattern(redisDb *db, robj *pattern, robj *subst) {
     char *p, *f, *k;
     sds spat, ssub;
     robj *keyobj, *fieldobj = NULL, *val;
+    /* The object handed back to the caller: either a hash field value we just
+     * created, or the looked-up kvobj itself with its refcount bumped. */
+    robj *res;
 
     int prefixlen, sublen, postfixlen, fieldlen;
 
@@ -99,7 +102,7 @@ robj *lookupKeyByPattern(redisDb *db, robj *pattern, robj *subst) {
          * is a new object with refcount already incremented. */
         int isHashDeleted;
         hashTypeGetValueObject(db, kv, fieldobj->ptr, HFE_LAZY_EXPIRE, &val, NULL, &isHashDeleted);
-        kv = val;
+        res = val;
 
         if (isHashDeleted)
             goto noobj;
@@ -110,10 +113,11 @@ robj *lookupKeyByPattern(redisDb *db, robj *pattern, robj *subst) {
         /* Every object that this function returns needs to have its refcount
          * increased. sortCommand decreases it again. */
         incrRefCount(kv);
+        res = kv;
     }
     decrRefCount(keyobj);
     if (fieldobj) decrRefCount(fieldobj);
-    return kv;
+    return res;
 
 noobj:
     decrRefCount(keyobj);
@@ -303,8 +307,11 @@ void sortCommandGeneric(client *c, int readonly) {
         return;
     }
 
-    /* Lookup the key to sort. It must be of the right types */
-    sortval = lookupKeyRead(c->db, c->argv[1]);
+    /* Lookup the key to sort. It must be of the right types.
+     * 'sortkv' keeps the keyspace object (NULL when the key is missing) since
+     * 'sortval' below may instead hold a synthetic, non-keyspace empty list. */
+    kvobj *sortkv = lookupKeyRead(c->db, c->argv[1]);
+    sortval = sortkv;
     if (sortval && sortval->type != OBJ_SET &&
                    sortval->type != OBJ_LIST &&
                    sortval->type != OBJ_ZSET)
@@ -341,10 +348,10 @@ void sortCommandGeneric(client *c, int readonly) {
     /* Destructively convert encoded sorted sets for SORT. */
     if (sortval->type == OBJ_ZSET) {
         if (server.memory_tracking_enabled)
-            oldsize = kvobjAllocSize(sortval);
+            oldsize = kvobjAllocSize(sortkv);
         zsetConvert(sortval, OBJ_ENCODING_SKIPLIST);
         if (server.memory_tracking_enabled)
-            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), sortval, oldsize, kvobjAllocSize(sortval));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), sortkv, oldsize, kvobjAllocSize(sortkv));
     }
 
     /* Obtain the length of the object to sort. */
@@ -425,7 +432,7 @@ void sortCommandGeneric(client *c, int readonly) {
         listTypeResetIterator(&li);
     } else if (sortval->type == OBJ_SET) {
         if (server.memory_tracking_enabled)
-            oldsize = kvobjAllocSize(sortval);
+            oldsize = kvobjAllocSize(sortkv);
         setTypeIterator si;
         sds sdsele;
         setTypeInitIterator(&si, sortval);
@@ -437,7 +444,7 @@ void sortCommandGeneric(client *c, int readonly) {
         }
         setTypeResetIterator(&si);
         if (server.memory_tracking_enabled)
-            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), sortval, oldsize, kvobjAllocSize(sortval));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), sortkv, oldsize, kvobjAllocSize(sortkv));
     } else if (sortval->type == OBJ_ZSET && dontsort) {
         /* Special handling for a sorted set, if 'dontsort' is true.
          * This makes sure we return elements in the sorted set original
@@ -484,7 +491,7 @@ void sortCommandGeneric(client *c, int readonly) {
         sds sdsele;
 
         if (server.memory_tracking_enabled)
-            oldsize = kvobjAllocSize(sortval);
+            oldsize = kvobjAllocSize(sortkv);
         dictInitIterator(&di, set);
         while((setele = dictNext(&di)) != NULL) {
             sdsele = zslGetNodeElement(dictGetKey(setele));
@@ -495,7 +502,7 @@ void sortCommandGeneric(client *c, int readonly) {
         }
         dictResetIterator(&di);
         if (server.memory_tracking_enabled)
-            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), sortval, oldsize, kvobjAllocSize(sortval));
+            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), sortkv, oldsize, kvobjAllocSize(sortkv));
     } else {
         serverPanic("Unknown type");
     }

--- a/src/stream.h
+++ b/src/stream.h
@@ -211,7 +211,7 @@ void streamDestroyNACK(stream *s, streamNACK *na, unsigned char *key);
 int streamIncrID(streamID *id);
 int streamDecrID(streamID *id);
 void streamPropagateConsumerCreation(client *c, robj *key, robj *groupname, sds consumername);
-robj *streamDup(robj *o);
+robj *streamDup(kvobj *o);
 int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep);
 int streamParseID(const robj *o, streamID *id);
 robj *createObjectFromStreamID(streamID *id);

--- a/src/t_array.c
+++ b/src/t_array.c
@@ -30,7 +30,7 @@
  * Array type operations for COPY command
  * -------------------------------------------------------------------------- */
 
-robj *arrayTypeDup(robj *o) {
+robj *arrayTypeDup(kvobj *o) {
     redisArray *ar = o->ptr;
     redisArray *dup = arDup(ar);
     robj *newobj = createObject(OBJ_ARRAY, dup);
@@ -46,15 +46,15 @@ robj *arrayTypeDup(robj *o) {
 
 /* Lookup array object for write, create it if missing, or reply with
  * WRONGTYPE and return NULL if the key holds a different type. */
-robj *lookupArrayForWriteOrReply(client *c, robj *key) {
-    robj *o = lookupKeyWrite(c->db, key);
-    if (o == NULL) {
-        o = createArrayObject();
-        dbAdd(c->db, key, &o);
-    } else if (checkType(c, o, OBJ_ARRAY)) {
+kvobj *lookupArrayForWriteOrReply(client *c, robj *key) {
+    kvobj *kv = lookupKeyWrite(c->db, key);
+    if (kv == NULL) {
+        robj *o = createArrayObject();
+        kv = dbAdd(c->db, key, &o);
+    } else if (checkType(c, kv, OBJ_ARRAY)) {
         return NULL;
     }
-    return o;
+    return kv;
 }
 
 /* Reply with an array value. This helper is needed because we used
@@ -109,7 +109,7 @@ int arrayParseIndexOrReply(client *c, robj *arg, uint64_t *idx) {
  * Returns the value at idx in O(1).
  * Missing keys and holes both reply with NULL. */
 void argetCommand(client *c) {
-    robj *o = lookupKeyRead(c->db, c->argv[1]);
+    kvobj *o = lookupKeyRead(c->db, c->argv[1]);
     if (o && checkType(c, o, OBJ_ARRAY)) return;
 
     uint64_t idx;
@@ -125,7 +125,7 @@ void argetCommand(client *c) {
  * of indices. Missing keys and holes reply with NULLs. All indices are
  * validated before the reply starts, so malformed input fails atomically. */
 void armgetCommand(client *c) {
-    robj *o = lookupKeyRead(c->db, c->argv[1]);
+    kvobj *o = lookupKeyRead(c->db, c->argv[1]);
     if (o != NULL && checkType(c, o, OBJ_ARRAY)) return;
 
     /* Pre-validate all indices so malformed input fails the whole command,
@@ -176,7 +176,7 @@ void armgetCommand(client *c) {
         return;
     }
 
-    robj *o = lookupArrayForWriteOrReply(c, c->argv[1]);
+    kvobj *o = lookupArrayForWriteOrReply(c, c->argv[1]);
     if (o == NULL) return;
 
     redisArray *ar = o->ptr;
@@ -225,7 +225,7 @@ void armsetCommand(client *c) {
         if (arrayParseIndexOrReply(c, c->argv[i], &idx) != C_OK) return;
     }
 
-    robj *o = lookupArrayForWriteOrReply(c, c->argv[1]);
+    kvobj *o = lookupArrayForWriteOrReply(c, c->argv[1]);
     if (o == NULL) return;
 
     redisArray *ar = o->ptr;
@@ -270,7 +270,7 @@ void ardelCommand(client *c) {
         if (arrayParseIndexOrReply(c, c->argv[i], &idx) != C_OK) return;
     }
 
-    robj *o = lookupKeyWrite(c->db, c->argv[1]);
+    kvobj *o = lookupKeyWrite(c->db, c->argv[1]);
     if (o == NULL) {
         addReplyLongLong(c, 0);
         return;
@@ -330,7 +330,7 @@ void ardelrangeCommand(client *c) {
         if (arrayParseIndexOrReply(c, c->argv[i + 1], &end) != C_OK) return;
     }
 
-    robj *o = lookupKeyWrite(c->db, c->argv[1]);
+    kvobj *o = lookupKeyWrite(c->db, c->argv[1]);
     if (o == NULL) {
         addReplyLongLong(c, 0);
         return;
@@ -383,7 +383,7 @@ void ardelrangeCommand(client *c) {
  * Returns max-index-plus-one in O(1).
  * Missing keys reply with 0. */
 void arlenCommand(client *c) {
-    robj *o = lookupKeyReadOrReply(c, c->argv[1], shared.czero);
+    kvobj *o = lookupKeyReadOrReply(c, c->argv[1], shared.czero);
     if (o == NULL || checkType(c, o, OBJ_ARRAY)) return;
 
     redisArray *ar = o->ptr;
@@ -395,7 +395,7 @@ void arlenCommand(client *c) {
  * Returns the number of non-empty elements in O(1).
  * Missing keys reply with 0. */
 void arcountCommand(client *c) {
-    robj *o = lookupKeyReadOrReply(c, c->argv[1], shared.czero);
+    kvobj *o = lookupKeyReadOrReply(c, c->argv[1], shared.czero);
     if (o == NULL || checkType(c, o, OBJ_ARRAY)) return;
 
     redisArray *ar = o->ptr;
@@ -421,7 +421,7 @@ void argetrangeCommand(client *c) {
     if (arrayParseIndexOrReply(c, c->argv[2], &start) != C_OK) return;
     if (arrayParseIndexOrReply(c, c->argv[3], &end) != C_OK) return;
 
-    robj *o = lookupKeyRead(c->db, c->argv[1]);
+    kvobj *o = lookupKeyRead(c->db, c->argv[1]);
     if (o != NULL && checkType(c, o, OBJ_ARRAY)) return;
 
     int reverse = start > end;
@@ -851,7 +851,7 @@ void arscanCommand(client *c) {
         return;
     }
 
-    robj *o = lookupKeyRead(c->db, c->argv[1]);
+    kvobj *o = lookupKeyRead(c->db, c->argv[1]);
     if (o != NULL && checkType(c, o, OBJ_ARRAY)) return;
 
     if (o == NULL) {
@@ -1208,7 +1208,7 @@ void argrepCommand(client *c) {
         return;
     }
 
-    robj *o = lookupKeyRead(c->db, c->argv[1]);
+    kvobj *o = lookupKeyRead(c->db, c->argv[1]);
     if (o != NULL && checkType(c, o, OBJ_ARRAY)) {
         arGrepFreePlan(&plan);
         return;
@@ -1421,7 +1421,7 @@ void aropCommand(client *c) {
         return;
     }
 
-    robj *o = lookupKeyRead(c->db, c->argv[1]);
+    kvobj *o = lookupKeyRead(c->db, c->argv[1]);
     if (o == NULL) {
         if (op == AROP_MATCH || op == AROP_USED) {
             addReplyLongLong(c, 0);
@@ -1483,7 +1483,7 @@ void aropCommand(client *c) {
  * returned as the command return value, and can be inspected later
  * with ARNEXT. */
 void arinsertCommand(client *c) {
-    robj *o = lookupArrayForWriteOrReply(c, c->argv[1]);
+    kvobj *o = lookupArrayForWriteOrReply(c, c->argv[1]);
     if (o == NULL) return;
 
     redisArray *ar = o->ptr;
@@ -1675,7 +1675,7 @@ void arringCommand(client *c) {
     }
     uint64_t ring_size = (uint64_t)ll;
 
-    robj *o = lookupArrayForWriteOrReply(c, c->argv[1]);
+    kvobj *o = lookupArrayForWriteOrReply(c, c->argv[1]);
     if (o == NULL) return;
 
     redisArray *ar = o->ptr;
@@ -1730,7 +1730,7 @@ void arringCommand(client *c) {
  * Missing keys and the pre-insert state reply with 0. If the cursor is in the
  * terminal state where the next append would overflow, the reply is NULL. */
 void arnextCommand(client *c) {
-    robj *o = lookupKeyRead(c->db, c->argv[1]);
+    kvobj *o = lookupKeyRead(c->db, c->argv[1]);
     if (o == NULL) {
         addReplyLongLong(c, 0);
         return;
@@ -1770,7 +1770,7 @@ void arseekCommand(client *c) {
      * well with the Redis commands usual semantics. However we need to signal
      * back that we ignored the index set if the key is not there, so zero
      * is returned. */
-    robj *o = lookupKeyWrite(c->db, c->argv[1]);
+    kvobj *o = lookupKeyWrite(c->db, c->argv[1]);
     if (o == NULL) {
         addReplyLongLong(c, 0);
         return;
@@ -1825,7 +1825,7 @@ void arlastitemsCommand(client *c) {
     }
 
     /* No key? Empty reply. */
-    robj *o = lookupKeyRead(c->db, c->argv[1]);
+    kvobj *o = lookupKeyRead(c->db, c->argv[1]);
     if (o == NULL) {
         addReplyArrayLen(c, 0);
         return;
@@ -1904,7 +1904,7 @@ void arinfoCommand(client *c) {
         }
     }
 
-    robj *o = lookupKeyRead(c->db, c->argv[1]);
+    kvobj *o = lookupKeyRead(c->db, c->argv[1]);
     if (o == NULL) {
         addReplyError(c, "no such key");
         return;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -138,7 +138,7 @@ EbucketsType hashFieldExpireBucketsType = {
 
 /* OnFieldExpireCtx passed to OnFieldExpire() */
 typedef struct OnFieldExpireCtx {
-    robj *hashObj;
+    kvobj *hashObj;
     redisDb *db;
     int activeEx; /* 1 for active expire, 0 for lazy expire */
     vec *vexpired; /* Expired fields vector */
@@ -207,7 +207,8 @@ typedef struct HashTypeSetEx {
     /*** metadata ***/
     uint64_t minExpire;                 /* if uninit EB_EXPIRE_TIME_INVALID */
     redisDb *db;
-    robj *key, *hashObj;
+    robj *key;
+    kvobj *hashObj;
     uint64_t minExpireFields;           /* Trace updated fields and their previous/new
                                          * minimum expiration time. If minimum recorded
                                          * is above minExpire of the hash, then we don't
@@ -3056,9 +3057,12 @@ void hashTypeConvertListpackEx(redisDb *db, robj *o, int enc) {
         listpackEx *lpt = o->ptr;
 
         if (db && lpt->meta.trash != 1) {
+            /* A non-NULL 'db' means 'o' is registered in the keyspace, and is
+             * therefore a kvobj. RDB load passes db=NULL with a plain robj. */
+            kvobj *kv = (kvobj *) o;
             minExpire = hashTypeGetMinExpire(o, 0);
-            slot = getKeySlot(kvobjGetKey(o));
-            estoreRemove(db->subexpires, slot, o);
+            slot = getKeySlot(kvobjGetKey(kv));
+            estoreRemove(db->subexpires, slot, kv);
         }
 
         dict = dictCreate(&entryHashDictTypeWithHFE);
@@ -3898,7 +3902,7 @@ void hsetnxCommand(client *c) {
     unsigned long hlen;
     int isHashDeleted;
     size_t oldsize = 0;
-    robj *kv = hashTypeLookupWriteOrCreate(c,c->argv[1]);
+    kvobj *kv = hashTypeLookupWriteOrCreate(c,c->argv[1]);
     if (kv == NULL) return;
 
     if (hashTypeExists(c->db, kv, c->argv[2]->ptr, HFE_LAZY_EXPIRE, &isHashDeleted)) {
@@ -4591,8 +4595,8 @@ void hsetexCommand(client *c) {
             addReplyLongLong(c, 0);
             return;
         }
-        o = createHashObject();
-        dbAddByLink(c->db, c->argv[1], &o, &link);
+        robj *newo = createHashObject();
+        o = dbAddByLink(c->db, c->argv[1], &newo, &link);
     }
     oldlen = (int64_t) hashTypeLength(o, 0);
     if (server.memory_tracking_enabled)
@@ -4764,8 +4768,8 @@ void hincrbyCommand(client *c) {
         updateKeysizesHist(c->db, OBJ_HASH, l, l + 1);
     } else {
         /* Field expired and in turn hash deleted. Create new one! */
-        o = createHashObject();
-        dbAdd(c->db,c->argv[1],&o);
+        robj *newo = createHashObject();
+        o = dbAdd(c->db,c->argv[1],&newo);
         value = 0;
         updateKeysizesHist(c->db, OBJ_HASH, 0, 1);
     }
@@ -4827,8 +4831,8 @@ void hincrbyfloatCommand(client *c) {
         updateKeysizesHist(c->db, OBJ_HASH, l, l + 1);
     } else {
         /* Field expired and in turn hash deleted. Create new one! */
-        o = createHashObject();
-        dbAdd(c->db, c->argv[1], &o);
+        robj *newo = createHashObject();
+        o = dbAdd(c->db, c->argv[1], &newo);
         value = 0;
         updateKeysizesHist(c->db, OBJ_HASH, 0, 1);
     }

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -444,7 +444,7 @@ void listTypeDelete(listTypeIterator *iter, listTypeEntry *entry) {
  * has the same encoding as the original one.
  *
  * The resulting object always has refcount set to 1 */
-robj *listTypeDup(robj *o) {
+robj *listTypeDup(kvobj *o) {
     robj *lobj;
 
     serverAssert(o->type == OBJ_LIST);
@@ -496,8 +496,8 @@ void pushGenericCommand(client *c, int where, int xx) {
             return;
         }
 
-        lobj = createListListpackObject();
-        dbAddByLink(c->db, c->argv[1], &lobj, &link);
+        robj *o = createListListpackObject();
+        lobj = dbAddByLink(c->db, c->argv[1], &o, &link);
     }
 
     if (server.memory_tracking_enabled)
@@ -690,7 +690,7 @@ void lsetCommand(client *c) {
  *
  * 'deleted' is an optional output argument to get an indication
  * if the key got deleted by this function. */
-void listPopRangeAndReplyWithKey(client *c, robj *o, robj *key, int where, long count, int signal, int *deleted) {
+void listPopRangeAndReplyWithKey(client *c, kvobj *o, robj *key, int where, long count, int signal, int *deleted) {
     long llen = listTypeLength(o);
     long rangelen = (count > llen) ? llen : count;
     long rangestart = (where == LIST_HEAD) ? 0 : -rangelen;
@@ -791,7 +791,7 @@ void addListRangeReply(client *c, robj *o, long start, long end, int reverse) {
  *
  * 'deleted' is an optional output argument to get an indication
  * if the key got deleted by this function. */
-void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, size_t oldsize, int signal, int *deleted) {
+void listElementsRemoved(client *c, robj *key, int where, kvobj *o, long count, size_t oldsize, int signal, int *deleted) {
     char *event = (where == LIST_HEAD) ? "lpop" : "rpop";
     unsigned long llen = listTypeLength(o);
     
@@ -878,7 +878,7 @@ void popGenericCommand(client *c, int where) {
  * Always reply with array. */
 void mpopGenericCommand(client *c, robj **keys, int numkeys, int where, long count) {
     int j;
-    robj *o;
+    kvobj *o;
     robj *key;
 
     for (j = 0; j < numkeys; j++) {
@@ -1170,14 +1170,14 @@ void lremCommand(client *c) {
     addReplyLongLong(c,removed);
 }
 
-void lmoveHandlePush(client *c, robj *dstkey, robj *dstobj, robj *value,
+void lmoveHandlePush(client *c, robj *dstkey, kvobj *dstobj, robj *value,
                      int where) {
     size_t oldsize = 0;
     int existed = (dstobj != NULL);
     /* Create the list if the key does not exist */
     if (!dstobj) {
-        dstobj = createListListpackObject();
-        dbAdd(c->db, dstkey, &dstobj);
+        robj *o = createListListpackObject();
+        dstobj = dbAdd(c->db, dstkey, &o);
     }
     if (server.memory_tracking_enabled)
         oldsize = kvobjAllocSize(dstobj);
@@ -1230,7 +1230,8 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
          * versions of Redis delete keys of empty lists. */
         addReplyNull(c);
     } else {
-        robj *kvdst, *skey = c->argv[1];
+        kvobj *kvdst;
+        robj *skey = c->argv[1];
         int64_t oldlen = 0, newlen = 1; /* init lengths assuming new dst object */
 
         if ((kvdst = lookupKeyWrite(c->db,c->argv[2])) != NULL) {
@@ -1304,7 +1305,7 @@ void rpoplpushCommand(client *c) {
  * When count is -1, a reply of a single bulk-string will be used.
  * When count > 0, an array reply will be used. */
 void blockingPopGenericCommand(client *c, robj **keys, int numkeys, int where, int timeout_idx, long count) {
-    robj *o;
+    kvobj *o;
     robj *key;
     mstime_t timeout;
     int j;
@@ -1382,7 +1383,7 @@ void brpopCommand(client *c) {
 }
 
 void blmoveGenericCommand(client *c, int wherefrom, int whereto, mstime_t timeout) {
-    robj *key = lookupKeyWrite(c->db, c->argv[1]);
+    kvobj *key = lookupKeyWrite(c->db, c->argv[1]);
     if (checkType(c,key,OBJ_LIST)) return;
 
     if (key == NULL) {
@@ -1582,8 +1583,8 @@ static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
     /* Create the destination list if needed (never the case when samekey). */
     int dst_existed = (dstobj != NULL);
     if (dstobj == NULL) {
-        dstobj = createListListpackObject();
-        dbAdd(c->db, dstkey, &dstobj);
+        robj *o = createListListpackObject();
+        dstobj = dbAdd(c->db, dstkey, &o);
     }
 
     long dst_oldlen = samekey ? 0 : (long) listTypeLength(dstobj);

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -584,7 +584,7 @@ int setTypeConvertAndExpand(robj *setobj, int enc, unsigned long cap, int panic)
  * has the same encoding as the original one.
  *
  * The resulting object always has refcount set to 1 */
-robj *setTypeDup(robj *o) {
+robj *setTypeDup(kvobj *o) {
     robj *set;
 
     serverAssert(o->type == OBJ_SET);
@@ -709,7 +709,8 @@ void sremCommand(client *c) {
 }
 
 void smoveCommand(client *c) {
-    robj *srcset, *dstset, *ele;
+    kvobj *srcset, *dstset;
+    robj *ele;
     size_t oldSrcAllocSize = 0, oldDstAllocSize = 0;
     srcset = lookupKeyWrite(c->db,c->argv[1]);
     dstset = lookupKeyWrite(c->db,c->argv[2]);
@@ -758,8 +759,8 @@ void smoveCommand(client *c) {
 
     /* Create the destination set when it doesn't exist */
     if (!dstset) {
-        dstset = setTypeCreate(ele->ptr, 1);
-        dbAdd(c->db, c->argv[2], &dstset);
+        robj *o = setTypeCreate(ele->ptr, 1);
+        dstset = dbAdd(c->db, c->argv[2], &o);
     }
 
     keyModified(c, c->db, c->argv[1], (srcNewLen > 0) ? srcset : NULL, 1);
@@ -846,7 +847,7 @@ void spopWithCountCommand(client *c) {
 
     /* Make sure a key with the name inputted exists, and that it's type is
      * indeed a kv. Otherwise, return nil */
-    robj *set = lookupKeyWriteOrReply(c, c->argv[1], shared.emptyset[c->resp]);
+    kvobj *set = lookupKeyWriteOrReply(c, c->argv[1], shared.emptyset[c->resp]);
     if (set == NULL || checkType(c, set, OBJ_SET)) return;
 
     /* If count is zero, serve an empty set ASAP to avoid special
@@ -1364,12 +1365,12 @@ void srandmemberCommand(client *c) {
 }
 
 typedef struct setopsrc {
-    robj *set;
+    kvobj *set;
     size_t oldsize;
 } setopsrc;
 
 int qsortCompareSetsByCardinality(const void *s1, const void *s2) {
-    robj *o1 = ((setopsrc*)s1)->set, *o2 = ((setopsrc*)s2)->set;
+    kvobj *o1 = ((setopsrc*)s1)->set, *o2 = ((setopsrc*)s2)->set;
     if (setTypeSize(o1) > setTypeSize(o2)) return 1;
     if (setTypeSize(o1) < setTypeSize(o2)) return -1;
     return 0;
@@ -1378,7 +1379,7 @@ int qsortCompareSetsByCardinality(const void *s1, const void *s2) {
 /* This is used by SDIFF and in this case we can receive NULL that should
  * be handled as empty sets. */
 int qsortCompareSetsByRevCardinality(const void *s1, const void *s2) {
-    robj *o1 = ((setopsrc*)s1)->set, *o2 = ((setopsrc*)s2)->set;
+    kvobj *o1 = ((setopsrc*)s1)->set, *o2 = ((setopsrc*)s2)->set;
     unsigned long first = o1 ? setTypeSize(o1) : 0;
     unsigned long second = o2 ? setTypeSize(o2) : 0;
 
@@ -1531,7 +1532,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
 
     if (server.memory_tracking_enabled) {
         for (j = 0; j < setnum; j++) {
-            robj *obj = sets[j].set;
+            kvobj *obj = sets[j].set;
             if (!obj) continue;
             updateSlotAllocSize(c->db, getKeySlot(setkeys[j]->ptr), obj,
                                 sets[j].oldsize, kvobjAllocSize(obj));
@@ -1888,7 +1889,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
     }
     if (must_track_memory) {
         for (j = 0; j < setnum; j++) {
-            robj *obj = sets[j].set;
+            kvobj *obj = sets[j].set;
             if (!obj) continue;
             updateSlotAllocSize(c->db, getKeySlot(setkeys[j]->ptr), obj,
                                 sets[j].oldsize, kvobjAllocSize(obj));

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -183,7 +183,7 @@ void streamNextID(streamID *last_id, streamID *new_id) {
  * has the same encoding as the original one.
  *
  * The resulting object always has refcount set to 1 */
-robj *streamDup(robj *o) {
+robj *streamDup(kvobj *o) {
     robj *sobj;
 
     serverAssert(o->type == OBJ_STREAM);
@@ -2401,8 +2401,7 @@ kvobj *streamTypeLookupWriteOrCreate(client *c, robj *key, int no_create) {
         return NULL;
     }
     robj *o = createStreamObject();
-    dbAddByLink(c->db, key, &o, &link);
-    return o;
+    return dbAddByLink(c->db, key, &o, &link);
 }
 
 /* Parse a stream ID in the format given by clients to Redis, that is
@@ -3557,7 +3556,7 @@ void xgroupCommand(client *c) {
     char *opt = c->argv[1]->ptr; /* Subcommand name. */
     int mkstream = 0;
     long long entries_read = SCG_INVALID_ENTRIES_READ;
-    robj *o;
+    kvobj *o = NULL; /* Only set (and only used) by subcommands that take a key. */
     size_t old_alloc = 0;
 
     /* Everything but the "HELP" option requires a key and group name. */
@@ -3652,8 +3651,8 @@ NULL
         /* Handle the MKSTREAM option now that the command can no longer fail. */
         if (s == NULL) {
             serverAssert(mkstream);
-            o = createStreamObject();
-            dbAdd(c->db, c->argv[2], &o);
+            robj *newo = createStreamObject();
+            o = dbAdd(c->db, c->argv[2], &newo);
             s = o->ptr;
             keyModified(c,c->db,c->argv[2],o,1);
         }

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -850,7 +850,7 @@ void msetexCommand(client *c) {
         /* Check NX/XX conditions for each key - pattern from setGenericCommand */
         for (int j = 0; j < kv_count; j++) {
             int key_idx = (j * 2) + 2;
-            robj *found = lookupKeyWrite(c->db, c->argv[key_idx]);
+            kvobj *found = lookupKeyWrite(c->db, c->argv[key_idx]);
 
             if ((args.flags & OBJ_SET_NX && found) ||
                 (args.flags & OBJ_SET_XX && !found))
@@ -1423,21 +1423,22 @@ void lcsCommand(client *c) {
     sds a = NULL, b = NULL;
     int getlen = 0, getidx = 0, withmatchlen = 0;
 
-    kvobj *obja = lookupKeyRead(c->db, c->argv[1]);
-    kvobj *objb = lookupKeyRead(c->db, c->argv[2]);
-    if ((obja && obja->type != OBJ_STRING) ||
-        (objb && objb->type != OBJ_STRING))
+    kvobj *kva = lookupKeyRead(c->db, c->argv[1]);
+    kvobj *kvb = lookupKeyRead(c->db, c->argv[2]);
+    /* Objects we own and have to release at cleanup, as opposed to the kvobjs
+     * above which belong to the keyspace. */
+    robj *obja = NULL, *objb = NULL;
+    if ((kva && kva->type != OBJ_STRING) ||
+        (kvb && kvb->type != OBJ_STRING))
     {
         addReplyError(c,
             "The specified keys must contain string values");
         /* Don't cleanup the objects, we need to do that
          * only after calling getDecodedObject(). */
-        obja = NULL;
-        objb = NULL;
         goto cleanup;
     }
-    obja = obja ? getDecodedObject(obja) : createStringObject("",0);
-    objb = objb ? getDecodedObject(objb) : createStringObject("",0);
+    obja = kva ? getDecodedObject(kva) : createStringObject("",0);
+    objb = kvb ? getDecodedObject(kvb) : createStringObject("",0);
     a = obja->ptr;
     b = objb->ptr;
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1866,7 +1866,7 @@ long zsetRank(robj *zobj, sds ele, int reverse, double *output_score) {
  * has the same encoding as the original one.
  *
  * The resulting object always has refcount set to 1 */
-robj *zsetDup(robj *o) {
+robj *zsetDup(kvobj *o) {
     robj *zobj;
     zset *zs;
     zset *new_zs;
@@ -1962,7 +1962,7 @@ void zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, listpackEntry 
 void zaddGenericCommand(client *c, int flags) {
     static char *nanerr = "resulting score is not a number (NaN)";
     robj *key = c->argv[1];
-    robj *zobj;
+    kvobj *zobj;
     sds ele;
     size_t oldsize = 0;
     double score = 0, *scores = NULL;
@@ -2299,7 +2299,7 @@ void zremrangebylexCommand(client *c) {
 /* Unified iterator source for set operations (ZUNION/ZINTER/ZDIFF).
  * Provides polymorphic iteration over sets and sorted sets with different encodings. */
 typedef struct {
-    robj *subject;
+    kvobj *subject;
     int type; /* Set, sorted set */
     int encoding;
     double weight;
@@ -3136,7 +3136,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
     }
     if (server.memory_tracking_enabled) {
         for (i = 0; i < setnum; i++) {
-            robj *obj = src[i].subject;
+            kvobj *obj = src[i].subject;
             if (obj == NULL) continue;
             updateSlotAllocSize(c->db, getKeySlot(kvobjGetKey(obj)), obj,
                                 src[i].oldsize, kvobjAllocSize(obj));
@@ -4228,7 +4228,7 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
                         long count, int use_nested_array, int reply_nil_when_empty, int *deleted) {
     int idx;
     robj *key = NULL;
-    robj *zobj = NULL;
+    kvobj *zobj = NULL;
     sds ele;
     double score;
     size_t oldsize = 0;
@@ -4414,7 +4414,7 @@ void zpopmaxCommand(client *c) {
  * */
 void blockingGenericZpopCommand(client *c, robj **keys, int numkeys, int where,
                                 int timeout_idx, long count, int use_nested_array, int reply_nil_when_empty) {
-    robj *o;
+    kvobj *o;
     robj *key;
     mstime_t timeout;
     int j;


### PR DESCRIPTION
`kvobj` is a typedef of `robj`, so the compiler cannot tell them apart and the declared type is documentation only. That documentation had drifted: many keyspace-resident objects were declared `robj*`, and a few variables were declared `kvobj*` while holding a plain, not-yet-added value.

Mismatches were found rather than guessed at, by temporarily redefining `kvobj` as a layout-identical but *distinct* struct and treating the resulting pointer-type warnings as the worklist. That scaffolding is reverted.

Two real inconsistencies fell out: `dbReplaceValue()` was declared with `kvobj **ioKeyVal` in `server.h` but defined with `robj **valref` in `db.c`, and `dbSetValue()` copied a kvobj through a plain `robj tmp`. The rest narrows declarations to `kvobj*` where an object must live in the keyspace, and splits variables that served as both a freshly created value and the stored object.

No behaviour change: `dbAdd*()` returns exactly what it writes back through `valref`, and no statement order or object lifetime was altered. Warning-free build and a full `./runtest` pass (153/153 files, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time/documentation-only pointer typing with no logic or lifetime changes; risk is limited to missed declaration sites, not altered server behavior.
> 
> **Overview**
> **Type-only cleanup** so pointer types document whether a value lives in the keyspace (`kvobj*`) or is a transient `robj*` before `dbAdd*`.
> 
> Declarations are updated across commands, persistence, migration, and dup/defrag helpers (e.g. `rewriteObject`, `rdbSaveKeyValuePair`, `*TypeDup`, `activeDefragKvobj`). Lookups and mutations now use `kvobj*` where the object is always keyspace-resident.
> 
> **Create-then-add** paths pass a local `robj *newo` into `dbAdd` / `dbAddByLink` and assign the returned `kvobj*` (bitops, lists, sets, hashes, streams, arrays). **`dbUnshareStringValueByLink`** uses a separate `unshared` `robj*` for `dbReplaceValueWithLink` instead of reusing the keyspace pointer. **`sort`**, **`lcs`**, and **`lookupKeyByPattern`** split keyspace handles from returned `robj*` results. **`createDumpPayload`** casts to `kvobj*` only when saving module metadata. **`dbReplaceValue`** in `server.h` is aligned with `robj **valref` (was `kvobj **ioKeyVal`); **`dbSetValue`** swaps via `kvobj tmp` instead of `robj tmp`.
> 
> No intended runtime behavior change—`kvobj` remains a typedef of `robj`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d03ec3b1acf1550a8856de73d1f1f397441fb5ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->