### PR TITLE
Fix ACL key permissions not being rechecked at EXEC time

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1964,7 +1964,8 @@ int ACLCheckAllPerm(client *c, pendingCommand *pcmd, int *idxptr) {
     /* The cached key result holds key positions within pcmd->argv, so it is only
      * usable for the command we are actually about to check. */
     debugServerAssert(!pcmd || (pcmd->cmd == c->cmd));
-    return ACLCheckAllUserCommandPerm(c->user, c->cmd, c->argv, c->argc, getClientCachedKeyResult(pcmd), idxptr);
+    return ACLCheckAllUserCommandPerm(c->user, c->cmd, c->argv, c->argc,
+                getClientCachedKeyResult(pcmd), idxptr);
 }
 
 /* If 'new' can access all channels 'original' could then return NULL;

--- a/src/acl.c
+++ b/src/acl.c
@@ -1963,7 +1963,7 @@ int ACLCheckAllUserCommandPerm(user *u, struct redisCommand *cmd, robj **argv, i
 int ACLCheckAllPerm(client *c, pendingCommand *pcmd, int *idxptr) {
     /* The cached key result holds key positions within pcmd->argv, so it is only
      * usable for the command we are actually about to check. */
-    debugServerAssert(!pcmd || (pcmd->cmd == c->cmd));
+    serverAssert(!pcmd || (pcmd->cmd == c->cmd));
     return ACLCheckAllUserCommandPerm(c->user, c->cmd, c->argv, c->argc,
                 getClientCachedKeyResult(pcmd), idxptr);
 }

--- a/src/acl.c
+++ b/src/acl.c
@@ -1954,9 +1954,17 @@ int ACLCheckAllUserCommandPerm(user *u, struct redisCommand *cmd, robj **argv, i
     return relevant_error;
 }
 
-/* High level API for checking if a client can execute the queued up command */
-int ACLCheckAllPerm(client *c, int *idxptr) {
-    return ACLCheckAllUserCommandPerm(c->user, c->cmd, c->argv, c->argc, getClientCachedKeyResult(c), idxptr);
+/* High level API for checking if a client can execute the queued up command.
+ *
+ * 'pcmd' is the pendingCommand that c->cmd / c->argv were populated from, and
+ * is used to reuse its cached key extraction result. It may be NULL for clients
+ * that don't build pendingCommand structs (module and script fake clients), in
+ * which case the keys are extracted from c->argv. */
+int ACLCheckAllPerm(client *c, pendingCommand *pcmd, int *idxptr) {
+    /* The cached key result holds key positions within pcmd->argv, so it is only
+     * usable for the command we are actually about to check. */
+    debugServerAssert(!pcmd || (pcmd->argv == c->argv && pcmd->argc == c->argc));
+    return ACLCheckAllUserCommandPerm(c->user, c->cmd, c->argv, c->argc, getClientCachedKeyResult(c, pcmd), idxptr);
 }
 
 /* If 'new' can access all channels 'original' could then return NULL;

--- a/src/acl.c
+++ b/src/acl.c
@@ -1964,7 +1964,7 @@ int ACLCheckAllPerm(client *c, pendingCommand *pcmd, int *idxptr) {
     /* The cached key result holds key positions within pcmd->argv, so it is only
      * usable for the command we are actually about to check. */
     debugServerAssert(!pcmd || (pcmd->argv == c->argv && pcmd->argc == c->argc));
-    return ACLCheckAllUserCommandPerm(c->user, c->cmd, c->argv, c->argc, getClientCachedKeyResult(c, pcmd), idxptr);
+    return ACLCheckAllUserCommandPerm(c->user, c->cmd, c->argv, c->argc, getClientCachedKeyResult(pcmd), idxptr);
 }
 
 /* If 'new' can access all channels 'original' could then return NULL;

--- a/src/acl.c
+++ b/src/acl.c
@@ -1963,7 +1963,7 @@ int ACLCheckAllUserCommandPerm(user *u, struct redisCommand *cmd, robj **argv, i
 int ACLCheckAllPerm(client *c, pendingCommand *pcmd, int *idxptr) {
     /* The cached key result holds key positions within pcmd->argv, so it is only
      * usable for the command we are actually about to check. */
