### PR TITLE
Enforce the ASM write-pause timeout before handing off slot ownership

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -2618,6 +2618,13 @@ void asmImportIncrAppliedBytes(struct asmTask *task, size_t bytes) {
 void asmSendStreamEofIfDrained(asmTask *task) {
     client *c = task->main_channel_client;
 
+    /* Don't hand ownership over once the write pause has expired. */
+    if (server.mstime - task->paused_time >= server.asm_write_pause_timeout) {
+        asmTaskSetFailed(task, "Write pause timeout during slot handoff: destination did not take ownership within %lld ms.",
+                         server.asm_write_pause_timeout);
+        return;
+    }
+
     /* The command streams for slot ranges have been drained. */
     if (!clientHasPendingReplies(c)) {
         serverLog(LL_NOTICE, "Slot migration command stream drained, sending STREAM-EOF to the destination");

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1459,6 +1459,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # set timeout to 0, so the task will fail immediately when checking timeout
         R 0 config set cluster-slot-migration-write-pause-timeout 0
         R 1 debug asm-failpoint "import-main-channel" "takeover"
+        R 1 debug pause-cron 1 ;# prevent retrying the failed import task
 
         # start migration from node 0 to 1
         set task_id [setup_slot_migration_with_delay 0 1 0 100]
@@ -1483,6 +1484,49 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 cluster migration cancel id $task_id
         R 1 cluster migration cancel id $task_id
         R 1 debug asm-failpoint "" ""
+        R 1 debug pause-cron 0
+    }
+
+    test "Source write pause timeout runs before STREAM-EOF" {
+        # hold the task right before the handoff, so we can expire the write
+        # pause while it is still waiting to send STREAM-EOF
+        R 0 debug asm-failpoint "migrate-main-channel" "handoff-prep"
+
+        # do not take over the slots, so a STREAM-EOF sent by mistake leaves
+        # the source in the stream-eof state instead of completing the task
+        R 1 debug asm-failpoint "import-main-channel" "takeover"
+
+        # start migration from node 0 to 1
+        set task_id [setup_slot_migration_with_delay 0 1 0 100]
+        wait_for_condition 2000 10 {
+            [string match {*send-stream*} [migration_status 0 $task_id state]] &&
+            [string match {*wait-stream-eof*} [migration_status 1 $task_id state]]
+        } else {
+            fail "ASM task did not reach the pre-handoff states"
+        }
+
+        # pause the source cron so it cannot enforce the timeout first, then
+        # expire the timeout and release the handoff while rejecting retries
+        R 0 debug pause-cron 1
+        R 0 config set cluster-slot-migration-write-pause-timeout 0
+        R 0 debug asm-failpoint "migrate-main-channel" "none"
+
+        # node 0 must fail while still in handoff, without handing the slots over
+        wait_for_condition 2000 10 {
+            [string match {*failed*} [migration_status 0 $task_id state]] &&
+            [string match {*Write pause timeout*state: handoff*} \
+                [migration_status 0 $task_id last_error]]
+        } else {
+            fail "ASM task did not leave handoff: [migration_status 0 $task_id state]"
+        }
+
+        # reset config
+        R 0 config set cluster-slot-migration-write-pause-timeout 10000
+        R 0 cluster migration cancel id $task_id
+        R 1 cluster migration cancel id $task_id
+        R 0 debug asm-failpoint "" ""
+        R 1 debug asm-failpoint "" ""
+        R 0 debug pause-cron 0
     }
 
     test "Sync buffer drain timeout" {


### PR DESCRIPTION
asmBeforeSleep() could send STREAM-EOF for an ASM_HANDOFF task without first checking the write-pause timeout. An already-expired handoff could therefore transfer ownership before the next asmCron() tick. 

Impact: The source may time out the ASM task and resume traffic before the destination takes ownership of the slots and publishes the new cluster configuration. Writes accepted by the source during this window could be lost. This PR eliminates that window by checking the write pause timeout before sending STREAM-EOF.

Add the timeout check to asmSendStreamEofIfDrained() before STREAM-EOF, while keeping the existing asmCron() check. The regression test expires the timeout before releasing handoff and verifies the source fails in handoff instead of advancing to stream-eof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster slot-migration handoff timing on the migrate source; incorrect behavior could still affect ownership and writes, but the change aligns two code paths and is covered by a targeted regression test.
> 
> **Overview**
> **Fixes a handoff race** where `asmBeforeSleep()` could send **STREAM-EOF** as soon as the migration command stream drained, without applying the same **write-pause timeout** already enforced in `asmCron()`. After a timeout, that could still transfer slot ownership before the next cron tick.
> 
> `asmSendStreamEofIfDrained()` now checks `cluster-slot-migration-write-pause-timeout` against `paused_time` **before** STREAM-EOF and fails the migrate task with the existing write-pause error instead of completing handoff.
> 
> A new **atomic-slot-migration** test parks the migration at handoff, blocks cron from firing first, sets the timeout to 0, releases handoff, and asserts the source fails in **handoff** with a write-pause message (destination takeover is blocked so a mistaken STREAM-EOF would not mask the bug).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 540bab4de5447dc37a4f3be1da4d4a624d871d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->