### PR TITLE
Avoid changing sorted set encoding in SORT and SORT_RO

### DIFF
--- a/src/sort.c
+++ b/src/sort.c
@@ -338,16 +338,6 @@ void sortCommandGeneric(client *c, int readonly) {
         sortby = NULL;
     }
 
-    /* Destructively convert encoded sorted sets for SORT. SORT_RO traverses
-     * listpack encoded sorted sets directly below. */
-    if (sortval->type == OBJ_ZSET && !readonly) {
-        if (server.memory_tracking_enabled)
-            oldsize = kvobjAllocSize(sortval);
-        zsetConvert(sortval, OBJ_ENCODING_SKIPLIST);
-        if (server.memory_tracking_enabled)
-            updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), sortval, oldsize, kvobjAllocSize(sortval));
-    }
-
     /* Obtain the length of the object to sort. */
     switch(sortval->type) {
     case OBJ_LIST: vectorlen = listTypeLength(sortval); break;
@@ -472,6 +462,8 @@ void sortCommandGeneric(client *c, int readonly) {
         end -= start;
         start = 0;
     } else if (sortval->type == OBJ_ZSET && sortval->encoding == OBJ_ENCODING_LISTPACK) {
+        /* Load every element of a listpack encoded sorted set, the actual
+         * sorting is performed later on the vector. */
         unsigned char *zl = sortval->ptr;
         unsigned char *eptr = lpSeek(zl,0);
         unsigned char *sptr;

--- a/src/sort.c
+++ b/src/sort.c
@@ -338,8 +338,9 @@ void sortCommandGeneric(client *c, int readonly) {
         sortby = NULL;
     }
 
-    /* Destructively convert encoded sorted sets for SORT. */
-    if (sortval->type == OBJ_ZSET) {
+    /* Destructively convert encoded sorted sets for SORT. SORT_RO traverses
+     * listpack encoded sorted sets directly below. */
+    if (sortval->type == OBJ_ZSET && !readonly) {
         if (server.memory_tracking_enabled)
             oldsize = kvobjAllocSize(sortval);
         zsetConvert(sortval, OBJ_ENCODING_SKIPLIST);
@@ -351,7 +352,7 @@ void sortCommandGeneric(client *c, int readonly) {
     switch(sortval->type) {
     case OBJ_LIST: vectorlen = listTypeLength(sortval); break;
     case OBJ_SET: vectorlen =  setTypeSize(sortval); break;
-    case OBJ_ZSET: vectorlen = dictSize(((zset*)sortval->ptr)->dict); break;
+    case OBJ_ZSET: vectorlen = zsetLength(sortval); break;
     default: vectorlen = 0; serverPanic("Bad SORT type"); /* Avoid GCC warning */
     }
 
@@ -438,6 +439,54 @@ void sortCommandGeneric(client *c, int readonly) {
         setTypeResetIterator(&si);
         if (server.memory_tracking_enabled)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), sortval, oldsize, kvobjAllocSize(sortval));
+    } else if (sortval->type == OBJ_ZSET &&
+               sortval->encoding == OBJ_ENCODING_LISTPACK &&
+               dontsort)
+    {
+        /* Special handling for a listpack encoded sorted set, if 'dontsort'
+         * is true. Load only the requested range directly from the listpack. */
+        unsigned char *zl = sortval->ptr;
+        unsigned char *eptr = NULL, *sptr = NULL;
+        sds sdsele;
+        int rangelen = vectorlen;
+
+        if (rangelen) {
+            eptr = desc ? lpSeek(zl,-2-(2*start)) : lpSeek(zl,2*start);
+            serverAssertWithInfo(c,sortval,eptr != NULL);
+            sptr = lpNext(zl,eptr);
+            serverAssertWithInfo(c,sortval,sptr != NULL);
+        }
+
+        while(rangelen--) {
+            sdsele = lpGetObject(eptr);
+            vector[j].obj = createObject(OBJ_STRING,sdsele);
+            vector[j].u.score = 0;
+            vector[j].u.cmpobj = NULL;
+            j++;
+            if (desc)
+                zzlPrev(zl,&eptr,&sptr);
+            else
+                zzlNext(zl,&eptr,&sptr);
+        }
+        /* Fix start/end: output code is not aware of this optimization. */
+        end -= start;
+        start = 0;
+    } else if (sortval->type == OBJ_ZSET && sortval->encoding == OBJ_ENCODING_LISTPACK) {
+        unsigned char *zl = sortval->ptr;
+        unsigned char *eptr = lpSeek(zl,0);
+        unsigned char *sptr;
+        sds sdsele;
+
+        while(eptr) {
+            sptr = lpNext(zl,eptr);
+            serverAssertWithInfo(c,sortval,sptr != NULL);
+            sdsele = lpGetObject(eptr);
+            vector[j].obj = createObject(OBJ_STRING,sdsele);
+            vector[j].u.score = 0;
+            vector[j].u.cmpobj = NULL;
+            j++;
+            zzlNext(zl,&eptr,&sptr);
+        }
     } else if (sortval->type == OBJ_ZSET && dontsort) {
         /* Special handling for a sorted set, if 'dontsort' is true.
          * This makes sure we return elements in the sorted set original

--- a/src/sort.c
+++ b/src/sort.c
@@ -430,8 +430,7 @@ void sortCommandGeneric(client *c, int readonly) {
         if (server.memory_tracking_enabled)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), sortval, oldsize, kvobjAllocSize(sortval));
     } else if (sortval->type == OBJ_ZSET &&
-               sortval->encoding == OBJ_ENCODING_LISTPACK &&
-               dontsort)
+               sortval->encoding == OBJ_ENCODING_LISTPACK && dontsort)
     {
         /* Special handling for a listpack encoded sorted set, if 'dontsort'
          * is true. Load only the requested range directly from the listpack. */

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -143,18 +143,21 @@ foreach command {SORT SORT_RO} {
         r sort zset alpha desc
     } {e d c b a}
 
-    test "SORT_RO sorted set preserves listpack encoding" {
-        r del zset
-        r zadd zset 1 a
-        r zadd zset 5 b
-        r zadd zset 2 c
-        r zadd zset 10 d
-        r zadd zset 3 e
-        assert_encoding listpack zset
-        assert_equal {e d c b a} [r sort_ro zset alpha desc]
-        assert_equal {a c e b d} [r sort_ro zset by nosort asc]
-        assert_equal {b e} [r sort_ro zset by nosort desc limit 1 2]
-        assert_encoding listpack zset
+    foreach command {SORT SORT_RO} {
+        test "$command sorted set preserves listpack encoding" {
+            r del zset
+            r zadd zset 1 a
+            r zadd zset 5 b
+            r zadd zset 2 c
+            r zadd zset 10 d
+            r zadd zset 3 e
+            assert_encoding listpack zset
+            assert_equal {e d c b a} [r $command zset alpha desc]
+            assert_equal {a c e b d} [r $command zset by nosort asc]
+            assert_equal {d b e c a} [r $command zset by nosort desc]
+            assert_equal {b e} [r $command zset by nosort desc limit 1 2]
+            assert_encoding listpack zset
+        }
     }
 
     test "SORT sorted set BY nosort should retain ordering" {
@@ -185,6 +188,39 @@ foreach command {SORT SORT_RO} {
         assert_equal [r sort zset by nosort limit -10 100] {a c e b d}
     }
 
+    foreach command {SORT SORT_RO} {
+        test "$command sorted set BY <pattern> preserves listpack encoding" {
+            r del zset
+            r zadd zset 1 a
+            r zadd zset 2 b
+            r zadd zset 3 c
+            foreach {ele weight} {a 3 b 1 c 2} {
+                r set weight_$ele $weight
+                r hset wobj_$ele weight $weight
+            }
+            assert_encoding listpack zset
+            assert_equal {b c a} [r $command zset by weight_*]
+            assert_equal {b 1 c 2 a 3} [r $command zset by weight_* get # get weight_*]
+            assert_equal {b c a} [r $command zset by wobj_*->weight]
+            assert_encoding listpack zset
+        } {} {cluster:skip}
+    }
+
+    test "SORT sorted set STORE preserves listpack encoding" {
+        r del zset sort-res
+        r zadd zset 1 a
+        r zadd zset 5 b
+        r zadd zset 2 c
+        r zadd zset 10 d
+        r zadd zset 3 e
+        assert_encoding listpack zset
+        assert_equal 5 [r sort zset alpha desc store sort-res]
+        assert_equal {e d c b a} [r lrange sort-res 0 -1]
+        assert_equal 5 [r sort zset by nosort store sort-res]
+        assert_equal {a c e b d} [r lrange sort-res 0 -1]
+        assert_encoding listpack zset
+    } {} {cluster:skip}
+
     test "SORT sorted set BY nosort works as expected from scripts" {
         r del zset
         r zadd zset 1 a
@@ -192,11 +228,13 @@ foreach command {SORT SORT_RO} {
         r zadd zset 2 c
         r zadd zset 10 d
         r zadd zset 3 e
-        r eval {
+        assert_encoding listpack zset
+        assert_equal {{a c e b d} {d b e c a}} [r eval {
             return {redis.call('sort',KEYS[1],'by','nosort','asc'),
                     redis.call('sort',KEYS[1],'by','nosort','desc')}
-        } 1 zset
-    } {{a c e b d} {d b e c a}}
+        } 1 zset]
+        assert_encoding listpack zset
+    }
 
     test "SORT sorted set: +inf and -inf handling" {
         r del zset

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -143,6 +143,20 @@ foreach command {SORT SORT_RO} {
         r sort zset alpha desc
     } {e d c b a}
 
+    test "SORT_RO sorted set preserves listpack encoding" {
+        r del zset
+        r zadd zset 1 a
+        r zadd zset 5 b
+        r zadd zset 2 c
+        r zadd zset 10 d
+        r zadd zset 3 e
+        assert_encoding listpack zset
+        assert_equal {e d c b a} [r sort_ro zset alpha desc]
+        assert_equal {a c e b d} [r sort_ro zset by nosort asc]
+        assert_equal {b e} [r sort_ro zset by nosort desc limit 1 2]
+        assert_encoding listpack zset
+    }
+
     test "SORT sorted set BY nosort should retain ordering" {
         r del zset
         r zadd zset 1 a


### PR DESCRIPTION
Before this change, `SORT` and `SORT_RO` converted listpack-encoded sorted sets to skiplist before sorting. The conversion was introduced when encoded sorted sets needed to be supported while the command handled a single sorted set representation. It permanently changed the source encoding and could substantially increase its memory usage.

This change makes both commands traverse listpack-encoded sorted sets directly. Full scans load listpack members into the sort vector, while `BY nosort` walks only the requested range in native score order. The existing skiplist paths remain unchanged.

Tests cover encoding preservation for both commands across plain sorting, `BY nosort`, `BY` and `GET` patterns, `STORE`, and scripts.

Tests:

- `make -j4`
- `./runtest --single unit/sort`
- `./runtest --single unit/type/zset`
- `./runtest --single unit/scripting`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SORT vector-loading for zsets (new listpack branches); behavior should match prior output but encoding and memory side effects change materially.
> 
> **Overview**
> **`SORT` and `SORT_RO` no longer convert listpack-encoded sorted sets to skiplist** before building the sort vector. That conversion could permanently inflate memory on the source key.
> 
> Sorted-set length now uses **`zsetLength`** instead of assuming a skiplist dict. **Listpack zsets** are read in-place: full scans walk the listpack into the sort vector, and **`BY nosort`** (with optional **`LIMIT`**) walks only the requested score-order range via listpack iterators—mirroring the existing skiplist optimization path.
> 
> Tests assert **listpack encoding is unchanged** after plain/`alpha` sort, **`BY nosort`**, **`BY`/`GET` patterns**, **`STORE`**, and Lua **`redis.call('sort', ...)`**, for both **`SORT`** and **`SORT_RO`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06ef2116f810a53a189da297ed3abf5562e1315e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->