### PR TITLE
MOD-17685 - fix make install & add make uninstall 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ endif
 .DEFAULT:
 	for dir in $(SUBDIRS); do $(MAKE) -C $$dir $@; done
 
-# `install` is an alias for `deploy` — same args, same PREFIX/DESTDIR.
+# `install` is an alias for `deploy` — same args, same PREFIX.
 install: deploy
 
 # clean [<name> ...|all|.|redis|none] — Redis core + selected modules.
@@ -114,7 +114,7 @@ build:
 bootstrap:
 	+@scripts/bootstrap.sh $(BOOTSTRAP_ARGS)
 
-# deploy [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]
+# deploy [<name> ...|all|.|redis|none] [PREFIX=<path>]
 #   Install Redis core + selected modules (default: every cloned module),
 #   then rewrite the `loadmodule` paths in redis-full.conf (and redis.conf, if
 #   it carries a Modules block) to point at the installed .so paths under
@@ -122,9 +122,9 @@ bootstrap:
 #   `make install`). Done directly by scripts/deploy.sh — no apply step.
 deploy: PREFIX ?= /usr/local
 deploy:
-	@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' scripts/deploy.sh $(DEPLOY_ARGS)
+	@PREFIX='$(PREFIX)' scripts/deploy.sh $(DEPLOY_ARGS)
 
-# uninstall [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]
+# uninstall [<name> ...|all|.|redis|none] [PREFIX=<path>]
 #   Exact inverse of `make install` / `make deploy`: removes the core binaries
 #   and symlinks from $(PREFIX)/bin and the selected modules' .so files from
 #   $(PREFIX)/lib/redis/modules (default: every module in modules.yaml, so a
@@ -132,7 +132,7 @@ deploy:
 #   `redis`/`none` uninstall the core only. See scripts/uninstall.sh.
 uninstall: PREFIX ?= /usr/local
 uninstall:
-	@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' scripts/uninstall.sh $(UNINSTALL_ARGS)
+	@PREFIX='$(PREFIX)' scripts/uninstall.sh $(UNINSTALL_ARGS)
 
 # run [<name> ...|all|.|none] [ARGS="<redis-server flags>"]
 run:

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ bootstrap:
 #   `make install`). Done directly by scripts/deploy.sh — no apply step.
 deploy: PREFIX ?= /usr/local
 deploy:
-	@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' PROG_SUFFIX='$(PROG_SUFFIX)' \
+	+@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' PROG_SUFFIX='$(PROG_SUFFIX)' \
 	    scripts/deploy.sh $(DEPLOY_ARGS)
 
 # uninstall [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export MAKE
 
 .DEFAULT_GOAL := build
 
-# Used only by .DEFAULT:/install: below, for goals with no explicit rule in
+# Used only by .DEFAULT: below, for goals with no explicit rule in
 # this Makefile (e.g. `make distclean`, `make 32bit`) — those still recurse
 # into src/ only, matching upstream Redis. Modules are never part of this;
 # `make` / `make build` route through scripts/build.sh instead,
@@ -42,6 +42,8 @@ GOALS_WITH_ARGS := \
     clean:CLEAN_ARGS \
     bootstrap:BOOTSTRAP_ARGS \
     deploy:DEPLOY_ARGS \
+    install:DEPLOY_ARGS \
+    uninstall:UNINSTALL_ARGS \
     test:TEST_ARGS \
     sync-redis-conf:SYNC_ARGS
 
@@ -88,8 +90,8 @@ endif
 .DEFAULT:
 	for dir in $(SUBDIRS); do $(MAKE) -C $$dir $@; done
 
-install:
-	for dir in $(SUBDIRS); do $(MAKE) -C $$dir $@; done
+# `install` is an alias for `deploy` — same args, same PREFIX/DESTDIR.
+install: deploy
 
 # clean [<name> ...|all|.|redis|none] — Redis core + selected modules.
 # Same per-module dispatch as scripts/build.sh. Env vars set on the make
@@ -121,6 +123,16 @@ bootstrap:
 deploy: PREFIX ?= /usr/local
 deploy:
 	@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' scripts/deploy.sh $(DEPLOY_ARGS)
+
+# uninstall [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]
+#   Exact inverse of `make install` / `make deploy`: removes the core binaries
+#   and symlinks from $(PREFIX)/bin and the selected modules' .so files from
+#   $(PREFIX)/lib/redis/modules (default: every module in modules.yaml, so a
+#   plain `sudo make uninstall` cleans up whatever a previous install left).
+#   `redis`/`none` uninstall the core only. See scripts/uninstall.sh.
+uninstall: PREFIX ?= /usr/local
+uninstall:
+	@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' scripts/uninstall.sh $(UNINSTALL_ARGS)
 
 # run [<name> ...|all|.|none] [ARGS="<redis-server flags>"]
 run:
@@ -157,4 +169,4 @@ sync-redis-conf:
 	    PREFIX='$(PREFIX)' \
 	    scripts/sync-redis-conf.sh
 
-.PHONY: install clean build run test bootstrap deploy modules-update modules-shallow sync-redis-conf tarball
+.PHONY: install uninstall clean build run test bootstrap deploy modules-update modules-shallow sync-redis-conf tarball

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ bootstrap:
 	+@scripts/bootstrap.sh $(BOOTSTRAP_ARGS)
 
 # deploy [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]
+#        [PROG_SUFFIX=<suffix>]
 #   Install Redis core + selected modules (default: every cloned module),
 #   then rewrite the `loadmodule` paths in redis-full.conf (and redis.conf, if
 #   it carries a Modules block) to point at the installed .so paths under
@@ -122,9 +123,11 @@ bootstrap:
 #   `make install`). Done directly by scripts/deploy.sh — no apply step.
 deploy: PREFIX ?= /usr/local
 deploy:
-	@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' scripts/deploy.sh $(DEPLOY_ARGS)
+	@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' PROG_SUFFIX='$(PROG_SUFFIX)' \
+	    scripts/deploy.sh $(DEPLOY_ARGS)
 
 # uninstall [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]
+#           [PROG_SUFFIX=<suffix>]
 #   Exact inverse of `make install` / `make deploy`: removes the core binaries
 #   and symlinks from $(PREFIX)/bin and the selected modules' .so files from
 #   $(PREFIX)/lib/redis/modules (default: every module in modules.yaml, so a
@@ -132,7 +135,8 @@ deploy:
 #   `redis`/`none` uninstall the core only. See scripts/uninstall.sh.
 uninstall: PREFIX ?= /usr/local
 uninstall:
