### PR TITLE
Fix Remote UAF in Redis Cluster bus FORGOTTEN_NODE handling with demonstrated RCE impact

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2717,8 +2717,7 @@ uint32_t writePingExt(clusterMsg *hdr, int gossipcount)  {
 
 /* We previously validated the extensions, so this function just needs to
  * handle the extensions. */
-void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
-    clusterNode *sender = link->node ? link->node : clusterLookupNode(hdr->sender, CLUSTER_NAMELEN);
+void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link, clusterNode *sender) {
     char *ext_hostname = NULL;
     char *ext_humannodename = NULL;
     char *ext_shardid = NULL;
@@ -2726,6 +2725,10 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
     /* Loop through all the extensions and process them */
     clusterMsgPingExt *ext = getInitialPingExt(hdr, ntohs(hdr->count));
     while (extensions--) {
+        /* Compute the cursor to the next extension before running any
+         * handler, so that the loop does not depend on memory that a
+         * handler may have invalidated. */
+        clusterMsgPingExt *next = getNextPingExt(ext);
         uint16_t type = ntohs(ext->type);
         if (type == CLUSTERMSG_EXT_TYPE_HOSTNAME) {
             clusterMsgPingExtHostname *hostname_ext = (clusterMsgPingExtHostname *) &(ext->ext[0].hostname);
@@ -2737,14 +2740,20 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
             clusterMsgPingExtForgottenNode *forgotten_node_ext = &(ext->ext[0].forgotten_node);
             clusterNode *n = clusterLookupNode(forgotten_node_ext->name, CLUSTER_NAMELEN);
             if (n && n != myself && !(nodeIsSlave(myself) && myself->slaveof == n)) {
-                sds id = sdsnewlen(forgotten_node_ext->name, CLUSTER_NAMELEN);
-                dictEntry *de = dictAddOrFind(server.cluster->nodes_black_list, id);
-                if (dictGetKey(de) != id) sdsfree(id);
-                uint64_t expire = server.unixtime + ntohu64(forgotten_node_ext->ttl);
-                dictSetUnsignedIntegerVal(de, expire);
-                clusterDelNode(n);
-                clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE|
-                                     CLUSTER_TODO_SAVE_CONFIG);
+                if (n == sender || n == link->node) {
+                    serverLog(LL_WARNING,
+                              "Ignoring FORGOTTEN_NODE for active sender %.40s while processing its packet",
+                              forgotten_node_ext->name);
+                } else {
+                    sds id = sdsnewlen(forgotten_node_ext->name, CLUSTER_NAMELEN);
+                    dictEntry *de = dictAddOrFind(server.cluster->nodes_black_list, id);
+                    if (dictGetKey(de) != id) sdsfree(id);
+                    uint64_t expire = server.unixtime + ntohu64(forgotten_node_ext->ttl);
+                    dictSetUnsignedIntegerVal(de, expire);
+                    clusterDelNode(n);
+                    clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE|
+                                         CLUSTER_TODO_SAVE_CONFIG);
+                }
             }
         } else if (type == CLUSTERMSG_EXT_TYPE_SHARDID) {
             clusterMsgPingExtShardId *shardid_ext = (clusterMsgPingExtShardId *) &(ext->ext[0].shard_id);
@@ -2759,8 +2768,7 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
             serverLog(LL_VERBOSE, "Received unknown extension type %d", type);
         }
 
