### PR TITLE
Fix signed overflow computing keynum key-spec ranges in getKeysUsingKeySpecs

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3306,8 +3306,22 @@ int getKeysUsingKeySpecs(struct redisCommand *cmd, robj **argv, int argc, int se
                 goto invalid_spec;
             }
 
-            first += spec->fk.keynum.firstkey;
-            last = first + ((long)numkeys - 1) * step;
+            /* A valid key count cannot exceed argc. Enforce that bound before
+             * computing the indexes so malformed counts cannot overflow. */
+            if (numkeys > argc)
+                goto invalid_spec;
+
+            long long first_ll, last_ll;
+            long long offset = (numkeys - 1) * (long long)step;
+            if (add_overflow_ll(first, spec->fk.keynum.firstkey, &first_ll) ||
+                add_overflow_ll(first_ll, offset, &last_ll) ||
+                first_ll < LONG_MIN || first_ll > LONG_MAX ||
+                last_ll < LONG_MIN || last_ll > LONG_MAX)
+            {
+                goto invalid_spec;
+            }
+            first = (long)first_ll;
+            last = (long)last_ll;
         } else {
             /* unknown spec */
             goto invalid_spec;

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -157,8 +157,9 @@ start_server {tags {"introspection"}} {
         assert_equal {{k1 {RW delete}}} [r command getkeysandflags delex k1 ifeq v1]
     }
 
-    test {COMMAND GETKEYSANDFLAGS invalid args} {
+    test {COMMAND GETKEYS and GETKEYSANDFLAGS invalid args} {
         assert_error "ERR Invalid arguments*" {r command getkeysandflags ZINTERSTORE zz 1443677133621497600 asdf}
+        assert_error "ERR Invalid arguments*" {r command getkeys ZUNION 9223372036854775807 key}
     }
 
     test {COMMAND GETKEYSANDFLAGS MSETEX} {


### PR DESCRIPTION
Fixes #15646

For `KSPEC_FK_KEYNUM` key specs, the key count parsed from the command line was only checked for being non-negative before computing `last = first + (numkeys - 1) * step`, so an oversized count such as `COMMAND GETKEYS ZUNION 9223372036854775807 key` overflowed signed `long` before the range bounds check. UBSan builds abort (`db.c:3310:26: runtime error: signed integer overflow`); regular builds relied on wrap-around to accidentally reach the `invalid_spec` path.

This bounds `numkeys` by `argc` up front (a valid key count can never exceed the argument count) and computes the range with `add_overflow_ll` checked arithmetic, rejecting anything that cannot be represented, so malformed counts deterministically take the `invalid_spec` path.

Adds a regression test to the existing `COMMAND GETKEYSANDFLAGS invalid args` test in `introspection-2.tcl`.

## Validation

On a clang `SANITIZER=undefined` build of current unstable, the repro kills the server:

```
db.c:3310:26: runtime error: signed integer overflow: 2 + 9223372036854775806 cannot be represented in type 'long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior db.c:3310:26
```

With this patch, the same build replies `ERR Invalid arguments specified for command` with no sanitizer report, and normal key extraction (`COMMAND GETKEYS ZUNION 2 a b`) is unchanged.

Found by fuzzing the command parser/executor (#15444); upstreamed separately from the fuzzing scaffold per review guidance there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to invalid-argument handling in key extraction; normal commands are unchanged and covered by new tests.
> 
> **Overview**
> Fixes **undefined signed integer overflow** when `COMMAND GETKEYS` / key-spec parsing handles `KSPEC_FK_KEYNUM` commands (e.g. `ZUNION`) with an absurd `numkeys` value. Previously only non-negative `numkeys` was checked before computing `last = first + (numkeys - 1) * step`, which could wrap in `long` and crash UBSan builds or rely on wrap-around before the bounds check.
> 
> The change **caps `numkeys` at `argc`** up front and computes `first`/`last` with **`add_overflow_ll`**, rejecting any result that overflows or does not fit in `long`, so bad input consistently hits `invalid_spec` and returns `ERR Invalid arguments`.
> 
> Adds a regression in `introspection-2.tcl` for `COMMAND GETKEYS ZUNION` with `LLONG_MAX` as the key count (alongside the existing GETKEYSANDFLAGS case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b7fa035778e0c74812bb456500638c9d23188b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->