-	@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' scripts/uninstall.sh $(UNINSTALL_ARGS)
+	@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' PROG_SUFFIX='$(PROG_SUFFIX)' \
+	    scripts/uninstall.sh $(UNINSTALL_ARGS)
 
 # run [<name> ...|all|.|none] [ARGS="<redis-server flags>"]
 run:

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ clean:
 
 # build [<name> ...|all|.|redis|core|none] — Redis core + selected modules.
 build:
-	+@scripts/build.sh $(BUILD_ARGS)
+	+@PROG_SUFFIX='$(PROG_SUFFIX)' scripts/build.sh $(BUILD_ARGS)
 
 # bootstrap [<name> ...|all|.] — install per-module build/test prereqs.
 bootstrap:
@@ -144,11 +144,11 @@ uninstall:
 
 # run [<name> ...|all|.|none] [ARGS="<redis-server flags>"]
 run:
-	@ARGS='$(ARGS)' scripts/run.sh $(RUN_ARGS)
+	@ARGS='$(ARGS)' PROG_SUFFIX='$(PROG_SUFFIX)' scripts/run.sh $(RUN_ARGS)
 
 # test [redis|all|<module> [<test_name>]] [TEST=<name>] — see scripts/test.sh.
 test:
-	+@TEST='$(TEST)' scripts/test.sh $(TEST_ARGS)
+	+@TEST='$(TEST)' PROG_SUFFIX='$(PROG_SUFFIX)' scripts/test.sh $(TEST_ARGS)
 
 # modules-update [<name> ...|all|.] [MODULES_UPDATE_SHALLOW=1]
 #   Idempotent clone/refresh per modules.yaml.

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,10 @@ endif
 .DEFAULT:
 	for dir in $(SUBDIRS); do $(MAKE) -C $$dir $@; done
 
-# `install` is an alias for `deploy` — same args, same PREFIX/DESTDIR.
+# `install` is an alias for `deploy` that does NOT build: it copies the
+# artifacts already in the tree, like upstream's install. Rebuild with
+# `make install SKIP_BUILD=0`, or just use `make deploy`.
+install: SKIP_BUILD ?= 1
 install: deploy
 
 # clean [<name> ...|all|.|redis|none] — Redis core + selected modules.
@@ -124,6 +127,7 @@ bootstrap:
 deploy: PREFIX ?= /usr/local
 deploy:
 	+@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' PROG_SUFFIX='$(PROG_SUFFIX)' \
+	    SKIP_BUILD='$(SKIP_BUILD)' \
 	    scripts/deploy.sh $(DEPLOY_ARGS)
 
 # uninstall [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ endif
 .DEFAULT:
 	for dir in $(SUBDIRS); do $(MAKE) -C $$dir $@; done
 
-# `install` is an alias for `deploy` — same args, same PREFIX.
+# `install` is an alias for `deploy` — same args, same PREFIX/DESTDIR.
 install: deploy
 
 # clean [<name> ...|all|.|redis|none] — Redis core + selected modules.
@@ -114,7 +114,7 @@ build:
 bootstrap:
 	+@scripts/bootstrap.sh $(BOOTSTRAP_ARGS)
 
-# deploy [<name> ...|all|.|redis|none] [PREFIX=<path>]
+# deploy [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]
 #   Install Redis core + selected modules (default: every cloned module),
 #   then rewrite the `loadmodule` paths in redis-full.conf (and redis.conf, if
 #   it carries a Modules block) to point at the installed .so paths under
@@ -122,9 +122,9 @@ bootstrap:
 #   `make install`). Done directly by scripts/deploy.sh — no apply step.
 deploy: PREFIX ?= /usr/local
 deploy:
-	@PREFIX='$(PREFIX)' scripts/deploy.sh $(DEPLOY_ARGS)
+	@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' scripts/deploy.sh $(DEPLOY_ARGS)
 
-# uninstall [<name> ...|all|.|redis|none] [PREFIX=<path>]
+# uninstall [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]
 #   Exact inverse of `make install` / `make deploy`: removes the core binaries
 #   and symlinks from $(PREFIX)/bin and the selected modules' .so files from
 #   $(PREFIX)/lib/redis/modules (default: every module in modules.yaml, so a
@@ -132,7 +132,7 @@ deploy:
 #   `redis`/`none` uninstall the core only. See scripts/uninstall.sh.
 uninstall: PREFIX ?= /usr/local
 uninstall:
-	@PREFIX='$(PREFIX)' scripts/uninstall.sh $(UNINSTALL_ARGS)
+	@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' scripts/uninstall.sh $(UNINSTALL_ARGS)
 
 # run [<name> ...|all|.|none] [ARGS="<redis-server flags>"]
 run:

--- a/README.md
+++ b/README.md
@@ -303,6 +303,17 @@ make -j "$(nproc)"
 
 `make` (same as `make build` / `make all`) builds whatever is cloned under `modules/*/src` alongside Redis core. To build just the core data structures — even with modules cloned — use `make build redis`.
 
+> **`redis-server` won't start: "Error loading the extension" / can't open a
+> `.so`.** The config still lists modules that weren't built successfully — a
+> release tarball's `redis.conf` carries `loadmodule` lines for every bundled
+> module, and a module whose build failed leaves no `.so` behind. Either build
+> them (`make bootstrap && make`, or `make <name>` for the one that failed), or
+> comment out everything that isn't Redis core in the config you pass: the
+> `loadmodule <path>` lines *and* that module's own settings below them (e.g.
+> `search-*`, `ts-*`, `bf-*`, `json-*`). Core-only alternative: `./src/redis-server`
+> with no config file, or `make build redis && ./src/redis-server redis.conf`
+> from a git checkout, where `redis.conf` has no module block at all.
+
 ### Building Redis - flags and general notes
 
 Redis can be compiled and used on Linux, OSX, OpenBSD, NetBSD, FreeBSD.

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ make -j "$(nproc)"
 > `.so`.** The config still lists modules that weren't built successfully — a
 > release tarball's `redis.conf` carries `loadmodule` lines for every bundled
 > module, and a module whose build failed leaves no `.so` behind. Either build
-> them (`make bootstrap && make`, or `make <name>` for the one that failed), or
+> them (`make bootstrap && make`, or `make build <name>` for the one that failed), or
 > comment out everything that isn't Redis core in the config you pass: the
 > `loadmodule <path>` lines *and* that module's own settings below them (e.g.
 > `search-*`, `ts-*`, `bf-*`, `json-*`). Core-only alternative: `./src/redis-server`

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,6 +25,7 @@ set -eu
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)" || exit 1
 . "$SCRIPT_DIR/lib/manifest.sh"
 cd "$REPO_ROOT"
+PROG_SUFFIX="${PROG_SUFFIX:-}"
 
 MAKE_BIN="${MAKE:-make}"
 
@@ -62,14 +63,14 @@ if [ -z "$modules" ]; then
   fi
 else
   echo
