### PR TITLE
Reject "." and ".." in pathIsBaseName()

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1097,10 +1097,13 @@ long getTimeZone(void) {
 }
 
 /* Return true if the specified path is just a file basename without any
- * relative or absolute path. This function just checks that no / or \
- * character exists inside the specified path, that's enough in the
- * environments where Redis runs. */
+ * relative or absolute path. This function checks that no / or \ character
+ * exists inside the specified path, and that the path is not "." or "..",
+ * which are relative paths that do not stay under the directory they are
+ * joined to. That's enough in the environments where Redis runs. */
 int pathIsBaseName(char *path) {
+    if (path[0] == '\0') return 0;
+    if (!strcmp(path,".") || !strcmp(path,"..")) return 0;
     return strchr(path,'/') == NULL && strchr(path,'\\') == NULL;
 }
 
@@ -1592,6 +1595,25 @@ static void test_string2ll(void) {
     assert(string2ll(buf,strlen(buf),&v) == 0);
 }
 
+static void test_pathIsBaseName(void) {
+    /* A base name has no path separators. */
+    assert(pathIsBaseName("dump.rdb") == 1);
+    assert(pathIsBaseName("appendonlydir") == 1);
+
+    /* Separators are rejected. */
+    assert(pathIsBaseName("a/b") == 0);
+    assert(pathIsBaseName("/abs") == 0);
+    assert(pathIsBaseName("a\\b") == 0);
+
+    /* "." and ".." are relative paths, not base names: joining them to a base
+     * directory does not stay under it. */
+    assert(pathIsBaseName(".") == 0);
+    assert(pathIsBaseName("..") == 0);
+
+    /* The empty string is not a usable base name either. */
+    assert(pathIsBaseName("") == 0);
+}
+
 static void test_string2l(void) {
     char buf[32];
     long v;
@@ -1856,6 +1878,7 @@ int utilTest(int argc, char **argv, int flags) {
 
     test_string2ll();
     test_string2l();
+    test_pathIsBaseName();
     test_string2d();
     test_ll2string();
     test_ld2string();


### PR DESCRIPTION
`pathIsBaseName()` documents itself as returning true only for "a file basename without any relative or absolute path", but it checks only for `/` and `\`. `"."` and `".."` contain neither, so they pass.

Callers join the result to a base directory, so a `".."` value leaves that directory.

## Reproduction

```
$ redis-server --dir /tmp/t/data --appendonly yes --appenddirname ".."
$ ls -A /tmp/t/data
$ ls -A /tmp/t
appendonly.aof.1.base.rdb
appendonly.aof.1.incr.aof
appendonly.aof.manifest
data
```

The whole AOF set is created in the parent of `dir`. Reproduced on 8.10 GA and the function is identical on `unstable`.

## The change

Reject `"."`, `".."` and the empty string, so the behaviour matches the comment. After the change the server refuses at startup using the existing message:

```
*** FATAL CONFIG FILE ERROR (Redis 8.10.0) ***
>>> 'appenddirname ".."'
appenddirname can't be a path, just a dirname
```

## Test

Adds `test_pathIsBaseName()` to `utilTest`, covering base names, both separators, `"."`, `".."` and the empty string. Run with `./src/redis-server test util`.

I checked that it is binding: with the two new guard lines removed and the test kept, it fails at `Assertion pathIsBaseName(".") == 0 failed`; with them restored it passes.

## Note on behaviour change

This does change accepted configuration. Anyone currently setting `appenddirname "."` or `".."` would fail to start after upgrading. My view is that this is the right outcome, since those configurations write outside the configured data directory, but it is a behaviour change and I would rather flag it than have you find it.

The four callers affected are `isValidDBfilename`, `isValidAOFfilename`, `isValidAOFdirname` and `isValidBackupdirname` in `config.c`, plus the AOF manifest parser in `aof.c`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes a path-escape issue in persistence config but changes accepted configuration on upgrade; scope is limited to basename validation, not broad auth or data-layer refactors.
> 
> **Overview**
> **`pathIsBaseName()`** no longer treats `"."`, `".."`, or the empty string as valid basenames. It still rejects paths containing `/` or `\`, but now also blocks these relative components that could escape the directory callers join them to (e.g. **`appenddirname ".."`** writing AOF outside **`--dir`**).
> 
> The function comment is updated to match. **`test_pathIsBaseName()`** is added to **`utilTest`** and wired into **`./src/redis-server test util`**.
> 
> Config validators that already call **`pathIsBaseName()`** (`appenddirname`, `dbfilename`, AOF names, backup dirname, manifest filenames) will **refuse startup** for those values via existing error messages—**breaking** configs that relied on `"."` or `".."`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4dc33537c1bbf87a7239371f9827848af3d4ef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->