### PR TITLE
Update redisbloom module reference to v8.10.1

### DIFF
--- a/modules/modules.yaml
+++ b/modules/modules.yaml
@@ -64,7 +64,7 @@
 modules:
   - name: redisbloom
     repo: https://github.com/redisbloom/redisbloom
-    ref: v8.10.0
+    ref: v8.10.1
     target_module: redisbloom.so
     loadmodule: ./modules/redisbloom/redisbloom.so
   - name: redisearch


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Manifest-only version pin with no build or load path changes.
> 
> **Overview**
> Bumps the bundled **redisbloom** upstream pin in `modules/modules.yaml` from **v8.10.0** to **v8.10.1**. Repo, `target_module`, and `loadmodule` paths are unchanged; consumers (`make modules-update`, Docker deps install, tarball clone) will fetch the new tag on the next refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9e689dcb9f7ca2756dff6b3900c4dd4d5c24e11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->