-  echo "==> Building modules (REDIS_SERVER=$REPO_ROOT/src/redis-server):"
+  echo "==> Building modules (REDIS_SERVER=$REPO_ROOT/src/redis-server$PROG_SUFFIX):"
   echo "   $modules"
   for name in $modules; do
     echo
     echo "==> [module] $name (modules/$name)"
     mkdir -p "modules/$name"
     if ! "$MAKE_BIN" -C "modules/$name" -f "$REPO_ROOT/modules/common.mk" \
-        REDIS_SERVER="$REPO_ROOT/src/redis-server"; then
+        REDIS_SERVER="$REPO_ROOT/src/redis-server$PROG_SUFFIX"; then
       failed="$failed $name"
       echo "==> [module] $name: FAILED (continuing with remaining modules)"
     fi
@@ -82,7 +83,7 @@ fi
 
 echo
 echo "==> Build complete."
-echo "    redis-server: $PWD/src/redis-server"
+echo "    redis-server: $PWD/src/redis-server$PROG_SUFFIX"
 if [ -n "$modules" ]; then
   echo "    Module artifacts:"
   for name in $modules; do

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,6 +5,8 @@
 # Env:    PREFIX    install root (default /usr/local). Files land in:
 #                     $PREFIX/bin/                  - redis-server, -cli, -benchmark
 #                     $PREFIX/lib/redis/modules/    - per-module .so files
+#         DESTDIR   optional staging root prepended to PREFIX (for packaging).
+#                   Where files are copied; never part of the conf's paths.
 #         MAKE      make binary (defaults to `make`); only used when shelling
 #                   into build.sh, which itself respects it.
 #
@@ -30,6 +32,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)" || exit 1
 cd "$REPO_ROOT"
 
 PREFIX="${PREFIX:-/usr/local}"
+DESTDIR="${DESTDIR:-}"
 
 cloned="$(cloned_modules)"
 modules="$(resolve_modules "$*" "$cloned" "redis none")"
