### PR TITLE
Honor selective propagation for effect commands queued via alsoPropagate()

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -3023,10 +3023,7 @@ static void propagateTrimSlots(slotRangeArray *slots) {
 
     enterExecutionUnit(1, 0);
 
-    int prev_replication_allowed = server.replication_allowed;
-    server.replication_allowed = 1;
-    alsoPropagate(-1, argv, argc, PROPAGATE_AOF | PROPAGATE_REPL);
-    server.replication_allowed = prev_replication_allowed;
+    alsoPropagateForced(-1, argv, argc, PROPAGATE_AOF | PROPAGATE_REPL);
 
     exitExecutionUnit();
     postExecutionUnitOperations();

--- a/src/db.c
+++ b/src/db.c
@@ -2944,10 +2944,7 @@ void propagateDeletion(redisDb *db, robj *key, int lazy) {
 
     /* If the master decided to delete a key we must propagate it to replicas no matter what.
      * Even if module executed a command without asking for propagation. */
-    int prev_replication_allowed = server.replication_allowed;
-    server.replication_allowed = 1;
-    alsoPropagate(db->id,argv,2,PROPAGATE_AOF|PROPAGATE_REPL);
-    server.replication_allowed = prev_replication_allowed;
+    alsoPropagateForced(db->id,argv,2,PROPAGATE_AOF|PROPAGATE_REPL);
 
     decrRefCount(argv[0]);
     decrRefCount(argv[1]);

--- a/src/module.c
+++ b/src/module.c
@@ -7192,7 +7192,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
          * these client flags are the only state surviving until then: record in
          * them every target it may not reach, the ones excluded by the outer
          * call() included (call() restored its targets before returning). */
-        int targets = callPropagateTargets(c, call_flags) & server.allowed_propagate_targets;
+        int targets = getPropagateTargetsForCall(c, call_flags) & server.allowed_propagate_targets;
         if (!(targets & PROPAGATE_AOF)) {
             /* No need for AOF propagation, set the relevant flags of the client */
             c->flags |= CLIENT_MODULE_PREVENT_AOF_PROP;

--- a/src/module.c
+++ b/src/module.c
@@ -7160,16 +7160,9 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
         goto cleanup;
     }
 
-    /* We need to use a global replication_allowed flag in order to prevent
-     * replication of nested RM_Calls. Example:
-     * 1. module1.foo does RM_Call of module2.bar without replication (i.e. no '!')
-     * 2. module2.bar internally calls RM_Call of INCR with '!'
-     * 3. at the end of module1.foo we call RM_ReplicateVerbatim
-     * We want the replica/AOF to see only module1.foo and not the INCR from module2.bar */
-    int prev_replication_allowed = server.replication_allowed;
-    server.replication_allowed = replicate && server.replication_allowed;
-
-    /* Run the command */
+    /* Run the command. call() takes care of restricting what the command may
+     * propagate (including nested RM_Calls) to the targets requested here, and
+     * of restoring the previous restrictions once it returns. */
     int call_flags = CMD_CALL_FROM_MODULE;
     if (replicate) {
         if (!(flags & REDISMODULE_ARGV_NO_AOF))
@@ -7178,7 +7171,6 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
             call_flags |= CMD_CALL_PROPAGATE_REPL;
     }
     call(c,call_flags);
-    server.replication_allowed = prev_replication_allowed;
 
     if (c->flags & CLIENT_BLOCKED) {
         serverAssert(flags & REDISMODULE_ARGV_ALLOW_BLOCK);
@@ -7196,11 +7188,16 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
         };
         reply = callReplyCreatePromise(promise);
         c->bstate.async_rm_call_handle = promise;
-        if (!(call_flags & CMD_CALL_PROPAGATE_AOF)) {
+        /* The unblocked command will be reprocessed by a brand new call(), and
+         * these client flags are the only state surviving until then: record in
+         * them every target it may not reach, the ones excluded by the outer
+         * call() included (call() restored its targets before returning). */
+        int targets = callPropagateTargets(c, call_flags) & server.allowed_propagate_targets;
+        if (!(targets & PROPAGATE_AOF)) {
             /* No need for AOF propagation, set the relevant flags of the client */
             c->flags |= CLIENT_MODULE_PREVENT_AOF_PROP;
         }
-        if (!(call_flags & CMD_CALL_PROPAGATE_REPL)) {
+        if (!(targets & PROPAGATE_REPL)) {
             /* No need for replication propagation, set the relevant flags of the client */
             c->flags |= CLIENT_MODULE_PREVENT_REPL_PROP;
         }

--- a/src/networking.c
+++ b/src/networking.c
@@ -5771,6 +5771,12 @@ void processEventsWhileBlocked(void) {
     mstime_t prev_cmd_time_snapshot = server.cmd_time_snapshot;
     server.cmd_time_snapshot = server.mstime;
 
+    /* The commands processed here belong to other clients, so they must not
+     * inherit the propagation restrictions of the command we are currently
+     * blocked in (see server.allowed_propagate_targets). */
+    int prev_propagate_targets = server.allowed_propagate_targets;
+    server.allowed_propagate_targets = PROPAGATE_AOF|PROPAGATE_REPL;
+
     /* Note: when we are processing events while blocked (for instance during
      * busy Lua scripts), we set a global flag. When such flag is set, we
      * avoid handling the read part of clients using threaded I/O.
@@ -5796,6 +5802,7 @@ void processEventsWhileBlocked(void) {
     ProcessingEventsWhileBlocked--;
     serverAssert(ProcessingEventsWhileBlocked >= 0);
 
+    server.allowed_propagate_targets = prev_propagate_targets;
     server.cmd_time_snapshot = prev_cmd_time_snapshot;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -3736,13 +3736,20 @@ int mustObeyClient(client *c) {
  * is, if the AOF is enabled or if there is a replica (or a slot migration) to
  * feed.
  *
- * Note that this ignores server.allowed_propagate_targets on purpose: whether
- * the command running now may reach a target is decided once, when the op is
- * queued by alsoPropagate(), and the target stored with the op is final. Doing
- * it here as well would also apply it while flushing ops queued earlier, where
- * it could only drop an op that was legitimately queued. The callers that do
- * need to account for it narrow 'target' themselves. */
-int shouldPropagate(int target) {
+ * With 'apply_allowed_targets' set, 'target' is first narrowed to the targets
+ * the command currently running is allowed to reach (see
+ * server.allowed_propagate_targets): that is what commands building an
+ * expensive payload for alsoPropagate() want, so that they don't build it for
+ * an AOF / replica excluded by Lua redis.set_repl() or by a selective
+ * RM_Call().
+ *
+ * It must be left off when 'target' is already the final one decided when the
+ * op was queued (see propagateNow()): narrowing it again by what the command
+ * running now may reach could only drop an op that was legitimately queued. */
+int shouldPropagate(int target, int apply_allowed_targets) {
+    if (apply_allowed_targets)
+        target &= server.allowed_propagate_targets;
+
     if (target == PROPAGATE_NONE || server.loading)
         return 0;
 
@@ -3774,13 +3781,13 @@ int shouldPropagate(int target) {
  * to replicate SELECT for this command (used for database neutral commands).
  */
 static void propagateNow(int dbid, robj **argv, int argc, int target) {
-    /* No need to intersect 'target' with server.allowed_propagate_targets: it is
-     * already the final one, either decided when the op was queued by
-     * alsoPropagate() (or deliberately left unrestricted by
+    /* No need to intersect 'target' with server.allowed_propagate_targets (hence
+     * the 0 below): it is already the final one, either decided when the op was
+     * queued by alsoPropagate() (or deliberately left unrestricted by
      * alsoPropagateForced()), or the MULTI / EXEC wrapping the ops. Restricting
      * it again by what the command running now may reach could only drop an op
      * that was legitimately queued. */
-    if (!shouldPropagate(target))
+    if (!shouldPropagate(target, 0))
         return;
 
     /* This needs to be unreachable since the dataset should be fixed during
@@ -3816,7 +3823,7 @@ void alsoPropagate(int dbid, robj **argv, int argc, int target) {
      * Lua redis.set_repl() or by a selective RM_Call(). */
     target &= server.allowed_propagate_targets;
 
-    if (!shouldPropagate(target))
+    if (!shouldPropagate(target, 0))
         return;
 
     argvcopy = zmalloc(sizeof(robj*)*argc);

--- a/src/server.c
+++ b/src/server.c
@@ -3876,7 +3876,7 @@ void preventCommandReplication(client *c) {
  * Everything the command propagates is limited to these targets: the command
  * itself, at the end of call(), and the effect commands its implementation
  * queues via alsoPropagate() while it runs. */
-int callPropagateTargets(client *c, int flags) {
+int getPropagateTargetsForCall(client *c, int flags) {
     int targets = PROPAGATE_NONE;
     if ((flags & CMD_CALL_PROPAGATE_AOF) && !(c->flags & CLIENT_MODULE_PREVENT_AOF_PROP))
         targets |= PROPAGATE_AOF;
@@ -4142,7 +4142,7 @@ void call(client *c, int flags) {
      * propagates it verbatim at the end, is what makes the effect commands
      * queued via alsoPropagate() (SPOP propagated as SREM, RM_Replicate(), and
      * so forth) honor Lua redis.set_repl() and selective RM_Call() too. */
-    int call_targets = callPropagateTargets(c, flags);
+    int call_targets = getPropagateTargetsForCall(c, flags);
     int prev_targets = server.allowed_propagate_targets;
     server.allowed_propagate_targets = prev_targets & call_targets;
 

--- a/src/server.c
+++ b/src/server.c
@@ -3736,20 +3736,13 @@ int mustObeyClient(client *c) {
  * is, if the AOF is enabled or if there is a replica (or a slot migration) to
  * feed.
  *
- * With 'apply_allowed_targets' set, 'target' is first narrowed to the targets
- * the command currently running is allowed to reach (see
- * server.allowed_propagate_targets): that is what commands building an
- * expensive payload for alsoPropagate() want, so that they don't build it for
- * an AOF / replica excluded by Lua redis.set_repl() or by a selective
- * RM_Call().
- *
- * It must be left off when 'target' is already the final one decided when the
- * op was queued (see propagateNow()): narrowing it again by what the command
- * running now may reach could only drop an op that was legitimately queued. */
-int shouldPropagate(int target, int apply_allowed_targets) {
-    if (apply_allowed_targets)
-        target &= server.allowed_propagate_targets;
-
+ * Note that this ignores server.allowed_propagate_targets on purpose: whether
+ * the command running now may reach a target is decided once, when the op is
+ * queued by alsoPropagate(), and the target stored with the op is final. Doing
+ * it here as well would also apply it while flushing ops queued earlier, where
+ * it could only drop an op that was legitimately queued. The callers that do
+ * need to account for it narrow 'target' themselves. */
+int shouldPropagate(int target) {
     if (target == PROPAGATE_NONE || server.loading)
         return 0;
 
@@ -3781,13 +3774,13 @@ int shouldPropagate(int target, int apply_allowed_targets) {
  * to replicate SELECT for this command (used for database neutral commands).
  */
 static void propagateNow(int dbid, robj **argv, int argc, int target) {
-    /* No need to intersect 'target' with server.allowed_propagate_targets (hence
-     * the 0 below): it is already the final one, either decided when the op was
-     * queued by alsoPropagate() (or deliberately left unrestricted by
+    /* No need to intersect 'target' with server.allowed_propagate_targets: it is
+     * already the final one, either decided when the op was queued by
+     * alsoPropagate() (or deliberately left unrestricted by
      * alsoPropagateForced()), or the MULTI / EXEC wrapping the ops. Restricting
      * it again by what the command running now may reach could only drop an op
      * that was legitimately queued. */
-    if (!shouldPropagate(target, 0))
+    if (!shouldPropagate(target))
         return;
 
     /* This needs to be unreachable since the dataset should be fixed during
@@ -3823,7 +3816,7 @@ void alsoPropagate(int dbid, robj **argv, int argc, int target) {
      * Lua redis.set_repl() or by a selective RM_Call(). */
     target &= server.allowed_propagate_targets;
 
-    if (!shouldPropagate(target, 0))
+    if (!shouldPropagate(target))
         return;
 
     argvcopy = zmalloc(sizeof(robj*)*argc);

--- a/src/server.c
+++ b/src/server.c
@@ -3614,6 +3614,7 @@ int redisOpArrayAppend(redisOpArray *oa, int dbid, robj **argv, int argc, int ta
     op->argc = argc;
     op->target = target;
     oa->numops++;
+    oa->targets |= target;
     return oa->numops;
 }
 
@@ -3630,6 +3631,7 @@ void redisOpArrayFree(redisOpArray *oa) {
     }
     /* no need to free the actual op array, we reuse the memory for future commands */
     serverAssert(!oa->numops);
+    oa->targets = PROPAGATE_NONE;
 }
 
 /* ====================== Commands lookup and execution ===================== */
@@ -3931,9 +3933,12 @@ static void propagatePendingCommands(void) {
     redisOp *rop;
 
     /* If we got here it means we have finished an execution-unit.
-     * If that unit has caused propagation of multiple commands, they
-     * should be propagated as a transaction */
-    int transaction = server.also_propagate.numops > 1;
+     * If that unit has caused propagation of multiple commands, they should be
+     * propagated as a transaction, to the targets the ops reach: the ops may
+     * have been restricted to a subset of them (see alsoPropagate()), and the
+     * excluded target would just get an empty MULTI / EXEC pair. */
+    int transaction_target = server.also_propagate.numops > 1 ?
+                             server.also_propagate.targets : PROPAGATE_NONE;
 
     /* In case a command that may modify random keys was run *directly*
      * (i.e. not from within a script, MULTI/EXEC, RM_Call, etc.) we want
@@ -3942,13 +3947,13 @@ static void propagatePendingCommands(void) {
         server.current_client->cmd &&
         server.current_client->cmd->flags & CMD_TOUCHES_ARBITRARY_KEYS)
     {
-        transaction = 0;
+        transaction_target = PROPAGATE_NONE;
     }
 
-    if (transaction) {
+    if (transaction_target) {
         /* We use dbid=-1 to indicate we do not want to replicate SELECT.
          * It'll be inserted together with the next command (inside the MULTI) */
-        propagateNow(-1,&shared.multi,1,PROPAGATE_AOF|PROPAGATE_REPL);
+        propagateNow(-1,&shared.multi,1,transaction_target);
     }
 
     for (j = 0; j < server.also_propagate.numops; j++) {
@@ -3957,9 +3962,9 @@ static void propagatePendingCommands(void) {
         propagateNow(rop->dbid,rop->argv,rop->argc,rop->target);
     }
 
-    if (transaction) {
+    if (transaction_target) {
         /* We use dbid=-1 to indicate we do not want to replicate select */
-        propagateNow(-1,&shared.exec,1,PROPAGATE_AOF|PROPAGATE_REPL);
+        propagateNow(-1,&shared.exec,1,transaction_target);
     }
 
     redisOpArrayFree(&server.also_propagate);

--- a/src/server.c
+++ b/src/server.c
@@ -3047,7 +3047,7 @@ void initServer(void) {
     /* clients_timeout_table key = 8 bytes BE mstime + 8 bytes client ID
      * (see CLIENT_ST_KEYLEN / encodeTimeoutKey in timeout.c). */
     server.clients_timeout_table = raxNewEx(0, NULL, sizeof(uint64_t) * 2);
-    server.replication_allowed = 1;
+    server.allowed_propagate_targets = PROPAGATE_AOF|PROPAGATE_REPL;
     server.slaveseldb = -1; /* Force to emit the first SELECT command. */
     server.unblocked_clients = listCreate();
     server.ready_keys = listCreate();
@@ -3732,8 +3732,18 @@ int mustObeyClient(client *c) {
     return c->id == CLIENT_ID_AOF || c->flags & CLIENT_MASTER;
 }
 
+/* Return true if any of the given targets can currently receive commands, that
+ * is, if the AOF is enabled or if there is a replica (or a slot migration) to
+ * feed.
+ *
+ * Note that this ignores server.allowed_propagate_targets on purpose: whether
+ * the command running now may reach a target is decided once, when the op is
+ * queued by alsoPropagate(), and the target stored with the op is final. Doing
+ * it here as well would also apply it while flushing ops queued earlier, where
+ * it could only drop an op that was legitimately queued. The callers that do
+ * need to account for it narrow 'target' themselves. */
 int shouldPropagate(int target) {
-    if (!server.replication_allowed || target == PROPAGATE_NONE || server.loading)
+    if (target == PROPAGATE_NONE || server.loading)
         return 0;
 
     if (target & PROPAGATE_AOF) {
@@ -3764,6 +3774,12 @@ int shouldPropagate(int target) {
  * to replicate SELECT for this command (used for database neutral commands).
  */
 static void propagateNow(int dbid, robj **argv, int argc, int target) {
+    /* No need to intersect 'target' with server.allowed_propagate_targets: it is
+     * already the final one, either decided when the op was queued by
+     * alsoPropagate() (or deliberately left unrestricted by
+     * alsoPropagateForced()), or the MULTI / EXEC wrapping the ops. Restricting
+     * it again by what the command running now may reach could only drop an op
+     * that was legitimately queued. */
     if (!shouldPropagate(target))
         return;
 
@@ -3795,6 +3811,11 @@ void alsoPropagate(int dbid, robj **argv, int argc, int target) {
     robj **argvcopy;
     int j;
 
+    /* Drop the targets the command currently running is not allowed to reach,
+     * so that its effect commands don't end up in an AOF / replica excluded by
+     * Lua redis.set_repl() or by a selective RM_Call(). */
+    target &= server.allowed_propagate_targets;
+
     if (!shouldPropagate(target))
         return;
 
@@ -3804,6 +3825,18 @@ void alsoPropagate(int dbid, robj **argv, int argc, int target) {
         incrRefCount(argv[j]);
     }
     redisOpArrayAppend(&server.also_propagate,dbid,argvcopy,argc,target);
+}
+
+/* Like alsoPropagate(), but ignoring the targets that were excluded for the
+ * command currently running. To be used only for implicit changes the server
+ * decided to make by itself (expired or evicted keys, slots trimmed after a
+ * migration): those must always reach the AOF and the replicas, no matter what
+ * the command that happened to trigger them asked for. */
+void alsoPropagateForced(int dbid, robj **argv, int argc, int target) {
+    int prev_targets = server.allowed_propagate_targets;
+    server.allowed_propagate_targets = PROPAGATE_AOF|PROPAGATE_REPL;
+    alsoPropagate(dbid,argv,argc,target);
+    server.allowed_propagate_targets = prev_targets;
 }
 
 /* It is possible to call the function forceCommandPropagation() inside a
@@ -3830,6 +3863,26 @@ void preventCommandAOF(client *c) {
 /* Replication specific version of preventCommandPropagation(). */
 void preventCommandReplication(client *c) {
     c->flags |= CLIENT_PREVENT_REPL_PROP;
+}
+
+/* Return the PROPAGATE_* targets that a call() of the given client with the
+ * given flags is allowed to reach: the ones the caller of call() asked for,
+ * minus the ones the module owning the client vetoed.
+ *
+ * The CLIENT_MODULE_PREVENT_*_PROP flags outlive the call() that set them, so
+ * that an RM_Call() that got blocked keeps its restrictions once the command is
+ * reprocessed by a brand new call() (see RM_Call()).
+ *
+ * Everything the command propagates is limited to these targets: the command
+ * itself, at the end of call(), and the effect commands its implementation
+ * queues via alsoPropagate() while it runs. */
+int callPropagateTargets(client *c, int flags) {
+    int targets = PROPAGATE_NONE;
+    if ((flags & CMD_CALL_PROPAGATE_AOF) && !(c->flags & CLIENT_MODULE_PREVENT_AOF_PROP))
+        targets |= PROPAGATE_AOF;
+    if ((flags & CMD_CALL_PROPAGATE_REPL) && !(c->flags & CLIENT_MODULE_PREVENT_REPL_PROP))
+        targets |= PROPAGATE_REPL;
+    return targets;
 }
 
 /* Log the last command a client executed into the slowlog. */
@@ -4077,7 +4130,25 @@ void call(client *c, int flags) {
      * re-processing and unblock the client.*/
     c->flags |= CLIENT_EXECUTING_COMMAND;
 
+    /* We need to use a global flag with the propagation targets allowed for the
+     * command we are about to run, in order to prevent propagation of nested
+     * calls to a target that an outer call excluded. Example:
+     * 1. module1.foo does RM_Call of module2.bar without replication (i.e. no '!')
+     * 2. module2.bar internally calls RM_Call of INCR with '!'
+     * 3. at the end of module1.foo we call RM_ReplicateVerbatim
+     * We want the replica/AOF to see only module1.foo and not the INCR from module2.bar
+     *
+     * Restricting the targets while the command runs, and not just when call()
+     * propagates it verbatim at the end, is what makes the effect commands
+     * queued via alsoPropagate() (SPOP propagated as SREM, RM_Replicate(), and
+     * so forth) honor Lua redis.set_repl() and selective RM_Call() too. */
+    int call_targets = callPropagateTargets(c, flags);
+    int prev_targets = server.allowed_propagate_targets;
+    server.allowed_propagate_targets = prev_targets & call_targets;
+
     c->cmd->proc(c);
+
+    server.allowed_propagate_targets = prev_targets;
 
     exitExecutionUnit();
 
@@ -4201,16 +4272,11 @@ void call(client *c, int flags) {
         if (c->flags & CLIENT_FORCE_AOF) propagate_flags |= PROPAGATE_AOF;
 
         /* However prevent AOF / replication propagation if the command
-         * implementation called preventCommandPropagation() or similar,
-         * or if we don't have the call() flags to do so. */
-        if (c->flags & CLIENT_PREVENT_REPL_PROP        ||
-            c->flags & CLIENT_MODULE_PREVENT_REPL_PROP ||
-            !(flags & CMD_CALL_PROPAGATE_REPL))
-                propagate_flags &= ~PROPAGATE_REPL;
-        if (c->flags & CLIENT_PREVENT_AOF_PROP        ||
-            c->flags & CLIENT_MODULE_PREVENT_AOF_PROP ||
-            !(flags & CMD_CALL_PROPAGATE_AOF))
-                propagate_flags &= ~PROPAGATE_AOF;
+         * implementation called preventCommandPropagation() or similar, or if
+         * this call() is not allowed to reach the target at all. */
+        if (c->flags & CLIENT_PREVENT_REPL_PROP) propagate_flags &= ~PROPAGATE_REPL;
+        if (c->flags & CLIENT_PREVENT_AOF_PROP) propagate_flags &= ~PROPAGATE_AOF;
+        propagate_flags &= call_targets;
 
         /* Call alsoPropagate() only if at least one of AOF / replication
          * propagation is needed. */

--- a/src/server.h
+++ b/src/server.h
@@ -2428,7 +2428,7 @@ struct redisServer {
     int allowed_propagate_targets;  /* The PROPAGATE_* targets that the command
                                        currently running may reach. Each call()
                                        intersects it with its own targets (see
-                                       callPropagateTargets()), so that effect
+                                       getPropagateTargetsForCall()), so that effect
                                        commands queued via alsoPropagate()
                                        honor Lua redis.set_repl() and selective
                                        RM_Call() propagation. */
@@ -3877,7 +3877,7 @@ int incrCommandStatsOnError(struct redisCommand *cmd, int flags);
 void call(client *c, int flags);
 void alsoPropagate(int dbid, robj **argv, int argc, int target);
 void alsoPropagateForced(int dbid, robj **argv, int argc, int target);
-int callPropagateTargets(client *c, int flags);
+int getPropagateTargetsForCall(client *c, int flags);
 int shouldPropagate(int target);
 void postExecutionUnitOperations(void);
 int redisOpArrayAppend(redisOpArray *oa, int dbid, robj **argv, int argc, int target);

--- a/src/server.h
+++ b/src/server.h
@@ -2425,7 +2425,13 @@ struct redisServer {
     int child_info_nread;           /* Num of bytes of the last read from pipe */
     /* Propagation of commands in AOF / replication */
     redisOpArray also_propagate;    /* Additional command to propagate. */
-    int replication_allowed;        /* Are we allowed to replicate? */
+    int allowed_propagate_targets;  /* The PROPAGATE_* targets that the command
+                                       currently running may reach. Each call()
+                                       intersects it with its own targets (see
+                                       callPropagateTargets()), so that effect
+                                       commands queued via alsoPropagate()
+                                       honor Lua redis.set_repl() and selective
+                                       RM_Call() propagation. */
     /* Logging */
     char *logfile;                  /* Path of log file */
     int syslog_enabled;             /* Is syslog enabled? */
@@ -3870,6 +3876,8 @@ void startCommandExecution(void);
 int incrCommandStatsOnError(struct redisCommand *cmd, int flags);
 void call(client *c, int flags);
 void alsoPropagate(int dbid, robj **argv, int argc, int target);
+void alsoPropagateForced(int dbid, robj **argv, int argc, int target);
+int callPropagateTargets(client *c, int flags);
 int shouldPropagate(int target);
 void postExecutionUnitOperations(void);
 int redisOpArrayAppend(redisOpArray *oa, int dbid, robj **argv, int argc, int target);

--- a/src/server.h
+++ b/src/server.h
@@ -3878,7 +3878,7 @@ void call(client *c, int flags);
 void alsoPropagate(int dbid, robj **argv, int argc, int target);
 void alsoPropagateForced(int dbid, robj **argv, int argc, int target);
 int callPropagateTargets(client *c, int flags);
-int shouldPropagate(int target, int apply_allowed_targets);
+int shouldPropagate(int target);
 void postExecutionUnitOperations(void);
 int redisOpArrayAppend(redisOpArray *oa, int dbid, robj **argv, int argc, int target);
 void redisOpArrayFree(redisOpArray *oa);

--- a/src/server.h
+++ b/src/server.h
@@ -3878,7 +3878,7 @@ void call(client *c, int flags);
 void alsoPropagate(int dbid, robj **argv, int argc, int target);
 void alsoPropagateForced(int dbid, robj **argv, int argc, int target);
 int callPropagateTargets(client *c, int flags);
-int shouldPropagate(int target);
+int shouldPropagate(int target, int apply_allowed_targets);
 void postExecutionUnitOperations(void);
 int redisOpArrayAppend(redisOpArray *oa, int dbid, robj **argv, int argc, int target);
 void redisOpArrayFree(redisOpArray *oa);

--- a/src/server.h
+++ b/src/server.h
@@ -1868,6 +1868,7 @@ typedef struct redisOpArray {
     redisOp *ops;
     int numops;
     int capacity;
+    int targets;    /* Union of the targets of the ops above. */
 } redisOpArray;
 
 /* This structure is returned by the getMemoryOverheadData() function in

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -4587,7 +4587,8 @@ void himportSetCommand(client *c) {
      *
      * In the future this can be improved to send the fields only once instead of
      * on every SET, lowering the propagation cost further. */
-    if (shouldPropagate(PROPAGATE_AOF | PROPAGATE_REPL, 1)) {
+    int prop_target = (PROPAGATE_AOF | PROPAGATE_REPL) & server.allowed_propagate_targets;
+    if (shouldPropagate(prop_target)) {
         /* Presize the payload: field-name footprint + value bytes (over-estimate ok). */
         sds payload = createRawDumpPayload(o, c->argv[2], c->db->id, 0,
                                            tmpl->mem_size + total_values_length);
@@ -4599,7 +4600,7 @@ void himportSetCommand(client *c) {
                 restore_pl,
                 shared.replace
         };
-        alsoPropagate(c->db->id, rargv, 5, PROPAGATE_AOF | PROPAGATE_REPL);
+        alsoPropagate(c->db->id, rargv, 5, prop_target);
         decrRefCount(restore_pl);
     }
     preventCommandPropagation(c);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -4587,7 +4587,8 @@ void himportSetCommand(client *c) {
      *
      * In the future this can be improved to send the fields only once instead of
      * on every SET, lowering the propagation cost further. */
-    if (shouldPropagate(PROPAGATE_AOF | PROPAGATE_REPL)) {
+    int prop_target = (PROPAGATE_AOF | PROPAGATE_REPL) & server.allowed_propagate_targets;
+    if (shouldPropagate(prop_target)) {
         /* Presize the payload: field-name footprint + value bytes (over-estimate ok). */
         sds payload = createRawDumpPayload(o, c->argv[2], c->db->id, 0,
                                            tmpl->mem_size + total_values_length);
@@ -4599,7 +4600,7 @@ void himportSetCommand(client *c) {
                 restore_pl,
                 shared.replace
         };
-        alsoPropagate(c->db->id, rargv, 5, PROPAGATE_AOF | PROPAGATE_REPL);
+        alsoPropagate(c->db->id, rargv, 5, prop_target);
         decrRefCount(restore_pl);
     }
     preventCommandPropagation(c);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -6242,10 +6242,9 @@ static void propagateHashFieldDeletion(redisDb *db, sds key, char *field, size_t
     };
 
     enterExecutionUnit(1, 0);
-    int prev_replication_allowed = server.replication_allowed;
-    server.replication_allowed = 1;
-    alsoPropagate(db->id,argv, 3, PROPAGATE_AOF|PROPAGATE_REPL);
-    server.replication_allowed = prev_replication_allowed;
+    /* Field expiration is decided by the server, so it must be propagated even
+     * if the command that triggered it asked not to propagate. */
+    alsoPropagateForced(db->id,argv, 3, PROPAGATE_AOF|PROPAGATE_REPL);
     exitExecutionUnit();
 
     /* Propagate the HDEL command */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -4587,8 +4587,7 @@ void himportSetCommand(client *c) {
      *
      * In the future this can be improved to send the fields only once instead of
      * on every SET, lowering the propagation cost further. */
-    int prop_target = (PROPAGATE_AOF | PROPAGATE_REPL) & server.allowed_propagate_targets;
-    if (shouldPropagate(prop_target)) {
+    if (shouldPropagate(PROPAGATE_AOF | PROPAGATE_REPL, 1)) {
         /* Presize the payload: field-name footprint + value bytes (over-estimate ok). */
         sds payload = createRawDumpPayload(o, c->argv[2], c->db->id, 0,
                                            tmpl->mem_size + total_values_length);
@@ -4600,7 +4599,7 @@ void himportSetCommand(client *c) {
                 restore_pl,
                 shared.replace
         };
-        alsoPropagate(c->db->id, rargv, 5, prop_target);
+        alsoPropagate(c->db->id, rargv, 5, PROPAGATE_AOF | PROPAGATE_REPL);
         decrRefCount(restore_pl);
     }
     preventCommandPropagation(c);

--- a/tests/unit/moduleapi/async_rm_call.tcl
+++ b/tests/unit/moduleapi/async_rm_call.tcl
@@ -297,6 +297,63 @@ start_server {tags {"modules external:skip"}} {
         wait_for_blocked_clients_count 0
         $rd close
     }
+
+    test {Test no propagation of effect commands queued by a blocking command} {
+        r flushall
+        r xgroup create s g $ MKSTREAM
+        set repl [attach_to_replication_stream]
+
+        set rd [redis_deferring_client]
+
+        $rd do_rm_call_async_no_replicate xreadgroup group g c block 0 streams s >
+        wait_for_blocked_clients_count 1
+        r xadd s * f v
+        assert {[$rd read] ne {}}
+
+        # XREADGROUP propagates the delivery to the consumer group as an XCLAIM
+        # queued via alsoPropagate(). The RM_Call was made without '!', and the
+        # restriction must survive the blocking of the command.
+        r set x 1
+
+        assert_replication_stream $repl {
+            {select *}
+            {xadd s * f v}
+            {set x 1}
+        }
+        close_replication_stream $repl
+
+        wait_for_blocked_clients_count 0
+        $rd close
+    }
+
+    test {Test no propagation of effect commands queued by a nested blocking command} {
+        r flushall
+        r xgroup create s g $ MKSTREAM
+        set repl [attach_to_replication_stream]
+
+        set rd [redis_deferring_client]
+
+        # The outer RM_Call omits '!' while the inner one asks for propagation
+        # and blocks: the restriction of the outer call must still be honored
+        # once the inner command is reprocessed.
+        $rd do_rm_call_async_no_replicate do_rm_call_async \
+            xreadgroup group g c block 0 streams s >
+        wait_for_blocked_clients_count 1
+        r xadd s * f v
+        assert {[$rd read] ne {}}
+
+        r set x 1
+
+        assert_replication_stream $repl {
+            {select *}
+            {xadd s * f v}
+            {set x 1}
+        }
+        close_replication_stream $repl
+
+        wait_for_blocked_clients_count 0
+        $rd close
+    }
 }
 
 start_server {tags {"modules external:skip"}} {

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -767,6 +767,53 @@ tags "modules aof external:skip" {
     }
 }
 
+tags "modules aof external:skip" {
+    start_server [list overrides [list loadmodule "$miscmodule"]] {
+        r config set appendonly yes
+        r config set auto-aof-rewrite-percentage 0 ; # Disable auto-rewrite.
+        waitForBgrewriteaof r
+
+        # The counted form of SPOP replaces its own propagation with an SREM
+        # queued through alsoPropagate(): it must reach only the targets the
+        # RM_Call asked for, just like the propagation of the command itself.
+        set keys {spop-none spop-repl spop-aof spop-all spop-nested}
+        foreach key $keys {
+            r sadd $key a b c d e
+        }
+
+        test {RM_Call effect commands honor the selective propagation flags} {
+            set repl [attach_to_replication_stream]
+
+            assert_equal 2 [llength [r test.rm_call spop spop-none 2]]
+            assert_equal 2 [llength [r test.rm_call_flags !A spop spop-repl 2]]
+            assert_equal 2 [llength [r test.rm_call_flags !R spop spop-aof 2]]
+            assert_equal 2 [llength [r test.rm_call_flags ! spop spop-all 2]]
+
+            # An inner RM_Call with '!' must not resurrect the propagation
+            # suppressed by the outer one.
+            assert_equal 2 [llength [r test.rm_call test.rm_call_flags ! spop spop-nested 2]]
+
+            # The master applied all of them.
+            assert_equal {3 3 3 3 3} [lmap key $keys {r scard $key}]
+
+            assert_replication_stream $repl {
+                {select *}
+                {srem spop-repl * *}
+                {srem spop-all * *}
+            }
+            close_replication_stream $repl
+        }
+
+        test {RM_Call effect commands honor the selective propagation flags after AOF reload} {
+            r debug loadaof
+
+            # Only the sets whose SREM reached the AOF are trimmed, the others
+            # are back to the 5 members added by the SADD above.
+            assert_equal {5 5 3 3 5} [lmap key $keys {r scard $key}]
+        }
+    }
+}
+
 # This test does not really test module functionality, but rather uses a module
 # command to test Redis replication mechanisms.
 test {Replicas that was marked as CLIENT_CLOSE_ASAP should not keep the replication backlog from been trimmed} {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1667,6 +1667,85 @@ start_server {tags {"scripting repl external:skip"}} {
             assert {[r mget a b c d] eq {1 {} 3 4}}
         }
 
+        test "Test selective replication of effect commands from Lua" {
+            # Commands that replace their own propagation (the counted form of
+            # SPOP propagates as SREM) queue the replacement via
+            # alsoPropagate(), which must honor set_repl() as well.
+            set keys {s1{t} s2{t} s3{t} s4{t}}
+            r del {*}$keys
+            foreach key $keys {
+                r sadd $key a b c d e
+            }
+            run_script {
+                redis.call('spop',KEYS[1],2);
+                redis.set_repl(redis.REPL_NONE);
+                redis.call('spop',KEYS[2],2);
+                redis.set_repl(redis.REPL_AOF);
+                redis.call('spop',KEYS[3],2);
+                redis.set_repl(redis.REPL_ALL);
+                redis.call('spop',KEYS[4],2);
+            } 4 {*}$keys
+
+            # The master popped members from all the four sets.
+            assert_equal {3 3 3 3} [lmap key $keys {r scard $key}]
+
+            # Only the SREM of s1 and s4 should have reached the replica.
+            wait_for_condition 50 100 {
+                [lmap key $keys {r -1 scard $key}] eq {3 5 5 3}
+            } else {
+                fail "Only the SREM of s1 and s4 should be replicated to replica"
+            }
+
+            # After an AOF reload only s1, s3 and s4 should be trimmed.
+            r debug loadaof
+
+            assert_equal {3 5 3 3} [lmap key $keys {r scard $key}]
+        }
+
+        test "Test implicit deletions are replicated despite set_repl(REPL_NONE)" {
+            # Keys and hash fields deleted because they expired are an implicit
+            # decision of the server, so they must always be propagated, no
+            # matter what the script that happened to touch them asked for.
+            r debug set-active-expire 0
+            r del expkey{t} exphash{t} sentinel{t}
+            r set expkey{t} v px 1
+            r hset exphash{t} f1 v1 f2 v2
+            r hpexpire exphash{t} 1 fields 1 f1
+            after 20
+
+            set repl [attach_to_replication_stream]
+            run_script {
+                redis.set_repl(redis.REPL_NONE);
+                redis.call('get',KEYS[1]);
+                redis.call('hget',KEYS[2],'f1');
+                redis.set_repl(redis.REPL_ALL);
+                redis.call('set',KEYS[3],'1');
+            } 3 expkey{t} exphash{t} sentinel{t}
+
+            if {$is_eval} {
+                assert_replication_stream $repl {
+                    {multi}
+                    {select *}
+                    {del expkey{t}}
+                    {hdel exphash{t} f1}
+                    {set sentinel{t} 1}
+                    {exec}
+                }
+            } else {
+                assert_replication_stream $repl {
+                    {select *}
+                    {function load *}
+                    {multi}
+                    {del expkey{t}}
+                    {hdel exphash{t} f1}
+                    {set sentinel{t} 1}
+                    {exec}
+                }
+            }
+            close_replication_stream $repl
+            r debug set-active-expire 1
+        }
+
         test "PRNG is seeded randomly for command replication" {
             if {$is_eval eq 1} {
                 # on is_eval Lua we need to call redis.replicate_commands() to get real randomization

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1771,6 +1771,36 @@ start_server {tags {"scripting repl external:skip"}} {
             r debug set-active-expire 1
         }
 
+        test "Test no empty MULTI/EXEC is replicated for AOF-only effects" {
+            # Both SREM the SPOP calls queue are restricted to the AOF, so the
+            # replica must receive nothing at all: not even the MULTI / EXEC
+            # that wraps them in the AOF.
+            r del myset{t} sentinel{t}
+            r sadd myset{t} a b c d e
+
+            set repl [attach_to_replication_stream]
+            run_script {
+                redis.set_repl(redis.REPL_AOF);
+                redis.call('spop',KEYS[1],2);
+                redis.call('spop',KEYS[1],2);
+            } 1 myset{t}
+            r set sentinel{t} 1
+
+            if {$is_eval} {
+                assert_replication_stream $repl {
+                    {select *}
+                    {set sentinel{t} 1}
+                }
+            } else {
+                assert_replication_stream $repl {
+                    {select *}
+                    {function load *}
+                    {set sentinel{t} 1}
+                }
+            }
+            close_replication_stream $repl
+        }
+
         test "PRNG is seeded randomly for command replication" {
             if {$is_eval eq 1} {
                 # on is_eval Lua we need to call redis.replicate_commands() to get real randomization

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1702,6 +1702,31 @@ start_server {tags {"scripting repl external:skip"}} {
             assert_equal {3 5 3 3} [lmap key $keys {r scard $key}]
         }
 
+        test "Test selective replication of HIMPORT SET from Lua" {
+            # HIMPORT SET replaces its own propagation with a RESTORE queued via
+            # alsoPropagate(), so it must honor set_repl() too. The fieldset
+            # prepared by HIMPORT PREPARE is per-client state, hence both calls
+            # have to happen inside the same script.
+            r del ht1{t} ht2{t}
+            run_script {
+                redis.call('himport','prepare','fs','f1','f2');
+                redis.set_repl(redis.REPL_NONE);
+                redis.call('himport','set',KEYS[1],'fs','v1','v2');
+                redis.set_repl(redis.REPL_ALL);
+                redis.call('himport','set',KEYS[2],'fs','v3','v4');
+            } 2 ht1{t} ht2{t}
+
+            assert_equal {v1 v2} [r hmget ht1{t} f1 f2]
+            assert_equal {v3 v4} [r hmget ht2{t} f1 f2]
+
+            wait_for_condition 50 100 {
+                [r -1 hmget ht2{t} f1 f2] eq {v3 v4}
+            } else {
+                fail "The RESTORE of ht2 should be replicated to replica"
+            }
+            assert_equal 0 [r -1 exists ht1{t}]
+        }
+
         test "Test implicit deletions are replicated despite set_repl(REPL_NONE)" {
             # Keys and hash fields deleted because they expired are an implicit
             # decision of the server, so they must always be propagated, no


### PR DESCRIPTION
Fixes #15638
Based on #15639

## Problem

Commands that replace their own propagation queue the replacement via `alsoPropagate()` with a hardcoded `PROPAGATE_AOF|PROPAGATE_REPL` target, while `call()` applied its `CMD_CALL_PROPAGATE_*` flags only to the verbatim propagation it performs itself. So the replacement leaked to targets excluded by Lua `redis.set_repl()` or by a selective `RM_Call()`:

```
sadd myset a b c d e
eval "redis.set_repl(redis.REPL_NONE); redis.call('spop', 'myset', 2)" 0
```

still replicated `SREM myset a d`. Same for the stream consumer-group rewrites (XREADGROUP → XCLAIM, XAUTOCLAIM → XCLAIM / XACK, and the XGROUP SETID / CREATECONSUMER they imply), `HIMPORT SET` (propagated as `RESTORE`), `RM_Replicate()`, and every other user of this pattern.

## Fix

Replace the `server.replication_allowed` boolean with `server.allowed_propagate_targets`, holding the `PROPAGATE_*` targets that the command currently running may reach:

- `call()` computes its own targets with `getPropagateTargetsForCall()` (the `CMD_CALL_PROPAGATE_*` flags minus the `CLIENT_MODULE_PREVENT_*_PROP` vetoes) and intersects `server.allowed_propagate_targets` with them around the command proc, so a nested `call()` can only drop a target an outer one excluded, never bring it back. The verbatim propagation at the end of `call()` is bounded by the same targets.
- `RM_Call()` no longer flips the global flag itself: `call()` does the restriction for it, nested `RM_Call()`s included.
- `alsoPropagate()` narrows the target before queuing the op, so the queued target is final; `propagateNow()` just honors it and `shouldPropagate()` is back to answering only "is the AOF / a replica there". `HIMPORT SET`, which checks `shouldPropagate()` before building its `RESTORE` payload, narrows the target itself first.
- Deletions the server decides by itself (expired or evicted keys, expired hash fields, slots trimmed after a migration) go through the new `alsoPropagateForced()` and are always propagated, whatever the command that happened to trigger them asked for.
- When the command of an `RM_Call()` blocks, the targets it may not reach (those excluded by the outer `call()` included) are recorded in `CLIENT_MODULE_PREVENT_*_PROP`: those flags are the only state that survives until the command is reprocessed by a brand new `call()`.
- `processEventsWhileBlocked()` restores the full targets while it runs: the commands it processes belong to other clients and must not inherit the restrictions of the command we are blocked in.
- `propagatePendingCommands()` wraps the queued ops in a `MULTI` / `EXEC` only for the targets they actually reach (the union of the ops' targets, now tracked in `redisOpArray`), instead of always for `PROPAGATE_AOF|PROPAGATE_REPL`.

That last point fixes a pre-existing bug rather than fallout from the change above. Whenever every op queued in one execution unit was restricted to a single target, the *other* target received a `MULTI` / `EXEC` pair with nothing in between. It reproduces on `unstable` without any of the changes here, with AOF enabled and a replica attached:

```
eval "redis.set_repl(redis.REPL_AOF); redis.call('set','a','1'); redis.call('set','b','2')" 0
```

replicates a bare `MULTI` / `EXEC` to the replica. So does a module command issuing two or more `RM_Call()` with `!A` / `!R`, or two or more `RM_Replicate()` with the `A` / `R` modifiers, so it affects the selective propagation of both module APIs as well. Harmless in practice, but it burns replication offset and backlog and makes the stream confusing to read.

---------

Co-authored-by: Antonio Viggiano <agfviggiano@gmail.com>