### PR TITLE
Fix flaky lazyfree stream test by using explicit stream IDs

### DIFF
--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -50,11 +50,20 @@ start_server {tags {"lazyfree"}} {
 
         r config resetstat
         r config set stream-node-max-entries 5
+        # Use explicit IDs one millisecond apart. What decides whether UNLINK
+        # frees the stream lazily is lazyfreeGetFreeEffort(), which for a stream
+        # is dominated by the number of nodes in its radix tree, and with
+        # server-generated IDs that is the number of distinct milliseconds these
+        # 1000 XADDs happen to span -- keys sharing a millisecond share a prefix
+        # and collapse into one compressed node. On a machine fast enough to run
+        # the loop in well under 64ms the whole stream fits in a handful of
+        # nodes, the effort falls below LAZYFREE_THRESHOLD, the stream is freed
+        # synchronously and lazyfreed_objects stays 0.
         for {set j 0} {$j < 1000} {incr j} {
             if {rand() < 0.9} {
-                r xadd stream * foo $j
+                r xadd stream $j-1 foo $j
             } else {
-                r xadd stream * bar $j
+                r xadd stream $j-1 bar $j
             }
         }
         r xgroup create stream mygroup 0


### PR DESCRIPTION
`lazy free a stream with all types of metadata` fails on fast machines, and intermittently on machines near the boundary.

The test asserts that `UNLINK` on a 1000-entry stream frees it via the lazyfree thread. That decision comes from `lazyfreeGetFreeEffort()`, which for a stream is

```
s->rax->numnodes + raxSize(cgroups) * (1 + raxSize(pel))
```

and only exceeds `LAZYFREE_THRESHOLD` (64) if the radix tree has more than 61 nodes — the single consumer group with its two-entry PEL contributes just 3.

The radix tree does not have a fixed node count. Its keys are the 200 master entry IDs, whose high 8 bytes are the wall-clock millisecond, so entries added within the same millisecond share a prefix and collapse into one compressed node. `numnodes` therefore tracks how many distinct milliseconds the XADD loop spanned — which is to say how long the loop took. Measured on one aarch64 host, with everything else identical:

| how the 1000 XADDs were issued | `radix-tree-nodes` | result |
| --- | --- | --- |
| the test's own loop, spanning ~200ms | 204 | lazy freed, passes |
| same XADDs pipelined (few ms) | 18 | freed inline, fails |
| same XADDs inside one `EVAL` (one ms) | 6 | freed inline, fails |

So any machine that gets through 1000 XADD round trips in appreciably under 64ms fails the test outright, and one just fast enough to sit on the boundary fails intermittently. That is what it does on openSUSE's aarch64 build workers: the same source passes on one worker and fails on another, which is how this was found.

This PR adds the entries with explicit IDs one millisecond apart. The radix tree then has the same shape on every machine (206 nodes) and the test measures lazyfree rather than the speed of the host. Nothing about the test's coverage changes — the stream still carries a consumer group, a PEL, an acknowledged entry and a tombstone.

Raising the `XREADGROUP COUNT` so the PEL term dominates instead would also work (`COUNT 200` gives an effort of ~207 regardless of the radix tree), if you would rather keep the server-generated IDs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code impact.
> 
> **Overview**
> Fixes flaky **`lazy free a stream with all types of metadata`** on fast hosts (e.g. aarch64 CI) where **`UNLINK`** sometimes freed the stream inline instead of via lazyfree, so **`lazyfreed_objects`** stayed 0.
> 
> The test still builds the same 1000-entry stream with consumer group, PEL, ack, and tombstone, but **`XADD`** now uses explicit IDs **`$j-1`** (one millisecond apart) instead of **`*`**. Server-generated IDs collapse entries that share a millisecond into few radix-tree nodes, so **`lazyfreeGetFreeEffort()`** could fall below **`LAZYFREE_THRESHOLD`** when the loop finished quickly. Explicit IDs force a stable tree shape on every machine so the test checks lazyfree behavior, not host speed. A comment in the test documents this.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76269505b8ff08aef80dd0545d96aec6be0d4640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->