### PR TITLE
[RED-213030] Dispatch modules-update tests after manifest changes

### DIFF
--- a/.github/workflows/dispatch-modules-update.yml
+++ b/.github/workflows/dispatch-modules-update.yml
@@ -1,0 +1,43 @@
+name: Dispatch Modules Update Tests
+
+on:
+  push:
+    branches:
+      - unstable
+    paths:
+      - modules/modules.yaml
+
+permissions: {}
+
+jobs:
+  dispatch-modules-update:
+    if: github.repository == 'redis/redis'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dispatch ce-testing modules-update workflow
+        env:
+          CE_TESTING_DISPATCH_TOKEN: ${{ secrets.CE_TESTING_DISPATCH_TOKEN }}
+          REDIS_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$CE_TESTING_DISPATCH_TOKEN" ]]; then
+            echo '::error::CE_TESTING_DISPATCH_TOKEN is not configured'
+            exit 1
+          fi
+
+          payload=$(printf \
+            '{"event_type":"redis_modules_manifest_updated","client_payload":{"redis_sha":"%s"}}' \
+            "$REDIS_SHA")
+
+          curl --fail-with-body --silent --show-error \
+            --connect-timeout 10 \
+            --max-time 60 \
+            --request POST \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer $CE_TESTING_DISPATCH_TOKEN" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            --header 'Content-Type: application/json' \
+            --data-binary "$payload" \
+            https://api.github.com/repos/redislabsdev/ce-testing/dispatches


### PR DESCRIPTION
## Summary

- add a push-only workflow for `unstable` changes to `modules/modules.yaml`
- send one `repository_dispatch` event to `redislabsdev/ce-testing` with event type `redis_modules_manifest_updated`
- pass the merged Redis commit as `client_payload.redis_sha`
- authenticate with the dedicated `CE_TESTING_DISPATCH_TOKEN` secret and fail clearly when the secret is missing or GitHub rejects the request
- avoid automatic POST retries so an ambiguous network response cannot create duplicate receiver runs

## Why

The existing `.github/workflows/modules-build-flow.yml` validates manifest changes in pull requests inside `redis/redis`. This workflow complements it by notifying the external full-platform receiver only after the manifest change reaches `unstable`.

The receiver was added and merged in [redislabsdev/ce-testing#179](https://github.com/redislabsdev/ce-testing/pull/179). It listens for this event type and checks out the exact Redis SHA supplied in the payload.

Jira: [RED-213030](https://redislabs.atlassian.net/browse/RED-213030)

## Validation

- actionlint 1.7.12 on `.github/workflows/dispatch-modules-update.yml`
- YAML contract checks for the event, branch, path, permissions, base-repository guard, secret, payload, and endpoint
- extracted workflow shell passed `bash -n`
- mocked successful dispatch verified the method, authentication header, endpoint, event type, and Redis SHA
- mocked missing-secret and rejected-request paths verified non-zero failure propagation
- `git diff --check`

## Remaining risk / follow-up

- Perform the ticket's credentialed end-to-end validation after this workflow is merged: change the modules manifest, confirm exactly one ce-testing run, and confirm it checks out the supplied Redis SHA.
- The `redis/redis` repository secret must be named `CE_TESTING_DISPATCH_TOKEN` and authorize repository dispatches to `redislabsdev/ce-testing`.
- GitHub-hosted execution and the real cross-repository credential were not available to exercise from this pull request.
- No Redis build or full test suite was run because this change only adds a narrowly scoped workflow sender.


[RED-213030]: https://redislabs.atlassian.net/browse/RED-213030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with scoped triggers and no application or data-path changes; operational risk is limited to misconfigured secrets or duplicate dispatches if the workflow is edited later.
> 
> **Overview**
> Adds **`.github/workflows/dispatch-modules-update.yml`**, which runs on pushes to **`unstable`** that touch **`modules/modules.yaml`** (only in **`redis/redis`**). It POSTs a **`repository_dispatch`** to **`redislabsdev/ce-testing`** with event type **`redis_modules_manifest_updated`** and **`client_payload.redis_sha`** set to the merge commit.
> 
> The job uses **`CE_TESTING_DISPATCH_TOKEN`**, fails fast if the secret is missing, and uses a single **`curl`** call (no retries) so downstream tests run once per manifest update after merge, complementing in-repo PR validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce087f2c61db0a129fb336ff69fa34d833a028b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->