### PR TITLE
Fix use-after-free in handleClientsBlockedOnKey

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -625,14 +625,25 @@ static void handleClientsBlockedOnKey(readyList *rl) {
 
     if (de) {
         list *clients = dictGetVal(de);
-        listNode *ln;
-        listIter li;
-        listRewind(clients,&li);
-
         /* Avoid processing more than the initial count so that we're not stuck
          * in an endless loop in case the reprocessing of the command blocks again. */
         long count = listLength(clients);
-        while ((ln = listNext(&li)) && count--) {
+        while (count-- > 0) {
+            /* Processing the previous client may have removed all blocked
+             * clients and freed the list, so look it up again each time. */
+            de = dictFind(rl->db->blocking_keys, rl->key);
+            if (!de) break;
+            list *clients = dictGetVal(de);
+            listNode *ln = listFirst(clients);
+            serverAssert(ln);
+
+            /* Rotate before reprocessing because unblocking may remove this
+             * client, and command reprocessing may evict other blocked clients
+             * and free the list. If the client remains blocked or blocks again,
+             * keeping it at the tail lets us advance to the next client while
+             * preserving the order of the other waiters. */
+            listRotateHeadToTail(clients);
+
             client *receiver = listNodeValue(ln);
             kvobj *o = lookupKeyReadWithFlags(rl->db, rl->key, LOOKUP_NOEFFECTS);
             /* 1. In case new key was added/touched we need to verify it satisfy the

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -642,5 +642,45 @@ start_server {} {
     }
 }
 
+start_server {} {
+    test "Evicting the next client while serving blocked clients is safe" {
+        r flushall
+        r client no-evict on
+        r config set maxmemory-clients 0
+
+        set rd1 [redis_deferring_client]
+        set rd2 [redis_deferring_client]
+        $rd2 CLIENT SETNAME client-to-evict
+        assert_equal OK [$rd2 read]
+
+        # Block two clients on the same key in a known order.
+        $rd1 BLPOP mylist 0
+        $rd2 BLPOP mylist 0
+        wait_for_blocked_clients_count 2
+
+        # Queue a large request behind the second client's blocking command so
+        # it will be selected for eviction while the first client is processed.
+        $rd2 get [string repeat Q [kb 2048]]
+        wait_for_condition 50 100 {
+            [client_field client-to-evict tot-mem] > [mb 1]
+        } else {
+            fail "Failed to increase the second blocked client's memory usage"
+        }
+
+        # Apply the client-memory limit and make the key ready in one transaction.
+        # Eviction then runs while rd1 is being reprocessed, selecting rd2 while
+        # it is still in the blocked-client list.
+        r MULTI
+        r CONFIG SET MAXMEMORY-CLIENTS [kb 128]
+        r LPUSH mylist x
+        r EXEC
+
+        assert_equal {mylist x} [$rd1 read]
+        assert {![client_exists client-to-evict]} ;# rd2 is evicted
+        $rd1 close
+        $rd2 close
+    }
+}
+
 } ;# tags
 

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -655,6 +655,7 @@ start_server {} {
 
         # Block two clients on the same key in a known order.
         $rd1 BLPOP mylist 0
+        wait_for_blocked_clients_count 1
         $rd2 BLPOP mylist 0
         wait_for_blocked_clients_count 2
 


### PR DESCRIPTION
Fixes https://github.com/redis/redis/issues/15562.

handleClientsBlockedOnKey() used a list iterator while reprocessing clients
blocked on the same key. Reprocessing one client may trigger client eviction,
which can remove another blocked client and free the node cached by the
iterator, resulting in a use-after-free.

Replace the iterator with a bounded head-to-tail traversal. Before reprocessing
a client, move its node to the tail so the next waiter remains at the head while
preserving FIFO order. Since reprocessing may remove all blocked clients and
free the list, look up the list again before each iteration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core blocked-client wakeup logic on the event loop path; a bug could mis-order unblocks or crash under client eviction, though the change is narrowly scoped and regression-tested.
> 
> **Overview**
> Fixes a **use-after-free** in `handleClientsBlockedOnKey()` when reprocessing waiters on a ready key: unblocking or re-running a command can **evict another blocked client** and free list nodes still referenced by a list iterator.
> 
> **`handleClientsBlockedOnKey`** no longer walks the waiter list with `listNext`. It keeps a bounded iteration count, **re-fetches** `blocking_keys` each loop (the list may be freed), takes the head node, **rotates it to the tail** before reprocessing (FIFO for clients that stay blocked), then serves that client.
> 
> Adds an integration test that blocks two clients on the same key, inflates the second client’s memory, and triggers **client eviction during** the first client’s unblock/reprocess path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d593df5e3ff813e740bdd591d579b319e32947b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->