### PR TITLE
Bump RedisBloom module version to v8.6.6

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.6.5
+MODULE_VERSION = v8.6.6
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single version-pin bump with no application logic changes; risk is limited to whatever is in the upstream v8.6.6 RedisBloom release.
> 
> **Overview**
> Updates **`MODULE_VERSION`** in `modules/redisbloom/Makefile` from **v8.6.5** to **v8.6.6**, so the shared `common.mk` fetch step clones and builds that RedisBloom release tag instead of the previous one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0510caeef4510b038aed27ac9cd21ba05ef59592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->