@@ -72,13 +75,15 @@ if [ "$build_rc" != 0 ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Phase 2: copy artifacts to $PREFIX. Pure file ops, no recursive make.
+# Phase 2: copy artifacts to $DESTDIR$PREFIX. Pure file ops, no recursive make.
 # ---------------------------------------------------------------------------
-INSTALL_BIN_DIR="$PREFIX/bin"
-INSTALL_MOD_DIR="$PREFIX/lib/redis/modules"
+INSTALL_BIN_DIR="$DESTDIR$PREFIX/bin"
+INSTALL_MOD_DIR="$DESTDIR$PREFIX/lib/redis/modules"
+# Path on the *target* system (no staging root) — what the conf must say.
+CONF_MOD_DIR="$PREFIX/lib/redis/modules"
 
 echo
-echo "==> Deploying to PREFIX=$PREFIX"
+echo "==> Deploying to PREFIX=$PREFIX${DESTDIR:+ (DESTDIR=$DESTDIR)}"
 echo
 
 # Redis core binaries + the three symlinks that point to redis-server.
@@ -121,7 +126,7 @@ if [ -n "$modules" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Phase 3: repoint the loadmodule paths at $INSTALL_MOD_DIR. Path rewrite
+# Phase 3: repoint the loadmodule paths at $CONF_MOD_DIR. Path rewrite
 # ONLY — inside the LOADMODULE_BEGIN/END block every line keeps its identity
 # and its comment state: a commented placeholder stays commented, an active
 # line stays active, and no line is ever added or removed. Which modules are
@@ -139,9 +144,9 @@ _patch_conf() {
   [ -f "$conf" ] || return 0
   grep -qF "$LOADMODULE_BEGIN" "$conf" 2>/dev/null || return 0
   tmp="$(mktemp "${conf}.deploy.XXXXXX")"
-  # Swap each loadmodule line's directory for $INSTALL_MOD_DIR, keeping the
+  # Swap each loadmodule line's directory for $CONF_MOD_DIR, keeping the
   # leading '#' (if any), the .so basename and any trailing module args.
-  awk -v begin="$LOADMODULE_BEGIN" -v end="$LOADMODULE_END" -v dir="$INSTALL_MOD_DIR" '
+  awk -v begin="$LOADMODULE_BEGIN" -v end="$LOADMODULE_END" -v dir="$CONF_MOD_DIR" '
     $0 == begin { inblock = 1; print; next }
     $0 == end   { inblock = 0; print; next }
     inblock && match($0, /^[ \t]*#?[ \t]*loadmodule[ \t]+/) {
@@ -157,7 +162,7 @@ _patch_conf() {
     { print }
   ' "$conf" > "$tmp"
   mv "$tmp" "$conf"
-  echo "==> Repointed loadmodule paths in $conf -> $INSTALL_MOD_DIR/"
+  echo "==> Repointed loadmodule paths in $conf -> $CONF_MOD_DIR/"
 }
 
 _patch_conf "$REDIS_FULL_CONF"
@@ -183,7 +188,7 @@ _report_unloadable() {
     target="$(manifest_field "$name" target_module)"
     [ -z "$target" ] && continue
     printf '    %-16s no .so at %s/%s (%s)\n' \
-      "$name" "$INSTALL_MOD_DIR" "$(basename "$target")" "$reason"
+      "$name" "$CONF_MOD_DIR" "$(basename "$target")" "$reason"
   done
 }
 
@@ -196,7 +201,7 @@ if [ -n "$failed$not_cloned" ]; then
   echo
   echo "    To start the server without them, comment out their loadmodule"
   echo "    lines in the conf you pass to redis-server, e.g.:"
-  echo "      # loadmodule $INSTALL_MOD_DIR/<module>.so"
+  echo "      # loadmodule $CONF_MOD_DIR/<module>.so"
   echo "    (deploy leaves those lines exactly as they are — it only rewrites"
   echo "     their directory. Fix the build, or run 'make sync-redis-conf'.)"
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -126,84 +126,64 @@ if [ -n "$modules" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Phase 3: repoint the loadmodule paths at $CONF_MOD_DIR. Path rewrite
-# ONLY — inside the LOADMODULE_BEGIN/END block every line keeps its identity
-# and its comment state: a commented placeholder stays commented, an active
-# line stays active, and no line is ever added or removed. Which modules are
-# enabled is sync-redis-conf's call (it tests the .so on disk); deploy must
-# not re-author the config just because a module failed to build or wasn't
-# part of this run.
+# Phase 3: rewrite the loadmodule paths in redis-full.conf and redis.conf
+# in-place. Only the LOADMODULE_BEGIN/END block is replaced — the rest of
+# each file is untouched. Runs even when some modules failed to copy so that
+# the successfully-installed ones get correct absolute paths.
 # ---------------------------------------------------------------------------
 REDIS_FULL_CONF="${REDIS_GEN_CONF:-redis-full.conf}"
 REDIS_CONF="${REDIS_CONF:-redis.conf}"
 LOADMODULE_BEGIN="# >>> BEGIN: loadmodule paths (replaced by make deploy) <<<"
 LOADMODULE_END="# <<< END: loadmodule paths <<<"
 
-_patch_conf() {
-  conf="$1"
-  [ -f "$conf" ] || return 0
-  grep -qF "$LOADMODULE_BEGIN" "$conf" 2>/dev/null || return 0
-  tmp="$(mktemp "${conf}.deploy.XXXXXX")"
-  # Swap each loadmodule line's directory for $CONF_MOD_DIR, keeping the
-  # leading '#' (if any), the .so basename and any trailing module args.
-  awk -v begin="$LOADMODULE_BEGIN" -v end="$LOADMODULE_END" -v dir="$CONF_MOD_DIR" '
-    $0 == begin { inblock = 1; print; next }
-    $0 == end   { inblock = 0; print; next }
-    inblock && match($0, /^[ \t]*#?[ \t]*loadmodule[ \t]+/) {
-      head = substr($0, 1, RLENGTH)
-      rest = substr($0, RLENGTH + 1)
-      sp = index(rest, " ")
-      path = (sp ? substr(rest, 1, sp - 1) : rest)
-      args = (sp ? substr(rest, sp)        : "")
-      n = split(path, parts, "/")
-      print head dir "/" parts[n] args
-      next
-    }
-    { print }
-  ' "$conf" > "$tmp"
-  mv "$tmp" "$conf"
-  echo "==> Repointed loadmodule paths in $conf -> $CONF_MOD_DIR/"
-}
-
-_patch_conf "$REDIS_FULL_CONF"
-_patch_conf "$REDIS_CONF"
-
-# ---------------------------------------------------------------------------
-# Phase 4: report modules the installed server cannot load — those that
-# failed to build / had no artifact to copy, plus manifest modules whose
-# source was never cloned. Nothing is edited on their behalf: the user
-# comments the matching loadmodule line out (or fixes the build).
-# ---------------------------------------------------------------------------
-not_cloned=""
-for name in $(manifest_modules); do
-  case " $cloned " in *" $name "*) continue ;; esac
-  case " $failed " in *" $name "*) continue ;; esac   # already reported above
-  not_cloned="$not_cloned $name"
+# Build the list of successfully-installed modules (i.e. those NOT in $failed).
+installed_modules=""
+for name in $modules; do
+  case " $failed " in *" $name "*) continue ;; esac
+  installed_modules="$installed_modules $name"
 done
+installed_modules="${installed_modules# }"
 
-_report_unloadable() {
-  reason="$1"
-  shift
-  for name in "$@"; do
+if [ -n "$installed_modules" ]; then
+  new_lines=""
+  for name in $installed_modules; do
     target="$(manifest_field "$name" target_module)"
     [ -z "$target" ] && continue
-    printf '    %-16s no .so at %s/%s (%s)\n' \
-      "$name" "$CONF_MOD_DIR" "$(basename "$target")" "$reason"
+    so_basename="$(basename "$target")"
+    new_lines="${new_lines}loadmodule $CONF_MOD_DIR/$so_basename
+"
   done
-}
 
-if [ -n "$failed$not_cloned" ]; then
-  echo
-  echo "==> WARNING: the following modules have no installed .so —"
-  echo "    redis-server will abort on their loadmodule line:"
-  [ -n "$failed" ]     && _report_unloadable "build failed or artifact missing" $failed
-  [ -n "$not_cloned" ] && _report_unloadable "source not cloned" $not_cloned
-  echo
-  echo "    To start the server without them, comment out their loadmodule"
-  echo "    lines in the conf you pass to redis-server, e.g.:"
-  echo "      # loadmodule $CONF_MOD_DIR/<module>.so"
-  echo "    (deploy leaves those lines exactly as they are — it only rewrites"
-  echo "     their directory. Fix the build, or run 'make sync-redis-conf'.)"
+  # Write new_lines to a temp file so awk can read it with getline — BSD awk
+  # (macOS /usr/bin/awk) rejects embedded newlines in -v values.
+  new_lines_file="$(mktemp)"
+  printf '%s' "$new_lines" > "$new_lines_file"
+
+  _patch_conf() {
+    local conf="$1"
+    [ -f "$conf" ] || return 0
+    grep -qF "$LOADMODULE_BEGIN" "$conf" 2>/dev/null || return 0
+    local tmp
+    tmp="$(mktemp "${conf}.deploy.XXXXXX")"
+    trap 'rm -f "$tmp" "$new_lines_file"' EXIT
+    awk -v begin="$LOADMODULE_BEGIN" -v end="$LOADMODULE_END" -v newfile="$new_lines_file" '
+      $0 == begin {
+        print
+        while ((getline line < newfile) > 0) print line
+        close(newfile)
+        skip=1; next
+      }
+      $0 == end   { skip=0 }
+      !skip        { print }
+    ' "$conf" > "$tmp"
+    mv "$tmp" "$conf"
+    trap - EXIT
+    echo "==> Updated loadmodule paths in $conf"
+  }
+
+  _patch_conf "$REDIS_FULL_CONF"
+  _patch_conf "$REDIS_CONF"
+  rm -f "$new_lines_file"
 fi
 
 echo
@@ -213,8 +193,17 @@ if [ -n "$modules" ]; then
   echo "    Module .so directory: $INSTALL_MOD_DIR/"
 fi
 
-if [ -n "$failed" ]; then
+# Any module that failed to build or to copy makes the whole deploy fail, so
+# `make deploy` / `make install` return non-zero even though the core and the
+# healthy modules are installed. build_rc covers a module that failed to build
+# but still had a stale .so lying around for phase 2 to copy.
+if [ -n "$failed" ] || [ "$build_rc" != 0 ]; then
   echo
-  echo "ERROR: deploy finished with module copy failure(s):$failed" >&2
+  if [ -n "$failed" ]; then
+    echo "ERROR: deploy finished with module copy failure(s):$failed" >&2
+  fi
+  if [ "$build_rc" != 0 ]; then
+    echo "ERROR: deploy finished with module build failure(s) (build.sh exit $build_rc)" >&2
+  fi
   exit 1
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -121,64 +121,84 @@ if [ -n "$modules" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Phase 3: rewrite the loadmodule paths in redis-full.conf and redis.conf
-# in-place. Only the LOADMODULE_BEGIN/END block is replaced — the rest of
-# each file is untouched. Runs even when some modules failed to copy so that
-# the successfully-installed ones get correct absolute paths.
+# Phase 3: repoint the loadmodule paths at $INSTALL_MOD_DIR. Path rewrite
+# ONLY — inside the LOADMODULE_BEGIN/END block every line keeps its identity
+# and its comment state: a commented placeholder stays commented, an active
+# line stays active, and no line is ever added or removed. Which modules are
+# enabled is sync-redis-conf's call (it tests the .so on disk); deploy must
+# not re-author the config just because a module failed to build or wasn't
+# part of this run.
 # ---------------------------------------------------------------------------
 REDIS_FULL_CONF="${REDIS_GEN_CONF:-redis-full.conf}"
 REDIS_CONF="${REDIS_CONF:-redis.conf}"
 LOADMODULE_BEGIN="# >>> BEGIN: loadmodule paths (replaced by make deploy) <<<"
 LOADMODULE_END="# <<< END: loadmodule paths <<<"
 
-# Build the list of successfully-installed modules (i.e. those NOT in $failed).
-installed_modules=""
-for name in $modules; do
-  case " $failed " in *" $name "*) continue ;; esac
-  installed_modules="$installed_modules $name"
-done
-installed_modules="${installed_modules# }"
+_patch_conf() {
+  conf="$1"
+  [ -f "$conf" ] || return 0
+  grep -qF "$LOADMODULE_BEGIN" "$conf" 2>/dev/null || return 0
+  tmp="$(mktemp "${conf}.deploy.XXXXXX")"
+  # Swap each loadmodule line's directory for $INSTALL_MOD_DIR, keeping the
+  # leading '#' (if any), the .so basename and any trailing module args.
+  awk -v begin="$LOADMODULE_BEGIN" -v end="$LOADMODULE_END" -v dir="$INSTALL_MOD_DIR" '
+    $0 == begin { inblock = 1; print; next }
+    $0 == end   { inblock = 0; print; next }
+    inblock && match($0, /^[ \t]*#?[ \t]*loadmodule[ \t]+/) {
+      head = substr($0, 1, RLENGTH)
+      rest = substr($0, RLENGTH + 1)
+      sp = index(rest, " ")
+      path = (sp ? substr(rest, 1, sp - 1) : rest)
+      args = (sp ? substr(rest, sp)        : "")
+      n = split(path, parts, "/")
+      print head dir "/" parts[n] args
+      next
+    }
+    { print }
+  ' "$conf" > "$tmp"
+  mv "$tmp" "$conf"
+  echo "==> Repointed loadmodule paths in $conf -> $INSTALL_MOD_DIR/"
+}
 
-if [ -n "$installed_modules" ]; then
-  new_lines=""
-  for name in $installed_modules; do
+_patch_conf "$REDIS_FULL_CONF"
+_patch_conf "$REDIS_CONF"
+
+# ---------------------------------------------------------------------------
+# Phase 4: report modules the installed server cannot load — those that
+# failed to build / had no artifact to copy, plus manifest modules whose
+# source was never cloned. Nothing is edited on their behalf: the user
+# comments the matching loadmodule line out (or fixes the build).
+# ---------------------------------------------------------------------------
+not_cloned=""
+for name in $(manifest_modules); do
+  case " $cloned " in *" $name "*) continue ;; esac
+  case " $failed " in *" $name "*) continue ;; esac   # already reported above
+  not_cloned="$not_cloned $name"
+done
+
+_report_unloadable() {
+  reason="$1"
+  shift
+  for name in "$@"; do
     target="$(manifest_field "$name" target_module)"
     [ -z "$target" ] && continue
-    so_basename="$(basename "$target")"
-    new_lines="${new_lines}loadmodule $INSTALL_MOD_DIR/$so_basename
-"
+    printf '    %-16s no .so at %s/%s (%s)\n' \
+      "$name" "$INSTALL_MOD_DIR" "$(basename "$target")" "$reason"
   done
+}
 
