### PR TITLE
Avoid resizing slot dict during atomic slot import

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5931,13 +5931,8 @@ int getClusterSize(void) {
 }
 
 int getMyShardSlotCount(void) {
-    if (!nodeIsSlave(server.cluster->myself)) {
-        return server.cluster->myself->numslots;
-    } else if (server.cluster->myself->slaveof) {
-        return server.cluster->myself->slaveof->numslots;
-    } else {
-        return 0;
-    }
+    clusterNode *master = clusterNodeGetMaster(getMyClusterNode());
+    return master->numslots;
 }
 
 char **getClusterNodesList(size_t *numnodes) {

--- a/src/db.c
+++ b/src/db.c
@@ -3067,11 +3067,10 @@ keyStatus expireIfNeeded(redisDb *db, robj *key, kvobj *kv, int flags) {
     return KEY_DELETED;
 }
 
-/* CB passed to kvstoreExpand.
- * The purpose is to skip expansion of unused dicts in cluster mode (all
- * dicts not mapped to *my* slots) */
+/* Callback passed to kvstoreExpand. Skip expansion for slots whose keys cannot
+ * be accessed by this node, the slot is not owned by this node or its master. */
 static int dbExpandSkipSlot(int slot) {
-    return !clusterNodeCoversSlot(getMyClusterNode(), slot);
+    return !clusterCanAccessKeysInSlot(slot);
 }
 
 /*

--- a/src/db.c
+++ b/src/db.c
@@ -3067,10 +3067,10 @@ keyStatus expireIfNeeded(redisDb *db, robj *key, kvobj *kv, int flags) {
     return KEY_DELETED;
 }
 
-/* Callback passed to kvstoreExpand. Skip expansion for slots whose keys cannot
- * be accessed by this node, the slot is not owned by this node or its master. */
+/* Callback passed to kvstoreExpand. Skip expansion for slots not owned by this
+ * node, or by its master when this node is a replica. */
 static int dbExpandSkipSlot(int slot) {
-    return !clusterCanAccessKeysInSlot(slot);
+    return !clusterNodeCoversSlot(clusterNodeGetMaster(getMyClusterNode()), slot);
 }
 
 /*

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -648,17 +648,19 @@ dictEntry *kvstoreIteratorNext(kvstoreIterator *kvs_it) {
     return de;
 }
 
-/* This method traverses through kvstore dictionaries and triggers a resize.
- * It first tries to shrink if needed, and if it isn't, it tries to expand. */
-void kvstoreTryResizeDicts(kvstore *kvs, int limit) {
+/* This method traverses through kvstore dictionaries and triggers a resize,
+ * unless skip_cb indicates otherwise. It first tries to shrink if needed, and
+ * if it doesn't try to shrink, it tries to expand. */
+void kvstoreTryResizeDicts(kvstore *kvs, int limit, kvstoreResizeShouldSkipDictIndex *skip_cb) {
     if (limit > kvs->num_dicts)
         limit = kvs->num_dicts;
 
     for (int i = 0; i < limit; i++) {
         int didx = kvs->resize_cursor;
         dict *d = kvstoreGetDict(kvs, didx);
-        if (d && dictShrinkIfNeeded(d) == DICT_ERR) {
-            dictExpandIfNeeded(d);
+        if (d && (!skip_cb || !skip_cb(didx))) {
+            if (dictShrinkIfNeeded(d) == DICT_ERR)
+                dictExpandIfNeeded(d);
         }
         kvs->resize_cursor = (didx + 1) % kvs->num_dicts;
     }

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -49,6 +49,7 @@ typedef struct _kvstoreDictIterator {
 typedef int (kvstoreScanShouldSkipDict)(dict *d, int didx);
 typedef int (kvstoreExpandShouldSkipDictIndex)(int didx);
 typedef int (kvstoreRandomShouldSkipDictIndex)(int didx);
+typedef int (kvstoreResizeShouldSkipDictIndex)(int didx);
 
 /* kvstoreType: Callback structure for kvstore-specific operations.
  * Similar to dictType for dict, this allows kvstore to be a generic data structure
@@ -115,7 +116,7 @@ int kvstoreIteratorGetCurrentDictIndex(kvstoreIterator *kvs_it);
 dictEntry *kvstoreIteratorNext(kvstoreIterator *kvs_it);
 
 /* Rehashing */
-void kvstoreTryResizeDicts(kvstore *kvs, int limit);
+void kvstoreTryResizeDicts(kvstore *kvs, int limit, kvstoreResizeShouldSkipDictIndex *skip_cb);
 uint64_t kvstoreIncrementallyRehash(kvstore *kvs, uint64_t threshold_us);
 size_t kvstoreOverheadHashtableLut(kvstore *kvs);
 size_t kvstoreOverheadHashtableRehashing(kvstore *kvs);

--- a/src/server.c
+++ b/src/server.c
@@ -1305,9 +1305,11 @@ void clientsCron(void) {
 }
 
 static int resizeShouldSkip(int didx) {
-    /* ASM resizes importing slot dictionaries using the size hint. Skip cron
-     * resizing until the slot becomes accessible. */
-    return !clusterCanAccessKeysInSlot(didx);
+    if (!server.cluster_enabled) return 0;
+
+    /* ASM resizes importing slot dict using the size hint. Skip cron
+     * resizing until this node, or its master, owns the slot. */
+    return !clusterNodeCoversSlot(clusterNodeGetMaster(getMyClusterNode()), didx);
 }
 
 /* This function handles 'background' operations we are required to do

--- a/src/server.c
+++ b/src/server.c
@@ -1304,6 +1304,12 @@ void clientsCron(void) {
     }
 }
 
+static int resizeShouldSkip(int didx) {
+    /* ASM resizes importing slot dictionaries using the size hint. Skip cron
+     * resizing until the slot becomes accessible. */
+    return !clusterCanAccessKeysInSlot(didx);
+}
+
 /* This function handles 'background' operations we are required to do
  * incrementally in Redis databases, such as active key expiring, resizing,
  * rehashing. */
@@ -1342,8 +1348,8 @@ void databasesCron(void) {
 
         for (j = 0; j < dbs_per_call; j++) {
             redisDb *db = &server.db[resize_db % server.dbnum];
-            kvstoreTryResizeDicts(db->keys, CRON_DICTS_PER_DB);
-            kvstoreTryResizeDicts(db->expires, CRON_DICTS_PER_DB);
+            kvstoreTryResizeDicts(db->keys, CRON_DICTS_PER_DB, resizeShouldSkip);
+            kvstoreTryResizeDicts(db->expires, CRON_DICTS_PER_DB, resizeShouldSkip);
             resize_db++;
         }
 


### PR DESCRIPTION
During atomic slot migration, the destination pre-expands each slot dictionary
using the source key-count hint. However, before enough keys are imported,
the cron resize cycle may shrink it, causing unnecessary re-expansion as
the import continues.

This change adds a filter to `kvstoreTryResizeDicts()` and skips cron-driven
resizing for slots that are not currently accessible, including slots being
imported by ASM.

Also fix slot dict not expanded when reading RDB_OPCODE_RESIZEDB from
old rdb version (before 7.4) in cluster mode, since replicas do not maintain their
own assigned slots. Now we check the master owned slots.

This PR also fixes getMyShardSlotCount() for the transient sub-replica state that
can occur during failover. A replica may temporarily still follow the old primary after
that primary has become a replica of the new primary, forming `replica -> old master -> new master`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster slot ownership checks on the hot database cron resize path; behavior change is scoped to non-owned/importing slots but affects memory sizing during ASM.
> 
> **Overview**
> **Cron-driven kvstore resize** no longer shrinks or expands slot dictionaries the node cannot serve yet—especially during atomic slot migration (ASM), where the destination pre-expands from a size hint and cron used to shrink before keys arrived.
> 
> `kvstoreTryResizeDicts` now takes an optional per-dict-index skip callback; `databasesCron` passes `resizeShouldSkip`, which in cluster mode skips slots not covered by **this node’s master** (so replicas follow the primary’s slot map). The same **master-based** slot check replaces ad hoc replica logic in `dbExpandSkipSlot` and `getMyShardSlotCount`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67df880aaaeb6a669578a02a19e9edba4431f8bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->