### PR TITLE
Update RedisBloom module version to v8.8.3

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.8.2
+MODULE_VERSION = v8.8.3
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single Makefile version constant change with no application logic or security surface touched.
> 
> **Overview**
> Bumps the **RedisBloom** build pin from **v8.8.2** to **v8.8.3** via `MODULE_VERSION` in `modules/redisbloom/Makefile`, so builds pull the newer upstream module release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61cb08b85a9dedf37ac21b98e41f5c809e4f474a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->