### PR TITLE
Fix MSETEX keyspace notification order

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -880,9 +880,11 @@ void msetexCommand(client *c) {
         /* Set expiration for each key (but not for KEEPTTL) */
         if (args.expire && !(args.flags & OBJ_KEEPTTL)) {
             setExpire(c, c->db, c->argv[key_idx], milliseconds);
-            notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",c->argv[key_idx],c->db->id);
         }
         notifyKeyspaceEvent(NOTIFY_STRING,"set",c->argv[key_idx],c->db->id);
+        if (args.expire && !(args.flags & OBJ_KEEPTTL)) {
+            notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",c->argv[key_idx],c->db->id);
+        }
     }
 
     /* Handle replication rewriting for relative expiration times */

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -316,6 +316,31 @@ start_server {tags {"string"}} {
         assert_morethan [r pttl pxat:key1{t}] 0
     }
 
+    test {MSETEX - keyspace notifications emit set before expire for each key} {
+        set orig_notify [lindex [r config get notify-keyspace-events] 1]
+        r config set notify-keyspace-events EA
+        r del msetex:k1{t} msetex:k2{t}
+
+        set rd [redis_deferring_client]
+        set pattern __keyevent@*__:*
+        assert_equal {1} [psubscribe $rd $pattern]
+
+        assert_equal 1 [
+            r msetex 2 \
+                msetex:k1{t} v1 \
+                msetex:k2{t} v2 \
+                px 60000
+        ]
+
+        assert_match "pmessage $pattern __keyevent@*__:set msetex:k1{t}" [$rd read]
+        assert_match "pmessage $pattern __keyevent@*__:expire msetex:k1{t}" [$rd read]
+        assert_match "pmessage $pattern __keyevent@*__:set msetex:k2{t}" [$rd read]
+        assert_match "pmessage $pattern __keyevent@*__:expire msetex:k2{t}" [$rd read]
+
+        $rd close
+        r config set notify-keyspace-events $orig_notify
+    }
+
     test {MSETEX - KEEPTTL preserves existing TTL} {
         r setex keepttl:key{t} 100 oldval
         set old_ttl [r ttl keepttl:key{t}]


### PR DESCRIPTION
## Summary

- emit the `set` keyspace notification before `expire` for each key written by `MSETEX`
- keep the database mutations in their existing `setKey` then `setExpire` order, so notification callbacks observe the final value and TTL
- add a regression test that covers both the per-key notification order and the ordering between multiple keys

## Problem

`MSETEX` correctly stored each value and expiration, but published its keyspace notifications in the opposite order from the underlying mutations and from other string commands:

```text
expire k1
set    k1
expire k2
set    k2
```

This was observable by both Pub/Sub subscribers and Redis module keyspace callbacks. It was also inconsistent with `SET key value PX ...`, `HSETEX`, and `INCREX`, which publish the value-change event before the expiration event.

The final values and TTLs, command atomicity, conditional `NX`/`XX` behavior, replication/AOF rewriting, dirty counter, and reply were not affected.

## Root cause

The `expire` notification was emitted immediately after `setExpire`, before the existing `set` notification. The state changes themselves already happened in the correct order:

```text
setKey -> setExpire
```

## Fix

Complete both state changes first, then emit notifications for each key in this order:

```text
setKey -> setExpire -> set notification -> expire notification
```

This deliberately does not move the `set` notification before `setExpire`; module callbacks handling `set` therefore continue to observe the fully applied TTL.

## Tests

- `make -j4`
- regression test before the fix: failed on the first `expire` event as expected
- `./runtest --single unit/type/string --only 'MSETEX - keyspace notifications emit set before expire for each key' --baseport 31000`
- `./runtest --single unit/type/string --baseport 31000`
- `./runtest --single unit/pubsub --baseport 32000`
- `./runtest --single unit/moduleapi/keyspace_events --baseport 33000`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Notification ordering only; stored values, TTLs, replication, and command semantics are unchanged.
> 
> **Overview**
> **MSETEX** keyspace notifications now match **`SET … EX/PX`** and other string commands: for each key, **`set`** is published before **`expire`**.
> 
> Previously **`expire`** was fired right after **`setExpire`**, before the **`set`** event, so subscribers saw `expire` then `set` per key. **`setKey`** / **`setExpire`** order is unchanged; only notification order was adjusted.
> 
> A regression test in **`tests/unit/type/string.tcl`** asserts per-key and multi-key event ordering via **`notify-keyspace-events`** and **`psubscribe`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2255d70fcbda23d5d072c4f88aa94fda3d1f84e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->