### PR TITLE
Fix PROTOCOL DESYNC in AUTH / HELLO commands when pipelined

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1506,7 +1506,6 @@ int ACLCheckUserCredentials(robj *username, robj *password) {
 /* If `err` is provided, this is added as an error reply to the client.
  * Otherwise, the standard Auth error is added as a reply. */
 void addAuthErrReply(client *c, robj *err) {
-    if (clientHasPendingReplies(c)) return;
     if (!err) {
         addReplyError(c, "-WRONGPASS invalid username-password pair or user is disabled.");
         return;
@@ -3392,12 +3391,15 @@ void authCommand(client *c) {
         }
     }
 
+    size_t prev_bufpos = c->bufpos;
+    size_t prev_reply_len = listLength(c->reply);
     robj *err = NULL;
     int result = ACLAuthenticateUser(c, username, password, &err);
     if (result == AUTH_OK) {
         addReply(c, shared.ok);
     } else if (result == AUTH_ERR) {
-        addAuthErrReply(c, err);
+        if (c->bufpos == prev_bufpos && listLength(c->reply) == prev_reply_len)
+            addAuthErrReply(c, err);
     }
     if (err) decrRefCount(err);
 }

--- a/src/acl.c
+++ b/src/acl.c
@@ -3392,13 +3392,13 @@ void authCommand(client *c) {
     }
 
     size_t prev_bufpos = c->bufpos;
-    size_t prev_reply_len = listLength(c->reply);
+    unsigned long long prev_reply_bytes = c->reply_bytes;
     robj *err = NULL;
     int result = ACLAuthenticateUser(c, username, password, &err);
     if (result == AUTH_OK) {
         addReply(c, shared.ok);
     } else if (result == AUTH_ERR) {
-        if (c->bufpos == prev_bufpos && listLength(c->reply) == prev_reply_len)
+        if (c->bufpos == prev_bufpos && c->reply_bytes == prev_reply_bytes)
             addAuthErrReply(c, err);
     }
     if (err) decrRefCount(err);

--- a/src/networking.c
+++ b/src/networking.c
@@ -5073,11 +5073,11 @@ void helloCommand(client *c) {
 
     if (username && password) {
         size_t prev_bufpos = c->bufpos;
-        size_t prev_reply_len = listLength(c->reply);
+        unsigned long long prev_reply_bytes = c->reply_bytes;
         robj *err = NULL;
         int auth_result = ACLAuthenticateUser(c, username, password, &err);
         if (auth_result == AUTH_ERR) {
-            if (c->bufpos == prev_bufpos && listLength(c->reply) == prev_reply_len)
+            if (c->bufpos == prev_bufpos && c->reply_bytes == prev_reply_bytes)
                 addAuthErrReply(c, err);
         }
         if (err) decrRefCount(err);

--- a/src/networking.c
+++ b/src/networking.c
@@ -5072,10 +5072,13 @@ void helloCommand(client *c) {
     }
 
     if (username && password) {
+        size_t prev_bufpos = c->bufpos;
+        size_t prev_reply_len = listLength(c->reply);
         robj *err = NULL;
         int auth_result = ACLAuthenticateUser(c, username, password, &err);
         if (auth_result == AUTH_ERR) {
-            addAuthErrReply(c, err);
+            if (c->bufpos == prev_bufpos && listLength(c->reply) == prev_reply_len)
+                addAuthErrReply(c, err);
         }
         if (err) decrRefCount(err);
         /* In case of auth errors, return early since we already replied with an ERR.


### PR DESCRIPTION
## Description

**Fixes #15640**

This PR fixes a protocol desynchronization bug that occurs when an `AUTH` (or `HELLO` with auth) command fails, and the client already has pending replies in its output buffer (e.g., from earlier commands in a pipeline).

### Root Cause
The bug was introduced in PR #11659 (Custom authentication for Modules). To prevent sending a duplicate error reply when a custom module auth callback explicitly replied to the client, `addAuthErrReply` was updated to include a broad guard:
```c
if (clientHasPendingReplies(c)) return;

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AUTH/HELLO error-reply handling, which can desynchronize clients if wrong. The change is small and does not alter credential checks.
> 
> **Overview**
> Failed `AUTH` and `HELLO` with auth now still send an error when the client already has pending output (typical of pipelines). Previously `addAuthErrReply` skipped any reply if *any* output was queued, so the client expected an extra response that never arrived.
> 
> The skip is now scoped to replies written *during* `ACLAuthenticateUser` (module auth that already replied). Callers snapshot `bufpos`/`reply_bytes` and only call `addAuthErrReply` if those did not change. The broad `clientHasPendingReplies` guard is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2ea1432b7e63c07700bd89d263b3ecaa0cea150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->