### PR TITLE
Fix flaky compressed replication buffer limit test

### DIFF
--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -337,6 +337,12 @@ start_server {tags {"repl external:skip"}} {
             $replica config set client-output-buffer-limit "replica 64kb 64kb 0"
             populate 2000 master 1
 
+            # Generate the incompressible value before full sync begins so
+            # payload generation doesn't consume the buffering window.
+            if {$::compression} {
+                set random_value [randstring 500000 500000]
+            }
+
             set prev_sync_full [s 0 sync_full]
             $replica replicaof $master_host $master_port
 
@@ -351,7 +357,7 @@ start_server {tags {"repl external:skip"}} {
             # In case of compression generate a command stream that is not well
             # compressed so we can reach the buffer limits easier.
             if {$::compression} {
-                populate 1000 master 500000 0 false 0 true
+                populate 1000 master 500000 0 false 0 true $random_value
             } else {
                 populate 100 master 100000
             }

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -736,12 +736,17 @@ proc stop_bg_complex_data {handle} {
 
 # Write num keys with the given key prefix and value size (in bytes). If idx is
 # given, it's the index (AKA level) used with the srv procedure and it specifies
-# to which Redis instance to write the keys.
-proc populate {num {prefix key:} {size 3} {idx 0} {prints false} {expires 0} {random false}} {
+# to which Redis instance to write the keys. random_value can be used to avoid
+# generating the random value during a timing-sensitive operation.
+proc populate {num {prefix key:} {size 3} {idx 0} {prints false} {expires 0} {random false} {random_value ""}} {
     r $idx deferred 1
     if {$num > 16} {set pipeline 16} else {set pipeline $num}
     if {$random} {
-        set baseval [randstring $size $size]
+        if {$random_value eq ""} {
+            set baseval [randstring $size $size]
+        } else {
+            set baseval $random_value
+        }
     } else {
         set val [string repeat A $size]
     }


### PR DESCRIPTION
## Problem

With replication compression enabled, the test waits for `send_bulk_and_stream` and then generates a 500 KB random value. Generating that value can take long enough for full sync to finish, so the writes arrive after the replica's buffering window and the expected buffer-limit log is never emitted.

## Fix

- Allow `populate` callers to provide an already-generated random value.
- Generate the incompressible test value before starting full sync, then reuse it as soon as the replica enters `send_bulk_and_stream`.

Fixes #15641.

## Testing

- `make REDIS_CFLAGS=-Werror BUILD_COMPRESSION=yes -j4`
- Full `integration/replication-rdbchannel` test file with `io-threads 4`, `repl-compression 1`, and `--compression`: all tests passed (106 seconds).
- Focused buffer-limit test with compression: passed twice.
- Focused buffer-limit test without compression: passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test harness code in `util.tcl` and `replication-rdbchannel.tcl`; no production Redis behavior changes.
> 
> **Overview**
> **Test-only** change to stop a timing flake in the rdb-channel replication test when **repl compression** is enabled.
> 
> The `populate` helper gains an optional **`random_value`** argument so callers can supply a pre-built base string instead of calling `randstring` during the test. In **Test replication stream buffer becomes full on replica**, a **500 KB** incompressible value is generated **before** `replicaof` / full sync; after the replica reaches `send_bulk_and_stream`, that same value is passed into `populate` for the compressed traffic burst. That keeps slow random-string generation out of the narrow window where the replica must hit its output buffer limit and log **Replication buffer limit has been reached**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6a931caa770087331661b51b7730621e7ac5a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->