### PR TITLE
Fix tls-cluster CONFIG SET not updating cluster bus announced port

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2879,8 +2879,9 @@ static int applyTlsCluster(const char **err) {
     if (!applyTlsCfg(err)) return 0;
 
     /* tls-cluster selects which client port is advertised by the cluster.
-     * Modules cache that topology through the cluster module APIs, so notify
-     * them when the preferred port changes. */
+     * Update myself->cport and notify modules when the preferred port
+     * changes. */
+    clusterUpdateMyselfAnnouncedPorts();
     clusterNotifyTopologyChanged(CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE, NULL);
     return 1;
 }


### PR DESCRIPTION
Fixes #15698

## Problem

When `port` and `tls-port` are both set and `cluster-port` is not, changing `tls-cluster` at runtime via `CONFIG SET` makes a node advertise a cluster-bus port that no listener is bound to. Peers adopt the advertised port, free their working link to that node, and then retry a dead port indefinitely.

The bus port is derived in three places, and only one of them follows the runtime config:

| | source | follows `tls-cluster` at runtime? |
|---|---|---|
| 1 | the bound listener — `clusterInitLast()`: computed once at startup | no |
| 2 | `myself->cport` — refreshed by `clusterUpdateMyselfAnnouncedPorts()` | **no** — `applyTlsCluster()` did not call it |
| 3 | the value on the wire — recomputed every outgoing message | yes |

After `tls-cluster` changes, source 3 computes a different port from source 2 because `clusterUpdateMyselfAnnouncedPorts()` was never called from `applyTlsCluster()`.

## Fix

Add `clusterUpdateMyselfAnnouncedPorts()` to `applyTlsCluster()` so that `myself->cport` is updated when `tls-cluster` changes at runtime. This ensures sources 2 and 3 agree after the config change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster topology advertisement on runtime config updates; wrong behavior previously broke peer connections, but cluster bus port selection is security-sensitive and should be verified with TLS + cluster integration tests.
> 
> **Overview**
> Fixes a runtime **CONFIG SET** on **`tls-cluster`** leaving **`myself->cport`** stale while outgoing cluster messages already use the new TLS/plain port preference. Peers could adopt a bus port with no listener and break cluster links.
> 
> **`applyTlsCluster()`** now calls **`clusterUpdateMyselfAnnouncedPorts()`** before **`clusterNotifyTopologyChanged()`**, matching **`applyTLSPort`** and **`updatePort`**, so the stored announced port and on-wire topology stay aligned after the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eeb6e685a9ae588f10cde8b5e4f8f6d3c5b851c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->