### PR TITLE
Fix potential defrag issues in the hash template registry

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -441,7 +441,7 @@ void activeDefragZsetNode(zset *zs, dictEntry *de, dictEntryLink plink) {
 #define DEFRAG_SDS_DICT_VAL_VOID_PTR 3
 #define DEFRAG_SDS_DICT_VAL_LUA_SCRIPT 4
 
-void activeDefragDictCallbackNoop(void *privdata, const dictEntry *de, dictEntryLink plink) {
+void activeDefragSdsDictCallback(void *privdata, const dictEntry *de, dictEntryLink plink) {
     UNUSED(plink);
     UNUSED(privdata);
     UNUSED(de);
@@ -486,7 +486,7 @@ void activeDefragSdsDict(dict* d, int val_type) {
                       NULL)
     };
     dictScanFunction *fn = (val_type == DEFRAG_SDS_DICT_VAL_LUA_SCRIPT ?
-        activeDefragLuaScriptDictCallback : activeDefragDictCallbackNoop);
+        activeDefragLuaScriptDictCallback : activeDefragSdsDictCallback);
     do {
         cursor = dictScanDefrag(d, cursor, fn,
                                 &defragfns, NULL);
@@ -796,15 +796,16 @@ void defragTmplArray(defragKeysCtx *ctx, kvobj *ob) {
     }
 }
 
-/* Incremental defrag of an sds array; cursor = next index.
+/* Incremental defrag of a TMPL_ARRAY's values; cursor = next index.
  * Returns 1 if time is up (more to do), 0 when done. */
-static long defragSdsArrayIncremental(sds *arr, unsigned long long n,
-                                      unsigned long *cursor, monotime endtime)
-{
+long scanLaterTmplArray(robj *ob, unsigned long *cursor, monotime endtime) {
+    serverAssert(ob->type == OBJ_HASH && ob->encoding == OBJ_ENCODING_TMPL_ARRAY);
+    hashTemplateArray *hta = ob->ptr;
+    unsigned long long n = hta->field_count;
     long iterations = 0;
     while (*cursor < n) {
-        sds newsds = activeDefragSds(arr[*cursor]);
-        if (newsds) arr[*cursor] = newsds;
+        sds newsds = activeDefragSds(hta->values[*cursor]);
+        if (newsds) hta->values[*cursor] = newsds;
         server.stat_active_defrag_scanned++;
         (*cursor)++;
         if (++iterations > 128) {
@@ -814,13 +815,6 @@ static long defragSdsArrayIncremental(sds *arr, unsigned long long n,
     }
     *cursor = 0;
     return 0;
-}
-
-/* Incremental defrag of a TMPL_ARRAY's values; cursor = next index. */
-long scanLaterTmplArray(robj *ob, unsigned long *cursor, monotime endtime) {
-    serverAssert(ob->type == OBJ_HASH && ob->encoding == OBJ_ENCODING_TMPL_ARRAY);
-    hashTemplateArray *hta = ob->ptr;
-    return defragSdsArrayIncremental(hta->values, hta->field_count, cursor, endtime);
 }
 
 /* Defrag callback for radix tree iterator, called for each node,
@@ -1703,87 +1697,23 @@ static doneStatus defragLuaScripts(void *ctx, monotime endtime) {
     return DEFRAG_DONE;
 }
 
-/* Cursor of a registry lookup dict stage. A template holding too many fields to
- * relocate during the scan is deferred to 'later' and drained a slice at a time
- * between scan steps, the way defragLater() defers big keys to defragLaterStep(). */
-typedef struct {
-    unsigned long cursor;      /* dict scan cursor */
-    int scan_done;             /* the dict scan finished, only 'later' is left */
-    list *later;               /* ids of templates with field work left */
-    unsigned long later_field; /* field cursor into the head of 'later' */
-} defragTmplCtx;
-
-static void freeDefragTmplContext(void *ctx) {
-    defragTmplCtx *tctx = ctx;
-    if (tctx->later) listRelease(tctx->later);
-    zfree(tctx);
-}
-
 static void defragTmplRegistryCb(void *privdata, const dictEntry *de, dictEntryLink plink) {
-    defragTmplCtx *ctx = privdata;
-    hashTemplate *tmpl = dictGetKey(de);
+    monotime endtime = *(monotime *)privdata;
     UNUSED(plink);
-
-    tmpl = hashTemplateDefrag(tmpl, (dictEntry *)de);
-    if (tmpl->field_count > server.active_defrag_max_scan_fields) {
-        if (!ctx->later) ctx->later = listCreate();
-        listAddNodeTail(ctx->later, (void *)(uintptr_t)tmpl->id);
-        return;
-    }
-    for (unsigned long long i = 0; i < tmpl->field_count; i++) {
-        sds newsds = activeDefragSds(tmpl->fields[i]);
-        if (newsds) tmpl->fields[i] = newsds;
-        server.stat_active_defrag_scanned++;
-    }
+    hashTemplateDefrag(dictGetKey(de), (dictEntry *)de, endtime);
 }
 
-/* Relocate the field names of the templates the scan deferred, mirroring
- * defragLaterStep() for big keys. A kvstoreHelperPreContinueFn. */
-static doneStatus defragTmplLaterStep(void *privdata, monotime endtime) {
-    defragTmplCtx *ctx = privdata;
-    unsigned int iterations = 0;
-    unsigned long long prev_defragged = server.stat_active_defrag_hits;
-    unsigned long long prev_scanned = server.stat_active_defrag_scanned;
-
-    while (ctx->later && listLength(ctx->later) > 0) {
-        listNode *head = listFirst(ctx->later);
-        hashTemplate *tmpl = hashTemplateGetById((uint64_t)(uintptr_t)head->value);
-
-        if (tmpl && defragSdsArrayIncremental(tmpl->fields, tmpl->field_count, &ctx->later_field, endtime))
-            break; /* time is up */
-
-        /* Drained it fully or it was freed since we deferred it. */
-        ctx->later_field = 0;
-        listDelNode(ctx->later, head);
-
-        if (++iterations > 16 ||
-            server.stat_active_defrag_hits - prev_defragged > 512 ||
-            server.stat_active_defrag_scanned - prev_scanned > 64)
-        {
-            if (getMonotonicUs() > endtime) break;
-            iterations = 0;
-            prev_defragged = server.stat_active_defrag_hits;
-            prev_scanned = server.stat_active_defrag_scanned;
-        }
-    }
-    return (!ctx->later || listLength(ctx->later) == 0) ? DEFRAG_DONE : DEFRAG_NOT_DONE;
-}
-
-/* Defrag a registry lookup dict, invoking 'callback' per entry and 'precontinue'
- * (optional) before each scan step, the way defragStageKvstoreHelper() does. */
-static doneStatus defragRegistryDict(monotime endtime, dict **dref, unsigned long *cursor,
-                                     void *ctx, dictScanFunction *scan_fn,
-                                     kvstoreHelperPreContinueFn precontinue_fn)
+/* Defrag a registry lookup dict, invoking 'scan_fn' per entry, the way
+ * defragStageKvstoreHelper() does. */
+static doneStatus defragRegistryDict(dict **dref, unsigned long *cursor,
+                                     dictScanFunction *scan_fn, monotime endtime)
 {
     dictDefragFunctions fns = { .defragAlloc = activeDefragAlloc };
     unsigned int iterations = 0;
     unsigned long long prev_defragged = server.stat_active_defrag_hits;
     unsigned long long prev_scanned = server.stat_active_defrag_scanned;
     do {
-        if (precontinue_fn && precontinue_fn(ctx, endtime) == DEFRAG_NOT_DONE)
-            return DEFRAG_NOT_DONE;
-
-        *cursor = dictScanDefrag(*dref, *cursor, scan_fn, &fns, ctx);
+        *cursor = dictScanDefrag(*dref, *cursor, scan_fn, &fns, &endtime);
 
         if (++iterations > 16 ||
             server.stat_active_defrag_hits - prev_defragged > 512 ||
@@ -1803,23 +1733,13 @@ static doneStatus defragRegistryDict(monotime endtime, dict **dref, unsigned lon
 }
 
 static doneStatus defragStageHashTemplatesByFields(void *ctx, monotime endtime) {
-    defragTmplCtx *tctx = ctx;
     if (server.htemplates == NULL) return DEFRAG_DONE;
-
-    if (!tctx->scan_done) {
-        if (defragRegistryDict(endtime, &server.htemplates->by_fields, &tctx->cursor,
-                               tctx, defragTmplRegistryCb,
-                               defragTmplLaterStep) == DEFRAG_NOT_DONE)
-            return DEFRAG_NOT_DONE;
-        tctx->scan_done = 1;
-    }
-    return defragTmplLaterStep(tctx, endtime);
+    return defragRegistryDict(&server.htemplates->by_fields, ctx, defragTmplRegistryCb, endtime);
 }
 
 static doneStatus defragStageHashTemplatesByFieldsLp(void *ctx, monotime endtime) {
     if (server.htemplates == NULL) return DEFRAG_DONE;
-    return defragRegistryDict(endtime, &server.htemplates->by_fields_lp, ctx, NULL,
-                              activeDefragDictCallbackNoop, NULL);
+    return defragRegistryDict(&server.htemplates->by_fields_lp, ctx, scanCallbackCountScanned, endtime);
 }
 
 static doneStatus defragStageHashTemplatesById(void *ctx, monotime endtime) {
@@ -2168,7 +2088,7 @@ static void beginDefragCycle(void) {
     addDefragStage(defragLuaScripts, NULL, NULL);
 
     /* Add stage for the hash template registry. */
-    addDefragStage(defragStageHashTemplatesByFields, freeDefragTmplContext, zcalloc(sizeof(defragTmplCtx)));
+    addDefragStage(defragStageHashTemplatesByFields, zfree, zcalloc(sizeof(unsigned long)));
     addDefragStage(defragStageHashTemplatesByFieldsLp, zfree, zcalloc(sizeof(unsigned long)));
     addDefragStage(defragStageHashTemplatesById, zfree, zcalloc(sizeof(unsigned long)));
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -441,7 +441,7 @@ void activeDefragZsetNode(zset *zs, dictEntry *de, dictEntryLink plink) {
 #define DEFRAG_SDS_DICT_VAL_VOID_PTR 3
 #define DEFRAG_SDS_DICT_VAL_LUA_SCRIPT 4
 
-void activeDefragSdsDictCallback(void *privdata, const dictEntry *de, dictEntryLink plink) {
+void activeDefragDictCallbackNoop(void *privdata, const dictEntry *de, dictEntryLink plink) {
     UNUSED(plink);
     UNUSED(privdata);
     UNUSED(de);
@@ -486,7 +486,7 @@ void activeDefragSdsDict(dict* d, int val_type) {
                       NULL)
     };
     dictScanFunction *fn = (val_type == DEFRAG_SDS_DICT_VAL_LUA_SCRIPT ?
-        activeDefragLuaScriptDictCallback : activeDefragSdsDictCallback);
+        activeDefragLuaScriptDictCallback : activeDefragDictCallbackNoop);
     do {
         cursor = dictScanDefrag(d, cursor, fn,
                                 &defragfns, NULL);
@@ -796,16 +796,15 @@ void defragTmplArray(defragKeysCtx *ctx, kvobj *ob) {
     }
 }
 
-/* Incremental defrag of a TMPL_ARRAY's values; cursor = next index.
+/* Incremental defrag of an sds array; cursor = next index.
  * Returns 1 if time is up (more to do), 0 when done. */
-long scanLaterTmplArray(robj *ob, unsigned long *cursor, monotime endtime) {
-    serverAssert(ob->type == OBJ_HASH && ob->encoding == OBJ_ENCODING_TMPL_ARRAY);
-    hashTemplateArray *hta = ob->ptr;
-    unsigned long long n = hta->field_count;
+static long defragSdsArrayIncremental(sds *arr, unsigned long long n,
+                                      unsigned long *cursor, monotime endtime)
+{
     long iterations = 0;
     while (*cursor < n) {
-        sds newsds = activeDefragSds(hta->values[*cursor]);
-        if (newsds) hta->values[*cursor] = newsds;
+        sds newsds = activeDefragSds(arr[*cursor]);
+        if (newsds) arr[*cursor] = newsds;
         server.stat_active_defrag_scanned++;
         (*cursor)++;
         if (++iterations > 128) {
@@ -815,6 +814,13 @@ long scanLaterTmplArray(robj *ob, unsigned long *cursor, monotime endtime) {
     }
     *cursor = 0;
     return 0;
+}
+
+/* Incremental defrag of a TMPL_ARRAY's values; cursor = next index. */
+long scanLaterTmplArray(robj *ob, unsigned long *cursor, monotime endtime) {
+    serverAssert(ob->type == OBJ_HASH && ob->encoding == OBJ_ENCODING_TMPL_ARRAY);
+    hashTemplateArray *hta = ob->ptr;
+    return defragSdsArrayIncremental(hta->values, hta->field_count, cursor, endtime);
 }
 
 /* Defrag callback for radix tree iterator, called for each node,
@@ -1697,43 +1703,98 @@ static doneStatus defragLuaScripts(void *ctx, monotime endtime) {
     return DEFRAG_DONE;
 }
 
-static doneStatus defragStageHashTemplates(void *ctx, monotime endtime) {
-    unsigned long *cursor = ctx;
-    hashTemplateRegistry *reg = server.htemplates;
-    if (reg == NULL || reg->by_id == NULL) return DEFRAG_DONE;
+/* Cursor of a registry lookup dict stage. A template holding too many fields to
+ * relocate during the scan is deferred to 'later' and drained a slice at a time
+ * between scan steps, the way defragLater() defers big keys to defragLaterStep(). */
+typedef struct {
+    unsigned long cursor;      /* dict scan cursor */
+    int scan_done;             /* the dict scan finished, only 'later' is left */
+    list *later;               /* ids of templates with field work left */
+    unsigned long later_field; /* field cursor into the head of 'later' */
+} defragTmplCtx;
 
-    unsigned long iterations = 0;
-    while (*cursor < reg->by_id_next) {
-        hashTemplate *tmpl = hashTemplateGetById(*cursor);
-        (*cursor)++;
-        if (tmpl == NULL) continue; /* freed or never-used slot */
-
-        hashTemplateDefrag(tmpl);
-
-        if (++iterations > 8) {
-            iterations = 0;
-            if (getMonotonicUs() >= endtime) return DEFRAG_NOT_DONE;
-        }
-    }
-    return DEFRAG_DONE;
+static void freeDefragTmplContext(void *ctx) {
+    defragTmplCtx *tctx = ctx;
+    if (tctx->later) listRelease(tctx->later);
+    zfree(tctx);
 }
 
 static void defragTmplRegistryCb(void *privdata, const dictEntry *de, dictEntryLink plink) {
-    UNUSED(privdata); 
-    UNUSED(de);
+    defragTmplCtx *ctx = privdata;
+    hashTemplate *tmpl = dictGetKey(de);
     UNUSED(plink);
+
+    tmpl = hashTemplateDefrag(tmpl, (dictEntry *)de);
+    if (tmpl->field_count > server.active_defrag_max_scan_fields) {
+        if (!ctx->later) ctx->later = listCreate();
+        listAddNodeTail(ctx->later, (void *)(uintptr_t)tmpl->id);
+        return;
+    }
+    for (unsigned long long i = 0; i < tmpl->field_count; i++) {
+        sds newsds = activeDefragSds(tmpl->fields[i]);
+        if (newsds) tmpl->fields[i] = newsds;
+        server.stat_active_defrag_scanned++;
+    }
 }
 
-/* Defrag a registry lookup dict. Keys/values (template/blob pointers) are
- * relocated by defragStageHashTemplates. */
-static doneStatus defragRegistryDict(dict **dref, unsigned long *cursor, monotime endtime) {
-    dictDefragFunctions fns = { .defragAlloc = activeDefragAlloc };
-    unsigned long iterations = 0;
-    do {
-        *cursor = dictScanDefrag(*dref, *cursor, defragTmplRegistryCb, &fns, NULL);
-        if (++iterations > 64) {
+/* Relocate the field names of the templates the scan deferred, mirroring
+ * defragLaterStep() for big keys. A kvstoreHelperPreContinueFn. */
+static doneStatus defragTmplLaterStep(void *privdata, monotime endtime) {
+    defragTmplCtx *ctx = privdata;
+    unsigned int iterations = 0;
+    unsigned long long prev_defragged = server.stat_active_defrag_hits;
+    unsigned long long prev_scanned = server.stat_active_defrag_scanned;
+
+    while (ctx->later && listLength(ctx->later) > 0) {
+        listNode *head = listFirst(ctx->later);
+        hashTemplate *tmpl = hashTemplateGetById((uint64_t)(uintptr_t)head->value);
+
+        if (tmpl && defragSdsArrayIncremental(tmpl->fields, tmpl->field_count, &ctx->later_field, endtime))
+            break; /* time is up */
+
+        /* Drained it fully or it was freed since we deferred it. */
+        ctx->later_field = 0;
+        listDelNode(ctx->later, head);
+
+        if (++iterations > 16 ||
+            server.stat_active_defrag_hits - prev_defragged > 512 ||
+            server.stat_active_defrag_scanned - prev_scanned > 64)
+        {
+            if (getMonotonicUs() > endtime) break;
             iterations = 0;
-            if (getMonotonicUs() >= endtime) return DEFRAG_NOT_DONE;
+            prev_defragged = server.stat_active_defrag_hits;
+            prev_scanned = server.stat_active_defrag_scanned;
+        }
+    }
+    return (!ctx->later || listLength(ctx->later) == 0) ? DEFRAG_DONE : DEFRAG_NOT_DONE;
+}
+
+/* Defrag a registry lookup dict, invoking 'callback' per entry and 'precontinue'
+ * (optional) before each scan step, the way defragStageKvstoreHelper() does. */
+static doneStatus defragRegistryDict(monotime endtime, dict **dref, unsigned long *cursor,
+                                     void *ctx, dictScanFunction *scan_fn,
+                                     kvstoreHelperPreContinueFn precontinue_fn)
+{
+    dictDefragFunctions fns = { .defragAlloc = activeDefragAlloc };
+    unsigned int iterations = 0;
+    unsigned long long prev_defragged = server.stat_active_defrag_hits;
+    unsigned long long prev_scanned = server.stat_active_defrag_scanned;
+    do {
+        if (precontinue_fn && precontinue_fn(ctx, endtime) == DEFRAG_NOT_DONE)
+            return DEFRAG_NOT_DONE;
+
+        *cursor = dictScanDefrag(*dref, *cursor, scan_fn, &fns, ctx);
+
+        if (++iterations > 16 ||
+            server.stat_active_defrag_hits - prev_defragged > 512 ||
+            server.stat_active_defrag_scanned - prev_scanned > 64)
+        {
+            iterations = 0;
+            prev_defragged = server.stat_active_defrag_hits;
+            prev_scanned = server.stat_active_defrag_scanned;
+
+            if (*cursor != 0 && getMonotonicUs() >= endtime)
+                return DEFRAG_NOT_DONE;
         }
     } while (*cursor != 0);
     dict *newd = dictDefragTables(*dref);
@@ -1742,13 +1803,23 @@ static doneStatus defragRegistryDict(dict **dref, unsigned long *cursor, monotim
 }
 
 static doneStatus defragStageHashTemplatesByFields(void *ctx, monotime endtime) {
+    defragTmplCtx *tctx = ctx;
     if (server.htemplates == NULL) return DEFRAG_DONE;
-    return defragRegistryDict(&server.htemplates->by_fields, ctx, endtime);
+
+    if (!tctx->scan_done) {
+        if (defragRegistryDict(endtime, &server.htemplates->by_fields, &tctx->cursor,
+                               tctx, defragTmplRegistryCb,
+                               defragTmplLaterStep) == DEFRAG_NOT_DONE)
+            return DEFRAG_NOT_DONE;
+        tctx->scan_done = 1;
+    }
+    return defragTmplLaterStep(tctx, endtime);
 }
 
 static doneStatus defragStageHashTemplatesByFieldsLp(void *ctx, monotime endtime) {
     if (server.htemplates == NULL) return DEFRAG_DONE;
-    return defragRegistryDict(&server.htemplates->by_fields_lp, ctx, endtime);
+    return defragRegistryDict(endtime, &server.htemplates->by_fields_lp, ctx, NULL,
+                              activeDefragDictCallbackNoop, NULL);
 }
 
 static doneStatus defragStageHashTemplatesById(void *ctx, monotime endtime) {
@@ -2097,8 +2168,7 @@ static void beginDefragCycle(void) {
     addDefragStage(defragLuaScripts, NULL, NULL);
 
     /* Add stage for the hash template registry. */
-    addDefragStage(defragStageHashTemplates, zfree, zcalloc(sizeof(unsigned long)));
-    addDefragStage(defragStageHashTemplatesByFields, zfree, zcalloc(sizeof(unsigned long)));
+    addDefragStage(defragStageHashTemplatesByFields, freeDefragTmplContext, zcalloc(sizeof(defragTmplCtx)));
     addDefragStage(defragStageHashTemplatesByFieldsLp, zfree, zcalloc(sizeof(unsigned long)));
     addDefragStage(defragStageHashTemplatesById, zfree, zcalloc(sizeof(unsigned long)));
 

--- a/src/server.h
+++ b/src/server.h
@@ -3993,6 +3993,7 @@ typedef struct hashTemplateRegistry {
     size_t by_id_cap;           /* How many chunk pointers by_id can hold. */
     size_t by_id_chunks;        /* How many chunks are currently allocated. */
     size_t by_id_next;          /* The next id that has never been used. */
+    size_t by_id_free_chunk_hint; /* Lowest chunk index that may hold a free id. */
     size_t total_key_refs;      /* Sum of key_refcount across all templates. */
     size_t fields_lp_cache_bytes; /* Total lpBytes() of cached fields listpack blobs. */
     size_t total_mem_size;      /* Sum of every live template's mem_size, plus any
@@ -4093,7 +4094,7 @@ void hashTemplatesInit(void);
 hashTemplate *hashTemplateGetOrCreate(sds *fields, unsigned long long field_count);
 hashTemplate *hashTemplateGetByFieldsLp(unsigned char *fields_lp);
 hashTemplate *hashTemplateGetById(uint64_t id);
-hashTemplate *hashTemplateDefrag(hashTemplate *tmpl);
+hashTemplate *hashTemplateDefrag(hashTemplate *tmpl, dictEntry *bf);
 int hashTemplateDefragByIdChunk(unsigned long chunk_idx);
 hashTemplate *hashTypeGetTemplate(robj *o);
 void hashTemplateIncrKeyRef(hashTemplate *tmpl);

--- a/src/server.h
+++ b/src/server.h
@@ -4095,7 +4095,7 @@ void hashTemplatesInit(void);
 hashTemplate *hashTemplateGetOrCreate(sds *fields, unsigned long long field_count);
 hashTemplate *hashTemplateGetByFieldsLp(unsigned char *fields_lp);
 hashTemplate *hashTemplateGetById(uint64_t id);
-hashTemplate *hashTemplateDefrag(hashTemplate *tmpl, dictEntry *bf, monotime endtime);
+void hashTemplateDefrag(hashTemplate *tmpl, dictEntry *bf, monotime endtime);
 int hashTemplateDefragByIdChunk(unsigned long chunk_idx);
 hashTemplate *hashTypeGetTemplate(robj *o);
 void hashTemplateIncrKeyRef(hashTemplate *tmpl);

--- a/src/server.h
+++ b/src/server.h
@@ -3980,7 +3980,8 @@ typedef struct hashTemplate {
                           * ship fields as one blob instead of N strings, and lets
                           * RESTORE find the template with one O(1) blob lookup.*/
     mstime_t fields_lp_last_used; /* Last time fields_lp was used, for cron idle reclaim. */
-    unsigned int fits_in_listpack;  /* 1 if fields fit in listpack (DUMP serializes them as LP blob) */
+    unsigned long long fits_in_listpack : 1; /* 1 if fields fit in listpack (DUMP serializes them as LP blob) */
+    unsigned long long defrag_field : 63; /* Defrag resume point into 'fields'. */
 } hashTemplate;
 
 /* Global registry for hash templates. */
@@ -4094,7 +4095,7 @@ void hashTemplatesInit(void);
 hashTemplate *hashTemplateGetOrCreate(sds *fields, unsigned long long field_count);
 hashTemplate *hashTemplateGetByFieldsLp(unsigned char *fields_lp);
 hashTemplate *hashTemplateGetById(uint64_t id);
-hashTemplate *hashTemplateDefrag(hashTemplate *tmpl, dictEntry *bf);
+hashTemplate *hashTemplateDefrag(hashTemplate *tmpl, dictEntry *bf, monotime endtime);
 int hashTemplateDefragByIdChunk(unsigned long chunk_idx);
 hashTemplate *hashTypeGetTemplate(robj *o);
 void hashTemplateIncrKeyRef(hashTemplate *tmpl);

--- a/src/server.h
+++ b/src/server.h
@@ -3980,8 +3980,8 @@ typedef struct hashTemplate {
                           * ship fields as one blob instead of N strings, and lets
                           * RESTORE find the template with one O(1) blob lookup.*/
     mstime_t fields_lp_last_used; /* Last time fields_lp was used, for cron idle reclaim. */
-    unsigned long long fits_in_listpack : 1; /* 1 if fields fit in listpack (DUMP serializes them as LP blob) */
-    unsigned long long defrag_field : 63; /* Defrag resume point into 'fields'. */
+    unsigned int fits_in_listpack;  /* 1 if fields fit in listpack (DUMP serializes them as LP blob) */
+    unsigned int defrag_field;      /* Defrag resume point into 'fields'. */
 } hashTemplate;
 
 /* Global registry for hash templates. */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -404,6 +404,11 @@ static tmplIdChunk *tmplIdGetOrCreateChunk(size_t id) {
  * by_id_free_chunk_hint are full, the scan starts there. */
 static size_t tmplIdGetLowestFree(void) {
     size_t chunk_idx = htemplates->by_id_free_chunk_hint;
+#ifdef DEBUG_ASSERTIONS
+    /* Chunks below the hint must be full. */
+    for (size_t i = 0; i < chunk_idx; i++)
+        serverAssert(htemplates->by_id[i] && htemplates->by_id[i]->used == TMPL_CHUNK_SIZE);
+#endif
     while (chunk_idx < htemplates->by_id_cap && htemplates->by_id[chunk_idx] &&
            htemplates->by_id[chunk_idx]->used == TMPL_CHUNK_SIZE) {
         chunk_idx++;
@@ -465,12 +470,28 @@ hashTemplate *hashTemplateGetById(uint64_t id) {
 }
 
 /* Defrag the template struct and re-point every reference
- * to it (by_id slot, by_fields key, by_fields_lp value).
- * Field name SDS allocations are handled by the registry defrag stage. */
-hashTemplate *hashTemplateDefrag(hashTemplate *tmpl, dictEntry *bf) {
+ * to it (by_id slot, by_fields key, by_fields_lp value).*/
+hashTemplate *hashTemplateDefrag(hashTemplate *tmpl, dictEntry *bf, monotime endtime) {
     /* Field-name array. */
     sds *newfields = activeDefragAlloc(tmpl->fields);
     if (newfields) tmpl->fields = newfields;
+
+    /* Field names, checking the clock every 128 so a wide template cannot
+     * blow the time budget. On timeout, defrag_field keeps the position, the
+     * leftover is picked up when the template is scanned again. */
+    unsigned long long i = tmpl->defrag_field;
+    long iterations = 0;
+    while (i < tmpl->field_count) {
+        sds newsds = activeDefragSds(tmpl->fields[i]);
+        if (newsds) tmpl->fields[i] = newsds;
+        server.stat_active_defrag_scanned++;
+        i++;
+        if (++iterations > 128) {
+            if (getMonotonicUs() > endtime) break;
+            iterations = 0;
+        }
+    }
+    tmpl->defrag_field = (i >= tmpl->field_count) ? 0 : i;
 
     /* fields_lp blob (the by_fields_lp key). */
     dictEntry *lp = NULL;
@@ -706,6 +727,7 @@ static hashTemplate *hashTemplateCreateInternal(uint64_t hash, sds *fields,
     tmpl->fields = zmalloc(sizeof(sds) * field_count);
     tmpl->fields_lp = NULL; /* Lazy built on first save/lookup due to RESTORE. */
     tmpl->fields_lp_last_used = 0;
+    tmpl->defrag_field = 0;
     tmpl->mem_size = sizeof(*tmpl) + sizeof(sds) * field_count;
 
     for (unsigned long long i = 0; i < field_count; i++) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -471,7 +471,7 @@ hashTemplate *hashTemplateGetById(uint64_t id) {
 
 /* Defrag the template struct and re-point every reference
  * to it (by_id slot, by_fields key, by_fields_lp value).*/
-hashTemplate *hashTemplateDefrag(hashTemplate *tmpl, dictEntry *bf, monotime endtime) {
+void hashTemplateDefrag(hashTemplate *tmpl, dictEntry *bf, monotime endtime) {
     /* Field-name array. */
     sds *newfields = activeDefragAlloc(tmpl->fields);
     if (newfields) tmpl->fields = newfields;
@@ -502,25 +502,26 @@ hashTemplate *hashTemplateDefrag(hashTemplate *tmpl, dictEntry *bf, monotime end
             /* oldlp is freed, find its entry by pointer. */
             uint64_t hash = dictGetHash(htemplates->by_fields_lp, newlp);
             lp = dictFindByHashAndPtr(htemplates->by_fields_lp, oldlp, hash);
+            serverAssert(lp);
             tmpl->fields_lp = newlp;
-            if (lp) dictSetKey(htemplates->by_fields_lp, lp, newlp);
+            dictSetKey(htemplates->by_fields_lp, lp, newlp);
         }
     }
 
     /* The struct itself: by_id slot, by_fields key, by_fields_lp value. */
     uint64_t id = tmpl->id;
     hashTemplate *newtmpl = activeDefragAlloc(tmpl);
-    if (!newtmpl) return tmpl;
+    if (!newtmpl) return;
 
     tmplIdChunk *chunk = htemplates->by_id[id / TMPL_CHUNK_SIZE];
     chunk->slots[id % TMPL_CHUNK_SIZE] = newtmpl;
 
-    if (bf) dictSetKey(htemplates->by_fields, bf, newtmpl);
+    dictSetKey(htemplates->by_fields, bf, newtmpl);
     if (newtmpl->fields_lp) {
         if (!lp) lp = dictFind(htemplates->by_fields_lp, newtmpl->fields_lp);
-        if (lp) dictSetVal(htemplates->by_fields_lp, lp, newtmpl);
+        serverAssert(lp);
+        dictSetVal(htemplates->by_fields_lp, lp, newtmpl);
     }
-    return newtmpl;
 }
 
 /* Defrag by_id top array (once, at idx 0) and the chunk at 'idx'. */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -400,13 +400,15 @@ static tmplIdChunk *tmplIdGetOrCreateChunk(size_t id) {
     return htemplates->by_id[chunk_idx];
 }
 
-/* Get lowest free id. Caller guarantees a gap exists. */
+/* Get lowest free id. Caller guarantees a gap exists. Chunks below
+ * by_id_free_chunk_hint are full, the scan starts there. */
 static size_t tmplIdGetLowestFree(void) {
-    size_t chunk_idx = 0;
+    size_t chunk_idx = htemplates->by_id_free_chunk_hint;
     while (chunk_idx < htemplates->by_id_cap && htemplates->by_id[chunk_idx] &&
            htemplates->by_id[chunk_idx]->used == TMPL_CHUNK_SIZE) {
         chunk_idx++;
     }
+    htemplates->by_id_free_chunk_hint = chunk_idx;
     tmplIdChunk *chunk = chunk_idx < htemplates->by_id_cap ? htemplates->by_id[chunk_idx] : NULL;
     size_t id = chunk_idx * TMPL_CHUNK_SIZE;
     while (chunk && chunk->slots[id % TMPL_CHUNK_SIZE] != NULL) id++;
@@ -418,6 +420,8 @@ static size_t tmplIdGetLowestFree(void) {
 static uint64_t tmplIdAllocate(hashTemplate *tmpl) {
     int no_gaps = dictSize(htemplates->by_fields) == htemplates->by_id_next;
     size_t id = no_gaps ? htemplates->by_id_next++ : tmplIdGetLowestFree();
+    /* Every lower id is in use, the hint can move up. */
+    if (no_gaps) htemplates->by_id_free_chunk_hint = id / TMPL_CHUNK_SIZE;
     tmplIdChunk *chunk = tmplIdGetOrCreateChunk(id);
     chunk->slots[id % TMPL_CHUNK_SIZE] = tmpl;
     chunk->used++;
@@ -429,6 +433,8 @@ static void tmplIdRecycle(uint64_t id) {
     size_t chunk_idx = id / TMPL_CHUNK_SIZE;
     tmplIdChunk *chunk = htemplates->by_id[chunk_idx];
     chunk->slots[id % TMPL_CHUNK_SIZE] = NULL;
+    if (htemplates->by_id_free_chunk_hint > chunk_idx)
+        htemplates->by_id_free_chunk_hint = chunk_idx;
     /* Free the chunk once it holds no live ids so the id space shrinks. */
     if (--chunk->used == 0) {
         zfree(chunk);
@@ -446,6 +452,7 @@ static void tmplIdRecycle(uint64_t id) {
         htemplates->by_id_cap = 0;
         htemplates->by_id_chunks = 0;
         htemplates->by_id_next = 0;
+        htemplates->by_id_free_chunk_hint = 0;
     }
 }
 
@@ -458,26 +465,22 @@ hashTemplate *hashTemplateGetById(uint64_t id) {
 }
 
 /* Defrag the template struct and re-point every reference
- * to it (by_id slot, by_fields key, by_fields_lp value).*/
-hashTemplate *hashTemplateDefrag(hashTemplate *tmpl) {
-    /* Field-name array and the strings it holds. */
+ * to it (by_id slot, by_fields key, by_fields_lp value).
+ * Field name SDS allocations are handled by the registry defrag stage. */
+hashTemplate *hashTemplateDefrag(hashTemplate *tmpl, dictEntry *bf) {
+    /* Field-name array. */
     sds *newfields = activeDefragAlloc(tmpl->fields);
     if (newfields) tmpl->fields = newfields;
-    for (unsigned long long i = 0; i < tmpl->field_count; i++) {
-        sds newsds = activeDefragSds(tmpl->fields[i]);
-        if (newsds) tmpl->fields[i] = newsds;
-    }
-
-    /* Find the entries referencing tmpl (by_fields key) and its blob
-     * (by_fields_lp key+value) before any realloc frees the old pointers. */
-    uint64_t bf_hash = dictGetHash(htemplates->by_fields, tmpl);
-    dictEntry *bf = dictFindByHashAndPtr(htemplates->by_fields, tmpl, bf_hash);
-    dictEntry *lp = tmpl->fields_lp ? dictFind(htemplates->by_fields_lp, tmpl->fields_lp) : NULL;
 
     /* fields_lp blob (the by_fields_lp key). */
+    dictEntry *lp = NULL;
     if (tmpl->fields_lp) {
-        unsigned char *newlp = activeDefragAlloc(tmpl->fields_lp);
+        unsigned char *oldlp = tmpl->fields_lp;
+        unsigned char *newlp = activeDefragAlloc(oldlp);
         if (newlp) {
+            /* oldlp is freed, find its entry by pointer. */
+            uint64_t hash = dictGetHash(htemplates->by_fields_lp, newlp);
+            lp = dictFindByHashAndPtr(htemplates->by_fields_lp, oldlp, hash);
             tmpl->fields_lp = newlp;
             if (lp) dictSetKey(htemplates->by_fields_lp, lp, newlp);
         }
@@ -492,7 +495,10 @@ hashTemplate *hashTemplateDefrag(hashTemplate *tmpl) {
     chunk->slots[id % TMPL_CHUNK_SIZE] = newtmpl;
 
     if (bf) dictSetKey(htemplates->by_fields, bf, newtmpl);
-    if (lp) dictSetVal(htemplates->by_fields_lp, lp, newtmpl);
+    if (newtmpl->fields_lp) {
+        if (!lp) lp = dictFind(htemplates->by_fields_lp, newtmpl->fields_lp);
+        if (lp) dictSetVal(htemplates->by_fields_lp, lp, newtmpl);
+    }
     return newtmpl;
 }
 

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -1318,6 +1318,7 @@ run_solo {defrag} {
 
             after 120
             if {$::verbose} { puts "frag before defrag: [s allocator_frag_ratio]" }
+            assert_morethan [s allocator_frag_ratio] 1.4
 
             set digest [debug_digest]
             catch {r config set activedefrag yes}
@@ -1327,7 +1328,8 @@ run_solo {defrag} {
                 } else {
                     fail "defrag not started."
                 }
-                wait_for_defrag_stop 500 100
+                # test the fragmentation is lower
+                wait_for_defrag_stop 500 100 1.1
             }
 
             # Data byte-identical after defrag moved the allocations.
@@ -1354,7 +1356,11 @@ run_solo {defrag} {
             r config set active-defrag-threshold-lower 5
             r config set active-defrag-cycle-min 65
             r config set active-defrag-cycle-max 75
-            r config set active-defrag-ignore-bytes 100kb
+            r config set active-defrag-ignore-bytes 1mb
+
+            # Most templates below have 3 fields, over this limit: their field
+            # names are relocated by the deferred drain
+            r config set active-defrag-max-scan-fields 2
             r config set maxmemory 0
             r config set hash-min-template-entries 0
 
@@ -1374,42 +1380,96 @@ run_solo {defrag} {
             $rd close
             assert {[s hash_templates] >= $n}
 
+            # A wide template goes over the max scan fields limit, so its field
+            # names are relocated by the deferred defrag
+            set wide_pad [string repeat _ 60]
+            set wide_fields {}
+            for {set f 0} {$f < 20000} {incr f} {
+                lappend wide_fields wf[format %05d $f]$wide_pad
+            }
+            r himport prepare wide {*}$wide_fields
+            r himport set wide:1 wide {*}[lrepeat 20000 wv]
+
+            # 2-field templates stay under the scan fields limit set above:
+            # their names can only be reclaimed by the regular path.
+            set rd [redis_deferring_client]
+            for {set j 0} {$j < 300} {incr j} {
+                $rd himport prepare is$j ia$j$pad ib$j$pad
+                $rd himport set ik:$j is$j 1 2
+            }
+            for {set j 0} {$j < 600} {incr j} { $rd read }
+            $rd close
+
+            # 9000 more templates: enough id chunks (>64) that the id-chunk
+            # defrag stage reaches its budget check.
+            set rd [redis_deferring_client]
+            for {set j 0} {$j < 9000} {incr j} {
+                $rd himport prepare bs$j x$j y$j z$j ; incr cmds
+                $rd himport set bk:$j bs$j 1 2 3     ; incr cmds
+                if {$cmds % $batch == 0} { for {set rc 0} {$rc < $batch} {incr rc} { $rd read } }
+            }
+            $rd close
+
+            # RESTORE caches small template's fields listpack
+            set rd [redis_deferring_client]
+            for {set j 0} {$j < 200} {incr j} {
+                $rd himport prepare lpfs$j a$j b$j c$j
+                $rd himport set lpk:$j lpfs$j v1 v2 v3
+            }
+            for {set j 0} {$j < 400} {incr j} { $rd read }
+            $rd close
+            for {set j 0} {$j < 200} {incr j} { r restore lpc:$j 0 [r dump lpk:$j] }
+
             # Fragment: delete every other key so its template (and long field-name
             # strings) is freed, leaving holes around the survivors.
             set rd [redis_deferring_client]
             set deleted 0
             for {set j 0} {$j < $n} {incr j 2} { $rd del k:$j; incr deleted }
+            for {set j 0} {$j < 200} {incr j 2} { $rd del lpk:$j lpc:$j; incr deleted }
+            for {set j 0} {$j < 300} {incr j 2} { $rd del ik:$j; incr deleted }
+            for {set j 0} {$j < 9000} {incr j 2} { $rd del bk:$j; incr deleted }
             for {set rc 0} {$rc < $deleted} {incr rc} { $rd read }
             $rd close
             wait_for_condition 300 100 {
-                [s hash_templates] <= [expr {$n / 2 + 50}]
+                [s hash_templates] <= [expr {$n / 2 + 4500 + 150 + 300}]
             } else { fail "templates not drained ([s hash_templates])" }
 
             after 120
             if {$::verbose} { puts "registry frag before defrag: [s allocator_frag_ratio]" }
+            assert_morethan [s allocator_frag_ratio] 1.1
+
+            # Touch the cached blobs again (RESTORE looks them up).
+            for {set j 1} {$j < 200} {incr j 2} { r restore lpc:$j 0 [r dump lpk:$j] replace }
 
             set digest [debug_digest]
             catch {r config set activedefrag yes}
             if {[r config get activedefrag] eq "activedefrag yes"} {
-                # Let defrag relocate the registry allocations; we only wait for
-                # progress (hits > 0), not for fragmentation to fully settle.
                 wait_for_condition 100 100 {
-                    [s active_defrag_hits] > 0
-                } else { fail "defrag made no progress" }
-                after 500 ;# let it churn the registry a bit more
-                r config set activedefrag no
-                wait_for_defrag_stop 500 100
+                    [s total_active_defrag_time] ne 0
+                } else {
+                    fail "defrag not started."
+                }
+                # test the fragmentation is lower
+                wait_for_defrag_stop 500 100 1.1
             }
 
             # Byte-identical after the registry field-name/array moves, and a
             # survivor still resolves (its relocated field name reads back right).
             assert_equal $digest [debug_digest]
             assert_equal v1a [r hget k:1 a1$pad]
+            assert_equal v1 [r hget lpc:1 a1]
+            # Access wide template's relocated field names.
+            assert_equal wv [r hget wide:1 wf00000$wide_pad]
+            assert_equal wv [r hget wide:1 wf19999$wide_pad]
             # After relocation, re-preparing an existing field set still finds its
             # template instead of creating a new one.
             set nt [s hash_templates]
             r himport prepare chk a1$pad b1$pad c1$pad
             assert_equal $nt [s hash_templates]
+            # RESTORE probes the relocated by_fields_lp entry.
+            r restore lpchk 0 [r dump lpc:1]
+            assert_equal $nt [s hash_templates]
+            assert_equal v1 [r hget lpchk a1]
             r save ;# iterate over all data / pointers
         } {OK}
     }

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -1358,11 +1358,12 @@ run_solo {defrag} {
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 1mb
 
-            # Most templates below have 3 fields, over this limit: their field
-            # names are relocated by the deferred drain
-            r config set active-defrag-max-scan-fields 2
             r config set maxmemory 0
             r config set hash-min-template-entries 0
+
+            # Extra plain keys grow the heap, so the small leftover that
+            # defrag cannot move stays below the 1.1 ratio target.
+            populate 5000 filler: 1024
 
             # Many distinct templates with long field names, fragmenting the
             # registry's per-template allocations (struct, field array + strings,
@@ -1375,38 +1376,19 @@ run_solo {defrag} {
             for {set j 0} {$j < $n} {incr j} {
                 $rd himport prepare fs$j a$j$pad b$j$pad c$j$pad ; incr cmds
                 $rd himport set k:$j fs$j v${j}a v${j}b v${j}c   ; incr cmds
-                if {$cmds % $batch == 0} { for {set rc 0} {$rc < $batch} {incr rc} { $rd read } }
+                discard_replies_every $rd $cmds $batch $batch
             }
             $rd close
             assert {[s hash_templates] >= $n}
 
-            # A wide template goes over the max scan fields limit, so its field
-            # names are relocated by the deferred defrag
-            set wide_pad [string repeat _ 60]
-            set wide_fields {}
-            for {set f 0} {$f < 20000} {incr f} {
-                lappend wide_fields wf[format %05d $f]$wide_pad
-            }
-            r himport prepare wide {*}$wide_fields
-            r himport set wide:1 wide {*}[lrepeat 20000 wv]
-
-            # 2-field templates stay under the scan fields limit set above:
-            # their names can only be reclaimed by the regular path.
-            set rd [redis_deferring_client]
-            for {set j 0} {$j < 300} {incr j} {
-                $rd himport prepare is$j ia$j$pad ib$j$pad
-                $rd himport set ik:$j is$j 1 2
-            }
-            for {set j 0} {$j < 600} {incr j} { $rd read }
-            $rd close
-
             # 9000 more templates: enough id chunks (>64) that the id-chunk
             # defrag stage reaches its budget check.
             set rd [redis_deferring_client]
+            set cmds 0
             for {set j 0} {$j < 9000} {incr j} {
                 $rd himport prepare bs$j x$j y$j z$j ; incr cmds
                 $rd himport set bk:$j bs$j 1 2 3     ; incr cmds
-                if {$cmds % $batch == 0} { for {set rc 0} {$rc < $batch} {incr rc} { $rd read } }
+                discard_replies_every $rd $cmds $batch $batch
             }
             $rd close
 
@@ -1426,20 +1408,20 @@ run_solo {defrag} {
             set deleted 0
             for {set j 0} {$j < $n} {incr j 2} { $rd del k:$j; incr deleted }
             for {set j 0} {$j < 200} {incr j 2} { $rd del lpk:$j lpc:$j; incr deleted }
-            for {set j 0} {$j < 300} {incr j 2} { $rd del ik:$j; incr deleted }
             for {set j 0} {$j < 9000} {incr j 2} { $rd del bk:$j; incr deleted }
             for {set rc 0} {$rc < $deleted} {incr rc} { $rd read }
             $rd close
             wait_for_condition 300 100 {
-                [s hash_templates] <= [expr {$n / 2 + 4500 + 150 + 300}]
+                [s hash_templates] <= [expr {$n / 2 + 4500 + 150}]
             } else { fail "templates not drained ([s hash_templates])" }
 
             after 120
             if {$::verbose} { puts "registry frag before defrag: [s allocator_frag_ratio]" }
             assert_morethan [s allocator_frag_ratio] 1.1
 
-            # Touch the cached blobs again (RESTORE looks them up).
+            # Touch the cached blobs again (RESTORE looks them up)
             for {set j 1} {$j < 200} {incr j 2} { r restore lpc:$j 0 [r dump lpk:$j] replace }
+            set lpdump [r dump lpc:1]
 
             set digest [debug_digest]
             catch {r config set activedefrag yes}
@@ -1453,23 +1435,81 @@ run_solo {defrag} {
                 wait_for_defrag_stop 500 100 1.1
             }
 
-            # Byte-identical after the registry field-name/array moves, and a
-            # survivor still resolves (its relocated field name reads back right).
+            # Validate: the data survived the moves and every relocated
+            # registry reference still resolves.
             assert_equal $digest [debug_digest]
             assert_equal v1a [r hget k:1 a1$pad]
             assert_equal v1 [r hget lpc:1 a1]
-            # Access wide template's relocated field names.
-            assert_equal wv [r hget wide:1 wf00000$wide_pad]
-            assert_equal wv [r hget wide:1 wf19999$wide_pad]
             # After relocation, re-preparing an existing field set still finds its
             # template instead of creating a new one.
             set nt [s hash_templates]
             r himport prepare chk a1$pad b1$pad c1$pad
             assert_equal $nt [s hash_templates]
-            # RESTORE probes the relocated by_fields_lp entry.
-            r restore lpchk 0 [r dump lpc:1]
+            # RESTORE probe
+            r restore lpchk 0 $lpdump
             assert_equal $nt [s hash_templates]
             assert_equal v1 [r hget lpchk a1]
+            r save ;# iterate over all data / pointers
+        } {OK}
+
+        # A wide template's field names cannot be relocated in one go: a scan
+        # visit is cut by the clock (one slice never fits 100000 names) and
+        # the next defrag cycle resumes from the position saved on the
+        # template.
+        test "Active defrag resumes a wide template across cycles: $type" {
+            r flushall
+            r config set hz 100
+            r config set activedefrag no
+            wait_for_defrag_stop 500 100
+            r config resetstat
+            r config set active-defrag-threshold-lower 1
+            r config set active-defrag-cycle-min 65
+            r config set active-defrag-cycle-max 75
+            r config set active-defrag-ignore-bytes 100kb
+            r config set hash-min-template-entries 0
+
+            set wide_pad [string repeat _ 60]
+            set wide_fields {}
+            for {set f 0} {$f < 100000} {incr f} {
+                lappend wide_fields wf[format %05d $f]$wide_pad
+            }
+            r himport prepare wide {*}$wide_fields
+            r himport set wide:1 wide {*}[lrepeat 100000 wv]
+
+            # Fragment: templates with long field names, half of them deleted,
+            # so defrag has cycles to run.
+            set pad [string repeat _ 2000]
+            set rd [redis_deferring_client]
+            for {set j 0} {$j < 300} {incr j} {
+                $rd himport prepare wfs$j a$j$pad b$j$pad c$j$pad
+                $rd himport set wk:$j wfs$j 1 2 3
+            }
+            for {set j 0} {$j < 600} {incr j} { $rd read }
+            $rd close
+            set rd [redis_deferring_client]
+            for {set j 0} {$j < 300} {incr j 2} { $rd del wk:$j }
+            for {set j 0} {$j < 150} {incr j} { $rd read }
+            $rd close
+
+            set digest [debug_digest]
+            catch {r config set activedefrag yes}
+            if {[r config get activedefrag] eq "activedefrag yes"} {
+                # Two completed cycles: the first visit of the wide template
+                # gets cut, the next one resumes it. The +1 covers the ms
+                # rounding of the two INFO fields.
+                for {set cycle 0} {$cycle < 2} {incr cycle} {
+                    set completed [expr {[s total_active_defrag_time] - [s current_active_defrag_time]}]
+                    wait_for_condition 500 100 {
+                        [s total_active_defrag_time] - [s current_active_defrag_time] > $completed + 1
+                    } else { fail "no defrag cycle" }
+                }
+                r config set activedefrag no
+                wait_for_defrag_stop 500 100
+            }
+
+            assert_equal $digest [debug_digest]
+            assert_equal wv [r hget wide:1 wf00000$wide_pad]
+            assert_equal wv [r hget wide:1 wf99999$wide_pad]
             r save ;# iterate over all data / pointers
         } {OK}
     }

--- a/tests/unit/type/hash-templates.tcl
+++ b/tests/unit/type/hash-templates.tcl
@@ -2784,3 +2784,69 @@ start_server {tags {"hash" "needs:debug" "cluster:skip"} overrides {hash-min-tem
         }
     }
 }
+
+start_server {tags {"hash" "external:skip" "cluster:skip"} overrides {hash-min-template-entries 0}} {
+    test {Stress test for template creation and deletion} {
+        # Create 10000 templates
+        set rd [redis_deferring_client]
+        for {set j 0} {$j < 10000} {incr j} {
+            $rd himport prepare rec$j a$j b$j c$j
+            $rd himport set reck:$j rec$j 1 2 3
+        }
+        for {set j 0} {$j < 20000} {incr j} { $rd read }
+        $rd close ;# releases the PREPARE holds
+        assert_equal 10000 [s hash_templates]
+
+        # Free every other template
+        set rd [redis_deferring_client]
+        for {set j 0} {$j < 10000} {incr j 2} { $rd del reck:$j }
+        for {set j 0} {$j < 5000} {incr j} { $rd read }
+        $rd close
+        wait_for_condition 100 100 {
+            [s hash_templates] == 5000
+        } else { fail "templates not freed ([s hash_templates])" }
+
+        # Create another 5000 template
+        set rd [redis_deferring_client]
+        for {set j 0} {$j < 5000} {incr j} {
+            $rd himport prepare rec2_$j x$j y$j z$j
+            $rd himport set reck2:$j rec2_$j 1 2 3
+        }
+        for {set j 0} {$j < 10000} {incr j} { $rd read }
+        $rd close
+        assert_equal 10000 [s hash_templates]
+
+        # Free a contiguous batch, then refill it.
+        set rd [redis_deferring_client]
+        for {set j 1} {$j < 1000} {incr j 2} { $rd del reck:$j }
+        for {set j 0} {$j < 500} {incr j} { $rd del reck2:$j }
+        for {set j 0} {$j < 1000} {incr j} { $rd read }
+        $rd close
+        wait_for_condition 100 100 {
+            [s hash_templates] == 9000
+        } else { fail "templates not freed ([s hash_templates])" }
+        set rd [redis_deferring_client]
+        for {set j 0} {$j < 1000} {incr j} {
+            $rd himport prepare rec3_$j p$j q$j w$j
+            $rd himport set reck3:$j rec3_$j 1 2 3
+        }
+        for {set j 0} {$j < 2000} {incr j} { $rd read }
+        $rd close
+        assert_equal 10000 [s hash_templates]
+
+        # Delete one, create one, back and forth.
+        set rd [redis_deferring_client]
+        for {set j 0} {$j < 100} {incr j} {
+            $rd del reck:[expr {2001 + 2*$j}]
+            $rd himport prepare rec4_$j f$j g$j h$j
+            $rd himport set reck4:$j rec4_$j 1 2 3
+        }
+        for {set j 0} {$j < 300} {incr j} { $rd read }
+        $rd close
+        assert_equal 10000 [s hash_templates]
+
+        r flushall
+        wait_num_template_keys 0
+        wait_num_templates 0
+    }
+}

--- a/tests/unit/type/hash-templates.tcl
+++ b/tests/unit/type/hash-templates.tcl
@@ -2802,9 +2802,7 @@ start_server {tags {"hash" "external:skip" "cluster:skip"} overrides {hash-min-t
         for {set j 0} {$j < 10000} {incr j 2} { $rd del reck:$j }
         for {set j 0} {$j < 5000} {incr j} { $rd read }
         $rd close
-        wait_for_condition 100 100 {
-            [s hash_templates] == 5000
-        } else { fail "templates not freed ([s hash_templates])" }
+        wait_num_templates 5000
 
         # Create another 5000 template
         set rd [redis_deferring_client]
@@ -2822,9 +2820,7 @@ start_server {tags {"hash" "external:skip" "cluster:skip"} overrides {hash-min-t
         for {set j 0} {$j < 500} {incr j} { $rd del reck2:$j }
         for {set j 0} {$j < 1000} {incr j} { $rd read }
         $rd close
-        wait_for_condition 100 100 {
-            [s hash_templates] == 9000
-        } else { fail "templates not freed ([s hash_templates])" }
+        wait_num_templates 9000
         set rd [redis_deferring_client]
         for {set j 0} {$j < 1000} {incr j} {
             $rd himport prepare rec3_$j p$j q$j w$j


### PR DESCRIPTION
The registry defrag stage had potential issues in some pathological cases. It walked the template id space (via by_id_next) which does not shrink when templates are deleted. If hundreds of thousands of templates were created and deleted, every defrag cycle would still walk the whole id space. It also relocated all field names of a template in one go. Normally, hash templates are expected to be small but a template with many fields could go above the defrag time budget in a single step.
These issues could cause latency spikes. 

Now field names are relocated during the by_fields scan. Fields are relocated in place with a time budget check every 128 fields. If the budget runs out mid template, the current position is saved in the template (defrag_field) and the next scan resumes that template from where it left off.

Also:
- Expanded the registry defrag test for better coverage.

Additional change:
- tmplIdGetLowestFree() starts from a hint instead of scanning from 0 to speed up id allocation when there are high amount of templates.

---------

Co-authored-by: debing.sun <debing.sun@redis.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes active defrag pointer updates across registry dicts and chunked id tables; mistakes could corrupt template lookups or cause defrag stalls, though behavior is covered by expanded integration tests.
> 
> **Overview**
> Fixes **active defrag** behavior for the **hash template registry** so large or sparse registries are less likely to cause latency spikes.
> 
> **Registry scanning** no longer uses a stage that walks the template id space up to `by_id_next` (which stayed large after mass create/delete). Template work now happens while scanning **`by_fields`**, with **`defragRegistryDict`** using the same iteration/time limits as other defrag helpers (hit/scan counters, optional early exit).
> 
> **Per-template defrag** relocates field-name SDS strings in slices (clock check every 128 fields). If the time budget expires mid-template, progress is stored in **`defrag_field`** and the next visit resumes there. Registry dict entries are updated from the scan callback instead of looking up `by_fields` inside defrag.
> 
> **ID allocation** adds **`by_id_free_chunk_hint`** so `tmplIdGetLowestFree()` skips full chunks instead of always scanning from chunk 0.
> 
> Tests add registry stress, fragmentation targets via **`wait_for_defrag_stop`**, listpack/RESTORE coverage, and a **100k-field** template case that must finish across multiple defrag cycles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e758a0d39596a4ba146d914d77f640bf15bfc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->