### PR TITLE
Fix SETBIT and BITFIELD keysizes histogram updates

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -788,8 +788,7 @@ int getBitfieldTypeFromArgument(client *c, robj *o, int *sign, int *bits) {
  * (Must provide all the arguments to the function)
  */
 static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit, 
-                                       size_t *strOldSize, size_t *strGrowSize,
-                                       int *created)
+                                       size_t *strOldSize, size_t *strGrowSize)
 {
     dictEntryLink link;
     size_t byte = maxbit >> 3;
@@ -800,12 +799,10 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
     if (o == NULL) {
         o = createObject(OBJ_STRING,sdsnewlen(NULL, byte+1));
         dbAddByLink(c->db,c->argv[1],&o,&link);
-        *created = 1;
         *strGrowSize = byte + 1;
         *strOldSize = 0;
     } else {
         o = dbUnshareStringValue(c->db,c->argv[1],o);
-        *created = 0;
         *strOldSize  = sdslen(o->ptr);
         if (server.memory_tracking_enabled)
             oldAllocSize = kvobjAllocSize(o);
@@ -813,6 +810,8 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
         if (server.memory_tracking_enabled)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldAllocSize, kvobjAllocSize(o));
         *strGrowSize = sdslen(o->ptr) - *strOldSize;
+        if (*strGrowSize != 0)
+            updateKeysizesHist(c->db, OBJ_STRING, *strOldSize, *strOldSize + *strGrowSize);
     }
     return o;
 }
@@ -869,8 +868,7 @@ void setbitCommand(client *c) {
     }
 
     size_t strOldSize, strGrowSize;
-    int created;
-    kvobj *o = lookupStringForBitCommand(c, bitoffset, &strOldSize, &strGrowSize, &created);
+    kvobj *o = lookupStringForBitCommand(c, bitoffset, &strOldSize, &strGrowSize);
     if (o == NULL) return;
 
     /* Get current values */