-  # Write new_lines to a temp file so awk can read it with getline — BSD awk
-  # (macOS /usr/bin/awk) rejects embedded newlines in -v values.
-  new_lines_file="$(mktemp)"
-  printf '%s' "$new_lines" > "$new_lines_file"
-
-  _patch_conf() {
-    local conf="$1"
-    [ -f "$conf" ] || return 0
-    grep -qF "$LOADMODULE_BEGIN" "$conf" 2>/dev/null || return 0
-    local tmp
-    tmp="$(mktemp "${conf}.deploy.XXXXXX")"
-    trap 'rm -f "$tmp" "$new_lines_file"' EXIT
-    awk -v begin="$LOADMODULE_BEGIN" -v end="$LOADMODULE_END" -v newfile="$new_lines_file" '
-      $0 == begin {
-        print
-        while ((getline line < newfile) > 0) print line
-        close(newfile)
-        skip=1; next
-      }
-      $0 == end   { skip=0 }
-      !skip        { print }
-    ' "$conf" > "$tmp"
-    mv "$tmp" "$conf"
-    trap - EXIT
-    echo "==> Updated loadmodule paths in $conf"
-  }
-
-  _patch_conf "$REDIS_FULL_CONF"
-  _patch_conf "$REDIS_CONF"
-  rm -f "$new_lines_file"
+if [ -n "$failed$not_cloned" ]; then
+  echo
+  echo "==> WARNING: the following modules have no installed .so —"
+  echo "    redis-server will abort on their loadmodule line:"
+  [ -n "$failed" ]     && _report_unloadable "build failed or artifact missing" $failed
+  [ -n "$not_cloned" ] && _report_unloadable "source not cloned" $not_cloned
+  echo
+  echo "    To start the server without them, comment out their loadmodule"
+  echo "    lines in the conf you pass to redis-server, e.g.:"
+  echo "      # loadmodule $INSTALL_MOD_DIR/<module>.so"
+  echo "    (deploy leaves those lines exactly as they are — it only rewrites"
+  echo "     their directory. Fix the build, or run 'make sync-redis-conf'.)"
 fi
 
 echo

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,6 @@
 # Env:    PREFIX    install root (default /usr/local). Files land in:
 #                     $PREFIX/bin/                  - redis-server, -cli, -benchmark
 #                     $PREFIX/lib/redis/modules/    - per-module .so files
-#         DESTDIR   optional staging root prepended to PREFIX (for packaging).
 #         MAKE      make binary (defaults to `make`); only used when shelling
 #                   into build.sh, which itself respects it.
 #
@@ -31,7 +30,6 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)" || exit 1
 cd "$REPO_ROOT"
 
 PREFIX="${PREFIX:-/usr/local}"
-DESTDIR="${DESTDIR:-}"
 
 cloned="$(cloned_modules)"
 modules="$(resolve_modules "$*" "$cloned" "redis none")"
