### PR TITLE
Fix tls-groups test to match handshake error wording across OpenSSL platforms

### DIFF
--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -186,7 +186,10 @@ start_server {tags {"tls"}} {
             # The client and server expose disjoint group lists, so the TLS
             # handshake must fail.
             assert_equal 1 [catch {tls_redis_cli [srv 0 host] [srv 0 port] secp384r1} e]
-            assert_match {*sslv3 alert handshake failure*} $e
+            # OpenSSL reports this alert differently across platforms:
+            # CentOS reports "ssl/tls alert handshake failure"
+            # Ubuntu reports "sslv3 alert handshake failure"
+            assert_match {*ssl* alert handshake failure*} $e
 
             r CONFIG SET tls-groups ""
             r CONFIG SET tls-protocols ""


### PR DESCRIPTION

### Issue 

Failed daily CI : https://github.com/redis/redis/actions/runs/32606983262/job/97113371883
>*** [err]: TLS: Verify tls-groups with disjoint groups in tests/unit/tls.tcl
Expected 'Could not connect to Redis at 127.0.0.1:27121: SSL_connect failed: ssl/tls alert handshake failure
child process exited abnormally' to match '*sslv3 alert handshake failure*' (context: type eval line 10 cmd {assert_match {*sslv3 alert handshake failure*} $e} proc ::test) 
Cleanup: may take some time... OK
Error: Process completed with exit code 1.

CentOS reports `ssl/tls alert handshake failure`, so the test failed.


### Test

Daily CI with param `--single unit/tls`: https://github.com/vitahlin/redis/actions/runs/32627784744

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only glob change; no production TLS or handshake behavior is modified.
> 
> **Overview**
> Relaxes the TLS disjoint-groups test so handshake-failure errors match both Ubuntu (`sslv3 alert handshake failure`) and CentOS (`ssl/tls alert handshake failure`) OpenSSL wording.
> 
> The assertion now uses `*ssl* alert handshake failure*` instead of a Ubuntu-only pattern, which was failing daily CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bc6de402687b38a4f24c26ae9693d517e496286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->