### PR TITLE
Client-side caching: Notify redirect client when tracking source disconnects

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2032,7 +2032,7 @@ void unlinkClient(client *c) {
     c->cmd = NULL;
 
     /* Clear the tracking status. */
-    if (c->flags & CLIENT_TRACKING) disableTracking(c);
+    if (c->flags & CLIENT_TRACKING) disableTracking(c,0);
 }
 
 /* Remove client from the list of clients with pending referenced replies.
@@ -2149,7 +2149,7 @@ void clearClientConnectionState(client *c) {
 
     serverAssert(!(c->flags &(CLIENT_SLAVE|CLIENT_MASTER)));
 
-    if (c->flags & CLIENT_TRACKING) disableTracking(c);
+    if (c->flags & CLIENT_TRACKING) disableTracking(c,0);
     selectDb(c,0);
 #ifdef LOG_REQ_RES
     c->resp = server.client_default_resp;
@@ -2187,7 +2187,7 @@ void deauthenticateAndCloseClient(client *c) {
     /* The victim may be owned by an IO thread that reads c->flags concurrently:
      * all flag writes below are guarded by flags implying main-thread residency
      * (see clearClientPubSubState); the other writes are not read by IO threads. */
-    disableTracking(c);
+    disableTracking(c,0);
     /* Clear all Pub/Sub subscriptions synchronously *before* dropping the ACL
      * identity. This removes any provenance-stamped user* values right now, so a
      * subsequent synchronous ACLFreeUser() (e.g. the DELUSER that triggered this
@@ -4906,7 +4906,7 @@ NULL
 
             enableTracking(c,redir,options,prefix,numprefix);
         } else if (!strcasecmp(c->argv[2]->ptr,"off")) {
-            disableTracking(c);
+            disableTracking(c,1);
         } else {
             zfree(prefix);
             addReplyErrorObject(c,shared.syntaxerr);

--- a/src/server.h
+++ b/src/server.h
@@ -3490,7 +3490,7 @@ void addReplyStatusFormat(client *c, const char *fmt, ...);
 
 /* Client side caching (tracking mode) */
 void enableTracking(client *c, uint64_t redirect_to, uint64_t options, robj **prefix, size_t numprefix);
-void disableTracking(client *c);
+void disableTracking(client *c, int voluntary);
 void trackingRememberKeys(client *tracking, client *executing);
 void trackingInvalidateKey(client *c, robj *keyobj, int bcast);
 void trackingScheduleKeyInvalidation(uint64_t client_id, robj *keyobj);

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -29,6 +29,9 @@ uint64_t TrackingTableTotalItems = 0; /* Total number of IDs stored across
                                          are using server side for CSC. */
 robj *TrackingChannelName;
 
+/* Forward declaration. */
+void sendTrackingMessage(client *c, char *keyname, size_t keylen, int proto);
+
 /* This is the structure that we have as value of the PrefixTable, and
  * represents the list of keys modified, and the list of clients that need
  * to be notified, for a given prefix. */
@@ -43,8 +46,14 @@ typedef struct bcastState {
  * tracking mode, because we just store the ID of the client in the tracking
  * table, so we'll remove the ID reference in a lazy way. Otherwise when a
  * client with many entries in the table is removed, it would cost a lot of
- * time to do the cleanup. */
-void disableTracking(client *c) {
+ * time to do the cleanup.
+ *
+ * The 'voluntary' parameter indicates whether tracking was disabled by an
+ * explicit CLIENT TRACKING OFF command from the client (1), or because the
+ * data connection was terminated (0). When the tracking source disconnects
+ * involuntarily and has a valid redirection target, we send a NULL message
+ * to the redirect client to signal that all keys should be invalidated. */
+void disableTracking(client *c, int voluntary) {
     /* If this client is in broadcasting mode, we need to unsubscribe it
      * from all the prefixes it is registered to. */
     if (c->flags & CLIENT_TRACKING_BCAST) {
@@ -71,8 +80,20 @@ void disableTracking(client *c) {
         c->client_tracking_prefixes = NULL;
     }
 
-    /* Clear flags and adjust the count. */
+    /* Clear flags and adjust the count. If tracking is disabled
+     * involuntarily (e.g. the connection was terminated) and the client
+     * redirects invalidation messages to another client, notify the
+     * redirection target that all keys should be invalidated. */
     if (c->flags & CLIENT_TRACKING) {
+        if (!voluntary &&
+            c->client_tracking_redirection &&
+            !(c->flags & CLIENT_TRACKING_BROKEN_REDIR))
+        {
+            /* Send a NULL invalidation to indicate that all keys
+             * should be invalidated. */
+            sendTrackingMessage(c,shared.null[c->resp]->ptr,
+                sdslen(shared.null[c->resp]->ptr),1);
+        }
         server.tracking_clients--;
         c->flags &= ~(CLIENT_TRACKING|CLIENT_TRACKING_BROKEN_REDIR|
                       CLIENT_TRACKING_BCAST|CLIENT_TRACKING_OPTIN|


### PR DESCRIPTION
## Problem

When using the [two-connection pattern](https://redis.io/docs/latest/develop/reference/client-side-caching/#two-connections-mode) for client-side caching with `CLIENT TRACKING on REDIRECT <pubsub-id>`, if the **data connection** drops (e.g., timeout, network failure, `CLIENT KILL`), the **pubsub connection** stays alive and receives no notification. The application continues serving potentially stale cached data.

The data connection is only used when there is a cache miss. If all subsequent requests hit the local cache, the application may never make another request on the data connection and thus never discover that it has been disconnected — silently serving stale data indefinitely.

## Solution

Add a `voluntary` parameter to `disableTracking()`:

- `voluntary = 1` — called from `CLIENT TRACKING OFF`, no notification
- `voluntary = 0` — called from `unlinkClient()` / `clearClientConnectionState()` / `deauthenticateAndCloseClient()`, sends an invalidation to the redirect target

When tracking is disabled involuntarily and the client has a valid redirect target, we send a NULL invalidation via `sendTrackingMessage()`. NULL means "all keys invalidated", following the same pattern as `trackingInvalidateKeysOnFlush()`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-side caching invalidation semantics on connection teardown; behavior is scoped to tracking + redirect but can cause broad cache drops for affected apps.
> 
> **Overview**
> Fixes **stale local cache** when the data connection in **two-connection client-side caching** (`CLIENT TRACKING` + `REDIRECT`) drops while the pubsub connection stays up.
> 
> `disableTracking()` gains a **`voluntary`** flag: **`CLIENT TRACKING OFF`** passes `1` (no extra notification). Disconnect / reset / deauth paths pass `0`. On involuntary disable, if the client had a valid redirect and tracking wasn’t in a broken-redir state, the server sends a **RESP NULL** invalidation via `sendTrackingMessage()` (same “flush all keys” signal as flush handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9788a9dc0c7982d225d5e2062f9dce9d675e1ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->