### PR TITLE
Preprocess command when a command filter modifies argv

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -383,10 +383,8 @@ typedef struct RedisModuleCommandFilterCtx {
     RedisModuleString **argv;
     int argv_len;
     int argc;
-    /* Set to 1 as soon as one of the filters modifies argv (insert, replace or
-     * delete), so that the caller knows it has to refresh whatever it cached
-     * about the command. */
-    int argv_changed;
+    int argv_changed; /* Set when a filter modified argv, so the caller knows
+                       * it must refresh what it cached about the command. */
     client *c;
 } RedisModuleCommandFilterCtx;
 

--- a/src/module.c
+++ b/src/module.c
@@ -383,6 +383,10 @@ typedef struct RedisModuleCommandFilterCtx {
     RedisModuleString **argv;
     int argv_len;
     int argc;
+    /* Set to 1 as soon as one of the filters modifies argv (insert, replace or
+     * delete), so that the caller knows it has to refresh whatever it cached
+     * about the command. */
+    int argv_changed;
     client *c;
 } RedisModuleCommandFilterCtx;
 
@@ -11999,6 +12003,7 @@ void moduleCallCommandFilters(client *c) {
         .argv = c->argv,
         .argv_len = c->argv_len,
         .argc = c->argc,
+        .argv_changed = 0,
         .c = c
     };
 
@@ -12014,6 +12019,9 @@ void moduleCallCommandFilters(client *c) {
         f->callback(&filter);
     }
 
+    /* Nothing was modified by the filters, there's nothing to refresh. */
+    if (!filter.argv_changed) return;
+
     /* If the filter sets a new command, including command or subcommand,
      * the command looked up will be invalid. */
     c->lookedcmd = NULL;
@@ -12022,7 +12030,9 @@ void moduleCallCommandFilters(client *c) {
     c->argv_len = filter.argv_len;
     c->argc = filter.argc;
 
-    /* Update pending command if it exists. */
+    /* Update pending command if it exists. Everything that was derived from the
+     * old argv (command, keys, slot, read error) is now stale, so we drop it and
+     * let preprocessCommand() compute it again from the new argv. */
     pendingCommand *pcmd = c->current_pending_cmd;
     if (pcmd) {
         pcmd->argv = filter.argv;
@@ -12031,10 +12041,19 @@ void moduleCallCommandFilters(client *c) {
         pcmd->cmd = NULL;
         pcmd->slot = INVALID_CLUSTER_SLOT;
         pcmd->flags = 0;
+        pcmd->read_error = 0;
 
         /* Reset keys result */
         getKeysFreeResult(&pcmd->keys_result);
         pcmd->keys_result = (getKeysResult)GETKEYS_RESULT_INIT;
+
+        preprocessCommand(c, pcmd);
+        pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
+
+        /* Keep the client fields we populated from the pending command in sync. */
+        c->lookedcmd = pcmd->cmd;
+        c->slot = pcmd->slot;
+        c->read_error = pcmd->read_error;
     }
 }
 
@@ -12075,6 +12094,7 @@ int RM_CommandFilterArgInsert(RedisModuleCommandFilterCtx *fctx, int pos, RedisM
     }
     fctx->argv[pos] = arg;
     fctx->argc++;
+    fctx->argv_changed = 1;
 
     return REDISMODULE_OK;
 }
@@ -12090,6 +12110,7 @@ int RM_CommandFilterArgReplace(RedisModuleCommandFilterCtx *fctx, int pos, Redis
 
     decrRefCount(fctx->argv[pos]);
     fctx->argv[pos] = arg;
+    fctx->argv_changed = 1;
 
     return REDISMODULE_OK;
 }
@@ -12107,6 +12128,7 @@ int RM_CommandFilterArgDelete(RedisModuleCommandFilterCtx *fctx, int pos)
         fctx->argv[i] = fctx->argv[i+1];
     }
     fctx->argc--;
