### PR TITLE
Use the common ASM API to complete tasks after legacy cluster slot updates

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -618,9 +618,9 @@ asmTask *asmLookupTaskById(const char *id) {
     return asmLookupTaskAt(asmManager->tasks, id);
 }
 
-/* Returns the ASM task that is identical to the given slot range array, or NULL
- * if no such task exists. */
-asmTask *asmLookupTaskBySlotRangeArray(slotRangeArray *slots) {
+/* Returns the ID of the ASM task whose slot ranges equal the given ranges,
+ * or NULL if no such task exists. */
+const char *asmLookupTaskBySlotRangeArray(slotRangeArray *slots) {
     listIter li;
     listNode *ln;
 
@@ -628,7 +628,7 @@ asmTask *asmLookupTaskBySlotRangeArray(slotRangeArray *slots) {
     while ((ln = listNext(&li)) != NULL) {
         asmTask *task = listNodeValue(ln);
         if (slotRangeArrayIsEqual(task->slots, slots))
-            return task;
+            return task->id;
     }
     return NULL;
 }
@@ -2922,10 +2922,17 @@ int clusterAsmHandoff(const char *task_id, sds *err) {
     return C_OK;
 }
 
-/* Notify Redis that the config is updated for the task. */
-int asmNotifyConfigUpdated(asmTask *task, sds *err) {
-    int event = -1;
+/* Import/Migrate task is done, config is updated. */
+int clusterAsmDone(const char *task_id, sds *err) {
+    serverAssert(task_id);
 
+    asmTask *task = asmLookupTaskById(task_id);
+    if (!task) {
+        *err = sdscatprintf(sdsempty(), "No ASM task found for id: %s", task_id);
+        return C_ERR;
+    }
+
+    int event = -1;
     if (task->operation == ASM_IMPORT && task->state == ASM_TAKEOVER) {
         event = ASM_EVENT_IMPORT_COMPLETED;
     } else if (task->operation == ASM_MIGRATE && task->state == ASM_STREAM_EOF) {
@@ -2951,18 +2958,6 @@ int asmNotifyConfigUpdated(asmTask *task, sds *err) {
         asmTrimJobSchedule(task->slots);
 
     return C_OK;
-}
-
-/* Import/Migrate task is done, config is updated. */
-int clusterAsmDone(const char *task_id, sds *err) {
-    serverAssert(task_id);
-
-    asmTask *task = asmLookupTaskById(task_id);
-    if (!task) {
-        *err = sdscatprintf(sdsempty(), "No ASM task found for id: %s", task_id);
-        return C_ERR;
-    }
-    return asmNotifyConfigUpdated(task, err);
 }
 
 int clusterAsmProcess(const char *task_id, int event, void *arg, char **err) {

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -34,7 +34,6 @@ int asmDebugSetTrimMethod(const char *method, int active_trim_delay);
 
 void asmImportIncrAppliedBytes(struct asmTask *task, size_t bytes);
 struct slotRangeArray *asmTaskGetSlotRanges(const char *task_id);
-int asmNotifyConfigUpdated(struct asmTask *task, sds *err);
 size_t asmGetPeakSyncBufferSize(void);
 size_t asmGetImportInputBufferSize(void);
 size_t asmGetMigrateOutputMemoryUsage(void);
@@ -47,7 +46,7 @@ int isSlotInTrimJob(int slot);
 sds asmCatInfoString(sds info);
 void clusterMigrationCommand(client *c);
 void clusterSyncSlotsCommand(client *c);
-struct asmTask *asmLookupTaskBySlotRangeArray(struct slotRangeArray *slots);
+const char *asmLookupTaskBySlotRangeArray(struct slotRangeArray *slots);
 void asmCancelTrimJobs(void);
 sds asmDumpActiveImportTask(void);
 int asmReplicaHandleMasterTask(sds task_info);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2435,7 +2435,7 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                 /* After completing slot ranges migration, the destination node
                  * will broadcast a PONG message to all the nodes. We need to
                  * detect that the slot was moved from us to the sender, and
-                 * call asmNotifyConfigUpdated() to notify the ASM state machine. */
+                 * call clusterAsmProcess() to notify the ASM state machine. */
                 if (server.cluster->slots[j] == myself && sender != myself)
                     sra = slotRangeArrayAppend(sra, j);
 
@@ -2472,19 +2472,20 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
     }
 
     /* Notify ASM about the config update */
-    struct asmTask *asm_task = NULL;
+    const char *asm_task_id = NULL;
     if (sra && sra->num_ranges > 0 && server.masterhost == NULL) {
-        sds err = NULL;
-        asm_task = asmLookupTaskBySlotRangeArray(sra);
-        if (!asm_task) {
+        char *err = NULL;
+        asm_task_id = asmLookupTaskBySlotRangeArray(sra);
+        if (!asm_task_id) {
             /* If no task was found, it means the config update is not related
              * to current ASM task, but this node learned about the config
              * update from cluster protocol, and we need to cancel any
              * conflicting tasks that overlap with the slot ranges. */
             clusterAsmCancelBySlotRangeArray(sra, "slots configuration updated");
-        } else if (asmNotifyConfigUpdated(asm_task, &err) != C_OK) {
-            serverLog(LL_WARNING, "ASM config update failed: %s", err);
-            sdsfree(err);
+        } else if (clusterAsmProcess(asm_task_id, ASM_EVENT_DONE, NULL, &err) != C_OK) {
+            serverLog(LL_WARNING,
+                    "Failed to complete ASM task %s after slot configuration update: %s",
+                    asm_task_id, err);
         }
     }
     slotRangeArrayFree(sra);
@@ -2533,7 +2534,7 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                              CLUSTER_TODO_UPDATE_STATE|
                              CLUSTER_TODO_FSYNC_CONFIG|
                              CLUSTER_TODO_BROADCAST_PONG);
-    } else if (dirty_slots_count && !asm_task) {
+    } else if (dirty_slots_count && !asm_task_id) {
         /* If we are here, we received an update message which removed
          * ownership for certain slots we still have keys about, but still
          * we are serving some slots, so this master node was not demoted to


### PR DESCRIPTION
The legacy cluster implementation directly accessed the internal `asmTask` to
mark a task as done after applying a slot configuration update.

This change looks up the corresponding task ID and reports `ASM_EVENT_DONE`
through the common `clusterAsmProcess()` API. This keeps ASM task internals
encapsulated and aligns the legacy cluster implementation with the interface
used by other cluster implementations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches slot-migration completion on the legacy cluster path when gossip updates ownership; behavior should match the prior finalize path but mis-association of task IDs could affect dirty-slot handling and task completion.
> 
> **Overview**
> **Legacy cluster** no longer calls internal `asmNotifyConfigUpdated()` on an `asmTask` after slot config changes from cluster gossip. It resolves the matching migration by slot ranges via **`asmLookupTaskBySlotRangeArray`**, which now returns a **task ID** (`const char *`) instead of an `asmTask *`, and finishes the task with **`clusterAsmProcess(task_id, ASM_EVENT_DONE, …)`**.
> 
> **ASM internals** fold config-completion into **`clusterAsmDone`** (lookup by ID, validate import/migrate state, notify, finalize, schedule trim on migrate complete). **`asmNotifyConfigUpdated`** is removed from the public header.
> 
> Dirty-slot cleanup after ownership loss still keys off whether an ASM task ID was found for the update (`asm_task_id` vs `asm_task`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a51b0f82080943de50d2add7139802385d655183. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->