### PR TITLE
Fix jsonSkipString bounds check on trailing backslash

### DIFF
--- a/modules/vector-sets/fastjson.c
+++ b/modules/vector-sets/fastjson.c
@@ -68,6 +68,9 @@ static int jsonSkipString(const char **p, const char *end) {
     (*p)++; /* Skip opening quote. */
     while (*p < end) {
         if (**p == '\\') {
+            /* Check there is a byte after the escape char; advancing two
+             * positions past `end` at once is undefined behavior. */
+            if (*p + 1 >= end) return 0; /* unterminated escape */
             (*p) += 2;
             continue;
         }
@@ -439,3 +442,4 @@ exprtoken *jsonExtractField(const char *json, size_t json_len,
      * Convert it into an expression token object. */
     return jsonParseValueToken(&valptr,end);
 }
+

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -622,7 +622,7 @@ int checkSignedBitfieldOverflow(int64_t value, int64_t incr, uint64_t bits, int 
      * happens. 'uint64_t' cast is there just to prevent undefined behavior on
      * overflow */
     int64_t maxincr = (uint64_t)max-value;
-    int64_t minincr = min-value;
+    int64_t minincr = (int64_t)((uint64_t)min - (uint64_t)value);
 
     if (value > max || (bits != 64 && incr > maxincr) || (value >= 0 && incr > 0 && incr > maxincr))
     {

--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -8,6 +8,15 @@ start_server {tags {"bitops"}} {
         set results
     } {0 -100 101}
 
+    test {BITFIELD i64 SET no signed overflow on positive value} {
+        r del bits
+        # Regression test for https://github.com/redis/redis/issues/15545
+        # checkSignedBitfieldOverflow() computed INT64_MIN minus a positive value
+        # for i64 SET operations, which is undefined signed overflow.
+        # This test verifies that a deterministic positive i64 SET works.
+        set results [r bitfield bits set i64 0 42 get i64 0]
+    } {0 42}
+
     test {BITFIELD unsigned SET and GET basics} {
         r del bits
         set results {}


### PR DESCRIPTION
Fix a bounds check issue in `jsonSkipString()` where a trailing backslash at the end of input would advance the pointer 2 positions past `end`, triggering undefined behavior per the C standard.

## Changes

- Added a bounds check before advancing past the escape character
- If no second byte exists before `end`, return 0 (unterminated escape)

Closes #15610

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized parser and overflow-check fixes with a regression test; behavior change is rejecting malformed trailing escapes and more reliable i64 overflow checks.
> 
> **Overview**
> Fixes two undefined-behavior cases in C helpers and adds a **BITFIELD** regression test.
> 
> In **`jsonSkipString()`** (vector-sets `fastjson.c`), a trailing `\` at the end of the buffer no longer advances the pointer two bytes past `end`. The parser now requires a byte after the escape and returns failure for an unterminated escape.
> 
> In **`checkSignedBitfieldOverflow()`** (`bitops.c`), **`minincr`** is computed with unsigned subtraction (`(uint64_t)min - (uint64_t)value`) instead of signed `min - value`, avoiding signed overflow when **`INT64_MIN`** is involved (e.g. full-width **`i64`** **`SET`**). A unit test locks in deterministic **`i64 SET`** with a positive value (issue #15545).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdfe592f07ade0a4211b21d399104cf6a3e5b78b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->