### PR TITLE
fix: mark BITFIELD key as modified even when all OVERFLOW FAIL writes return null [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -2107,7 +2107,7 @@ void bitfieldGeneric(client *c, int flags) {
         }
     }
 
-    if (changes) {
+    if (changes || strGrowSize) {
 
         /* If this is not a new key (old size not 0) and size changed, then 
          * update the keysizes histogram. Otherwise, the histogram already 
@@ -2117,7 +2117,7 @@ void bitfieldGeneric(client *c, int flags) {
         
         keyModified(c,c->db,c->argv[1],o,1);
         notifyKeyspaceEvent(NOTIFY_STRING,"setbit",c->argv[1],c->db->id);
-        server.dirty += changes;
+        server.dirty += changes ? changes : 1;
     }
     zfree(ops);
 }


### PR DESCRIPTION
### Problem

`BITFIELD` with `OVERFLOW FAIL` can mutate a string without persistence or replication.

`lookupStringForBitCommand()` eagerly creates or grows the destination string before the operation loop. When every write subcommand overflows under `OVERFLOW FAIL`, `changes` stays zero, so the key is never marked as modified. The mutation is consequently omitted from AOF and replication, so the primary can diverge from replicas.

### Fix

Change `if (changes)` to `if (changes || strGrowSize)` in `bitfieldGeneric()`. When `strGrowSize > 0` (string was created or grown) but `changes == 0` (all writes overflowed), the key is still properly marked modified, notified, and counted in server.dirty.

Closes #15599

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence/replication semantics for BITFIELD in an edge case; change is minimal and aligned with existing SETBIT-style handling when `strGrowSize` is set.
> 
> **Overview**
> Fixes a **replication/AOF bug** where `BITFIELD` could grow or create the target string but never mark the key as modified when every `SET`/`INCRBY` hit `OVERFLOW FAIL` (so `changes` stayed 0).
> 
> In `bitfieldGeneric()`, the post-command path now runs when **`changes || strGrowSize`**, not only when `changes` is non-zero. That still calls `keyModified`, keyspace notification, and bumps **`server.dirty`** by `changes` when writes succeeded, or by **1** when only the string was allocated/grown with no successful field writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ac62478d9618faaba5d4160c163e2038ea993e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->