-        /* We know this will be valid since we validated it ahead of time */
-        ext = getNextPingExt(ext);
+        ext = next;
     }
 
     /* If the node did not send us a hostname extension, assume
@@ -3349,7 +3357,7 @@ int clusterProcessPacket(clusterLink *link) {
         /* Get info from the gossip section */
         if (sender) {
             clusterProcessGossipSection(hdr,link);
-            clusterProcessPingExtensions(hdr,link);
+            clusterProcessPingExtensions(hdr,link,sender);
         }
     } else if (type == CLUSTERMSG_TYPE_FAIL) {
         clusterNode *failing;

--- a/tests/unit/cluster/packet-validation.tcl
+++ b/tests/unit/cluster/packet-validation.tcl
@@ -102,12 +102,11 @@ test "FORGOTTEN_NODE cannot delete the active packet sender" {
     set sender_cport [expr {$sender_port + 10000}]
     set totlen [expr {$CLUSTERMSG_MIN_LEN + $FORGOTTEN_NODE_EXT_LEN}]
 
+    # build_cluster_bus_header already encodes 'slaveof' as 40 NUL bytes
+    # which is CLUSTER_NODE_MASTER so the sender is treated like master
+    # and packet doesnt alter its slot ownership
     set packet [build_cluster_bus_header $node_id $sender_port $sender_cport \
         $CLUSTERMSG_TYPE_PING $totlen 1 $CLUSTER_NODE_MASTER $CLUSTERMSG_FLAG0_EXT_DATA]
-    # Set "slaveof" (offset 2128 in the header) to the null node name, so the
-    # sender keeps being treated as a master and the packet does not alter
-    # its role or slot ownership.
-    set packet [string replace $packet 2128 2167 [string repeat 0 40]]
     append packet [binary format I $FORGOTTEN_NODE_EXT_LEN]
     append packet [binary format S $CLUSTERMSG_EXT_TYPE_FORGOTTEN_NODE]
     append packet [binary format S 0]               ;# unused

--- a/tests/unit/cluster/packet-validation.tcl
+++ b/tests/unit/cluster/packet-validation.tcl
@@ -87,4 +87,53 @@ test "MODULE with len overflow is rejected" {
     assert_equal [R 0 PING] {PONG}
 }
 
+test "FORGOTTEN_NODE cannot delete the active packet sender" {
+    set CLUSTERMSG_TYPE_PING 0
+    set CLUSTERMSG_EXT_TYPE_FORGOTTEN_NODE 2
+    set CLUSTERMSG_FLAG0_EXT_DATA 4
+    set CLUSTER_NODE_MASTER 1
+    set CLUSTERMSG_MIN_LEN 2256
+    set FORGOTTEN_NODE_EXT_LEN 56
+
+    set target_host [srv 0 host]
+    set target_bus_port [expr {[srv 0 port] + 10000}]
+    set node_id [R 1 CLUSTER MYID]
+    set sender_port [srv -1 port]
+    set sender_cport [expr {$sender_port + 10000}]
+    set totlen [expr {$CLUSTERMSG_MIN_LEN + $FORGOTTEN_NODE_EXT_LEN}]
+
+    set packet [build_cluster_bus_header $node_id $sender_port $sender_cport \
+        $CLUSTERMSG_TYPE_PING $totlen 1 $CLUSTER_NODE_MASTER $CLUSTERMSG_FLAG0_EXT_DATA]
+    # Set "slaveof" (offset 2128 in the header) to the null node name, so the
+    # sender keeps being treated as a master and the packet does not alter
+    # its role or slot ownership.
+    set packet [string replace $packet 2128 2167 [string repeat 0 40]]
+    append packet [binary format I $FORGOTTEN_NODE_EXT_LEN]
+    append packet [binary format S $CLUSTERMSG_EXT_TYPE_FORGOTTEN_NODE]
+    append packet [binary format S 0]               ;# unused
+    append packet [binary format a40 $node_id]
+    append packet [binary format W 60]              ;# blacklist TTL
+
+    if {$::tls} {
+        set fd [::tls::socket \
+            -cafile "$::tlsdir/ca.crt" \
+            -certfile "$::tlsdir/client.crt" \
+            -keyfile "$::tlsdir/client.key" \
+            $target_host $target_bus_port]
+    } else {
+        set fd [socket $target_host $target_bus_port]
+    }
+    fconfigure $fd -translation binary -buffering full
+    puts -nonewline $fd $packet
+    flush $fd
+
+    wait_for_log_messages 0 {"*Ignoring FORGOTTEN_NODE for active sender*"} 0 20 500
+    close $fd
+
+    # The sender must still be part of the cluster, with its slots intact.
+    assert_equal [R 0 PING] {PONG}
+    assert_match "*$node_id*" [R 0 CLUSTER NODES]
+    wait_for_cluster_state "ok"
+}
+
 }


### PR DESCRIPTION
Addresses #15672 

## The fix in src/cluster_legacy.c

Two changes in `clusterProcessPingExtensions`:

1. Never delete the active sender. A `FORGOTTEN_NODE` naming the node whose packet is being parsed is now ignored with a warning, instead of calling clusterDelNode() - which freed the inbound clusterLink and its `rcvbuf` while `hdr`,` ext`, and sender still pointed into them. The function now receives the already resolved sender from `clusterProcessPacket`, so the protected identity is unambiguous.

2. Precompute the extension cursor. `next = getNextPingExt(ext)` is computed before handlers run and the loop advances with `ext = next`, so iteration no longer re-reads length metadata from memory a handler could have invalidated. This is just defense while not deleting the active sender fixes the UAF.

## Regression test 

`tests/unit/cluster/packet-validation.tcl`
A new test crafts a raw cluster bus PING (via the existing build_cluster_bus_header helper) whose FORGOTTEN_NODE extension names the sender itself, then asserts the warning is logged, the server stays responsive, the sender remains in CLUSTER NODES, and cluster state states ok. The packet's `slaveof` field is set to the null node name so the test doesn't perturb the sender's role or slots as a side effect.

## Verification

- Full build succeeds with no warnings.
- unit/cluster/packet-validation and unit/cluster/hostnames (the other extension-processing suite) pass, including memory-leak checks.
- Negative control: with the guard disabled in a scratch copy, the new test fails as expected - confirming it actually detects the bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-critical cluster-bus path: previously a remote packet could UAF the receive buffer (RCE-class). The change is a small guard plus a defensive cursor, but it sits in gossip/node-deletion logic.
> 
> **Overview**
> Fixes a use-after-free in cluster bus ping handling: a `FORGOTTEN_NODE` extension that named the node whose packet was being parsed could call `clusterDelNode()` and free the inbound `clusterLink`/`rcvbuf` while `hdr` and extension pointers still referred to that memory.
> 
> `clusterProcessPingExtensions` now takes the already-resolved `sender` and skips (with a warning) forgetting that sender or `link->node`. The extension loop also snapshots `getNextPingExt` before handlers run so iteration does not re-read length fields from potentially invalidated memory.
> 
> Adds a packet-validation test that crafts a PING whose forgotten-node name is the sender and checks the warning, that the node remains in `CLUSTER NODES`, and that cluster state stays `ok`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4640902e67979dc04b54a2be80ea779838581418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->