### PR TITLE
Fix BITFIELD OVERFLOW FAIL growth propagation

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -2107,17 +2107,18 @@ void bitfieldGeneric(client *c, int flags) {
         }
     }
 
-    if (changes) {
+    /* If this is not a new key (old size not 0) and size changed, then
+     * update the keysizes histogram. Otherwise, the histogram already
+     * updated in lookupStringForBitCommand() by calling dbAdd(). */
+    if (changes && (strOldSize > 0) && (strGrowSize != 0))
+        updateKeysizesHist(c->db, OBJ_STRING, strOldSize, strOldSize + strGrowSize);
 
-        /* If this is not a new key (old size not 0) and size changed, then 
-         * update the keysizes histogram. Otherwise, the histogram already 
-         * updated in lookupStringForBitCommand() by calling dbAdd(). */
-        if ((strOldSize > 0) && (strGrowSize != 0))
-            updateKeysizesHist(c->db, OBJ_STRING, strOldSize, strOldSize + strGrowSize);
-        
+    if (changes || strGrowSize) {
         keyModified(c,c->db,c->argv[1],o,1);
         notifyKeyspaceEvent(NOTIFY_STRING,"setbit",c->argv[1],c->db->id);
-        server.dirty += changes;
+        /* OVERFLOW FAIL can reject every write after the string has already
+         * grown. Account for that growth as one mutation. */
+        server.dirty += changes ? changes : 1;
     }
     zfree(ops);
 }

--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -165,6 +165,52 @@ start_server {tags {"bitops"}} {
         }
     }
 
