### PR TITLE
For docs: update to replace group=module with real module group

### DIFF
--- a/utils/generate-commands-json.py
+++ b/utils/generate-commands-json.py
@@ -7,6 +7,38 @@ import subprocess
 from collections import OrderedDict
 
 
+# Module commands are reported by `COMMAND DOCS` with a group of "module", so
+# the group is derived from the command's name prefix instead. Prefixes are
+# matched longest-first, so overlapping prefixes are unambiguous.
+MODULE_COMMAND_GROUPS = {
+    'BF.': 'bf',
+    'CF.': 'cf',
+    'CMS.': 'cms',
+    'FT.': 'search',
+    '_FT.': 'search',
+    'SEARCH.': 'search',
+    'JSON.': 'json',
+    'TDIGEST.': 'tdigest',
+    'TOPK.': 'topk',
+    'TS.': 'timeseries',
+    'TIMESERIES.': 'timeseries',
+    'V': 'vector_set',
+}
+
+MODULE_COMMAND_PREFIXES = sorted(MODULE_COMMAND_GROUPS, key=len, reverse=True)
+
+
+def get_module_command_group(name):
+    """Return the group of a module command, based on its name prefix.
+
+    'name' is the command's full upper-case name. Commands with an unknown
+    prefix keep the generic "module" group."""
+    for prefix in MODULE_COMMAND_PREFIXES:
+        if name.startswith(prefix):
+            return MODULE_COMMAND_GROUPS[prefix]
+    return 'module'
+
+
 def convert_flags_to_boolean_dict(flags):
     """Return a dict with a key set to `True` per element in the flags list."""
     return {f: True for f in flags}
@@ -71,6 +103,8 @@ def convert_entry_to_objects_array(cmd, docs):
     value = OrderedDict()
     group = docs.pop('group')
     if group == 'module':
+        # Modules don't declare a group, so it is derived from the command's name
+        group = get_module_command_group(name)
         set_if_not_none_or_empty(value, 'summary', docs.pop('summary', None))
         set_if_not_none_or_empty(value, 'since', docs.pop('since', None))
     else:


### PR DESCRIPTION
The docs team relies on each command's `group` designation. With 8.x, the `utils/generate-commands-json.py` script produces output for all commands; Redis core commands and all the module commands. However, for the module commands, their `group` is set to `module`.

The utility script `utils/generate-commands-json.py:9-38` now has a `MODULE_COMMAND_GROUPS` table plus a `get_module_command_group()` helper, and the `group == 'module'` branch in `convert_entry_to_objects_array()` derives the group from the command name instead of emitting `module`.

Details:

- Longest-prefix matching — prefixes are sorted by descending length so overlaps (TS. vs TIMESERIES., FT. vs _FT.) resolve to the more specific one regardless of dict order.
- Mappings: JSON.→json, TS./TIMESERIES.→timeseries, BF.→bf, CF.→cf, CMS.→cms, TOPK.→topk, TDIGEST.→tdigest, FT./_FT./SEARCH.→search, V→vector_set.
- Fallback — an unrecognized prefix keeps "module", so a future bundled module won't produce a bogus group.
- Subcommands work too: `COMMAND` reports them as parent|sub (e.g. `_FT.CONFIG|GET`), so the prefix is still present when the recursion converts them.
- The relaxed handling of `summary/since` for module commands is unchanged — it's still keyed off the original `module` group, not the derived one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change to the commands JSON generator; no server or runtime behavior is affected.
> 
> **Overview**
> **`utils/generate-commands-json.py`** no longer emits `group: "module"` for bundled module commands in generated `commands.json`. When `COMMAND DOCS` reports `group == 'module'`, the script now sets **`group`** from the upper-case command name via a prefix table (e.g. `JSON.` → `json`, `TS.` / `TIMESERIES.` → `timeseries`, `FT.` / `_FT.` / `SEARCH.` → `search`, Bloom/CF/CMS/TOPK/TDigest, `V` → `vector_set`). Prefixes are matched **longest-first** so overlapping names resolve consistently; unknown prefixes still use **`module`**.
> 
> The branch that treats **`summary`** / **`since`** as optional for module commands is unchanged—it still keys off the original **`module`** group from docs, not the derived group name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3adb2ca58daeffcb254ebd1e5092b607b817c5a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->