-    debugServerAssert(!pcmd || (pcmd->argv == c->argv && pcmd->argc == c->argc));
+    debugServerAssert(!pcmd || pcmd->cmd == c->cmd);
     return ACLCheckAllUserCommandPerm(c->user, c->cmd, c->argv, c->argc, getClientCachedKeyResult(c, pcmd), idxptr);
 }
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -1963,7 +1963,7 @@ int ACLCheckAllUserCommandPerm(user *u, struct redisCommand *cmd, robj **argv, i
 int ACLCheckAllPerm(client *c, pendingCommand *pcmd, int *idxptr) {
     /* The cached key result holds key positions within pcmd->argv, so it is only
      * usable for the command we are actually about to check. */
-    debugServerAssert(!pcmd || (pcmd->argv == c->argv && pcmd->argc == c->argc));
+    debugServerAssert(!pcmd || (pcmd->cmd == c->cmd));
     return ACLCheckAllUserCommandPerm(c->user, c->cmd, c->argv, c->argc, getClientCachedKeyResult(pcmd), idxptr);
 }
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -1963,7 +1963,7 @@ int ACLCheckAllUserCommandPerm(user *u, struct redisCommand *cmd, robj **argv, i
 int ACLCheckAllPerm(client *c, pendingCommand *pcmd, int *idxptr) {
     /* The cached key result holds key positions within pcmd->argv, so it is only
      * usable for the command we are actually about to check. */
-    debugServerAssert(!pcmd || pcmd->cmd == c->cmd);
+    debugServerAssert(!pcmd || (pcmd->argv == c->argv && pcmd->argc == c->argc));
     return ACLCheckAllUserCommandPerm(c->user, c->cmd, c->argv, c->argc, getClientCachedKeyResult(c, pcmd), idxptr);
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -383,10 +383,8 @@ typedef struct RedisModuleCommandFilterCtx {
     RedisModuleString **argv;
     int argv_len;
     int argc;
-    /* Set to 1 as soon as one of the filters modifies argv (insert, replace or
-     * delete), so that the caller knows it has to refresh whatever it cached
-     * about the command. */
-    int argv_changed;
+    int argv_changed; /* Set when a filter modified argv, so the caller knows
+                       * it must refresh what it cached about the command. */
     client *c;
 } RedisModuleCommandFilterCtx;
 

--- a/src/module.c
+++ b/src/module.c
@@ -383,6 +383,10 @@ typedef struct RedisModuleCommandFilterCtx {
     RedisModuleString **argv;
     int argv_len;
     int argc;
+    /* Set to 1 as soon as one of the filters modifies argv (insert, replace or
+     * delete), so that the caller knows it has to refresh whatever it cached
+     * about the command. */
+    int argv_changed;
     client *c;
 } RedisModuleCommandFilterCtx;
 
@@ -11999,6 +12003,7 @@ void moduleCallCommandFilters(client *c) {
         .argv = c->argv,
         .argv_len = c->argv_len,
         .argc = c->argc,
+        .argv_changed = 0,
         .c = c
     };
 
@@ -12014,6 +12019,9 @@ void moduleCallCommandFilters(client *c) {
         f->callback(&filter);
     }
 
+    /* Nothing was modified by the filters, there's nothing to refresh. */
+    if (!filter.argv_changed) return;
+
     /* If the filter sets a new command, including command or subcommand,
      * the command looked up will be invalid. */
     c->lookedcmd = NULL;
@@ -12022,7 +12030,9 @@ void moduleCallCommandFilters(client *c) {
     c->argv_len = filter.argv_len;
     c->argc = filter.argc;
 
-    /* Update pending command if it exists. */
+    /* Update pending command if it exists. Everything that was derived from the
+     * old argv (command, keys, slot, read error) is now stale, so we drop it and
+     * let preprocessCommand() compute it again from the new argv. */
     pendingCommand *pcmd = c->current_pending_cmd;
     if (pcmd) {
         pcmd->argv = filter.argv;
@@ -12031,10 +12041,19 @@ void moduleCallCommandFilters(client *c) {
         pcmd->cmd = NULL;
         pcmd->slot = INVALID_CLUSTER_SLOT;
         pcmd->flags = 0;
+        pcmd->read_error = 0;
 
         /* Reset keys result */
         getKeysFreeResult(&pcmd->keys_result);
         pcmd->keys_result = (getKeysResult)GETKEYS_RESULT_INIT;
+
+        preprocessCommand(c, pcmd);
+        pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
+
+        /* Keep the client fields we populated from the pending command in sync. */
+        c->lookedcmd = pcmd->cmd;
+        c->slot = pcmd->slot;
+        c->read_error = pcmd->read_error;
     }
 }
 
@@ -12075,6 +12094,7 @@ int RM_CommandFilterArgInsert(RedisModuleCommandFilterCtx *fctx, int pos, RedisM
     }
     fctx->argv[pos] = arg;
     fctx->argc++;
+    fctx->argv_changed = 1;
 
     return REDISMODULE_OK;
 }
@@ -12090,6 +12110,7 @@ int RM_CommandFilterArgReplace(RedisModuleCommandFilterCtx *fctx, int pos, Redis
 
     decrRefCount(fctx->argv[pos]);
     fctx->argv[pos] = arg;
+    fctx->argv_changed = 1;
 
     return REDISMODULE_OK;
 }
@@ -12107,6 +12128,7 @@ int RM_CommandFilterArgDelete(RedisModuleCommandFilterCtx *fctx, int pos)
         fctx->argv[i] = fctx->argv[i+1];
     }
     fctx->argc--;
+    fctx->argv_changed = 1;
 
     return REDISMODULE_OK;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -12028,25 +12028,14 @@ void moduleCallCommandFilters(client *c) {
     c->argv_len = filter.argv_len;
     c->argc = filter.argc;
 
-    /* Update pending command if it exists. Everything that was derived from the
-     * old argv (command, keys, slot, read error) is now stale, so we drop it and
-     * let preprocessCommand() compute it again from the new argv. */
+    /* Everything the pending command derived from the old argv (command, keys,
+     * slot, read error) is stale now, so preprocess it again. */
     pendingCommand *pcmd = c->current_pending_cmd;
     if (pcmd) {
         pcmd->argv = filter.argv;
         pcmd->argc = filter.argc;
         pcmd->argv_len = filter.argv_len;
-        pcmd->cmd = NULL;
-        pcmd->slot = INVALID_CLUSTER_SLOT;
-        pcmd->flags = 0;
-        pcmd->read_error = 0;
-
-        /* Reset keys result */
-        getKeysFreeResult(&pcmd->keys_result);
-        pcmd->keys_result = (getKeysResult)GETKEYS_RESULT_INIT;
-
         preprocessCommand(c, pcmd);
-        pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
 
         /* Keep the client fields we populated from the pending command in sync. */
         c->lookedcmd = pcmd->cmd;

--- a/src/multi.c
+++ b/src/multi.c
@@ -190,11 +190,13 @@ void execCommand(client *c) {
         c->cmd = c->realcmd = c->mstate.commands[j]->cmd;
 
         /* ACL permissions are also checked at the time of execution in case
-         * they were changed after the commands were queued. */
+         * they were changed after the commands were queued. Note we pass the
+         * queued command itself, so that the key permissions are checked against
+         * its keys and not against the EXEC command we are currently running. */
         int acl_errpos;
         int acl_retval = ACL_OK;
         if (!skip_acl_check) {
-            acl_retval = ACLCheckAllPerm(c,&acl_errpos);
+            acl_retval = ACLCheckAllPerm(c,c->mstate.commands[j],&acl_errpos);
         }
         if (acl_retval != ACL_OK) {
             char *reason;

--- a/src/networking.c
+++ b/src/networking.c
@@ -6085,7 +6085,6 @@ pendingCommand *popPendingCommandFromTail(pendingCommandList *list) {
  * key positions that have nothing to do with the command being checked. */
 getKeysResult *getClientCachedKeyResult(pendingCommand *pcmd) {
     if (!pcmd) return NULL;
-
     serverAssert(pcmd->flags & PENDING_CMD_FLAG_PREPROCESSED);
 
     /* Return cached result if available */

--- a/src/networking.c
+++ b/src/networking.c
@@ -6076,20 +6076,30 @@ pendingCommand *popPendingCommandFromTail(pendingCommandList *list) {
     return cmd;
 }
 
-/* Get cached key result for current pending command */
-getKeysResult *getClientCachedKeyResult(client *c) {
-    pendingCommand *pcmd = c->current_pending_cmd;
-    if (pcmd) {
-        /* Preprocess the command if needed */
-        if (!(pcmd->flags & PENDING_CMD_FLAG_PREPROCESSED)) {
-            preprocessCommand(c, pcmd);
-            pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
-        }
+/* Get the cached key result of 'pcmd', or NULL if it has none, in which case
+ * the caller is expected to extract the keys from the command arguments itself.
+ *
+ * 'pcmd' must be the pendingCommand that 'c->cmd' / 'c->argv' were populated
+ * from: the cached result records key positions within that command's argv, so
+ * handing over an unrelated pendingCommand (for instance the client's current
+ * pending command while a queued MULTI command is being executed) would return
+ * key positions that have nothing to do with the command being checked. */
+getKeysResult *getClientCachedKeyResult(client *c, pendingCommand *pcmd) {
+    if (!pcmd) return NULL;
 
-        /* Return cached result if available */
-        if (pcmd->flags & PENDING_CMD_KEYS_RESULT_VALID)
-            return &c->current_pending_cmd->keys_result;
+    /* Preprocess the command if needed. Only the command currently being read
+     * from the client may still be unprocessed: commands queued in a MULTI were
+     * preprocessed when they were parsed, and re-running preprocessCommand() on
+     * one of them here would look its command up again and overwrite pcmd->cmd
+     * after execCommand() already copied it into c->cmd. */
+    if (pcmd == c->current_pending_cmd && !(pcmd->flags & PENDING_CMD_FLAG_PREPROCESSED)) {
+        preprocessCommand(c, pcmd);
+        pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
     }
+
+    /* Return cached result if available */
+    if (pcmd->flags & PENDING_CMD_KEYS_RESULT_VALID)
+        return &pcmd->keys_result;
     return NULL;
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -6083,7 +6083,7 @@ pendingCommand *popPendingCommandFromTail(pendingCommandList *list) {
  * handing over an unrelated pendingCommand (for instance the client's current
  * pending command while a queued MULTI command is being executed) would return
  * key positions that have nothing to do with the command being checked. */
-getKeysResult *getClientCachedKeyResult(client *c, pendingCommand *pcmd) {
+getKeysResult *getClientCachedKeyResult(pendingCommand *pcmd) {
     if (!pcmd) return NULL;
 
     serverAssert(pcmd->flags & PENDING_CMD_FLAG_PREPROCESSED);

--- a/src/networking.c
+++ b/src/networking.c
@@ -6087,15 +6087,7 @@ pendingCommand *popPendingCommandFromTail(pendingCommandList *list) {
 getKeysResult *getClientCachedKeyResult(client *c, pendingCommand *pcmd) {
     if (!pcmd) return NULL;
 
-    /* Preprocess the command if needed. Only the command currently being read
-     * from the client may still be unprocessed: commands queued in a MULTI were
-     * preprocessed when they were parsed, and re-running preprocessCommand() on
-     * one of them here would look its command up again and overwrite pcmd->cmd
-     * after execCommand() already copied it into c->cmd. */
-    if (pcmd == c->current_pending_cmd && !(pcmd->flags & PENDING_CMD_FLAG_PREPROCESSED)) {
-        preprocessCommand(c, pcmd);
-        pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
-    }
+    serverAssert(pcmd->flags & PENDING_CMD_FLAG_PREPROCESSED);
 
     /* Return cached result if available */
     if (pcmd->flags & PENDING_CMD_KEYS_RESULT_VALID)

--- a/src/networking.c
+++ b/src/networking.c
@@ -3870,7 +3870,6 @@ int processInputBuffer(client *c) {
                 pcmd->reploff = c->io_read_reploff - sdslen(c->querybuf) + c->qb_pos;
 
             preprocessCommand(c, pcmd);
-            pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
             resetClientQbufState(c);
         }
 

--- a/src/script.c
+++ b/src/script.c
@@ -404,7 +404,9 @@ static int scriptVerifyCommandArity(struct redisCommand *cmd, int argc, sds *err
 static int scriptVerifyACL(client *c, sds *err) {
     /* Check the ACLs. */
     int acl_errpos;
-    int acl_retval = ACLCheckAllPerm(c, &acl_errpos);
+    /* 'c' is the script engine's fake client, which has no pending command, so
+     * the keys are extracted from c->argv. */
+    int acl_retval = ACLCheckAllPerm(c, c->current_pending_cmd, &acl_errpos);
     if (acl_retval != ACL_OK) {
         addACLLogEntry(c,acl_retval,ACL_LOG_CTX_LUA,acl_errpos,NULL,NULL);
         sds msg = getAclErrorMessage(acl_retval, c->user, c->cmd, c->argv[acl_errpos]->ptr, 0);

--- a/src/server.c
+++ b/src/server.c
@@ -4424,8 +4424,21 @@ uint64_t getCommandFlags(client *c) {
     return cmd_flags;
 }
 
+/* Compute what can be derived from the command argv alone: the command itself,
+ * its keys and slot, and the read errors that can be detected this early.
+ *
+ * It may be called again on the same pending command if the argv changed
+ * (a module command filter may insert, replace or delete arguments), so it
+ * starts by dropping whatever a previous call derived from the old argv. */
 void preprocessCommand(client *c, pendingCommand *pcmd) {
+    pcmd->cmd = NULL;
     pcmd->slot = INVALID_CLUSTER_SLOT;
+    pcmd->read_error = 0;
+    pcmd->flags &= ~PENDING_CMD_KEYS_RESULT_VALID;
+    pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
+    getKeysFreeResult(&pcmd->keys_result);
+    pcmd->keys_result = (getKeysResult)GETKEYS_RESULT_INIT;
+
     if (pcmd->argc == 0)
         return;
 
@@ -4450,7 +4463,6 @@ void preprocessCommand(client *c, pendingCommand *pcmd) {
         return;
     }
 
-    pcmd->keys_result = (getKeysResult)GETKEYS_RESULT_INIT;
     int num_keys = extractKeysAndSlot(pcmd->cmd, pcmd->argv, pcmd->argc,
                                       &pcmd->keys_result, &pcmd->slot);
     if (num_keys < 0) {

--- a/src/server.c
+++ b/src/server.c
@@ -4597,7 +4597,7 @@ int processCommand(client *c) {
     /* Check if the user can run this command according to the current
      * ACLs. */
     int acl_errpos;
-    int acl_retval = ACLCheckAllPerm(c,&acl_errpos);
+    int acl_retval = ACLCheckAllPerm(c,c->current_pending_cmd,&acl_errpos);
     if (acl_retval != ACL_OK) {
         addACLLogEntry(c,acl_retval,(c->flags & CLIENT_MULTI) ? ACL_LOG_CTX_MULTI : ACL_LOG_CTX_TOPLEVEL,acl_errpos,NULL,NULL);
         sds msg = getAclErrorMessage(acl_retval, c->user, c->cmd, c->argv[acl_errpos]->ptr, 0);
@@ -4617,7 +4617,7 @@ int processCommand(client *c) {
     {
         int error_code;
         clusterNode *n = getNodeByQuery(c,c->cmd,c->argv,c->argc,
-            &c->slot,getClientCachedKeyResult(c),c->read_error,cmd_flags,&error_code);
+            &c->slot,getClientCachedKeyResult(c,c->current_pending_cmd),c->read_error,cmd_flags,&error_code);
         if (n == NULL || !clusterNodeIsMyself(n)) {
             if (c->cmd->proc == execCommand) {
                 discardTransaction(c);

--- a/src/server.c
+++ b/src/server.c
@@ -4629,7 +4629,7 @@ int processCommand(client *c) {
     {
         int error_code;
         clusterNode *n = getNodeByQuery(c,c->cmd,c->argv,c->argc,
-            &c->slot,getClientCachedKeyResult(c,c->current_pending_cmd),c->read_error,cmd_flags,&error_code);
+            &c->slot,getClientCachedKeyResult(c->current_pending_cmd),c->read_error,cmd_flags,&error_code);
         if (n == NULL || !clusterNodeIsMyself(n)) {
             if (c->cmd->proc == execCommand) {
                 discardTransaction(c);

--- a/src/server.c
+++ b/src/server.c
@@ -4628,8 +4628,9 @@ int processCommand(client *c) {
           c->cmd->proc != execCommand))
     {
         int error_code;
+        getKeysResult *keyresult = getClientCachedKeyResult(c->current_pending_cmd);
         clusterNode *n = getNodeByQuery(c,c->cmd,c->argv,c->argc,
-            &c->slot,getClientCachedKeyResult(c->current_pending_cmd),c->read_error,cmd_flags,&error_code);
+            &c->slot,keyresult,c->read_error,cmd_flags,&error_code);
         if (n == NULL || !clusterNodeIsMyself(n)) {
             if (c->cmd->proc == execCommand) {
                 discardTransaction(c);

--- a/src/server.h
+++ b/src/server.h
@@ -3449,7 +3449,7 @@ void unprotectClient(client *c);
 client *lookupClientByID(uint64_t id);
 int authRequired(client *c);
 void putClientInPendingWriteQueue(client *c);
-getKeysResult *getClientCachedKeyResult(client *c, pendingCommand *pcmd);
+getKeysResult *getClientCachedKeyResult(pendingCommand *pcmd);
 /* reply macros */
 #define ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c, str) addReplyBulkCBuffer(c, str, strlen(str))
 

--- a/src/server.h
+++ b/src/server.h
@@ -3449,7 +3449,7 @@ void unprotectClient(client *c);
 client *lookupClientByID(uint64_t id);
 int authRequired(client *c);
 void putClientInPendingWriteQueue(client *c);
-getKeysResult *getClientCachedKeyResult(client *c);
+getKeysResult *getClientCachedKeyResult(client *c, pendingCommand *pcmd);
 /* reply macros */
 #define ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c, str) addReplyBulkCBuffer(c, str, strlen(str))
 
@@ -3739,7 +3739,7 @@ int ACLUserHasUnrestrictedKeyAccess(user *u, int flags);
 int ACLUserCheckChannelPerm(user *u, sds channel, int literal);
 int ACLCheckAllUserCommandPerm(user *u, struct redisCommand *cmd, robj **argv, int argc, getKeysResult *key_result, int *idxptr);
 int ACLUserCheckCmdWithUnrestrictedKeyAccess(user *u, struct redisCommand *cmd, robj **argv, int argc, int flags);
-int ACLCheckAllPerm(client *c, int *idxptr);
+int ACLCheckAllPerm(client *c, pendingCommand *pcmd, int *idxptr);
 int ACLSetUser(user *u, const char *op, ssize_t oplen);
 sds ACLStringSetUser(user *u, sds username, sds *argv, int argc);
 uint64_t ACLGetCommandCategoryFlagByName(const char *name);

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1039,6 +1039,46 @@ start_server {tags {"acl external:skip"}} {
         r ACL SETUSER antirez -incr
     }
 
+    test {ACL key permissions are rechecked at EXEC time} {
+        # Same scenario as the test above, but revoking the key pattern instead
+        # of the command, so that the key half of the EXEC time re-check is the
+        # one being exercised.
+        set rd1 [redis_deferring_client]
+        r ACL LOG RESET
+        r SET object:1234 original
+        r ACL SETUSER antirez +get
+
+        r AUTH antirez foo
+        r MULTI
+        r GET object:1234
+        r SET object:1234 written-by-revoked-user
+        # Revoke the key pattern while the transaction is still parked.
+        $rd1 ACL SETUSER antirez resetkeys ~other:*
+        $rd1 read
+        catch {r EXEC} e
+        $rd1 close
+        r AUTH default ""
+
+        # The queued read is refused...
+        assert_match {*NOPERM*no permission to touch the specified keys*} $e
+        # ...and so is the queued write, so the value is left untouched.
+        assert_equal {original} [r GET object:1234]
+
+        # Both refusals are logged, and grouped into a single entry since they
+        # share username, context, reason and object.
+        set entry [lindex [r ACL LOG] 0]
+        assert_equal {multi} [dict get $entry context]
+        assert_equal {key} [dict get $entry reason]
+        assert_equal {object:1234} [dict get $entry object]
+        assert_equal {antirez} [dict get $entry username]
+        assert_equal 2 [dict get $entry count]
+        assert_match {*cmd=exec*} [dict get $entry client-info]
+
+        # Restore the user to the state the following tests expect.
+        r ACL SETUSER antirez -get resetkeys ~object:1234
+        r DEL object:1234
+    }
+
     test {ACL can log errors in the context of Lua scripting} {
         r AUTH antirez foo
         catch {r EVAL {redis.call('incr','foo')} 0}

--- a/tests/unit/moduleapi/commandfilter.tcl
+++ b/tests/unit/moduleapi/commandfilter.tcl
@@ -192,10 +192,9 @@ start_cluster 1 0 [list tags {modules cluster external:skip} config_lines [list 
     }
 
     test {Command Filter refreshes cross-slot state when args are inserted} {
-        # "mget {t}a @insertafter" is a valid single-slot command before
-        # filtering, but the filter appends --inserted-after--, which turns it
-        # into a cross-slot command.
-        assert_error "CROSSSLOT*" {r mget a{t} @insertafter}
+        # Both keys hash to the same slot before filtering, but the filter
+        # appends --inserted-after--, which turns it into a cross-slot command.
+        assert_error "CROSSSLOT*" {r mget a{@insertafter} @insertafter}
     }
 
     test {Command Filter refreshes the slot when a key argument is replaced} {

--- a/tests/unit/moduleapi/commandfilter.tcl
+++ b/tests/unit/moduleapi/commandfilter.tcl
@@ -177,7 +177,7 @@ start_server {tags {"external:skip"}} {
 # A command filter that changes argv invalidates everything the server already
 # derived from the pre-filter argv (looked up command, keys, slot, cross-slot
 # error). These tests make sure the outside world is refreshed accordingly.
-start_cluster 1 0 [list tags {modules cluster external:skip} config_lines [list "loadmodule $testmodule log-key 0"]] {
+start_cluster 1 0 [list tags {modules cluster external:skip} config_lines [list loadmodule "$testmodule log-key 0"]] {
     test {Command Filter refreshes cross-slot state when args are deleted} {
         # "del a{t} @delme" is cross-slot before filtering, and a single-key
         # command after the filter deleted @delme. It must not be rejected.

--- a/tests/unit/moduleapi/commandfilter.tcl
+++ b/tests/unit/moduleapi/commandfilter.tcl
@@ -173,3 +173,53 @@ start_server {tags {"external:skip"}} {
         assert_equal [r lrange mylist 0 -1] {elem1 @delme elem2}
     }
 }
+
+# A command filter that changes argv invalidates everything the server already
+# derived from the pre-filter argv (looked up command, keys, slot, cross-slot
+# error). These tests make sure the outside world is refreshed accordingly.
+start_cluster 1 0 [list tags {modules cluster external:skip} config_lines [list "loadmodule [file normalize tests/modules/commandfilter.so] log-key 0"]] {
+    test {Command Filter refreshes cross-slot state when args are deleted} {
+        # "del {t}a @delme" is cross-slot before filtering, and a single-key
+        # command after the filter deleted @delme. It must not be rejected.
+        assert_equal 0 [r del "{t}a" @delme]
+
+        r set "{t}a" v1
+        assert_equal 1 [r del "{t}a" @delme]
+
+        # Same thing for a read command with more than one key left.
+        r mset "{t}a" v1 "{t}b" v2
+        assert_equal {v1 v2} [r mget "{t}a" @delme "{t}b"]
+    }
+
+    test {Command Filter refreshes cross-slot state when args are inserted} {
+        # "mget {t}a @insertafter" is a valid single-slot command before
+        # filtering, but the filter appends --inserted-after--, which turns it
+        # into a cross-slot command.
+        assert_error "CROSSSLOT*" {r mget "{t}a" @insertafter}
+    }
+
+    test {Command Filter refreshes cross-slot state on pipelined commands} {
+        # Pipelining makes the server parse and preprocess several commands
+        # up-front, so the filter runs against already-preprocessed state.
+        r del "{t}a"
+        set rd [redis_deferring_client]
+        $rd del "{t}a" @delme
+        $rd set "{t}a" v1
+        $rd del "{t}a" @delme
+        $rd mget "{t}a" @insertafter
+        $rd flush
+        assert_equal 0 [$rd read]
+        assert_equal {OK} [$rd read]
+        assert_equal 1 [$rd read]
+        assert_error "CROSSSLOT*" {$rd read}
+        $rd close
+    }
+
+    test {Command Filter refreshes the slot when a key argument is replaced} {
+        # The filter rewrites @replaceme into --replaced--, so the slot cached
+        # for the original key must not leak into the new command.
+        r set --replaced-- v1
+        assert_equal v1 [r get @replaceme]
+        assert_equal 1 [r del @replaceme]
+    }
+}

--- a/tests/unit/moduleapi/commandfilter.tcl
+++ b/tests/unit/moduleapi/commandfilter.tcl
@@ -177,42 +177,25 @@ start_server {tags {"external:skip"}} {
 # A command filter that changes argv invalidates everything the server already
 # derived from the pre-filter argv (looked up command, keys, slot, cross-slot
 # error). These tests make sure the outside world is refreshed accordingly.
-start_cluster 1 0 [list tags {modules cluster external:skip} config_lines [list "loadmodule [file normalize tests/modules/commandfilter.so] log-key 0"]] {
+start_cluster 1 0 [list tags {modules cluster external:skip} config_lines [list "loadmodule $testmodule log-key 0"]] {
     test {Command Filter refreshes cross-slot state when args are deleted} {
-        # "del {t}a @delme" is cross-slot before filtering, and a single-key
+        # "del a{t} @delme" is cross-slot before filtering, and a single-key
         # command after the filter deleted @delme. It must not be rejected.
-        assert_equal 0 [r del "{t}a" @delme]
+        assert_equal 0 [r del a{t} @delme]
 
-        r set "{t}a" v1
-        assert_equal 1 [r del "{t}a" @delme]
+        r set a{t} v1
+        assert_equal 1 [r del a{t} @delme]
 
         # Same thing for a read command with more than one key left.
-        r mset "{t}a" v1 "{t}b" v2
-        assert_equal {v1 v2} [r mget "{t}a" @delme "{t}b"]
+        r mset a{t} v1 b{t} v2
+        assert_equal {v1 v2} [r mget a{t} @delme b{t}]
     }
 
     test {Command Filter refreshes cross-slot state when args are inserted} {
         # "mget {t}a @insertafter" is a valid single-slot command before
         # filtering, but the filter appends --inserted-after--, which turns it
         # into a cross-slot command.
-        assert_error "CROSSSLOT*" {r mget "{t}a" @insertafter}
-    }
-
-    test {Command Filter refreshes cross-slot state on pipelined commands} {
-        # Pipelining makes the server parse and preprocess several commands
-        # up-front, so the filter runs against already-preprocessed state.
-        r del "{t}a"
-        set rd [redis_deferring_client]
-        $rd del "{t}a" @delme
-        $rd set "{t}a" v1
-        $rd del "{t}a" @delme
-        $rd mget "{t}a" @insertafter
-        $rd flush
-        assert_equal 0 [$rd read]
-        assert_equal {OK} [$rd read]
-        assert_equal 1 [$rd read]
-        assert_error "CROSSSLOT*" {$rd read}
-        $rd close
+        assert_error "CROSSSLOT*" {r mget a{t} @insertafter}
     }
 
     test {Command Filter refreshes the slot when a key argument is replaced} {


### PR DESCRIPTION
## MULTI/EXEC keys ACL permissions were not checked on EXEC

`execCommand()` rechecks the ACLs of every queued command before running it, so that permission changes made while the transaction was parked are honoured. Since 235e688b0 the key half of that check examined nothing: a client could queue commands while a key pattern was granted, and still read and write those keys after an operator revoked the pattern with `ACL SETUSER u resetkeys ...`. The same commands, issued fresh on the same connection, were correctly refused.

The key set used by the check is cached per pending command, and during a transaction the client's current pending command is `EXEC`, not the queued command being executed. `EXEC` has no keys, but its cached key result is flagged valid, so `ACLCheckAllUserCommandPerm()` seeded its cache with an empty key set, `ACLSelectorCheckCmd()` skipped key extraction, and `ACLSelectorCheckKey()` was never reached. The check returned `ACL_OK` having examined no key at all, which also made the dedicated error in `execCommand()` unreachable. Command permissions were still rechecked correctly, and the scripting call site was unaffected since the engine's fake client has no pending command.

`getClientCachedKeyResult()` and `ACLCheckAllPerm()` now take the `pendingCommand` whose keys are to be checked, instead of reading `c->current_pending_cmd`, and `execCommand()` passes the queued command. The cached result records key positions within a specific command's argv, so making it a caller obligation to hand over the command that `c->cmd` / `c->argv` were populated from keeps the two from drifting apart again. A `debugServerAssert()` in `ACLCheckAllPerm()` now checks that invariant.

The lazy `preprocessCommand()` call is limited to the command currently being read from the client. Commands queued in a MULTI were already preprocessed when they were parsed, and re-running preprocessing on one of them at EXEC time would look the command up again and overwrite `pcmd->cmd` after `execCommand()` had already copied it into `c->cmd`. A queued command whose cached result was invalidated (by a module command filter, which clears the pending command flags) now falls back to extracting keys from `c->argv`.

Note that `keys_result` records which argv positions hold keys, not an authorization decision, so the selectors are still evaluated as they stand at EXEC time.

Added a test that revokes a key pattern between queueing and `EXEC`, asserting that both a queued read and a queued write are refused, that the written value is left untouched, and that the refusals are recorded in `ACL LOG` with `context=multi` and `reason=key`. The existing test covering this scenario revokes a command rather than a key pattern, which is the half that kept working, so it passed regardless.

## Fixing lazy preprocessing when a module changes command keys

Since #14440 the command, keys, slot and read error are preprocessed at parse
time, but a command filter may insert/delete/replace arguments afterwards.
`moduleCallCommandFilters()` only reset part of that state, so what was derived
from the pre-filter argv — most notably the slot — could still be used later.
Today this is masked in practice: the only consumer, `getClientCachedKeyResult()`,
re-preprocesses lazily whenever the cached result was invalidated.

## How it is fixed

Instead of relying on that lazy path, track whether a filter actually changed
argv, and if so run `preprocessCommand()` right away on the new argv and sync
`c->lookedcmd` / `c->slot` / `c->read_error` from it. If no filter changed argv
there is nothing to refresh and we return early. The state is now always
consistent at the point it is produced, which also removes the lazy
preprocessing from `getClientCachedKeyResult()` (it asserts instead).



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security-sensitive ACL and command-preprocessing paths used at EXEC and by module filters; behavior is more correct but affects permission enforcement and cluster routing after argv mutation.
> 
> **Overview**
> Fixes a bug where **ACL key checks during `MULTI`/`EXEC` always passed** because `EXEC` was the client's current pending command (no keys), so the cached key list was empty and queued commands were never validated against key patterns revoked while the transaction was open.
> 
> **`ACLCheckAllPerm` and `getClientCachedKeyResult` now take the `pendingCommand` whose argv/keys are being checked** (nullable for fake clients). `execCommand` passes each queued command; normal command processing passes `c->current_pending_cmd`. An assert ties `pcmd->cmd` to `c->cmd` when a pending command is supplied.
> 
> **Module command filters** set `argv_changed` when they alter argv; if so, **`preprocessCommand` is run immediately** on the pending command and `c->lookedcmd` / slot / read error are synced. **`preprocessCommand` is safe to re-run** (clears prior cmd/keys/slot/read-error state first). Lazy preprocessing was removed from `getClientCachedKeyResult`.
> 
> Tests cover EXEC-time key ACL denial/logging and cluster cross-slot/slot behavior after filter insert/delete/replace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb3c29bfb69568e2ef331f7f995d466a4f1f01b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->