@@ -74,13 +72,13 @@ if [ "$build_rc" != 0 ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Phase 2: copy artifacts to $DESTDIR$PREFIX. Pure file ops, no recursive make.
+# Phase 2: copy artifacts to $PREFIX. Pure file ops, no recursive make.
 # ---------------------------------------------------------------------------
-INSTALL_BIN_DIR="$DESTDIR$PREFIX/bin"
-INSTALL_MOD_DIR="$DESTDIR$PREFIX/lib/redis/modules"
+INSTALL_BIN_DIR="$PREFIX/bin"
+INSTALL_MOD_DIR="$PREFIX/lib/redis/modules"
 
 echo
-echo "==> Deploying to PREFIX=$PREFIX${DESTDIR:+ (DESTDIR=$DESTDIR)}"
+echo "==> Deploying to PREFIX=$PREFIX"
 echo
 
 # Redis core binaries + the three symlinks that point to redis-server.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,6 +7,8 @@
 #                     $PREFIX/lib/redis/modules/    - per-module .so files
 #         DESTDIR   optional staging root prepended to PREFIX (for packaging).
 #                   Where files are copied; never part of the conf's paths.
+#         PROG_SUFFIX  suffix appended to the core program names, matching
+#                   `make PROG_SUFFIX=…` (src/Makefile). Modules are unaffected.
 #         MAKE      make binary (defaults to `make`); only used when shelling
 #                   into build.sh, which itself respects it.
 #
@@ -33,6 +35,7 @@ cd "$REPO_ROOT"
 
 PREFIX="${PREFIX:-/usr/local}"
 DESTDIR="${DESTDIR:-}"
+PROG_SUFFIX="${PROG_SUFFIX:-}"
 
 cloned="$(cloned_modules)"
 modules="$(resolve_modules "$*" "$cloned" "redis none")"
@@ -89,12 +92,12 @@ echo
 # Redis core binaries + the three symlinks that point to redis-server.
 echo "==> Installing Redis core binaries to $INSTALL_BIN_DIR"
 install -d "$INSTALL_BIN_DIR"
-install -m 0755 src/redis-server     "$INSTALL_BIN_DIR/redis-server"
-install -m 0755 src/redis-cli        "$INSTALL_BIN_DIR/redis-cli"
-install -m 0755 src/redis-benchmark  "$INSTALL_BIN_DIR/redis-benchmark"
-ln -sf redis-server "$INSTALL_BIN_DIR/redis-check-rdb"
-ln -sf redis-server "$INSTALL_BIN_DIR/redis-check-aof"
-ln -sf redis-server "$INSTALL_BIN_DIR/redis-sentinel"
+install -m 0755 "src/redis-server$PROG_SUFFIX"    "$INSTALL_BIN_DIR/redis-server$PROG_SUFFIX"
+install -m 0755 "src/redis-cli$PROG_SUFFIX"       "$INSTALL_BIN_DIR/redis-cli$PROG_SUFFIX"
+install -m 0755 "src/redis-benchmark$PROG_SUFFIX" "$INSTALL_BIN_DIR/redis-benchmark$PROG_SUFFIX"
+ln -sf "redis-server$PROG_SUFFIX" "$INSTALL_BIN_DIR/redis-check-rdb$PROG_SUFFIX"
+ln -sf "redis-server$PROG_SUFFIX" "$INSTALL_BIN_DIR/redis-check-aof$PROG_SUFFIX"
+ln -sf "redis-server$PROG_SUFFIX" "$INSTALL_BIN_DIR/redis-sentinel$PROG_SUFFIX"
 
 # Per-module `.so` files. After scripts/build.sh, each cloned module has its
 # .so copied to modules/<name>/<basename> by common.mk (the `cp $(TARGET_MODULE) ./`
@@ -188,7 +191,7 @@ fi
 
 echo
 echo "==> Deploy complete."
-echo "    redis-server: $INSTALL_BIN_DIR/redis-server"
+echo "    redis-server: $INSTALL_BIN_DIR/redis-server$PROG_SUFFIX"
 if [ -n "$modules" ]; then
   echo "    Module .so directory: $INSTALL_MOD_DIR/"
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,6 +7,8 @@
 #                     $PREFIX/lib/redis/modules/    - per-module .so files
 #         DESTDIR   optional staging root prepended to PREFIX (for packaging).
 #                   Where files are copied; never part of the conf's paths.
+#         SKIP_BUILD  1 = install what is already built, skip phase 1 entirely
+#                   (the default for `make install`; `make deploy` builds).
 #         PROG_SUFFIX  suffix appended to the core program names, matching
 #                   `make PROG_SUFFIX=…` (src/Makefile). Modules are unaffected.
 #         MAKE      make binary (defaults to `make`); only used when shelling
@@ -44,8 +46,10 @@ modules="$(resolve_modules "$*" "$cloned" "redis none")"
 # Phase 1: build via the shared orchestrator. Pass the resolved module list
 # verbatim so build.sh sees the same selection we intend to install.
 # ---------------------------------------------------------------------------
-echo "==> Building before deploy (delegating to scripts/build.sh)"
-echo
+if [ "${SKIP_BUILD:-0}" = 0 ]; then
+  echo "==> Building before deploy (delegating to scripts/build.sh)"
+  echo
+fi
 # Build artifacts always go to the dev tree — PREFIX is irrelevant to the
 # build phase. Two scrubs needed before handing off to build.sh:
 #   1. PREFIX env shadow — so anything reading $PREFIX in build.sh / scripts
@@ -67,7 +71,9 @@ build_makeflags="$(printf '%s' " ${MAKEFLAGS:-} " | sed -E 's/ PREFIX=[^ ]*/ /g;
 # phase 2 below filters out modules that genuinely don't have a .so to copy,
 # so we'd rather install what's available than bail out wholesale.
 build_rc=0
-if [ -z "$modules" ]; then
+if [ "${SKIP_BUILD:-0}" != 0 ]; then
+  echo "==> SKIP_BUILD=$SKIP_BUILD — installing the artifacts already in the tree"
+elif [ -z "$modules" ]; then
   MAKEFLAGS="$build_makeflags" PREFIX="" "$SCRIPT_DIR/build.sh" redis || build_rc=$?
 else
   MAKEFLAGS="$build_makeflags" PREFIX="" "$SCRIPT_DIR/build.sh" $modules || build_rc=$?

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -17,9 +17,10 @@ set -eu
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)" || exit 1
 . "$SCRIPT_DIR/lib/manifest.sh"
 cd "$REPO_ROOT"
+PROG_SUFFIX="${PROG_SUFFIX:-}"
 
