### PR TITLE
Security issues into unstable

### DIFF
--- a/modules/vector-sets/hnsw.c
+++ b/modules/vector-sets/hnsw.c
@@ -794,7 +794,7 @@ uint32_t random_level(void) {
     static const int threshold = HNSW_P * RAND_MAX;
     uint32_t level = 0;
 
-    while (rand() < threshold && level < HNSW_MAX_LEVEL)
+    while (rand() < threshold && level < HNSW_MAX_LEVEL - 1)
         level += 1;
     return level;
 }
@@ -903,6 +903,13 @@ uint32_t hnsw_quants_bytes(HNSW *index) {
  * after the node creation (see later for the serialization API that
  * handles this and more). */
 hnswNode *hnsw_node_new(HNSW *index, uint64_t id, const float *vector, const int8_t *qvector, float qrange, uint32_t level, int normalize) {
+    /* Defense in depth: every node level must stay within the architectural
+     * cap. Untrusted input (e.g. a tampered serialized stream) is already
+     * rejected by the caller before reaching this point, so a violation here
+     * can only be an internal bug: fail fast instead of over-allocating the
+     * node and poisoning index->max_level. */
+    assert(level < HNSW_MAX_LEVEL);
+
     hnswNode *node = hmalloc(sizeof(hnswNode)+(sizeof(hnswNodeLayer)*(level+1)));
     if (!node) return NULL;
 
@@ -2593,6 +2600,12 @@ hnswNode *hnsw_insert_serialized(HNSW *index, void *vector, uint64_t *params, ui
     uint32_t version = (params[1] & 0xff000000) >> 24;  // Format version.
 
     if (version > HNSW_SERIALIZATION_VERSION) return NULL;
+
+    /* A serialized stream coming from an untrusted source (e.g. a tampered
+     * RDB file) could encode an out of range level: reject it here, otherwise
+     * we would over-allocate the node layers and poison index->max_level with
+     * an illegal value. */
+    if (level >= HNSW_MAX_LEVEL) return NULL;
     int has_worst_link_info = version > 0;
 
     /* Keep track of maximum ID seen while loading. */

--- a/modules/vector-sets/tests/concurrent_vsim_and_vrem.py
+++ b/modules/vector-sets/tests/concurrent_vsim_and_vrem.py
@@ -1,0 +1,68 @@
+from test import TestCase, fill_redis_with_vectors, generate_random_vector
+import redis
+import threading
+
+
+class ConcurrentVSIMAndVREM(TestCase):
+    def getname(self):
+        return "Concurrent VSIM and VREM operations"
+
+    def estimated_runtime(self):
+        return 5
+
+    def test(self):
+        # Concurrent VSIM (background search threads) and VREM (element removal)
+        # must not corrupt the HNSW graph: VREM frees nodes that a running VSIM
+        # may still be reading. Keep VSIM searches running on their own
+        # connections while the main thread churns elements in and out of a
+        # populated set, then verify the server is still alive.
+        dim = 128
+        base_count = 2000
+        iterations = 5000
+        num_vsim_threads = 4
+
+        # Fill the key with base vectors so the set never empties during churn
+        fill_redis_with_vectors(self.redis, self.test_key, base_count, dim)
+
+        # VSIM only races VREM when it runs in a background thread
+        cfg = 'vset-force-single-threaded-execution'
+        original_cfg = self.redis.config_get(cfg).get(cfg, 'no')
+        self.redis.config_set(cfg, 'no')
+
+        stop = threading.Event()
+
+        def vsim_worker():
+            """Thread function to perform VSIM operations until stopped"""
+            conn = redis.Redis(port=self.primary_port, db=9)
+            while not stop.is_set():
+                query = [str(x) for x in generate_random_vector(dim)]
+                try:
+                    conn.execute_command('VSIM', self.test_key, 'VALUES', dim,
+                                         *query, 'COUNT', 10)
+                except redis.exceptions.RedisError:
+                    pass
+
+        # Start VSIM threads, each on its own connection
+        threads = [threading.Thread(target=vsim_worker)
+                   for _ in range(num_vsim_threads)]
+        for t in threads:
+            t.start()
+
+        # Repeatedly add and remove an element while the searches run
+        try:
+            churn_vec = [str(x) for x in generate_random_vector(dim)]
+            for i in range(iterations):
+                elem = f'churn:{i % 64}'
+                self.redis.execute_command('VADD', self.test_key, 'VALUES', dim,
+                                           *churn_vec, elem)
+                self.redis.execute_command('VREM', self.test_key, elem)
+        finally:
+            stop.set()
+            for t in threads:
+                t.join(timeout=5.0)
+            try:
+                self.redis.config_set(cfg, original_cfg)
+            except redis.exceptions.RedisError:
+                pass  # server may be down if the race crashed it
+
+        assert self.redis.ping(), "Redis crashed during concurrent VSIM/VREM"

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -838,7 +838,7 @@ void VSIM_execute(RedisModuleCtx *ctx, struct vsetObject *vset,
     /* Perform search */
     hnswNode **neighbors = RedisModule_Alloc(sizeof(hnswNode*)*ef);
     float *distances = RedisModule_Alloc(sizeof(float)*ef);
-    unsigned int found;
+    int found;
     if (ground_truth) {
         found = hnsw_ground_truth_with_filter(vset->hnsw, vec, ef, neighbors,
                     distances, slot, 0,
@@ -865,7 +865,7 @@ void VSIM_execute(RedisModuleCtx *ctx, struct vsetObject *vset,
         RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
 
     long long arraylen = 0;
-    for (unsigned int i = 0; i < found && i < count; i++) {
+    for (int i = 0; i < found && (unsigned long)i < count; i++) {
         if (distances[i]/2 > epsilon) break;
         struct vsetNodeVal *nv = neighbors[i]->value;
         RedisModule_ReplyWithString(ctx, nv->item);

--- a/modules/vector-sets/vset.c
+++ b/modules/vector-sets/vset.c
@@ -49,9 +49,9 @@
  *       operations destroying the object, we need to wait that all the
  *       background threads working with this object finished their work.
  *    B) When we modify the HNSW nodes bypassing the normal locking
- *       provided by the HNSW library. This only happens when we update
- *       an existing node attribute so far, in VSETATTR and when we call
- *       VADD to update a node with the SETATTR option.
+ *       provided by the HNSW library. This happens when we update an
+ *       existing node attribute (VSETATTR, VADD with SETATTR) or when
+ *       we delete a node from the graph (VREM).
  *
  *  3. Often during read operations performed by Redis commands in the
  *     main thread (VCARD, VEMB, VRANDMEMBER, ...) we don't acquire any
@@ -1251,6 +1251,10 @@ int VREM_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (!node) {
         return RedisModule_ReplyWithBool(ctx, 0);
     }
+
+    /* Background VSIM operations read the nodes we are about to free,
+     * so wait for background operations before deleting from the graph. */
+    vectorSetWaitAllBackgroundClients(vset, 0);
 
     /* Remove from dictionary */
     RedisModule_DictDel(vset->dict, element, NULL);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4775,6 +4775,16 @@ static int rdbLoadRioWithLoadingCtxInternal(rio *rdb, int rdbflags, rdbSaveInfo 
             if (!server.cluster_enabled) {
                 continue; /* Ignore gracefully. */
             }
+            /* slot_id comes straight from the RDB and is used as an index into the
+             * per-slot kvstore dictionaries. A malformed RDB can supply a value
+             * outside the valid slot range, which would be truncated to a negative or
+             * out-of-range int index inside the kvstore layer and cause an
+             * out-of-bounds access. Reject such records as corrupt before expanding. */
+            if (slot_id >= (uint64_t)kvstoreNumDicts(db->keys)) {
+                rdbReportCorruptRDB("SLOT_INFO slot id %llu is out of range (max %d)",
+                    (unsigned long long)slot_id, kvstoreNumDicts(db->keys));
+                return C_ERR;
+            }
             /* In cluster mode we resize individual slot specific dictionaries based on the number of keys that slot holds. */
             kvstoreDictExpand(db->keys, slot_id, slot_size);
             kvstoreDictExpand(db->expires, slot_id, expires_slot_size);

--- a/src/tls.c
+++ b/src/tls.c
@@ -652,8 +652,10 @@ static void tlsPendingRemove(tls_connection *conn) {
     }
 }
 
-static int getCertFieldByName(X509 *cert, const char *field, char *out, size_t outlen) {
-    if (!cert || !field || !out) return 0;
+/* Returns the requested certificate subject field as a newly allocated,
+ * binary-safe sds, or NULL on failure. */
+static sds getCertFieldByName(X509 *cert, const char *field) {
+    if (!cert || !field) return NULL;
 
     int nid = -1;
 
@@ -663,12 +665,18 @@ static int getCertFieldByName(X509 *cert, const char *field, char *out, size_t o
         nid = NID_organizationName;
     /* Add more mappings here as needed */
 
-    if (nid == -1) return 0;
+    if (nid == -1) return NULL;
 
     X509_NAME *subject = X509_get_subject_name(cert);
-    if (!subject) return 0;
+    if (!subject) return NULL;
 
-    return X509_NAME_get_text_by_NID(subject, nid, out, outlen) > 0;
+    /* The name may contain embedded NULs, so use the returned length, not
+     * strlen, to build the proper binary-safe string. */
+    char buf[256];
+    int len = X509_NAME_get_text_by_NID(subject, nid, buf, sizeof(buf));
+    if (len <= 0) return NULL;
+
+    return sdstrynewlen(buf, len);
 }
 
 sds tlsGetPeerUsername(connection *conn_) {
@@ -690,14 +698,9 @@ sds tlsGetPeerUsername(connection *conn_) {
     X509 *cert = SSL_get_peer_certificate(conn->ssl);
     if (!cert) return NULL;
 
-    char field_value[256];
-    sds result = NULL;
-
-    if (getCertFieldByName(cert, field, field_value, sizeof(field_value))) {
-        result = sdsnew(field_value);
-    } else {
+    sds result = getCertFieldByName(cert, field);
+    if (!result)
         serverLog(LL_NOTICE, "TLS: Failed to extract field '%s' from certificate", field);
-    }
 
     X509_free(cert);
     return result;

--- a/src/tls.c
+++ b/src/tls.c
@@ -1270,15 +1270,14 @@ static int tlsHasPendingData(struct aeEventLoop *el) {
 }
 
 static int tlsProcessPendingData(struct aeEventLoop *el) {
-    listIter li;
-    listNode *ln;
-
     list *pending_list = el->privdata[1];
     if (!pending_list) return 0;
     int processed = listLength(pending_list);
-    listRewind(pending_list,&li);
-    while((ln = listNext(&li))) {
+    for (int i = 0; i < processed; i++) {
+        listNode *ln = listFirst(pending_list);
+        if (!ln) break;
         tls_connection *conn = listNodeValue(ln);
+        tlsPendingRemove(conn);
         tlsHandleEvent(conn, AE_READABLE);
     }
     return processed;

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -1,3 +1,69 @@
+# Mint a CA-signed cert whose CN has an embedded NUL: CN = "<visible>\x00<suffix>".
+# openssl's -subj parser can't emit a NUL, so we sign a cert with a 'Q' placeholder,
+# flip it to 0x00 inside the tbsCertificate, then re-sign and reassemble the DER.
+proc mint_nul_cn_cert {tlsdir outbase visible suffix} {
+    set cacrt "$tlsdir/ca.crt"
+    set cakey "$tlsdir/ca.key"
+    set key   "$tlsdir/$outbase.key"
+    set crt   "$tlsdir/$outbase.crt"
+    set csr   "$tlsdir/$outbase.csr"
+    set der   "$tlsdir/$outbase.der"
+    set tbs   "$tlsdir/$outbase.tbs"
+    set sig   "$tlsdir/$outbase.sig"
+
+    proc _der_len {n} {
+        if {$n < 0x80} { return [binary format c $n] }
+        set bytes {}
+        while {$n > 0} {
+            set bytes [linsert $bytes 0 [expr {$n & 0xff}]]
+            set n [expr {$n >> 8}]
+        }
+        return [binary format c [expr {0x80 | [llength $bytes]}]][binary format c* $bytes]
+    }
+    proc _read_bin {path} {
+        set f [open $path rb]; set d [read $f]; close $f; return $d
+    }
+    proc _write_bin {path data} {
+        set f [open $path wb]; puts -nonewline $f $data; close $f
+    }
+
+    exec openssl genrsa -out $key 2048 2>/dev/null
+    exec -ignorestderr openssl req -new -key $key \
+        -subj "/O=Redis Test/CN=${visible}Q${suffix}" -out $csr 2>/dev/null
+    exec -ignorestderr openssl x509 -req -sha256 -CA $cacrt -CAkey $cakey \
+        -CAcreateserial -days 365 -in $csr -outform DER -out $der 2>/dev/null
+
+    set data [_read_bin $der]
+
+    # Locate the 'Q' placeholder via its unique surrounding context.
+    set marker "${visible}\x51${suffix}"
+    set idx [string first $marker $data]
+    if {$idx < 0} { error "placeholder marker not found in certificate DER" }
+    set qpos [expr {$idx + [string length $visible]}]
+
+    # tbsCertificate is the second ASN.1 element (depth 1) of the Certificate.
+    set lines [split [exec openssl asn1parse -inform DER -in $der] "\n"]
+    regexp {^\s*(\d+):d=\d+\s+hl=(\d+)\s+l=\s*(\d+)} [lindex $lines 1] -> tbs_off tbs_hl tbs_len
+    set tbs_start $tbs_off
+    set tbs_end   [expr {$tbs_off + $tbs_hl + $tbs_len}]
+
+    # Patch placeholder -> NUL, then re-sign the modified tbsCertificate.
+    set data [string replace $data $qpos $qpos [binary format c 0]]
+    _write_bin $tbs [string range $data $tbs_start [expr {$tbs_end - 1}]]
+    exec openssl dgst -sha256 -sign $cakey -out $sig $tbs
+
+    set tbs_bytes [_read_bin $tbs]
+    set sig_bytes [_read_bin $sig]
+    set algid     [binary format H* "300d06092a864886f70d01010b0500"]
+    set bitstr    "\x03[_der_len [expr {[string length $sig_bytes] + 1}]]\x00$sig_bytes"
+    set body      "$tbs_bytes$algid$bitstr"
+    set cert      "\x30[_der_len [string length $body]]$body"
+    _write_bin $der $cert
+
+    exec -ignorestderr openssl x509 -inform DER -in $der -out $crt 2>/dev/null
+    return [list $crt $key]
+}
+
 start_server {tags {"tls"}} {
     if {$::tls} {
         package require tls
@@ -215,6 +281,46 @@ start_server {tags {"tls"}} {
 	            catch {r ACL DELUSER {Client-only}}
 	        }
 	    }
+
+        test {TLS: cert CN with embedded NUL cannot impersonate ACL user} {
+            # Regression test for the cert-CN NUL-byte auth bypass: a CA-signed
+            # cert with CN "admin\x00innocent" must not auto-authenticate as the
+            # privileged "admin" user, since sdsnew() would truncate it at the NUL.
+            r ACL SETUSER admin on >admin-very-strong-password-1234567890 allcommands allkeys
+            r CONFIG SET tls-auth-clients-user CN
+            r ACL LOG RESET
+
+            lassign [mint_nul_cn_cert $::tlsdir attacker_nul "admin" "innocent"] crt key
+            set s [redis [srv 0 host] [srv 0 port] 0 1 [list -certfile $crt -keyfile $key]]
+
+            # ::tls::init sets process-global defaults for every later ::tls::socket in
+            # this test client, so restore them now that the handshake is done — the cert
+            # files are deleted below, and a stale default would break all later servers.
+            ::tls::init \
+                -cafile "$::tlsdir/ca.crt" \
+                -certfile "$::tlsdir/client.crt" \
+                -keyfile "$::tlsdir/client.key"
+
+            # Capture before cleanup so it always runs even if the assertion fails.
+            set whoami [$s ACL WHOAMI]
+            set log [r ACL LOG]
+
+            catch {$s close}
+            r ACL DELUSER admin
+            r CONFIG SET tls-auth-clients-user OFF
+            foreach ext {crt key csr der tbs sig} {
+                file delete -force "$::tlsdir/attacker_nul.$ext"
+            }
+
+            assert_equal "default" $whoami
+
+            # The full binary-safe CN must be logged verbatim (NUL preserved),
+            # proving it was never truncated to "admin" and used for auto-auth.
+            assert_equal 1 [llength $log]
+            set entry [lindex $log 0]
+            assert_equal "tls-cert" [dict get $entry reason]
+            assert_equal "admin\x00innocent" [dict get $entry username]
+        }
     }
 }
 


### PR DESCRIPTION
* Use-after-free in the TLS pending-data list when a command closes another pending connection
* A malicious RDB payload with an out-of-range `SLOT_INFO` slot id causes memory corruption during RDB loading, which may lead to Remote Code Execution
* Vector Sets: missing node level validation when loading a vector set from RDB may lead to out-of-bounds access (VDP-4971)
* Vector Sets: use-after-free when `VREM` mutates the HNSW graph while background `VSIM` threads are still running (MOD-16035)
* Vector Sets: a negative `hnsw_search()` return was treated as a huge unsigned count, reading past the end of the result arrays (MOD-16035)
* TLS client certificate authentication bypass: a Common Name containing an embedded NUL byte was truncated, allowing a client to authenticate as another (possibly privileged) ACL user

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch authentication, RDB parsing, and concurrent graph mutation in Vector Sets; incorrect fixes could break TLS login, cluster RDB load, or vector search/removal.
> 
> **Overview**
> This PR bundles several **security and stability fixes** across TLS, RDB loading, and Vector Sets.
> 
> **TLS client auth:** Certificate CN extraction now uses length from OpenSSL (`sdstrynewlen`) instead of C-string APIs, so embedded NUL bytes cannot truncate the identity and impersonate another ACL user. A regression test mints a cert with `admin\x00innocent` in the CN.
> 
> **TLS event loop:** `tlsProcessPendingData` no longer iterates a list while handlers may remove arbitrary nodes (use-after-free); it repeatedly processes the list head and removes each connection before handling it.
> 
> **RDB:** `SLOT_INFO` records reject `slot_id` values outside the kvstore dictionary count before expansion, avoiding OOB indexing from malicious RDBs.
> 
> **Vector Sets / HNSW:** Serialized node levels are rejected if `>= HNSW_MAX_LEVEL`; `random_level()` caps at `HNSW_MAX_LEVEL - 1`; `hnsw_node_new` asserts level bounds. **`VREM`** waits for background VSIM threads via `vectorSetWaitAllBackgroundClients` before freeing graph nodes. **`VSIM`** treats `hnsw_search`’s signed return as `int` so `-1` is not interpreted as a huge unsigned loop bound. A concurrent VSIM/VREM stress test was added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 543b92659a6166fd24752a41bcab10bfe4c3e30f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->