### PR TITLE
Make LMOVEM notifications consistent with LMOVE

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1613,11 +1613,12 @@ static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
 
     if (samekey) {
         /* In-place rotation: the length is unchanged, so there is no key
-         * creation/deletion and no histogram change. Fire both the pop and the
-         * push notifications and account for the (possibly re-encoded) object. */
-        notifyKeyspaceEvent(NOTIFY_LIST, wherefrom == LIST_HEAD ? "lpop" : "rpop",
-                            srckey, c->db->id);
+         * creation/deletion and no histogram change. Fire the push notification
+         * before the pop notification, matching LMOVE and the distinct-key path,
+         * and account for the (possibly re-encoded) object. */
         notifyKeyspaceEvent(NOTIFY_LIST, whereto == LIST_HEAD ? "lpush" : "rpush",
+                            srckey, c->db->id);
+        notifyKeyspaceEvent(NOTIFY_LIST, wherefrom == LIST_HEAD ? "lpop" : "rpop",
                             srckey, c->db->id);
         keyModified(c, c->db, srckey, srcobj, 1);
         if (server.memory_tracking_enabled)

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1613,12 +1613,12 @@ static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
 
     if (samekey) {
         /* In-place rotation: the length is unchanged, so there is no key
-         * creation/deletion and no histogram change. Fire the pop notification
-         * before the push notification, matching the distinct-key path and the
-         * documented move order, and account for the (possibly re-encoded) object. */
-        notifyKeyspaceEvent(NOTIFY_LIST, wherefrom == LIST_HEAD ? "lpop" : "rpop",
-                            srckey, c->db->id);
+         * creation/deletion and no histogram change. Fire the push notification
+         * before the pop notification, matching LMOVE and the distinct-key path,
+         * and account for the (possibly re-encoded) object. */
         notifyKeyspaceEvent(NOTIFY_LIST, whereto == LIST_HEAD ? "lpush" : "rpush",
+                            srckey, c->db->id);
+        notifyKeyspaceEvent(NOTIFY_LIST, wherefrom == LIST_HEAD ? "lpop" : "rpop",
                             srckey, c->db->id);
         keyModified(c, c->db, srckey, srcobj, 1);
         if (server.memory_tracking_enabled)
@@ -1627,10 +1627,6 @@ static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
         server.dirty += count;
         return;
     }
-
-    /* Source accounting is done first so the pop notification (and a possible
-     * deletion notification) precedes the destination push notification. */
-    listElementsRemoved(c, srckey, wherefrom, srcobj, count, src_oldsize, 1, NULL);
 
     /* Destination accounting (a batched version of lmoveHandlePush). */
     updateKeysizesHist(c->db, OBJ_LIST, dst_oldlen, dst_oldlen + count);
@@ -1644,6 +1640,10 @@ static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
         signalKeyAsReadyNonEmptyList(c->db, dstkey);
     notifyKeyspaceEvent(NOTIFY_LIST, whereto == LIST_HEAD ? "lpush" : "rpush",
                         dstkey, c->db->id);
+
+    /* Source accounting: notifications, histogram, deletion if emptied and the
+     * dirty counter (dirty += count) are all handled here. */
+    listElementsRemoved(c, srckey, wherefrom, srcobj, count, src_oldsize, 1, NULL);
 }
 
 /* Core of LMOVEM, also reused by BLMOVEM once the source has enough elements. */

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1613,12 +1613,12 @@ static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
 
     if (samekey) {
         /* In-place rotation: the length is unchanged, so there is no key
-         * creation/deletion and no histogram change. Fire the push notification
-         * before the pop notification, matching LMOVE and the distinct-key path,
-         * and account for the (possibly re-encoded) object. */
-        notifyKeyspaceEvent(NOTIFY_LIST, whereto == LIST_HEAD ? "lpush" : "rpush",
-                            srckey, c->db->id);
+         * creation/deletion and no histogram change. Fire the pop notification
+         * before the push notification, matching the distinct-key path and the
+         * documented move order, and account for the (possibly re-encoded) object. */
         notifyKeyspaceEvent(NOTIFY_LIST, wherefrom == LIST_HEAD ? "lpop" : "rpop",
+                            srckey, c->db->id);
+        notifyKeyspaceEvent(NOTIFY_LIST, whereto == LIST_HEAD ? "lpush" : "rpush",
                             srckey, c->db->id);
         keyModified(c, c->db, srckey, srcobj, 1);
         if (server.memory_tracking_enabled)
@@ -1627,6 +1627,10 @@ static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
         server.dirty += count;
         return;
     }
