### PR TITLE
Fix flaky cluster tests failing with "READONLY You can't write against a read only replica"

### DIFF
--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -148,16 +148,26 @@ proc cluster_allocate_slaves {masters slaves} {
     }
 }
 
+# Verify that every node which will own slots is writable.
+proc assert_cluster_master_nodes {masters} {
+    for {set id 0} {$id < $masters} {incr id} {
+        assert_equal master [RI $id role]
+    }
+}
+
 # Create a cluster composed of the specified number of masters and slaves.
 proc create_cluster {masters slaves} {
-    cluster_allocate_slots $masters
-    if {$slaves} {
-        cluster_allocate_slaves $masters $slaves
-    }
-    assert_cluster_state ok
-
     set ::cluster_master_nodes $masters
     set ::cluster_replica_nodes $slaves
+
+    assert_cluster_master_nodes $masters
+    cluster_allocate_slots $masters
+    wait_for_cluster_propagation
+    if {$slaves} {
+        cluster_allocate_slaves $masters $slaves
+        wait_for_cluster_propagation
+    }
+    assert_cluster_state ok
 }
 
 proc cluster_allocate_with_continuous_slots {n} {
@@ -176,14 +186,17 @@ proc cluster_allocate_with_continuous_slots {n} {
 # Create a cluster composed of the specified number of masters and slaves,
 # but with a continuous slot range. 
 proc cluster_create_with_continuous_slots {masters slaves} {
-    cluster_allocate_with_continuous_slots $masters
-    if {$slaves} {
-        cluster_allocate_slaves $masters $slaves
-    }
-    assert_cluster_state ok
-
     set ::cluster_master_nodes $masters
     set ::cluster_replica_nodes $slaves
+
+    assert_cluster_master_nodes $masters
+    cluster_allocate_with_continuous_slots $masters
+    wait_for_cluster_propagation
+    if {$slaves} {
+        cluster_allocate_slaves $masters $slaves
+        wait_for_cluster_propagation
+    }
+    assert_cluster_state ok
 }
 
 

--- a/tests/cluster/tests/includes/init-tests.tcl
+++ b/tests/cluster/tests/includes/init-tests.tcl
@@ -26,36 +26,62 @@ test "Cluster nodes are reachable" {
 }
 
 test "Cluster nodes hard reset" {
-    foreach_redis_id id {
-        if {$::valgrind} {
-            set node_timeout 10000
-        } else {
-            set node_timeout 3000
+    if {$::valgrind} {
+        set node_timeout 10000
+    } else {
+        set node_timeout 3000
+    }
+
+    # A reset node can learn stale topology from nodes that have not been
+    # reset yet. Repeat until every node is an isolated master.
+    for {set attempts 3} {$attempts > 0} {incr attempts -1} {
+        foreach_redis_id id {
+            # Wait until slave is synced. Otherwise, it may reply -LOADING
+            # for any commands below.
+            if {[RI $id role] eq {slave}} {
+                wait_for_condition 50 1000 {
+                    [RI $id master_link_status] eq {up}
+                } else {
+                    fail "Slave were not able to sync."
+                }
+            }
+
+            # Make FLUSHALL executable regardless of whether the node is currently
+            # a replica. Run it in the same transaction as CLUSTER RESET so a node
+            # cannot be promoted with data in between the two commands.
+            R $id config set replica-read-only no
+            R $id MULTI
+            R $id flushall
+            R $id cluster reset hard
+            R $id cluster set-config-epoch [expr {$id+1}]
+            set reset_results [R $id EXEC]
+            R $id config set replica-read-only yes
+            assert_equal OK [lindex $reset_results 0]
+            assert_equal OK [lindex $reset_results 1]
+            assert_equal OK [lindex $reset_results 2]
+            R $id config set cluster-node-timeout $node_timeout
+            R $id config set cluster-slave-validity-factor 10
+            R $id config set loading-process-events-interval-bytes 2097152
+            R $id config set key-load-delay 0
+            R $id config set repl-diskless-load disabled
+            R $id config set cluster-announce-hostname ""
+            R $id DEBUG DROP-CLUSTER-PACKET-FILTER -1
+            R $id config rewrite
         }
 
-        # Wait until slave is synced. Otherwise, it may reply -LOADING
-        # for any commands below.
-        if {[RI $id role] eq {slave}} {
-            wait_for_condition 50 1000 {
-                [RI $id master_link_status] eq {up}
-            } else {
-                fail "Slave were not able to sync."
+        set reset_complete 1
+        foreach_redis_id id {
+            if {[RI $id role] ne {master} || [CI $id cluster_known_nodes] != 1} {
+                set reset_complete 0
+                break
             }
         }
-
-        catch {R $id flushall} ; # May fail for readonly slaves.
-        R $id MULTI
-        R $id cluster reset hard
-        R $id cluster set-config-epoch [expr {$id+1}]
-        R $id EXEC
-        R $id config set cluster-node-timeout $node_timeout
-        R $id config set cluster-slave-validity-factor 10
-        R $id config set loading-process-events-interval-bytes 2097152
-        R $id config set key-load-delay 0
-        R $id config set repl-diskless-load disabled
-        R $id config set cluster-announce-hostname ""
-        R $id DEBUG DROP-CLUSTER-PACKET-FILTER -1
-        R $id config rewrite
+        if {$reset_complete} {
+            break
+        }
+    }
+    if {!$reset_complete} {
+        fail "Cluster nodes did not become isolated masters after hard reset"
     }
 }
 


### PR DESCRIPTION
Fixes #15365

## Problem

The old cluster test suite spawns 20 servers once and reuses them for every unit, so each unit depends on Cluster nodes hard reset in `tests/cluster/tests/includes/init-tests.tcl` to hand back a clean topology. 

In the reported CI run, `07-replica-migration.tcl` failed its replica-attachment assertion and the harness jumped to the next unit, leaving killed instances and a half-built cluster behind. The following units then reported init and Cluster is up as OK, but failed immediately on Cluster is writable with READONLY You can't write against a read only replica.

READONLY is only returned when `server.masterhost` is set (myy understanding), after cluster routing already decided the local node owns the slot. So the failing state is a node that the cluster layer treats as a slot owner while the replication layer still considers it a replica. 
Two gaps in the harness allow that:
- `FLUSHALL` ran before `MULTI` and was wrapped in catch, since it fails on a read only replica. If gossip promoted the node between `FLUSHALL` and `CLUSTER RESET HARD`, the reset was rejected with "`CLUSTER RESET` can't be called with master nodes containing keys". The `EXEC` reply was never inspected, so the failure was invisible and the node kept its old role and data.

- Nodes were reset sequentially with the cluster bus live. A node that had already been reset has no slots, so `clusterUpdateSlotsConfigWith` can demote it to a replica of a node that has not been reset yet. The window closes only once slots are assigned, which happens later in `create_cluster`.

`create_cluster` then called `CLUSTER ADDSLOTS` without checking replication role, and `CLUSTER ADDSLOTS` does not clear replication mastership, so the split state survived into the write test. Unlike `cluster_setup` in the unit framework, `create_cluster` also never waited for configuration to propagate, so `assert_cluster_state` ok could pass while nodes still disagreed on slot ownership.

## Changes

`tests/cluster/tests/includes/init-tests.tcl`
- Run `FLUSHALL` inside the same transaction as `CLUSTER RESET HARD` and `CLUSTER SET-CONFIG-EPOCH`, with replica-read-only temporarily disabled so it cannot fail on a replica, and assert each `EXEC `reply is OK.
- Repeat the reset loop until every node reports role:master and cluster_known_nodes of 1, and fail with a clear message otherwise, so a node cannot enter the join phase carrying stale topology.

`tests/cluster/cluster.tcl`
- Add assert_cluster_master_nodes, and assert slot owners are masters before allocating slots in create_cluster and cluster_create_with_continuous_slots.
- Call wait_for_cluster_propagation after slot allocation and after replica allocation, matching cluster_setup in tests/support/cluster_util.tcl.
- Set ::cluster_master_nodes / ::cluster_replica_nodes up front, since wait_for_cluster_propagation relies on them.

This is test-only changes, no server side changes.

## Testing
- ./runtest-cluster --single 07-replica-migration --single 08-update-msg --stop, the reported failure sequence
- ./runtest-cluster --single 14-consistency-check --single 15-cluster-slots --single 16-transactions-on-replica --stop, the units that failed with READONLY
- ./runtest-cluster --single 00-base --stop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness only; no server, auth, or data-path changes. Slightly stricter waits may make setup fail louder instead of silently flaking.
> 
> **Overview**
> Makes the reused cluster test harness leave every node as an isolated master before join/slot allocation, so later units no longer inherit a replica that still owns slots and fail with `READONLY`.
> 
> Hard reset now runs `FLUSHALL`, `CLUSTER RESET HARD`, and `CLUSTER SET-CONFIG-EPOCH` in one `MULTI`/`EXEC` (with `replica-read-only` briefly off), asserts each reply is `OK`, and retries until every node is `role:master` with `cluster_known_nodes` of 1.
> 
> `create_cluster` and `cluster_create_with_continuous_slots` now require slot owners to be masters, set `::cluster_master_nodes` / `::cluster_replica_nodes` first, and wait for config propagation after slots and replicas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8b6da51f0b17344cbbf6c72d8f8379d6708a9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->