### PR TITLE
Fix SETBIT and BITFIELD string growth accounting

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -810,6 +810,9 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
         if (server.memory_tracking_enabled)
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldAllocSize, kvobjAllocSize(o));
         *strGrowSize = sdslen(o->ptr) - *strOldSize;
+        
+        if (*strGrowSize != 0)
+            updateKeysizesHist(c->db, OBJ_STRING, *strOldSize, *strOldSize + *strGrowSize);
     }
     return o;
 }
@@ -886,12 +889,6 @@ void setbitCommand(client *c) {
         keyModified(c,c->db,c->argv[1],o,1);
         notifyKeyspaceEvent(NOTIFY_STRING,"setbit",c->argv[1],c->db->id);
         server.dirty++;
-
-        /* If this is not a new key (old size not 0) and size changed, then 
-         * update the keysizes histogram. Otherwise, the histogram already 
-         * updated in lookupStringForBitCommand() by calling dbAdd(). */
-        if ((strOldSize > 0) && (strGrowSize != 0))
-            updateKeysizesHist(c->db, OBJ_STRING, strOldSize, strOldSize + strGrowSize);
     }
 
     /* Return original value. */
@@ -2108,13 +2105,6 @@ void bitfieldGeneric(client *c, int flags) {
     }
 
     if (changes) {
-
-        /* If this is not a new key (old size not 0) and size changed, then 
-         * update the keysizes histogram. Otherwise, the histogram already 
-         * updated in lookupStringForBitCommand() by calling dbAdd(). */
-        if ((strOldSize > 0) && (strGrowSize != 0))
-            updateKeysizesHist(c->db, OBJ_STRING, strOldSize, strOldSize + strGrowSize);
-        
         keyModified(c,c->db,c->argv[1],o,1);
         notifyKeyspaceEvent(NOTIFY_STRING,"setbit",c->argv[1],c->db->id);
         server.dirty += changes;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -2104,10 +2104,12 @@ void bitfieldGeneric(client *c, int flags) {
         }
     }
 
