### PR TITLE
Refactor ASM slot trimming

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2237,10 +2237,7 @@ void sflushCommand(client *c) {
     /* If client is AOF or master, we must obey the slot ranges. */
     int must_obey = mustObeyClient(c);
 
-    /* Iterate and find the slot ranges that belong to this node. Save them in
-     * a new slotRangeArray. It is allocated on heap since there is a chance
-     * that FLUSH SYNC will be running as blocking ASYNC and only later reply
-     * with slot ranges */
+    /* Iterate and find the slot ranges that belong to this node. */
     slotRangeArray *myslots = NULL;
     for (int i = 0; i < slots->num_ranges; i++) {
         for (int j = slots->ranges[i].start; j <= slots->ranges[i].end; j++) {
@@ -2257,9 +2254,6 @@ void sflushCommand(client *c) {
         return;
     }
     slotRangeArrayFree(slots);
-    
-    /* takes ownership of myslots */
-    asmTrimCtx *trim_ctx = asmTrimCtxCreate(myslots, server.db[0].keys);
 
     /* If the selected slots are exactly the same as the local slots, we can
      * simply flush the entire DB by flushCommandCommon. */
@@ -2268,10 +2262,9 @@ void sflushCommand(client *c) {
     slotRangeArrayFree(local_slots);
     if (all_slots_covered) {
         /* If not flush as blocking async, then reply immediately */
-        if (flushCommandCommon(c, FLUSH_TYPE_SLOTS, flags, trim_ctx) == 0) {
-            replySlotsFlush(c, trim_ctx->slots);
-        }
-        asmTrimCtxRelease(trim_ctx);
+        if (flushCommandCommon(c, FLUSH_TYPE_SLOTS, flags, myslots) == 0)
+            replySlotsFlush(c, myslots);
+        slotRangeArrayFree(myslots);
         return;
     }
 
@@ -2290,8 +2283,9 @@ void sflushCommand(client *c) {
     if (flags & EMPTYDB_ASYNC && server.loading == 0) {
         /* Update dirty stats before trimming. */
         server.dirty += getKeyCountInSlotRangeArray(myslots);
-        /* Pass client id for active trim to unblock client when trim completes. */
-        trim_method = asmTrimSlots(trim_ctx, blocking_async ? c->id : CLIENT_ID_NONE, 0);
+        /* Pass the client ID so either trim method can unblock the client when
+         * the trim completes. */
+        trim_method = asmTrimSlots(myslots, blocking_async ? c->id : CLIENT_ID_NONE, 0);
     } else {
         clusterDelKeysInSlotRangeArray(myslots, 1);
     }
@@ -2300,21 +2294,18 @@ void sflushCommand(client *c) {
      * SFLUSH will not be replicated nor put into the AOF. */
     forceCommandPropagation(c, PROPAGATE_REPL | PROPAGATE_AOF);
 
-    /* Handle waiting for trim job to complete in case of blocking async flush.
-     * Block the client and schedule completion callback based on trim method:
-     * - BG trim uses BIO lazyfree worker to trim the slots, so schedule a new
-     *   BIO lazyfree worker to wait for completion, then unblock client and reply.
-     * - Active trim works in cron job of the main thread, it will automatically
-     *   unblock client and reply in active trim completion. */
+    /* If a trim job was scheduled for a blocking async flush, block the client
+     * now. The job has recorded the client ID and will unblock and reply when
+     * finalized. */
     if (blocking_async && trim_method != ASM_TRIM_METHOD_NONE) {
         blockClientForAsyncFlush(c);
     } else {
         /* Reply with slot ranges that were flushed. SYNC and ASYNC mode will be
          * replied here immediately. */
-        replySlotsFlush(c, trim_ctx->slots);
+        replySlotsFlush(c, myslots);
     }
 
-    asmTrimCtxRelease(trim_ctx); /* if bg trim, released later by kvsAsyncFreeDoneCB() */
+    slotRangeArrayFree(myslots);
 }
 
 /* The READWRITE command just clears the READONLY command state. */

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -200,12 +200,12 @@ static void propagateTrimSlots(slotRangeArray *slots);
 void asmTrimJobSchedule(slotRangeArray *slots);
 void asmTrimJobProcessPending(void);
 void asmCancelPendingTrimJobs(void);
-static void asmTriggerActiveTrim(asmTrimJob *job);
+void asmTriggerActiveTrim(asmTrimJob *job);
 void asmActiveTrimEnd(void);
 int asmIsAnyTrimJobOverlaps(slotRangeArray *slots);
 void asmTrimSlotsIfNotOwned(slotRangeArray *slots);
 void asmNotifyStateChange(asmTask *task, int event);
-static void asmTrimJobUnblockClientAndFree(void *ptr);
+void asmTrimJobUnblockClientAndFree(void *ptr);
 
 void asmInit(void) {
     asmManager = zcalloc(sizeof(*asmManager));

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -3511,7 +3511,7 @@ void asmCancelPendingTrimJobs(void) {
 /* Finalize a trim job after completion or cancellation. If the job belongs to
  * a blocking SFLUSH client, reply with the trimmed slots and unblock it before
  * releasing all job-owned resources. */
-static void asmTrimJobUnblockClientAndFree(void *ptr) {
+void asmTrimJobUnblockClientAndFree(void *ptr) {
     asmTrimJob *job = ptr;
     if (job->client_id != 0) {
         /* Reply with the slot ranges that requested to be trimmed. Generally we
@@ -3640,7 +3640,7 @@ void asmActiveTrimStart(void) {
 }
 
 /* Schedule an active trim job, taking ownership of the job. */
-static void asmTriggerActiveTrim(asmTrimJob *job) {
+void asmTriggerActiveTrim(asmTrimJob *job) {
     listAddNodeTail(asmManager->active_trim_jobs, job);
     sds str = slotRangeArrayToString(job->slots);
     serverLog(LL_NOTICE, "Active trim scheduled for slots: %s", str);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -3110,8 +3110,7 @@ static void asmTrimJobPopulateDeltaHistograms(kvstore *kvs, void *userdata) {
  * Apply the histogram deltas, reply to the client, and free the trim job. */
 static void asmBackgroundTrimDoneCB(uint64_t client_id, void *userdata) {
     asmTrimJob *job = userdata;
-    serverAssert(job && job->bg);
-    serverAssert(job->client_id == client_id);
+    serverAssert(job && job->bg && job->client_id == client_id);
 
     kvstoreMetadata *meta = kvstoreGetMetadata(server.db[0].keys);
     /* Apply histogram deltas only if the target kvstore has not changed. */

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -3065,9 +3065,11 @@ void asmUnblockMasterAfterTrim(void) {
 }
 
 /* Create a trim job that takes ownership of slots. */
-static asmTrimJob *asmTrimJobCreate(slotRangeArray *slots) {
+static asmTrimJob *asmTrimJobCreate(slotRangeArray *slots, uint64_t client_id, int migration_cleanup) {
     asmTrimJob *job = zcalloc(sizeof(*job));
     job->slots = slots;
+    job->client_id = client_id;
+    job->migration_cleanup = migration_cleanup;
     return job;
 }
 
@@ -3250,18 +3252,13 @@ static void asmTriggerBackgroundTrim(asmTrimJob *job) {
  * If migration_cleanup is true, this is a migration cleanup of slots no longer owned. */
 
 /* Start a trim job and transfer its ownership to the selected trim method. */
-static int asmTrimJobStart(asmTrimJob *job, uint64_t client_id, int migration_cleanup) {
+static int asmTrimJobStart(asmTrimJob *job) {
     serverAssert(job != NULL);
 
     if (asmManager->debug_trim_method == ASM_DEBUG_TRIM_NONE) {
         asmTrimJobUnblockClientAndFree(job);
         return ASM_TRIM_METHOD_NONE;
     }
-
-    /* The trim implementation itself does not use the client ID, but the job
-     * keeps it so either completion path can unblock the waiting client. */
-    job->client_id = client_id;
-    job->migration_cleanup = migration_cleanup;
 
     /* Trigger active trim for the following cases:
      * 1. Debug override: trim method is set to 'active'.
@@ -3287,8 +3284,8 @@ static int asmTrimJobStart(asmTrimJob *job, uint64_t client_id, int migration_cl
 /* Trim slots using a job-owned copy. The caller retains ownership of slots. */
 int asmTrimSlots(slotRangeArray *slots, uint64_t client_id, int migration_cleanup) {
     serverAssert(slots != NULL);
-    return asmTrimJobStart(asmTrimJobCreate(slotRangeArrayDup(slots)),
-                           client_id, migration_cleanup);
+    return asmTrimJobStart(asmTrimJobCreate(slotRangeArrayDup(slots),
+                                            client_id, migration_cleanup));
 }
 
 /* Schedule a trim job for the specified slot ranges. The job will be
@@ -3297,7 +3294,7 @@ int asmTrimSlots(slotRangeArray *slots, uint64_t client_id, int migration_cleanu
  * For trim method details, see asmTrimSlots(). */
 void asmTrimJobSchedule(slotRangeArray *slots) {
     listAddNodeTail(asmManager->pending_trim_jobs,
-                    asmTrimJobCreate(slotRangeArrayDup(slots)));
+                    asmTrimJobCreate(slotRangeArrayDup(slots), CLIENT_ID_NONE, 1));
 }
 
 /* Process any pending trim jobs. */
@@ -3347,7 +3344,7 @@ void asmTrimJobProcessPending(void) {
          * for propagation after ownership transfer. */
         slotRangeArray *slots = slotRangeArrayDup(job->slots);
         listDelNode(asmManager->pending_trim_jobs, ln);
-        asmTrimJobStart(job, CLIENT_ID_NONE, 1);
+        asmTrimJobStart(job);
         propagateTrimSlots(slots);
         slotRangeArrayFree(slots);
     }

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -96,11 +96,18 @@ typedef struct asmTask {
     redisOpArray *post_stream_module_cmds;  /* Module commands to be propagated at the end of slot migration, just before STREAM-EOF */
 } asmTask;
 
-typedef struct activeTrimJob {
-    slotRangeArray *slots;      /* Slots being trimmed */
-    uint64_t client_id;         /* Client ID waiting for active trim completion (0 if none) */
-    int migration_cleanup;      /* Whether this is a migration cleanup of slots no longer owned */
-} activeTrimJob;
+typedef struct asmBgTrimState {
+    kvstore *target_kvstore;
+    keysizesHist delta_keysizes_hist;
+    keysizesHist delta_allocsizes_hist;
+} asmBgTrimState;
+
+typedef struct asmTrimJob {
+    slotRangeArray *slots; /* Slots being trimmed */
+    uint64_t client_id;    /* Client ID waiting for trim completion (0 if none) */
+    int migration_cleanup; /* Whether this is a migration cleanup of slots no longer owned */
+    asmBgTrimState *bg;    /* Allocated only for background trim */
+} asmTrimJob;
 
 /* ASM Manager: Global singleton that manages all ASM operations.
  * Coordinates migration tasks, trim jobs, and maintains statistics. */
@@ -193,12 +200,12 @@ static void propagateTrimSlots(slotRangeArray *slots);
 void asmTrimJobSchedule(slotRangeArray *slots);
 void asmTrimJobProcessPending(void);
 void asmCancelPendingTrimJobs(void);
-void asmTriggerActiveTrim(slotRangeArray *slots, uint64_t client_id, int migration_cleanup);
+static void asmTriggerActiveTrim(asmTrimJob *job);
 void asmActiveTrimEnd(void);
 int asmIsAnyTrimJobOverlaps(slotRangeArray *slots);
 void asmTrimSlotsIfNotOwned(slotRangeArray *slots);
 void asmNotifyStateChange(asmTask *task, int event);
-void activeTrimJobFreeMethod(void *ptr);
+static void asmTrimJobUnblockClientAndFree(void *ptr);
 
 void asmInit(void) {
     asmManager = zcalloc(sizeof(*asmManager));
@@ -215,7 +222,7 @@ void asmInit(void) {
     asmManager->active_trim_started = 0;
     asmManager->active_trim_completed = 0;
     asmManager->active_trim_cancelled = 0;
-    listSetFreeMethod(asmManager->active_trim_jobs, activeTrimJobFreeMethod);
+    listSetFreeMethod(asmManager->active_trim_jobs, asmTrimJobUnblockClientAndFree);
 }
 
 char *asmTaskStateToString(int state) {
@@ -2885,15 +2892,15 @@ int isSlotInTrimJob(int slot) {
     listNode *ln;
     listRewind(asmManager->pending_trim_jobs, &li);
     while ((ln = listNext(&li)) != NULL) {
-        slotRangeArray *slots = listNodeValue(ln);
-        if (slotRangeArrayOverlaps(slots, &req))
+        asmTrimJob *job = listNodeValue(ln);
+        if (slotRangeArrayOverlaps(job->slots, &req))
             return 1;
     }
 
     /* Check if the slot is in any active trim job. */
     listRewind(asmManager->active_trim_jobs, &li);
     while ((ln = listNext(&li)) != NULL) {
-        activeTrimJob *job = listNodeValue(ln);
+        asmTrimJob *job = listNodeValue(ln);
         if (slotRangeArrayOverlaps(job->slots, &req))
             return 1;
     }
@@ -3057,23 +3064,98 @@ void asmUnblockMasterAfterTrim(void) {
     }
 }
 
-/* Background Trim: Delete migrated keys asynchronously in BIO thread.
+/* Create a trim job that takes ownership of slots. */
+static asmTrimJob *asmTrimJobCreate(slotRangeArray *slots) {
+    asmTrimJob *job = zcalloc(sizeof(*job));
+    job->slots = slots;
+    return job;
+}
+
+/* Populate the histogram deltas while the detached slot dictionaries are
+ * owned by the BIO thread. The completion callback applies these deltas in
+ * the main thread before freeing the trim job. */
+static void asmTrimJobPopulateDeltaHistograms(kvstore *kvs, void *userdata) {
+    asmTrimJob *trim_job = userdata;
+    serverAssert(trim_job && trim_job->bg);
+
+    kvstoreIterator kvs_it;
+    kvstoreIteratorInit(&kvs_it, kvs);
+    dictEntry *de;
+
+    while ((de = kvstoreIteratorNext(&kvs_it)) != NULL) {
+        kvobj *kv = dictGetKV(de);
+        if (!kv) continue;
+        int64_t *keysizes_row = keysizesHistRow(trim_job->bg->delta_keysizes_hist, kv->type);
+        if (!keysizes_row) continue; /* untracked type, e.g. OBJ_MODULE */
+
+        size_t len = getObjectLength(kv);
+        int size_bin = (len == 0) ? 0 : log2ceil(len) + 1; /* Only strings can be empty */
+        debugServerAssert(size_bin < MAX_KEYSIZES_BINS);
+        keysizes_row[size_bin]++;
+
+        if (server.memory_tracking_enabled) {
+            int64_t *allocsizes_row = keysizesHistRow(trim_job->bg->delta_allocsizes_hist, kv->type);
+            size_t alloc_size = kvobjAllocSize(kv);
+            int alloc_bin = (alloc_size == 0) ? 0 : log2ceil(alloc_size) + 1;
+            debugServerAssert(alloc_bin < MAX_KEYSIZES_BINS);
+            allocsizes_row[alloc_bin]++;
+        }
+    }
+    kvstoreIteratorReset(&kvs_it);
+}
+
+/* Complete a background trim in the main thread after lazyfree finishes.
+ * Apply the histogram deltas, reply to the client, and free the trim job. */
+static void asmBackgroundTrimDoneCB(uint64_t client_id, void *userdata) {
+    asmTrimJob *job = userdata;
+    serverAssert(job && job->bg);
+    serverAssert(job->client_id == client_id);
+
+    kvstoreMetadata *meta = kvstoreGetMetadata(server.db[0].keys);
+    /* Apply histogram deltas only if the target kvstore has not changed. */
+    if (job->bg->target_kvstore == server.db[0].keys && meta) {
+        for (int row = 0; row < MAX_KEYSIZES_ROWS; row++) {
+            for (int bin = 0; bin < MAX_KEYSIZES_BINS; bin++) {
+                meta->keysizes_hist[row][bin] -= job->bg->delta_keysizes_hist[row][bin];
+                meta->allocsizes_hist[row][bin] -= job->bg->delta_allocsizes_hist[row][bin];
+            }
+        }
+    }
+
+    /* Decrement counter unconditionally to track job completion. If kvstore was
+     * replaced (e.g., by FLUSHALL), the new histogram is already consistent (reset
+     * to 0 for empty DB), so it's safe to resume assertions when counter reaches 0. */
+    debugServerAssert(asmManager->bg_trim_running > 0);
+    asmManager->bg_trim_running--;
+
+    /* Unblock and reply to the client if needed, then free the job. */
+    asmTrimJobUnblockClientAndFree(job);
+}
+
+/* Start a background trim and take ownership of the job.
  *
- * It works by moving entire slot data structures (dictionaries) to temporary
- * kvstores, then handing them off to BIO thread for deletion.
- *
- * @param trim_ctx Context for slot ranges and histogram tracking  
- * @param migration_cleanup True if this is post-migration cleanup (fires module events)
- */
-void asmTriggerBackgroundTrim(asmTrimCtx *trim_ctx, int migration_cleanup) {
-    slotRangeArray *slots = trim_ctx->slots;
+ * Initialize the background state and move the slot data structures to temporary
+ * kvstores. Queue a lazyfree job to collect histogram deltas and release the
+ * detached data, followed by a completion request that notifies the main thread
+ * to apply the deltas, reply to the client if needed. */
+static void asmTriggerBackgroundTrim(asmTrimJob *job) {
+    /* Allocate histogram tracking state only for background trim. */
+    serverAssert(job && job->bg == NULL);
+    job->bg = zcalloc(sizeof(*job->bg));
+    /* Save the target kvstore for completion validation. */
+    job->bg->target_kvstore = server.db[0].keys;
+
+    /* Increment background trim counter. */
+    asmManager->bg_trim_running++;
+
+    slotRangeArray *slots = job->slots;
     RedisModuleClusterSlotMigrationTrimInfoV1 fsi = {
             REDISMODULE_CLUSTER_SLOT_MIGRATION_TRIMINFO_VERSION,
             (RedisModuleSlotRangeArray *) slots
     };
 
     /* Fire the trim event to modules only if this is a migration cleanup. */
-    if (migration_cleanup)
+    if (job->migration_cleanup)
         moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM,
                 REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_BACKGROUND,
                 &fsi);
@@ -3105,7 +3187,11 @@ void asmTriggerBackgroundTrim(asmTrimCtx *trim_ctx, int migration_cleanup) {
     /* Move stream IDMP keys from main DB to temp dict (O(IDMP entries x number of slot ranges)) */
     streamMoveIdmpKeys(server.db[0].stream_idmp_keys, stream_idmp_keys, slots);
 
-    emptyDbDataAsync(keys, expires, subexpires, stream_idmp_keys, trim_ctx);
+    emptyDbDataAsync(keys, expires, subexpires, stream_idmp_keys,
+                     asmTrimJobPopulateDeltaHistograms, job);
+
+    /* Queue completion after the lazyfree job on the same BIO worker. */
+    bioCreateCompRq(BIO_WORKER_LAZY_FREE, asmBackgroundTrimDoneCB, job->client_id, job);
 
     sds str = slotRangeArrayToString(slots);
     serverLog(LL_NOTICE, "Background trim started for slots: %s to trim %zu keys.", str, total_keys);
@@ -3163,40 +3249,19 @@ void asmTriggerBackgroundTrim(asmTrimCtx *trim_ctx, int migration_cleanup) {
  * If client_id is non-zero, the client will be unblocked when trim completes.
  * If migration_cleanup is true, this is a migration cleanup of slots no longer owned. */
 
-/* Create ASM trim context with refcount=1 */
-asmTrimCtx *asmTrimCtxCreate(slotRangeArray *slots, kvstore *target_kvstore) {
-    asmTrimCtx *ctx = zcalloc(sizeof(asmTrimCtx));
-    ctx->refcount = 1;
-    ctx->slots = slots;
-    ctx->target_kvstore = target_kvstore;
-    /* delta histograms are zero-initialized by zcalloc */
-    return ctx;
-}
+/* Start a trim job and transfer its ownership to the selected trim method. */
+static int asmTrimJobStart(asmTrimJob *job, uint64_t client_id, int migration_cleanup) {
+    serverAssert(job != NULL);
 
-/* Increment refcount */
-void asmTrimCtxRetain(asmTrimCtx *ctx) {
-    if (!ctx) return;
-    ctx->refcount++;
-}
-
-/* Decrement refcount, free if reaches 0 */
-void asmTrimCtxRelease(asmTrimCtx *ctx) {
-    if (!ctx) return;
-
-    serverAssert(ctx->refcount > 0);
-    ctx->refcount--;
-
-    if (ctx->refcount == 0) {
-        slotRangeArrayFree(ctx->slots);
-        zfree(ctx);
-    }
-}
-
-int asmTrimSlots(asmTrimCtx *ctx, uint64_t client_id, int migration_cleanup) {
-    serverAssert(ctx != NULL);
-
-    if (asmManager->debug_trim_method == ASM_DEBUG_TRIM_NONE)
+    if (asmManager->debug_trim_method == ASM_DEBUG_TRIM_NONE) {
+        asmTrimJobUnblockClientAndFree(job);
         return ASM_TRIM_METHOD_NONE;
+    }
+
+    /* The trim implementation itself does not use the client ID, but the job
+     * keeps it so either completion path can unblock the waiting client. */
+    job->client_id = client_id;
+    job->migration_cleanup = migration_cleanup;
 
     /* Trigger active trim for the following cases:
      * 1. Debug override: trim method is set to 'active'.
@@ -3211,19 +3276,19 @@ int asmTrimSlots(asmTrimCtx *ctx, uint64_t client_id, int migration_cleanup) {
                      (asmManager->debug_trim_method == ASM_DEBUG_TRIM_DEFAULT &&
                       moduleHasSubscribersForKeyspaceEvent(NOTIFY_KEY_TRIMMED));
     if (activetrim) {
-        asmTriggerActiveTrim(ctx->slots, client_id, migration_cleanup);
+        asmTriggerActiveTrim(job);
     } else {
-        /* Background trim:
-         * - Retain ctx for kvsAsyncFreeDoneCB() to release ctx later
-         * - Trigger background trim. Also updates ctx delta histogram.
-         * - Schedule completion cb to deduce delta histogram from DB */
-        asmBgTrimCounterIncr();
-        asmTrimCtxRetain(ctx);
-        asmTriggerBackgroundTrim(ctx, migration_cleanup);
-        bioCreateCompRq(BIO_WORKER_LAZY_FREE, kvsAsyncFreeDoneCB, client_id, ctx);
+        asmTriggerBackgroundTrim(job);
     }
 
     return activetrim ? ASM_TRIM_METHOD_ACTIVE : ASM_TRIM_METHOD_BG;
+}
+
+/* Trim slots using a job-owned copy. The caller retains ownership of slots. */
+int asmTrimSlots(slotRangeArray *slots, uint64_t client_id, int migration_cleanup) {
+    serverAssert(slots != NULL);
+    return asmTrimJobStart(asmTrimJobCreate(slotRangeArrayDup(slots)),
+                           client_id, migration_cleanup);
 }
 
 /* Schedule a trim job for the specified slot ranges. The job will be
@@ -3231,7 +3296,8 @@ int asmTrimSlots(asmTrimCtx *ctx, uint64_t client_id, int migration_cleanup) {
  * asmBeforeSleep() to ensure it only runs when there is no write pause. 
  * For trim method details, see asmTrimSlots(). */
 void asmTrimJobSchedule(slotRangeArray *slots) {
-    listAddNodeTail(asmManager->pending_trim_jobs, slotRangeArrayDup(slots));
+    listAddNodeTail(asmManager->pending_trim_jobs,
+                    asmTrimJobCreate(slotRangeArrayDup(slots)));
 }
 
 /* Process any pending trim jobs. */
@@ -3274,16 +3340,16 @@ void asmTrimJobProcessPending(void) {
     }
     logged = 0;
 
-    listIter li;
     listNode *ln;
-    listRewind(asmManager->pending_trim_jobs, &li);
-    while ((ln = listNext(&li)) != NULL) {
-        slotRangeArray *slots = listNodeValue(ln);
-        asmTrimCtx *ctx = asmTrimCtxCreate(slots, server.db[0].keys);
-        asmTrimSlots(ctx, CLIENT_ID_NONE, 1);  
-        propagateTrimSlots(slots);
+    while ((ln = listFirst(asmManager->pending_trim_jobs)) != NULL) {
+        asmTrimJob *job = listNodeValue(ln);
+        /* asmTrimJobStart() consumes the job. Keep an independent slots copy
+         * for propagation after ownership transfer. */
+        slotRangeArray *slots = slotRangeArrayDup(job->slots);
         listDelNode(asmManager->pending_trim_jobs, ln);
-        asmTrimCtxRelease(ctx); /* Release ctx (if bg trim, released later by kvsAsyncFreeDoneCB) */
+        asmTrimJobStart(job, CLIENT_ID_NONE, 1);
+        propagateTrimSlots(slots);
+        slotRangeArrayFree(slots);
     }
 }
 
@@ -3437,24 +3503,27 @@ void asmCancelPendingTrimJobs(void) {
     listNode *ln;
     listRewind(asmManager->pending_trim_jobs, &li);
     while ((ln = listNext(&li)) != NULL) {
-        slotRangeArray *slots = listNodeValue(ln);
-        listDelNode(asmManager->pending_trim_jobs, ln);
-        sds str = slotRangeArrayToString(slots);
+        asmTrimJob *job = listNodeValue(ln);
+        sds str = slotRangeArrayToString(job->slots);
         serverLog(LL_NOTICE, "Cancelling the pending trim job for slots: %s", str);
         sdsfree(str);
-        slotRangeArrayFree(slots);
+        listDelNode(asmManager->pending_trim_jobs, ln);
+        asmTrimJobUnblockClientAndFree(job);
     }
 }
 
-/* Free an activeTrimJob and unblock pending client if needed. */
-void activeTrimJobFreeMethod(void *ptr) {
-    activeTrimJob *job = ptr;
+/* Finalize a trim job after completion or cancellation. If the job belongs to
+ * a blocking SFLUSH client, reply with the trimmed slots and unblock it before
+ * releasing all job-owned resources. */
+static void asmTrimJobUnblockClientAndFree(void *ptr) {
+    asmTrimJob *job = ptr;
     if (job->client_id != 0) {
         /* Reply with the slot ranges that requested to be trimmed. Generally we
          * cancel trim jobs as the dataset is reset, no need to trim anymore. */
         unblockClientForAsyncFlush(job->client_id, job->slots);
     }
-    if (job->slots) slotRangeArrayFree(job->slots);
+    slotRangeArrayFree(job->slots);
+    if (job->bg) zfree(job->bg);
     zfree(job);
 }
 
@@ -3475,6 +3544,7 @@ void asmCancelTrimJobs(void) {
     serverLog(LL_NOTICE, "Cancelling all active trim jobs");
     asmManager->active_trim_cancelled += listLength(asmManager->active_trim_jobs);
     asmActiveTrimEnd();
+    /* The list free method unblocks clients and frees the remaining jobs. */
     listEmpty(asmManager->active_trim_jobs);
 }
 
@@ -3519,7 +3589,6 @@ void trimslotsCommand(client *c) {
          * command may have an update for the same key that is supposed to be
          * trimmed. We have to trim the keys synchronously. */
         clusterDelKeysInSlotRangeArray(slots, 1);
-        slotRangeArrayFree(slots);
     } else {
         /* We cannot trim any slot served by this node. */
         if (clusterNodeIsMaster(getMyClusterNode())) {
@@ -3533,11 +3602,9 @@ void trimslotsCommand(client *c) {
                 }
             }
         }
-        asmTrimCtx *ctx = asmTrimCtxCreate(slots, server.db[0].keys);
-        asmTrimSlots(ctx, CLIENT_ID_NONE, 1);
-        /* Release ctx - if bg trim, will be freed when BIO completes */
-        asmTrimCtxRelease(ctx);
+        asmTrimSlots(slots, CLIENT_ID_NONE, 1);
     }
+    slotRangeArrayFree(slots);
 
     /* Command will not be propagated automatically since it does not modify
      * the dataset. */
@@ -3547,7 +3614,7 @@ void trimslotsCommand(client *c) {
 
 /* Start the active trim job. */
 void asmActiveTrimStart(void) {
-    activeTrimJob *job = listNodeValue(listFirst(asmManager->active_trim_jobs));
+    asmTrimJob *job = listNodeValue(listFirst(asmManager->active_trim_jobs));
     slotRangeArray *slots = job->slots;
 
     serverAssert(asmManager->active_trim_it == NULL);
@@ -3576,15 +3643,10 @@ void asmActiveTrimStart(void) {
     sdsfree(str);
 }
 
-/* Schedule an active trim job with optional client waiting for completion. */
-void asmTriggerActiveTrim(slotRangeArray *slots, uint64_t client_id, int migration_cleanup) {
-    activeTrimJob *job = zmalloc(sizeof(*job));
-    job->slots = slotRangeArrayDup(slots);
-    job->client_id = client_id;
-    job->migration_cleanup = migration_cleanup;
-
+/* Schedule an active trim job, taking ownership of the job. */
+static void asmTriggerActiveTrim(asmTrimJob *job) {
     listAddNodeTail(asmManager->active_trim_jobs, job);
-    sds str = slotRangeArrayToString(slots);
+    sds str = slotRangeArrayToString(job->slots);
     serverLog(LL_NOTICE, "Active trim scheduled for slots: %s", str);
     sdsfree(str);
 
@@ -3597,7 +3659,7 @@ void asmTriggerActiveTrim(slotRangeArray *slots, uint64_t client_id, int migrati
 
 /* End the active trim job. */
 void asmActiveTrimEnd(void) {
-    activeTrimJob *job = listNodeValue(listFirst(asmManager->active_trim_jobs));
+    asmTrimJob *job = listNodeValue(listFirst(asmManager->active_trim_jobs));
     slotRangeArray *slots = job->slots;
 
     if (asmManager->active_trim_it) {
@@ -3623,6 +3685,8 @@ void asmActiveTrimEnd(void) {
     serverLog(LL_NOTICE, "Active trim completed for slots: %s, %llu keys trimmed.",
               str, asmManager->active_trim_current_job_trimmed);
     sdsfree(str);
+    /* Removing the node invokes the list free method, which unblocks the
+     * client if needed and frees the job. */
     listDelNode(asmManager->active_trim_jobs, listFirst(asmManager->active_trim_jobs));
     asmManager->active_trim_completed++;
 }
@@ -3636,19 +3700,6 @@ int asmIsAnyTrimJobOverlaps(slotRangeArray *slots) {
         }
     }
     return 0;
-}
-
-/* Decrement background trim counter. Called from completion callback. */
-void asmBgTrimCounterDecr(void) {
-    if (!asmManager) return;
-    debugServerAssert(asmManager->bg_trim_running > 0);
-    asmManager->bg_trim_running--;
-}
-
-/* Increment background trim counter. */
-void asmBgTrimCounterIncr(void) {
-    if (!asmManager) return;
-    asmManager->bg_trim_running++;
 }
 
 /* Check if background trim is running (for skipping debug assertions). */
@@ -3754,7 +3805,7 @@ void asmActiveTrimCycle(void) {
     timelimit = 1000000 * trim_cycle_time_perc / server.hz / 100;
     if (timelimit <= 0) timelimit = 1;
 
-    activeTrimJob *job = listNodeValue(listFirst(asmManager->active_trim_jobs));
+    asmTrimJob *job = listNodeValue(listFirst(asmManager->active_trim_jobs));
 
     serverAssert(asmManager->active_trim_it);
     int slot = slotRangeArrayGetCurrentSlot(asmManager->active_trim_it);

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -57,13 +57,6 @@ int asmGetTrimmingSlotForCommand(struct redisCommand *cmd, robj **argv, int argc
 void asmActiveTrimCycle(void);
 int asmIsKeyInTrimJob(sds keyname);
 int asmModulePropagateForSlotMigration(struct redisCommand *cmd, robj **argv, int argc);
-int asmTrimSlots(struct asmTrimCtx *ctx, uint64_t client_id, int migration_cleanup);
+int asmTrimSlots(struct slotRangeArray *slots, uint64_t client_id, int migration_cleanup);
 int asmIsBgTrimRunning(void);
-void asmBgTrimCounterDecr(void);
-void asmBgTrimCounterIncr(void);
-
-/* Context for ASM background trim */
-struct asmTrimCtx *asmTrimCtxCreate(struct slotRangeArray *slots, kvstore *target_kvstore);
-void asmTrimCtxRetain(struct asmTrimCtx *ctx);
-void asmTrimCtxRelease(struct asmTrimCtx *ctx);
 #endif

--- a/src/db.c
+++ b/src/db.c
@@ -1300,35 +1300,11 @@ void blockClientForAsyncFlush(client *c) {
     blockClient(c, BLOCKED_LAZYFREE);
 }
 
-/* CB function on blocking ASYNC FLUSH/TRIM completion.
- * We will unblock the client and send the proper reply if provided. */
-void kvsAsyncFreeDoneCB(uint64_t client_id, void *userdata) {
-
-    /* If ASM Trim context provided, apply histogram delta */
-    asmTrimCtx *ctx = userdata;
-    if (ctx) {
-        kvstoreMetadata *meta = kvstoreGetMetadata(server.db[0].keys);
-        /* Apply histogram delta only if target_kvstore hasn't changed */
-        if (ctx->target_kvstore == server.db[0].keys && meta) {
-            /* Subtract the delta from the live histogram. Both histograms have
-             * the same shape, so plain row-by-row subtraction is enough. */
-            for (int row = 0; row < MAX_KEYSIZES_ROWS; row++) {
-                for (int bin = 0; bin < MAX_KEYSIZES_BINS; bin++) {
-                    meta->keysizes_hist[row][bin] -= ctx->delta_keysizes_hist[row][bin];
-                    meta->allocsizes_hist[row][bin] -= ctx->delta_allocsizes_hist[row][bin];
-                }
-            }
-        }
-        /* Decrement counter unconditionally to track job completion. If kvstore was
-         * replaced (e.g., by FLUSHALL), the new histogram is already consistent (reset
-         * to 0 for empty DB), so it's safe to resume assertions when counter reaches 0. */
-        asmBgTrimCounterDecr();
-    }
-
-    unblockClientForAsyncFlush(client_id, (ctx) ? ctx->slots : NULL);
-
-    /* Release context and slots */
-    asmTrimCtxRelease(ctx);
+/* CB function on blocking ASYNC FLUSH completion. */
+static void kvsAsyncFreeDoneCB(uint64_t client_id, void *userdata) {
+    slotRangeArray *slots = userdata;
+    unblockClientForAsyncFlush(client_id, slots);
+    slotRangeArrayFree(slots);
 }
 
 /* Unblock client on async flush/trim completion */
@@ -1376,10 +1352,10 @@ void unblockClientForAsyncFlush(uint64_t client_id, struct slotRangeArray *slots
  * Return 1 indicates that flush SYNC is actually running in bg as blocking ASYNC
  * Return 0 otherwise
  *
- * trim_ctx - provided only by SFLUSH command, otherwise NULL. Contains slots to
- *            be used on completion to reply with the slots flush result. 
+ * slots - provided only by SFLUSH command, otherwise NULL. Used on completion
+ *         to reply with the slots flush result; ownership remains with caller.
  */
-int flushCommandCommon(client *c, int type, int flags, asmTrimCtx *trim_ctx) {
+int flushCommandCommon(client *c, int type, int flags, slotRangeArray *slots) {
     int blocking_async = 0; /* Flush SYNC option to run as blocking ASYNC */
 
     /* in case of SYNC, check if we can optimize and run it in bg as blocking ASYNC */
@@ -1403,12 +1379,8 @@ int flushCommandCommon(client *c, int type, int flags, asmTrimCtx *trim_ctx) {
      * lazyfree jobs in queue were processed */
     if (blocking_async) {
         blockClientForAsyncFlush(c);
-        /* Retain trim_ctx if provided so kvsAsyncFreeDoneCB can release it later */
-        if (trim_ctx) {
-            asmBgTrimCounterIncr();
-            asmTrimCtxRetain(trim_ctx);
-        }
-        bioCreateCompRq(BIO_WORKER_LAZY_FREE, kvsAsyncFreeDoneCB, c->id, trim_ctx);
+        bioCreateCompRq(BIO_WORKER_LAZY_FREE, kvsAsyncFreeDoneCB, c->id,
+                        slots ? slotRangeArrayDup(slots) : NULL);
     }
 
 #if defined(USE_JEMALLOC)

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -3,7 +3,6 @@
 #include "atomicvar.h"
 #include "functions.h"
 #include "cluster.h"
-#include "cluster_asm.h"
 #include "ebuckets.h"
 
 static redisAtomic size_t lazyfree_objects = 0;
@@ -18,52 +17,20 @@ void lazyfreeFreeObject(void *args[]) {
     atomicIncr(lazyfreed_objects,1);
 }
 
-/* Populate delta histograms by iterating through keys in the kvstore. To be 
- * deduced from the main db histogram later on kvsAsyncFreeDoneCB */
-static void populateDeltaHistograms(kvstore *kvs, asmTrimCtx *ctx) {
-    kvstoreIterator kvs_it;
-    kvstoreIteratorInit(&kvs_it, kvs);
-    dictEntry *de;
-
-    while ((de = kvstoreIteratorNext(&kvs_it)) != NULL) {
-        kvobj *kv = dictGetKV(de);
-        if (!kv) continue;
-        int64_t *keysizesRow = keysizesHistRow(ctx->delta_keysizes_hist, kv->type);
-        if (!keysizesRow) continue; /* untracked type, e.g. OBJ_MODULE */
-
-        /* Update keysizes_hist delta */
-        size_t len = getObjectLength(kv);
-        int sizeBin = (len == 0) ? 0 : log2ceil(len) + 1; /* Only strings can be empty */
-        debugServerAssert(sizeBin < MAX_KEYSIZES_BINS);
-        keysizesRow[sizeBin]++;
-
-        /* Update allocsizes_hist delta */
-        if (server.memory_tracking_enabled) {
-            int64_t *allocsizesRow = keysizesHistRow(ctx->delta_allocsizes_hist, kv->type);
-            size_t alloc_size = kvobjAllocSize(kv);
-            int allocBin = (alloc_size == 0) ? 0 : log2ceil(alloc_size) + 1;
-            debugServerAssert(allocBin < MAX_KEYSIZES_BINS);
-            allocsizesRow[allocBin]++;
-        }
-    }
-    kvstoreIteratorReset(&kvs_it);
-}
-
 /* Release a database from the lazyfree thread. The 'db' pointer is the
  * database which was substituted with a fresh one in the main thread
- * when the database was logically deleted.
- *
- * If args[3] is provided, it's an asmTrimCtx for tracking histogram deltas
- * during ASM background trim. */
-void kvsLazyfreeFree(void *args[]) {
+ * when the database was logically deleted. */
+static void lazyfreeFreeKvs(void *args[]) {
     kvstore *da1 = args[0];
     kvstore *da2 = args[1];
     estore *subexpires = args[2];
     dict *stream_idmp_keys = args[3];
-    asmTrimCtx *ctx = args[4];  /* Optional: ASM trim context */
 
-    /* If ASM context provided, populate delta histograms */
-    if (ctx) populateDeltaHistograms(da1, ctx);
+    /* Run the optional callback in the BIO thread before releasing the
+     * detached kvstores. args[4] holds the callback and args[5] its userdata. */
+    lazyfreeKvsCallback callback = (lazyfreeKvsCallback)(uintptr_t)args[4];
+    void *userdata = args[5];
+    if (callback) callback(da1, userdata);
 
     estoreRelease(subexpires);
     dictRelease(stream_idmp_keys);
@@ -343,13 +310,18 @@ void emptyDbAsync(redisDb *db) {
     db->subexpires = estoreCreate(&subexpiresBucketsType, slot_count_bits);
     db->stream_idmp_keys = dictCreate(&objectKeyNoValueDictType);
     protectClientReplyObjects(); /* Protect client reply objects before async free. */
-    emptyDbDataAsync(oldkeys, oldexpires, oldsubexpires, old_stream_idmp_keys, NULL);
+    emptyDbDataAsync(oldkeys, oldexpires, oldsubexpires, old_stream_idmp_keys, NULL, NULL);
 }
 
-/* Empty a kvstore data asynchronously. */
-void emptyDbDataAsync(kvstore *keys, kvstore *expires, ebuckets hexpires, dict *stream_idmp_keys, asmTrimCtx *ctx) {
+/* Empty kvstore data asynchronously. If callback is provided, invoke it from
+ * the BIO thread before releasing the detached kvstores. */
+void emptyDbDataAsync(kvstore *keys, kvstore *expires, ebuckets hexpires,
+                      dict *stream_idmp_keys, lazyfreeKvsCallback callback, void *userdata) {
+    serverAssert(callback || userdata == NULL);
+
     atomicIncr(lazyfree_objects, kvstoreSize(keys));
-    bioCreateLazyFreeJob(kvsLazyfreeFree, 5, keys, expires, hexpires, stream_idmp_keys, ctx);
+    bioCreateLazyFreeJob(lazyfreeFreeKvs, 6, keys, expires, hexpires, stream_idmp_keys,
+                         (void *)(uintptr_t)callback, userdata);
 }
 
 /* Free the key tracking table.

--- a/src/server.h
+++ b/src/server.h
@@ -1271,15 +1271,6 @@ typedef struct {
     uint64_t network_bytes_out; /* Network egress (in bytes) sent for given slot */
 } kvstoreDictMetadata;
 
-/* Context for ASM background trim with delta histogram tracking */
-typedef struct asmTrimCtx {
-    int refcount;                      /* For shared bg/main thread ownership */
-    struct slotRangeArray *slots;      /* Slot ranges being trimmed */
-    kvstore *target_kvstore;           /* Target kvstore to update (for validation) */
-    keysizesHist delta_keysizes_hist;  /* Delta populated by BIO thread */
-    keysizesHist delta_allocsizes_hist;/* Delta populated by BIO thread */
-} asmTrimCtx;
-
 /* forward declaration for functions ctx */
 typedef struct functionsLibCtx functionsLibCtx;
 
@@ -4338,8 +4329,7 @@ kvobj *dbUnshareStringValueByLink(redisDb *db, robj *key, kvobj *kv, dictEntryLi
 #define FLUSH_TYPE_DB    1
 #define FLUSH_TYPE_SLOTS 2
 void replySlotsFlush(client *c, struct slotRangeArray *slots);
-int flushCommandCommon(client *c, int type, int flags, struct asmTrimCtx *trim_ctx);
-void kvsAsyncFreeDoneCB(uint64_t client_id, void *userdata);
+int flushCommandCommon(client *c, int type, int flags, struct slotRangeArray *slots);
 void unblockClientForAsyncFlush(uint64_t client_id, struct slotRangeArray *slots);
 void blockClientForAsyncFlush(client *c);
 #define EMPTYDB_NO_FLAGS 0      /* No flags. */
@@ -4361,7 +4351,9 @@ int parseScanCursorOrReply(client *c, robj *o, unsigned long long *cursor);
 int dbAsyncDelete(redisDb *db, robj *key);
 void emptyDbAsync(redisDb *db);
 void streamMoveIdmpKeys(dict *src, dict *dst, struct slotRangeArray *slots);
-void emptyDbDataAsync(kvstore *keys, kvstore *expires, ebuckets hexpires, dict *stream_idmp_keys, struct asmTrimCtx *ctx);
+typedef void (*lazyfreeKvsCallback)(kvstore *kvs, void *userdata);
+void emptyDbDataAsync(kvstore *keys, kvstore *expires, ebuckets hexpires,
+                      dict *stream_idmp_keys, lazyfreeKvsCallback callback, void *userdata);
 size_t lazyfreeGetPendingObjectsCount(void);
 size_t lazyfreeGetFreedObjectsCount(void);
 void lazyfreeResetStats(void);


### PR DESCRIPTION
This PR follows up on the discussion in [#14877](https://github.com/redis/redis/pull/14877#discussion_r2944268070) and simplifies the ownership model used by ASM slot trimming.

- Use a single asmTrimJob to represent pending, active, and background trim jobs.
- Create the job when trimming is scheduled and transfer its ownership to the selected trim method.
- Remove asmTrimCtx and its reference counting.
- Allocate histogram tracking state only for background trims.
- Keep lazyfree.c independent of ASM by using a generic callback to collect histogram deltas in the BIO thread.

With this model, active jobs are released by the active-job list, while background jobs are released by their completion callback.

Test: enable sflush command, then run the following tests successfully
```
./runtest \
  --single unit/cluster/multi-slot-operations \
  --tags "cluster experimental modules " \       
  --config cluster-slot-stats-enabled yes \
  --verbose \
  --dump-logs
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster SFLUSH/slot trim, blocking async flush, and keysizes histogram updates during background trim—behavior-sensitive but largely an ownership refactor with explicit completion paths.
> 
> **Overview**
> **Refactors ASM slot trimming** so one `asmTrimJob` owns slots, optional blocking `client_id`, migration-cleanup flag, and background-only histogram state—replacing separate `activeTrimJob` / `asmTrimCtx` and reference counting.
> 
> **Call sites** (`SFLUSH`, `TRIMSLOTS`, pending/active trim lists) pass `slotRangeArray *` into `asmTrimSlots()` (which duplicates when starting a job) or hand a job to `asmTrimJobStart()` / `asmTriggerActiveTrim()`. **Background trim** moves slot dicts to temp kvstores, uses `emptyDbDataAsync()` with a generic `lazyfreeKvsCallback` to build histogram deltas on the BIO thread, then `asmBackgroundTrimDoneCB` on the main thread applies deltas, decrements `bg_trim_running`, and frees via `asmTrimJobUnblockClientAndFree`.
> 
> **Flush path** is split: blocking async **FLUSH** completion only unblocks and frees a dup’d `slots` array; ASM trim completion no longer goes through `kvsAsyncFreeDoneCB` in `db.c`. **`lazyfree.c`** no longer includes ASM headers or `asmTrimCtx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a51ee8cc81ad0e7161c9fdb7c749725e9c769362. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->