### PR TITLE
Drain post-notification jobs after active hash-field expiration

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -214,14 +214,14 @@ uint64_t activeSubexpires(redisDb *db, int slot, uint32_t maxFieldsToExpire) {
             .now = commandTimeSnapshot(),
             .itemsExpired = 0};
 
-    /* Wrap the batch in an execution unit, as whole-key expiry does in
-     * activeExpireCycleTryExpire(), so module post-notification jobs queued from
-     * the "hexpired"/"del" events are drained before the cycle returns. The unit
-     * spans the batch rather than each hash to keep the drain outside the estore
-     * iteration, which a job writing to the keyspace could otherwise mutate. */
-    enterExecutionUnit(1, 0);
     estoreActiveExpire(db->subexpires, slot, &info);
-    exitExecutionUnit();
+
+    /* Drain module post-notification jobs queued by the "hexpired"/"del" events.
+     * The per-field propagation in propagateHashFieldDeletion() runs before those
+     * notifications fire, so its own drain cannot pick them up and they would
+     * otherwise linger until the tail of the next command's call(). No execution
+     * unit is wrapped around the walk: that would suppress the per-field drains
+     * and batch the HDELs into a single MULTI/EXEC. */
     postExecutionUnitOperations();
 
     /* Return number of fields active-expired */

--- a/src/expire.c
+++ b/src/expire.c
@@ -214,7 +214,23 @@ uint64_t activeSubexpires(redisDb *db, int slot, uint32_t maxFieldsToExpire) {
             .now = commandTimeSnapshot(),
             .itemsExpired = 0};
 
+    /* Wrap the batch in an execution unit, as whole-key active expiration does in
+     * activeExpireCycleTryExpire(). Field deletions here fire keyspace
+     * notifications ("hexpired", and "del" when the hash empties), and a module
+     * may queue a post-notification job from them. Without an execution unit
+     * those jobs are not drained when the cycle ends, so they linger until the
+     * tail of the next command's call() -- a client command in between observes
+     * state the module has not reacted to yet.
+     *
+     * The unit wraps the whole batch rather than each hash so that the drain
+     * happens outside the estore iteration: a regular (non per-key) job is
+     * allowed to write to the keyspace, which could otherwise mutate the
+     * subexpires structure while it is being walked. */
+    enterExecutionUnit(1, 0);
     estoreActiveExpire(db->subexpires, slot, &info);
+    exitExecutionUnit();
+    /* Propagate the field deletions and drain post-notification jobs. */
+    postExecutionUnitOperations();
 
     /* Return number of fields active-expired */
     return maxFieldsToExpire - ctx.fieldsToExpireQuota;

--- a/src/expire.c
+++ b/src/expire.c
@@ -214,22 +214,14 @@ uint64_t activeSubexpires(redisDb *db, int slot, uint32_t maxFieldsToExpire) {
             .now = commandTimeSnapshot(),
             .itemsExpired = 0};
 
-    /* Wrap the batch in an execution unit, as whole-key active expiration does in
-     * activeExpireCycleTryExpire(). Field deletions here fire keyspace
-     * notifications ("hexpired", and "del" when the hash empties), and a module
-     * may queue a post-notification job from them. Without an execution unit
-     * those jobs are not drained when the cycle ends, so they linger until the
-     * tail of the next command's call() -- a client command in between observes
-     * state the module has not reacted to yet.
-     *
-     * The unit wraps the whole batch rather than each hash so that the drain
-     * happens outside the estore iteration: a regular (non per-key) job is
-     * allowed to write to the keyspace, which could otherwise mutate the
-     * subexpires structure while it is being walked. */
+    /* Wrap the batch in an execution unit, as whole-key expiry does in
+     * activeExpireCycleTryExpire(), so module post-notification jobs queued from
+     * the "hexpired"/"del" events are drained before the cycle returns. The unit
+     * spans the batch rather than each hash to keep the drain outside the estore
+     * iteration, which a job writing to the keyspace could otherwise mutate. */
     enterExecutionUnit(1, 0);
     estoreActiveExpire(db->subexpires, slot, &info);
     exitExecutionUnit();
-    /* Propagate the field deletions and drain post-notification jobs. */
     postExecutionUnitOperations();
 
     /* Return number of fields active-expired */

--- a/tests/unit/moduleapi/postnotifications_perkey.tcl
+++ b/tests/unit/moduleapi/postnotifications_perkey.tcl
@@ -408,6 +408,24 @@ tags "modules external:skip" {
             assert_equal {ak} [r pkmeta.empty_firelog]
         }
     }
+
+    test "perkey-expire: active field expire (cron) fires the per-key job without a read" {
+        start_server [list overrides [list loadmodule "$testmodule"]] {
+            r debug set-active-expire 1
+            # Field g outlives f, so hk survives its field's expiry and the job
+            # can attach metadata (fire_count, not empty_fire_count).
+            r hset hk f v g w
+            r hpexpire hk 100 FIELDS 1 f
+            r pkmeta.reset
+            # A fixed client-side wait and a single observation, deliberately not
+            # wait_for_condition: every command drains pending per-key jobs at the
+            # tail of its call(), so a poll loop would drain the job itself and
+            # pass even if the active-expire cycle never did.
+            after 500
+            assert_equal 1 [r pkmeta.firecount]
+            assert_equal "notified" [r pkmeta.getmeta hk]
+        }
+    }
 }
 
 # Pointer-safety guard: the per-key job's first RM_SetKeyMeta attach reallocates


