### PR TITLE
Fix fixedpoint_d2string() for odd fractional_digits

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -786,6 +786,8 @@ int fixedpoint_d2string(char *dst, size_t dstlen, double dvalue, int fractional_
     10000000.0, 100000000.0, 1000000000.0, 10000000000.0, 100000000000.0, 1000000000000.0,
     10000000000000.0, 100000000000000.0, 1000000000000000.0, 10000000000000000.0,
     100000000000000000.0 };
+    if (fabs(dvalue) > (double)LLONG_MAX / powers_of_ten[fractional_digits])
+        goto err;
     long long svalue = llrint(dvalue * powers_of_ten[fractional_digits]);
     unsigned long long value;
     /* write sign */
@@ -833,11 +835,15 @@ int fixedpoint_d2string(char *dst, size_t dstlen, double dvalue, int fractional_
         int const i = (value % 100) * 2;
         value /= 100;
         dst[next] = digitsd[i + 1];
-        dst[next - 1] = digitsd[i];
-        next -= 2;
-        /* dot position */
-        if (next == integer_digits) {
-            next--;
+        if (next - 1 == integer_digits) {
+            dst[next - 2] = digitsd[i];
+            next -= 3;
+        } else {
+            dst[next - 1] = digitsd[i];
+            next -= 2;
+            if (next == integer_digits) {
+                next--;
+            }
         }
     }
 
@@ -847,7 +853,11 @@ int fixedpoint_d2string(char *dst, size_t dstlen, double dvalue, int fractional_
     } else {
         int i = (uint32_t) value * 2;
         dst[next] = digitsd[i + 1];
-        dst[next - 1] = digitsd[i];
+        if (next - 1 == integer_digits) {
+            dst[next - 2] = digitsd[i];
+        } else {
+            dst[next - 1] = digitsd[i];
+        }
     }
     /* Null term. */
     dst[size] = '\0';
@@ -1802,6 +1812,40 @@ static void test_fixedpoint_d2string(void) {
     sz = fixedpoint_d2string(buf, sizeof buf, v, 4);
     assert(sz == 7);
     assert(!strcmp(buf, "10.0100"));
+    memset(buf,'A',32);
+    v = 12.345678;
+    sz = fixedpoint_d2string(buf, sizeof buf, v, 3);
+    assert(sz == 6);
+    assert(!strcmp(buf, "12.346"));
+    memset(buf,'A',32);
+    v = 100.0;
+    sz = fixedpoint_d2string(buf, sizeof buf, v, 5);
+    assert(sz == 9);
+    assert(!strcmp(buf, "100.00000"));
+    memset(buf,'A',32);
+    v = 1234.5;
+    sz = fixedpoint_d2string(buf, sizeof buf, v, 1);
+    assert(sz == 6);
+    assert(!strcmp(buf, "1234.5"));
+    memset(buf,'A',32);
+    v = 5.5;
+    sz = fixedpoint_d2string(buf, sizeof buf, v, 1);
+    assert(sz == 3);
+    assert(!strcmp(buf, "5.5"));
+    memset(buf,'A',32);
+    v = 1.234;
+    sz = fixedpoint_d2string(buf, sizeof buf, v, 3);
+    assert(sz == 5);
+    assert(!strcmp(buf, "1.234"));
+    memset(buf,'A',32);
+    v = -1234.5;
+    sz = fixedpoint_d2string(buf, sizeof buf, v, 1);
+    assert(sz == 7);
+    assert(!strcmp(buf, "-1234.5"));
+    memset(buf,'A',32);
+    v = 100.0;
+    sz = fixedpoint_d2string(buf, sizeof buf, v, 17);
+    assert(sz == 0);
     /* negative tests */
     sz = fixedpoint_d2string(buf, sizeof buf, v, 18);
     assert(sz == 0);


### PR DESCRIPTION
## Problem
`fixedpoint_d2string()` wrote digits two at a time (right to left) and relies on landing exactly on decimal point to skip it. With an odd `fractional_digits`, one digit pair straddles the dot: the left digit overwrites the `.`, and so `dst[0]` is never written (stale buffer content leaks into the output)

    fixedpoint_d2string(buf, 32, 12.345678, 3) -> "A12346"   (expected "12.346")
    fixedpoint_d2string(buf, 32, 5.5, 1)       -> "A55"      (expected "5.5")

Also `llrint(dvalue * 10^fractional_digits)` had no overflow check, so out-of-range values returned success with garbage (`100.0` with 17 digits)

The only in-tree caller (`addReplyDoubleDistance` in geo.c) uses 4 digits (even), so the bug was not reachable from commands — the function is exported in util.h.

## Fix
- When a digit pair straddles the dot, write its left digit before the dot instead of on top of it (in both the main loop and the final 1-2 digit handling). Even`fractional_digits` output is byte-identical to before
- Reject `|dvalue| * 10^fractional_digits > LLONG_MAX` with a return value of 0, consistent with the other error paths

## Testing
- Extended `test_fixedpoint_d2string()` with odd-digit, negative, and overflow cases (assert-only, buffers pre-filled with junk so unwritten bytes are caught). Verified the new tests fail on the unfixed code and pass after the fix
- `./redis-server test util` and `./runtest --single unit/geo` passs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized string conversion fix; the only in-tree caller uses even precision, so command behavior is unchanged.
> 
> **Overview**
> Fixes `fixedpoint_d2string()` so digit pairs that straddle the decimal point no longer overwrite `.` when `fractional_digits` is odd. That bug left the first character unwritten (stale buffer content in the output). Even-digit output is unchanged.
> 
> Also rejects scaled values that would overflow `llrint` (`|dvalue| * 10^n > LLONG_MAX`) instead of returning garbage. Tests cover odd precision, negatives, and overflow. The in-tree geo caller still uses 4 digits, so command output is unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8323de99c6a9df7de806ae8b899c97f2fe7139a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->