### PR TITLE
Honor selective propagation for effect commands queued via alsoPropagate()

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -3028,12 +3028,9 @@ static void propagateTrimSlots(slotRangeArray *slots) {
 
     enterExecutionUnit(1, 0);
 
-    int prev_replication_allowed = server.replication_allowed;
     int prev_also_propagate_mask = server.also_propagate_mask;
-    server.replication_allowed = 1;
     server.also_propagate_mask = PROPAGATE_AOF|PROPAGATE_REPL;
     alsoPropagate(-1, argv, argc, PROPAGATE_AOF | PROPAGATE_REPL);
-    server.replication_allowed = prev_replication_allowed;
     server.also_propagate_mask = prev_also_propagate_mask;
 
     exitExecutionUnit();

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -3029,9 +3029,12 @@ static void propagateTrimSlots(slotRangeArray *slots) {
     enterExecutionUnit(1, 0);
 
     int prev_replication_allowed = server.replication_allowed;
+    int prev_also_propagate_mask = server.also_propagate_mask;
     server.replication_allowed = 1;
+    server.also_propagate_mask = PROPAGATE_AOF|PROPAGATE_REPL;
     alsoPropagate(-1, argv, argc, PROPAGATE_AOF | PROPAGATE_REPL);
     server.replication_allowed = prev_replication_allowed;
+    server.also_propagate_mask = prev_also_propagate_mask;
 
     exitExecutionUnit();
     postExecutionUnitOperations();

--- a/src/db.c
+++ b/src/db.c
@@ -2945,11 +2945,16 @@ void propagateDeletion(redisDb *db, robj *key, int lazy) {
     incrRefCount(argv[1]);
 
     /* If the master decided to delete a key we must propagate it to replicas no matter what.
-     * Even if module executed a command without asking for propagation. */
+     * Even if module executed a command without asking for propagation, or the
+     * deletion was triggered from a call() with propagation suppressed (e.g.
+     * lazy expire during a Lua script that called redis.set_repl()). */
     int prev_replication_allowed = server.replication_allowed;
+    int prev_also_propagate_mask = server.also_propagate_mask;
     server.replication_allowed = 1;
+    server.also_propagate_mask = PROPAGATE_AOF|PROPAGATE_REPL;
     alsoPropagate(db->id,argv,2,PROPAGATE_AOF|PROPAGATE_REPL);
     server.replication_allowed = prev_replication_allowed;
+    server.also_propagate_mask = prev_also_propagate_mask;
 
     decrRefCount(argv[0]);
     decrRefCount(argv[1]);

--- a/src/db.c
+++ b/src/db.c
@@ -2948,12 +2948,9 @@ void propagateDeletion(redisDb *db, robj *key, int lazy) {
      * Even if module executed a command without asking for propagation, or the
      * deletion was triggered from a call() with propagation suppressed (e.g.
      * lazy expire during a Lua script that called redis.set_repl()). */
-    int prev_replication_allowed = server.replication_allowed;
     int prev_also_propagate_mask = server.also_propagate_mask;
-    server.replication_allowed = 1;
     server.also_propagate_mask = PROPAGATE_AOF|PROPAGATE_REPL;
     alsoPropagate(db->id,argv,2,PROPAGATE_AOF|PROPAGATE_REPL);
-    server.replication_allowed = prev_replication_allowed;
     server.also_propagate_mask = prev_also_propagate_mask;
 
     decrRefCount(argv[0]);

--- a/src/module.c
+++ b/src/module.c
@@ -7169,11 +7169,16 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
             call_flags |= CMD_CALL_PROPAGATE_REPL;
     }
 
-    /* Preserve inherited restrictions if the command blocks and is later
-     * reprocessed after the outer call's propagation mask was restored. */
-    int effective_propagate_mask = server.also_propagate_mask &
-        (((call_flags & CMD_CALL_PROPAGATE_AOF) ? PROPAGATE_AOF : 0) |
-         ((call_flags & CMD_CALL_PROPAGATE_REPL) ? PROPAGATE_REPL : 0));
+    /* An inner RM_Call with `!` must not re-enable targets suppressed by an
+     * outer RM_Call without `!`. Snapshot the effective targets so a blocking
+     * call keeps those inherited restrictions after the outer mask is restored.
+     * Keep this calculation in sync with call()'s target narrowing. */
+    int effective_propagate_mask = PROPAGATE_NONE;
+    if ((call_flags & CMD_CALL_PROPAGATE_AOF) && !(c->flags & CLIENT_MODULE_PREVENT_AOF_PROP))
+        effective_propagate_mask |= PROPAGATE_AOF;
+    if ((call_flags & CMD_CALL_PROPAGATE_REPL) && !(c->flags & CLIENT_MODULE_PREVENT_REPL_PROP))
+        effective_propagate_mask |= PROPAGATE_REPL;
+    effective_propagate_mask &= server.also_propagate_mask;
     call(c,call_flags);
 
     if (c->flags & CLIENT_BLOCKED) {

--- a/src/module.c
+++ b/src/module.c
@@ -7168,6 +7168,12 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
         if (!(flags & REDISMODULE_ARGV_NO_REPLICAS))
             call_flags |= CMD_CALL_PROPAGATE_REPL;
     }
+
+    /* Preserve inherited restrictions if the command blocks and is later
+     * reprocessed after the outer call's propagation mask was restored. */
+    int effective_propagate_mask = server.also_propagate_mask &
+        (((call_flags & CMD_CALL_PROPAGATE_AOF) ? PROPAGATE_AOF : 0) |
+         ((call_flags & CMD_CALL_PROPAGATE_REPL) ? PROPAGATE_REPL : 0));
     call(c,call_flags);
 
     if (c->flags & CLIENT_BLOCKED) {
@@ -7186,11 +7192,11 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
         };
         reply = callReplyCreatePromise(promise);
         c->bstate.async_rm_call_handle = promise;
-        if (!(call_flags & CMD_CALL_PROPAGATE_AOF)) {
+        if (!(effective_propagate_mask & PROPAGATE_AOF)) {
             /* No need for AOF propagation, set the relevant flags of the client */
             c->flags |= CLIENT_MODULE_PREVENT_AOF_PROP;
         }
-        if (!(call_flags & CMD_CALL_PROPAGATE_REPL)) {
+        if (!(effective_propagate_mask & PROPAGATE_REPL)) {
             /* No need for replication propagation, set the relevant flags of the client */
             c->flags |= CLIENT_MODULE_PREVENT_REPL_PROP;
         }

--- a/src/module.c
+++ b/src/module.c
@@ -7160,15 +7160,6 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
         goto cleanup;
     }
 
-    /* We need to use a global replication_allowed flag in order to prevent
-     * replication of nested RM_Calls. Example:
-     * 1. module1.foo does RM_Call of module2.bar without replication (i.e. no '!')
-     * 2. module2.bar internally calls RM_Call of INCR with '!'
-     * 3. at the end of module1.foo we call RM_ReplicateVerbatim
-     * We want the replica/AOF to see only module1.foo and not the INCR from module2.bar */
-    int prev_replication_allowed = server.replication_allowed;
-    server.replication_allowed = replicate && server.replication_allowed;
-
     /* Run the command */
     int call_flags = CMD_CALL_FROM_MODULE;
     if (replicate) {
@@ -7178,7 +7169,6 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
             call_flags |= CMD_CALL_PROPAGATE_REPL;
     }
     call(c,call_flags);
-    server.replication_allowed = prev_replication_allowed;
 
     if (c->flags & CLIENT_BLOCKED) {
         serverAssert(flags & REDISMODULE_ARGV_ALLOW_BLOCK);

--- a/src/server.c
+++ b/src/server.c
@@ -3047,7 +3047,6 @@ void initServer(void) {
     /* clients_timeout_table key = 8 bytes BE mstime + 8 bytes client ID
      * (see CLIENT_ST_KEYLEN / encodeTimeoutKey in timeout.c). */
     server.clients_timeout_table = raxNewEx(0, NULL, sizeof(uint64_t) * 2);
-    server.replication_allowed = 1;
     server.also_propagate_mask = PROPAGATE_AOF|PROPAGATE_REPL;
     server.slaveseldb = -1; /* Force to emit the first SELECT command. */
     server.unblocked_clients = listCreate();
@@ -3734,7 +3733,7 @@ int mustObeyClient(client *c) {
 }
 
 int shouldPropagate(int target) {
-    if (!server.replication_allowed || target == PROPAGATE_NONE || server.loading)
+    if (target == PROPAGATE_NONE || server.loading)
         return 0;
 
     if (target & PROPAGATE_AOF) {
@@ -4088,13 +4087,17 @@ void call(client *c, int flags) {
 
     /* Narrow the targets allowed for alsoPropagate() to the ones enabled for
      * this invocation, so effect commands queued by the implementation honor
-     * Lua redis.set_repl() and selective RM_Call propagation. Nested call()s
-     * can only narrow the mask further, never widen what an outer level
-     * suppressed. */
+     * Lua redis.set_repl() and selective RM_Call propagation, including when a
+     * blocked RM_Call is reprocessed. Nested call()s can only narrow the mask
+     * further, never widen what an outer level suppressed. */
+    int call_propagate_mask = PROPAGATE_NONE;
+    if ((flags & CMD_CALL_PROPAGATE_AOF) && !(c->flags & CLIENT_MODULE_PREVENT_AOF_PROP))
+        call_propagate_mask |= PROPAGATE_AOF;
+    if ((flags & CMD_CALL_PROPAGATE_REPL) && !(c->flags & CLIENT_MODULE_PREVENT_REPL_PROP))
+        call_propagate_mask |= PROPAGATE_REPL;
+
     int prev_also_propagate_mask = server.also_propagate_mask;
-    server.also_propagate_mask &=
-        ((flags & CMD_CALL_PROPAGATE_AOF) ? PROPAGATE_AOF : 0) |
-        ((flags & CMD_CALL_PROPAGATE_REPL) ? PROPAGATE_REPL : 0);
+    server.also_propagate_mask &= call_propagate_mask;
 
     c->cmd->proc(c);
 

--- a/src/server.c
+++ b/src/server.c
@@ -3048,6 +3048,7 @@ void initServer(void) {
      * (see CLIENT_ST_KEYLEN / encodeTimeoutKey in timeout.c). */
     server.clients_timeout_table = raxNewEx(0, NULL, sizeof(uint64_t) * 2);
     server.replication_allowed = 1;
+    server.also_propagate_mask = PROPAGATE_AOF|PROPAGATE_REPL;
     server.slaveseldb = -1; /* Force to emit the first SELECT command. */
     server.unblocked_clients = listCreate();
     server.ready_keys = listCreate();
@@ -3795,6 +3796,14 @@ void alsoPropagate(int dbid, robj **argv, int argc, int target) {
     robj **argvcopy;
     int j;
 
+    /* Restrict the requested targets to the ones enabled for the currently
+     * executing call(), so that effect commands don't reach an AOF / replica
+     * target that was suppressed for the command that generated them (e.g.
+     * by Lua redis.set_repl() or a selective RM_Call). Callers propagating
+     * implicit deletions (expired keys, evictions) force the mask open, as
+     * those must always reach replicas and the AOF. */
+    target &= server.also_propagate_mask;
+
     if (!shouldPropagate(target))
         return;
 
@@ -4077,7 +4086,19 @@ void call(client *c, int flags) {
      * re-processing and unblock the client.*/
     c->flags |= CLIENT_EXECUTING_COMMAND;
 
+    /* Narrow the targets allowed for alsoPropagate() to the ones enabled for
+     * this invocation, so effect commands queued by the implementation honor
+     * Lua redis.set_repl() and selective RM_Call propagation. Nested call()s
+     * can only narrow the mask further, never widen what an outer level
+     * suppressed. */
+    int prev_also_propagate_mask = server.also_propagate_mask;
+    server.also_propagate_mask &=
+        ((flags & CMD_CALL_PROPAGATE_AOF) ? PROPAGATE_AOF : 0) |
+        ((flags & CMD_CALL_PROPAGATE_REPL) ? PROPAGATE_REPL : 0);
+
     c->cmd->proc(c);
+
+    server.also_propagate_mask = prev_also_propagate_mask;
 
     exitExecutionUnit();
 

--- a/src/server.h
+++ b/src/server.h
@@ -2423,7 +2423,6 @@ struct redisServer {
                                        flags, so effect commands honor Lua
                                        redis.set_repl() and selective RM_Call
                                        propagation. */
-    int replication_allowed;        /* Are we allowed to replicate? */
     /* Logging */
     char *logfile;                  /* Path of log file */
     int syslog_enabled;             /* Is syslog enabled? */

--- a/src/server.h
+++ b/src/server.h
@@ -2417,6 +2417,12 @@ struct redisServer {
     int child_info_nread;           /* Num of bytes of the last read from pipe */
     /* Propagation of commands in AOF / replication */
     redisOpArray also_propagate;    /* Additional command to propagate. */
+    int also_propagate_mask;        /* PROPAGATE_* targets allowed for commands
+                                       queued via alsoPropagate(). Narrowed by
+                                       call() from its CMD_CALL_PROPAGATE_*
+                                       flags, so effect commands honor Lua
+                                       redis.set_repl() and selective RM_Call
+                                       propagation. */
     int replication_allowed;        /* Are we allowed to replicate? */
     /* Logging */
     char *logfile;                  /* Path of log file */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -4323,7 +4323,7 @@ void himportSetCommand(client *c) {
      *
      * In the future this can be improved to send the fields only once instead of
      * on every SET, lowering the propagation cost further. */
-    if (shouldPropagate(PROPAGATE_AOF | PROPAGATE_REPL)) {
+    if (shouldPropagate((PROPAGATE_AOF | PROPAGATE_REPL) & server.also_propagate_mask)) {
         /* Presize the payload: field-name footprint + value bytes (over-estimate ok). */
         sds payload = createRawDumpPayload(o, c->argv[2], c->db->id, 0,
                                            tmpl->mem_size + total_values_length);
@@ -5957,12 +5957,9 @@ static void propagateHashFieldDeletion(redisDb *db, sds key, char *field, size_t
     };
 
     enterExecutionUnit(1, 0);
-    int prev_replication_allowed = server.replication_allowed;
     int prev_also_propagate_mask = server.also_propagate_mask;
-    server.replication_allowed = 1;
     server.also_propagate_mask = PROPAGATE_AOF|PROPAGATE_REPL;
     alsoPropagate(db->id,argv, 3, PROPAGATE_AOF|PROPAGATE_REPL);
-    server.replication_allowed = prev_replication_allowed;
     server.also_propagate_mask = prev_also_propagate_mask;
     exitExecutionUnit();
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -5958,9 +5958,12 @@ static void propagateHashFieldDeletion(redisDb *db, sds key, char *field, size_t
 
     enterExecutionUnit(1, 0);
     int prev_replication_allowed = server.replication_allowed;
+    int prev_also_propagate_mask = server.also_propagate_mask;
     server.replication_allowed = 1;
+    server.also_propagate_mask = PROPAGATE_AOF|PROPAGATE_REPL;
     alsoPropagate(db->id,argv, 3, PROPAGATE_AOF|PROPAGATE_REPL);
     server.replication_allowed = prev_replication_allowed;
+    server.also_propagate_mask = prev_also_propagate_mask;
     exitExecutionUnit();
 
     /* Propagate the HDEL command */

--- a/tests/unit/moduleapi/async_rm_call.tcl
+++ b/tests/unit/moduleapi/async_rm_call.tcl
@@ -300,9 +300,11 @@ start_server {tags {"modules external:skip"}} {
 
     test {Test no propagation of effect command after blocking RM_Call} {
         r flushall
-        r config set appendonly yes
+        # Keep AOF deterministic through DEBUG LOADAOF: fsync each command and
+        # prevent automatic rewrites from snapshotting the in-memory PEL.
         r config set appendfsync always
         r config set auto-aof-rewrite-percentage 0
+        r config set appendonly yes
         waitForBgrewriteaof r
         r xgroup create s g $ MKSTREAM
         set repl [attach_to_replication_stream]
@@ -327,11 +329,10 @@ start_server {tags {"modules external:skip"}} {
 
         r debug loadaof
         assert_equal 0 [lindex [r xpending s g] 0]
-        r config set appendonly no
 
         wait_for_blocked_clients_count 0
         $rd close
-    }
+    } undefined {config:restore}
 
     test {Test inherited propagation suppression after nested blocking RM_Call} {
         r flushall

--- a/tests/unit/moduleapi/async_rm_call.tcl
+++ b/tests/unit/moduleapi/async_rm_call.tcl
@@ -300,6 +300,10 @@ start_server {tags {"modules external:skip"}} {
 
     test {Test no propagation of effect command after blocking RM_Call} {
         r flushall
+        r config set appendonly yes
+        r config set appendfsync always
+        r config set auto-aof-rewrite-percentage 0
+        waitForBgrewriteaof r
         r xgroup create s g $ MKSTREAM
         set repl [attach_to_replication_stream]
 
@@ -312,6 +316,39 @@ start_server {tags {"modules external:skip"}} {
 
         # XREADGROUP propagates its effect as XCLAIM. The RM_Call did not use
         # `!`, so neither the command nor its effect should be propagated.
+        r set x 1
+
+        assert_replication_stream $repl {
+            {select *}
+            {xadd s * f v}
+            {set x 1}
+        }
+        close_replication_stream $repl
+
+        r debug loadaof
+        assert_equal 0 [lindex [r xpending s g] 0]
+        r config set appendonly no
+
+        wait_for_blocked_clients_count 0
+        $rd close
+    }
+
+    test {Test inherited propagation suppression after nested blocking RM_Call} {
+        r flushall
+        r xgroup create s g $ MKSTREAM
+        set repl [attach_to_replication_stream]
+
+        set rd [redis_deferring_client]
+
+        # The outer RM_Call omits `!`, while the inner RM_Call requests
+        # propagation and blocks. Its resumed execution must retain the outer
+        # suppression after the outer call's mask has been restored.
+        $rd do_rm_call_async_no_replicate do_rm_call_async \
+            xreadgroup group g c block 0 streams s >
+        wait_for_blocked_clients_count 1
+        r xadd s * f v
+        assert {[$rd read] ne {}}
+
         r set x 1
 
         assert_replication_stream $repl {

--- a/tests/unit/moduleapi/async_rm_call.tcl
+++ b/tests/unit/moduleapi/async_rm_call.tcl
@@ -297,6 +297,33 @@ start_server {tags {"modules external:skip"}} {
         wait_for_blocked_clients_count 0
         $rd close
     }
+
+    test {Test no propagation of effect command after blocking RM_Call} {
+        r flushall
+        r xgroup create s g $ MKSTREAM
+        set repl [attach_to_replication_stream]
+
+        set rd [redis_deferring_client]
+
+        $rd do_rm_call_async_no_replicate xreadgroup group g c block 0 streams s >
+        wait_for_blocked_clients_count 1
+        r xadd s * f v
+        assert {[$rd read] ne {}}
+
+        # XREADGROUP propagates its effect as XCLAIM. The RM_Call did not use
+        # `!`, so neither the command nor its effect should be propagated.
+        r set x 1
+
+        assert_replication_stream $repl {
+            {select *}
+            {xadd s * f v}
+            {set x 1}
+        }
+        close_replication_stream $repl
+
+        wait_for_blocked_clients_count 0
+        $rd close
+    }
 }
 
 start_server {tags {"modules external:skip"}} {

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -681,6 +681,92 @@ tags "modules external:skip" {
     }
 }
 
+tags "modules aof external:skip" {
+    start_server {} {
+        set replica [srv 0 client]
+        start_server [list overrides [list loadmodule "$miscmodule"]] {
+            set master [srv 0 client]
+            set master_host [srv 0 host]
+            set master_port [srv 0 port]
+
+            $master module load $keyspace_events
+            $master config set appendonly yes
+            $master config set appendfsync always
+            $master config set auto-aof-rewrite-percentage 0
+            waitForBgrewriteaof $master
+
+            foreach key {rmcall-none rmcall-repl-only rmcall-aof-only rmcall-all} {
+                $master sadd $key a b c d e
+            }
+
+            $replica replicaof $master_host $master_port
+            wait_for_sync $replica
+
+            test {RM_Call effect commands honor replica propagation flags} {
+                # The counted form of SPOP propagates its effect as SREM.
+                assert_equal 2 [llength [$master test.rm_call spop rmcall-none 2]]
+                assert_equal 2 [llength [$master test.rm_call_flags !A spop rmcall-repl-only 2]]
+                assert_equal 2 [llength [$master test.rm_call_flags !R spop rmcall-aof-only 2]]
+                assert_equal 2 [llength [$master test.rm_call_flags ! spop rmcall-all 2]]
+
+                # A suppresses AOF propagation and R suppresses replica propagation.
+                $master set rmcall-spop-sentinel 1
+                wait_for_ofs_sync $master $replica
+
+                foreach key {rmcall-none rmcall-repl-only rmcall-aof-only rmcall-all} {
+                    assert_equal 3 [$master scard $key]
+                }
+                assert_equal 5 [$replica scard rmcall-none]
+                assert_equal 3 [$replica scard rmcall-repl-only]
+                assert_equal 5 [$replica scard rmcall-aof-only]
+                assert_equal 3 [$replica scard rmcall-all]
+                assert_equal 1 [$replica get rmcall-spop-sentinel]
+            }
+
+            test {Nested RM_Replicate honors outer RM_Call replica propagation flags} {
+                # keyspace.incr_case2 changes the key through RM_Call without
+                # `!`, then queues the same INCR through RM_Replicate.
+                assert_equal 1 [$master test.rm_call keyspace.incr_case2 rmcall-nested-none]
+                assert_equal 1 [$master test.rm_call_flags !A keyspace.incr_case2 rmcall-nested-repl-only]
+                assert_equal 1 [$master test.rm_call_flags !R keyspace.incr_case2 rmcall-nested-aof-only]
+                assert_equal 1 [$master test.rm_call_flags ! keyspace.incr_case2 rmcall-nested-all]
+
+                $master set rmcall-nested-sentinel 1
+                wait_for_ofs_sync $master $replica
+
+                foreach key {rmcall-nested-none rmcall-nested-repl-only rmcall-nested-aof-only rmcall-nested-all} {
+                    assert_equal 1 [$master get $key]
+                }
+                assert_equal {} [$replica get rmcall-nested-none]
+                assert_equal 1 [$replica get rmcall-nested-repl-only]
+                assert_equal {} [$replica get rmcall-nested-aof-only]
+                assert_equal 1 [$replica get rmcall-nested-all]
+                assert_equal 1 [$replica get rmcall-nested-sentinel]
+            }
+
+            test {RM_Call effect commands honor AOF propagation flags} {
+                # Reload only after checking the replica: DEBUG LOADAOF replaces
+                # the master's data set and intentionally makes it diverge.
+                $master debug loadaof
+
+                assert_equal 5 [$master scard rmcall-none]
+                assert_equal 5 [$master scard rmcall-repl-only]
+                assert_equal 3 [$master scard rmcall-aof-only]
+                assert_equal 3 [$master scard rmcall-all]
+                assert_equal 1 [$master get rmcall-spop-sentinel]
+            }
+
+            test {Nested RM_Replicate honors outer RM_Call AOF propagation flags} {
+                assert_equal {} [$master get rmcall-nested-none]
+                assert_equal {} [$master get rmcall-nested-repl-only]
+                assert_equal 1 [$master get rmcall-nested-aof-only]
+                assert_equal 1 [$master get rmcall-nested-all]
+                assert_equal 1 [$master get rmcall-nested-sentinel]
+            }
+        }
+    }
+}
+
 
 tags "modules aof external:skip" {
     foreach aofload_type {debug_cmd startup} {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1667,6 +1667,70 @@ start_server {tags {"scripting repl external:skip"}} {
             assert {[r mget a b c d] eq {1 {} 3 4}}
         }
 
+        test "Test selective replication of effect commands (SPOP) from Lua" {
+            r del myset
+            r sadd myset a b c d e
+            set repl [attach_to_replication_stream]
+            run_script {
+                redis.call('set','before','1');
+                redis.set_repl(redis.REPL_NONE);
+                redis.call('spop',KEYS[1],2);
+                redis.set_repl(redis.REPL_ALL);
+                redis.call('set','after','1');
+            } 1 myset
+            # SPOP propagates itself as SREM via alsoPropagate(): with
+            # REPL_NONE it must not reach replicas or the AOF.
+            if {$is_eval} {
+                assert_replication_stream $repl {
+                    {multi}
+                    {select *}
+                    {set before 1}
+                    {set after 1}
+                    {exec}
+                }
+            } else {
+                assert_replication_stream $repl {
+                    {select *}
+                    {function load *}
+                    {multi}
+                    {set before 1}
+                    {set after 1}
+                    {exec}
+                }
+            }
+            close_replication_stream $repl
+            assert_equal 3 [r scard myset]
+        }
+
+        test "Lazy expire deletion is propagated despite set_repl(REPL_NONE)" {
+            r debug set-active-expire 0
+            r del foo
+            r set foo bar px 1
+            after 10
+            set repl [attach_to_replication_stream]
+            run_script {
+                redis.set_repl(redis.REPL_NONE);
+                redis.call('get',KEYS[1]);
+                redis.set_repl(redis.REPL_ALL);
+            } 1 foo
+            # Implicit deletions of expired keys must always be propagated,
+            # regardless of the script's replication mode.
+            if {$is_eval} {
+                assert_replication_stream $repl {
+                    {select *}
+                    {del foo}
+                }
+            } else {
+                assert_replication_stream $repl {
+                    {select *}
+                    {function load *}
+                    {del foo}
+                }
+            }
+            close_replication_stream $repl
+            r debug set-active-expire 1
+        }
+
         test "PRNG is seeded randomly for command replication" {
             if {$is_eval eq 1} {
                 # on is_eval Lua we need to call redis.replicate_commands() to get real randomization

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1743,8 +1743,8 @@ start_server {tags {"scripting repl external:skip"}} {
                 redis.call('hget',KEYS[1],ARGV[1]);
                 redis.set_repl(redis.REPL_ALL);
             } 1 myhash field
-            # Hash field expiration is an implicit deletion and must propagate
-            # even while the script suppresses its explicit command effects.
+            # Hash field expiration is an implicit deletion and must remain
+            # propagated while the script suppresses its explicit command effects.
             if {$is_eval} {
                 assert_replication_stream $repl {
                     {select *}

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1731,6 +1731,36 @@ start_server {tags {"scripting repl external:skip"}} {
             r debug set-active-expire 1
         }
 
+        test "Lazy hash field expiration is propagated despite set_repl(REPL_NONE)" {
+            r debug set-active-expire 0
+            r del myhash
+            r hset myhash field value keep alive
+            r hpexpire myhash 1 fields 1 field
+            after 10
+            set repl [attach_to_replication_stream]
+            run_script {
+                redis.set_repl(redis.REPL_NONE);
+                redis.call('hget',KEYS[1],ARGV[1]);
+                redis.set_repl(redis.REPL_ALL);
+            } 1 myhash field
+            # Hash field expiration is an implicit deletion and must propagate
+            # even while the script suppresses its explicit command effects.
+            if {$is_eval} {
+                assert_replication_stream $repl {
+                    {select *}
+                    {hdel myhash field}
+                }
+            } else {
+                assert_replication_stream $repl {
+                    {select *}
+                    {function load *}
+                    {hdel myhash field}
+                }
+            }
+            close_replication_stream $repl
+            r debug set-active-expire 1
+        }
+
         test "PRNG is seeded randomly for command replication" {
             if {$is_eval eq 1} {
                 # on is_eval Lua we need to call redis.replicate_commands() to get real randomization


### PR DESCRIPTION
Fixes #15638

### Problem

Commands that replace their own propagation (SPOP → SREM, stream/hash-TTL rewrites, `RM_Replicate`, etc.) queue the replacement via `alsoPropagate()` with a hard-coded `PROPAGATE_AOF|PROPAGATE_REPL` target. `call()` applies its `CMD_CALL_PROPAGATE_*` flags only to the verbatim propagation it performs itself, so the replacement commands leak to targets suppressed by Lua `redis.set_repl()` or a selective `RM_Call`:

```
sadd myset a b c d e
eval "redis.set_repl(redis.REPL_NONE); redis.call('spop', 'myset', 2)" 0
```

still replicated `SREM myset a d` (reported by @sundb in https://github.com/redis/redis/pull/15331#discussion_r3782475903).

### Fix

Add `server.also_propagate_mask` with the targets allowed for commands queued via `alsoPropagate()`:

- `call()` narrows the mask from its `CMD_CALL_PROPAGATE_*` flags around the command proc, and restores it afterwards. Nested `call()`s can only narrow the mask further, never widen what an outer level suppressed.
- `alsoPropagate()` intersects the requested target with the mask (an op masked to `PROPAGATE_NONE` is simply not queued).
- Implicit deletions must always reach the AOF and replicas no matter what, so `propagateDeletion()` (expired/evicted keys), `propagateHashFieldDeletion()` and `propagateTrimSlots()` force the mask open — mirroring the `server.replication_allowed` override that already exists at exactly those three call sites.

Unblocked clients are unaffected: `handleClientsBlockedOnKeys()` runs after `call()` returns, when the mask is already restored.

Note this also applies to `RM_Call` without `!`: effect commands queued by the invoked command (including `RM_Replicate` from nested code) no longer propagate, consistent with the documented "module is in charge of propagation" contract. All `moduleapi/propagate` tests pass unchanged.

### Tests

- `Test selective replication of effect commands (SPOP) from Lua` — asserts the replication stream contains no `SREM` under `REPL_NONE` (fails without the fix).
- `Lazy expire deletion is propagated despite set_repl(REPL_NONE)` — asserts the implicit `DEL` still reaches the stream.

Ran `unit/scripting`, `unit/expire`, `unit/multi`, `unit/type/{set,stream-cgroups,hash-field-expire}` and the full moduleapi suite — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core AOF and replication propagation for command effects, modules, and Lua. Incorrect masking could drop or leak writes to replicas and the AOF.
> 
> **Overview**
> Effect commands queued via `alsoPropagate()` (e.g. SPOP→SREM, `RM_Replicate`, stream/hash rewrites) now honor Lua `redis.set_repl()` and selective `RM_Call` flags instead of always going to AOF and replicas.
> 
> `call()` narrows a new `server.also_propagate_mask` from its `CMD_CALL_PROPAGATE_*` flags; nested calls can only restrict it further. `alsoPropagate()` intersects the requested target with that mask. Implicit deletions (expired/evicted keys, hash-field expire, slot trim) still force the mask fully open.
> 
> Blocking `RM_Call` snapshots the inherited mask onto `CLIENT_MODULE_PREVENT_*` so resumed execution keeps outer suppression. Tests cover Lua SPOP/`set_repl`, lazy expire still replicating, and module/AOF flag combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2989e40b1bdbb4fe7372d473f5fd203d65fd6132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->