-if [ ! -x src/redis-server ]; then
-  echo "ERROR: src/redis-server is not built. Run 'make build' (or 'make -C src all') first."
+if [ ! -x "src/redis-server$PROG_SUFFIX" ]; then
+  echo "ERROR: src/redis-server$PROG_SUFFIX is not built. Run 'make build' (or 'make -C src all') first."
   exit 1
 fi
 
@@ -81,6 +82,6 @@ if [ -z "$load_flags" ]; then
 fi
 
 # shellcheck disable=SC2086
-echo "==> exec src/redis-server$load_flags ${ARGS:-}"
+echo "==> exec src/redis-server$PROG_SUFFIX$load_flags ${ARGS:-}"
 # shellcheck disable=SC2086
-exec src/redis-server $load_flags ${ARGS:-}
+exec "src/redis-server$PROG_SUFFIX" $load_flags ${ARGS:-}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,6 +15,7 @@ set -eu
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)" || exit 1
 . "$SCRIPT_DIR/lib/manifest.sh"
 cd "$REPO_ROOT"
+PROG_SUFFIX="${PROG_SUFFIX:-}"
 
 MAKE_BIN="${MAKE:-make}"
 test_var="${TEST:-}"
@@ -54,7 +55,7 @@ case "$target" in
       echo
       echo "==> [test] $name (modules/$name/src)"
       if ! "$MAKE_BIN" -C "modules/$name/src" test \
-          REDIS_SERVER="$REPO_ROOT/src/redis-server"; then
+          REDIS_SERVER="$REPO_ROOT/src/redis-server$PROG_SUFFIX"; then
         failed="$failed $name"
       fi
     done
@@ -92,11 +93,11 @@ case "$target" in
     if [ -z "$tname" ]; then
       echo "==> Running all tests for module '$target'"
       exec "$MAKE_BIN" -C "modules/$target/src" test \
-          REDIS_SERVER="$REPO_ROOT/src/redis-server"
+          REDIS_SERVER="$REPO_ROOT/src/redis-server$PROG_SUFFIX"
     else
       echo "==> Running test '$tname' for module '$target' (TEST=$tname)"
       exec "$MAKE_BIN" -C "modules/$target/src" test TEST="$tname" \
-          REDIS_SERVER="$REPO_ROOT/src/redis-server"
+          REDIS_SERVER="$REPO_ROOT/src/redis-server$PROG_SUFFIX"
     fi
     ;;
 esac

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -7,7 +7,6 @@
 #                                                     -benchmark + the three
 #                                                     redis-server symlinks
 #                     $PREFIX/lib/redis/modules/    - per-module .so files
-#         DESTDIR   optional staging root prepended to PREFIX (for packaging).
 #
 # Tokens (same grammar as deploy.sh):
 #   (no args) | all | . | '*'   core + every module in modules.yaml
@@ -19,7 +18,7 @@
 # may since have been cleaned. rm -f on a path that was never installed is a
 # no-op, so over-listing is free.
 #
-# Nothing outside $DESTDIR$PREFIX is touched — the in-tree redis.conf /
+# Nothing outside $PREFIX is touched — the in-tree redis.conf /
 # redis-full.conf are left as they are.
 
 set -eu
@@ -29,14 +28,13 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)" || exit 1
 cd "$REPO_ROOT"
 
 PREFIX="${PREFIX:-/usr/local}"
-DESTDIR="${DESTDIR:-}"
 
 modules="$(resolve_modules "$*" "$(manifest_modules)" "redis none")"
 
-INSTALL_BIN_DIR="$DESTDIR$PREFIX/bin"
-INSTALL_MOD_DIR="$DESTDIR$PREFIX/lib/redis/modules"
+INSTALL_BIN_DIR="$PREFIX/bin"
+INSTALL_MOD_DIR="$PREFIX/lib/redis/modules"
 
-echo "==> Uninstalling from PREFIX=$PREFIX${DESTDIR:+ (DESTDIR=$DESTDIR)}"
+echo "==> Uninstalling from PREFIX=$PREFIX"
 echo
 
 for f in redis-server redis-cli redis-benchmark \
@@ -57,7 +55,7 @@ if [ -n "$modules" ]; then
   done
   # Prune the directories we created in deploy, but only when empty — a
   # user's own files under lib/redis are none of our business.
-  rmdir "$INSTALL_MOD_DIR" "$DESTDIR$PREFIX/lib/redis" 2>/dev/null || true
+  rmdir "$INSTALL_MOD_DIR" "$PREFIX/lib/redis" 2>/dev/null || true
 fi
 
 echo

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -7,6 +7,7 @@
 #                                                     -benchmark + the three
 #                                                     redis-server symlinks
 #                     $PREFIX/lib/redis/modules/    - per-module .so files
+#         DESTDIR   optional staging root prepended to PREFIX (for packaging).
 #
 # Tokens (same grammar as deploy.sh):
 #   (no args) | all | . | '*'   core + every module in modules.yaml
@@ -18,7 +19,7 @@
 # may since have been cleaned. rm -f on a path that was never installed is a
 # no-op, so over-listing is free.
 #
-# Nothing outside $PREFIX is touched — the in-tree redis.conf /
+# Nothing outside $DESTDIR$PREFIX is touched — the in-tree redis.conf /
 # redis-full.conf are left as they are.
 
 set -eu
@@ -28,13 +29,14 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)" || exit 1
 cd "$REPO_ROOT"
 
 PREFIX="${PREFIX:-/usr/local}"
+DESTDIR="${DESTDIR:-}"
 
 modules="$(resolve_modules "$*" "$(manifest_modules)" "redis none")"
 
-INSTALL_BIN_DIR="$PREFIX/bin"
-INSTALL_MOD_DIR="$PREFIX/lib/redis/modules"
+INSTALL_BIN_DIR="$DESTDIR$PREFIX/bin"
+INSTALL_MOD_DIR="$DESTDIR$PREFIX/lib/redis/modules"
 
-echo "==> Uninstalling from PREFIX=$PREFIX"
+echo "==> Uninstalling from PREFIX=$PREFIX${DESTDIR:+ (DESTDIR=$DESTDIR)}"
 echo
 
 for f in redis-server redis-cli redis-benchmark \
@@ -55,7 +57,7 @@ if [ -n "$modules" ]; then
   done
   # Prune the directories we created in deploy, but only when empty — a
   # user's own files under lib/redis are none of our business.
-  rmdir "$INSTALL_MOD_DIR" "$PREFIX/lib/redis" 2>/dev/null || true
+  rmdir "$INSTALL_MOD_DIR" "$DESTDIR$PREFIX/lib/redis" 2>/dev/null || true
 fi
 
 echo

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -7,6 +7,8 @@
 #                                                     -benchmark + the three
 #                                                     redis-server symlinks
 #                     $PREFIX/lib/redis/modules/    - per-module .so files
