### PR TITLE
Fix reversed keyspace notification order for same-key LMOVEM

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1613,11 +1613,12 @@ static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
 
     if (samekey) {
         /* In-place rotation: the length is unchanged, so there is no key
-         * creation/deletion and no histogram change. Fire both the pop and the
-         * push notifications and account for the (possibly re-encoded) object. */
-        notifyKeyspaceEvent(NOTIFY_LIST, wherefrom == LIST_HEAD ? "lpop" : "rpop",
-                            srckey, c->db->id);
+         * creation/deletion and no histogram change. Fire the push notification
+         * before the pop one, matching LMOVE and the distinct-key LMOVEM path,
+         * and account for the (possibly re-encoded) object. */
         notifyKeyspaceEvent(NOTIFY_LIST, whereto == LIST_HEAD ? "lpush" : "rpush",
+                            srckey, c->db->id);
+        notifyKeyspaceEvent(NOTIFY_LIST, wherefrom == LIST_HEAD ? "lpop" : "rpop",
                             srckey, c->db->id);
         keyModified(c, c->db, srckey, srcobj, 1);
         if (server.memory_tracking_enabled)

--- a/tests/unit/type/list-4.tcl
+++ b/tests/unit/type/list-4.tcl
@@ -98,6 +98,47 @@ foreach {type large} [array get largevalue] {
     }
 }
 
+    test {LMOVE and LMOVEM emit keyspace notifications push-before-pop} {
+        # All move paths must share one event order: the destination push
+        # event is emitted before the source pop event.
+
+        # LMOVE
+        r del src{t} dst{t}
+        r rpush src{t} a b c
+        r config set notify-keyspace-events KEA
+        set rd [redis_deferring_client]
+        assert_equal {1} [psubscribe $rd __keyevent@*__:*]
+        r lmove src{t} dst{t} left right
+        assert_match "*rpush*dst{t}*" [$rd read]
+        assert_match "*lpop*src{t}*" [$rd read]
+        $rd close
+        r config set notify-keyspace-events ""
+
+        # LMOVEM, distinct keys
+        r del src{t} dst{t}
+        r rpush src{t} a b c
+        r config set notify-keyspace-events KEA
+        set rd [redis_deferring_client]
+        assert_equal {1} [psubscribe $rd __keyevent@*__:*]
+        r lmovem src{t} dst{t} left right count 2 bulk
+        assert_match "*rpush*dst{t}*" [$rd read]
+        assert_match "*lpop*src{t}*" [$rd read]
+        $rd close
+        r config set notify-keyspace-events ""
+
+        # LMOVEM, same source and destination
+        r del k{t}
+        r rpush k{t} 1 2 3 4
+        r config set notify-keyspace-events KEA
+        set rd [redis_deferring_client]
+        assert_equal {1} [psubscribe $rd __keyevent@*__:*]
+        r lmovem k{t} k{t} left right count 2 bulk
+        assert_match "*rpush*k{t}*" [$rd read]
+        assert_match "*lpop*k{t}*" [$rd read]
+        $rd close
+        r config set notify-keyspace-events ""
+    }
+
     test {LMOVEM missing or empty source} {
         r del src{t} dst{t}
         assert_equal {} [r lmovem src{t} dst{t} left right]


### PR DESCRIPTION
Fixes #15586

## Problem

For same-key moves, `LMOVEM` and `LMOVE` deliver keyspace/keyevent notifications in different orders:

- `LMOVE k k LEFT RIGHT` emits the destination push first, then the source pop: `(rpush, lpop)`
- `LMOVEM k k LEFT RIGHT` emits the source pop first, then the destination push: `(lpop, rpush)`

The distinct-key `LMOVEM` path already matches `LMOVE` (push before pop). The inconsistency breaks notification consumers that rely on a consistent ordering across move commands, and contradicts the LMOVEM documentation stating that option-less `LMOVEM` behaves like `LMOVE`.

## Fix

Swap the two `notifyKeyspaceEvent()` calls in the same-key branch of `lmovemMoveAndReply()` so every move path emits push-before-pop. No behavior change other than the notification order.

## Test

Added a regression test in `tests/unit/type/list-4.tcl` covering all three move paths (`LMOVE`, distinct-key `LMOVEM`, same-key `LMOVEM`), asserting the push event is delivered before the pop event for each.

Verified locally:

- `./runtest --single unit/type/list-4` — all green
- Reverse check: with the fix reverted and the new test kept, the test fails as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to keyspace notification ordering for same-key LMOVEM; no data or command semantics change.
> 
> **Overview**
> Same-key **LMOVEM** (source and destination are one key) used to emit keyspace/keyevent notifications as **pop then push**, while **LMOVE** and distinct-key **LMOVEM** already emitted **push then pop**. That mismatch broke consumers that assume a single ordering across move commands and conflicted with LMOVEM behaving like LMOVE when options are omitted.
> 
> The fix only reorders the two `notifyKeyspaceEvent()` calls in the same-key branch of `lmovemMoveAndReply()` in `t_list.c`. List contents, replies, and replication are unchanged.
> 
> A regression test in `list-4.tcl` subscribes to keyevents and checks push-before-pop for **LMOVE**, distinct-key **LMOVEM**, and same-key **LMOVEM**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71ccdbb753f71e60c9d566a493d7d3cb9b1b8279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->