### PR TITLE
Redis 7.2.16

### DIFF
--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -23,6 +23,7 @@ Update urgency: `SECURITY`: There are security fixes in the release.
 - Use-after-free in the TLS pending-data list when a command closes another pending connection
 - ACL key permission bypass in `SORT`, `GEORADIUS`/`GEORADIUSBYMEMBER` and `XREAD`/`XREADGROUP`: the keys validated by ACL could differ from the keys the command actually accesses
 - Out-of-bounds `argv` access during key extraction when checking ACL permissions of a KEYNUM keyspec command (e.g. `EVAL`) with wrong arity
+- Use-after-free in the blocked-client list when reprocessing a command evicts another client blocked on the same key
 
 
 ================================================================================

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -567,14 +567,25 @@ static void handleClientsBlockedOnKey(readyList *rl) {
 
     if (de) {
         list *clients = dictGetVal(de);
-        listNode *ln;
-        listIter li;
-        listRewind(clients,&li);
-
         /* Avoid processing more than the initial count so that we're not stuck
          * in an endless loop in case the reprocessing of the command blocks again. */
         long count = listLength(clients);
-        while ((ln = listNext(&li)) && count--) {
+        while (count-- > 0) {
+            /* Processing the previous client may have removed all blocked
+             * clients and freed the list, so look it up again each time. */
+            de = dictFind(rl->db->blocking_keys, rl->key);
+            if (!de) break;
+            list *clients = dictGetVal(de);
+            listNode *ln = listFirst(clients);
+            serverAssert(ln);
+
+            /* Rotate before reprocessing because unblocking may remove this
+             * client, and command reprocessing may evict other blocked clients
+             * and free the list. If the client remains blocked or blocks again,
+             * keeping it at the tail lets us advance to the next client while
+             * preserving the order of the other waiters. */
+            listRotateHeadToTail(clients);
+
             client *receiver = listNodeValue(ln);
             robj *o = lookupKeyReadWithFlags(rl->db, rl->key, LOOKUP_NOEFFECTS);
             /* 1. In case new key was added/touched we need to verify it satisfy the

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -611,5 +611,46 @@ start_server {} {
     }
 }
 
+start_server {} {
+    test "Evicting the next client while serving blocked clients is safe" {
+        r flushall
+        r client no-evict on
+        r config set maxmemory-clients 0
+
+        set rd1 [redis_deferring_client]
+        set rd2 [redis_deferring_client]
+        $rd2 CLIENT SETNAME client-to-evict
+        assert_equal OK [$rd2 read]
+
+        # Block two clients on the same key in a known order.
+        $rd1 BLPOP mylist 0
+        wait_for_blocked_clients_count 1
+        $rd2 BLPOP mylist 0
+        wait_for_blocked_clients_count 2
+
+        # Queue a large request behind the second client's blocking command so
+        # it will be selected for eviction while the first client is processed.
+        $rd2 get [string repeat Q [kb 2048]]
+        wait_for_condition 50 100 {
+            [client_field client-to-evict tot-mem] > [mb 1]
+        } else {
+            fail "Failed to increase the second blocked client's memory usage"
+        }
+
+        # Apply the client-memory limit and make the key ready in one transaction.
+        # Eviction then runs while rd1 is being reprocessed, selecting rd2 while
+        # it is still in the blocked-client list.
+        r MULTI
+        r CONFIG SET MAXMEMORY-CLIENTS [kb 128]
+        r LPUSH mylist x
+        r EXEC
+
+        assert_equal {mylist x} [$rd1 read]
+        assert {![client_exists client-to-evict]} ;# rd2 is evicted
+        $rd1 close
+        $rd2 close
+    }
+}
+
 } ;# tags
 


### PR DESCRIPTION
# Security fixes

- Use-after-free in the blocked-client list when reprocessing a command evicts another client blocked on the same key


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Patches memory-unsafe concurrency between blocked-key wakeup and maxmemory-clients eviction; incorrect handling could cause crashes or worse in production blocking paths.
> 
> **Overview**
> **Security release (7.2.16)** documents a use-after-free in the per-key blocked-client list when command reprocessing triggers client eviction while another waiter on the same key is still queued.
> 
> `handleClientsBlockedOnKey` no longer walks the waiter list with a long-lived iterator. Each iteration re-resolves the `blocking_keys` entry (the list may be freed during unblock/reprocess/eviction), takes the head client, and **rotates head to tail** before re-running the blocked command so FIFO order is preserved when a client stays blocked.
> 
> A new client-eviction integration test covers two `BLPOP` waiters on one key, a large queued command on the second client, and eviction firing while the first client is served.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80311c8fb98a230904975b850e4b55f3ce117ce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->