### PR TITLE
Update redisbloom module reference to v8.10.1

### DIFF
--- a/modules/modules.yaml
+++ b/modules/modules.yaml
@@ -64,7 +64,7 @@
 modules:
   - name: redisbloom
     repo: https://github.com/redisbloom/redisbloom
-    ref: v8.10.0
+    ref: v8.10.1
     target_module: redisbloom.so
     loadmodule: ./modules/redisbloom/redisbloom.so
   - name: redisearch


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Manifest-only version bump with no application code changes; risk is limited to RedisBloom v8.10.1 upstream behavior when modules are rebuilt.
> 
> **Overview**
> Bumps the bundled **RedisBloom** module pin in `modules/modules.yaml` from **v8.10.0** to **v8.10.1**. Other bundled modules (RediSearch, RedisJSON, RedisTimeSeries) stay on v8.10.0.
> 
> After merge, run `make modules-update redisbloom` to refresh `modules/redisbloom/src/` at the new tag for local builds, Docker image builds, and release tarballs that consume this manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c409bd2226ee23711922204af0ba0e66c978c5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->