+    test {BITFIELD OVERFLOW FAIL accounts for eager string growth} {
+        r del bitfield-fail-created bitfield-fail-grown bitfield-fail-marker
+        set old_notify_config [lindex [r config get notify-keyspace-events] 1]
+        r config set notify-keyspace-events {E$}
+
+        set rd [redis_deferring_client]
+        set event_pattern {__keyevent@*__:setbit}
+        assert_equal {1} [psubscribe $rd $event_pattern]
+
+        # A failed write still creates enough zero-filled storage for the
+        # requested bit. That allocation is a mutation even though the result
+        # contains a null entry.
+        set dirty [s rdb_changes_since_last_save]
+        set result [r bitfield bitfield-fail-created overflow fail set u1 0 2]
+        assert_equal 1 [llength $result]
+        assert_equal {} [lindex $result 0]
+        assert_equal 1 [r exists bitfield-fail-created]
+        assert_equal 1 [r strlen bitfield-fail-created]
+        assert_equal [expr {$dirty + 1}] [s rdb_changes_since_last_save]
+        assert_equal bitfield-fail-created [lindex [$rd read] 3]
+
+        # The same applies when an existing string is extended.
+        r set bitfield-fail-grown {}
+        set dirty [s rdb_changes_since_last_save]
+        set result [r bitfield bitfield-fail-grown overflow fail set u1 63 2]
+        assert_equal 1 [llength $result]
+        assert_equal {} [lindex $result 0]
+        assert_equal 8 [r strlen bitfield-fail-grown]
+        assert_equal [string repeat "\x00" 8] [r get bitfield-fail-grown]
+        assert_equal [expr {$dirty + 1}] [s rdb_changes_since_last_save]
+        assert_equal bitfield-fail-grown [lindex [$rd read] 3]
+
+        # If no storage grows, an all-failed command remains a no-op. The
+        # marker event proves that no notification was queued for it.
+        set dirty [s rdb_changes_since_last_save]
+        set result [r bitfield bitfield-fail-grown overflow fail set u1 0 2]
+        assert_equal 1 [llength $result]
+        assert_equal {} [lindex $result 0]
+        assert_equal $dirty [s rdb_changes_since_last_save]
+        r setbit bitfield-fail-marker 0 1
+        assert_equal bitfield-fail-marker [lindex [$rd read] 3]
+
+        $rd close
+        r config set notify-keyspace-events $old_notify_config
+    }
+
     test {BITFIELD overflow wrap fuzzing} {
         for {set j 0} {$j < 1000} {incr j} {
             set bits [expr {[randomInt 64]+1}]
@@ -264,6 +310,23 @@ start_server {tags {"repl external:skip"}} {
             assert_equal 100 [$slave bitfield_ro bits get u8 0]
         }
 
+        test {BITFIELD OVERFLOW FAIL growth is replicated} {
+            $master del bitfield-fail-created bitfield-fail-grown
+            $master set bitfield-fail-grown {}
+            wait_for_ofs_sync $master $slave
+
+            set created_result [$master bitfield bitfield-fail-created overflow fail set u1 0 2]
+            set grown_result [$master bitfield bitfield-fail-grown overflow fail set u1 63 2]
+            assert_equal {} [lindex $created_result 0]
+            assert_equal {} [lindex $grown_result 0]
+            wait_for_ofs_sync $master $slave
+
+            assert_equal 1 [$slave strlen bitfield-fail-created]
+            assert_equal "\x00" [$slave get bitfield-fail-created]
+            assert_equal 8 [$slave strlen bitfield-fail-grown]
+            assert_equal [string repeat "\x00" 8] [$slave get bitfield-fail-grown]
+        }
+
         test {BITFIELD_RO with only key as argument on read-only replica} {
             set res [$slave bitfield_ro bits]
             assert {$res eq {}}
@@ -273,5 +336,25 @@ start_server {tags {"repl external:skip"}} {
             catch {$slave bitfield_ro bits set u8 0 100 get u8 0} err
             assert_match {*ERR BITFIELD_RO only supports the GET subcommand*} $err
         }
+    }
+}
+
+start_server {tags {"bitops aof external:skip"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save {}}} {
+    test {BITFIELD OVERFLOW FAIL growth is persisted to AOF} {
+        r flushall
+        r set bitfield-fail-grown {}
+
+        set created_result [r bitfield bitfield-fail-created overflow fail set u1 0 2]
+        set grown_result [r bitfield bitfield-fail-grown overflow fail set u1 63 2]
+        assert_equal {} [lindex $created_result 0]
+        assert_equal {} [lindex $grown_result 0]
+        assert_equal {1 0} [r waitaof 1 0 0]
+
+        restart_server 0 true false true nosave
+
+        assert_equal 1 [r strlen bitfield-fail-created]
+        assert_equal "\x00" [r get bitfield-fail-created]
+        assert_equal 8 [r strlen bitfield-fail-grown]
+        assert_equal [string repeat "\x00" 8] [r get bitfield-fail-grown]
     }
 }


### PR DESCRIPTION
Fixes #15599.

## Problem

`BITFIELD` grows its destination string before processing its operations. If every
write overflows with `OVERFLOW FAIL`, the command returns null results but the
string may already have been created or extended. Because `changes` remains zero,
Redis skips mutation bookkeeping and the primary can diverge from replicas or an
AOF-reloaded dataset.

## Change

* Keep the KEYSIZES histogram update gated by successful writes, leaving the
  adjacent #15598 work separate.
* Run `keyModified`, the existing `setbit` notification, and dirty accounting when
  the destination actually grew even if no bit write succeeded.
* Count a growth-only mutation once. Failed operations without growth remain no-ops,
  and successful-write dirty accounting is unchanged.

## Tests

The unfixed `unstable` baseline reproduced both cases: a failed write created a
one-byte key and expanded an existing empty string to eight bytes while
`rdb_changes_since_last_save` did not change.

* `make -C src -j8 MALLOC=libc redis-server redis-cli`
* `./runtest --clients 1 --single unit/bitfield` (27/27 passed, including
  notification, replication, and AOF-reload coverage)
* `./runtest --clients 1 --single unit/bitops` (all enabled tests passed; two
  large-memory tests were ignored because the large-memory flag was not enabled)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core BITFIELD mutation and persistence paths; behavior change is narrow (FAIL + growth) but affects replication and AOF consistency.
> 
> **Overview**
> Fixes **#15599**: when `BITFIELD` uses `OVERFLOW FAIL` and every write overflows, Redis can still **create or extend** the string up front, but previously skipped mutation bookkeeping because `changes` stayed zero—so replicas and AOF reload could miss that growth.
> 
> **`bitfieldGeneric`** now treats **string growth** (`strGrowSize`) like a mutation: it runs `keyModified`, the `setbit` keyspace notification, and bumps `server.dirty` (once when growth happened but no bit write succeeded). The keysizes histogram update stays tied to successful writes and is only moved/re-gated so it does not run on growth-only FAIL paths.
> 
> Tests assert dirty counting and notifications for create/extend FAIL cases, confirm no dirty bump when nothing grows, and add replication and AOF-restart coverage for the grown keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f45fc8a44a7cdd3d15167a1c31c97bbf8f5a2a29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->