### PR TITLE
Update RedisBloom module version to v8.2.16

### DIFF
--- a/modules/redisbloom/Makefile
+++ b/modules/redisbloom/Makefile
@@ -1,5 +1,5 @@
 SRC_DIR = src
-MODULE_VERSION = v8.2.15
+MODULE_VERSION = v8.2.16
 MODULE_REPO = https://github.com/redisbloom/redisbloom
 TARGET_MODULE = $(SRC_DIR)/bin/$(FULL_VARIANT)/redisbloom.so
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single Makefile version pin with no application logic changes; risk is limited to whatever is in the upstream v8.2.16 RedisBloom release.
> 
> **Overview**
> Bumps the **RedisBloom** build pin from `v8.2.15` to **`v8.2.16`** in `modules/redisbloom/Makefile`.
> 
> That `MODULE_VERSION` value is what `common.mk` uses when cloning the upstream `redisbloom` repo at build time, so packaged images will ship the newer module release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36a451a600d58788daa0a35420a25781675cf4aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->