### PR TITLE
RESET should clear CLIENT_INTERNAL

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2180,7 +2180,8 @@ void clearClientConnectionState(client *c) {
     
     /* Selectively clear state flags not covered above */
     c->flags &= ~(CLIENT_ASKING|CLIENT_READONLY|CLIENT_REPLY_OFF|
-                  CLIENT_REPLY_SKIP_NEXT|CLIENT_NO_TOUCH|CLIENT_NO_EVICT);
+                  CLIENT_REPLY_SKIP_NEXT|CLIENT_NO_TOUCH|CLIENT_NO_EVICT|
+                  CLIENT_INTERNAL);
 }
 
 void deauthenticateAndCloseClient(client *c) {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -589,6 +589,13 @@ start_server {tags {"introspection"}} {
         r client info
     } {*lib-name=redis.py lib-ver=1.2.3*}
 
+
+    test {RESET clears the internal client flag} {
+        r debug mark-internal-client
+        assert_match {*flags=I*} [r client info]
+        r reset
+        assert_no_match {*flags=I*} [r client info]
+    } {} {needs:reset needs:debug}
     test {RESET does NOT clean library name} {
         r reset
         r client info


### PR DESCRIPTION
`clearClientConnectionState()` restores the connection's identity — it calls `clientSetDefaultAuth()`, so the client returns to the default user and is re-subjected to `authRequired()`. It does not clear `CLIENT_INTERNAL`, which is absent from the selective flag clear a few lines below.

The result is a connection that keeps internal-command authority while holding a different ACL identity.

## Reproduction

```
> DEBUG mark-internal-client
OK
> CLIENT INFO
id=4 ... flags=I ...
> RESET
RESET
> CLIENT INFO
id=4 ... flags=I ...        <- still internal
```

With an ACL user in play the split is clearer — `ACL WHOAMI` returns `alice` while `CLIENT INFO` still reports `flags=I`.

Both `CMD_INTERNAL` gates key on the flag alone, not on the user, so the retained flag is no longer paired with the identity it was granted alongside.

## The change

Add `CLIENT_INTERNAL` to the selective clear in `clearClientConnectionState()`.

The only place that clears the flag today is `DEBUG mark-internal-client` itself. The clients that legitimately carry it — the ASM importing links and connections authenticated with the cluster internal secret — are server-created or re-authenticate, and do not issue `RESET`.

## Test

Adds a test to `tests/unit/introspection.tcl`, beside the existing `RESET does NOT clean library name` test, tagged `needs:reset needs:debug`.

I checked that it is binding: with the fix reverted and the test kept, `CLIENT INFO` still reports `flags=I` after `RESET`; with the fix, it reports `flags=N`.

## Scope

This is a state-hygiene fix rather than a privilege boundary. Reaching `CLIENT_INTERNAL` in the first place requires either the cluster internal secret or `DEBUG` (which is off unless `enable-debug-command` is set), and both already confer more than the `CMD_INTERNAL` command set. I am raising it because the flag outliving the identity it came with looks unintended, not because I have an escalation to show.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client identity and internal-command gating on `RESET`, but only for normal connections and in a narrow state-hygiene fix with a targeted test.
> 
> **Overview**
> **`RESET` now drops internal-client authority** along with the other connection state it already clears in `clearClientConnectionState()`.
> 
> Previously, `RESET` could re-establish default ACL/auth while leaving `CLIENT_INTERNAL` set, so `CLIENT INFO` could still show `flags=I` and `CMD_INTERNAL` checks could still treat the connection as internal under a different user. The fix adds `CLIENT_INTERNAL` to the selective flag clear in `networking.c`.
> 
> A regression test in `tests/unit/introspection.tcl` uses `DEBUG mark-internal-client`, asserts `flags=I`, runs `RESET`, and expects the internal flag to be gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaffb186f8e12fc8c09c6956cec2d2a870677de7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->