### PR TITLE
Fix flaky ASM error handling test: wait for cancellation to settle

### DIFF
--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -764,6 +764,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             # Cancel the task
             R 0 CLUSTER MIGRATION CANCEL ID $task_id
             R 1 CLUSTER MIGRATION CANCEL ID $task_id
+            wait_for_asm_done
 
             R 1 config set rdb-key-save-delay 0
             R 0 config set key-load-delay 0


### PR DESCRIPTION
Fixes #15340

## Problem
`CLUSTER MIGRATION CANCEL` only finished the local task. The next `IMPORT` in `asm_basic_error_handling_test` could still see a stale slot ownership.

## Fix
Wait for the cancellation to propogate through (wait_for_asm_done)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing wait; no production code or behavior changes.
> 
> **Overview**
> Stabilizes the flaky ASM basic error-handling tests by waiting after `CLUSTER MIGRATION CANCEL` so cancellation fully settles before the next `IMPORT`.
> 
> Without `wait_for_asm_done`, a later import in `asm_basic_error_handling_test` could still see stale slot ownership because cancel only finished the local task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7540adb501faf3b1c2bec4562ac5da6eb970ac08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->