-    if (changes) {
+    if (changes || strGrowSize) {
         keyModified(c,c->db,c->argv[1],o,1);
         notifyKeyspaceEvent(NOTIFY_STRING,"setbit",c->argv[1],c->db->id);
-        server.dirty += changes;
+        /* OVERFLOW FAIL can reject every write after the string has already
+         * grown. Account for that growth as one mutation. */
+        server.dirty += changes ? changes : 1;
     }
     zfree(ops);
 }

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -811,6 +811,8 @@ static kvobj *lookupStringForBitCommand(client *c, uint64_t maxbit,
             updateSlotAllocSize(c->db, getKeySlot(c->argv[1]->ptr), o, oldAllocSize, kvobjAllocSize(o));
         *strGrowSize = sdslen(o->ptr) - *strOldSize;
         
+        /* New keys are accounted for by dbAddByLink() above; here the key
+         * already existed, so account for the growth ourselves. */
         if (*strGrowSize != 0)
             updateKeysizesHist(c->db, OBJ_STRING, *strOldSize, *strOldSize + *strGrowSize);
     }

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -122,7 +122,14 @@ static int KeySpace_NotificationModuleKeyMiss(RedisModuleCtx *ctx, int type, con
 
 static int KeySpace_NotificationModuleString(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
     REDISMODULE_NOT_USED(type);
-    REDISMODULE_NOT_USED(event);
+    const char *key_str = RedisModule_StringPtrLen(key, NULL);
+
+    if (strcmp(event, "setbit") == 0 && strncmp(key_str, "stringdel_", 10) == 0) {
+        RedisModuleCallReply *rep = RedisModule_Call(ctx, "DEL", "s!", key);
+        if (rep) RedisModule_FreeCallReply(rep);
+        return REDISMODULE_OK;
+    }
+
     RedisModuleKey *redis_key = RedisModule_OpenKey(ctx, key, REDISMODULE_READ);
 
     size_t len = 0;

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -124,6 +124,10 @@ static int KeySpace_NotificationModuleString(RedisModuleCtx *ctx, int type, cons
     REDISMODULE_NOT_USED(type);
     const char *key_str = RedisModule_StringPtrLen(key, NULL);
 
+    /* Delete the key from within the notification callback, to verify the
+     * keyspace bookkeeping (e.g. keysizes histogram) was already updated by
+     * the time subscribers run. Returns early, intentionally skipping the
+     * StringDMA check below, which expects the key to still exist. */
     if (strcmp(event, "setbit") == 0 && strncmp(key_str, "stringdel_", 10) == 0) {
         RedisModuleCallReply *rep = RedisModule_Call(ctx, "DEL", "s!", key);
         if (rep) RedisModule_FreeCallReply(rep);

--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -165,6 +165,20 @@ start_server {tags {"bitops"}} {
         }
     }
 
+    test {BITFIELD OVERFLOW FAIL accounts for string growth} {
+        r set bits {}
+        set dirty [s rdb_changes_since_last_save]
+        set result [r bitfield bits overflow fail set u1 63 2]
+        assert_equal {} [lindex $result 0]
+        assert_equal 8 [r strlen bits]
+        assert_equal [expr {$dirty + 1}] [s rdb_changes_since_last_save]
+
+        set dirty [s rdb_changes_since_last_save]
+        set result [r bitfield bits overflow fail set u1 0 2]
+        assert_equal {} [lindex $result 0]
+        assert_equal $dirty [s rdb_changes_since_last_save]
+    }
+
     test {BITFIELD overflow wrap fuzzing} {
         for {set j 0} {$j < 1000} {incr j} {
             set bits [expr {[randomInt 64]+1}]
@@ -262,6 +276,23 @@ start_server {tags {"repl external:skip"}} {
             assert_equal 255 [$master bitfield bits set u8 0 100]
             wait_for_ofs_sync $master $slave
             assert_equal 100 [$slave bitfield_ro bits get u8 0]
+        }
+
+        test {BITFIELD OVERFLOW FAIL growth is replicated} {
+            $master del bitfield-fail-created bitfield-fail-grown
+            $master set bitfield-fail-grown {}
+            wait_for_ofs_sync $master $slave
+
+            set created_result [$master bitfield bitfield-fail-created overflow fail set u1 0 2]
+            set grown_result [$master bitfield bitfield-fail-grown overflow fail set u1 63 2]
+            assert_equal {} [lindex $created_result 0]
+            assert_equal {} [lindex $grown_result 0]
+            wait_for_ofs_sync $master $slave
+
+            assert_equal 1 [$slave strlen bitfield-fail-created]
+            assert_equal "\x00" [$slave get bitfield-fail-created]
+            assert_equal 8 [$slave strlen bitfield-fail-grown]
+            assert_equal [string repeat "\x00" 8] [$slave get bitfield-fail-grown]
         }
 
         test {BITFIELD_RO with only key as argument on read-only replica} {

--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -166,6 +166,7 @@ start_server {tags {"bitops"}} {
     }
 
     test {BITFIELD OVERFLOW FAIL accounts for string growth} {
+        r del bits
         r set bits {}
         set dirty [s rdb_changes_since_last_save]
         set result [r bitfield bits overflow fail set u1 63 2]

--- a/tests/unit/info-keysizes.tcl
+++ b/tests/unit/info-keysizes.tcl
@@ -708,11 +708,19 @@ proc test_all_keysizes { {replMode 0} } {
         run_cmd_verify_hist {$server BITOP XOR b5 b1 b2} {db0_STR:8=5}        
         # SETBIT
         run_cmd_verify_hist {$server FLUSHALL} {}
+        # Grow an existing empty string
+        run_cmd_verify_hist {$server SET b1 ""} {db0_STR:0=1}
+        run_cmd_verify_hist {$server SETBIT b1 72 1} {db0_STR:8=1}
+        run_cmd_verify_hist {$server FLUSHALL} {}
         run_cmd_verify_hist {$server setbit b1 71 1} {db0_STR:8=1}
         run_cmd_verify_hist {$server setbit b1 72 1} {db0_STR:8=1}
         run_cmd_verify_hist {$server setbit b2 72 1} {db0_STR:8=2}
         run_cmd_verify_hist {$server setbit b2 640 0} {db0_STR:8=1,64=1}
         # BITFIELD
+        run_cmd_verify_hist {$server FLUSHALL} {}
+        # Grow an existing empty string
+        run_cmd_verify_hist {$server SET b1 ""} {db0_STR:0=1}
+        run_cmd_verify_hist {$server BITFIELD b1 SET u8 72 255} {db0_STR:8=1}
         run_cmd_verify_hist {$server FLUSHALL} {}
         run_cmd_verify_hist {$server bitfield b3 set u8 6 255} {db0_STR:2=1}
         run_cmd_verify_hist {$server bitfield b3 set u8 65 255} {db0_STR:8=1}

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -339,6 +339,35 @@ tags "modules external:skip" {
         }
     }
 
+    # Keep callback-ordering regression tests in a dedicated server because
+    # they enable the keysizes histogram assertion. Future tests for other
+    # commands can share this isolated server without leaking that state.
+    start_server [list overrides [list loadmodule "$testmodule" enable-debug-command yes]] {
+        tags {"modules" "regression"} {
+            test "SETBIT and BITFIELD should update keysizes before module callbacks" {
+                # Enable keysizes histogram assertion for this isolated server.
+                r DEBUG KEYSIZES-HIST-ASSERT 1
+
+                # SETBIT callback deletion.
+                r set stringdel_setbit x
+                r setbit stringdel_setbit 16 1
+                assert_equal 0 [r exists stringdel_setbit]
+
+                # BITFIELD SET callback deletion.
+                r set stringdel_bitfield x
+                r bitfield stringdel_bitfield set u8 16 1
+                assert_equal 0 [r exists stringdel_bitfield]
+
+                # BITFIELD OVERFLOW FAIL still grows the string before rejecting the write.
+                r set stringdel_bitfield_fail x
+                r bitfield stringdel_bitfield_fail overflow fail set u8 72 256
+                assert_equal 0 [r exists stringdel_bitfield_fail]
+            }
+
+            # Future callback-ordering tests for other commands can be placed here.
+        }
+    }
+
     # Replication test: replica module receives subkey notifications
     start_server [list overrides [list loadmodule "$testmodule"]] {
         set master [srv 0 client]

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -363,8 +363,6 @@ tags "modules external:skip" {
                 r bitfield stringdel_bitfield_fail overflow fail set u8 72 256
                 assert_equal 0 [r exists stringdel_bitfield_fail]
             }
-
-            # Future callback-ordering tests for other commands can be placed here.
         }
     }
 

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -343,7 +343,7 @@ tags "modules external:skip" {
     # they enable the keysizes histogram assertion. Future tests for other
     # commands can share this isolated server without leaking that state.
     start_server [list overrides [list loadmodule "$testmodule" enable-debug-command yes]] {
-        tags {"modules" "regression"} {
+        tags {"regression"} {
             test "SETBIT and BITFIELD should update keysizes before module callbacks" {
                 # Enable keysizes histogram assertion for this isolated server.
                 r DEBUG KEYSIZES-HIST-ASSERT 1


### PR DESCRIPTION
Fixed https://github.com/redis/redis/issues/15597, https://github.com/redis/redis/issues/15599
Based PR: https://github.com/redis/redis/pull/15598

## Issue
 
#### 1. Fix wrong KEYSIZES accounting for empty strings
If a key already exists with size 0, growing it is treated like creating a new key. So the key still stays in the zero-size bin after growing.

#### 2. Fix missing dirty tracking and propagation in `BITFIELD OVERFLOW FAIL`

For `BITFIELD ... OVERFLOW FAIL`, the string size is already grown, but all writes get rejected. This leaves `changes` at 0, which causes dirty tracking and propagation not be triggered.


## Changes

- Update `keysizes histogram` in `lookupStringForBitCommand()` when growing an existing string (new key is still handled by `dbAddByLink`).
- For `BITFIELD`, treat `strGrowSize` as a real write even if all later writes fail, so dirty count and propagation will not missed.


Thanks to the original author @aviggiano  for discovering and fixing this first
Co-authored-by: Antonio Viggiano agfviggiano@gmail.com


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core string mutation paths (SETBIT/BITFIELD), keysizes accounting, and dirty/replication semantics; behavior change is intentional but affects observability and persistence edge cases.
> 
> **Overview**
> Fixes **KEYSIZES histogram** and **mutation/replication** bugs when bit commands grow existing strings (especially empty ones) or when **BITFIELD OVERFLOW FAIL** pads the string but rejects writes.
> 
> **KEYSIZES:** Growing an existing key (e.g. `SET key ""` then `SETBIT`/`BITFIELD`) now updates the string-size histogram in `lookupStringForBitCommand()` when `sdsgrowzero` increases length; new keys stay on the `dbAddByLink()` path. Duplicate histogram updates were removed from `setbitCommand` and `bitfieldGeneric`.
> 
> **BITFIELD OVERFLOW FAIL:** The post-command path runs when `strGrowSize` is non-zero even if `changes` is 0, so `keyModified`, keyspace notification, and `server.dirty` (counted as one mutation when growth happened but every write failed) still run—fixing missing persistence/replication for padding-only growth.
> 
> **Tests:** KEYSIZES cases for empty-string growth via SETBIT/BITFIELD; BITFIELD dirty and master/replica replication; module keyspace callback that `DEL`s on `setbit` under `DEBUG KEYSIZES-HIST-ASSERT` to assert bookkeeping runs before subscribers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e413020341bfe2b0914b3d13382082316f2a71bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->