### PR TITLE
Derive keysizes histogram row count from an enum

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -65,17 +65,15 @@ void updateLRM(robj *o) {
     }
 }
 
-static_assert(MAX_KEYSIZES_ROWS == 6, "keysizesHistRow(): add/remove a row mapping");
-
 /* Return the histogram row that tracks `type`, or NULL if the type is untracked. */
 int64_t *keysizesHistRow(keysizesHist hist, uint32_t type) {
     switch (type) {
-    case OBJ_STRING: return hist[0];
-    case OBJ_LIST:   return hist[1];
-    case OBJ_SET:    return hist[2];
-    case OBJ_ZSET:   return hist[3];
-    case OBJ_HASH:   return hist[4];
-    case OBJ_STREAM: return hist[5];
+    case OBJ_STRING: return hist[KEYSIZES_ROW_STRING];
+    case OBJ_LIST:   return hist[KEYSIZES_ROW_LIST];
+    case OBJ_SET:    return hist[KEYSIZES_ROW_SET];
+    case OBJ_ZSET:   return hist[KEYSIZES_ROW_ZSET];
+    case OBJ_HASH:   return hist[KEYSIZES_ROW_HASH];
+    case OBJ_STREAM: return hist[KEYSIZES_ROW_STREAM];
     default:         return NULL;
     }
 }

--- a/src/server.h
+++ b/src/server.h
@@ -882,7 +882,6 @@ typedef enum {
 #define OBJ_SET 2       /* Set object. */
 #define OBJ_ZSET 3      /* Sorted set object. */
 #define OBJ_HASH 4      /* Hash object. */
-#define OBJ_TYPE_BASIC_MAX 5 /* Max number of basic object types. */
 
 /* The "module" object type is a special one that signals that the object
  * is one directly managed by a Redis module. In this case the value points
@@ -1253,7 +1252,15 @@ typedef struct redisDb {
  * than by object type, so untracked types in between (OBJ_MODULE) cost no row
  * and the histogram stays plain storage: zeroing initializes it, and it can be
  * copied or moved like any other array. */
-#define MAX_KEYSIZES_ROWS (OBJ_TYPE_BASIC_MAX + 1)  /* basic types + streams */
+enum {
+    KEYSIZES_ROW_STRING = 0,
+    KEYSIZES_ROW_LIST,
+    KEYSIZES_ROW_SET,
+    KEYSIZES_ROW_ZSET,
+    KEYSIZES_ROW_HASH,
+    KEYSIZES_ROW_STREAM,
+    MAX_KEYSIZES_ROWS   /* must stay last */
+};
 typedef int64_t keysizesHist[MAX_KEYSIZES_ROWS][MAX_KEYSIZES_BINS];
 
 /* Metadata structure used for kvstores with type `kvstoreExType`, managed outside kvstore */


### PR DESCRIPTION
Followup #15374

The keysizes histogram rows were indexed by bare integer literals in
keysizesHistRow(), with a static_assert guarding that the row count and
the mapping stay in sync. Replace them with a KEYSIZES_ROW_* enum whose
last member defines MAX_KEYSIZES_ROWS, so adding or removing a row
updates the count automatically and the assert is no longer needed.

Also drop OBJ_TYPE_BASIC_MAX, which existed only to derive
MAX_KEYSIZES_ROWS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only naming for INFO keysizes histogram indexing; no runtime logic or data layout change beyond the same row count derived from the enum.
> 
> **Overview**
> Keysizes histogram row indices are now **named `KEYSIZES_ROW_*` enum constants** in `server.h`, with **`MAX_KEYSIZES_ROWS` defined as the enum’s last member** instead of `OBJ_TYPE_BASIC_MAX + 1`.
> 
> `keysizesHistRow()` in `db.c` indexes rows with those names instead of literals `hist[0]`–`hist[5]`, and the **`static_assert` that kept the switch and row count in sync is removed**.
> 
> **`OBJ_TYPE_BASIC_MAX` is dropped** because it only existed to size the histogram.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9af6e1806a0f96b18369c3dacdd3ce5325cf6a3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->