@@ -887,13 +885,6 @@ void setbitCommand(client *c) {
         byteval &= ~(1 << bit);
         byteval |= ((on & 0x1) << bit);
         ((uint8_t*)o->ptr)[byte] = byteval;
-
-        /* dbAddByLink() already recorded newly created keys in the histogram.
-         * For existing keys, update it before notifications whose callbacks
-         * may mutate or delete the key. */
-        if (!created && strGrowSize != 0)
-            updateKeysizesHist(c->db, OBJ_STRING, strOldSize, strOldSize + strGrowSize);
-
         keyModified(c,c->db,c->argv[1],o,1);
         notifyKeyspaceEvent(NOTIFY_STRING,"setbit",c->argv[1],c->db->id);
         server.dirty++;
@@ -1893,7 +1884,6 @@ void bitfieldGeneric(client *c, int flags) {
     uint64_t bitoffset;
     int j, numops = 0, changes = 0;
     size_t strOldSize = 0, strGrowSize = 0;
-    int created = 0;
     struct bitfieldOp *ops = NULL; /* Array of ops to execute at end. */
     int owtype = BFOVERFLOW_WRAP; /* Overflow type. */
     int readonly = 1;
@@ -1987,7 +1977,7 @@ void bitfieldGeneric(client *c, int flags) {
         /* Lookup by making room up to the farthest bit reached by
          * this operation. */
         if ((o = lookupStringForBitCommand(c,
-            highest_write_offset,&strOldSize,&strGrowSize,&created)) == NULL) {
+            highest_write_offset,&strOldSize,&strGrowSize)) == NULL) {
             zfree(ops);
             return;
         }
@@ -2114,10 +2104,6 @@ void bitfieldGeneric(client *c, int flags) {
     }
 
     if (changes) {
-        /* See the equivalent SETBIT update above. */
-        if (!created && strGrowSize != 0)
-            updateKeysizesHist(c->db, OBJ_STRING, strOldSize, strOldSize + strGrowSize);
-
         keyModified(c,c->db,c->argv[1],o,1);
         notifyKeyspaceEvent(NOTIFY_STRING,"setbit",c->argv[1],c->db->id);
         server.dirty += changes;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -788,7 +788,8 @@ int getBitfieldTypeFromArgument(client *c, robj *o, int *sign, int *bits) {
  * (Must provide all the arguments to the function)
  */
 static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit, 
-                                       size_t *strOldSize, size_t *strGrowSize) 
+                                       size_t *strOldSize, size_t *strGrowSize,
+                                       int *created)
 {
     dictEntryLink link;
     size_t byte = maxbit >> 3;
@@ -799,10 +800,12 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
     if (o == NULL) {
         o = createObject(OBJ_STRING,sdsnewlen(NULL, byte+1));
         dbAddByLink(c->db,c->argv[1],&o,&link);
+        *created = 1;
         *strGrowSize = byte + 1;
         *strOldSize = 0;
     } else {
         o = dbUnshareStringValue(c->db,c->argv[1],o);
+        *created = 0;
         *strOldSize  = sdslen(o->ptr);
         if (server.memory_tracking_enabled)
             oldAllocSize = kvobjAllocSize(o);
@@ -866,7 +869,8 @@ void setbitCommand(client *c) {
     }
 
     size_t strOldSize, strGrowSize;
-    kvobj *o = lookupStringForBitCommand(c, bitoffset, &strOldSize, &strGrowSize);
+    int created;
+    kvobj *o = lookupStringForBitCommand(c, bitoffset, &strOldSize, &strGrowSize, &created);
     if (o == NULL) return;
 
     /* Get current values */
@@ -883,15 +887,16 @@ void setbitCommand(client *c) {
         byteval &= ~(1 << bit);
         byteval |= ((on & 0x1) << bit);
         ((uint8_t*)o->ptr)[byte] = byteval;
+
+        /* dbAddByLink() already recorded newly created keys in the histogram.
+         * For existing keys, update it before notifications whose callbacks
+         * may mutate or delete the key. */
+        if (!created && strGrowSize != 0)
+            updateKeysizesHist(c->db, OBJ_STRING, strOldSize, strOldSize + strGrowSize);
+
         keyModified(c,c->db,c->argv[1],o,1);
         notifyKeyspaceEvent(NOTIFY_STRING,"setbit",c->argv[1],c->db->id);
         server.dirty++;
-
-        /* If this is not a new key (old size not 0) and size changed, then 
-         * update the keysizes histogram. Otherwise, the histogram already 
-         * updated in lookupStringForBitCommand() by calling dbAdd(). */
-        if ((strOldSize > 0) && (strGrowSize != 0))
-            updateKeysizesHist(c->db, OBJ_STRING, strOldSize, strOldSize + strGrowSize);
     }
 
     /* Return original value. */
@@ -1888,6 +1893,7 @@ void bitfieldGeneric(client *c, int flags) {
     uint64_t bitoffset;
     int j, numops = 0, changes = 0;
     size_t strOldSize = 0, strGrowSize = 0;
+    int created = 0;
     struct bitfieldOp *ops = NULL; /* Array of ops to execute at end. */
     int owtype = BFOVERFLOW_WRAP; /* Overflow type. */
     int readonly = 1;
@@ -1981,7 +1987,7 @@ void bitfieldGeneric(client *c, int flags) {
         /* Lookup by making room up to the farthest bit reached by
          * this operation. */
         if ((o = lookupStringForBitCommand(c,
-            highest_write_offset,&strOldSize,&strGrowSize)) == NULL) {
+            highest_write_offset,&strOldSize,&strGrowSize,&created)) == NULL) {
             zfree(ops);
             return;
         }
@@ -2108,13 +2114,10 @@ void bitfieldGeneric(client *c, int flags) {
     }
 
     if (changes) {
-
-        /* If this is not a new key (old size not 0) and size changed, then 
-         * update the keysizes histogram. Otherwise, the histogram already 
-         * updated in lookupStringForBitCommand() by calling dbAdd(). */
-        if ((strOldSize > 0) && (strGrowSize != 0))
+        /* See the equivalent SETBIT update above. */
+        if (!created && strGrowSize != 0)
             updateKeysizesHist(c->db, OBJ_STRING, strOldSize, strOldSize + strGrowSize);
-        
+
         keyModified(c,c->db,c->argv[1],o,1);
         notifyKeyspaceEvent(NOTIFY_STRING,"setbit",c->argv[1],c->db->id);
         server.dirty += changes;

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -122,7 +122,14 @@ static int KeySpace_NotificationModuleKeyMiss(RedisModuleCtx *ctx, int type, con
 
 static int KeySpace_NotificationModuleString(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
     REDISMODULE_NOT_USED(type);
-    REDISMODULE_NOT_USED(event);
+    const char *key_str = RedisModule_StringPtrLen(key, NULL);
+
+    if (strcmp(event, "setbit") == 0 && strncmp(key_str, "stringdel_", 10) == 0) {
+        RedisModuleCallReply *rep = RedisModule_Call(ctx, "DEL", "s!", key);
+        if (rep) RedisModule_FreeCallReply(rep);
+        return REDISMODULE_OK;
+    }
+
     RedisModuleKey *redis_key = RedisModule_OpenKey(ctx, key, REDISMODULE_READ);
 
     size_t len = 0;

--- a/tests/unit/info-keysizes.tcl
+++ b/tests/unit/info-keysizes.tcl
@@ -703,11 +703,17 @@ proc test_all_keysizes { {replMode 0} } {
         run_cmd_verify_hist {$server BITOP XOR b5 b1 b2} {db0_STR:8=5}        
         # SETBIT
         run_cmd_verify_hist {$server FLUSHALL} {}
+        run_cmd_verify_hist {$server SET b0 ""} {db0_STR:0=1}
+        run_cmd_verify_hist {$server SETBIT b0 72 1} {db0_STR:8=1}
+        run_cmd_verify_hist {$server FLUSHALL} {}
         run_cmd_verify_hist {$server setbit b1 71 1} {db0_STR:8=1}
         run_cmd_verify_hist {$server setbit b1 72 1} {db0_STR:8=1}
         run_cmd_verify_hist {$server setbit b2 72 1} {db0_STR:8=2}
         run_cmd_verify_hist {$server setbit b2 640 0} {db0_STR:8=1,64=1}
         # BITFIELD
+        run_cmd_verify_hist {$server FLUSHALL} {}
+        run_cmd_verify_hist {$server SET b0 ""} {db0_STR:0=1}
+        run_cmd_verify_hist {$server BITFIELD b0 SET u8 72 255} {db0_STR:8=1}
         run_cmd_verify_hist {$server FLUSHALL} {}
         run_cmd_verify_hist {$server bitfield b3 set u8 6 255} {db0_STR:2=1}
         run_cmd_verify_hist {$server bitfield b3 set u8 65 255} {db0_STR:8=1}

--- a/tests/unit/info-keysizes.tcl
+++ b/tests/unit/info-keysizes.tcl
@@ -778,6 +778,13 @@ proc test_all_keysizes { {replMode 0} } {
 start_server {} {
     r select 0
     test_all_keysizes 0
+
+    test "KEYSIZES - BITFIELD OVERFLOW FAIL growth updates histogram" {
+        run_cmd_verify_hist {r FLUSHALL} {}
+        run_cmd_verify_hist {r SET b0 ""} {db0_STR:0=1}
+        run_cmd_verify_hist {r BITFIELD b0 OVERFLOW FAIL SET u8 72 256} {db0_STR:8=1}
+    } {} {cluster:skip}
+
     # Start another server to test replication of KEYSIZES
     start_server {tags {needs:repl external:skip}} {
         # Set the outer layer server as primary

--- a/tests/unit/info-keysizes.tcl
+++ b/tests/unit/info-keysizes.tcl
@@ -780,6 +780,7 @@ start_server {} {
     test_all_keysizes 0
 
     test "KEYSIZES - BITFIELD OVERFLOW FAIL growth updates histogram" {
+        r select 0
         run_cmd_verify_hist {r FLUSHALL} {}
         run_cmd_verify_hist {r SET b0 ""} {db0_STR:0=1}
         run_cmd_verify_hist {r BITFIELD b0 OVERFLOW FAIL SET u8 72 256} {db0_STR:8=1}

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -105,6 +105,20 @@ tags "modules external:skip" {
             assert_equal $before_unsub $after_unsub
         }
 
+        test "Keyspace notifications: bit writes update keysizes before module callbacks" {
+            assert_equal OK [r DEBUG KEYSIZES-HIST-ASSERT 1]
+
+            r set stringdel_setbit x
+            r setbit stringdel_setbit 16 1
+            assert_equal 0 [r exists stringdel_setbit]
+
+            r set stringdel_bitfield x
+            r bitfield stringdel_bitfield set u8 16 1
+            assert_equal 0 [r exists stringdel_bitfield]
+
+            assert_equal OK [r DEBUG KEYSIZES-HIST-ASSERT 0]
+        } {} {needs:debug}
+
         test {Test expired key space event} {
             set prev_expired [s expired_keys]
             r set exp 1 PX 10


### PR DESCRIPTION
Fixes #15597

This was found while reviewing #15331.

## Summary

- Centralize existing-string histogram updates in the shared bitmap write lookup, immediately after the string grows.
- Keep newly created keys on the existing `dbAddByLink()` accounting path.
- Remove the `created` out-parameter and duplicate SETBIT/BITFIELD call-site accounting.
- Add regression coverage for existing empty strings, all-failing `BITFIELD OVERFLOW FAIL` growth, successful-write replication, and nested module callback deletion.

## Root cause

Histogram accounting was deferred to the SETBIT and BITFIELD command tails. It used `strOldSize > 0` as a proxy for key existence, so existing empty strings were mistaken for new keys. BITFIELD also eagerly grows the string before executing operations, so when every operation returns `FAIL`, the string grows without reaching the `changes`-guarded accounting block.

Updating the histogram alongside `sdsgrowzero()` records every existing-string size change and does so before any later notification callback can mutate or delete the key. This PR is intentionally limited to histogram accounting; dirty tracking and propagation for all-failing BITFIELD writes are a separate issue.

## Validation

- `make -C src bitops.o redis-server` with the default GCC/LTO build flags
- `./runtest --single unit/info-keysizes --only "KEYSIZES - BITFIELD OVERFLOW FAIL growth updates histogram"`
- `./runtest --single unit/info-keysizes --only "/KEYSIZES - Test STRING BITS"`
- `./runtest --single unit/bitops`
- `./runtest --single unit/bitfield`
- `./runtest --single unit/moduleapi/keyspace_events --only "Keyspace notifications: bit writes update keysizes before module callbacks"` with `DEBUG_ASSERTIONS`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to keysizes histogram accounting in bit string helpers; behavior of SETBIT/BITFIELD data and replication dirty flags is unchanged aside from histogram correctness.
> 
> **Overview**
> Fixes incorrect or missing **INFO keysizes** string histogram updates when **SETBIT** and **BITFIELD** grow an existing key’s bitmap.
> 
> Histogram updates for existing strings now run in **`lookupStringForBitCommand`** immediately after **`sdsgrowzero`**, instead of at the end of SETBIT/BITFIELD using a `strOldSize > 0` check that skipped **existing empty strings** and missed **BITFIELD** growth when every write returns **OVERFLOW FAIL** (no `changes` path). New keys still rely on **`dbAddByLink`** accounting; duplicate tail logic in SETBIT and BITFIELD is removed so sizing is recorded **before** `setbit` keyspace notifications fire.
> 
> Regression tests cover empty-string SETBIT/BITFIELD growth, all-failing BITFIELD OVERFLOW FAIL growth, and a module that **DEL**s the key on `setbit` while **DEBUG KEYSIZES-HIST-ASSERT** is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5b5aae03da098d165b5edf15c694e64f8612a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->