+    fctx->argv_changed = 1;
 
     return REDISMODULE_OK;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -12028,25 +12028,14 @@ void moduleCallCommandFilters(client *c) {
     c->argv_len = filter.argv_len;
     c->argc = filter.argc;
 
-    /* Update pending command if it exists. Everything that was derived from the
-     * old argv (command, keys, slot, read error) is now stale, so we drop it and
-     * let preprocessCommand() compute it again from the new argv. */
+    /* Everything the pending command derived from the old argv (command, keys,
+     * slot, read error) is stale now, so preprocess it again. */
     pendingCommand *pcmd = c->current_pending_cmd;
     if (pcmd) {
         pcmd->argv = filter.argv;
         pcmd->argc = filter.argc;
         pcmd->argv_len = filter.argv_len;
-        pcmd->cmd = NULL;
-        pcmd->slot = INVALID_CLUSTER_SLOT;
-        pcmd->flags = 0;
-        pcmd->read_error = 0;
-
-        /* Reset keys result */
-        getKeysFreeResult(&pcmd->keys_result);
-        pcmd->keys_result = (getKeysResult)GETKEYS_RESULT_INIT;
-
         preprocessCommand(c, pcmd);
-        pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
 
         /* Keep the client fields we populated from the pending command in sync. */
         c->lookedcmd = pcmd->cmd;

--- a/src/networking.c
+++ b/src/networking.c
@@ -6080,12 +6080,7 @@ pendingCommand *popPendingCommandFromTail(pendingCommandList *list) {
 getKeysResult *getClientCachedKeyResult(client *c) {
     pendingCommand *pcmd = c->current_pending_cmd;
     if (pcmd) {
-        /* Preprocess the command if needed */
-        if (!(pcmd->flags & PENDING_CMD_FLAG_PREPROCESSED)) {
-            preprocessCommand(c, pcmd);
-            pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
-        }
-
+        serverAssert(pcmd->flags & PENDING_CMD_FLAG_PREPROCESSED);
         /* Return cached result if available */
         if (pcmd->flags & PENDING_CMD_KEYS_RESULT_VALID)
             return &c->current_pending_cmd->keys_result;

--- a/src/networking.c
+++ b/src/networking.c
@@ -3870,7 +3870,6 @@ int processInputBuffer(client *c) {
                 pcmd->reploff = c->io_read_reploff - sdslen(c->querybuf) + c->qb_pos;
 
             preprocessCommand(c, pcmd);
-            pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
             resetClientQbufState(c);
         }
 

--- a/src/server.c
+++ b/src/server.c
@@ -4424,8 +4424,21 @@ uint64_t getCommandFlags(client *c) {
     return cmd_flags;
 }
 
+/* Compute what can be derived from the command argv alone: the command itself,
+ * its keys and slot, and the read errors that can be detected this early.
+ *
+ * It may be called again on the same pending command if the argv changed
+ * (a module command filter may insert, replace or delete arguments), so it
+ * starts by dropping whatever a previous call derived from the old argv. */
 void preprocessCommand(client *c, pendingCommand *pcmd) {
+    pcmd->cmd = NULL;
     pcmd->slot = INVALID_CLUSTER_SLOT;
+    pcmd->read_error = 0;
+    pcmd->flags &= ~PENDING_CMD_KEYS_RESULT_VALID;
+    pcmd->flags |= PENDING_CMD_FLAG_PREPROCESSED;
+    getKeysFreeResult(&pcmd->keys_result);
+    pcmd->keys_result = (getKeysResult)GETKEYS_RESULT_INIT;
+
     if (pcmd->argc == 0)
         return;
 
@@ -4450,7 +4463,6 @@ void preprocessCommand(client *c, pendingCommand *pcmd) {
         return;
     }
 
-    pcmd->keys_result = (getKeysResult)GETKEYS_RESULT_INIT;
     int num_keys = extractKeysAndSlot(pcmd->cmd, pcmd->argv, pcmd->argc,
                                       &pcmd->keys_result, &pcmd->slot);
     if (num_keys < 0) {

--- a/tests/unit/moduleapi/commandfilter.tcl
+++ b/tests/unit/moduleapi/commandfilter.tcl
@@ -192,10 +192,9 @@ start_cluster 1 0 [list tags {modules cluster external:skip} config_lines [list 
     }
 
     test {Command Filter refreshes cross-slot state when args are inserted} {
-        # "mget {t}a @insertafter" is a valid single-slot command before
-        # filtering, but the filter appends --inserted-after--, which turns it
-        # into a cross-slot command.
-        assert_error "CROSSSLOT*" {r mget a{t} @insertafter}
+        # Both keys hash to the same slot before filtering, but the filter
+        # appends --inserted-after--, which turns it into a cross-slot command.
+        assert_error "CROSSSLOT*" {r mget a{@insertafter} @insertafter}
     }
 
     test {Command Filter refreshes the slot when a key argument is replaced} {

--- a/tests/unit/moduleapi/commandfilter.tcl
+++ b/tests/unit/moduleapi/commandfilter.tcl
@@ -173,3 +173,53 @@ start_server {tags {"external:skip"}} {
         assert_equal [r lrange mylist 0 -1] {elem1 @delme elem2}
     }
 }
+
+# A command filter that changes argv invalidates everything the server already
+# derived from the pre-filter argv (looked up command, keys, slot, cross-slot
+# error). These tests make sure the outside world is refreshed accordingly.
+start_cluster 1 0 [list tags {modules cluster external:skip} config_lines [list "loadmodule [file normalize tests/modules/commandfilter.so] log-key 0"]] {
+    test {Command Filter refreshes cross-slot state when args are deleted} {
+        # "del {t}a @delme" is cross-slot before filtering, and a single-key
+        # command after the filter deleted @delme. It must not be rejected.
+        assert_equal 0 [r del "{t}a" @delme]
+
+        r set "{t}a" v1
+        assert_equal 1 [r del "{t}a" @delme]
+
+        # Same thing for a read command with more than one key left.
+        r mset "{t}a" v1 "{t}b" v2
+        assert_equal {v1 v2} [r mget "{t}a" @delme "{t}b"]
+    }
+
+    test {Command Filter refreshes cross-slot state when args are inserted} {
+        # "mget {t}a @insertafter" is a valid single-slot command before
+        # filtering, but the filter appends --inserted-after--, which turns it
+        # into a cross-slot command.
+        assert_error "CROSSSLOT*" {r mget "{t}a" @insertafter}
+    }
+
+    test {Command Filter refreshes cross-slot state on pipelined commands} {
+        # Pipelining makes the server parse and preprocess several commands
+        # up-front, so the filter runs against already-preprocessed state.
+        r del "{t}a"
+        set rd [redis_deferring_client]
+        $rd del "{t}a" @delme
+        $rd set "{t}a" v1
+        $rd del "{t}a" @delme
+        $rd mget "{t}a" @insertafter
+        $rd flush
+        assert_equal 0 [$rd read]
+        assert_equal {OK} [$rd read]
+        assert_equal 1 [$rd read]
+        assert_error "CROSSSLOT*" {$rd read}
+        $rd close
+    }
+
+    test {Command Filter refreshes the slot when a key argument is replaced} {
+        # The filter rewrites @replaceme into --replaced--, so the slot cached
+        # for the original key must not leak into the new command.
+        r set --replaced-- v1
+        assert_equal v1 [r get @replaceme]
+        assert_equal 1 [r del @replaceme]
+    }
+}

--- a/tests/unit/moduleapi/commandfilter.tcl
+++ b/tests/unit/moduleapi/commandfilter.tcl
@@ -177,42 +177,25 @@ start_server {tags {"external:skip"}} {
 # A command filter that changes argv invalidates everything the server already
 # derived from the pre-filter argv (looked up command, keys, slot, cross-slot
 # error). These tests make sure the outside world is refreshed accordingly.
-start_cluster 1 0 [list tags {modules cluster external:skip} config_lines [list "loadmodule [file normalize tests/modules/commandfilter.so] log-key 0"]] {
+start_cluster 1 0 [list tags {modules cluster external:skip} config_lines [list "loadmodule $testmodule log-key 0"]] {
     test {Command Filter refreshes cross-slot state when args are deleted} {
-        # "del {t}a @delme" is cross-slot before filtering, and a single-key
+        # "del a{t} @delme" is cross-slot before filtering, and a single-key
         # command after the filter deleted @delme. It must not be rejected.
-        assert_equal 0 [r del "{t}a" @delme]
+        assert_equal 0 [r del a{t} @delme]
 
-        r set "{t}a" v1
-        assert_equal 1 [r del "{t}a" @delme]
+        r set a{t} v1
+        assert_equal 1 [r del a{t} @delme]
 
         # Same thing for a read command with more than one key left.
-        r mset "{t}a" v1 "{t}b" v2
-        assert_equal {v1 v2} [r mget "{t}a" @delme "{t}b"]
+        r mset a{t} v1 b{t} v2
+        assert_equal {v1 v2} [r mget a{t} @delme b{t}]
     }
 
     test {Command Filter refreshes cross-slot state when args are inserted} {
         # "mget {t}a @insertafter" is a valid single-slot command before
         # filtering, but the filter appends --inserted-after--, which turns it
         # into a cross-slot command.
-        assert_error "CROSSSLOT*" {r mget "{t}a" @insertafter}
-    }
-
-    test {Command Filter refreshes cross-slot state on pipelined commands} {
-        # Pipelining makes the server parse and preprocess several commands
-        # up-front, so the filter runs against already-preprocessed state.
-        r del "{t}a"
-        set rd [redis_deferring_client]
-        $rd del "{t}a" @delme
-        $rd set "{t}a" v1
-        $rd del "{t}a" @delme
-        $rd mget "{t}a" @insertafter
-        $rd flush
-        assert_equal 0 [$rd read]
-        assert_equal {OK} [$rd read]
-        assert_equal 1 [$rd read]
-        assert_error "CROSSSLOT*" {$rd read}
-        $rd close
+        assert_error "CROSSSLOT*" {r mget a{t} @insertafter}
     }
 
     test {Command Filter refreshes the slot when a key argument is replaced} {


### PR DESCRIPTION
## Summary

Since #14440 the command, keys, slot and read error are preprocessed at parse
time, but a command filter may insert/delete/replace arguments afterwards.
`moduleCallCommandFilters()` only reset part of that state, so what was derived
from the pre-filter argv — most notably the slot — could still be used later.
Today this is masked in practice: the only consumer, `getClientCachedKeyResult()`,
re-preprocesses lazily whenever the cached result was invalidated.

## How it is fixed

Instead of relying on that lazy path, track whether a filter actually changed
argv, and if so run `preprocessCommand()` right away on the new argv and sync
`c->lookedcmd` / `c->slot` / `c->read_error` from it. If no filter changed argv
there is nothing to refresh and we return early. The state is now always
consistent at the point it is produced, which also removes the lazy
preprocessing from `getClientCachedKeyResult()` (it asserts instead).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches command execution and cluster slot/cross-slot handling on the hot path when modules use filters, but behavior is narrowed to when argv actually changes and adds regression tests.
> 
> **Overview**
> **Fixes stale cluster/command state after module command filters change `argv`.** Parse-time preprocessing (#14440) could leave slot, cross-slot errors, keys, and looked-up command out of date when a filter inserted, deleted, or replaced arguments afterward.
> 
> Filters now set an **`argv_changed`** flag on insert/replace/delete. **`moduleCallCommandFilters()`** returns early if nothing changed; otherwise it clears derived pending-command state (including **`read_error`**), runs **`preprocessCommand()`** on the new argv, and copies **`lookedcmd`**, **`slot`**, and **`read_error`** back onto the client.
> 
> **`getClientCachedKeyResult()`** no longer lazily preprocesses—it **`serverAssert`s** the pending command is already preprocessed. New cluster module tests cover cross-slot behavior when filters delete, insert, or replace key arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e49db95ebe2d3a1145b5263ac7754b8ecda4ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->