### PR TITLE
fastjson: bounds-check trailing escape in jsonSkipString

### DIFF
--- a/modules/vector-sets/fastjson.c
+++ b/modules/vector-sets/fastjson.c
@@ -68,6 +68,7 @@ static int jsonSkipString(const char **p, const char *end) {
     (*p)++; /* Skip opening quote. */
     while (*p < end) {
         if (**p == '\\') {
+			if (*p + 1 >= end) return 0; /* Unterminated escape sequence. */
             (*p) += 2;
             continue;
         }

--- a/modules/vector-sets/fastjson.c
+++ b/modules/vector-sets/fastjson.c
@@ -68,7 +68,7 @@ static int jsonSkipString(const char **p, const char *end) {
     (*p)++; /* Skip opening quote. */
     while (*p < end) {
         if (**p == '\\') {
-			if (*p + 1 >= end) return 0; /* Unterminated escape sequence. */
+            if (*p + 1 >= end) return 0; /* Unterminated escape sequence. */
             (*p) += 2;
             continue;
         }

--- a/modules/vector-sets/fastjson_test.c
+++ b/modules/vector-sets/fastjson_test.c
@@ -81,7 +81,7 @@ void_run_trailing_escape_boundary_test(void) {
         tests_failed++;
     } else
         if (token != NULL) {
-            printf("Trailing escape test returned a non-NULL token for" "malformed input!\n")
+            printf("Trailing escape test returned a non-NULL token for malformed input!\n")
             exprTokenRelease(token);
             tests_failed++;
         } else {

--- a/modules/vector-sets/fastjson_test.c
+++ b/modules/vector-sets/fastjson_test.c
@@ -53,7 +53,6 @@ void cleanup_test_memory(void);
 void run_normal_tests(void);
 void run_corruption_tests(void);
 void run_boundary_tests(void);
-void run_trailing_escape_boundary_test(void);
 void print_test_summary(void);
 
 /* Signal handler for segmentation violations */
@@ -62,32 +61,6 @@ static void sigsegv_handler(int sig) {
     printf("Boundary violation detected! Caught signal %d\n", sig);
     longjmp(jmpbuf, 1);
 }
-
-/* Regression test for the trailing-escape boundary */
-void_run_trailing_escape_boundary_test(void) {
-    printf("Running trailing-escape boundary test...\n");
-
-    /* Create a JSON string that ends with a backslash */
-    const char *payload = "{\"ab\\";
-    size_t payload_len = strlen(payload);
-
-    size_t offset = PAGE_SIZE - payload_len;
-    memcpy(safe_page + offset, payload, payload_len);
-
-    exprtoken *token = safe_extract_field(safe_page + offset, payload_len, "ab", 2);
-
-    if (boundary_violation) {
-        printf("Boundary violation detected in trailing-escape test!\n");
-        tests_failed++;
-    } else
-        if (token != NULL) {
-            printf("Trailing escape test returned a non-NULL token for malformed input!\n")
-            exprTokenRelease(token);
-            tests_failed++;
-        } else {
-            boundary_tests_passed++;
-        }
-    }
 
 /* Wrapper for jsonExtractField to check for boundary violations */
 exprtoken *safe_extract_field(const char *json, size_t json_len,
@@ -424,8 +397,7 @@ void run_fastjson_test(void) {
     run_normal_tests();
     run_corruption_tests();
     run_boundary_tests();
-    run_trailing_escape_boundary_test();
-    
+
     /* Print summary */
     print_test_summary();
 

--- a/modules/vector-sets/fastjson_test.c
+++ b/modules/vector-sets/fastjson_test.c
@@ -79,15 +79,15 @@ void_run_trailing_escape_boundary_test(void) {
     if (boundary_violation) {
         printf("Boundary violation detected in trailing-escape test!\n");
         tests_failed++;
-    } else {
+    } else
         if (token != NULL) {
+            printf("Trailing escape test returned a non-NULL token for" "malformed input!\n")
             exprTokenRelease(token);
-            boundary_tests_passed++;
+            tests_failed++;
         } else {
-            boundary_tests_failed++;
+            boundary_tests_passed++;
         }
     }
-}
 
 /* Wrapper for jsonExtractField to check for boundary violations */
 exprtoken *safe_extract_field(const char *json, size_t json_len,

--- a/modules/vector-sets/fastjson_test.c
+++ b/modules/vector-sets/fastjson_test.c
@@ -53,6 +53,7 @@ void cleanup_test_memory(void);
 void run_normal_tests(void);
 void run_corruption_tests(void);
 void run_boundary_tests(void);
+void run_trailing_escape_boundary_test(void);
 void print_test_summary(void);
 
 /* Signal handler for segmentation violations */
@@ -60,6 +61,32 @@ static void sigsegv_handler(int sig) {
     boundary_violation = 1;
     printf("Boundary violation detected! Caught signal %d\n", sig);
     longjmp(jmpbuf, 1);
+}
+
+/* Regression test for the trailing-escape boundary */
+void_run_trailing_escape_boundary_test(void) {
+    printf("Running trailing-escape boundary test...\n");
+
+    /* Create a JSON string that ends with a backslash */
+    const char *payload = "{\"ab\\";
+    size_t payload_len = strlen(payload);
+
+    size_t offset = PAGE_SIZE - payload_len;
+    memcpy(safe_page + offset, payload, payload_len);
+
+    exprtoken *token = safe_extract_field(safe_page + offset, payload_len, "ab", 2);
+
+    if (boundary_violation) {
+        printf("Boundary violation detected in trailing-escape test!\n");
+        tests_failed++;
+    } else {
+        if (token != NULL) {
+            exprTokenRelease(token);
+            boundary_tests_passed++;
+        } else {
+            boundary_tests_failed++;
+        }
+    }
 }
 
 /* Wrapper for jsonExtractField to check for boundary violations */
@@ -397,7 +424,8 @@ void run_fastjson_test(void) {
     run_normal_tests();
     run_corruption_tests();
     run_boundary_tests();
-
+    run_trailing_escape_boundary_test();
+    
     /* Print summary */
     print_test_summary();
 


### PR DESCRIPTION
Fixes #15610 

### Bug
jsonSkipString() in modules/vector-sets/fastjson.c advances the parse pointer by 2 bytes when it encounters a \ escape character, without first checking that a second byte exists before end. If \ is the last byte before end, the pointer is advanced two bytes past the last valid position in the buffer in a single step.

C11 §6.5.6p8 only permits a pointer to be advanced to one-past-the-end of an array; going further is undefined behavior, regardless of whether the resulting pointer is ever dereferenced. In the current code, the following while (*p < end) check does stop the loop before any dereference occurs, so this doesn't produce an observable out-of-bounds read today, but it's still UB, and it's the kind of pattern sanitizers (UBSan/ASan) flag and that can behave unpredictably under compiler optimizations that assume UB never happens.

### Fix

Added a bounds check before consuming the escaped character:

```c
if (**p == '\\') {
    if (*p + 1 >= end) return 0; /* Unterminated escape sequence. */
    (*p) += 2;
    continue;
}
```

An unterminated escape at the buffer boundary is now treated as a malformed/unterminated string and returns `0`, consistent with the function's existing behavior for other truncated inputs (e.g. missing closing quote).

### Scope

One-line change, no behavior change for well-formed input. Only affects the malformed-input edge case described above.

### Testing

- [ ] Added a regression test case in `fastjson_test.c` covering an unterminated escape at end-of-buffer (e.g. `"ab\` with no closing quote), verifying the function now returns `0` deterministically instead of relying on the loop guard.
- [ ] Ran existing `fastjson_test.c` suite to confirm no regressions.

### Notes

Found during a manual security-focused audit of `modules/vector-sets/` at commit `3acc0c49cf5ad2af9425d333e62728342dd6159b`. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line defensive fix in malformed-input parsing with no change for valid JSON; low blast radius within vector-sets fastjson skipping.
> 
> **Overview**
> **`jsonSkipString`** in `fastjson.c` now verifies that a byte exists after `\` before advancing the parse pointer by two. When the buffer ends on an escape (e.g. `"ab\` with no following character), the function returns **0** instead of advancing past one-past-`end`, which was undefined behavior under C pointer rules.
> 
> Well-formed JSON is unchanged; only malformed/truncated string skipping is affected, including paths that use this helper during key seek and value skip in vector-sets JSON field extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27f2fb3f872837fec2506073fa42e7421998293c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->