### PR TITLE
Fix gcov CI warnings and failures in multi-threaded coverage

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -544,7 +544,8 @@ lcov:
 	@lcov --version
 	$(MAKE) gcov
 	@(set -e; cd ..; ./runtest)
-	@#geninfo_unexecuted_blocks=1 count partially executed lines as uncovered. May lower coverage but gives a strict result
+	# geninfo_unexecuted_blocks=1 count partially executed lines as uncovered.
+	# May lower coverage but gives a strict result
 	@geninfo --rc geninfo_unexecuted_blocks=1 -o redis.info .
 	@genhtml --legend -o lcov-html redis.info
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -559,7 +559,7 @@ bench: $(REDIS_BENCHMARK_NAME)
 	$(MAKE) CFLAGS="-m32" LDFLAGS="-m32" SKIP_VEC_SETS="yes"
 
 gcov:
-	$(MAKE) REDIS_CFLAGS="-fprofile-arcs -ftest-coverage -DCOVERAGE_TEST" REDIS_LDFLAGS="-fprofile-arcs -ftest-coverage"
+	$(MAKE) REDIS_CFLAGS="-fprofile-arcs -ftest-coverage -fprofile-update=atomic -DCOVERAGE_TEST" REDIS_LDFLAGS="-fprofile-arcs -ftest-coverage"
 
 noopt:
 	$(MAKE) OPTIMIZATION="-O0"

--- a/src/Makefile
+++ b/src/Makefile
@@ -559,10 +559,9 @@ bench: $(REDIS_BENCHMARK_NAME)
 	@echo ""
 	$(MAKE) CFLAGS="-m32" LDFLAGS="-m32" SKIP_VEC_SETS="yes"
 
-# OPTIMIZATION=-O0 to keep gcov's source-line and basic-block mappings accurate.
 # Use -fprofile-update=atomic because IO threads can update counters concurrently.
 gcov:
-	$(MAKE) OPTIMIZATION="-O0" REDIS_CFLAGS="-fprofile-arcs -ftest-coverage -fprofile-update=atomic -DCOVERAGE_TEST" REDIS_LDFLAGS="-fprofile-arcs -ftest-coverage"
+	$(MAKE) REDIS_CFLAGS="-fprofile-arcs -ftest-coverage -fprofile-update=atomic -DCOVERAGE_TEST" REDIS_LDFLAGS="-fprofile-arcs -ftest-coverage"
 
 noopt:
 	$(MAKE) OPTIMIZATION="-O0"

--- a/src/Makefile
+++ b/src/Makefile
@@ -558,8 +558,10 @@ bench: $(REDIS_BENCHMARK_NAME)
 	@echo ""
 	$(MAKE) CFLAGS="-m32" LDFLAGS="-m32" SKIP_VEC_SETS="yes"
 
+# OPTIMIZATION=-O0 to keep gcov's source-line and basic-block mappings accurate.
+# Use -fprofile-update=atomic because IO threads can update counters concurrently.
 gcov:
-	$(MAKE) REDIS_CFLAGS="-fprofile-arcs -ftest-coverage -fprofile-update=atomic -DCOVERAGE_TEST" REDIS_LDFLAGS="-fprofile-arcs -ftest-coverage"
+	$(MAKE) OPTIMIZATION="-O0" OPT="-O0" REDIS_CFLAGS="-fprofile-arcs -ftest-coverage -fprofile-update=atomic -DCOVERAGE_TEST" REDIS_LDFLAGS="-fprofile-arcs -ftest-coverage"
 
 noopt:
 	$(MAKE) OPTIMIZATION="-O0"

--- a/src/Makefile
+++ b/src/Makefile
@@ -561,7 +561,7 @@ bench: $(REDIS_BENCHMARK_NAME)
 # OPTIMIZATION=-O0 to keep gcov's source-line and basic-block mappings accurate.
 # Use -fprofile-update=atomic because IO threads can update counters concurrently.
 gcov:
-	$(MAKE) OPTIMIZATION="-O0" OPT="-O0" REDIS_CFLAGS="-fprofile-arcs -ftest-coverage -fprofile-update=atomic -DCOVERAGE_TEST" REDIS_LDFLAGS="-fprofile-arcs -ftest-coverage"
+	$(MAKE) OPTIMIZATION="-O0" REDIS_CFLAGS="-fprofile-arcs -ftest-coverage -fprofile-update=atomic -DCOVERAGE_TEST" REDIS_LDFLAGS="-fprofile-arcs -ftest-coverage"
 
 noopt:
 	$(MAKE) OPTIMIZATION="-O0"

--- a/src/Makefile
+++ b/src/Makefile
@@ -544,7 +544,8 @@ lcov:
 	@lcov --version
 	$(MAKE) gcov
 	@(set -e; cd ..; ./runtest)
-	@geninfo -o redis.info .
+	@#geninfo_unexecuted_blocks=1 count partially executed lines as uncovered. May lower coverage but gives a strict result
+	@geninfo --rc geninfo_unexecuted_blocks=1 -o redis.info .
 	@genhtml --legend -o lcov-html redis.info
 
 .PHONY: lcov


### PR DESCRIPTION

## Issue


The coverage CI can fail with a negative count when multiple IO threads update the same non-atomic gcov counter at the same time.

It may also warn about an "unexecuted block on non-branch line with non-zero hit count" when gcov maps both executed and unexecuted blocks to the same source line.


Failed CI: https://github.com/redis/redis/actions/runs/31624138290/job/94375194877

> Processing ./hyperloglog.gcda
geninfo: WARNING: /home/runner/work/redis/redis/src/hyperloglog.c:468: unexecuted block on non-branch line with non-zero hit count.  Use "geninfo --rc geninfo_unexecuted_blocks=1 to set count to zero.
	(use "geninfo --ignore-errors gcov,gcov ..." to suppress this warning)
Processing ./networking.gcda
geninfo: WARNING: /home/runner/work/redis/redis/src/connection.h:250: unexecuted block on non-branch line with non-zero hit count.  Use "geninfo --rc geninfo_unexecuted_blocks=1 to set count to zero.
	(use "geninfo --ignore-errors gcov,gcov ..." to suppress this warning)
geninfo: ERROR: Unexpected negative count '-38' for /home/runner/work/redis/redis/src/networking.c:3992.
	Perhaps you need to compile with '-fprofile-update=atomic
	(use "geninfo --ignore-errors negative ..." to bypass this error)
make[1]: *** [Makefile:547: lcov] Error 1
make[1]: Leaving directory '/home/runner/work/redis/redis/src'
make: *** [Makefile:89: lcov] Error 2
Error: Process completed with exit code 2.


## Change
1. Fixes an error: Added -fprofile-update=atomic to prevent negative gcov counts caused by IO thread race conditions.
2. Cleans up warnings: Enabled geninfo_unexecuted_blocks=1 to properly handle partially executed lines with multiple basic blocks.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect optional coverage builds (`make gcov`/`make lcov`), not default release binaries or runtime behavior.
> 
> **Overview**
> **Fixes coverage CI failures and noisy `geninfo` warnings** by tightening how Redis is built and how LCOV data is collected in `src/Makefile`.
> 
> The **`gcov`** target now passes **` -fprofile-update=atomic`** when compiling with profile instrumentation so concurrent IO threads do not corrupt gcov counters (which previously produced errors like unexpected negative hit counts in `networking.c`).
> 
> The **`lcov`** target runs **`geninfo`** with **`geninfo_unexecuted_blocks=1`**, treating partially executed lines with multiple basic blocks as uncovered. That matches `geninfo`'s guidance for “unexecuted block on non-branch line” warnings and may report slightly lower coverage for a stricter result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f56f9dd6841b196e0fd25d17ad2b54e947db869. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->