+#         PROG_SUFFIX  suffix the core programs were installed with
+#                   (see `make PROG_SUFFIX=…`).
 #         DESTDIR   optional staging root prepended to PREFIX (for packaging).
 #
 # Tokens (same grammar as deploy.sh):
@@ -30,6 +32,7 @@ cd "$REPO_ROOT"
 
 PREFIX="${PREFIX:-/usr/local}"
 DESTDIR="${DESTDIR:-}"
+PROG_SUFFIX="${PROG_SUFFIX:-}"
 
 modules="$(resolve_modules "$*" "$(manifest_modules)" "redis none")"
 
@@ -41,7 +44,7 @@ echo
 
 for f in redis-server redis-cli redis-benchmark \
          redis-check-rdb redis-check-aof redis-sentinel; do
-  rm -f "$INSTALL_BIN_DIR/$f"
+  rm -f "$INSTALL_BIN_DIR/$f$PROG_SUFFIX"
 done
 echo "==> Removed Redis core binaries from $INSTALL_BIN_DIR"
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# uninstall.sh — remove what scripts/deploy.sh installed under $PREFIX.
+#
+# Usage:  scripts/uninstall.sh [<name> ...|all|.|'*'|redis|none]
+# Env:    PREFIX    install root (default /usr/local). Files removed from:
+#                     $PREFIX/bin/                  - redis-server, -cli,
+#                                                     -benchmark + the three
+#                                                     redis-server symlinks
+#                     $PREFIX/lib/redis/modules/    - per-module .so files
+#         DESTDIR   optional staging root prepended to PREFIX (for packaging).
+#
+# Tokens (same grammar as deploy.sh):
+#   (no args) | all | . | '*'   core + every module in modules.yaml
+#   redis | none                 core only
+#   <name> [<name> ...]          core + the listed modules
+#
+# Unlike deploy.sh the default set is every *manifest* module, not every
+# *cloned* one: uninstall has to clean up after installs made from a tree that
+# may since have been cleaned. rm -f on a path that was never installed is a
+# no-op, so over-listing is free.
+#
+# Nothing outside $DESTDIR$PREFIX is touched — the in-tree redis.conf /
+# redis-full.conf are left as they are.
+
+set -eu
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)" || exit 1
+. "$SCRIPT_DIR/lib/manifest.sh"
+cd "$REPO_ROOT"
+
+PREFIX="${PREFIX:-/usr/local}"
+DESTDIR="${DESTDIR:-}"
+
+modules="$(resolve_modules "$*" "$(manifest_modules)" "redis none")"
+
+INSTALL_BIN_DIR="$DESTDIR$PREFIX/bin"
+INSTALL_MOD_DIR="$DESTDIR$PREFIX/lib/redis/modules"
+
+echo "==> Uninstalling from PREFIX=$PREFIX${DESTDIR:+ (DESTDIR=$DESTDIR)}"
+echo
+
+for f in redis-server redis-cli redis-benchmark \
+         redis-check-rdb redis-check-aof redis-sentinel; do
+  rm -f "$INSTALL_BIN_DIR/$f"
+done
+echo "==> Removed Redis core binaries from $INSTALL_BIN_DIR"
+
+if [ -n "$modules" ]; then
+  echo
+  echo "==> Removing modules from $INSTALL_MOD_DIR"
+  for name in $modules; do
+    target="$(manifest_field "$name" target_module)"
+    [ -z "$target" ] && continue
+    so="$INSTALL_MOD_DIR/$(basename "$target")"
+    rm -f "$so"
+    echo "    [module] $name -> $so"
+  done
+  # Prune the directories we created in deploy, but only when empty — a
+  # user's own files under lib/redis are none of our business.
+  rmdir "$INSTALL_MOD_DIR" "$DESTDIR$PREFIX/lib/redis" 2>/dev/null || true
+fi
+
+echo
+echo "==> Uninstall complete."


### PR DESCRIPTION
- `make install` is now an alias for `make deploy` instead of recursing into `src/`, so a single
  command installs Redis core **and** the built modules, and repoints the `loadmodule` paths in
  `redis.conf` / `redis-full.conf` at the install prefix. Same positional args, same `PREFIX`.
- New `make uninstall` (`scripts/uninstall.sh`) — the symmetric inverse: removes the core binaries
  and symlinks plus the selected modules' `.so` files, and prunes the module dirs when empty.
  Accepts the same tokens (`all` / `.` / `redis` / `none` / explicit names).
- `DESTDIR` is a staging root only: artifacts are copied to `$DESTDIR$PREFIX/...`, while the
  `loadmodule` lines written to the conf stay `$PREFIX`-relative, since a staging path exists only
  on the build machine.
- `deploy` now exits non-zero when any module fails to **build** or to **copy**. Previously a module
  that failed to compile but still had a stale `.so` on disk exited 0. Failures are still collected,
  not aborted on — the core and healthy modules are installed first.
- `PROG_SUFFIX` is honored by install / deploy / uninstall, matching `src/Makefile`'s naming
  (`redis-server-alt` etc., with the three symlinks suffixed and pointing at the suffixed server).
- README: troubleshooting note for `redis-server` failing to start on a `loadmodule` line when a
  module wasn't built — comment out that line and the module's own settings, or build it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install/uninstall behavior and system paths under PREFIX; misconfigured PREFIX/DESTDIR or partial module failures now surface as non-zero exit from deploy/install.
> 
> **Overview**
> **`make install`** no longer recurses into `src/` only. It delegates to **`deploy`** with **`SKIP_BUILD=1`** by default (install existing artifacts, like upstream); use **`make install SKIP_BUILD=0`** or **`make deploy`** to build first. Install still copies core + modules and rewrites **`loadmodule`** paths in **`redis.conf`** / **`redis-full.conf`**.
> 
> Adds **`make uninstall`** via **`scripts/uninstall.sh`**: removes core binaries/symlinks and module **`.so`** files under **`PREFIX`**, with the same module selection tokens as deploy. Uninstall defaults to all manifest modules (not only cloned) so cleanup matches prior installs.
> 
> **`deploy.sh`** writes **`loadmodule`** paths using **`$PREFIX/lib/redis/modules`** (not **`DESTDIR`**), fixes staging vs runtime paths, honors **`PROG_SUFFIX`** on installed binaries, and returns **non-zero** if any module failed to build (**`build_rc`**) or copy—not only copy failures.
> 
> **`PROG_SUFFIX`** is threaded through **`build`**, **`run`**, and **`test`** scripts so module builds/tests use the suffixed **`redis-server`**.
> 
> README adds troubleshooting when **`redis-server`** fails on missing module **`.so`** files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acbe4edd8b37bb6ad6ebd3b1d68190b0590b38ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->