### PR TITLE
Add  8.8 and 8.10 into the supported versions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,8 @@ unless this is not possible or feasible with a reasonable effort.
 
 | Version | Supported                                                              |
 |---------|------------------------------------------------------------------------|
+| 8.10.x  | :white_check_mark:                                                     |
+| 8.8.x   | :white_check_mark:                                                     |
 | 8.6.x   | :white_check_mark:                                                     |
 | 8.4.x   | :white_check_mark:                                                     |
 | 8.2.x   | :white_check_mark:                                                     |


### PR DESCRIPTION
We have released 8.8 and 8.10, but don't update the supported versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the security policy version matrix; no runtime or security logic is modified.
> 
> **Overview**
> Updates the **Supported Versions** table in `SECURITY.md` to reflect recent releases.
> 
> Adds **8.10.x** and **8.8.x** as supported (`:white_check_mark:`), and marks **8.0.x** as no longer supported (`:x:`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb20df715d5fe62d2e8f336ff37cdaba3f6b06ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->