### PR TITLE
Fix out-of-bounds pointer advance in fastjson jsonSkipString

### DIFF
--- a/modules/vector-sets/fastjson.c
+++ b/modules/vector-sets/fastjson.c
@@ -68,6 +68,7 @@ static int jsonSkipString(const char **p, const char *end) {
     (*p)++; /* Skip opening quote. */
     while (*p < end) {
         if (**p == '\\') {
+            if (*p + 1 >= end) return 0; /* unterminated escape */
             (*p) += 2;
             continue;
         }


### PR DESCRIPTION
## Description

In `modules/vector-sets/fastjson.c`, `jsonSkipString()` advances the parse pointer by 2 bytes on encountering a backslash escape without first checking that a second byte exists before `end`:

```c
if (**p == '\\') {
    (*p) += 2;
    continue;
}
```

If `\` is the last byte before `end`, `*p` is advanced two bytes past the final valid position in one step. While the loop condition `while (*p < end)` catches the overrun before any further dereference, advancing a pointer more than one past the end of an object is undefined behavior per the C standard.

### Fix

Add a bounds check before advancing past the escape character:

```c
if (*p + 1 >= end) return 0; /* unterminated escape */
```

Closes #15610

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line defensive parse fix with no behavior change for well-formed JSON; only affects malformed string edge cases in the vector-sets JSON skipper.
> 
> **Overview**
> Fixes **undefined behavior** in the vector-sets `fastjson` string skipper when JSON ends with a lone `\` inside a quoted string.
> 
> `jsonSkipString()` now returns failure if a backslash has no following byte before `end`, instead of advancing the parse pointer by two bytes past the buffer. That path is used while skipping values during expression `FILTER` / `jsonExtractField` parsing, so malformed input is rejected safely without pointer arithmetic past the end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3efba1abedb3ba6864d368e25b113bb8efc03960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->