### PR TITLE
Fix overflowing relative expiration times in SET

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -255,12 +255,7 @@ static int getExpireMillisecondsOrReply(client *c, robj *expire, int relative_tt
 
     if (unit == UNIT_SECONDS) *milliseconds *= 1000;
 
-    if (relative_ttl) {
-        *milliseconds += commandTimeSnapshot();
-    }
-
-    if (*milliseconds <= 0) {
-        /* Overflow detected. */
+    if (relative_ttl && add_overflow_ll(*milliseconds, commandTimeSnapshot(), milliseconds)) {
         addReplyErrorExpireTime(c);
         return C_ERR;
     }

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -751,6 +751,15 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         assert {$ttl <= 10 && $ttl > 5}
     }
 
+    test {Extended SET PX option with a TTL that overflows when added to the current time} {
+        r set foo bar
+        assert_error "ERR invalid expire time in 'set' command" {
+            r set foo baz px 9223372036854775807
+        }
+        assert_equal bar [r get foo]
+        assert_equal -1 [r pttl foo]
+    }
+
     test "Extended SET EXAT option" {
         r del foo
         r set foo bar exat [expr [clock seconds] + 10]

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -752,6 +752,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
     }
 
     test {Extended SET PX option with a TTL that overflows when added to the current time} {
+        r del foo
         r set foo bar
         assert_error "ERR invalid expire time in 'set' command" {
             r set foo baz px 9223372036854775807


### PR DESCRIPTION

## Issue

`getExpireMillisecondsOrReply()` adds a relative `EX` or `PX` value to the current command time without safely checking for signed integer overflow.

For example:

```text
SET k v PX 9223372036854775807 -> OK
EXISTS k                       -> 0
PTTL k                         -> -2
expired_keys                   -> +1
```

The relative TTL overflows while being converted to an absolute expiration time. The command incorrectly returns `OK`, but the resulting timestamp is in the past, so the key is immediately expired and `expired_keys` is incremented.

## Change

Use `add_overflow_ll()` when adding the command time to a relative TTL. Return an invalid expire time error before modifying the key if the addition overflows.


## Test

Daily CI with param ` --single unit/type/string`: https://github.com/vitahlin/redis/actions/runs/31563879422/job/94011629390

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches expiration-time validation used by SET/GETEX/MSETEX, which affects key lifetime correctness, but the change is a small overflow-safe rejection path.
> 
> **Overview**
> Fixes a bug where relative `EX`/`PX` values in `SET` (and other callers of `getExpireMillisecondsOrReply`) could overflow when converted to an absolute timestamp.
> 
> Previously, a huge relative TTL could wrap to a past time, so the command returned `OK` but the key was immediately expired. The helper now uses `add_overflow_ll()` and rejects the command with an invalid expire time error before modifying the key. Adds a regression test for overflowing `SET ... PX`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d65227f4dda135e71dada992eb3657eea2d2d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->