+
+    /* Source accounting is done first so the pop notification (and a possible
+     * deletion notification) precedes the destination push notification. */
+    listElementsRemoved(c, srckey, wherefrom, srcobj, count, src_oldsize, 1, NULL);
 
     /* Destination accounting (a batched version of lmoveHandlePush). */
     updateKeysizesHist(c->db, OBJ_LIST, dst_oldlen, dst_oldlen + count);
@@ -1640,10 +1644,6 @@ static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
         signalKeyAsReadyNonEmptyList(c->db, dstkey);
     notifyKeyspaceEvent(NOTIFY_LIST, whereto == LIST_HEAD ? "lpush" : "rpush",
                         dstkey, c->db->id);
-
-    /* Source accounting: notifications, histogram, deletion if emptied and the
-     * dirty counter (dirty += count) are all handled here. */
-    listElementsRemoved(c, srckey, wherefrom, srcobj, count, src_oldsize, 1, NULL);
 }
 
 /* Core of LMOVEM, also reused by BLMOVEM once the source has enough elements. */

--- a/tests/unit/type/list-4.tcl
+++ b/tests/unit/type/list-4.tcl
@@ -98,6 +98,25 @@ foreach {type large} [array get largevalue] {
     }
 }
 
+    test {LMOVEM same-key notifications match LMOVE order} {
+        set orig_notify [lindex [r config get notify-keyspace-events] 1]
+        r config set notify-keyspace-events El
+        r del k{t}
+        r rpush k{t} a b
+
+        set rd [redis_deferring_client]
+        set pattern __keyevent@*__:*
+        assert_equal {1} [psubscribe $rd $pattern]
+
+        assert_equal {a} [r lmovem k{t} k{t} left right]
+        assert_match "pmessage $pattern __keyevent@*__:rpush k{t}" [$rd read]
+        assert_match "pmessage $pattern __keyevent@*__:lpop k{t}" [$rd read]
+        assert_equal {b a} [r lrange k{t} 0 -1]
+
+        $rd close
+        r config set notify-keyspace-events $orig_notify
+    }
+
     test {LMOVEM missing or empty source} {
         r del src{t} dst{t}
         assert_equal {} [r lmovem src{t} dst{t} left right]

--- a/tests/unit/type/list-4.tcl
+++ b/tests/unit/type/list-4.tcl
@@ -98,7 +98,7 @@ foreach {type large} [array get largevalue] {
     }
 }
 
