### PR TITLE
Report only changed options in CONFIG SET events

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -902,7 +902,6 @@ void configSetCommand(client *c) {
             }
         }
         set_configs[i] = config;
-        config_names[i] = config->name;
         new_values[i] = c->argv[2+i*2+1]->ptr;
     }
     
@@ -924,9 +923,12 @@ void configSetCommand(client *c) {
         else config_changed[i] = 0;
     }
 
+    int num_changes = 0;
+
     /* Apply all configs that need it */
     for (i = 0; i < config_count; i++) {
         if (!config_changed[i]) continue;
+        config_names[num_changes++] = set_configs[i]->name;
 
         /* A new value was set, if this config has an apply function try to apply
          * it and restore if apply fails. */
@@ -945,8 +947,10 @@ void configSetCommand(client *c) {
         }
     }
 
-    RedisModuleConfigChangeV1 cc = {.num_changes = config_count, .config_names = config_names};
-    moduleFireServerEvent(REDISMODULE_EVENT_CONFIG, REDISMODULE_SUBEVENT_CONFIG_CHANGE, &cc);
+    if (num_changes) {
+        RedisModuleConfigChangeV1 cc = {.num_changes = num_changes, .config_names = config_names};
+        moduleFireServerEvent(REDISMODULE_EVENT_CONFIG, REDISMODULE_SUBEVENT_CONFIG_CHANGE, &cc);
+    }
     addReply(c,shared.ok);
     goto end;
 

--- a/src/config.c
+++ b/src/config.c
@@ -923,9 +923,8 @@ void configSetCommand(client *c) {
         else config_changed[i] = 0;
     }
 
-    int num_changes = 0;
-
     /* Apply all configs that need it */
+    int num_changes = 0;
     for (i = 0; i < config_count; i++) {
         if (!config_changed[i]) continue;
         config_names[num_changes++] = set_configs[i]->name;

--- a/tests/unit/moduleapi/hooks.tcl
+++ b/tests/unit/moduleapi/hooks.tcl
@@ -300,9 +300,31 @@ tags "modules external:skip" {
         }
 
         test {Test configchange hooks} {
-            r config set rdbcompression no 
+            set rdbcompression [lindex [r config get rdbcompression] 1]
+            set dynamic_hz [lindex [r config get dynamic-hz] 1]
+
+            r config set rdbcompression yes dynamic-hz yes
+
+            # Only configs whose values changed are included in the event.
+            set events_before [r hooks.event_count config-change-count]
+            r config set rdbcompression no dynamic-hz yes
+            assert_equal [r hooks.event_count config-change-count] [expr {$events_before + 1}]
             assert_equal [r hooks.event_last config-change-count] 1
             assert_equal [r hooks.event_last config-change-first] rdbcompression
+
+            # Also verify that an unchanged config before a changed one is filtered out.
+            set events_before [r hooks.event_count config-change-count]
+            r config set rdbcompression no dynamic-hz no
+            assert_equal [r hooks.event_count config-change-count] [expr {$events_before + 1}]
+            assert_equal [r hooks.event_last config-change-count] 1
+            assert_equal [r hooks.event_last config-change-first] dynamic-hz
+
+            # No event is fired when none of the specified configs changed.
+            set events_before [r hooks.event_count config-change-count]
+            r config set rdbcompression no dynamic-hz no
+            assert_equal [r hooks.event_count config-change-count] $events_before
+
+            r config set rdbcompression $rdbcompression dynamic-hz $dynamic_hz
         }
 
         # look into the log file of the server that just exited


### PR DESCRIPTION

## Issue

`CONFIG SET` tracks whether each setter changed its value, but `REDISMODULE_EVENT_CONFIG_CHANGE` reports every option passed to the command. As a result, `num_changes` and `config_names` include unchanged options, and an event is fired even when nothing changed.

## Change

Build `config_names` from options whose setters report a change, preserving their command order. Do not fire the configuration change event when `num_changes` is zero.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change for modules listening on config-change events; low blast radius but may break consumers that assumed all CONFIG SET arguments were reported.
> 
> **Overview**
> **`CONFIG SET`** now aligns **`REDISMODULE_EVENT_CONFIG`** / **`REDISMODULE_SUBEVENT_CONFIG_CHANGE`** with what setters already track: **`num_changes`** and **`config_names`** list only options whose values actually changed (still in **`CONFIG SET`** argument order), and the event is **not** fired when every option in the command is a no-op.
> 
> Module API tests in **`hooks.tcl`** cover mixed changed/unchanged pairs, filtering unchanged options that appear before a changed one, and skipping the event when nothing changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a794d604433813176a2f7000b2491f063fb41ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->