### PR TITLE
Fix stringmatchlen() not matching "" against the empty string

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -194,6 +194,17 @@ static int stringmatchlen_impl(const char *pattern, int patternLen,
             break;
         }
     }
+    /* A '*' matches zero characters, so if the string is exhausted but the
+     * remaining pattern is only '*' (possibly several), it's a match. This
+     * fixes patterns such as "*" not matching the empty string, which
+     * silently dropped empty set/hash/list/zset members during
+     * SCAN ... MATCH *. See redis/redis#15643. */
+    if (stringLen == 0) {
+        while (patternLen && *pattern == '*') {
+            pattern++;
+            patternLen--;
+        }
+    }
     if (patternLen == 0 && stringLen == 0)
         return 1;
     return 0;


### PR DESCRIPTION
## Issue
Fixes redis/redis#15643.

`stringmatchlen()` does not match `""` (and any pattern starting with `*`) against the empty string, silently dropping empty set/hash/list/zset members during `SCAN ... MATCH *`.

## Root cause
`stringmatchlen_impl` is guarded by `while (patternLen && stringLen)`. When the candidate string is empty (`stringLen == 0`) the loop body never executes, so a leading/trailing `*` (which matches zero characters) can never match, and the function falls through to `return 0`.

## Fix
After the loop, if the string is exhausted, consume any remaining `*` from the pattern (a `*` matches zero characters), then apply the existing `patternLen == 0 && stringLen == 0` → match check. This makes `*` (and patterns ending in `*`) correctly match the empty string, while `a*`, `*b`, `*foo*` with an empty candidate still correctly return no match.

## Verification
Compiled the two functions in isolation and ran the reported reproducer plus regression cases:

    stringmatchlen("*", 1, "", 0, 0) == 1   (was 0 — the bug)
    "*"~"abc"=1  "a*"~""=0  "*b"~""=0  "*foo*"~""=0  "**"~""=1  "?"~""=0

All 10 cases pass (see test output in commit discussion).

## Checklist
- [x] DCO sign-off (`Signed-off-by`)
- [x] No new public API / behavior change beyond the bug fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized behavior fix in internal glob matching with clear regression cases; no API or security surface change beyond correcting MATCH semantics for empty keys.
> 
> **Overview**
> Fixes glob matching so patterns made only of `*` (e.g. `MATCH *`) correctly match the **empty string**, which previously failed when both lengths were zero because `stringmatchlen_impl` never entered its main loop.
> 
> After the matching loop, when the candidate string is exhausted, the change **strips any remaining `*`** from the pattern (each matches zero characters) and then reuses the existing “both exhausted → match” check. That restores visibility of empty set/hash/list/zset members in **`SCAN ... MATCH *`** and similar `stringmatchlen` call sites, without changing cases where a non-`*` suffix still requires characters (e.g. `a*`, `*b` on `""`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a99b9bc8a17f17cd426a486ffd307c117dfa5c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->