### PR TITLE
[8.8] Backport blocked-client UAF and cluster packet overflow fixes

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -595,14 +595,25 @@ static void handleClientsBlockedOnKey(readyList *rl) {
 
     if (de) {
         list *clients = dictGetVal(de);
-        listNode *ln;
-        listIter li;
-        listRewind(clients,&li);
-
         /* Avoid processing more than the initial count so that we're not stuck
          * in an endless loop in case the reprocessing of the command blocks again. */
         long count = listLength(clients);
-        while ((ln = listNext(&li)) && count--) {
+        while (count-- > 0) {
+            /* Processing the previous client may have removed all blocked
+             * clients and freed the list, so look it up again each time. */
+            de = dictFind(rl->db->blocking_keys, rl->key);
+            if (!de) break;
+            list *clients = dictGetVal(de);
+            listNode *ln = listFirst(clients);
+            serverAssert(ln);
+
+            /* Rotate before reprocessing because unblocking may remove this
+             * client, and command reprocessing may evict other blocked clients
+             * and free the list. If the client remains blocked or blocks again,
+             * keeping it at the tail lets us advance to the next client while
+             * preserving the order of the other waiters. */
+            listRotateHeadToTail(clients);
+
             client *receiver = listNodeValue(ln);
             kvobj *o = lookupKeyReadWithFlags(rl->db, rl->key, LOOKUP_NOEFFECTS);
             /* 1. In case new key was added/touched we need to verify it satisfy the

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2839,11 +2839,16 @@ int clusterProcessPacket(clusterLink *link) {
         explen = sizeof(clusterMsg)-sizeof(union clusterMsgData);
         explen += sizeof(clusterMsgDataFail);
     } else if (type == CLUSTERMSG_TYPE_PUBLISH || type == CLUSTERMSG_TYPE_PUBLISHSHARD) {
+        uint32_t ch_len = ntohl(hdr->data.publish.msg.channel_len);
+        uint32_t msg_len = ntohl(hdr->data.publish.msg.message_len);
         explen = sizeof(clusterMsg)-sizeof(union clusterMsgData);
-        explen += sizeof(clusterMsgDataPublish) -
-                8 +
-                ntohl(hdr->data.publish.msg.channel_len) +
-                ntohl(hdr->data.publish.msg.message_len);
+        explen += sizeof(clusterMsgDataPublish) - 8;
+        if (ch_len > UINT32_MAX - explen || msg_len > UINT32_MAX - explen - ch_len) {
+            serverLog(LL_WARNING, "Received invalid %s packet with overflow in length fields "
+                "(channel_len:%u, message_len:%u)", clusterGetMessageTypeString(type), ch_len, msg_len);
+            return 1;
+        }
+        explen += ch_len + msg_len;
     } else if (type == CLUSTERMSG_TYPE_FAILOVER_AUTH_REQUEST ||
                type == CLUSTERMSG_TYPE_FAILOVER_AUTH_ACK ||
                type == CLUSTERMSG_TYPE_MFSTART)
@@ -2853,9 +2858,15 @@ int clusterProcessPacket(clusterLink *link) {
         explen = sizeof(clusterMsg)-sizeof(union clusterMsgData);
         explen += sizeof(clusterMsgDataUpdate);
     } else if (type == CLUSTERMSG_TYPE_MODULE) {
+        uint32_t module_len = ntohl(hdr->data.module.msg.len);
         explen = sizeof(clusterMsg)-sizeof(union clusterMsgData);
-        explen += sizeof(clusterMsgModule) -
-                3 + ntohl(hdr->data.module.msg.len);
+        explen += sizeof(clusterMsgModule) - 3;
+        if (module_len > UINT32_MAX - explen) {
+            serverLog(LL_WARNING, "Received invalid %s packet with overflow in length field "
+                "(len:%u)", clusterGetMessageTypeString(type), module_len);
+            return 1;
+        }
+        explen += module_len;
     } else {
         /* We don't know this type of packet, so we assume it's well formed. */
         explen = totlen;

--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -262,3 +262,40 @@ proc check_cluster_node_mark {flag ref_node_index instance_id_to_check} {
     }
     fail "Unable to find instance id in cluster nodes. ID: $instance_id_to_check"
 }
+
+# Build the 2256-byte cluster bus header (CLUSTERMSG_MIN_LEN) common to all
+# message types.  Only the type field and the data that follows differ.
+proc build_cluster_bus_header {sender_name sender_port sender_cport msg_type totlen} {
+    set CLUSTER_NAMELEN 40
+    set NET_IP_STR_LEN 46
+
+    set sender_padded [binary format a${CLUSTER_NAMELEN} $sender_name]
+    set myslots [string repeat \x00 [expr {16384/8}]]
+    set slaveof [string repeat \x00 $CLUSTER_NAMELEN]
+    set myip [string repeat \x00 $NET_IP_STR_LEN]
+    set notused1 [string repeat \x00 30]
+
+    set hdr ""
+    append hdr "RCmb"
+    append hdr [binary format I $totlen]
+    append hdr [binary format S 1]              ;# ver
+    append hdr [binary format S $sender_port]   ;# port
+    append hdr [binary format S $msg_type]      ;# type
+    append hdr [binary format S 0]              ;# count
+    append hdr [binary format W 1]              ;# currentEpoch
+    append hdr [binary format W 2]              ;# configEpoch
+    append hdr [binary format W 0]              ;# offset
+    append hdr $sender_padded                   ;# sender
+    append hdr $myslots                         ;# myslots
+    append hdr $slaveof                         ;# slaveof
+    append hdr $myip                            ;# myip
+    append hdr [binary format S 0]              ;# extensions
+    append hdr $notused1                        ;# notused1
+    append hdr [binary format S 0]              ;# pport
+    append hdr [binary format S $sender_cport]  ;# cport
+    append hdr [binary format S 0]              ;# flags
+    append hdr [binary format c 0]              ;# state
+    append hdr [binary format ccc 0 0 0]        ;# mflags
+
+    return $hdr
+}

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -640,5 +640,46 @@ start_server {} {
     }
 }
 
+start_server {} {
+    test "Evicting the next client while serving blocked clients is safe" {
+        r flushall
+        r client no-evict on
+        r config set maxmemory-clients 0
+
+        set rd1 [redis_deferring_client]
+        set rd2 [redis_deferring_client]
+        $rd2 CLIENT SETNAME client-to-evict
+        assert_equal OK [$rd2 read]
+
+        # Block two clients on the same key in a known order.
+        $rd1 BLPOP mylist 0
+        wait_for_blocked_clients_count 1
+        $rd2 BLPOP mylist 0
+        wait_for_blocked_clients_count 2
+
+        # Queue a large request behind the second client's blocking command so
+        # it will be selected for eviction while the first client is processed.
+        $rd2 get [string repeat Q [kb 2048]]
+        wait_for_condition 50 100 {
+            [client_field client-to-evict tot-mem] > [mb 1]
+        } else {
+            fail "Failed to increase the second blocked client's memory usage"
+        }
+
+        # Apply the client-memory limit and make the key ready in one transaction.
+        # Eviction then runs while rd1 is being reprocessed, selecting rd2 while
+        # it is still in the blocked-client list.
+        r MULTI
+        r CONFIG SET MAXMEMORY-CLIENTS [kb 128]
+        r LPUSH mylist x
+        r EXEC
+
+        assert_equal {mylist x} [$rd1 read]
+        assert {![client_exists client-to-evict]} ;# rd2 is evicted
+        $rd1 close
+        $rd2 close
+    }
+}
+
 } ;# tags
 

--- a/tests/unit/cluster/packet-validation.tcl
+++ b/tests/unit/cluster/packet-validation.tcl
@@ -1,0 +1,90 @@
+start_cluster 2 0 {tags {external:skip cluster}} {
+
+test "PUBLISH with channel_len + message_len overflow is rejected" {
+    set CLUSTERMSG_TYPE_PUBLISH 4
+    set CLUSTERMSG_MIN_LEN 2256
+
+    set target_host [srv 0 host]
+    set target_bus_port [expr {[srv 0 port] + 10000}]
+    set node_id [R 1 CLUSTER MYID]
+    set sender_port [srv -1 port]
+    set sender_cport [expr {$sender_port + 10000}]
+
+    # sizeof(clusterMsgDataPublish) - 8 = 16 - 8 = 8
+    # With channel_len=0x80000000 and message_len=0x80000000, their sum
+    # overflows uint32 to 0, making explen = 2256 + 8 = 2264 without the fix.
+    # The fix detects the overflow before computing explen.
+    set channel_len 0x80000000
+    set message_len 0x80000000
+    set totlen [expr {$CLUSTERMSG_MIN_LEN + 8}] ;# 2264
+
+    set packet [build_cluster_bus_header $node_id $sender_port $sender_cport \
+        $CLUSTERMSG_TYPE_PUBLISH $totlen]
+    append packet [binary format I $channel_len]
+    append packet [binary format I $message_len]
+
+    if {$::tls} {
+        set fd [::tls::socket \
+            -cafile "$::tlsdir/ca.crt" \
+            -certfile "$::tlsdir/client.crt" \
+            -keyfile "$::tlsdir/client.key" \
+            $target_host $target_bus_port]
+    } else {
+        set fd [socket $target_host $target_bus_port]
+    }
+    fconfigure $fd -translation binary -buffering full
+    puts -nonewline $fd $packet
+    flush $fd
+
+    # The fix rejects the packet and logs a warning about the overflow.
+    wait_for_log_messages 0 {"*publish*overflow in length fields*"} 0 20 500
+    close $fd
+
+    # Verify the server is still responsive after the malformed packet.
+    assert_equal [R 0 PING] {PONG}
+}
+
+test "MODULE with len overflow is rejected" {
+    set CLUSTERMSG_TYPE_MODULE 9
+    set CLUSTERMSG_MIN_LEN 2256
+
+    set target_host [srv 0 host]
+    set target_bus_port [expr {[srv 0 port] + 10000}]
+    set node_id [R 1 CLUSTER MYID]
+    set sender_port [srv -1 port]
+    set sender_cport [expr {$sender_port + 10000}]
+
+    # sizeof(clusterMsgModule) - 3 = 16 - 3 = 13
+    # With module_len=0xFFFFFFFF, adding to base explen (2256+13=2269)
+    # overflows uint32, wrapping to 2268 without the fix.
+    # The fix detects the overflow before computing explen.
+    set module_len 0xFFFFFFFF
+    set totlen [expr {($CLUSTERMSG_MIN_LEN + 13 + $module_len) & 0xFFFFFFFF}] ;# 2268
+
+    set packet [build_cluster_bus_header $node_id $sender_port $sender_cport \
+        $CLUSTERMSG_TYPE_MODULE $totlen]
+    append packet [binary format W 0]           ;# module_id
+    append packet [binary format I $module_len] ;# len
+
+    if {$::tls} {
+        set fd [::tls::socket \
+            -cafile "$::tlsdir/ca.crt" \
+            -certfile "$::tlsdir/client.crt" \
+            -keyfile "$::tlsdir/client.key" \
+            $target_host $target_bus_port]
+    } else {
+        set fd [socket $target_host $target_bus_port]
+    }
+    fconfigure $fd -translation binary -buffering full
+    puts -nonewline $fd $packet
+    flush $fd
+
+    # The fix rejects the packet and logs a warning about the overflow.
+    wait_for_log_messages 0 {"*module*overflow in length field*"} 0 20 500
+    close $fd
+
+    # Verify the server is still responsive after the malformed packet.
+    assert_equal [R 0 PING] {PONG}
+}
+
+}


### PR DESCRIPTION
## Summary

Backport the two fixes tracked by #15615 to the 8.8 maintenance branch:

- `a8edcfc98c50bb01c850e5dab3998ce57807144d` / #15594 avoids a use-after-free while reprocessing clients blocked on the same key.
- `c0a83262a34de8781dc9f076ed3f4ae4235c2d70` / #15187 rejects cluster-bus PUBLISH, PUBLISHSHARD, and MODULE messages whose attacker-controlled lengths overflow the expected packet size.

Both commits are cherry-picked with provenance and preserve their original authorship.

## Root cause

- `handleClientsBlockedOnKey()` retained a list iterator whose cached node could be freed if reprocessing one waiter evicted another waiter.
- `clusterProcessPacket()` accumulated untrusted `uint32_t` lengths into `explen` without overflow checks, allowing wrapped values to bypass total-length validation.

## Validation

- `make -j4`
- `./runtest --single unit/client-eviction`
- `./runtest --single unit/cluster/packet-validation`
- `make -j4 SANITIZER=address REDIS_CFLAGS='-DREDIS_TEST -DDEBUG_ASSERTIONS'`
- Both targeted suites repeated against the ASAN build

All targeted tests passed, including the new blocked-client UAF and malformed cluster-packet regression tests.

The unmodified full `make test` baseline reached 129/149 test files before the WSL filesystem remounted read-only. This occurred before applying the backport and is unrelated to these changes.

Closes #15615

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches memory-safety in blocked-client handling and untrusted cluster-bus length parsing; both are security- and stability-sensitive server paths.
> 
> **Overview**
> Backports two safety fixes to the 8.8 branch: safer reprocessing of clients blocked on the same key, and stricter cluster-bus packet length validation.
> 
> **Blocked clients:** `handleClientsBlockedOnKey()` no longer walks the waiter list with a cached iterator/node. Each iteration re-fetches the `blocking_keys` entry, takes the head client, rotates that node to the tail before re-running the command, and then processes the saved receiver. That avoids use-after-free when unblocking or client eviction frees the list or other waiters while one client is being served.
> 
> **Cluster bus:** `clusterProcessPacket()` now checks `uint32_t` overflow when computing expected size for `PUBLISH` / `PUBLISHSHARD` (`channel_len` + `message_len`) and `MODULE` (`len`). Malformed lengths are logged and the packet is rejected instead of accepting a wrapped `explen`.
> 
> Regression coverage adds a client-eviction scenario (eviction while serving blocked waiters), raw bus packets for overflow cases, and a shared `build_cluster_bus_header` test helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d55b657f0ba6eacd41b70847ec92d0d59035993b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->