-    test {LMOVEM notifications are pop before push} {
+    test {LMOVEM notifications match LMOVE push-before-pop order} {
         set orig_notify [lindex [r config get notify-keyspace-events] 1]
         r config set notify-keyspace-events Egl
         r del k{t} src{t} dst{t} last{t} new{t}
@@ -111,20 +111,20 @@ foreach {type large} [array get largevalue] {
         assert_equal {1} [psubscribe $rd $pattern]
 
         assert_equal {a} [r lmovem k{t} k{t} left right]
-        assert_match "pmessage $pattern __keyevent@*__:lpop k{t}" [$rd read]
         assert_match "pmessage $pattern __keyevent@*__:rpush k{t}" [$rd read]
+        assert_match "pmessage $pattern __keyevent@*__:lpop k{t}" [$rd read]
         assert_equal {b a} [r lrange k{t} 0 -1]
 
         assert_equal {a} [r lmovem src{t} dst{t} left right]
-        assert_match "pmessage $pattern __keyevent@*__:lpop src{t}" [$rd read]
         assert_match "pmessage $pattern __keyevent@*__:rpush dst{t}" [$rd read]
+        assert_match "pmessage $pattern __keyevent@*__:lpop src{t}" [$rd read]
         assert_equal {b} [r lrange src{t} 0 -1]
         assert_equal {a} [r lrange dst{t} 0 -1]
 
         assert_equal {a} [r lmovem last{t} new{t} left right]
+        assert_match "pmessage $pattern __keyevent@*__:rpush new{t}" [$rd read]
         assert_match "pmessage $pattern __keyevent@*__:lpop last{t}" [$rd read]
         assert_match "pmessage $pattern __keyevent@*__:del last{t}" [$rd read]
-        assert_match "pmessage $pattern __keyevent@*__:rpush new{t}" [$rd read]
         assert_equal {0} [r exists last{t}]
         assert_equal {a} [r lrange new{t} 0 -1]
 

--- a/tests/unit/type/list-4.tcl
+++ b/tests/unit/type/list-4.tcl
@@ -98,20 +98,35 @@ foreach {type large} [array get largevalue] {
     }
 }
 
-    test {LMOVEM same-key notifications match LMOVE order} {
+    test {LMOVEM notifications are pop before push} {
         set orig_notify [lindex [r config get notify-keyspace-events] 1]
-        r config set notify-keyspace-events El
-        r del k{t}
+        r config set notify-keyspace-events Egl
+        r del k{t} src{t} dst{t} last{t} new{t}
         r rpush k{t} a b
+        r rpush src{t} a b
+        r rpush last{t} a
 
         set rd [redis_deferring_client]
         set pattern __keyevent@*__:*
         assert_equal {1} [psubscribe $rd $pattern]
 
         assert_equal {a} [r lmovem k{t} k{t} left right]
-        assert_match "pmessage $pattern __keyevent@*__:rpush k{t}" [$rd read]
         assert_match "pmessage $pattern __keyevent@*__:lpop k{t}" [$rd read]
+        assert_match "pmessage $pattern __keyevent@*__:rpush k{t}" [$rd read]
         assert_equal {b a} [r lrange k{t} 0 -1]
+
+        assert_equal {a} [r lmovem src{t} dst{t} left right]
+        assert_match "pmessage $pattern __keyevent@*__:lpop src{t}" [$rd read]
+        assert_match "pmessage $pattern __keyevent@*__:rpush dst{t}" [$rd read]
+        assert_equal {b} [r lrange src{t} 0 -1]
+        assert_equal {a} [r lrange dst{t} 0 -1]
+
+        assert_equal {a} [r lmovem last{t} new{t} left right]
+        assert_match "pmessage $pattern __keyevent@*__:lpop last{t}" [$rd read]
+        assert_match "pmessage $pattern __keyevent@*__:del last{t}" [$rd read]
+        assert_match "pmessage $pattern __keyevent@*__:rpush new{t}" [$rd read]
+        assert_equal {0} [r exists last{t}]
+        assert_equal {a} [r lrange new{t} 0 -1]
 
         $rd close
         r config set notify-keyspace-events $orig_notify


### PR DESCRIPTION
## Summary

- Emit the destination push notification before the source pop notification for same-key `LMOVEM` operations.
- Keep the existing distinct-key order unchanged, matching `LMOVE` push-before-pop behavior.
- Add regression coverage for same-key moves, distinct-key moves, and moves that delete the source key.

## Background

`LMOVEM` emitted keyspace notifications in different orders depending on whether the source and destination were the same key. The distinct-key path emitted push before pop, matching `LMOVE`, while the same-key path emitted pop before push.

Following the discussion in this PR, this change aligns the same-key path with `LMOVE` and the distinct-key path. The keyspace notification documentation was also updated in redis/docs#3855 to describe the existing `LMOVE`/`BLMOVE` push-before-pop order.

`BLMOVEM` uses the same move helper once the command can execute, so it receives the same ordering behavior.

## Testing

- `make -j4`
- `./runtest --baseport 43111 --portcount 128 --single unit/type/list-4`
- `./runtest --baseport 45111 --portcount 128 --single unit/pubsub`
- `make test` - all tests passed; large-memory-only cases were skipped because the large-memory flag was not enabled.

Fixes #15586.