### PR DESCRIPTION
## The problem

Whole-key active expiration wraps each expiry in an execution unit, so post-notification jobs a module queues from the resulting keyspace notification are drained before the cycle returns:

```c
/* expire.c -- activeExpireCycleTryExpire() */
enterExecutionUnit(1, 0);
deleteExpiredKeyAndPropagate(db, keyobj);
exitExecutionUnit();
postExecutionUnitOperations();   /* drains queued jobs */
```

The hash-field equivalent has no such drain. `activeSubexpires()` calls `estoreActiveExpire()` directly, and `hashTypeExpire()` fires `hexpired` (and `del` when the hash empties) from inside it.

`propagateHashFieldDeletion()` does wrap each field deletion in its own execution unit and drain at the end of it, but those per-field drains run *before* the `hexpired`/`del` notifications fire, so they cannot pick up the jobs those notifications queue.

A per-key job queued from those notifications therefore stays on the queue until the tail of the *next* command's `call()`. A client command issued in between is served while the module has not yet reacted to the expiry — and that command's own `call()` tail then drains the job, so the effect is self-correcting and visible for exactly one command. That last part makes it easy to miss: a retry always looks fine.

This matters for the documented use case of `RM_AddPostNotificationJobForKey`, whose contract says the callback should maintain module-attached key metadata via `RM_SetKeyMeta` / `RM_GetKeyMeta`. A module keeping such metadata in sync with field expiry serves one stale read per expiry.

Incidentally, `postExecutionUnitOperations()`'s own doc comment already uses active expiry as its worked example of an execution unit.

## Reproducing

With the in-tree `tests/modules/postnotifications_perkey_metadata.so`:

```
HSET hk f v g w
HPEXPIRE hk 100 FIELDS 1 f
PKMETA.RESET
<wait ~500ms, sending nothing>
PKMETA.FIRECOUNT
```

`0` before this change, `1` after. Field `g` outlives `f` so the hash survives its field's expiry and the job can attach metadata.

## The fix

A single `postExecutionUnitOperations()` after the `estoreActiveExpire()` walk in `activeSubexpires()`, with **no** execution unit wrapped around the walk:

```c
estoreActiveExpire(db->subexpires, slot, &info);
postExecutionUnitOperations();
```

The drain on its own is sufficient, and wrapping the walk would be actively harmful:

- By the time the walk returns, `propagateHashFieldDeletion()`'s per-field units have all opened and closed, so nesting is already zero and the queued jobs are drainable as-is.
- An outer unit would instead keep nesting non-zero for the whole walk, turning each of those per-field drains into a no-op and batching the per-field `HDEL`s into one `MULTI`/`EXEC` — a propagation change well outside the scope of this fix. An earlier revision of this PR did wrap the walk; see the review thread on `src/expire.c`.

Keeping the drain outside the walk also keeps it clear of the estore iteration: a regular (non per-key) job is allowed to write to the keyspace, which could otherwise mutate the `subexpires` structure while it is being walked.

Per-field propagation is therefore unchanged from before. The only added work on the hot path is one `postExecutionUnitOperations()` per `activeSubexpires()` batch — per db/slot per cron tick, not per field — which early-outs when nothing is pending.

## Testing

- Added a regression test next to the existing whole-key cron test in `tests/unit/moduleapi/postnotifications_perkey.tcl`. It uses a fixed wait and a **single** observation rather than `wait_for_condition`: every command drains pending per-key jobs, so a poll loop would drain the job itself and pass even when the cron never did. Worth keeping in mind if anyone later tidies it into a poll loop.
- Verified by A/B on the same tree (patch applied vs reverted, rebuilt each time) using the scenario above, and re-verified after the outer execution unit was dropped.
- `action:run-benchmark` has been applied by a maintainer so the CE performance suite covers this path.
- I was not able to run the TCL harness locally — it hangs during port allocation on my machine, unrelated to this change — so the suite results here rely on CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches active expiration and module job draining on a background path; behavior change is narrow but affects metadata sync timing for `RM_AddPostNotificationJobForKey` on field expiry.
> 
> **Overview**
> **Active hash-field expiration** now calls `postExecutionUnitOperations()` right after the `estoreActiveExpire()` walk in `activeSubexpires()`, so module per-key post-notification jobs queued from `hexpired` / `del` during the cron path run in the same cycle instead of waiting until the next client command’s `call()` tail.
> 
> The change **does not** wrap the walk in an execution unit: that would defer per-field propagation drains and batch HDELs into one MULTI/EXEC. Comments in `expire.c` document that tradeoff.
> 
> A regression test in `postnotifications_perkey.tcl` covers cron-driven field expiry with a fixed `after 500` and a single read (no `wait_for_condition`, which would falsely pass by draining the job via polling commands).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c25eb93c5e5c3ef4d28cdaf902146e6e4628f38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
