### PR TITLE
Finalize master ASM tasks in common topology handling

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2494,12 +2494,24 @@ static void clusterFireTopologyChangeEventIfNeeded(void) {
         .version = REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_INFO_VERSION,
         .change_flags = module_flags,
     };
-    server.cluster_topology_change_flags = 0;
     moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE, 0, &info);
 }
 
 /* Handle common cluster work after cluster implementation-specific beforeSleep(). */
 void clusterCommonBeforeSleep(void) {
     asmBeforeSleep();
+
+    /* The legacy cluster records a role change before it finishes transferring
+     * slot ownership during promotion. Finalize the previous master's ASM task
+     * here, after implementation-specific topology updates are complete. */
+    if (server.cluster_topology_change_flags & CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE) {
+        if (clusterNodeIsMaster(getMyClusterNode())) {
+            asmFinalizeMasterTask();
+        }
+    }
+
     clusterFireTopologyChangeEventIfNeeded();
+
+    /* Finally reset topology change flags explicitly here. */
+    server.cluster_topology_change_flags = 0;
 }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4398,9 +4398,6 @@ void clusterFailoverReplaceYourMaster(void) {
 
     /* 5) If there was a manual failover in progress, clear the state. */
     resetManualFailover();
-
-    /* 6) Handle the ASM task from previous master. */
-    asmFinalizeMasterTask();
 }
 
 /* This function is called if we are a slave node and our master serving


### PR DESCRIPTION
ASM task finalization after promotion was handled directly by the legacy cluster
failover path. This made the behavior specific to one cluster implementation,
even though finalizing an inherited master task is common cluster behavior.

This change moves the handling into `clusterCommonBeforeSleep()`. When a role
topology change leaves the local node as master, Redis finalizes the inherited
ASM task after implementation-specific topology processing has completed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bcc5e43fec003d50c6730f0eced1d043075e0104. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->