### PR TITLE
Update RedisBloom module version to v8.4.9

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.4.8
+MODULE_VERSION = v8.4.9
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single version constant change with no application logic or security surface changes.
> 
> **Overview**
> Bumps the **RedisBloom** module build pin from **v8.4.8** to **v8.4.9** in `modules/redisbloom/Makefile` (`MODULE_VERSION`), so builds pull and package the newer upstream release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13563c143c6d8f87d0c3db5272ecc4494fff2301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->