### PR TITLE
Preserve errno in RM_Fork across the failure log

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -12502,7 +12502,9 @@ int RM_Fork(RedisModuleForkDoneHandler cb, void *user_data) {
         /* Child */
         redisSetProcTitle("redis-module-fork");
     } else if (childpid == -1) {
-        serverLog(LL_WARNING,"Can't fork for module: %s", strerror(errno));
+        int fork_errno = errno;
+        serverLog(LL_WARNING,"Can't fork for module: %s", strerror(fork_errno));
+        errno = fork_errno;
     } else {
         /* Parent */
         moduleForkInfo.done_handler = cb;


### PR DESCRIPTION
## Description

`RM_Fork()` sets `errno` to `EEXIST` in `redisFork()` when a mutually-exclusive child type (e.g., `BGSAVE`, AOF rewrite) is already running, but then calls `serverLog()` before returning. The log call's file I/O can clobber `errno`, so a module inspecting `errno` after `RM_Fork()` returns `-1` cannot reliably distinguish a transient busy slot from a real fork failure.

### Fix

Save `errno` before the `serverLog` call and restore it before returning, so `errno == EEXIST` remains a dependable test for "another child is active".

### Impact

RediSearch's fork GC is one affected caller: it retries while the failure is `EEXIST` and gives up otherwise. Under the conditions described in the bug report, it misclassifies a busy slot as permanent and abandons a collection it was explicitly asked to perform.

Closes #15612

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Three-line behavioral fix on the module fork error path; no change to successful forks or child lifecycle.
> 
> **Overview**
> When `RM_Fork()` fails, it now **saves `errno` before `serverLog()` and restores it before returning** so callers can still read the value `redisFork()` set (e.g. `EEXIST` when another child is already running).
> 
> Previously, logging could overwrite `errno`, so modules that branch on `errno` after a `-1` return could treat a busy slot as a permanent fork failure—**RediSearch fork GC retry behavior** was one affected case (#15612).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03bf8becf7350821303633c4710181864fa0a556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->