### PR TITLE
Make ASM tests work with --single

### DIFF
--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -123,6 +123,19 @@ proc failover_and_wait_for_done {node_id {failover_arg ""}} {
     fail "Failover did not complete after $max_attempts attempts for node $node_id"
 }
 
+# Return 1 if the given node is the current owner of the given slot, from that
+# node's own view of the cluster.
+proc node_owns_slot {node_id slot} {
+    set myid [R $node_id cluster myid]
+    foreach range [R $node_id cluster slots] {
+        lassign $range start end owner
+        if {$slot >= $start && $slot <= $end} {
+            return [expr {[lindex $owner 2] eq $myid}]
+        }
+    }
+    return 0
+}
+
 proc migration_status {node_id task_id field} {
     set status [R $node_id CLUSTER MIGRATION STATUS ID $task_id]
 
@@ -716,6 +729,22 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     }
 
     proc asm_basic_error_handling_test {operation channel all_states} {
+        # Slots 0-100 must start on the source node, since this test imports them
+        # to node 0. Earlier tests in this block happen to leave them there, but
+        # inheriting that is what makes this test fail as
+        # "ERR this node is already the owner of the slot range" - an error that
+        # names neither the absent setup nor this test, and which also makes the
+        # test impossible to run on its own with --only.
+        if {[node_owns_slot 0 0]} {
+            set setup_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
+            wait_for_condition 1000 10 {
+                [string match {*completed*} [migration_status 0 $setup_id state]] &&
+                [string match {*completed*} [migration_status 1 $setup_id state]]
+            } else {
+                fail "setup: slots 0-100 could not be moved to the source node"
+            }
+        }
+
         foreach state $all_states {
             if {$::verbose} { puts "Testing $operation $channel channel with state: $state"}
 

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1591,6 +1591,17 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 CLUSTER MIGRATION IMPORT 0 100
         wait_for_asm_done
     }
+
+    # The calls elsewhere in this file only take the no-op path, since in an
+    # ordered run the slots are already on the node that needs them.
+    test "move_slots_to_node migrates a range that is not on the target node" {
+        move_slots_to_node 1 0 100
+        move_slots_to_node 0 0 100
+        assert_equal 1 [node_owns_slots 0 0 100]
+        assert_equal 0 [node_owns_slots 1 0 100]
+        move_slots_to_node 1 0 100
+        assert_equal 1 [node_owns_slots 1 0 100]
+    }
 }
 
 start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 60000 cluster-allow-replica-migration no}} {

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -123,17 +123,35 @@ proc failover_and_wait_for_done {node_id {failover_arg ""}} {
     fail "Failover did not complete after $max_attempts attempts for node $node_id"
 }
 
-# Return 1 if the given node is the current owner of the given slot, from that
-# node's own view of the cluster.
-proc node_owns_slot {node_id slot} {
+# Return 1 if the given node owns every slot in the range, from that node's own
+# view of the cluster. CLUSTER SLOTS reports one range per owner, so a node that
+# owns the whole range covers it with a single entry.
+proc node_owns_slots {node_id start_slot end_slot} {
     set myid [R $node_id cluster myid]
     foreach range [R $node_id cluster slots] {
-        lassign $range start end owner
-        if {$slot >= $start && $slot <= $end} {
-            return [expr {[lindex $owner 2] eq $myid}]
+        lassign $range start end node
+        if {[lindex $node 2] eq $myid && $start <= $start_slot && $end_slot <= $end} {
+            return 1
         }
     }
     return 0
+}
+
+# Move a slot range to a node, unless it owns all of it already. A range split
+# across owners is left to the server, which rejects the import with "slots
+# belong to different source nodes".
+proc move_slots_to_node {node_id start_slot end_slot} {
+    if {[node_owns_slots $node_id $start_slot $end_slot]} {
+        return
+    }
+    set task_id [R $node_id CLUSTER MIGRATION IMPORT $start_slot $end_slot]
+    wait_for_condition 1000 10 {
+        [string match {*completed*} [migration_status $node_id $task_id state]]
+    } else {
+        fail "could not move slots $start_slot-$end_slot to node $node_id -
+             ([migration_status $node_id $task_id state]
+              [migration_status $node_id $task_id last_error])"
+    }
 }
 
 proc migration_status {node_id task_id field} {
@@ -164,6 +182,10 @@ proc migration_status {node_id task_id field} {
 # Setup slot migration test with keys and delay, then start migration
 # Returns the task_id for the migration
 proc setup_slot_migration_with_delay {src_node dst_node start_slot end_slot {keys 2} {delay 1000000}} {
+    # This populates the range on src_node and imports it to dst_node, so the
+    # range has to be on src_node to begin with.
+    move_slots_to_node $src_node $start_slot $end_slot
+
     # Two keys on the start slot
     populate_slot $keys -idx $src_node -slot $start_slot
 
@@ -601,6 +623,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     }
 
     test "Verify expire time is migrated correctly" {
+        move_slots_to_node 1 0 100
         R 0 flushall
         R 1 flushall
 
@@ -640,6 +663,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     }
 
     test "Slot migration with complex data types can work well" {
+        move_slots_to_node 1 0 100
         R 0 flushall
         R 1 flushall
 
@@ -673,6 +697,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     }
 
     test "Slot migration preserves template-encoded hashes" {
+        move_slots_to_node 1 0 100
         R 0 flushall
         R 1 flushall
         R 0 config set hash-min-template-entries 0
@@ -729,21 +754,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     }
 
     proc asm_basic_error_handling_test {operation channel all_states} {
-        # Slots 0-100 must start on the source node, since this test imports them
-        # to node 0. Earlier tests in this block happen to leave them there, but
-        # inheriting that is what makes this test fail as
-        # "ERR this node is already the owner of the slot range" - an error that
-        # names neither the absent setup nor this test, and which also makes the
-        # test impossible to run on its own with --only.
-        if {[node_owns_slot 0 0]} {
-            set setup_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
-            wait_for_condition 1000 10 {
-                [string match {*completed*} [migration_status 0 $setup_id state]] &&
-                [string match {*completed*} [migration_status 1 $setup_id state]]
-            } else {
-                fail "setup: slots 0-100 could not be moved to the source node"
-            }
-        }
+        move_slots_to_node 1 0 100
 
         foreach state $all_states {
             if {$::verbose} { puts "Testing $operation $channel channel with state: $state"}
@@ -841,6 +852,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     }
 
     test "Migration will be successful after fail points are cleared" {
+        move_slots_to_node 1 0 100
         R 0 flushall
         R 1 flushall
         set slot0_key [slot_key 0 mykey]
@@ -953,6 +965,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     }
 
     test "Expired key is not deleted and SCAN/KEYS/RANDOMKEY/CLUSTER GETKEYSINSLOT filter keys in importing slots" {
+        move_slots_to_node 1 0 100
         set slot0_key [slot_key 0 mykey]
         set slot1_key [slot_key 1 mykey]
         set slot2_key [slot_key 2 mykey]
@@ -3431,6 +3444,7 @@ start_cluster 3 0 [list tags {external:skip cluster tls:skip modules} config_lin
     test "redis-cli --cluster rebalance automatically uses atomic slot migration" {
         # Rebalance distributes 16384 slots evenly across the 3 nodes.
         # (0-999) will be moved back to node 0.
+        move_slots_to_node 1 0 999
         clear_module_event_log
         exec src/redis-cli --cluster rebalance 127.0.0.1:[get_port 0] --cluster-yes
         wait_for_asm_done


### PR DESCRIPTION
Some ASM tests don't set up the slots they need, they just assume the previous test did it. So they fail with --only.
Added a helper that moves the slots to the right node, and called it in those tests.

-----
`asm_basic_error_handling_test` imports slots 0-100 to node 0, so the slots have to be on the source node when it starts. The test doesn't do that itself — it relies on earlier tests in the block having migrated them away. Running it alone fails:

```
./runtest --single unit/cluster/atomic-slot-migration \
          --only "Destination node rdb channel basic error-handling tests"
[exception]: ERR this node is already the owner of the slot range.
```

With `continuous_slot_allocation` node 0 owns 0-5460 from the start, so the import is refused, same as `Test IMPORT not allowed if the node is already the owner` checks.

It isn't only this test. Of the 95 tests in the file, 89 can be addressed with `--only`, and 9 of those fail on their own — all of them because they inherit cluster state instead of setting it up. Eight fail with `MOVED 0`, writing to a slot they turn out not to own, which is the error in #15341. The `redis-cli --cluster rebalance` test fails because run alone the cluster is already balanced, so nothing migrates and its event-log assertion sees nothing.

`move_slots_to_node {node_id start_slot end_slot}` moves a range to a node unless it owns all of it already. The guard also goes inside `setup_slot_migration_with_delay`, which populates on `src_node` and imports to `dst_node` and so already requires the range to be on the source; that covers 3 of the 9. Five write to the source node before reaching any helper and call it directly, and the rebalance test creates the imbalance its own comment describes.

Re-ran all 89 individually after the fix: none fail. The ordered run is unchanged: 104 assertions, 0 failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to TCL helpers and setup; no production Redis or cluster behavior is modified.
> 
> **Overview**
> Atomic slot migration tests no longer depend on cluster layout left by earlier cases in the same file.
> 
> The PR adds **`node_owns_slots`** and **`move_slots_to_node`** helpers: the latter runs `CLUSTER MIGRATION IMPORT` only when the target does not already own the range, then waits for ASM completion and propagation. **`setup_slot_migration_with_delay`** calls it on the source node first so keys are populated on the real owner. Several tests that write to node 1 for slots 0–100 (and the redis-cli rebalance case) now call **`move_slots_to_node`** up front so `--only` runs do not hit `MOVED`, “already the owner”, or empty rebalance event logs. A dedicated test exercises moving 0–100 between nodes 0 and 1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c147aaaeddaff130508a7939367bc31153fc18b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



