### PR TITLE
Hash avoid duplicating external SDS on field TTL updates

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -336,12 +336,9 @@ Entry *entryUpdate(Entry *entry, sds value, uint32_t flags, ssize_t *usableDiff)
     if (needsNewAlloc(entry, &info, isUpdateVal, expiryAddRemove)) {
         Entry *oldEntry = entry;
         /* If not updating value */
-        if (value == NULL) {
+        if (!isUpdateVal) {
             /* Should not flag ownership of value if not updating value */
             debugServerAssert((info.flags & ENTRY_TAKE_VALUE) == 0);
-            
-            /* Try reuse the existing value */
-            value = entryGetValue(oldEntry);
             
             /* If value is a pointer, we can transfer it from old to new entry  */
             if (entryHasValuePtr(oldEntry)) {

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -292,6 +292,30 @@ start_server {tags {"external:skip needs:debug"}} {
             assert_range [r HEXPIRETIME myhash FIELDS 1 field1] $lo $hi
             assert_range [r HPEXPIRETIME myhash FIELDS 1 field1] [expr $lo*1000] [expr $hi*1000]
         }
+
+        test "HPEXPIRE keeps existing field values unchanged when adding expiry metadata ($type)" {
+            r del myhash
+            set value value1
+            if {$type eq "hashtable"} {
+                set value [string repeat x 1024]
+            }
+            r HSET myhash field1 $value field2 value2
+
+            # HPEXPIRE updates expiry metadata without passing a new value to entryUpdate.
+            assert_equal [r HPEXPIRE myhash 60000 FIELDS 1 field1] [list $E_OK]
+            assert_encoding $type myhash
+            assert_equal [r HGET myhash field1] $value
+            assert_equal [r HGET myhash field2] value2
+            assert_equal [r HLEN myhash] 2
+            assert_range [r HPTTL myhash FIELDS 1 field1] 1 60000
+            assert_equal [r HPTTL myhash FIELDS 1 field2] [list $T_NO_EXPIRY]
+
+            # Verify the non-NULL value update path is unaffected.
+            assert_equal [r HSET myhash field1 updated] 0
+            assert_equal [r HGET myhash field1] updated
+            assert_equal [r HGET myhash field2] value2
+            assert_equal [r HPTTL myhash FIELDS 1 field1] [list $T_NO_EXPIRY]
+        }
         
         test "HPEXPIRETIME persists after RDB reload ($type)" {
             r del myhash


### PR DESCRIPTION

## Issue

When `HEXPIRE` or `HPEXPIRE` adds expiry metadata, `entryUpdate()` is called without a new value. The function saves the existing value before deciding how to rebuild the entry:

```c
if (!value)
    value = entryGetValue(entry);
```

The later `if (value == NULL)` check is therefore dead code. Its external SDS ownership transfer never runs.

For a large external SDS, `entryWriteNew()` calls `sdsdup()` and `entryFree()` then releases the old copy. This temporarily keeps two full copies of the value in memory and can cause unnecessary OOM under memory pressure.

## Change

Use `isUpdateVal`, captured before replacing `value`, to identify expiry-only updates.


## Test

CI of `--single unit/type/hash-field-expire`: https://github.com/vitahlin/redis/actions/runs/31095245455

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core hash entry memory ownership during realloc; behavior change is narrow (expiry-only, pointer values) and covered by new tests.
> 
> **Overview**
> Fixes **expiry-only** hash field updates (`HPEXPIRE` / `HEXPIRE`) so pointer-backed values are **moved** into the new entry instead of duplicated.
> 
> In `entryUpdate()`, when the caller passes no new value, the code still resolves `value` from the existing entry before reallocating. The rebuild path therefore used `value == NULL` to detect “metadata only” updates, which never matched, so **`ENTRY_TAKE_VALUE` transfer from the old entry was skipped** and `entryWriteNew()` **`sdsdup()`’d** large external SDS values—briefly doubling memory and risking OOM.
> 
> The realloc branch now keys off **`isUpdateVal`** (whether a new value was supplied) so expiry-only rebuilds clear the old value pointer and pass ownership to the new entry.
> 
> Adds a unit test that **`HPEXPIRE`** preserves field data (including a **1KB** value under **hashtable** encoding) and that a normal **`HSET`** update still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4fb6345ba6d212a8453ea4296b544f993acdf31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->