### PR TITLE
Fix XTRIM with DELREF leaving dangling consumer group references on tombstone

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -972,15 +972,20 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
             while(to_skip--) p = lpNext(lp,p); /* Skip the whole entry. */
             p = lpNext(lp,p); /* Skip the final lp-count field. */
 
+            /* Remove all consumer group references for this entry. This is
+             * done even for entries that are already marked as deleted: a
+             * tombstone left behind by XDEL/XDELEX with KEEPREF may still be
+             * referenced by consumer groups, and once it is trimmed away those
+             * references could never be removed anymore. */
+            if (delete_strategy == DELETE_STRATEGY_DELREF)
+                streamCleanupEntryCGroupRefs(s, &currid);
+
             /* Mark the entry as deleted if allowed. */
             if (!(flags & STREAM_ITEM_FLAG_DELETED)) {
                 int can_delete = 1;
                 if (delete_strategy == DELETE_STRATEGY_ACKED) {
                     /* Only delete entry that has been acknowledged by all consumer groups. */
                     can_delete = (streamEntryIsReferenced(s, &currid) == 0);
-                } else if (delete_strategy == DELETE_STRATEGY_DELREF) {
-                    /* Remove all consumer group references for this entry */
-                    streamCleanupEntryCGroupRefs(s, &currid);
                 }
 
                 if (can_delete) {

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -3523,6 +3523,28 @@ start_server {
 
         r config set stream-node-max-entries $origin_max_entries
     }
+
+    test {XTRIM with DELREF cleans up references of already deleted entries} {
+        r DEL mystream
+
+        r XADD mystream 1-0 f v
+        r XADD mystream 2-0 f v
+        r XADD mystream 3-0 f v
+
+        r XGROUP CREATE mystream mygroup 0
+        r XREADGROUP GROUP mygroup consumer1 STREAMS mystream >
+        assert_equal 3 [lindex [r XPENDING mystream mygroup] 0]
+
+        # Turn 1-0 into a tombstone: the entry is gone from the stream, but
+        # the consumer group still holds a reference to it.
+        assert_equal 1 [r XDEL mystream 1-0]
+
+        # Trimming past the tombstone with DELREF must drop its dangling
+        # reference too, not just the references of the live entries.
+        assert_equal 2 [r XTRIM mystream MINID 4 DELREF]
+        assert_equal 0 [r XLEN mystream]
+        assert_equal {0 {} {} {}} [r XPENDING mystream mygroup]
+    }
 }
 
 start_server {tags {"stream needs:debug"} overrides {appendonly yes}} {


### PR DESCRIPTION
Introduced by #14130

## Problem

Trimming with `DELREF` is supposed to drop every consumer group reference to the entries it removes. However the cleanup call is nested inside the `if (!(flags & STREAM_ITEM_FLAG_DELETED))` block, so entries that are already tombstones — deleted earlier by `XDEL`/`XDELEX`/`XACKDEL` with the default `KEEPREF` — are skipped entirely.

## Fix

Perform the `streamCleanupEntryCGroupRefs()` call for every entry in the trimmed range,
tombstones included, before deciding whether the entry itself can be marked as deleted.

Note that because this bug is not very risky and only results in dangling references, it has been backported only to the previous version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stream trim/delete paths and consumer-group PEL bookkeeping; behavior change is narrow (DELREF + tombstones) but affects correctness of pending-entry state.
> 
> **Overview**
> **Fixes dangling PEL references when `XTRIM … DELREF` removes entries that were already deleted with `KEEPREF`.**
> 
> Consumer-group cleanup (`streamCleanupEntryCGroupRefs`) used to run only inside the branch for entries not yet marked `STREAM_ITEM_FLAG_DELETED`. Tombstones left by `XDEL`/`XDELEX` with default `KEEPREF` could still sit in a group’s pending list; trimming past them skipped cleanup, so `XPENDING` could stay non-empty after the stream was empty.
> 
> The change runs `DELREF` cleanup for **every** entry in the trimmed range before deciding whether to mark the listpack item deleted. A regression test covers `XDEL` → tombstone → `XTRIM MINID … DELREF` and asserts the PEL is cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 450917fb8aae577dd5180bf09b3c938ee396fdbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->