### PR TITLE
fix(module): defer ae operations in RM_CreateTimer to main thread

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -10357,6 +10357,11 @@ static void processDeferredAeOps(void) {
             aeDeleteTimeEvent(server.el, op->id);
             aeTimer = -1;
         } else if (op->type == AE_DEFER_CREATE) {
+            /* If we already have a timer, delete it first to avoid leaking.
+             * Only the last CREATE matters since we maintain a single main timer. */
+            if (aeTimer != -1) {
+                aeDeleteTimeEvent(server.el, aeTimer);
+            }
             aeTimer = aeCreateTimeEvent(server.el, op->period, moduleTimerHandler, NULL, NULL);
         }
         zfree(op);
@@ -10411,6 +10416,8 @@ RedisModuleTimerID RM_CreateTimer(RedisModuleCtx *ctx, mstime_t period, RedisMod
                 if (write(server.module_pipe[1],"A",1) != 1) {
                     /* Ignore error, best-effort. */
                 }
+                /* Set aeTimer to -1 so the subsequent CREATE path is taken. */
+                aeTimer = -1;
             } else {
                 aeDeleteTimeEvent(server.el,aeTimer);
                 aeTimer = -1;

--- a/src/module.c
+++ b/src/module.c
@@ -10328,6 +10328,45 @@ int moduleTimerHandler(struct aeEventLoop *eventLoop, long long id, void *client
  * there will 'period' milliseconds gaps between events.
  * (If the time it takes to execute 'callback' is negligible the two
  * statements above mean the same) */
+
+/* Deferred ae operations from non-main threads to avoid GIL races. */
+typedef struct DeferredAeOp {
+    int type; /* AE_DEFER_DELETE or AE_DEFER_CREATE */
+    long long id;
+    mstime_t period;
+} DeferredAeOp;
+
+#define AE_DEFER_DELETE 1
+#define AE_DEFER_CREATE 2
+
+static list *deferredAeOps = NULL;
+static pthread_mutex_t deferredAeOpsMutex = PTHREAD_MUTEX_INITIALIZER;
+
+/* Helper: process deferred ae operations on the main thread. */
+static void processDeferredAeOps(void) {
+    if (!deferredAeOps) return;
+
+    pthread_mutex_lock(&deferredAeOpsMutex);
+    while (listLength(deferredAeOps)) {
+        listNode *ln = listFirst(deferredAeOps);
+        DeferredAeOp *op = ln->value;
+        listDelNode(deferredAeOps, ln);
+        pthread_mutex_unlock(&deferredAeOpsMutex);
+
+        if (op->type == AE_DEFER_DELETE) {
+            aeDeleteTimeEvent(server.el, op->id);
+            aeTimer = -1;
+        } else if (op->type == AE_DEFER_CREATE) {
+            aeTimer = aeCreateTimeEvent(server.el, op->period, moduleTimerHandler, NULL, NULL);
+        }
+        zfree(op);
+
+        /* Lock again for the next iteration */
+        pthread_mutex_lock(&deferredAeOpsMutex);
+    }
+    pthread_mutex_unlock(&deferredAeOpsMutex);
+}
+
 RedisModuleTimerID RM_CreateTimer(RedisModuleCtx *ctx, mstime_t period, RedisModuleTimerProc callback, void *data) {
     RedisModuleTimer *timer = zmalloc(sizeof(*timer));
     timer->module = ctx->module;
@@ -10360,16 +10399,45 @@ RedisModuleTimerID RM_CreateTimer(RedisModuleCtx *ctx, mstime_t period, RedisMod
         if (memcmp(ri.key,&key,sizeof(key)) == 0) {
             /* This is the first key, we need to re-install the timer according
              * to the just added event. */
-            aeDeleteTimeEvent(server.el,aeTimer);
-            aeTimer = -1;
+            if (!pthread_equal(server.main_thread_id, pthread_self())) {
+                /* Defer ae mutation to main thread to avoid GIL race. */
+                DeferredAeOp *op = zmalloc(sizeof(*op));
+                op->type = AE_DEFER_DELETE;
+                op->id = aeTimer;
+                pthread_mutex_lock(&deferredAeOpsMutex);
+                if (!deferredAeOps) deferredAeOps = listCreate();
+                listAddNodeTail(deferredAeOps, op);
+                pthread_mutex_unlock(&deferredAeOpsMutex);
+                if (write(server.module_pipe[1],"A",1) != 1) {
+                    /* Ignore error, best-effort. */
+                }
+            } else {
+                aeDeleteTimeEvent(server.el,aeTimer);
+                aeTimer = -1;
+            }
         }
         raxStop(&ri);
     }
 
     /* If we have no main timer (the old one was invalidated, or this is the
      * first module timer we have), install one. */
-    if (aeTimer == -1)
-        aeTimer = aeCreateTimeEvent(server.el,period,moduleTimerHandler,NULL,NULL);
+    if (aeTimer == -1) {
+        if (!pthread_equal(server.main_thread_id, pthread_self())) {
+            /* Defer ae mutation to main thread to avoid GIL race. */
+            DeferredAeOp *op = zmalloc(sizeof(*op));
+            op->type = AE_DEFER_CREATE;
+            op->period = period;
+            pthread_mutex_lock(&deferredAeOpsMutex);
+            if (!deferredAeOps) deferredAeOps = listCreate();
+            listAddNodeTail(deferredAeOps, op);
+            pthread_mutex_unlock(&deferredAeOpsMutex);
+            if (write(server.module_pipe[1],"A",1) != 1) {
+                /* Ignore error, best-effort. */
+            }
+        } else {
+            aeTimer = aeCreateTimeEvent(server.el,period,moduleTimerHandler,NULL,NULL);
+        }
+    }
 
     return key;
 }
@@ -10621,6 +10689,7 @@ int RM_EventLoopAddOneShot(RedisModuleEventLoopOneShotFunc func, void *user_data
 /* This function will check the moduleEventLoopOneShots queue in order to
  * call the callback for the registered oneshot events. */
 static void eventLoopHandleOneShotEvents(void) {
+    processDeferredAeOps();
     pthread_mutex_lock(&moduleEventLoopMutex);
     if (moduleEventLoopOneShots) {
         while (listLength(moduleEventLoopOneShots)) {


### PR DESCRIPTION
## Summary

Fixes Redis #15582 - Module GIL Race to SIGSEGV on aarch64.

## Problem

`aeProcessEvents()` walks `timeEventHead` after `beforeSleep()` releases the GIL. When a module thread calls `RM_CreateTimer()` while holding the GIL, it inserts into the same list, causing a race that can lead to SIGSEGV on weakly-ordered architectures (aarch64).

## Fix

Reuse the existing `RM_Yield` defer mechanism via `module_pipe`:

- When `RM_CreateTimer()` is called from a non-main thread, defer ae mutations (timer create/delete) to the main thread
- The rax insert (GIL-protected) stays synchronous - the returned `RedisModuleTimerID` is correct
- Deferred ops are processed in `eventLoopHandleOneShotEvents()` on the main thread

## Changes

- `src/module.c`: Added `DeferredAeOp` struct and `processDeferredAeOps()` helper
- Modified `RM_CreateTimer()` to check thread context and defer ae operations when called from non-main threads
- Called `processDeferredAeOps()` in `eventLoopHandleOneShotEvents()` before handling oneshot events

## Testing

- Build: `make` succeeds
- Existing module timer tests pass
- No new test failures introduced

Fixes #15582

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes module timer scheduling and cross-thread event-loop interaction, but scope is narrow and follows an existing main-thread deferral pattern rather than broad refactors.
> 
> **Overview**
> Fixes a **GIL/event-loop race** where module threads calling `RM_CreateTimer()` could mutate the ae timer list while the main thread walks it after releasing the GIL (SIGSEGV on aarch64, #15582).
> 
> **`RM_CreateTimer()`** now checks `server.main_thread_id`: on non-main threads, **`aeDeleteTimeEvent` / `aeCreateTimeEvent` are not called inline**. Instead, **`DeferredAeOp`** entries (delete or create with period) are queued under a mutex, **`module_pipe`** wakes the main loop (same pattern as other module deferrals), and **`aeTimer`** is cleared on the caller so the deferred create path runs. The **rax timer insert and returned timer ID stay synchronous** on the calling thread under the GIL.
> 
> A new **`processDeferredAeOps()`** drains that queue on the **main thread** at the start of **`eventLoopHandleOneShotEvents()`**, coalescing to a single main ae timer (last create wins; prior timer deleted before create).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f76cee0bb5c4682f7b22f9110370381ede074a4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->