### PR TITLE
Improve batch mutation performance of hash template keys

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1268,14 +1268,14 @@ static void hashTypeTmplAddFields(redisDb *db, robj *o, hashTemplate *tmpl,
     }
 
     /* Merge old and new names into the new template's field array. */
-    unsigned long long new_field_count = old_field_count + num_new_fields;
+    unsigned long long total_field_count = old_field_count + num_new_fields;
     sds stack_fields[HASH_TMPL_STACK_ENTRIES];
-    sds *fields_arr = (new_field_count <= HASH_TMPL_STACK_ENTRIES) ? stack_fields :
-                                                                     zmalloc(sizeof(sds) * new_field_count);
+    sds *fields_arr = (total_field_count <= HASH_TMPL_STACK_ENTRIES) ? stack_fields :
+                                                                     zmalloc(sizeof(sds) * total_field_count);
     uint64_t hash = tmpl->hash;
     unsigned long long old_pos = 0;
     int added = 0;
-    for (unsigned long long i = 0; i < new_field_count; i++) {
+    for (unsigned long long i = 0; i < total_field_count; i++) {
         if (added < num_new_fields && new_fields[added].insert_pos == i) {
             fields_arr[i] = new_fields[added].field;
             hash += computeFieldHash(new_fields[added].field); /* incremental set hash */
@@ -1287,7 +1287,7 @@ static void hashTypeTmplAddFields(redisDb *db, robj *o, hashTemplate *tmpl,
     }
     serverAssert(added == num_new_fields && old_pos == old_field_count);
 
-    hashTemplate *new_tmpl = hashTemplateGetOrCreateWithHash(hash, fields_arr, new_field_count);
+    hashTemplate *new_tmpl = hashTemplateGetOrCreateWithHash(hash, fields_arr, total_field_count);
     if (fields_arr != stack_fields) zfree(fields_arr);
     
     /* Update the values */
@@ -1308,14 +1308,28 @@ static void hashTypeTmplAddFields(redisDb *db, robj *o, hashTemplate *tmpl,
         o->ptr = lp;
     } else {
         serverAssert(o->encoding == OBJ_ENCODING_TMPL_ARRAY);
-        hashTemplateArray *hta = hashTemplateArrayResize(o->ptr, new_field_count);
-        for (int i = 0; i < num_new_fields; i++) {
-            unsigned long long pos = new_fields[i].insert_pos;
-            serverAssert(pos <= old_field_count + (unsigned long long)i);
-            /* Shift the values after it right by one to open a gap. */
-            memmove(&hta->values[pos + 1], &hta->values[pos], sizeof(sds) * (old_field_count + i - pos));
-            hta->values[pos] = sdsdup(new_fields[i].value);
-            hta->alloc_size += sdsAllocSize(hta->values[pos]);
+        serverAssert(num_new_fields > 0);
+        hashTemplateArray *hta = hashTemplateArrayResize(o->ptr, total_field_count);
+
+        /* Open a gap: move the old values from the first insert position
+         * onwards to the end of the array. Then fill each slot in order,
+         * either with the next new value or with the next old one. */
+        unsigned long long first = new_fields[0].insert_pos;
+        serverAssert(first <= old_field_count);
+        memmove(&hta->values[first + num_new_fields], &hta->values[first],
+                sizeof(sds) * (old_field_count - first));
+        old_pos = first + num_new_fields;
+        added = 0;
+        for (unsigned long long i = first; added < num_new_fields; i++) {
+            serverAssert(i < total_field_count);
+            if (new_fields[added].insert_pos == i) {
+                hta->values[i] = sdsdup(new_fields[added].value);
+                hta->alloc_size += sdsAllocSize(hta->values[i]);
+                added++;
+            } else {
+                serverAssert(old_pos < total_field_count);
+                hta->values[i] = hta->values[old_pos++];
+            }
         }
         o->ptr = hta;
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1298,22 +1298,25 @@ static void hashTypeTmplAddFields(redisDb *db, robj *o, hashTemplate *tmpl,
     if (o->encoding == OBJ_ENCODING_TMPL_LP) {
         unsigned char *lp = o->ptr;
 
-        /* Fields going past the old values: append them in ascending order. */
+        /* Fields going past the old values are appended below; find where
+         * they start. */
         int tail = num_new_fields;
         while (tail > 0 && (unsigned long long)new_fields[tail - 1].insert_pos == old_count)
             tail--;
-        for (int i = tail; i < num_new_fields; i++) {
-            sds v = new_fields[i].value;
-            lp = lpAppend(lp, (unsigned char *)v, sdslen(v));
-            serverAssert(lp != NULL);
-        }
 
-        /* The rest go in front of an old value. insert_pos values refer to
+        /* Fields going in front of an old value. insert_pos values refer to
          * the old layout, walking backwards so they stay correct as is. */
         for (int i = tail - 1; i >= 0; i--) {
             sds v = new_fields[i].value;
             unsigned char *p = hashTemplateLpSeekValue(lp, new_fields[i].insert_pos);
             lp = lpInsertString(lp, (unsigned char *)v, sdslen(v), p, LP_BEFORE, NULL);
+            serverAssert(lp != NULL);
+        }
+
+        /* The rest go past the old values: append them in ascending order. */
+        for (int i = tail; i < num_new_fields; i++) {
+            sds v = new_fields[i].value;
+            lp = lpAppend(lp, (unsigned char *)v, sdslen(v));
             serverAssert(lp != NULL);
         }
         o->ptr = lp;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -975,7 +975,6 @@ static hashTemplate *hashTemplateLpGetTemplate(unsigned char *lp) {
     hashTemplate *tmpl = hashTemplateGetById(hashTemplateLpGetTemplateId(lp));
     if (tmpl == NULL)
         serverPanic("TMPL_LP listpack references unknown template ID");
-    serverAssert(lpLength(lp) == tmpl->field_count + 1); /* +1 for template-id entry */
     return tmpl;
 }
 
@@ -1242,7 +1241,7 @@ typedef struct {
     sds field;
     sds value;
     unsigned long long insert_pos;
-    int arg_idx;          /* argv order, so the last of duplicate fields wins */
+    int arg_idx;          /* argv order, so the last of duplicate fields sets the value */
 } tmplNewField;
 
 /* qsort comparator: field name ascending, then argv position. */
@@ -1374,7 +1373,7 @@ static int hashTypeTmplSetFields(redisDb *db, robj *o, robj **argv, int n) {
          * neither. */
         if (num_new_fields > 1) {
             qsort(new_fields, num_new_fields, sizeof(*new_fields), tmplNewFieldCmp);
-            int uniq = 0;
+            int unique = 0;
             for (int i = 0; i < num_new_fields; i++) {
                 /* Skip the entry if the next one is the same field. */
                 if (i + 1 < num_new_fields &&
@@ -1382,9 +1381,9 @@ static int hashTypeTmplSetFields(redisDb *db, robj *o, robj **argv, int n) {
                 {
                     continue;
                 }
-                new_fields[uniq++] = new_fields[i];
+                new_fields[unique++] = new_fields[i];
             }
-            num_new_fields = uniq;
+            num_new_fields = unique;
         }
 
         /* So far insert_pos is where the field goes among the OLD template fields.
@@ -1444,7 +1443,8 @@ static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
         qsort(del_indexes, num_del_fields, sizeof(*del_indexes), tmplIdxCmp);
 
     if (num_del_fields == old_field_count) {
-        /* Losing the last field turns the hash into a plain empty listpack. */
+        /* Losing the last field turns the hash into a plain empty listpack.
+         * Caller will delete the key. */
         if (o->encoding == OBJ_ENCODING_TMPL_LP) {
             hashTemplateLpFree(o->ptr);
         } else {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -940,48 +940,6 @@ long long hashTemplateFieldIndex(hashTemplate *tmpl, sds field) {
     return -(lo + 1);
 }
 
-/* Return the template with `field` inserted at `insert_pos` (key-ref taken). */
-static hashTemplate *hashTemplateForInsertedField(hashTemplate *tmpl, sds field,
-                                                  long long insert_pos) {
-    serverAssert(insert_pos >= 0 && (unsigned long long)insert_pos <= tmpl->field_count);
-    unsigned long long new_count = tmpl->field_count + 1;
-    sds stack_fields[HASH_TMPL_STACK_ENTRIES];
-    sds *new_fields = (new_count <= HASH_TMPL_STACK_ENTRIES) ?
-                      stack_fields : zmalloc(sizeof(sds) * new_count);
-    memcpy(new_fields, tmpl->fields, sizeof(sds) * insert_pos);
-    new_fields[insert_pos] = field;
-    memcpy(&new_fields[insert_pos + 1], &tmpl->fields[insert_pos],
-           sizeof(sds) * (tmpl->field_count - insert_pos));
-
-    /* Incremental hash: add the new field's hash. */
-    uint64_t new_hash = tmpl->hash + computeFieldHash(field);
-    hashTemplate *new_tmpl = hashTemplateGetOrCreateWithHash(new_hash, new_fields, new_count);
-    hashTemplateIncrKeyRef(new_tmpl);
-    if (new_fields != stack_fields) zfree(new_fields);
-    return new_tmpl;
-}
-
-/* Return the template with the field at `idx` deleted (key-ref taken).
- * Precondition: at least one field remains. */
-static hashTemplate *hashTemplateForDeletedField(hashTemplate *tmpl, long long idx) {
-    serverAssert(tmpl->field_count >= 2); /* at least one field remains after delete */
-    serverAssert(idx >= 0 && (unsigned long long)idx < tmpl->field_count);
-    unsigned long long new_count = tmpl->field_count - 1;
-    sds stack_fields[HASH_TMPL_STACK_ENTRIES];
-    sds *new_fields = (new_count <= HASH_TMPL_STACK_ENTRIES) ?
-                      stack_fields : zmalloc(sizeof(sds) * new_count);
-    unsigned long long j = 0;
-    for (unsigned long long i = 0; i < tmpl->field_count; i++)
-        if ((long long)i != idx) new_fields[j++] = tmpl->fields[i];
-
-    /* Incremental hash: subtract the removed field's hash. */
-    uint64_t new_hash = tmpl->hash - computeFieldHash(tmpl->fields[idx]);
-    hashTemplate *new_tmpl = hashTemplateGetOrCreateWithHash(new_hash, new_fields, new_count);
-    hashTemplateIncrKeyRef(new_tmpl);
-    if (new_fields != stack_fields) zfree(new_fields);
-    return new_tmpl;
-}
-
 /* Return 1 if fields are strictly ascending (sorted, no duplicates), else 0. */
 int hashTemplateValidateFields(sds *fields, unsigned long long field_count) {
     for (unsigned long long i = 1; i < field_count; i++)
@@ -1235,6 +1193,357 @@ robj *createHashObjectFromTemplate(hashTemplate *tmpl, sds *values, int take) {
         o->encoding = OBJ_ENCODING_TMPL_ARRAY;
     }
     return o;
+}
+
+/* Move a template hash to `new_tmpl` whose field set must already match the
+ * values held by the key. */
+static void hashTypeTmplSwitch(robj *o, hashTemplate *old_tmpl, hashTemplate *new_tmpl) {
+    hashTemplateIncrKeyRef(new_tmpl);
+    if (o->encoding == OBJ_ENCODING_TMPL_LP) {
+        o->ptr = hashTemplateLpSetTemplate(o->ptr, new_tmpl);
+    } else {
+        serverAssert(o->encoding == OBJ_ENCODING_TMPL_ARRAY);
+        hashTemplateArray *hta = o->ptr;
+        hta->tmpl_id = new_tmpl->id;
+        hta->field_count = new_tmpl->field_count;
+    }
+    hashTemplateDecrKeyRef(old_tmpl);
+}
+
+/* Overwrite the value of the field at template index `idx`. Returns 1 if
+ * `value` was adopted. */
+static int hashTypeTmplWriteValueAt(robj *o, long long idx, sds value, int take) {
+    if (o->encoding == OBJ_ENCODING_TMPL_LP) {
+        unsigned char *lp = o->ptr;
+        unsigned char *p = hashTemplateLpSeekValue(lp, idx);
+        o->ptr = lpReplace(lp, &p, (unsigned char *)value, sdslen(value));
+        serverAssert(o->ptr != NULL);
+        return 0;
+    } else {
+        serverAssert(o->encoding == OBJ_ENCODING_TMPL_ARRAY);
+        hashTemplateArray *hta = o->ptr;
+        serverAssert((unsigned long long)idx < hta->field_count);
+        hta->alloc_size -= sdsAllocSize(hta->values[idx]);
+        sdsfree(hta->values[idx]);
+        hta->values[idx] = take ? value : sdsdup(value);
+        hta->alloc_size += sdsAllocSize(hta->values[idx]);
+        return take;
+    }
+}
+
+/* A field an HSET-style command adds to a template hash. */
+typedef struct {
+    sds field;
+    sds value;
+    long long insert_pos; /* insert position in the old template's index space */
+    int arg_idx;          /* argv order, so the last of duplicate fields wins */
+} tmplNewField;
+
+/* qsort comparator: field name ascending, then argv position. */
+static int tmplNewFieldCmp(const void *a, const void *b) {
+    const tmplNewField *x = a, *y = b;
+    int cmp = sdscmplen(x->field, y->field);
+    return cmp ? cmp : x->arg_idx - y->arg_idx;
+}
+
+/* Add new fields to a template hash with a single template switch.
+ * `new_fields` must be sorted by field name and have no duplicates. The
+ * caller must have converted the encoding to its final form. Values are copied. */
+static void hashTypeTmplAddFields(robj *o, hashTemplate *tmpl,
+                                  tmplNewField *new_fields, 
+                                  int num_new_fields)
+{
+    unsigned long long old_count = tmpl->field_count;
+
+    /* Build the new template's field array: old and new names merged in sorted order. */
+    unsigned long long new_count = old_count + num_new_fields;
+    sds stack_fields[HASH_TMPL_STACK_ENTRIES];
+    sds *fields_arr = (new_count <= HASH_TMPL_STACK_ENTRIES) ? stack_fields :
+                                                              zmalloc(sizeof(sds) * new_count);
+    uint64_t hash = tmpl->hash;
+    unsigned long long old_pos = 0, new_pos = 0;
+
+    for (int i = 0; i < num_new_fields; i++) {
+        serverAssert((unsigned long long)new_fields[i].insert_pos >= old_pos &&
+                     (unsigned long long)new_fields[i].insert_pos <= old_count);
+        /* Copy the old fields that come before this new field, then add the
+         * new field itself. */
+        unsigned long long ncopy = new_fields[i].insert_pos - old_pos;
+        memcpy(&fields_arr[new_pos], &tmpl->fields[old_pos], sizeof(sds) * ncopy);
+        new_pos += ncopy;
+        old_pos += ncopy;
+        fields_arr[new_pos++] = new_fields[i].field;
+        hash += computeFieldHash(new_fields[i].field); /* incremental set hash */
+    }
+    /* Copy the old fields after the last new one. */
+    memcpy(&fields_arr[new_pos], &tmpl->fields[old_pos], sizeof(sds) * (old_count - old_pos));
+    new_pos += old_count - old_pos;
+    serverAssert(new_pos == new_count);
+
+    hashTemplate *new_tmpl = hashTemplateGetOrCreateWithHash(hash, fields_arr, new_count);
+    if (fields_arr != stack_fields) zfree(fields_arr);
+    
+    /* Update the values */
+    if (o->encoding == OBJ_ENCODING_TMPL_LP) {
+        unsigned char *lp = o->ptr;
+
+        /* Fields going past the old values: append them in ascending order. */
+        int tail = num_new_fields;
+        while (tail > 0 && (unsigned long long)new_fields[tail - 1].insert_pos == old_count)
+            tail--;
+        for (int i = tail; i < num_new_fields; i++) {
+            sds v = new_fields[i].value;
+            lp = lpAppend(lp, (unsigned char *)v, sdslen(v));
+            serverAssert(lp != NULL);
+        }
+
+        /* The rest go in front of an old value. insert_pos values refer to
+         * the old layout, walking backwards so they stay correct as is. */
+        for (int i = tail - 1; i >= 0; i--) {
+            sds v = new_fields[i].value;
+            unsigned char *p = hashTemplateLpSeekValue(lp, new_fields[i].insert_pos);
+            lp = lpInsertString(lp, (unsigned char *)v, sdslen(v), p, LP_BEFORE, NULL);
+            serverAssert(lp != NULL);
+        }
+        o->ptr = lp;
+    } else {
+        serverAssert(o->encoding == OBJ_ENCODING_TMPL_ARRAY);
+        /* The resize will put the empty slots at the end of the array, so fill 
+         * it from the end: shift each block of old values right to its final
+         * place and drop the new value into the gap that opens.  */
+        hashTemplateArray *hta = hashTemplateArrayResize(o->ptr, new_count);
+
+        old_pos = old_count;
+        new_pos = new_count;
+        for (int i = num_new_fields - 1; i >= 0; i--) {
+            unsigned long long insert_pos = new_fields[i].insert_pos;
+            unsigned long long move_count = old_pos - insert_pos; /* old values after this new field */
+            new_pos -= move_count;
+            if (move_count)
+                memmove(&hta->values[new_pos], &hta->values[insert_pos], sizeof(sds) * move_count);
+            old_pos = insert_pos;
+            hta->values[--new_pos] = sdsdup(new_fields[i].value);
+            hta->alloc_size += sdsAllocSize(hta->values[new_pos]);
+        }
+        serverAssert(new_pos == old_pos);
+        o->ptr = hta;
+    }
+    hashTypeTmplSwitch(o, tmpl, new_tmpl);
+}
+
+/* Set the `n` field-value pairs at argv[i * 2] and argv[i * 2 + 1] on a template
+ * hash: an existing field's value is overwritten in place and the fields the
+ * template lacks are all added in a single template switch.
+ * Returns the number of fields added. */
+static int hashTypeTmplSetFields(redisDb *db, robj *o, robj **argv, int n) {
+    hashTemplate *tmpl = hashTypeGetTemplate(o);
+    tmplNewField stack_new_fields[HASH_TMPL_STACK_ENTRIES];
+    tmplNewField *new_fields = (n <= HASH_TMPL_STACK_ENTRIES) ? stack_new_fields :
+                               zmalloc(sizeof(tmplNewField) * n);
+    int num_new_fields = 0;
+
+    /* One pass: overwrite the fields that exist, collect the ones that do not.
+     * Binary searching here is the only field lookup the command does. */
+    for (int i = 0; i < n; i++) {
+        sds field = argv[i * 2]->ptr;
+        sds value = argv[i * 2 + 1]->ptr;
+
+        long long idx = hashTemplateFieldIndex(tmpl, field);
+        if (idx >= 0) {
+            hashTypeTmplWriteValueAt(o, idx, value, 0);
+            continue;
+        }
+        new_fields[num_new_fields].field = field;
+        new_fields[num_new_fields].value = value;
+        new_fields[num_new_fields].insert_pos = -idx - 1; /* ascends with the field name */
+        new_fields[num_new_fields].arg_idx = i;
+        num_new_fields++;
+    }
+
+    if (num_new_fields > 0) {
+        /* Sort and drop duplicates, keeping the last occurrence of a field
+         * given more than once, so its last value wins. */
+        qsort(new_fields, num_new_fields, sizeof(*new_fields), tmplNewFieldCmp);
+        int uniq = 0;
+        for (int i = 0; i < num_new_fields; i++) {
+            /* Skip the entry if the next one is the same field. */
+            if (i + 1 < num_new_fields &&
+                sdscmplen(new_fields[i].field, new_fields[i + 1].field) == 0)
+            {
+                continue;
+            }
+            new_fields[uniq++] = new_fields[i];
+        }
+        num_new_fields = uniq;
+
+        /* Check if the listpack needs to be converted to array */
+        if (o->encoding == OBJ_ENCODING_TMPL_LP &&
+            tmpl->field_count + num_new_fields > server.hash_max_listpack_entries) 
+        {
+            hashTypeConvert(db, o, OBJ_ENCODING_TMPL_ARRAY);
+        }
+ 
+        hashTypeTmplAddFields(o, tmpl, new_fields, num_new_fields);
+    }
+
+    if (new_fields != stack_new_fields) zfree(new_fields);
+    return num_new_fields;
+}
+
+/* Reply with the value of the field at template index `idx`. */
+static void addTmplValueToReply(client *c, robj *o, long long idx) {
+    if (o->encoding == OBJ_ENCODING_TMPL_LP) {
+        unsigned int vlen;
+        long long vll;
+        unsigned char *p = hashTemplateLpSeekValue(o->ptr, idx);
+        unsigned char *vstr = lpGetValue(p, &vlen, &vll);
+        if (vstr)
+            addReplyBulkCBuffer(c, vstr, vlen);
+        else
+            addReplyBulkLongLong(c, vll);
+    } else {
+        serverAssert(o->encoding == OBJ_ENCODING_TMPL_ARRAY);
+        hashTemplateArray *hta = o->ptr;
+        serverAssert((unsigned long long)idx < hta->field_count);
+        sds value = hta->values[idx];
+        addReplyBulkCBuffer(c, value, sdslen(value));
+    }
+}
+
+/* Delete fields from a template hash with a single template switch. `del_indexes` 
+ * holds the template indexes of the fields to delete in ascending order. */
+static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
+                                   long long *del_indexes,
+                                   unsigned long long num_del_fields)
+{
+    unsigned long long old_count = tmpl->field_count;
+    serverAssert(num_del_fields > 0 && num_del_fields <= old_count);
+
+    if (num_del_fields == old_count) {
+        /* Losing the last field turns the hash into a plain empty listpack. */
+        if (o->encoding == OBJ_ENCODING_TMPL_LP) {
+            hashTemplateLpFree(o->ptr);
+        } else {
+            serverAssert(o->encoding == OBJ_ENCODING_TMPL_ARRAY);
+            hashTemplateArrayFree(o->ptr);
+        }
+        o->ptr = lpNew(0);
+        o->encoding = OBJ_ENCODING_LISTPACK;
+        return;
+    }
+
+    /* The surviving fields, in order, are the new field set. */
+    unsigned long long new_count = old_count - num_del_fields;
+    sds stack_fields[HASH_TMPL_STACK_ENTRIES];
+    sds *fields = (new_count <= HASH_TMPL_STACK_ENTRIES) ? stack_fields :
+                                                           zmalloc(sizeof(sds) * new_count);
+    uint64_t hash = tmpl->hash;
+    unsigned long long kept = 0, dropped = 0;
+
+    for (unsigned long long i = 0; i < old_count; i++) {
+        if (dropped < num_del_fields && del_indexes[dropped] == (long long)i) {
+            hash -= computeFieldHash(tmpl->fields[i]); /* incremental set hash */
+            dropped++;
+        } else {
+            fields[kept++] = tmpl->fields[i];
+        }
+    }
+    serverAssert(kept == new_count && dropped == num_del_fields);
+
+    hashTemplate *new_tmpl = hashTemplateGetOrCreateWithHash(hash, fields, new_count);
+    if (fields != stack_fields) zfree(fields);
+
+    /* Update the values */
+    if (o->encoding == OBJ_ENCODING_TMPL_LP) {
+        /* Collect the dropped entries in one walk, then delete them in one pass. */
+        unsigned char *lp = o->ptr;
+        unsigned char *stack_ps[HASH_TMPL_STACK_ENTRIES];
+        unsigned char **ps = (num_del_fields <= HASH_TMPL_STACK_ENTRIES) ? stack_ps :
+                             zmalloc(sizeof(unsigned char *) * num_del_fields);
+        unsigned char *p = hashTemplateLpFirstValue(lp);
+        unsigned long long collected = 0;
+        /* Walk the values in order, stop once every dropped entry is collected. */
+        for (unsigned long long i = 0; collected < num_del_fields; i++) {
+            serverAssert(p != NULL); /* value entry always present per field */
+            if (del_indexes[collected] == (long long)i)
+                ps[collected++] = p;
+            p = lpNext(lp, p);
+        }
+        o->ptr = lpBatchDelete(lp, ps, num_del_fields);
+        if (ps != stack_ps) zfree(ps);
+    } else {
+        serverAssert(o->encoding == OBJ_ENCODING_TMPL_ARRAY);
+        hashTemplateArray *hta = o->ptr;
+        /* Same walk as the field loop above, this time over the values. */
+        kept = dropped = 0;
+        for (unsigned long long i = 0; i < old_count; i++) {
+            if (dropped < num_del_fields && del_indexes[dropped] == (long long)i) {
+                hta->alloc_size -= sdsAllocSize(hta->values[i]);
+                sdsfree(hta->values[i]);
+                dropped++;
+            } else {
+                hta->values[kept++] = hta->values[i];
+            }
+        }
+        o->ptr = hashTemplateArrayResize(hta, new_count);
+    }
+    hashTypeTmplSwitch(o, tmpl, new_tmpl);
+}
+
+/* qsort comparator for template field indexes. */
+static int tmplIdxCmp(const void *a, const void *b) {
+    long long x = *(const long long *)a;
+    long long y = *(const long long *)b;
+    return (x > y) - (x < y);
+}
+
+/* Delete the `n` fields in argv[] from a template hash in a single template
+ * switch, pushing the fields actually deleted into `vdeleted` in argv order.
+ * With `c`, each value is replied first (HGETDEL), null for a miss or repeat. */
+static void hashTypeTmplDeleteFields(robj *o, robj **argv, int n, vec *vdeleted, client *c) {
+    hashTemplate *tmpl = hashTypeGetTemplate(o);
+    unsigned long long old_count = tmpl->field_count;
+    unsigned long long num_del_fields = 0;
+    /* Fields are collected first and dropped all at once at the end. Since the 
+     * hash stays untouched during the scan, a field given twice in argv would be 
+     * found twice: delmark[] marks the fields seen in an earlier argv position. */
+    unsigned char stack_delmark[HASH_TMPL_STACK_ENTRIES] = {0};
+    unsigned char *delmark = NULL;
+    long long stack_del_indexes[HASH_TMPL_STACK_ENTRIES];
+    long long *del_indexes = (n <= HASH_TMPL_STACK_ENTRIES) ? stack_del_indexes :
+                                                              zmalloc(sizeof(long long) * n);
+    for (int i = 0; i < n; i++) {
+        long long idx = hashTemplateFieldIndex(tmpl, argv[i]->ptr);
+        /* Skip missing fields or if a field given twice in argv. */
+        if (idx < 0 || (delmark && delmark[idx])) {
+            if (c) addReplyNull(c);
+            continue;
+        }
+        /* Reply while the values are still in place. */
+        if (c) addTmplValueToReply(c, o, idx);
+        
+        /* Mark the field as deleted */
+        if (n > 1) {
+            if (delmark == NULL) {
+                delmark = (old_count <= HASH_TMPL_STACK_ENTRIES) ?
+                          stack_delmark : zcalloc(old_count);
+            }
+            delmark[idx] = 1;
+        }
+        
+        /* Mark field idx to delete */
+        del_indexes[num_del_fields++] = idx;
+        vecPush(vdeleted, argv[i]);
+    }
+    
+    /* Delete the fields */
+    if (num_del_fields > 0) {
+        qsort(del_indexes, num_del_fields, sizeof(*del_indexes), tmplIdxCmp);
+        hashTypeTmplDropFields(o, tmpl, del_indexes, num_del_fields);
+    }
+
+    if (delmark && delmark != stack_delmark) zfree(delmark);
+    if (del_indexes != stack_del_indexes) zfree(del_indexes);
 }
 
 /*-----------------------------------------------------------------------------
@@ -2057,79 +2366,27 @@ int hashTypeSet(redisDb *db, kvobj *o, sds field, sds value, int flags) {
         long long field_idx = hashTemplateFieldIndex(tmpl, field);
         int is_new = field_idx < 0;
 
-        /* Promote TMPL_LP -> TMPL_ARRAY up front if the value or field count no
-         * longer fits a listpack. The template (and field_idx) is unchanged. */
-        if (o->encoding == OBJ_ENCODING_TMPL_LP &&
-            (sdslen(value) > server.hash_max_listpack_value ||
-             !lpSafeToAdd(o->ptr, sdslen(value)) ||
-             (is_new && tmpl->field_count + 1 > server.hash_max_listpack_entries)))
-        {
+        /* Convert TMPL_LP -> TMPL_ARRAY up front if adding a field would cross
+         * the listpack entry limit. The template (and field_idx) is unchanged. */
+        if (o->encoding == OBJ_ENCODING_TMPL_LP && is_new &&
+            tmpl->field_count + 1 > server.hash_max_listpack_entries)
             hashTypeConvert(db, o, OBJ_ENCODING_TMPL_ARRAY);
-        }
 
         if (!is_new) {
             /* Field exists - update value in place. */
-            if (o->encoding == OBJ_ENCODING_TMPL_LP) {
-                unsigned char *lp = o->ptr;
-                unsigned char *p = hashTemplateLpSeekValue(lp, field_idx);
-                o->ptr = lpReplace(lp, &p, (unsigned char *)value, sdslen(value));
-                serverAssert(o->ptr != NULL);
-            } else {
-                hashTemplateArray *hta = o->ptr;
-                hta->alloc_size -= sdsAllocSize(hta->values[field_idx]);
-                sdsfree(hta->values[field_idx]);
-                if (flags & HASH_SET_TAKE_VALUE) {
-                    hta->values[field_idx] = value;  /* adopt, don't copy */
-                    value = NULL;
-                } else {
-                    hta->values[field_idx] = sdsdup(value);
-                }
-                hta->alloc_size += sdsAllocSize(hta->values[field_idx]);
-            }
+            if (hashTypeTmplWriteValueAt(o, field_idx, value, flags & HASH_SET_TAKE_VALUE))
+                value = NULL; /* adopted */
             update = 1;
             goto cleanup;
         }
 
-        /* Field not in tmpl - switch to the template that adds it at insert_pos. */
-        long long insert_pos = -field_idx - 1;
-        unsigned long long new_field_count = tmpl->field_count + 1;
-        hashTemplate *new_tmpl = hashTemplateForInsertedField(tmpl, field, insert_pos);
-
-        /* Insert value at insert_pos in existing structure. */
-        if (o->encoding == OBJ_ENCODING_TMPL_LP) {
-            unsigned char *lp = o->ptr;
-            /* Update template ID. */
-            lp = hashTemplateLpSetTemplate(lp, new_tmpl);
-            /* Insert value at position (offset +1 for template ID). */
-            if ((unsigned long long)insert_pos == tmpl->field_count) {
-                lp = lpAppend(lp, (unsigned char *)value, sdslen(value));
-            } else {
-                unsigned char *p = hashTemplateLpSeekValue(lp, insert_pos);
-                lp = lpInsertString(lp, (unsigned char *)value, sdslen(value), p, LP_BEFORE, NULL);
-            }
-            serverAssert(lp != NULL);
-            hashTemplateDecrKeyRef(tmpl);
-            o->ptr = lp;
-        } else {
-            hashTemplateArray *hta = o->ptr;
-            /* Expand struct and shift elements to make room. */
-            hta = hashTemplateArrayResize(hta, new_field_count);
-            if ((unsigned long long)insert_pos < tmpl->field_count) {
-                memmove(&hta->values[insert_pos + 1], &hta->values[insert_pos],
-                        sizeof(sds) * (tmpl->field_count - insert_pos));
-            }
-            if (flags & HASH_SET_TAKE_VALUE) {
-                hta->values[insert_pos] = value;  /* adopt, don't copy */
-                value = NULL;
-            } else {
-                hta->values[insert_pos] = sdsdup(value);
-            }
-            hta->alloc_size += sdsAllocSize(hta->values[insert_pos]);
-            hashTemplateDecrKeyRef(tmpl);
-            hta->tmpl_id = new_tmpl->id;
-            hta->field_count = new_tmpl->field_count;
-            o->ptr = hta;
-        }
+        /* Field not in tmpl. Adding it will switch the template holding it. */
+        tmplNewField new_field = { 
+            .field = field, 
+            .value = value,
+            .insert_pos = -field_idx - 1 
+        };
+        hashTypeTmplAddFields(o, tmpl, &new_field, 1);
     } else {
         serverPanic("Unknown hash encoding");
     }
@@ -2419,40 +2676,7 @@ int hashTypeDelete(robj *o, void *field) {
         hashTemplate *tmpl = hashTypeGetTemplate(o);
         long long idx = hashTemplateFieldIndex(tmpl, field);
         if (idx >= 0) {
-            long long old_count = tmpl->field_count;
-            long long new_count = old_count - 1;
-
-            if (new_count == 0) {
-                /* Last field deleted - convert to empty listpack. */
-                if (o->encoding == OBJ_ENCODING_TMPL_LP)
-                    hashTemplateLpFree(o->ptr);
-                else
-                    hashTemplateArrayFree(o->ptr);
-                o->ptr = lpNew(0);
-                o->encoding = OBJ_ENCODING_LISTPACK;
-            } else {
-                hashTemplate *new_tmpl = hashTemplateForDeletedField(tmpl, idx);
-
-                if (o->encoding == OBJ_ENCODING_TMPL_LP) {
-                    /* Delete value at idx. */
-                    unsigned char *lp = o->ptr;
-                    unsigned char *p = hashTemplateLpSeekValue(lp, idx);
-                    lp = lpDeleteRangeWithEntry(lp, &p, 1);
-                    lp = hashTemplateLpSetTemplate(lp, new_tmpl);
-                    o->ptr = lp;
-                } else {
-                    hashTemplateArray *hta = o->ptr;
-                    hta->alloc_size -= sdsAllocSize(hta->values[idx]);
-                    sdsfree(hta->values[idx]);
-                    memmove(&hta->values[idx], &hta->values[idx + 1],
-                            sizeof(sds) * (old_count - idx - 1));
-                    hta->tmpl_id = new_tmpl->id;
-                    hta->field_count = new_count;
-                    hta = hashTemplateArrayResize(hta, new_count);
-                    o->ptr = hta;
-                }
-                hashTemplateDecrKeyRef(tmpl);
-            }
+            hashTypeTmplDropFields(o, tmpl, &idx, 1);
             deleted = 1;
         }
     } else {
@@ -4020,6 +4244,12 @@ void hsetCommand(client *c) {
     if (kv->encoding == OBJ_ENCODING_LISTPACK && numfields >= 5 && lpLength(kv->ptr) == 0) {
         /* Fresh wide build: single dict pass (last-wins) + one batch append. */
         created = hashTypeBuildFreshListpack(kv, c->argv + 2, numfields);
+    } else if (kv->encoding == OBJ_ENCODING_TMPL_LP ||
+               kv->encoding == OBJ_ENCODING_TMPL_ARRAY)
+    {
+        /* Template hash: existing fields are overwritten in place and the
+         * missing ones are added in a single template switch. */
+        created = hashTypeTmplSetFields(c->db, kv, c->argv + 2, numfields);
     } else {
         for (i = 2; i < c->argc; i += 2)
             created += !hashTypeSet(c->db, kv, c->argv[i]->ptr, c->argv[i+1]->ptr, HASH_SET_COPY | HASH_SET_NO_TEMPLATE_CONVERT);
@@ -4662,25 +4892,35 @@ void hsetexCommand(client *c) {
     if (set_expiry)
         hashTypeSetExInit(c->argv[1], o, c, c->db, 0, &setex);
 
-    for (int i = 0; i < field_count; i++) {
-        sds field = c->argv[first_field_pos + (i * 2)]->ptr;
-        sds value = c->argv[first_field_pos + (i * 2) + 1]->ptr;
+    if (o->encoding == OBJ_ENCODING_TMPL_LP ||
+        o->encoding == OBJ_ENCODING_TMPL_ARRAY)
+    {
+        /* Template hash: set every field at once in a single template switch. */
+        serverAssert(!set_expiry);
+        hashTypeTmplSetFields(c->db, o, c->argv + first_field_pos, field_count);
+        for (int i = 0; i < field_count; i++)
+            vecPush(vset, c->argv[first_field_pos + (i * 2)]);
+    } else {
+        for (int i = 0; i < field_count; i++) {
+            sds field = c->argv[first_field_pos + (i * 2)]->ptr;
+            sds value = c->argv[first_field_pos + (i * 2) + 1]->ptr;
 
-        int opt = HASH_SET_COPY | HASH_SET_NO_TEMPLATE_CONVERT;
-        /* If we are going to set the expiration time later, no need to discard
-         * it as part of set operation now. */
-        if (flags & (HFE_EX | HFE_PX | HFE_EXAT | HFE_PXAT | HFE_KEEPTTL))
-            opt |= HASH_SET_KEEP_TTL;
+            int opt = HASH_SET_COPY | HASH_SET_NO_TEMPLATE_CONVERT;
+            /* If we are going to set the expiration time later, no need to discard
+             * it as part of set operation now. */
+            if (flags & (HFE_EX | HFE_PX | HFE_EXAT | HFE_PXAT | HFE_KEEPTTL))
+                opt |= HASH_SET_KEEP_TTL;
 
-        hashTypeSet(c->db, o, field, value, opt);
-        vecPush(vset, c->argv[first_field_pos + (i * 2)]);
-        /* Update the expiration time. */
-        if (set_expiry) {
-            int ret = hashTypeSetEx(o, field, expire_time, &setex);
-            if (ret == HSETEX_OK) {
-                vecPush(vupdated, c->argv[first_field_pos + (i * 2)]);
-            } else if (ret == HSETEX_DELETED) {
-                vecPush(vdeleted, c->argv[first_field_pos + (i * 2)]);
+            hashTypeSet(c->db, o, field, value, opt);
+            vecPush(vset, c->argv[first_field_pos + (i * 2)]);
+            /* Update the expiration time. */
+            if (set_expiry) {
+                int ret = hashTypeSetEx(o, field, expire_time, &setex);
+                if (ret == HSETEX_OK) {
+                    vecPush(vupdated, c->argv[first_field_pos + (i * 2)]);
+                } else if (ret == HSETEX_DELETED) {
+                    vecPush(vdeleted, c->argv[first_field_pos + (i * 2)]);
+                }
             }
         }
     }
@@ -5003,20 +5243,28 @@ void hgetdelCommand(client *c) {
     vec *vdeleted = fieldvecInit(&fvdeleted, num_fields);
 
     addReplyArrayLen(c, num_fields);
-    for (int i = 4; i < c->argc; i++) {
-        const int flags = HFE_LAZY_NO_NOTIFICATION |
-                          HFE_LAZY_NO_SIGNAL |
-                          HFE_LAZY_AVOID_HASH_DEL |
-                          HFE_LAZY_NO_UPDATE_KEYSIZES |
-                          HFE_LAZY_NO_UPDATE_ALLOCSIZES;
-        res = addHashFieldToReply(c, o, c->argv[i]->ptr, flags);
-        if (res == GETF_EXPIRED) {
-            vecPush(vexpired, c->argv[i]);
-        }
-        /* Try to delete only if it's found and not expired lazily. */
-        if (res == GETF_OK) {
-            vecPush(vdeleted, c->argv[i]);
-            serverAssert(hashTypeDelete(o, c->argv[i]->ptr) == 1);
+    if (o && (o->encoding == OBJ_ENCODING_TMPL_LP ||
+              o->encoding == OBJ_ENCODING_TMPL_ARRAY))
+    {
+        /* Template hash: reply every value, then drop all the fields in one
+         * template switch. */
+        hashTypeTmplDeleteFields(o, c->argv + 4, c->argc - 4, vdeleted, c);
+    } else {
+        for (int i = 4; i < c->argc; i++) {
+            const int flags = HFE_LAZY_NO_NOTIFICATION |
+                              HFE_LAZY_NO_SIGNAL |
+                              HFE_LAZY_AVOID_HASH_DEL |
+                              HFE_LAZY_NO_UPDATE_KEYSIZES |
+                              HFE_LAZY_NO_UPDATE_ALLOCSIZES;
+            res = addHashFieldToReply(c, o, c->argv[i]->ptr, flags);
+            if (res == GETF_EXPIRED) {
+                vecPush(vexpired, c->argv[i]);
+            }
+            /* Try to delete only if it's found and not expired lazily. */
+            if (res == GETF_OK) {
+                vecPush(vdeleted, c->argv[i]);
+                serverAssert(hashTypeDelete(o, c->argv[i]->ptr) == 1);
+            }
         }
     }
 
@@ -5261,12 +5509,21 @@ void hdelCommand(client *c) {
 
     if (o->encoding == OBJ_ENCODING_HT)
         dictPauseAutoResize((dict*)o->ptr);
-    for (j = 2; j < c->argc; j++) {
-        if (hashTypeDelete(o,c->argv[j]->ptr)) {
-            vecPush(vdeleted, c->argv[j]);
-            if (hashTypeLength(o, 0) == 0) {
-                keyremoved = 1;
-                break;
+
+    /* Template hash: drop all the fields in one template switch. */
+    if (o->encoding == OBJ_ENCODING_TMPL_LP ||
+        o->encoding == OBJ_ENCODING_TMPL_ARRAY)
+    {
+        hashTypeTmplDeleteFields(o, c->argv + 2, c->argc - 2, vdeleted, NULL);
+        keyremoved = (hashTypeLength(o, 0) == 0);
+    } else {
+        for (j = 2; j < c->argc; j++) {
+            if (hashTypeDelete(o,c->argv[j]->ptr)) {
+                vecPush(vdeleted, c->argv[j]);
+                if (hashTypeLength(o, 0) == 0) {
+                    keyremoved = 1;
+                    break;
+                }
             }
         }
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1246,14 +1246,19 @@ static int tmplNewFieldCmp(const void *a, const void *b) {
     return cmp ? cmp : x->arg_idx - y->arg_idx;
 }
 
-/* Add new fields to a template hash with a single template switch.
- * `new_fields` must be sorted by field name and have no duplicates. The
- * caller must have converted the encoding to its final form. Values are copied. */
-static void hashTypeTmplAddFields(robj *o, hashTemplate *tmpl,
-                                  tmplNewField *new_fields, 
-                                  int num_new_fields)
+/* Add new fields to a template hash with a single template switch. `new_fields`
+ * must be sorted by field name and have no duplicates. Values are copied. */
+static void hashTypeTmplAddFields(redisDb *db, robj *o, hashTemplate *tmpl,
+                                  tmplNewField *new_fields, int num_new_fields)
 {
     unsigned long long old_count = tmpl->field_count;
+
+    /* Check if the listpack needs to be converted to array */
+    if (o->encoding == OBJ_ENCODING_TMPL_LP &&
+        old_count + num_new_fields > server.hash_max_listpack_entries)
+    {
+        hashTypeConvert(db, o, OBJ_ENCODING_TMPL_ARRAY);
+    }
 
     /* Build the new template's field array: old and new names merged in sorted order. */
     unsigned long long new_count = old_count + num_new_fields;
@@ -1362,28 +1367,24 @@ static int hashTypeTmplSetFields(redisDb *db, robj *o, robj **argv, int n) {
 
     if (num_new_fields > 0) {
         /* Sort and drop duplicates, keeping the last occurrence of a field
-         * given more than once, so its last value wins. */
-        qsort(new_fields, num_new_fields, sizeof(*new_fields), tmplNewFieldCmp);
-        int uniq = 0;
-        for (int i = 0; i < num_new_fields; i++) {
-            /* Skip the entry if the next one is the same field. */
-            if (i + 1 < num_new_fields &&
-                sdscmplen(new_fields[i].field, new_fields[i + 1].field) == 0)
-            {
-                continue;
+         * given more than once, so its last value wins. A single field needs
+         * neither. */
+        if (num_new_fields > 1) {
+            qsort(new_fields, num_new_fields, sizeof(*new_fields), tmplNewFieldCmp);
+            int uniq = 0;
+            for (int i = 0; i < num_new_fields; i++) {
+                /* Skip the entry if the next one is the same field. */
+                if (i + 1 < num_new_fields &&
+                    sdscmplen(new_fields[i].field, new_fields[i + 1].field) == 0)
+                {
+                    continue;
+                }
+                new_fields[uniq++] = new_fields[i];
             }
-            new_fields[uniq++] = new_fields[i];
+            num_new_fields = uniq;
         }
-        num_new_fields = uniq;
 
-        /* Check if the listpack needs to be converted to array */
-        if (o->encoding == OBJ_ENCODING_TMPL_LP &&
-            tmpl->field_count + num_new_fields > server.hash_max_listpack_entries) 
-        {
-            hashTypeConvert(db, o, OBJ_ENCODING_TMPL_ARRAY);
-        }
- 
-        hashTypeTmplAddFields(o, tmpl, new_fields, num_new_fields);
+        hashTypeTmplAddFields(db, o, tmpl, new_fields, num_new_fields);
     }
 
     if (new_fields != stack_new_fields) zfree(new_fields);
@@ -1410,14 +1411,25 @@ static void addTmplValueToReply(client *c, robj *o, long long idx) {
     }
 }
 
-/* Delete fields from a template hash with a single template switch. `del_indexes` 
- * holds the template indexes of the fields to delete in ascending order. */
+/* qsort comparator for template field indexes. */
+static int tmplIdxCmp(const void *a, const void *b) {
+    long long x = *(const long long *)a;
+    long long y = *(const long long *)b;
+    return (x > y) - (x < y);
+}
+
+/* Delete fields from a template hash with a single template switch. `del_indexes`
+ * holds the template indexes of the fields to delete, in any order. */
 static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
                                    long long *del_indexes,
                                    unsigned long long num_del_fields)
 {
     unsigned long long old_count = tmpl->field_count;
     serverAssert(num_del_fields > 0 && num_del_fields <= old_count);
+
+    /* The walks below expect ascending indexes. */
+    if (num_del_fields > 1)
+        qsort(del_indexes, num_del_fields, sizeof(*del_indexes), tmplIdxCmp);
 
     if (num_del_fields == old_count) {
         /* Losing the last field turns the hash into a plain empty listpack. */
@@ -1460,14 +1472,13 @@ static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
         unsigned char *stack_ps[HASH_TMPL_STACK_ENTRIES];
         unsigned char **ps = (num_del_fields <= HASH_TMPL_STACK_ENTRIES) ? stack_ps :
                              zmalloc(sizeof(unsigned char *) * num_del_fields);
-        unsigned char *p = hashTemplateLpFirstValue(lp);
-        unsigned long long collected = 0;
-        /* Walk the values in order, stop once every dropped entry is collected. */
-        for (unsigned long long i = 0; collected < num_del_fields; i++) {
-            serverAssert(p != NULL); /* value entry always present per field */
-            if (del_indexes[collected] == (long long)i)
-                ps[collected++] = p;
-            p = lpNext(lp, p);
+        /* Seek the first dropped entry; each next one is `distance` entries
+         * after the previous, so step forward instead of a fresh seek. */
+        ps[0] = hashTemplateLpSeekValue(lp, del_indexes[0]);
+        for (unsigned long long i = 1; i < num_del_fields; i++) {
+            unsigned long long distance = del_indexes[i] - del_indexes[i - 1];
+            ps[i] = lpNextN(lp, ps[i - 1], distance);
+            serverAssert(ps[i] != NULL);
         }
         o->ptr = lpBatchDelete(lp, ps, num_del_fields);
         if (ps != stack_ps) zfree(ps);
@@ -1488,13 +1499,6 @@ static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
         o->ptr = hashTemplateArrayResize(hta, new_count);
     }
     hashTypeTmplSwitch(o, tmpl, new_tmpl);
-}
-
-/* qsort comparator for template field indexes. */
-static int tmplIdxCmp(const void *a, const void *b) {
-    long long x = *(const long long *)a;
-    long long y = *(const long long *)b;
-    return (x > y) - (x < y);
 }
 
 /* Delete the `n` fields in argv[] from a template hash in a single template
@@ -1537,10 +1541,8 @@ static void hashTypeTmplDeleteFields(robj *o, robj **argv, int n, vec *vdeleted,
     }
     
     /* Delete the fields */
-    if (num_del_fields > 0) {
-        qsort(del_indexes, num_del_fields, sizeof(*del_indexes), tmplIdxCmp);
+    if (num_del_fields > 0)
         hashTypeTmplDropFields(o, tmpl, del_indexes, num_del_fields);
-    }
 
     if (delmark && delmark != stack_delmark) zfree(delmark);
     if (del_indexes != stack_del_indexes) zfree(del_indexes);
@@ -2366,12 +2368,6 @@ int hashTypeSet(redisDb *db, kvobj *o, sds field, sds value, int flags) {
         long long field_idx = hashTemplateFieldIndex(tmpl, field);
         int is_new = field_idx < 0;
 
-        /* Convert TMPL_LP -> TMPL_ARRAY up front if adding a field would cross
-         * the listpack entry limit. The template (and field_idx) is unchanged. */
-        if (o->encoding == OBJ_ENCODING_TMPL_LP && is_new &&
-            tmpl->field_count + 1 > server.hash_max_listpack_entries)
-            hashTypeConvert(db, o, OBJ_ENCODING_TMPL_ARRAY);
-
         if (!is_new) {
             /* Field exists - update value in place. */
             if (hashTypeTmplWriteValueAt(o, field_idx, value, flags & HASH_SET_TAKE_VALUE))
@@ -2386,7 +2382,7 @@ int hashTypeSet(redisDb *db, kvobj *o, sds field, sds value, int flags) {
             .value = value,
             .insert_pos = -field_idx - 1 
         };
-        hashTypeTmplAddFields(o, tmpl, &new_field, 1);
+        hashTypeTmplAddFields(db, o, tmpl, &new_field, 1);
     } else {
         serverPanic("Unknown hash encoding");
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1233,7 +1233,7 @@ static int hashTypeTmplWriteValueAt(robj *o, long long idx, sds value, int take)
         sdsfree(hta->values[idx]);
         hta->values[idx] = take ? value : sdsdup(value);
         hta->alloc_size += sdsAllocSize(hta->values[idx]);
-        return take;
+        return take != 0;
     }
 }
 
@@ -1241,7 +1241,7 @@ static int hashTypeTmplWriteValueAt(robj *o, long long idx, sds value, int take)
 typedef struct {
     sds field;
     sds value;
-    long long insert_pos; /* insert position in the old template's index space */
+    unsigned long long insert_pos;
     int arg_idx;          /* argv order, so the last of duplicate fields wins */
 } tmplNewField;
 
@@ -1253,93 +1253,70 @@ static int tmplNewFieldCmp(const void *a, const void *b) {
 }
 
 /* Add new fields to a template hash with a single template switch. `new_fields`
- * must be sorted by field name and have no duplicates. Values are copied. */
+ * must be sorted by field name and have no duplicates, and insert_pos must be
+ * the field's final position in the new template. Values are copied. */
 static void hashTypeTmplAddFields(redisDb *db, robj *o, hashTemplate *tmpl,
                                   tmplNewField *new_fields, int num_new_fields)
 {
-    unsigned long long old_count = tmpl->field_count;
+    unsigned long long old_field_count = tmpl->field_count;
 
     /* Check if the listpack needs to be converted to array */
     if (o->encoding == OBJ_ENCODING_TMPL_LP &&
-        old_count + num_new_fields > server.hash_max_listpack_entries)
+        old_field_count + num_new_fields > server.hash_max_listpack_entries)
     {
         hashTypeConvert(db, o, OBJ_ENCODING_TMPL_ARRAY);
     }
 
-    /* Build the new template's field array: old and new names merged in sorted order. */
-    unsigned long long new_count = old_count + num_new_fields;
+    /* Merge old and new names into the new template's field array. */
+    unsigned long long new_field_count = old_field_count + num_new_fields;
     sds stack_fields[HASH_TMPL_STACK_ENTRIES];
-    sds *fields_arr = (new_count <= HASH_TMPL_STACK_ENTRIES) ? stack_fields :
-                                                              zmalloc(sizeof(sds) * new_count);
+    sds *fields_arr = (new_field_count <= HASH_TMPL_STACK_ENTRIES) ? stack_fields :
+                                                                     zmalloc(sizeof(sds) * new_field_count);
     uint64_t hash = tmpl->hash;
-    unsigned long long old_pos = 0, new_pos = 0;
-
-    for (int i = 0; i < num_new_fields; i++) {
-        serverAssert((unsigned long long)new_fields[i].insert_pos >= old_pos &&
-                     (unsigned long long)new_fields[i].insert_pos <= old_count);
-        /* Copy the old fields that come before this new field, then add the
-         * new field itself. */
-        unsigned long long ncopy = new_fields[i].insert_pos - old_pos;
-        memcpy(&fields_arr[new_pos], &tmpl->fields[old_pos], sizeof(sds) * ncopy);
-        new_pos += ncopy;
-        old_pos += ncopy;
-        fields_arr[new_pos++] = new_fields[i].field;
-        hash += computeFieldHash(new_fields[i].field); /* incremental set hash */
+    unsigned long long old_pos = 0;
+    int added = 0;
+    for (unsigned long long i = 0; i < new_field_count; i++) {
+        if (added < num_new_fields && new_fields[added].insert_pos == i) {
+            fields_arr[i] = new_fields[added].field;
+            hash += computeFieldHash(new_fields[added].field); /* incremental set hash */
+            added++;
+        } else {
+            serverAssert(old_pos < old_field_count);
+            fields_arr[i] = tmpl->fields[old_pos++];
+        }
     }
-    /* Copy the old fields after the last new one. */
-    memcpy(&fields_arr[new_pos], &tmpl->fields[old_pos], sizeof(sds) * (old_count - old_pos));
-    new_pos += old_count - old_pos;
-    serverAssert(new_pos == new_count);
+    serverAssert(added == num_new_fields && old_pos == old_field_count);
 
-    hashTemplate *new_tmpl = hashTemplateGetOrCreateWithHash(hash, fields_arr, new_count);
+    hashTemplate *new_tmpl = hashTemplateGetOrCreateWithHash(hash, fields_arr, new_field_count);
     if (fields_arr != stack_fields) zfree(fields_arr);
     
     /* Update the values */
     if (o->encoding == OBJ_ENCODING_TMPL_LP) {
         unsigned char *lp = o->ptr;
-
-        /* Fields going past the old values are appended below; find where
-         * they start. */
-        int tail = num_new_fields;
-        while (tail > 0 && (unsigned long long)new_fields[tail - 1].insert_pos == old_count)
-            tail--;
-
-        /* Fields going in front of an old value. insert_pos values refer to
-         * the old layout, walking backwards so they stay correct as is. */
-        for (int i = tail - 1; i >= 0; i--) {
+        for (int i = 0; i < num_new_fields; i++) {
             sds v = new_fields[i].value;
-            unsigned char *p = hashTemplateLpSeekValue(lp, new_fields[i].insert_pos);
-            lp = lpInsertString(lp, (unsigned char *)v, sdslen(v), p, LP_BEFORE, NULL);
-            serverAssert(lp != NULL);
-        }
-
-        /* The rest go past the old values: append them in ascending order. */
-        for (int i = tail; i < num_new_fields; i++) {
-            sds v = new_fields[i].value;
-            lp = lpAppend(lp, (unsigned char *)v, sdslen(v));
+            serverAssert(new_fields[i].insert_pos <= old_field_count + (unsigned long long)i);
+            /* Check if this is an insert or an append */
+            if (new_fields[i].insert_pos < old_field_count + (unsigned long long)i) {
+                unsigned char *p = hashTemplateLpSeekValue(lp, new_fields[i].insert_pos);
+                lp = lpInsertString(lp, (unsigned char *)v, sdslen(v), p, LP_BEFORE, NULL);
+            } else {
+                lp = lpAppend(lp, (unsigned char *)v, sdslen(v));
+            }
             serverAssert(lp != NULL);
         }
         o->ptr = lp;
     } else {
         serverAssert(o->encoding == OBJ_ENCODING_TMPL_ARRAY);
-        /* The resize will put the empty slots at the end of the array, so fill 
-         * it from the end: shift each block of old values right to its final
-         * place and drop the new value into the gap that opens.  */
-        hashTemplateArray *hta = hashTemplateArrayResize(o->ptr, new_count);
-
-        old_pos = old_count;
-        new_pos = new_count;
-        for (int i = num_new_fields - 1; i >= 0; i--) {
-            unsigned long long insert_pos = new_fields[i].insert_pos;
-            unsigned long long move_count = old_pos - insert_pos; /* old values after this new field */
-            new_pos -= move_count;
-            if (move_count)
-                memmove(&hta->values[new_pos], &hta->values[insert_pos], sizeof(sds) * move_count);
-            old_pos = insert_pos;
-            hta->values[--new_pos] = sdsdup(new_fields[i].value);
-            hta->alloc_size += sdsAllocSize(hta->values[new_pos]);
+        hashTemplateArray *hta = hashTemplateArrayResize(o->ptr, new_field_count);
+        for (int i = 0; i < num_new_fields; i++) {
+            unsigned long long pos = new_fields[i].insert_pos;
+            serverAssert(pos <= old_field_count + (unsigned long long)i);
+            /* Shift the values after it right by one to open a gap. */
+            memmove(&hta->values[pos + 1], &hta->values[pos], sizeof(sds) * (old_field_count + i - pos));
+            hta->values[pos] = sdsdup(new_fields[i].value);
+            hta->alloc_size += sdsAllocSize(hta->values[pos]);
         }
-        serverAssert(new_pos == old_pos);
         o->ptr = hta;
     }
     hashTypeTmplSwitch(o, tmpl, new_tmpl);
@@ -1364,12 +1341,15 @@ static int hashTypeTmplSetFields(redisDb *db, robj *o, robj **argv, int n) {
 
         long long idx = hashTemplateFieldIndex(tmpl, field);
         if (idx >= 0) {
-            hashTypeTmplWriteValueAt(o, idx, value, 0);
+            hashTypeTmplWriteValueAt(o, idx, value, 0); /* Existing field */
             continue;
         }
+
+        /* Temporarily set insert pos for the existing template.
+         * Later, it will be adjusted for the new template below */
+        new_fields[num_new_fields].insert_pos = -idx - 1;
         new_fields[num_new_fields].field = field;
         new_fields[num_new_fields].value = value;
-        new_fields[num_new_fields].insert_pos = -idx - 1; /* ascends with the field name */
         new_fields[num_new_fields].arg_idx = i;
         num_new_fields++;
     }
@@ -1391,6 +1371,14 @@ static int hashTypeTmplSetFields(redisDb *db, robj *o, robj **argv, int n) {
                 new_fields[uniq++] = new_fields[i];
             }
             num_new_fields = uniq;
+        }
+
+        /* So far insert_pos is where the field goes among the OLD template fields.
+         * Every new field placed before it shifts it right by one, so its
+         * final position in the new template is insert_pos + k. */
+        for (int k = 0; k < num_new_fields; k++) {
+            serverAssert(new_fields[k].insert_pos <= tmpl->field_count);
+            new_fields[k].insert_pos += k;
         }
 
         hashTypeTmplAddFields(db, o, tmpl, new_fields, num_new_fields);
@@ -1428,19 +1416,20 @@ static int tmplIdxCmp(const void *a, const void *b) {
 }
 
 /* Delete fields from a template hash with a single template switch. `del_indexes`
- * holds the template indexes of the fields to delete, in any order. */
+ * holds the template indexes of the fields to delete, in any order. Each index
+ * must be valid and given once. */
 static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
                                    long long *del_indexes,
                                    unsigned long long num_del_fields)
 {
-    unsigned long long old_count = tmpl->field_count;
-    serverAssert(num_del_fields > 0 && num_del_fields <= old_count);
+    unsigned long long old_field_count = tmpl->field_count;
+    serverAssert(num_del_fields > 0 && num_del_fields <= old_field_count);
 
     /* The walks below expect ascending indexes. */
     if (num_del_fields > 1)
         qsort(del_indexes, num_del_fields, sizeof(*del_indexes), tmplIdxCmp);
 
-    if (num_del_fields == old_count) {
+    if (num_del_fields == old_field_count) {
         /* Losing the last field turns the hash into a plain empty listpack. */
         if (o->encoding == OBJ_ENCODING_TMPL_LP) {
             hashTemplateLpFree(o->ptr);
@@ -1454,13 +1443,13 @@ static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
     }
 
     /* The surviving fields, in order, are the new field set. */
-    unsigned long long new_count = old_count - num_del_fields;
+    unsigned long long new_field_count = old_field_count - num_del_fields;
     fieldvec fvfields;
-    vec *vfields = fieldvecInit(&fvfields, new_count);
+    vec *vfields = fieldvecInit(&fvfields, new_field_count);
     uint64_t hash = tmpl->hash;
     unsigned long long kept = 0, dropped = 0;
 
-    for (unsigned long long i = 0; i < old_count; i++) {
+    for (unsigned long long i = 0; i < old_field_count; i++) {
         if (dropped < num_del_fields && del_indexes[dropped] == (long long)i) {
             hash -= computeFieldHash(tmpl->fields[i]); /* incremental set hash */
             dropped++;
@@ -1468,9 +1457,9 @@ static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
             vecPush(vfields, tmpl->fields[i]);
         }
     }
-    serverAssert(vecSize(vfields) == new_count && dropped == num_del_fields);
+    serverAssert(vecSize(vfields) == new_field_count && dropped == num_del_fields);
 
-    hashTemplate *new_tmpl = hashTemplateGetOrCreateWithHash(hash, (sds *)vecData(vfields), new_count);
+    hashTemplate *new_tmpl = hashTemplateGetOrCreateWithHash(hash, (sds *)vecData(vfields), new_field_count);
     vecRelease(vfields);
 
     /* Update the values */
@@ -1495,7 +1484,7 @@ static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
         hashTemplateArray *hta = o->ptr;
         /* Same walk as the field loop above, this time over the values. */
         kept = dropped = 0;
-        for (unsigned long long i = 0; i < old_count; i++) {
+        for (unsigned long long i = 0; i < old_field_count; i++) {
             if (dropped < num_del_fields && del_indexes[dropped] == (long long)i) {
                 hta->alloc_size -= sdsAllocSize(hta->values[i]);
                 sdsfree(hta->values[i]);
@@ -1504,7 +1493,8 @@ static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
                 hta->values[kept++] = hta->values[i];
             }
         }
-        o->ptr = hashTemplateArrayResize(hta, new_count);
+        serverAssert(kept == new_field_count && dropped == num_del_fields);
+        o->ptr = hashTemplateArrayResize(hta, new_field_count);
     }
     hashTypeTmplSwitch(o, tmpl, new_tmpl);
 }
@@ -1514,7 +1504,7 @@ static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
  * With `c`, each value is replied first (HGETDEL), null for a miss or repeat. */
 static void hashTypeTmplDeleteFields(robj *o, robj **argv, int n, vec *vdeleted, client *c) {
     hashTemplate *tmpl = hashTypeGetTemplate(o);
-    unsigned long long old_count = tmpl->field_count;
+    unsigned long long old_field_count = tmpl->field_count;
     unsigned long long num_del_fields = 0;
     /* Fields are collected first and dropped all at once at the end. Since the 
      * hash stays untouched during the scan, a field given twice in argv would be 
@@ -1537,9 +1527,10 @@ static void hashTypeTmplDeleteFields(robj *o, robj **argv, int n, vec *vdeleted,
         /* Mark the field as deleted */
         if (n > 1) {
             if (delmark == NULL) {
-                delmark = (old_count <= HASH_TMPL_STACK_ENTRIES) ?
-                          stack_delmark : zcalloc(old_count);
+                delmark = (old_field_count <= HASH_TMPL_STACK_ENTRIES) ?
+                          stack_delmark : zcalloc(old_field_count);
             }
+            serverAssert((unsigned long long)idx < old_field_count);
             delmark[idx] = 1;
         }
         

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -46,7 +46,7 @@ typedef enum GetFieldRes {
 
 typedef listpackEntry CommonEntry; /* extend usage beyond lp */
 
-#define FIELDS_STACK_SIZE 16
+#define FIELDS_STACK_SIZE 64
 
 /* A vec with an embedded stack buffer, used to collect field robj pointers
  * for subkey notifications without heap allocation in the common case. */
@@ -371,6 +371,12 @@ static int hashTypeSdsArrayFitsLp(sds *arr, unsigned long long n) {
     if (n > server.hash_max_listpack_entries) return 0;
     ssize_t sum = hashTypeSdsArrayLpBytes(arr, n);
     return sum >= 0 && lpSafeToAdd(NULL, sum);
+}
+
+/* True if the hash uses one of the template encodings. */
+static inline int hashTypeIsTemplate(const robj *o) {
+    return o->encoding == OBJ_ENCODING_TMPL_LP ||
+           o->encoding == OBJ_ENCODING_TMPL_ARRAY;
 }
 
 /* by_id is a chunked array: fixed-size chunks of template pointers. */
@@ -969,13 +975,13 @@ static hashTemplate *hashTemplateLpGetTemplate(unsigned char *lp) {
     hashTemplate *tmpl = hashTemplateGetById(hashTemplateLpGetTemplateId(lp));
     if (tmpl == NULL)
         serverPanic("TMPL_LP listpack references unknown template ID");
+    serverAssert(lpLength(lp) == tmpl->field_count + 1); /* +1 for template-id entry */
     return tmpl;
 }
 
 /* Return the shared template of a template-encoded hash (TMPL_LP or TMPL_ARRAY). */
 hashTemplate *hashTypeGetTemplate(robj *o) {
-    serverAssert(o->encoding == OBJ_ENCODING_TMPL_LP ||
-                 o->encoding == OBJ_ENCODING_TMPL_ARRAY);
+    serverAssert(hashTypeIsTemplate(o));
     return (o->encoding == OBJ_ENCODING_TMPL_LP) ?
         hashTemplateLpGetTemplate(o->ptr) :
         hashTemplateArrayGetTemplate(o->ptr);
@@ -1446,9 +1452,8 @@ static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
 
     /* The surviving fields, in order, are the new field set. */
     unsigned long long new_count = old_count - num_del_fields;
-    sds stack_fields[HASH_TMPL_STACK_ENTRIES];
-    sds *fields = (new_count <= HASH_TMPL_STACK_ENTRIES) ? stack_fields :
-                                                           zmalloc(sizeof(sds) * new_count);
+    fieldvec fvfields;
+    vec *vfields = fieldvecInit(&fvfields, new_count);
     uint64_t hash = tmpl->hash;
     unsigned long long kept = 0, dropped = 0;
 
@@ -1457,31 +1462,31 @@ static void hashTypeTmplDropFields(robj *o, hashTemplate *tmpl,
             hash -= computeFieldHash(tmpl->fields[i]); /* incremental set hash */
             dropped++;
         } else {
-            fields[kept++] = tmpl->fields[i];
+            vecPush(vfields, tmpl->fields[i]);
         }
     }
-    serverAssert(kept == new_count && dropped == num_del_fields);
+    serverAssert(vecSize(vfields) == new_count && dropped == num_del_fields);
 
-    hashTemplate *new_tmpl = hashTemplateGetOrCreateWithHash(hash, fields, new_count);
-    if (fields != stack_fields) zfree(fields);
+    hashTemplate *new_tmpl = hashTemplateGetOrCreateWithHash(hash, (sds *)vecData(vfields), new_count);
+    vecRelease(vfields);
 
     /* Update the values */
     if (o->encoding == OBJ_ENCODING_TMPL_LP) {
         /* Collect the dropped entries in one walk, then delete them in one pass. */
         unsigned char *lp = o->ptr;
-        unsigned char *stack_ps[HASH_TMPL_STACK_ENTRIES];
-        unsigned char **ps = (num_del_fields <= HASH_TMPL_STACK_ENTRIES) ? stack_ps :
-                             zmalloc(sizeof(unsigned char *) * num_del_fields);
+        fieldvec fvps;
+        vec *vps = fieldvecInit(&fvps, num_del_fields);
         /* Seek the first dropped entry; each next one is `distance` entries
          * after the previous, so step forward instead of a fresh seek. */
-        ps[0] = hashTemplateLpSeekValue(lp, del_indexes[0]);
+        vecPush(vps, hashTemplateLpSeekValue(lp, del_indexes[0]));
         for (unsigned long long i = 1; i < num_del_fields; i++) {
             unsigned long long distance = del_indexes[i] - del_indexes[i - 1];
-            ps[i] = lpNextN(lp, ps[i - 1], distance);
-            serverAssert(ps[i] != NULL);
+            unsigned char *p = lpNextN(lp, vecGet(vps, i - 1), distance);
+            serverAssert(p != NULL);
+            vecPush(vps, p);
         }
-        o->ptr = lpBatchDelete(lp, ps, num_del_fields);
-        if (ps != stack_ps) zfree(ps);
+        o->ptr = lpBatchDelete(lp, (unsigned char **)vecData(vps), num_del_fields);
+        vecRelease(vps);
     } else {
         serverAssert(o->encoding == OBJ_ENCODING_TMPL_ARRAY);
         hashTemplateArray *hta = o->ptr;
@@ -3096,8 +3101,7 @@ static kvobj *hashTypeLookupWriteOrCreate(client *c, robj *key) {
 
 /* Can a TMPL_LP / TMPL_ARRAY hash be re-encoded as a plain listpack? */
 static int hashTypeCanConvertTmplToListpack(robj *o) {
-    serverAssert(o->encoding == OBJ_ENCODING_TMPL_LP ||
-                 o->encoding == OBJ_ENCODING_TMPL_ARRAY);
+    serverAssert(hashTypeIsTemplate(o));
     hashTemplate *tmpl = hashTypeGetTemplate(o);
 
     if (tmpl->field_count > server.hash_max_listpack_entries)
@@ -3122,8 +3126,7 @@ static int hashTypeCanConvertTmplToListpack(robj *o) {
  * abstracts over both template encodings, so one body covers every
  * source/target pair. 'with_hfe' implies 'HT with hfe'. */
 static void hashTypeConvertTmplToListpackOrHT(robj *o, int lp_enc, int with_hfe) {
-    serverAssert(o->encoding == OBJ_ENCODING_TMPL_LP ||
-                 o->encoding == OBJ_ENCODING_TMPL_ARRAY);
+    serverAssert(hashTypeIsTemplate(o));
     int target_enc = hashTypeCanConvertTmplToListpack(o) ? lp_enc : OBJ_ENCODING_HT;
     int src_enc = o->encoding;
     void *old_ptr = o->ptr;
@@ -4240,9 +4243,7 @@ void hsetCommand(client *c) {
     if (kv->encoding == OBJ_ENCODING_LISTPACK && numfields >= 5 && lpLength(kv->ptr) == 0) {
         /* Fresh wide build: single dict pass (last-wins) + one batch append. */
         created = hashTypeBuildFreshListpack(kv, c->argv + 2, numfields);
-    } else if (kv->encoding == OBJ_ENCODING_TMPL_LP ||
-               kv->encoding == OBJ_ENCODING_TMPL_ARRAY)
-    {
+    } else if (hashTypeIsTemplate(kv)) {
         /* Template hash: existing fields are overwritten in place and the
          * missing ones are added in a single template switch. */
         created = hashTypeTmplSetFields(c->db, kv, c->argv + 2, numfields);
@@ -4888,9 +4889,7 @@ void hsetexCommand(client *c) {
     if (set_expiry)
         hashTypeSetExInit(c->argv[1], o, c, c->db, 0, &setex);
 
-    if (o->encoding == OBJ_ENCODING_TMPL_LP ||
-        o->encoding == OBJ_ENCODING_TMPL_ARRAY)
-    {
+    if (hashTypeIsTemplate(o)) {
         /* Template hash: set every field at once in a single template switch. */
         serverAssert(!set_expiry);
         hashTypeTmplSetFields(c->db, o, c->argv + first_field_pos, field_count);
@@ -5239,9 +5238,7 @@ void hgetdelCommand(client *c) {
     vec *vdeleted = fieldvecInit(&fvdeleted, num_fields);
 
     addReplyArrayLen(c, num_fields);
-    if (o && (o->encoding == OBJ_ENCODING_TMPL_LP ||
-              o->encoding == OBJ_ENCODING_TMPL_ARRAY))
-    {
+    if (o && hashTypeIsTemplate(o)) {
         /* Template hash: reply every value, then drop all the fields in one
          * template switch. */
         hashTypeTmplDeleteFields(o, c->argv + 4, c->argc - 4, vdeleted, c);
@@ -5507,9 +5504,7 @@ void hdelCommand(client *c) {
         dictPauseAutoResize((dict*)o->ptr);
 
     /* Template hash: drop all the fields in one template switch. */
-    if (o->encoding == OBJ_ENCODING_TMPL_LP ||
-        o->encoding == OBJ_ENCODING_TMPL_ARRAY)
-    {
+    if (hashTypeIsTemplate(o)) {
         hashTypeTmplDeleteFields(o, c->argv + 2, c->argc - 2, vdeleted, NULL);
         keyremoved = (hashTypeLength(o, 0) == 0);
     } else {
@@ -6406,9 +6401,7 @@ static void httlGenericCommand(client *c, const char *cmd, long long basetime, i
     }
 
     /* Template encodings don't support HFE. */
-    if (hashObj->encoding == OBJ_ENCODING_TMPL_LP ||
-        hashObj->encoding == OBJ_ENCODING_TMPL_ARRAY)
-    {
+    if (hashTypeIsTemplate(hashObj)) {
         hashTemplate *tmpl = hashTypeGetTemplate(hashObj);
 
         addReplyArrayLen(c, numFields);
@@ -6751,9 +6744,7 @@ void hpersistCommand(client *c) {
     }
 
     /* Template encodings don't support HFE. */
-    if (hashObj->encoding == OBJ_ENCODING_TMPL_LP ||
-        hashObj->encoding == OBJ_ENCODING_TMPL_ARRAY)
-    {
+    if (hashTypeIsTemplate(hashObj)) {
         hashTemplate *tmpl = hashTypeGetTemplate(hashObj);
 
         addReplyArrayLen(c, numFields);

--- a/tests/unit/moduleapi/hash.tcl
+++ b/tests/unit/moduleapi/hash.tcl
@@ -175,16 +175,16 @@ start_server {tags {"modules external:skip"}} {
         r del htmpl
         r hash.set htmpl "a" f1 v1 f2 v2 f3 v3
         assert_equal [r object encoding htmpl] "template-listpack"
-        assert_equal [lsort [r hgetall htmpl]] {f1 f2 f3 v1 v2 v3}
+        assert_equal [r hgetall htmpl] {f1 v1 f2 v2 f3 v3}
         # Delete a field of a template hash through RM_HashSet.
         assert_equal 1 [r hash.set htmpl "" f2 :delete:]
-        assert_equal [lsort [r hgetall htmpl]] {f1 f3 v1 v3}
+        assert_equal [r hgetall htmpl] {f1 v1 f3 v3}
         assert_equal [r object encoding htmpl] "template-listpack"
         # Same delete on a template-array hash (large value converts it).
         r hash.set htmpl "" f3 [string repeat x 100]
         assert_equal [r object encoding htmpl] "template-array"
         assert_equal 1 [r hash.set htmpl "" f3 :delete:]
-        assert_equal [lsort [r hgetall htmpl]] {f1 v1}
+        assert_equal [r hgetall htmpl] {f1 v1}
         assert_equal [r object encoding htmpl] "template-array"
         r config set hash-min-template-entries 0
     }

--- a/tests/unit/moduleapi/hash.tcl
+++ b/tests/unit/moduleapi/hash.tcl
@@ -176,6 +176,16 @@ start_server {tags {"modules external:skip"}} {
         r hash.set htmpl "a" f1 v1 f2 v2 f3 v3
         assert_equal [r object encoding htmpl] "template-listpack"
         assert_equal [lsort [r hgetall htmpl]] {f1 f2 f3 v1 v2 v3}
+        # Delete a field of a template hash through RM_HashSet.
+        assert_equal 1 [r hash.set htmpl "" f2 :delete:]
+        assert_equal [lsort [r hgetall htmpl]] {f1 f3 v1 v3}
+        assert_equal [r object encoding htmpl] "template-listpack"
+        # Same delete on a template-array hash (large value converts it).
+        r hash.set htmpl "" f3 [string repeat x 100]
+        assert_equal [r object encoding htmpl] "template-array"
+        assert_equal 1 [r hash.set htmpl "" f3 :delete:]
+        assert_equal [lsort [r hgetall htmpl]] {f1 v1}
+        assert_equal [r object encoding htmpl] "template-array"
         r config set hash-min-template-entries 0
     }
 

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -176,6 +176,18 @@ tags "modules external:skip" {
             r himport discard bigfs
         }
 
+        test "Subkey notification: HSETEX on a template hash triggers hset" {
+            r himport prepare fieldset2 f1 f2
+            r himport set myhash fieldset2 v1 v2
+            r keyspace.reset_subkey_events
+            r hsetex myhash FIELDS 2 f1 v9 f3 v3
+            set events [r keyspace.get_subkey_events]
+            assert_equal 1 [llength $events]
+            assert_equal "hset myhash 2 f1 f3" [lindex $events 0]
+            r del myhash
+            r himport discard fieldset2
+        }
+
         test "Subkey notification: HDEL triggers module subkey callback" {
             r hset myhash f1 v1 f2 v2
             r keyspace.reset_subkey_events
@@ -184,6 +196,18 @@ tags "modules external:skip" {
             assert_equal 1 [llength $events]
             assert_equal "hdel myhash 1 f1" [lindex $events 0]
             r del myhash
+        }
+
+        test "Subkey notification: HDEL on a template hash lists a repeated field once" {
+            r himport prepare fieldset3 f1 f2 f3
+            r himport set myhash fieldset3 v1 v2 v3
+            r keyspace.reset_subkey_events
+            r hdel myhash f1 f1 f2
+            set events [r keyspace.get_subkey_events]
+            assert_equal 1 [llength $events]
+            assert_equal "hdel myhash 2 f1 f2" [lindex $events 0]
+            r del myhash
+            r himport discard fieldset3
         }
 
         test "Subkey notification: non-subkey event calls subkey callback with count=0" {

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -210,6 +210,18 @@ tags "modules external:skip" {
             r himport discard fieldset3
         }
 
+        test "Subkey notification: HGETDEL on a template hash lists a repeated field once" {
+            r himport prepare fieldset4 f1 f2 f3
+            r himport set myhash fieldset4 v1 v2 v3
+            r keyspace.reset_subkey_events
+            assert_equal {v1 {} v2} [r hgetdel myhash FIELDS 3 f1 f1 f2]
+            set events [r keyspace.get_subkey_events]
+            assert_equal 1 [llength $events]
+            assert_equal "hdel myhash 2 f1 f2" [lindex $events 0]
+            r del myhash
+            r himport discard fieldset4
+        }
+
         test "Subkey notification: non-subkey event calls subkey callback with count=0" {
             r hset myhash f1 v1
             r keyspace.reset_subkey_events

--- a/tests/unit/type/hash-templates.tcl
+++ b/tests/unit/type/hash-templates.tcl
@@ -521,6 +521,9 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         make_hashtmpl basic:incr counter 10
         assert_equal [r hincrby basic:incr counter 5] 15
         assert_equal [r hget basic:incr counter] 15
+
+        assert_equal 5 [r hincrby basic:incr newcnt 5]
+        assert_equal [r hget basic:incr newcnt] 5
         assert_encoding $encoding basic:incr
     }
 
@@ -528,6 +531,9 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         make_hashtmpl basic:incrfloat value 10.5
         set result [r hincrbyfloat basic:incrfloat value 0.1]
         assert_range $result 10.5 10.7
+
+        set result [r hincrbyfloat basic:incrfloat newval 1.5]
+        assert_range $result 1.4 1.6
         assert_encoding $encoding basic:incrfloat
     }
 
@@ -581,6 +587,33 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         assert_equal [r hgetall hdel:dup] {c 3}
     }
 
+    test {HDEL/HGETDEL with unsorted and non-adjacent repeated fields} {
+        # Fields given out of order, one of them twice.
+        make_hashtmpl hdel:unsorted a 1 b 2 c 3 d 4 e 5
+        assert_equal 2 [r hdel hdel:unsorted d a d]
+        assert_equal {b 2 c 3 e 5} [r hgetall hdel:unsorted]
+
+        make_hashtmpl hgetdel:unsorted a 1 b 2 c 3 d 4 e 5
+        assert_equal {3 1 {} 5} [r hgetdel hgetdel:unsorted FIELDS 4 c a c e]
+        assert_equal {b 2 d 4} [r hgetall hgetdel:unsorted]
+        assert_encoding $encoding hgetdel:unsorted
+    }
+
+    test {HSET and HDEL move the key to an existing template, not a duplicate} {
+        # Two keys ending up with the same fields must share one template,
+        # no matter how they got there (PREPARE, HSET add or HDEL drop).
+        make_hashtmpl same:1 a 1 b 2 c 3
+        make_hashtmpl same:2 a 1 b 2
+        set base [s hash_templates]
+        # Adding c moves same:2 to same:1's template, no new one.
+        r hset same:2 c 9
+        assert_equal $base [s hash_templates]
+        # Deleting c moves same:1 to same:2's old template.
+        r hdel same:1 c
+        assert_equal $base [s hash_templates]
+        assert_encoding $encoding same:1
+    }
+
     test {HGETDEL returns value and keeps template encoding} {
         make_hashtmpl hgetdel:test a 1 b 2 c 3 d 4
         assert_encoding $encoding hgetdel:test
@@ -594,6 +627,9 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         assert_equal [r hgetdel hgetdel:multi FIELDS 2 b d] {2 4}
         assert_encoding $encoding hgetdel:multi
         assert_equal [r hgetall hgetdel:multi] {a 1 c 3 e 5}
+
+        assert_equal [r hgetdel hgetdel:multi FIELDS 2 a a] {1 {}}
+        assert_equal [r hgetall hgetdel:multi] {c 3 e 5}
     }
 
     test {HGETDEL non-existent field returns nil and keeps encoding} {
@@ -704,6 +740,13 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         assert_equal 2 [r hset hset:repeat c 1 d 4 c 3]
         assert_equal 3 [r hget hset:repeat c]
         assert_equal 4 [r hget hset:repeat d]
+        # A repeated existing field: two in-place overwrites, last value wins.
+        assert_equal 0 [r hset hset:repeat a 9 a 10]
+        assert_equal 10 [r hget hset:repeat a]
+        # A new field between the repeats of an existing one.
+        assert_equal 1 [r hset hset:repeat a 11 e 5 a 12]
+        assert_equal 12 [r hget hset:repeat a]
+        assert_equal 5 [r hget hset:repeat e]
         assert_encoding $encoding hset:repeat
     }
 
@@ -935,6 +978,14 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         assert_encoding $encoding hfe:noexp
         assert_equal [r hget hfe:noexp email] alice@example.com
         assert_equal [r hget hfe:noexp name] bob
+        # A repeated new field is created once, last value wins.
+        assert_equal [r hsetex hfe:noexp FIELDS 2 age 25 age 26] 1
+        assert_equal [r hget hfe:noexp age] 26
+        # KEEPTTL sets no expiration either, so it stays as template encoded.
+        assert_equal [r hsetex hfe:noexp KEEPTTL FIELDS 2 name carol title dev] 1
+        assert_equal [r hget hfe:noexp name] carol
+        assert_equal [r hget hfe:noexp title] dev
+        assert_encoding $encoding hfe:noexp
     }
 
     test {HSETEX with expiration converts template key to regular hash} {

--- a/tests/unit/type/hash-templates.tcl
+++ b/tests/unit/type/hash-templates.tcl
@@ -11,6 +11,17 @@ proc make_hashtmpl {key args} {
     r himport set $key $fsname {*}$values
 }
 
+# Assert two hashes hold exactly the same field/value pairs. Order-insensitive:
+# the two keys may use different encodings.
+proc assert_same_hash_content {key1 key2} {
+    set a {}
+    foreach {f v} [r hgetall $key1] { lappend a [list $f $v] }
+    set b {}
+    foreach {f v} [r hgetall $key2] { lappend b [list $f $v] }
+    assert_equal [lsort $a] [lsort $b]
+    assert_equal [r exists $key1] [r exists $key2]
+}
+
 # A key ref released by a BIO lazyfree thread (flushall etc.) is
 # dropped on that background thread, so num_template_keys is eventually
 # consistent: it settles once the BIO free job runs.
@@ -564,6 +575,12 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         assert_equal [r exists hdel:all] 0
     }
 
+    test {HDEL counts a repeated field once} {
+        make_hashtmpl hdel:dup a 1 b 2 c 3
+        assert_equal [r hdel hdel:dup a a b zzz] 2
+        assert_equal [r hgetall hdel:dup] {c 3}
+    }
+
     test {HGETDEL returns value and keeps template encoding} {
         make_hashtmpl hgetdel:test a 1 b 2 c 3 d 4
         assert_encoding $encoding hgetdel:test
@@ -591,6 +608,12 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         make_hashtmpl hgetdel:all a 1 b 2
         assert_equal [r hgetdel hgetdel:all FIELDS 2 a b] {1 2}
         assert_equal [r exists hgetdel:all] 0
+    }
+
+    test {HGETDEL replies a repeated field once, then nil} {
+        make_hashtmpl hgetdel:dup a 1 b 2 c 3
+        assert_equal [r hgetdel hgetdel:dup FIELDS 4 a a b zzz] {1 {} 2 {}}
+        assert_equal [r hgetall hgetdel:dup] {c 3}
     }
 
     test {HGETEX without options returns values and keeps template encoding} {
@@ -656,6 +679,28 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         assert_equal {a 1 b 2 c 3 d 4} [r hgetall hset:multi]
     }
 
+    test {HSET on template-based hash returns number of new fields} {
+        make_hashtmpl hset:count a 1 b 2
+        # Updating existing fields creates nothing.
+        assert_equal 0 [r hset hset:count a 10 b 20]
+        # A mixed update and add counts only the added field.
+        assert_equal 1 [r hset hset:count a 11 c 3]
+        assert_equal 3 [r hlen hset:count]
+        assert_encoding $encoding hset:count
+    }
+
+    test {HSET with a field repeated in one command: last value wins} {
+        make_hashtmpl hset:repeat a 1
+        # A repeated new field is created once and keeps the last value.
+        assert_equal 1 [r hset hset:repeat b 1 b 2 b 3]
+        assert_equal 3 [r hget hset:repeat b]
+        # Also when another new field sits between the repeats.
+        assert_equal 2 [r hset hset:repeat c 1 d 4 c 3]
+        assert_equal 3 [r hget hset:repeat c]
+        assert_equal 4 [r hget hset:repeat d]
+        assert_encoding $encoding hset:repeat
+    }
+
     test {HSETNX on existing field in template-based hash} {
         make_hashtmpl hsetnx:test name alice
         assert_equal [r hsetnx hsetnx:test name bob] 0
@@ -667,6 +712,39 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         assert_equal [r hsetnx hsetnx:new email alice@example.com] 1
         assert_encoding $encoding hsetnx:new
         assert_equal [r hget hsetnx:new email] alice@example.com
+    }
+
+    # One command mutating more than 128 fields spills the batch bookkeeping
+    # from stack buffers to the heap. Exercise that path with HSET/HGETDEL/HDEL
+    test {wide batch HSET/HGETDEL/HDEL on template-based hash} {
+        make_hashtmpl wide:batch a 1 b 2 c 3 d 4
+
+        # Add 200 new fields (f0 v0 .. f199 v199) in a single HSET.
+        set pairs {}
+        for {set i 0} {$i < 200} {incr i} { lappend pairs f$i v$i }
+        assert_equal 200 [r hset wide:batch {*}$pairs]
+        assert_equal 204 [r hlen wide:batch]
+        assert_encoding $encoding wide:batch
+
+        # Take back the first 150 (f0 .. f149) in a single HGETDEL; it must
+        # reply their values in argument order (v0 .. v149).
+        set fields {}
+        set values {}
+        for {set i 0} {$i < 150} {incr i} {
+            lappend fields f$i
+            lappend values v$i
+        }
+        assert_equal $values [r hgetdel wide:batch FIELDS 150 {*}$fields]
+        assert_equal 54 [r hlen wide:batch]
+
+        # Drop the remaining 50 (f150 .. f199) in a single HDEL.
+        set fields {}
+        for {set i 150} {$i < 200} {incr i} { lappend fields f$i }
+        assert_equal 50 [r hdel wide:batch {*}$fields]
+
+        # Only the four seed fields are left, untouched.
+        assert_equal [r hgetall wide:batch] {a 1 b 2 c 3 d 4}
+        assert_encoding $encoding wide:batch
     }
 
     # HSCAN on template-based hash
@@ -845,10 +923,12 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
     test {HSETEX without expiration keeps template encoding} {
         make_hashtmpl hfe:noexp name alice
         # HSETEX with no expiration token only sets fields, so the hash must
-        # stay template-encoded just like a plain HSET.
-        assert_equal [r hsetex hfe:noexp FIELDS 1 email alice@example.com] 1
+        # stay template-encoded just like a plain HSET. One command may both
+        # update an existing field and add a new one.
+        assert_equal [r hsetex hfe:noexp FIELDS 2 email alice@example.com name bob] 1
         assert_encoding $encoding hfe:noexp
         assert_equal [r hget hfe:noexp email] alice@example.com
+        assert_equal [r hget hfe:noexp name] bob
     }
 
     test {HSETEX with expiration converts template key to regular hash} {
@@ -1010,6 +1090,74 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         r copy copy:replace:src copy:replace:dst REPLACE
         assert_equal [r type copy:replace:dst] hash
         assert_encoding $encoding copy:replace:dst
+    }
+
+    # Differential fuzz for the batch mutation paths: feed the same random
+    # multi-field HSET/HDEL/HGETDEL commands to a template hash and to a
+    # regular hash and require identical replies and identical content after
+    # every command.
+    test "random batch HSET/HDEL/HGETDEL match a regular hash ($encoding)" {
+        # A random field from a pool of 30 (f0 .. f29). The pool is small so
+        # commands hit a mix of existing, new, missing and repeated fields.
+        proc rand_field {} { return f[expr {int(rand()*30)}] }
+        
+        for {set round 0} {$round < 300} {incr round} {
+            # Start each round with both keys holding the same 4..11 fields.
+            r del fuzz:tmpl fuzz:plain
+            unset -nocomplain seed
+            set nseed [expr {4 + int(rand()*8)}]
+            for {set i 0} {$i < $nseed} {incr i} { set seed([rand_field]) seed$i }
+            set pairs {}
+            foreach f [array names seed] { lappend pairs $f $seed($f) }
+
+            make_hashtmpl fuzz:tmpl {*}$pairs
+            r hset fuzz:plain {*}$pairs
+            assert_encoding $encoding fuzz:tmpl
+
+            # 25 random commands of 1..6 fields each, HSET twice as likely as
+            # each other command. Both keys are compared after every command.
+            for {set op 0} {$op < 25} {incr op} {
+                set n [expr {1 + int(rand()*6)}]
+                set cmd [lindex {hset hset hsetex hdel hgetdel} [expr {int(rand()*5)}]]
+                switch $cmd {
+                    hset - hsetex {
+                        # Values are unique per command ("v<round>.<op>.<i>")
+                        # so a stale value can never match.
+                        set args {}
+                        for {set i 0} {$i < $n} {incr i} {
+                            set v v$round.$op.$i
+                            if {rand() < 0.1} { append v [string repeat x 100] }
+                            lappend args [rand_field] $v
+                        }
+                        if {$cmd eq "hset"} {
+                            assert_equal [r hset fuzz:plain {*}$args] \
+                                         [r hset fuzz:tmpl {*}$args] "hset $args"
+                        } else {
+                            assert_equal [r hsetex fuzz:plain FIELDS $n {*}$args] \
+                                         [r hsetex fuzz:tmpl FIELDS $n {*}$args] \
+                                         "hsetex $args"
+                        }
+                    }
+                    hdel {
+                        set fields {}
+                        for {set i 0} {$i < $n} {incr i} { lappend fields [rand_field] }
+                        assert_equal [r hdel fuzz:plain {*}$fields] \
+                                     [r hdel fuzz:tmpl {*}$fields] "hdel $fields"
+                    }
+                    hgetdel {
+                        set fields {}
+                        for {set i 0} {$i < $n} {incr i} { lappend fields [rand_field] }
+                        assert_equal [r hgetdel fuzz:plain FIELDS $n {*}$fields] \
+                                     [r hgetdel fuzz:tmpl FIELDS $n {*}$fields] \
+                                     "hgetdel $fields"
+                    }
+                }
+                assert_same_hash_content fuzz:tmpl fuzz:plain
+
+                # Deleting the last field deletes the key; start a new round.
+                if {![r exists fuzz:tmpl]} break
+            }
+        }
     }
 }
 
@@ -1698,6 +1846,24 @@ start_server {tags {"hash" "convert" "needs:debug" "cluster:skip"}
         assert_encoding template-array key
         assert_equal [r hlen key] 9
         for {set i 0} {$i < 9} {incr i} { assert_equal [r hget key f$i] v$i }
+
+        r del key
+        r himport discard fieldset
+    }
+
+    test {convert: TMPL_LP -> TMPL_ARRAY when one HSET crosses hash-max-listpack-entries mid-batch} {
+        # Start below the limit of 8 and cross it in the middle of a single
+        # multi field HSET: the conversion happens while some of the command's
+        # values are still waiting to be stored.
+        r himport prepare fieldset a b c d
+        r himport set key fieldset 1 2 3 4
+        assert_encoding template-listpack key
+
+        r hset key n0 0 n1 1 n2 2 n3 3 n4 4 n5 5
+        assert_encoding template-array key
+        assert_equal [r hlen key] 10
+        assert_equal [r hget key a] 1
+        assert_equal [r hget key n5] 5
 
         r del key
         r himport discard fieldset

--- a/tests/unit/type/hash-templates.tcl
+++ b/tests/unit/type/hash-templates.tcl
@@ -677,6 +677,12 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         r hset hset:multi b 2 c 3 d 4
         assert_encoding $encoding hset:multi
         assert_equal {a 1 b 2 c 3 d 4} [r hgetall hset:multi]
+
+        # New fields land before, between and after the old ones.
+        make_hashtmpl hset:multi2 c 3 f 6
+        assert_equal 3 [r hset hset:multi2 h 8 a 1 d 4]
+        assert_encoding $encoding hset:multi2
+        assert_equal {a 1 c 3 d 4 f 6 h 8} [r hgetall hset:multi2]
     }
 
     test {HSET on template-based hash returns number of new fields} {


### PR DESCRIPTION
Adding or removing a field on a template hash means switching the key to another template. Commands used to do this once per field, so HSET/HDEL with many fields created and dropped a template for every single field. Now HSET, HSETEX, HDEL and HGETDEL collect all the fields first and switch the template once per command. Existing fields are still updated in place.

Note: Some extra tests added for coverage. 

-------------
Some local benchmarks:

Workload: continuous mix of HSET (add 5 new fields) and HDEL (delete the same 5 fields) at a 1:1 ratio, so every key keeps cycling between templates (every mutation is a switch to an existing template).

**20-field hash:**

| Encoding            | Before | After  | Regular hash equivalent |
|---------------------|--------|--------|-------------------------|
| template-listpack   | 88.4k  | 235.8k | 204.6k (listpack)       |
| template-array      | 94.1k  | 254.6k | 291.7k (hashtable)      |

**100-field hash:**

| Encoding            | Before | After  | Regular hash equivalent |
|---------------------|--------|--------|-------------------------|
| template-listpack   | 31.6k  | 177.1k | 102.4k (listpack)       |
| template-array      | 32.6k  | 195.0k | 285.6k (hashtable)      |

memtier command was like:

    memtier_benchmark -t 2 -c 25 --pipeline=32 --test-time=15 \
      --command="HSET __key__ last_login 1755207612042 login_count 17 session_token 9f2ab6de1c0b4c69 last_ip 203.0.113.57 device ios" \
      --command-ratio=1 --command-key-pattern=P \
      --command="HDEL __key__ last_login login_count session_token last_ip device" \
      --command-ratio=1 --command-key-pattern=P \
      --key-prefix="k:" --key-maximum=199999



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core hash mutation and template refcounting for TMPL_LP/TMPL_ARRAY; incorrect batching could corrupt field order, values, or template sharing, though extensive new tests mitigate this.
> 
> **Overview**
> **Template-encoded hashes** no longer create or drop a shared field template once per field when a command touches many fields. **HSET**, **HSETEX** (without expiry), **HDEL**, and **HGETDEL** now scan argv once, update existing values in place, then perform **one** template switch for all adds or all deletes.
> 
> The refactor centralizes that logic in new helpers (`hashTypeTmplSetFields`, `hashTypeTmplAddFields`, `hashTypeTmplDropFields`, `hashTypeTmplDeleteFields`) and reuses them from single-field `hashTypeSet` / `hashTypeDelete`. Batch paths handle duplicate field names (last wins on set), dedupe deletes, **TMPL_LP → TMPL_ARRAY** when a multi-field add crosses `hash-max-listpack-entries`, and listpack batch deletes via `lpBatchDelete`. `hashTypeIsTemplate` replaces repeated encoding checks; `FIELDS_STACK_SIZE` grows from 16 to 64 for notification bookkeeping.
> 
> **HSETEX with TTL** still uses the per-field loop (template hashes do not support HFE). Tests add wide-batch coverage, duplicate-field behavior, subkey events, module `RM_HashSet` deletes, and a differential fuzz comparing template vs plain hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b732ada8229ad0cb4f786bcaa653444c3e687061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->