### PR TITLE
Hash: resolve multi-field lookups in a single listpack pass

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2026,6 +2026,324 @@ GetFieldRes hashTypeGetFromListpack(robj *o, sds field,
     return GETF_NOT_FOUND;
 }
 
+/* -----------------------------------------------------------------------------
+ * Single-pass multi-field lookup on listpack encoded hashes
+ *
+ * hashTypeGetFromListpack() walks the listpack from the head for every field,
+ * so resolving N fields one by one costs O(N x entries). The helpers below
+ * resolve all the requested fields in a single walk instead, by indexing the
+ * requested field names in a small open-addressing table and probing it once
+ * per listpack tuple.
+ *
+ * The scratch space needed is proportional to the number of requested fields,
+ * not to the size of the hash: ~40 bytes per requested field, held only for the
+ * duration of the command, and taken from the stack for small requests. That is
+ * a fraction of what the client already paid to send the field names in argv.
+ * -------------------------------------------------------------------------- */
+
+/* Up to this number of requested fields the scratch space is kept on the stack.
+ * Above it, it is allocated on the heap. */
+#define HASH_MULTIGET_STACK_FIELDS 64
+
+/* Up to this number of requested fields the single pass lookup compares each
+ * visited field name against all of them, instead of building a hash index of
+ * the requested names. Hashing costs one dictGenHashFunction() call per
+ * requested field to build the index plus one per visited field to probe it,
+ * which for a handful of fields is more than just comparing them. */
+#define HASH_MULTIGET_LINEAR_FIELDS 8
+
+/* Result of resolving one requested field. 'vstr'/'vlen'/'vll' follow the
+ * hashTypeGetValue() convention. Note that 'vstr' points INTO the listpack, so
+ * all the fields below become invalid as soon as the hash object is modified.
+ * 'expiredAt' is only meaningful when 'found' is set. The field order keeps the
+ * struct at 32 bytes, i.e. a 2KB array for HASH_MULTIGET_STACK_FIELDS fields. */
+typedef struct hashFieldRes {
+    unsigned char *vstr;
+    unsigned int vlen;
+    int found;
+    long long vll;
+    uint64_t expiredAt; /* EB_EXPIRE_TIME_INVALID if the field has no TTL */
+} hashFieldRes;
+
+/* Returns the size of the index table to use for 'numFields' needles. It is a
+ * power of two, keeping the load factor at 0.5 or below. */
+static size_t hashFieldsIndexSize(int numFields) {
+    size_t size = 2;
+    while (size < (size_t) numFields * 2)
+        size *= 2;
+    return size;
+}
+
+/* Scratch space for one single pass lookup of 'numFields' fields: the resolved
+ * values, plus the index of the requested names when there are enough of them to
+ * be worth hashing (see HASH_MULTIGET_LINEAR_FIELDS). Requests of up to
+ * HASH_MULTIGET_STACK_FIELDS fields are served from the embedded arrays, larger
+ * ones from a single heap block. */
+typedef struct hashMultiGetScratch {
+    hashFieldRes *res;  /* [numFields] resolved values, in request order */
+    int *index;         /* [mask+1] needle indexes, -1 empty. NULL if linear */
+    int *dupNext;       /* [numFields] same-name chains. NULL if linear */
+    size_t mask;        /* Number of slots in 'index' minus one */
+    void *heap;         /* Backing allocation, NULL when the arrays below are used */
+    hashFieldRes stackRes[HASH_MULTIGET_STACK_FIELDS];
+    int stackIndex[HASH_MULTIGET_STACK_FIELDS * 2];
+    int stackDupNext[HASH_MULTIGET_STACK_FIELDS];
+} hashMultiGetScratch;
+
+/* Set up 's' for a lookup of 'numFields' fields. When 'linear' is set, no index
+ * is built and the requested names are compared one by one instead. */
+static void hashMultiGetScratchInit(hashMultiGetScratch *s, int numFields, int linear) {
+    size_t size = linear ? 0 : hashFieldsIndexSize(numFields);
+
+    s->mask = linear ? 0 : size - 1;
+
+    if (numFields > HASH_MULTIGET_STACK_FIELDS) {
+        /* Requests this large are never served by the linear variant, which is
+         * capped at HASH_MULTIGET_LINEAR_FIELDS fields. One allocation for all
+         * the arrays, hashFieldRes first so the ints that follow are aligned. */
+        serverAssert(!linear);
+        s->heap = zmalloc(sizeof(hashFieldRes) * numFields +
+                          sizeof(int) * (size + numFields));
+        s->res = s->heap;
+        s->index = (int *) (s->res + numFields);
+        s->dupNext = s->index + size;
+        return;
+    }
+
+    /* Sizing invariant of the embedded arrays: at load factor 0.5 the index of
+     * the largest stack served request still fits in stackIndex[]. */
+    serverAssert(size <= HASH_MULTIGET_STACK_FIELDS * 2);
+    s->heap = NULL;
+    s->res = s->stackRes;
+    s->index = linear ? NULL : s->stackIndex;
+    s->dupNext = linear ? NULL : s->stackDupNext;
+}
+
+static void hashMultiGetScratchRelease(hashMultiGetScratch *s) {
+    zfree(s->heap);
+}
+
+/* Index fields[0..numFields-1] into 's->index', an open-addressing table of
+ * 's->mask'+1 slots (a power of two, as returned by hashFieldsIndexSize())
+ * holding needle indexes, where -1 means "empty". Needles sharing the same name
+ * are linked together through 's->dupNext' (also -1 terminated) so that a single
+ * slot refers to all of them, in request order.
+ *
+ * Returns 1 if any field name appears more than once. */
+static int hashFieldsIndexBuild(hashMultiGetScratch *s, robj **fields, int numFields)
+{
+    int hasDups = 0;
+    int *index = s->index, *dupNext = s->dupNext;
+    size_t mask = s->mask;
+
+    for (size_t i = 0; i <= mask; i++)
+        index[i] = -1;
+
+    /* Walk backwards and prepend, so that duplicate chains end up ordered by
+     * position in the command. */
+    for (int i = numFields - 1; i >= 0; i--) {
+        sds field = fields[i]->ptr;
+        size_t len = sdslen(field);
+        size_t slot = dictGenHashFunction(field, len) & mask;
+
+        dupNext[i] = -1;
+        while (index[slot] != -1) {
+            sds other = fields[index[slot]]->ptr;
+            if (sdslen(other) == len && memcmp(other, field, len) == 0) {
+                dupNext[i] = index[slot]; /* Same name, prepend to its chain. */
+                hasDups = 1;
+                break;
+            }
+            slot = (slot + 1) & mask; /* Different name, keep probing. */
+        }
+        index[slot] = i;
+    }
+
+    return hasDups;
+}
+
+/* Returns 1 if the same field name appears more than once in
+ * fields[0..numFields-1], comparing the names pairwise. Only used below
+ * HASH_MULTIGET_LINEAR_FIELDS fields, where that beats hashing them; above it
+ * hashFieldsIndexBuild() reports duplicates as a side effect of indexing.
+ *
+ * Duplicates matter to the commands that both read and modify fields, where the
+ * reply of a repeated field depends on what the previous occurrence did, and so
+ * replies and modifications cannot be reordered. */
+static int hashFieldsHaveDupsLinear(robj **fields, int numFields) {
+    for (int i = 1; i < numFields; i++) {
+        sds field = fields[i]->ptr;
+        size_t len = sdslen(field);
+        for (int j = 0; j < i; j++) {
+            sds other = fields[j]->ptr;
+            if (sdslen(other) == len && memcmp(other, field, len) == 0)
+                return 1;
+        }
+    }
+    return 0;
+}
+
+/* Returns 1 if fields[0..numFields-1] can be resolved by a single pass over the
+ * listpack, which requires more than one field requested from a listpack encoded
+ * hash. Callers must check this before calling addHashMultiFieldsToReply(). */
+static inline int hashTypeMultiGetApplies(kvobj *o, int numFields) {
+    return o != NULL && numFields > 1 &&
+           (o->encoding == OBJ_ENCODING_LISTPACK ||
+            o->encoding == OBJ_ENCODING_LISTPACK_EX);
+}
+
+/* State of the single listpack walk done by hashTypeGetMultiFromListpack(). */
+struct lpMultiGetArgs {
+    unsigned char *lp;   /* [in] Listpack being walked */
+    size_t lpbytes;      /* [in] Cached lpBytes(lp) */
+    int listpackex;      /* [in] 1 if tuples are field-value-ttl, 0 if field-value */
+    robj **fields;       /* [in] Requested fields */
+    int numFields;       /* [in] Number of requested fields */
+    int *index;          /* [in] Index of requested fields, see hashFieldsIndexBuild().
+                          *      NULL when the fields are compared one by one. */
+    int *dupNext;        /* [in] Chains of same-name fields, unused without 'index' */
+    size_t mask;         /* [in] Size of 'index' minus one */
+    hashFieldRes *res;   /* [out] One entry per requested field */
+    int found;           /* [out] Number of fields resolved so far */
+};
+
+/* Callback for lpFindCb(). Invoked once per tuple of a listpack encoded hash,
+ * with 'p' pointing at the field name. Resolves every requested field matching
+ * it and stops the walk as soon as all of them have been resolved. */
+static int cbGetMultiFromListpack(const unsigned char *lp, unsigned char *p,
+                                  void *user, unsigned char *s, long long slen)
+{
+    (void) lp;
+    struct lpMultiGetArgs *r = user;
+    char buf[LONG_STR_SIZE];
+    size_t len;
+    int first = -1; /* First requested field with this name, -1 if none. */
+
+    if (s) {
+        len = (size_t) slen;
+    } else {
+        /* Integer encoded field name. Comparing the requested names against its
+         * canonical decimal representation matches exactly the same needles as
+         * lpFindCmp() does, because lpStringToInt64() only accepts canonical
+         * decimal (no sign for positives, no leading zeros, no padding). */
+        len = ll2string(buf, sizeof(buf), slen);
+        s = (unsigned char *) buf;
+    }
+
+    if (r->index) {
+        for (size_t slot = dictGenHashFunction(s, len) & r->mask;
+             r->index[slot] != -1;
+             slot = (slot + 1) & r->mask)
+        {
+            int i = r->index[slot];
+            sds field = r->fields[i]->ptr;
+
+            /* Compare the names: a slot can hold an unrelated needle, either
+             * because its own hash landed here or because it probed into this
+             * slot. Those keep the loop going to the next slot. */
+            if (sdslen(field) == len && memcmp(field, s, len) == 0) {
+                first = i;
+                break;
+            }
+        }
+    } else {
+        for (int i = 0; i < r->numFields; i++) {
+            sds field = r->fields[i]->ptr;
+            if (sdslen(field) == len && memcmp(field, s, len) == 0) {
+                first = i;
+                break;
+            }
+        }
+    }
+
+    if (first == -1)
+        return 1;
+
+    /* Decode the tuple once, then hand it to all the fields that ask for this
+     * name. */
+    unsigned char *vptr = lpNextWithBytes(r->lp, p, r->lpbytes);
+    serverAssert(vptr != NULL);
+
+    unsigned char *vstr;
+    unsigned int vlen = 0;
+    long long vll = 0;
+    uint64_t expiredAt = EB_EXPIRE_TIME_INVALID;
+
+    vstr = lpGetValue(vptr, &vlen, &vll);
+
+    if (r->listpackex) {
+        long long expire;
+        unsigned char *tptr = lpNextWithBytes(r->lp, vptr, r->lpbytes);
+        serverAssert(tptr && lpGetIntegerValue(tptr, &expire));
+        if (expire != HASH_LP_NO_TTL)
+            expiredAt = (uint64_t) expire;
+    }
+
+    for (int i = first; i != -1; ) {
+        r->res[i].vstr = vstr;
+        r->res[i].vlen = vlen;
+        r->res[i].vll = vll;
+        r->res[i].expiredAt = expiredAt;
+        r->res[i].found = 1;
+        r->found++;
+
+        if (r->index) {
+            i = r->dupNext[i];
+        } else {
+            /* No index to chain duplicates through, look for the next request
+             * of the same name. */
+            for (i++; i < r->numFields; i++) {
+                sds field = r->fields[i]->ptr;
+                if (sdslen(field) == len && memcmp(field, s, len) == 0)
+                    break;
+            }
+            if (i == r->numFields) i = -1;
+        }
+    }
+
+    return (r->found == r->numFields) ? 0 : 1;
+}
+
+/* Resolve fields[0..numFields-1] of a listpack or listpackEx encoded hash in a
+ * single pass over the listpack, instead of one lpFind() walk per field, into
+ * 's->res' which is fully initialized here.
+ *
+ * 's' must have been set up by hashMultiGetScratchInit(), and its index built by
+ * hashFieldsIndexBuild() unless the fields are compared one by one.
+ *
+ * Note that expired fields are reported as found, with their expiration time in
+ * 'expiredAt': it is up to the caller to apply the lazy expiration logic. */
+static void hashTypeGetMultiFromListpack(kvobj *o, robj **fields, int numFields,
+                                         hashMultiGetScratch *s)
+{
+    serverAssert(o->encoding == OBJ_ENCODING_LISTPACK ||
+                 o->encoding == OBJ_ENCODING_LISTPACK_EX);
+    serverAssert(numFields > 0);
+
+    struct lpMultiGetArgs r;
+
+    r.lp = hashTypeListpackGetLp(o);
+    r.lpbytes = lpBytes(r.lp);
+    r.listpackex = (o->encoding == OBJ_ENCODING_LISTPACK_EX);
+    r.fields = fields;
+    r.numFields = numFields;
+    r.index = s->index;
+    r.dupNext = s->dupNext;
+    r.mask = s->mask;
+    r.res = s->res;
+    r.found = 0;
+
+    for (int i = 0; i < numFields; i++) {
+        s->res[i].vstr = NULL;
+        s->res[i].vlen = 0;
+        s->res[i].vll = 0;
+        s->res[i].expiredAt = EB_EXPIRE_TIME_INVALID;
+        s->res[i].found = 0;
+    }
+
+    lpFindCb(r.lp, NULL, &r, cbGetMultiFromListpack, r.listpackex ? 2 : 1);
+}
+
 /* Get the value from a hash table encoded hash, identified by field.
  * Returns NULL when the field cannot be found, otherwise the SDS value
  * is returned. */
@@ -2045,6 +2363,15 @@ GetFieldRes hashTypeGetFromHashTable(robj *o, sds field, sds *value, uint64_t *e
     *expiredAt = entryGetExpiry(entry);
     *value = entryGetValue(entry);
     return GETF_OK;
+}
+
+/* Returns 1 if a field whose expiration time is 'expiredAt' has to be treated
+ * as logically expired, and 0 if it can be returned as a valid field. */
+static inline int hashTypeFieldNeedsLazyExpire(uint64_t expiredAt, int hfeFlags) {
+    if (server.allow_access_expired) return 0;
+    if (expiredAt >= (uint64_t) commandTimeSnapshot()) return 0;
+    if (hfeFlags & HFE_LAZY_ACCESS_EXPIRED) return 0;
+    return 1;
 }
 
 /* Higher level function of hashTypeGet*() that returns the hash value
@@ -2113,9 +2440,7 @@ GetFieldRes hashTypeGetValue(redisDb *db, kvobj *o, sds field, unsigned char **v
         serverPanic("Unknown hash encoding");
     }
 
-    if ((server.allow_access_expired) ||
-        (*expiredAt >= (uint64_t) commandTimeSnapshot()) ||
-        (hfeFlags & HFE_LAZY_ACCESS_EXPIRED))
+    if (!hashTypeFieldNeedsLazyExpire(*expiredAt, hfeFlags))
         return GETF_OK;
 
     if (server.masterhost || server.cluster_enabled) {
@@ -5155,8 +5480,13 @@ void hincrbyfloatCommand(client *c) {
     decrRefCount(newobj);
 }
 
-static GetFieldRes addHashFieldToReply(client *c, kvobj *o, sds field, int hfeFlags) {
+/* Reply with the value of 'field'. If 'expiredAt' is not NULL, it is set to the
+ * expiration time of the field, or to EB_EXPIRE_TIME_INVALID if it has none. */
+static GetFieldRes addHashFieldToReply(client *c, kvobj *o, sds field, int hfeFlags,
+                                       uint64_t *expiredAt)
+{
     if (o == NULL) {
+        if (expiredAt) *expiredAt = EB_EXPIRE_TIME_INVALID;
         addReplyNull(c);
         return GETF_NOT_FOUND;
     }
@@ -5165,7 +5495,7 @@ static GetFieldRes addHashFieldToReply(client *c, kvobj *o, sds field, int hfeFl
     unsigned int vlen = UINT_MAX;
     long long vll = LLONG_MAX;
 
-    GetFieldRes res = hashTypeGetValue(c->db, o, field, &vstr, &vlen, &vll, hfeFlags, NULL);
+    GetFieldRes res = hashTypeGetValue(c->db, o, field, &vstr, &vlen, &vll, hfeFlags, expiredAt);
     if (res == GETF_OK) {
         if (vstr) {
             addReplyBulkCBuffer(c, vstr, vlen);
@@ -5178,18 +5508,120 @@ static GetFieldRes addHashFieldToReply(client *c, kvobj *o, sds field, int hfeFl
     return res;
 }
 
+/* Reply with the values of fields[from..numFields-1], in request order, looking
+ * up one field at a time.
+ *
+ * 'resOut' must have room for 'numFields' entries and receives the per-field
+ * GetFieldRes. If 'expiredOut' is not NULL, it receives the per-field
+ * expiration time (EB_EXPIRE_TIME_INVALID when there is none). */
+static void addHashFieldsToReplyOneByOne(client *c, kvobj *o, robj **fields,
+                                         int numFields, int from, int hfeFlags,
+                                         GetFieldRes *resOut, uint64_t *expiredOut)
+{
+    for (int i = from; i < numFields; i++) {
+        if (o == NULL) {
+            /* No such key, or the hash was deleted because the last of its
+             * fields expired. */
+            addReplyNull(c);
+            resOut[i] = GETF_NOT_FOUND;
+            if (expiredOut) expiredOut[i] = EB_EXPIRE_TIME_INVALID;
+            continue;
+        }
+        resOut[i] = addHashFieldToReply(c, o, fields[i]->ptr, hfeFlags,
+                                        expiredOut ? &expiredOut[i] : NULL);
+        if (resOut[i] == GETF_EXPIRED_HASH)
+            o = NULL;
+    }
+}
+
+/* Reply with the values of fields[0..numFields-1], in request order, resolving
+ * all of them in a single pass over the listpack rather than with one lpFind()
+ * walk each. Requires hashTypeMultiGetApplies(o, numFields).
+ *
+ * Fields requiring hash-field-expiration work - which modifies the hash and
+ * invalidates the resolved pointers - are delegated to addHashFieldToReply(),
+ * and so is every field after them.
+ *
+ * 'resOut' and 'expiredOut' are as in addHashFieldsToReplyOneByOne().
+ *
+ * Note that this function only reads. Callers that also modify the fields must
+ * do so after it returns, and must set 'rejectDups' because the reply of a field
+ * requested twice depends on what the previous occurrence modified: nothing is
+ * replied and 0 is returned when a duplicate is found, and the caller then has
+ * to reply one field at a time, interleaving its modifications. Returns 1 after
+ * replying to all the fields (always, when 'rejectDups' is not set).
+ *
+ * Not inlined on purpose: its ~3KB of scratch space would otherwise end up in
+ * the frame of callers that never resolve a single field through it. */
+static __attribute__((noinline))
+int addHashMultiFieldsToReply(client *c, kvobj *o, robj **fields, int numFields,
+                              int hfeFlags, int rejectDups,
+                              GetFieldRes *resOut, uint64_t *expiredOut)
+{
+    hashMultiGetScratch s;
+    int linear = (numFields <= HASH_MULTIGET_LINEAR_FIELDS);
+    int i = 0;
+
+    serverAssert(hashTypeMultiGetApplies(o, numFields));
+
+    if (linear) {
+        if (rejectDups && hashFieldsHaveDupsLinear(fields, numFields))
+            return 0;
+        hashMultiGetScratchInit(&s, numFields, linear);
+    } else {
+        hashMultiGetScratchInit(&s, numFields, linear);
+        if (hashFieldsIndexBuild(&s, fields, numFields) && rejectDups) {
+            hashMultiGetScratchRelease(&s);
+            return 0;
+        }
+    }
+
+    hashTypeGetMultiFromListpack(o, fields, numFields, &s);
+
+    while (i < numFields) {
+        hashFieldRes *res = &s.res[i];
+
+        /* Lazy expiration deletes the field and may delete the whole hash,
+         * invalidating every pointer resolved above. Let the single-field path
+         * own it, and fall back for the remaining fields as well. */
+        if (res->found && hashTypeFieldNeedsLazyExpire(res->expiredAt, hfeFlags))
+            break;
+
+        if (!res->found) {
+            addReplyNull(c);
+            resOut[i] = GETF_NOT_FOUND;
+            if (expiredOut) expiredOut[i] = EB_EXPIRE_TIME_INVALID;
+        } else {
+            if (res->vstr)
+                addReplyBulkCBuffer(c, res->vstr, res->vlen);
+            else
+                addReplyBulkLongLong(c, res->vll);
+            resOut[i] = GETF_OK;
+            if (expiredOut) expiredOut[i] = res->expiredAt;
+        }
+        i++;
+    }
+
+    hashMultiGetScratchRelease(&s);
+
+    if (i < numFields) {
+        addHashFieldsToReplyOneByOne(c, o, fields, numFields, i, hfeFlags,
+                                     resOut, expiredOut);
+    }
+    return 1;
+}
+
 void hgetCommand(client *c) {
     kvobj *o;
 
     if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp])) == NULL ||
         checkType(c,o,OBJ_HASH)) return;
 
-    addHashFieldToReply(c, o, c->argv[2]->ptr, HFE_LAZY_EXPIRE);
+    addHashFieldToReply(c, o, c->argv[2]->ptr, HFE_LAZY_EXPIRE, NULL);
 }
 
 void hmgetCommand(client *c) {
-    GetFieldRes res = GETF_OK;
-    int i, deleted = 0;
+    int numFields = c->argc - 2;
 
     /* Don't abort when the key cannot be found. Non-existing keys are empty
      * hashes, where HMGET should respond with a series of null bulks. */
@@ -5198,22 +5630,29 @@ void hmgetCommand(client *c) {
 
     /* Track expired fields for subkey notification. */
     fieldvec fvexpired;
-    vec *vexpired = fieldvecInit(&fvexpired, c->argc-2);
+    vec *vexpired = fieldvecInit(&fvexpired, numFields);
 
-    addReplyArrayLen(c, c->argc-2);
-    for (i = 2; i < c->argc ; i++) {
-        if (!deleted) {
-            res = addHashFieldToReply(c, o, c->argv[i]->ptr, HFE_LAZY_NO_NOTIFICATION);
-            if (res == GETF_EXPIRED) {
-                vecPush(vexpired, c->argv[i]);
-            }
-            deleted += (res == GETF_EXPIRED_HASH);
-        } else {
-            /* If hash got lazy expired since all fields are expired (o is invalid),
-             * then fill the rest with trivial nulls and return. */
-            addReplyNull(c);
-        }
+    GetFieldRes stackres[HASH_MULTIGET_STACK_FIELDS];
+    GetFieldRes *resOut = (numFields <= HASH_MULTIGET_STACK_FIELDS) ?
+                          stackres : zmalloc(sizeof(GetFieldRes) * numFields);
+
+    addReplyArrayLen(c, numFields);
+    if (!hashTypeMultiGetApplies(o, numFields) ||
+        !addHashMultiFieldsToReply(c, o, &c->argv[2], numFields,
+                                   HFE_LAZY_NO_NOTIFICATION, 0, resOut, NULL))
+    {
+        addHashFieldsToReplyOneByOne(c, o, &c->argv[2], numFields, 0,
+                                     HFE_LAZY_NO_NOTIFICATION, resOut, NULL);
     }
+
+    int deleted = 0;
+    for (int i = 0; i < numFields; i++) {
+        if (resOut[i] == GETF_EXPIRED)
+            vecPush(vexpired, c->argv[2 + i]);
+        deleted += (resOut[i] == GETF_EXPIRED_HASH);
+    }
+
+    if (resOut != stackres) zfree(resOut);
 
     if (vecSize(vexpired)) {
         notifyKeyspaceEventWithSubkeys(NOTIFY_HASH, "hexpired", c->argv[1],
@@ -5274,19 +5713,44 @@ void hgetdelCommand(client *c) {
     vec *vexpired = fieldvecInit(&fvexpired, num_fields);
     vec *vdeleted = fieldvecInit(&fvdeleted, num_fields);
 
+    const int flags = HFE_LAZY_NO_NOTIFICATION |
+                      HFE_LAZY_NO_SIGNAL |
+                      HFE_LAZY_AVOID_HASH_DEL |
+                      HFE_LAZY_NO_UPDATE_KEYSIZES |
+                      HFE_LAZY_NO_UPDATE_ALLOCSIZES;
+
     addReplyArrayLen(c, num_fields);
+
+    int numFields = (int) num_fields; /* Bounded by argc, see the check above. */
+    GetFieldRes stackres[HASH_MULTIGET_STACK_FIELDS];
+    GetFieldRes *resOut = (numFields <= HASH_MULTIGET_STACK_FIELDS) ?
+                          stackres : zmalloc(sizeof(GetFieldRes) * numFields);
+
     if (o && hashTypeIsTemplate(o)) {
         /* Template hash: reply every value, then drop all the fields in one
          * template switch. */
         hashTypeTmplDeleteFields(o, c->argv + 4, c->argc - 4, vdeleted, c);
+    } else if (hashTypeMultiGetApplies(o, numFields) &&
+               addHashMultiFieldsToReply(c, o, &c->argv[4], numFields, flags,
+                                         1, resOut, NULL))
+    {
+        /* Replied to all the fields in a single pass over the listpack. Delete
+         * them afterwards: doing it as we reply would invalidate the values the
+         * single pass resolved. */
+        for (int i = 0; i < numFields; i++) {
+            if (resOut[i] == GETF_EXPIRED) {
+                vecPush(vexpired, c->argv[4 + i]);
+            } else if (resOut[i] == GETF_OK) {
+                vecPush(vdeleted, c->argv[4 + i]);
+                serverAssert(hashTypeDelete(o, c->argv[4 + i]->ptr) == 1);
+            }
+        }
     } else {
+        /* Not a listpack, or the same field was requested twice - the reply of
+         * the second occurrence depends on the deletion done by the first one,
+         * so replies and deletions have to stay interleaved. */
         for (int i = 4; i < c->argc; i++) {
-            const int flags = HFE_LAZY_NO_NOTIFICATION |
-                              HFE_LAZY_NO_SIGNAL |
-                              HFE_LAZY_AVOID_HASH_DEL |
-                              HFE_LAZY_NO_UPDATE_KEYSIZES |
-                              HFE_LAZY_NO_UPDATE_ALLOCSIZES;
-            res = addHashFieldToReply(c, o, c->argv[i]->ptr, flags);
+            res = addHashFieldToReply(c, o, c->argv[i]->ptr, flags, NULL);
             if (res == GETF_EXPIRED) {
                 vecPush(vexpired, c->argv[i]);
             }
@@ -5297,6 +5761,8 @@ void hgetdelCommand(client *c) {
             }
         }
     }
+
+    if (resOut != stackres) zfree(resOut);
 
     /* Return if no modification has been made. */
     if (vecSize(vexpired) == 0 && vecSize(vdeleted) == 0) {
@@ -5396,31 +5862,86 @@ void hgetexCommand(client *c) {
     vec *vdeleted = fieldvecInit(&fvdeleted, num_fields);
     vec *vupdated = fieldvecInit(&fvupdated, num_fields);
 
+    const int flags = HFE_LAZY_NO_NOTIFICATION |
+                      HFE_LAZY_NO_SIGNAL |
+                      HFE_LAZY_AVOID_HASH_DEL |
+                      HFE_LAZY_NO_UPDATE_KEYSIZES |
+                      HFE_LAZY_NO_UPDATE_ALLOCSIZES;
+
+    if (parse_flags & HFE_PERSIST)
+        expire_time = EB_EXPIRE_TIME_INVALID;
+
     addReplyArrayLen(c, num_fields);
-    for (int i = first_field_pos; i < first_field_pos + num_fields; i++) {
-        const int flags = HFE_LAZY_NO_NOTIFICATION |
-                          HFE_LAZY_NO_SIGNAL |
-                          HFE_LAZY_AVOID_HASH_DEL |
-                          HFE_LAZY_NO_UPDATE_KEYSIZES |
-                          HFE_LAZY_NO_UPDATE_ALLOCSIZES;
-        sds field = c->argv[i]->ptr;
-        int res = addHashFieldToReply(c, o, c->argv[i]->ptr, flags);
-        if (res == GETF_EXPIRED) {
-            vecPush(vexpired, c->argv[i]);
-        }
 
-        /* Set expiration only if the field exists and not expired lazily. */
-        if (res == GETF_OK && parse_flags) {
-            if (parse_flags & HFE_PERSIST)
-                expire_time = EB_EXPIRE_TIME_INVALID;
+    GetFieldRes stackres[HASH_MULTIGET_STACK_FIELDS];
+    uint64_t stackexpired[HASH_MULTIGET_STACK_FIELDS];
+    GetFieldRes *resOut = stackres;
+    uint64_t *expiredOut = stackexpired;
 
-            res = hashTypeSetEx(o, field, expire_time, &setex);
+    if (num_fields > HASH_MULTIGET_STACK_FIELDS) {
+        resOut = zmalloc(sizeof(GetFieldRes) * num_fields);
+        expiredOut = zmalloc(sizeof(uint64_t) * num_fields);
+    }
+
+    /* Reply to all the fields first - which takes a single pass over a listpack
+     * encoded hash - and update their expiration afterwards, since updating one
+     * would invalidate the values the single pass resolved. */
+    if (hashTypeMultiGetApplies(o, num_fields) &&
+        addHashMultiFieldsToReply(c, o, &c->argv[first_field_pos], num_fields,
+                                  flags, 1, resOut, expiredOut))
+    {
+        for (int i = 0; i < num_fields; i++) {
+            robj *fieldobj = c->argv[first_field_pos + i];
+
+            if (resOut[i] == GETF_EXPIRED) {
+                vecPush(vexpired, fieldobj);
+                continue;
+            }
+
+            /* Set expiration only if the field exists and not expired lazily. */
+            if (resOut[i] != GETF_OK || !parse_flags)
+                continue;
+
+            /* PERSIST on a field that has no TTL: hashTypeSetEx() would just
+             * return HSETEX_NO_CONDITION_MET without any side effect, so skip
+             * the lookup it would do to figure that out. */
+            if ((parse_flags & HFE_PERSIST) && expiredOut[i] == EB_EXPIRE_TIME_INVALID)
+                continue;
+
+            int res = hashTypeSetEx(o, fieldobj->ptr, expire_time, &setex);
             if (res == HSETEX_DELETED) {
-                vecPush(vdeleted, c->argv[i]);
+                vecPush(vdeleted, fieldobj);
             } else if (res == HSETEX_OK) {
-                vecPush(vupdated, c->argv[i]);
+                vecPush(vupdated, fieldobj);
             }
         }
+
+    } else {
+        /* Not a listpack, or the same field was requested twice - the reply of
+         * the second occurrence depends on what the first one did to its TTL, so
+         * replies and expiration updates have to stay interleaved. */
+        for (int i = first_field_pos; i < first_field_pos + num_fields; i++) {
+            sds field = c->argv[i]->ptr;
+            int res = addHashFieldToReply(c, o, c->argv[i]->ptr, flags, NULL);
+            if (res == GETF_EXPIRED) {
+                vecPush(vexpired, c->argv[i]);
+            }
+
+            /* Set expiration only if the field exists and not expired lazily. */
+            if (res == GETF_OK && parse_flags) {
+                res = hashTypeSetEx(o, field, expire_time, &setex);
+                if (res == HSETEX_DELETED) {
+                    vecPush(vdeleted, c->argv[i]);
+                } else if (res == HSETEX_OK) {
+                    vecPush(vupdated, c->argv[i]);
+                }
+            }
+        }
+    }
+
+    if (resOut != stackres) {
+        zfree(resOut);
+        zfree(expiredOut);
     }
 
     if (parse_flags)

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -5508,29 +5508,60 @@ static GetFieldRes addHashFieldToReply(client *c, kvobj *o, sds field, int hfeFl
     return res;
 }
 
-/* Reply with the values of fields[from..numFields-1], in request order, looking
- * up one field at a time.
+/* Where the multi-field reply helpers report what each requested field resolved
+ * to. All the members are optional, so that a caller only pays for what it uses:
  *
- * 'resOut' must have room for 'numFields' entries and receives the per-field
- * GetFieldRes. If 'expiredOut' is not NULL, it receives the per-field
- * expiration time (EB_EXPIRE_TIME_INVALID when there is none). */
+ * - 'res' and 'expiredAt' hold the per-field result and expiration time, and are
+ *   what a caller that modifies the fields afterwards needs to drive its
+ *   modification pass.
+ * - 'expired' and 'hashDeleted' hold just what is needed to notify about fields
+ *   the reply pass expired lazily, gathered while replying. A read-only caller
+ *   passes these alone and is then spared an array store per field and a second
+ *   pass over the array to find results it makes no other use of. */
+typedef struct hashMultiGetOut {
+    GetFieldRes *res;     /* room for numFields entries, or NULL */
+    uint64_t *expiredAt;  /* room for numFields entries, or NULL. EB_EXPIRE_TIME_INVALID
+                             for fields without an expiration time */
+    vec *expired;         /* receives the fields that were expired lazily, or NULL */
+    int hashDeleted;      /* set when the hash was deleted, its last field having
+                             expired lazily */
+} hashMultiGetOut;
+
+/* Report what fields[i] resolved to. */
+static inline void hashMultiGetOutSet(hashMultiGetOut *out, robj **fields, int i,
+                                      GetFieldRes res, uint64_t expiredAt)
+{
+    if (out->res) out->res[i] = res;
+    if (out->expiredAt) out->expiredAt[i] = expiredAt;
+    if (out->expired) {
+        if (res == GETF_EXPIRED)
+            vecPush(out->expired, fields[i]);
+        else if (res == GETF_EXPIRED_HASH)
+            out->hashDeleted = 1;
+    }
+}
+
+/* Reply with the values of fields[from..numFields-1], in request order, looking
+ * up one field at a time, reporting the results in 'out'. */
 static void addHashFieldsToReplyOneByOne(client *c, kvobj *o, robj **fields,
                                          int numFields, int from, int hfeFlags,
-                                         GetFieldRes *resOut, uint64_t *expiredOut)
+                                         hashMultiGetOut *out)
 {
     for (int i = from; i < numFields; i++) {
+        uint64_t expiredAt = EB_EXPIRE_TIME_INVALID;
+        GetFieldRes res;
+
         if (o == NULL) {
             /* No such key, or the hash was deleted because the last of its
              * fields expired. */
             addReplyNull(c);
-            resOut[i] = GETF_NOT_FOUND;
-            if (expiredOut) expiredOut[i] = EB_EXPIRE_TIME_INVALID;
-            continue;
+            res = GETF_NOT_FOUND;
+        } else {
+            res = addHashFieldToReply(c, o, fields[i]->ptr, hfeFlags, &expiredAt);
+            if (res == GETF_EXPIRED_HASH)
+                o = NULL;
         }
-        resOut[i] = addHashFieldToReply(c, o, fields[i]->ptr, hfeFlags,
-                                        expiredOut ? &expiredOut[i] : NULL);
-        if (resOut[i] == GETF_EXPIRED_HASH)
-            o = NULL;
+        hashMultiGetOutSet(out, fields, i, res, expiredAt);
     }
 }
 
@@ -5542,7 +5573,7 @@ static void addHashFieldsToReplyOneByOne(client *c, kvobj *o, robj **fields,
  * invalidates the resolved pointers - are delegated to addHashFieldToReply(),
  * and so is every field after them.
  *
- * 'resOut' and 'expiredOut' are as in addHashFieldsToReplyOneByOne().
+ * Results are reported in 'out', as in addHashFieldsToReplyOneByOne().
  *
  * Note that this function only reads. Callers that also modify the fields must
  * do so after it returns, and must set 'rejectDups' because the reply of a field
@@ -5555,8 +5586,7 @@ static void addHashFieldsToReplyOneByOne(client *c, kvobj *o, robj **fields,
  * the frame of callers that never resolve a single field through it. */
 static __attribute__((noinline))
 int addHashMultiFieldsToReply(client *c, kvobj *o, robj **fields, int numFields,
-                              int hfeFlags, int rejectDups,
-                              GetFieldRes *resOut, uint64_t *expiredOut)
+                              int hfeFlags, int rejectDups, hashMultiGetOut *out)
 {
     hashMultiGetScratch s;
     int linear = (numFields <= HASH_MULTIGET_LINEAR_FIELDS);
@@ -5587,17 +5617,20 @@ int addHashMultiFieldsToReply(client *c, kvobj *o, robj **fields, int numFields,
         if (res->found && hashTypeFieldNeedsLazyExpire(res->expiredAt, hfeFlags))
             break;
 
+        /* Every field replied to here is either missing or alive - the loop
+         * breaks out above on the first one that needs lazy expiration - so
+         * 'out->expired' cannot have anything to collect and is left alone. */
         if (!res->found) {
             addReplyNull(c);
-            resOut[i] = GETF_NOT_FOUND;
-            if (expiredOut) expiredOut[i] = EB_EXPIRE_TIME_INVALID;
+            if (out->res) out->res[i] = GETF_NOT_FOUND;
+            if (out->expiredAt) out->expiredAt[i] = EB_EXPIRE_TIME_INVALID;
         } else {
             if (res->vstr)
                 addReplyBulkCBuffer(c, res->vstr, res->vlen);
             else
                 addReplyBulkLongLong(c, res->vll);
-            resOut[i] = GETF_OK;
-            if (expiredOut) expiredOut[i] = res->expiredAt;
+            if (out->res) out->res[i] = GETF_OK;
+            if (out->expiredAt) out->expiredAt[i] = res->expiredAt;
         }
         i++;
     }
@@ -5605,8 +5638,7 @@ int addHashMultiFieldsToReply(client *c, kvobj *o, robj **fields, int numFields,
     hashMultiGetScratchRelease(&s);
 
     if (i < numFields) {
-        addHashFieldsToReplyOneByOne(c, o, fields, numFields, i, hfeFlags,
-                                     resOut, expiredOut);
+        addHashFieldsToReplyOneByOne(c, o, fields, numFields, i, hfeFlags, out);
     }
     return 1;
 }
@@ -5632,33 +5664,24 @@ void hmgetCommand(client *c) {
     fieldvec fvexpired;
     vec *vexpired = fieldvecInit(&fvexpired, numFields);
 
-    GetFieldRes stackres[HASH_MULTIGET_STACK_FIELDS];
-    GetFieldRes *resOut = (numFields <= HASH_MULTIGET_STACK_FIELDS) ?
-                          stackres : zmalloc(sizeof(GetFieldRes) * numFields);
+    /* HMGET only reads, so it has no use for the per-field results: collecting
+     * the fields to notify about while replying is all it needs. */
+    hashMultiGetOut out = { .expired = vexpired };
 
     addReplyArrayLen(c, numFields);
     if (!hashTypeMultiGetApplies(o, numFields) ||
         !addHashMultiFieldsToReply(c, o, &c->argv[2], numFields,
-                                   HFE_LAZY_NO_NOTIFICATION, 0, resOut, NULL))
+                                   HFE_LAZY_NO_NOTIFICATION, 0, &out))
     {
         addHashFieldsToReplyOneByOne(c, o, &c->argv[2], numFields, 0,
-                                     HFE_LAZY_NO_NOTIFICATION, resOut, NULL);
+                                     HFE_LAZY_NO_NOTIFICATION, &out);
     }
-
-    int deleted = 0;
-    for (int i = 0; i < numFields; i++) {
-        if (resOut[i] == GETF_EXPIRED)
-            vecPush(vexpired, c->argv[2 + i]);
-        deleted += (resOut[i] == GETF_EXPIRED_HASH);
-    }
-
-    if (resOut != stackres) zfree(resOut);
 
     if (vecSize(vexpired)) {
         notifyKeyspaceEventWithSubkeys(NOTIFY_HASH, "hexpired", c->argv[1],
                                        c->db->id, (robj**)vecData(vexpired), vecSize(vexpired));
     }
-    if (deleted)
+    if (out.hashDeleted)
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
 
     vecRelease(vexpired);
@@ -5725,6 +5748,7 @@ void hgetdelCommand(client *c) {
     GetFieldRes stackres[HASH_MULTIGET_STACK_FIELDS];
     GetFieldRes *resOut = (numFields <= HASH_MULTIGET_STACK_FIELDS) ?
                           stackres : zmalloc(sizeof(GetFieldRes) * numFields);
+    hashMultiGetOut out = { .res = resOut };
 
     if (o && hashTypeIsTemplate(o)) {
         /* Template hash: reply every value, then drop all the fields in one
@@ -5732,7 +5756,7 @@ void hgetdelCommand(client *c) {
         hashTypeTmplDeleteFields(o, c->argv + 4, c->argc - 4, vdeleted, c);
     } else if (hashTypeMultiGetApplies(o, numFields) &&
                addHashMultiFieldsToReply(c, o, &c->argv[4], numFields, flags,
-                                         1, resOut, NULL))
+                                         1, &out))
     {
         /* Replied to all the fields in a single pass over the listpack. Delete
          * them afterwards: doing it as we reply would invalidate the values the
@@ -5882,13 +5906,14 @@ void hgetexCommand(client *c) {
         resOut = zmalloc(sizeof(GetFieldRes) * num_fields);
         expiredOut = zmalloc(sizeof(uint64_t) * num_fields);
     }
+    hashMultiGetOut out = { .res = resOut, .expiredAt = expiredOut };
 
     /* Reply to all the fields first - which takes a single pass over a listpack
      * encoded hash - and update their expiration afterwards, since updating one
      * would invalidate the values the single pass resolved. */
     if (hashTypeMultiGetApplies(o, num_fields) &&
         addHashMultiFieldsToReply(c, o, &c->argv[first_field_pos], num_fields,
-                                  flags, 1, resOut, expiredOut))
+                                  flags, 1, &out))
     {
         for (int i = 0; i < num_fields; i++) {
             robj *fieldobj = c->argv[first_field_pos + i];

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -1116,6 +1116,238 @@ start_server {tags {"external:skip needs:debug"}} {
             r debug set-active-expire 1
         }
 
+        test "HGETEX - PERSIST on fields without TTL is a no-op ($type)" {
+            r del myhash
+            r hset myhash f1 v1 f2 v2 f3 v3
+
+            set repl [attach_to_replication_stream]
+            set dirty [s rdb_changes_since_last_save]
+            assert_equal [r hgetex myhash PERSIST FIELDS 3 f1 f2 f3] "v1 v2 v3"
+            assert_equal [s rdb_changes_since_last_save] $dirty
+
+            # Only fields that actually lost a TTL are persisted and propagated.
+            r hexpire myhash 100 FIELDS 1 f2
+            assert_equal [r hgetex myhash PERSIST FIELDS 3 f1 f2 f3] "v1 v2 v3"
+            assert_equal [r httl myhash FIELDS 3 f1 f2 f3] "$T_NO_EXPIRY $T_NO_EXPIRY $T_NO_EXPIRY"
+
+            assert_replication_stream $repl {
+                {select *}
+                {hpexpireat myhash * FIELDS 1 f2}
+                {hpersist myhash FIELDS 3 f1 f2 f3}
+            }
+            close_replication_stream $repl
+        } {} {needs:repl}
+
+        test "HGETEX - Multiple fields mixing present, absent and expired ($type)" {
+            r del myhash
+            r debug set-active-expire 0
+
+            r hset myhash f1 v1 f2 v2 f3 v3 f4 v4
+            r hpexpire myhash 1 FIELDS 1 f2
+            after 10
+
+            # f2 lazily expires in the middle of the reply, which mutates the
+            # hash: the fields after it must still be resolved correctly.
+            assert_equal [r hgetex myhash FIELDS 5 f1 f2 nofield f3 f4] "v1 {} {} v3 v4"
+            assert_equal [lsort [r hgetall myhash]] [lsort "f1 v1 f3 v3 f4 v4"]
+
+            # Same, with the last live fields expiring so the hash is removed.
+            r hpexpire myhash 1 FIELDS 3 f1 f3 f4
+            after 10
+            assert_equal [r hgetex myhash FIELDS 4 nofield f1 f3 f4] "{} {} {} {}"
+            assert_equal [r exists myhash] 0
+
+            r debug set-active-expire 1
+        }
+
+        test "HGETEX - Duplicate fields ($type)" {
+            r del myhash
+            r hset myhash f1 v1 f2 v2
+
+            # Reads only: every occurrence gets the value.
+            assert_equal [r hgetex myhash FIELDS 4 f1 f1 f2 f1] "v1 v1 v2 v1"
+
+            # Setting a TTL in the past deletes the field, so the second
+            # occurrence must not see it anymore.
+            assert_equal [r hgetex myhash PXAT 1 FIELDS 3 f1 f1 f2] "v1 {} v2"
+            assert_equal [r hgetall myhash] ""
+            assert_equal [r exists myhash] 0
+        }
+
+        test "HGETDEL - Duplicate fields ($type)" {
+            r del myhash
+            r hset myhash f1 v1 f2 v2 f3 v3
+            r hexpire myhash 100 FIELDS 1 f3
+
+            assert_equal [r hgetdel myhash FIELDS 3 f1 f1 f2] "v1 {} v2"
+            assert_equal [r hgetdel myhash FIELDS 2 f3 f3] "v3 {}"
+            assert_equal [r exists myhash] 0
+        }
+
+        test "HGETEX - Lazy expiry and past TTL deletions are both propagated ($type)" {
+            r del myhash
+            r debug set-active-expire 0
+            r hset myhash f1 v1 f2 v2
+            r hpexpire myhash 1 FIELDS 1 f2
+            after 10
+
+            set repl [attach_to_replication_stream]
+            # f2 is already logically expired, so reading it deletes it, while
+            # f1 is deleted by the past timestamp of this very command.
+            assert_equal [r hgetex myhash PXAT 1 FIELDS 2 f1 f2] "v1 {}"
+
+            if {$type eq "listpackex"} {
+                # The single pass replies to every field before mutating any of
+                # them, so the lazy expiration HDEL comes first.
+                set expected {
+                    {multi}
+                    {select *}
+                    {hdel myhash f2}
+                    {hdel myhash f1}
+                    {exec}
+                }
+            } else {
+                # The per-field path interleaves reads and mutations, so the
+                # HDELs follow the order of the requested fields.
+                set expected {
+                    {multi}
+                    {select *}
+                    {hdel myhash f1}
+                    {hdel myhash f2}
+                    {exec}
+                }
+            }
+            assert_replication_stream $repl $expected
+            close_replication_stream $repl
+
+            assert_equal [r exists myhash] 0
+            r debug set-active-expire 1
+        } {OK} {needs:repl}
+
+        # Cross check multi field lookups against single field HGET on hashes
+        # holding a random mix of TTL-free, live, far future and already
+        # logically expired fields.
+        test "Multi field lookup fuzzing with TTLs ($type)" {
+            set orig_maxval [lindex [r config get hash-max-listpack-value] 1]
+            # randomValue returns values of up to 256 bytes, which would
+            # otherwise convert the hash away from listpackex.
+            r config set hash-max-listpack-value 1024
+            r debug set-active-expire 0
+
+            set err [catch {
+            for {set times 0} {$times < 20} {incr times} {
+                r del myhash
+                catch {unset hash}
+                array set hash {}
+
+                set nfields [randomRange 2 60]
+                for {set j 0} {$j < $nfields} {incr j} {
+                    set value [randomValue]
+                    r hset myhash "f$j" $value
+                    set hash(f$j) $value
+                }
+
+                # f0 keeps no TTL so that the hash cannot be deleted from
+                # under the encoding assertion, f1 always gets one so the
+                # encoding is listpackex rather than plain listpack.
+                set expiring {}
+                for {set j 1} {$j < $nfields} {incr j} {
+                    set field "f$j"
+                    if {$j == 1} {
+                        r hexpire myhash 1000 FIELDS 1 $field
+                        continue
+                    }
+                    randpath {
+                        # Keep it TTL free.
+                    } {
+                        r hexpire myhash 1000 FIELDS 1 $field
+                    } {
+                        r hpexpireat myhash [expr {[clock milliseconds] + 100000000}] \
+                            FIELDS 1 $field
+                    } {
+                        # Logically expired below, but still stored since
+                        # active expiration is off.
+                        r hpexpire myhash 10 FIELDS 1 $field
+                        lappend expiring $field
+                    }
+                }
+
+                if {[llength $expiring] > 0} {
+                    after 20
+                    foreach field $expiring {
+                        unset -nocomplain hash($field)
+                    }
+                }
+
+                if {$type eq "listpackex"} {
+                    assert_encoding listpackex myhash
+                } else {
+                    assert_encoding hashtable myhash
+                }
+
+                # Cover the linear (< 8), stack indexed (<= 64) and heap
+                # indexed (> 64) request sizes.
+                set numfields [randomRange 1 71]
+                set fields {}
+                set expected {}
+                for {set j 0} {$j < $numfields} {incr j} {
+                    randpath {
+                        set field "f[randomInt $nfields]"
+                    } {
+                        set field "nofield[randomInt 10]"
+                    } {
+                        if {[llength $fields] > 0} {
+                            set field [lindex $fields [randomInt [llength $fields]]]
+                        } else {
+                            set field "f0"
+                        }
+                    }
+                    lappend fields $field
+                    if {[info exists hash($field)]} {
+                        lappend expected $hash($field)
+                    } else {
+                        lappend expected ""
+                    }
+                }
+
+                assert_equal $expected [r hmget myhash {*}$fields]
+                assert_equal $expected \
+                    [r hgetex myhash FIELDS [llength $fields] {*}$fields]
+
+                # HGETDEL removes a field on its first occurrence, so a
+                # repeated one replies nil from the second occurrence on.
+                set expected_del {}
+                array set seen {}
+                foreach field $fields {
+                    if {[info exists hash($field)] && ![info exists seen($field)]} {
+                        lappend expected_del $hash($field)
+                    } else {
+                        lappend expected_del ""
+                    }
+                    set seen($field) 1
+                }
+                unset seen
+                assert_equal $expected_del \
+                    [r hgetdel myhash FIELDS [llength $fields] {*}$fields]
+
+                # Everything that was requested is gone now, the rest is intact.
+                foreach field $fields {
+                    unset -nocomplain hash($field)
+                    assert_equal "" [r hget myhash $field]
+                }
+                foreach {k v} [array get hash] {
+                    assert_equal $v [r hget myhash $k]
+                }
+            }
+            } res opts]
+
+            # Restore even on failure, so that one assertion does not cascade
+            # into every later test in this file.
+            r config set hash-max-listpack-value $orig_maxval
+            r debug set-active-expire 1
+            return -options $opts $res
+        }
+
 
         test "HSETEX - input validation ($type)" {
             assert_error {*wrong number of arguments*} {r hsetex myhash}

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -882,6 +882,97 @@ start_server {tags {"hash"}} {
              assert_equal [r hgetdel key1 fields 3 f1 f2 f3] "{} {} {}"
         }
 
+        test "HGETDEL with duplicate fields - $type" {
+            r del key1
+            r hset key1 f1 1 f2 2 f3 3
+
+            # The second occurrence sees the deletion done by the first one.
+            assert_equal [r hgetdel key1 fields 2 f1 f1] "1 {}"
+            assert_equal [r hgetdel key1 fields 3 f2 f3 f2] "2 3 {}"
+            assert_equal [r exists key1] 0
+        }
+
+        test "HMGET with duplicate fields - $type" {
+            r del key1
+            r hset key1 f1 1 f2 2
+            assert_equal [r hmget key1 f1 f1 f2 f1 nofield nofield] "1 1 2 1 {} {}"
+        }
+
+        test "Multi field lookup with integer field names - $type" {
+            r del key1
+            r hset key1 1 a 2 b 42 c -1 d 0 e
+
+            assert_equal [r hmget key1 1 42 0 -1 2] "a c e d b"
+
+            # Non canonical decimal representations must not match the
+            # integer encoded field names.
+            assert_equal [r hmget key1 01 +1 " 1" 1. 0042 -0] "{} {} {} {} {} {}"
+
+            # Same via HGETDEL / HGETEX, which use the same lookup path.
+            assert_equal [r hgetex key1 fields 3 42 007 -1] "c {} d"
+            assert_equal [r hgetdel key1 fields 3 0 +42 1] "e {} a"
+            assert_equal [lsort [r hgetall key1]] [lsort "2 b 42 c -1 d"]
+        }
+
+        test "Multi field lookup mixing present and absent fields - $type" {
+            r del key1
+            r hset key1 f1 1 f2 2 f3 3 f4 4
+
+            # Absent field last, first, and in the middle.
+            assert_equal [r hmget key1 f1 f2 nope] "1 2 {}"
+            assert_equal [r hmget key1 nope f1 f2] "{} 1 2"
+            assert_equal [r hmget key1 f1 nope f2 nope2 f3] "1 {} 2 {} 3"
+
+            # More fields than the stack budget of the single pass lookup.
+            set fields {}
+            set expected {}
+            for {set i 1} {$i <= 200} {incr i} {
+                lappend fields "f$i"
+                lappend expected [expr {$i <= 4 ? $i : ""}]
+            }
+            assert_equal [r hmget key1 {*}$fields] $expected
+            assert_equal [r hgetdel key1 fields 200 {*}$fields] $expected
+            assert_equal [r exists key1] 0
+        }
+
+        test "Multi field lookup with an empty field name - $type" {
+            r del key1
+            r hset key1 "" v0 f1 1
+
+            assert_equal [r hmget key1 "" f1] "v0 1"
+            assert_equal [r hmget key1 f1 "" nope] "1 v0 {}"
+            assert_equal [r hgetex key1 fields 2 "" f1] "v0 1"
+            assert_equal [r hgetdel key1 fields 2 "" nope] "v0 {}"
+            assert_equal [r hmget key1 "" f1] "{} 1"
+            assert_equal [r hgetall key1] "f1 1"
+        }
+
+        test "Multi field lookup with integer field names, indexed path - $type" {
+            r del key1
+            r hset key1 1 a 2 b 42 c -1 d 0 e 100 f \
+                        -9223372036854775808 g 9223372036854775807 h
+            assert_encoding [expr {$type eq "listpack" ? "listpack" : "hashtable"}] key1
+
+            # More requested fields than the linear compare budget, so the
+            # names go through the hashed index. Integer encoded field names
+            # are rendered back to decimal before being matched.
+            assert_equal [r hmget key1 1 2 42 -1 0 100 \
+                          -9223372036854775808 9223372036854775807 nope 1] \
+                         "a b c d e f g h {} a"
+
+            # Non canonical decimal representations must still miss on the
+            # indexed path.
+            assert_equal [r hmget key1 01 +1 " 1" 1. 0042 -0 007 +42 -01 00 1e2 0x2] \
+                         "{} {} {} {} {} {} {} {} {} {} {} {}"
+
+            assert_equal [r hgetex key1 fields 10 1 2 42 -1 0 100 x1 x2 x3 x4] \
+                         "a b c d e f {} {} {} {}"
+            assert_equal [r hgetdel key1 fields 10 1 2 42 -1 0 100 x1 x2 x3 x4] \
+                         "a b c d e f {} {} {} {}"
+            assert_equal [lsort [r hgetall key1]] \
+                         [lsort "-9223372036854775808 g 9223372036854775807 h"]
+        }
+
         r config set hash-max-listpack-entries $orig_config
     }
 
@@ -971,6 +1062,104 @@ start_server {tags {"hash"}} {
                 }
                 assert_equal [array size hash] [r hlen hash]
             }
+        }
+
+        # Multi field lookups resolve every requested field in one pass over a
+        # listpack encoded hash. Cross check them against single field HGET on
+        # random mixes of present, absent and repeated fields.
+        test "Hash multi field lookup fuzzing - $size fields" {
+            set orig_maxlp [lindex [r config get hash-max-listpack-entries] 1]
+            set orig_maxval [lindex [r config get hash-max-listpack-value] 1]
+
+            # randomValue returns strings of up to 256 bytes, so the file level
+            # hash-max-listpack-value of 64 would convert almost every hash to
+            # hashtable and the listpack arm below would never reach the single
+            # pass code it exists to cover.
+            r config set hash-max-listpack-value 1024
+
+            set err [catch {
+            foreach maxlp {512 0} {
+                r config set hash-max-listpack-entries $maxlp
+
+                for {set times 0} {$times < 10} {incr times} {
+                    catch {unset hash}
+                    array set hash {}
+                    r del hash
+
+                    for {set j 0} {$j < $size} {incr j} {
+                        randpath {
+                            set field [randomValue]
+                        } {
+                            set field [randomSignedInt 512]
+                        }
+                        set value [randomValue]
+                        r hset hash $field $value
+                        set hash($field) $value
+                    }
+
+                    if {$maxlp == 0} {
+                        assert_encoding hashtable hash
+                    } else {
+                        assert_encoding listpack hash
+                    }
+
+                    # Vary the number of requested fields so that all three
+                    # request sizes are covered: the linear compare path (< 8),
+                    # the stack allocated index (<= 64) and the heap allocated
+                    # one (> 64).
+                    set numfields [randomRange 1 71]
+                    set present [array names hash]
+                    set fields {}
+                    set expected {}
+                    for {set j 0} {$j < $numfields} {incr j} {
+                        randpath {
+                            set field [lindex $present [randomInt [llength $present]]]
+                        } {
+                            set field [randomValue]
+                        } {
+                            set field [randomSignedInt 512]
+                        } {
+                            # Repeat an already requested field.
+                            if {[llength $fields] > 0} {
+                                set field [lindex $fields [randomInt [llength $fields]]]
+                            } else {
+                                set field [randomValue]
+                            }
+                        }
+                        lappend fields $field
+                        if {[info exists hash($field)]} {
+                            lappend expected $hash($field)
+                        } else {
+                            lappend expected ""
+                        }
+                    }
+
+                    assert_equal $expected [r hmget hash {*}$fields]
+                    assert_equal $expected [r hgetex hash FIELDS [llength $fields] {*}$fields]
+
+                    # HGETDEL removes each field on its first occurrence, so a
+                    # repeated field replies nil from the second one on.
+                    set expected_del {}
+                    array set seen {}
+                    foreach field $fields {
+                        if {[info exists hash($field)] && ![info exists seen($field)]} {
+                            lappend expected_del $hash($field)
+                        } else {
+                            lappend expected_del ""
+                        }
+                        set seen($field) 1
+                    }
+                    unset seen
+                    assert_equal $expected_del [r hgetdel hash FIELDS [llength $fields] {*}$fields]
+                }
+            }
+            } res opts]
+
+            # Restore even on failure, otherwise a single assertion leaks
+            # hash-max-listpack-entries 0 into every later test in this file.
+            r config set hash-max-listpack-entries $orig_maxlp
+            r config set hash-max-listpack-value $orig_maxval
+            return -options $opts $res
         }
     }
 


### PR DESCRIPTION
# Hash: resolve multi-field lookups in a single listpack pass

## Problem

On listpack-encoded hashes every multi-field hash read resolves each field with its own `lpFind()` walk
from the head of the listpack, so `HMGET`, `HGETEX` and `HGETDEL` are **O(fields × entries)** —
and `HGETEX`/`HGETDEL` pay it twice, because the mutation that follows each read (`hashTypeSetEx()` /
`hashTypeDelete()`) walks the listpack again to find the same field.

`HGETEX` over 5 fields costs 2.59 µs and over 50 fields 48.98 µs: 18.9× the time for 10× the fields,
with the per-field cost itself nearly doubling. `HMGET` of 100 fields from a 100-field hash does ~5,050
tuple visits to return 100 values.

## Change

Resolve every requested field in **one** pass, making the lookup O(entries + fields).

* `hashTypeGetMultiFromListpack()` walks the listpack once through the existing `lpFindCb()` callback
  API — no changes to `listpack.c`/`.h`. Requested names go into an open-addressing index keyed by
  `dictGenHashFunction()`, with the bytes `memcmp`-verified on every hit so a hash collision cannot
  produce a wrong match; integer-encoded entries are compared through `ll2string()`, exactly equivalent
  to `lpFindCmp()`'s integer path. The walk stops as soon as all fields are resolved.
* Below `HASH_MULTIGET_LINEAR_FIELDS` (8) fields no index is built and names are compared directly.
  Hashing needles is not free — an earlier revision that always built the index regressed the 5-field
  `HGETEX` spec by 16 %.
* `HGETEX`/`HGETDEL` are split into a read phase that emits all replies and a mutation phase after it.
  Requesting the same field name twice would change the observable result (`HGETDEL k FIELDS 2 f f`
  must reply `[val, nil]`), so a duplicate check — a by-product of building the index — routes those
  requests to the pre-existing interleaved loop, before any reply is emitted.
* `HGETEX ... PERSIST` on a field with no TTL is a no-op that `hashTypeSetEx()` only discovers after a
  full `lpFind()`. The read pass already knows every field's TTL, so that call is skipped entirely.
* Fields needing lazy expiration are handed to the existing single-field path — that field and all
  remaining ones — because expiring a field mutates the listpack and invalidates resolved pointers.
  `OBJ_ENCODING_HT`, missing keys and single-field requests take exactly the code path they take today.
* One observable consequence of the read/mutate split: on `HGETEX`, lazy-expiration `HDEL`s are now
  propagated before the `HDEL`s caused by a past timestamp in the command itself, where they used to be
  interleaved per field. Same key, distinct fields, same wrapper, identical replica state — and the
  ordering is pinned by a new `assert_replication_stream` test in both encodings.

## Benchmarks

`redis-benchmarks-specification` 0.3.32, baseline `unstable` @ **`065d39703`** (v8.9.241) against the
same tree plus this patch.

### Hardware

| | |
|---|---|
| CPU | Intel Xeon 6972P (Granite Rapids), 2 sockets × 96 physical cores, **384 logical CPUs** (SMT2), 800 – 3900 MHz |
| Caches / memory | L3 960 MiB total (480 MiB per socket), 1.5 TiB DRAM |
| NUMA | **6 nodes** — sub-NUMA clustering, 3 nodes per socket, 32 physical (64 logical) cores and ~256 GB per node. Node distances: 12 within a socket, 21 across |
| OS | Ubuntu, kernel 5.15.0-187-generic |
| Power/frequency | governor **`performance`**, all idle states (`POLL`, `C1_ACPI`, `C2_ACPI`) **disabled**, host otherwise idle |

### Methodology — client and server co-located, on different NUMA nodes of one socket

The benchmark client runs **on the same host as the server**, talking to it over **loopback**
(`127.0.0.1`), with the two pinned to different NUMA nodes so they never compete for cores:

* **Server** — `numactl -N 0 -m 0 redis-server --protected-mode no --save '' --appendonly no [--io-threads 16]`,
  i.e. CPUs `0-31,192-223` and memory on node 0.
* **Client** — `numactl -N 1 -m 1 redis-benchmarks-spec-client-runner --db_server_host 127.0.0.1
  --benchmark_local_install --cpuset_start_pos 32`, i.e. CPUs `32-63,224-255` and memory on node 1.
  `--cpuset_start_pos 32` is required: the runner's local-install branch prepends its own
  `taskset -c <cpus from cpuset_start_pos>`, which would otherwise override `numactl -N` and split
  memtier's CPUs (node 0) from its memory (node 1). memtier is the **native** binary, not the Docker
  image — that is what makes `Hits/sec` / `Misses/sec` accounting real on `--command`-style tests.
  4 threads × 50 connections, per the spec YAMLs.
* Nodes 0 and 1 are two sub-NUMA clusters of the **same socket** (distance 12), so loopback traffic and
  the client's memory stay on one socket's mesh — no cross-socket hop and no NIC anywhere in the path.
* Pinning is verified per run from `taskset -cp` and `/proc/<pid>/numa_maps`, alongside the server's
  `cmdline`, thread count and names, `redis_git_sha1` and `io-threads`.

Each test is measured in two threading modes:

* **single-thread** — `redis-server` with **no `--io-threads` flag at all**. Verified per run from
  `/proc/<pid>/task`: 6 threads (main + 3 `bio_*` + 2 `jemalloc_bg_thd`), **no `io_thd_*`**.
* **`--io-threads 16`** — 21 threads, `io_thd_1 … io_thd_16`, `io_threads_active:1`.

Arms are **interleaved per test** (`base`, `patched`, same test, then move on) with the server restarted
and `CONFIG RESETSTAT` before every run, so host drift cannot bias one arm. `--flushall_on_every_test_start`
on every run; `dbsize`, `OBJECT ENCODING` and `Misses/sec 0.00` verified afterwards. The primary metric is
`usec_per_call` (`usec / calls` from `INFO commandstats`) — server CPU inside command execution, the only
thing this patch changes; `Ops/sec` is the end-to-end consequence.

| test case | enc | mode | Ops/sec | Δ | p50 ms | p99 ms | µs/call |
|---|---|---|---|---|---|---|---|
| `1Mkeys-hash-hmget-100of100-fields-with-32B-values-pipeline-1` | listpack | single-thread | 23,036 → **55,957** | **+142.9 %** | 6.911 → 2.975 | 13.375 → 5.631 | 34.526 → 8.286 |
| | | `io-threads 16` | 27,261 → **112,282** | **+311.9 %** | 7.327 → 1.767 | 7.615 → 2.023 | 35.748 → 7.833 |
| `100Kkeys-hash-hgetex-persist-50-fields-10B-values` | listpackex | single-thread | 34,829 → **78,926** | **+126.6 %** | 5.567 → 2.447 | 11.135 → 4.959 | 21.254 → 4.613 |
| | | `io-threads 16` | 45,762 → **178,691** | **+290.5 %** | 4.383 → 1.111 | 4.607 → 1.319 | 21.134 → 4.738 |
| `100Kkeys-hash-hgetex-50-fields-10B-values` | listpackex | single-thread | 17,646 → **19,626** | **+11.2 %** | 10.943 → 9.855 | 21.887 → 19.711 | 48.979 → 42.857 |
| | | `io-threads 16` | 18,804 → **22,980** | **+22.2 %** | 10.623 → 8.703 | 11.199 → 9.023 | 52.237 → 42.528 |
| `100Kkeys-hash-hgetex-5-fields-10B-values` | listpackex | single-thread | 111,283 → 110,498 | −0.7 % | 1.783 → 1.791 | 3.487 → 3.503 | 2.594 → 2.600 |
| | | `io-threads 16` | 293,756 → 292,252 | −0.5 % | 0.679 → 0.679 | 0.799 → 0.815 | 2.645 → 2.646 |

`hgetex-persist` is the best case: after the first sweep every call is a no-op `PERSIST`, so both walk
sets disappear — ~100 listpack walks per call become one.

The 5-field `HGETEX` case is unchanged rather than faster: with 5 fields in a 5-field hash the old
code's early-exiting walks visit ~15 tuples against the new one's 5, and what remains — `hashTypeSetEx()`
plus the per-field TTL re-encode in `listpackExUpdateExpiry()` — dominates. Batching that re-encode is
the next step; VTune puts it at ~27 µs of the 42.5 µs still left in `hgetex-50-fields`.

**Why `io-threads` roughly doubles the gain.** `io-threads` offloads socket work but command execution
stays serialized on the main thread, so at `--io-threads 16` these tests are already execution-bound —
`Ops/sec × usec_per_call` is **0.97 core** for all three baselines — and throughput is pinned at
`1 core / usec_per_call`, tracking the per-call win almost exactly. `hgetex-50-fields` is the cleanest
check: both arms sit on the same 0.98-core ceiling, so the ops ratio must equal the inverse per-call
ratio — 52.237 / 42.528 = 1.228 against +22.2 % measured. Single-threaded the one thread also does the
socket work (baseline `hgetex-persist` at 0.74 core, 0.36 after the patch), so only part of the saved
execution time converts into throughput.

These are exactly the tests `io-threads` alone cannot help, and the two optimizations compose: on
`hgetex-persist-50-fields`, `unstable` single-threaded does 34,829 ops/s and this patch with
`io-threads 16` does **178,691 ops/s, 5.1× more**.

### All 13 hash-read specs

Throughput, base → patched:

| test case | enc | Ops/sec, single-thread | Δ | Ops/sec, `io-threads 16` | Δ |
|---|---|---|---|---|---|
| `1Mkeys-hash-hmget-100of100-fields-with-32B-values-pipeline-1` | listpack | 23,036 → **55,957** | **+142.9 %** | 27,261 → **112,282** | **+311.9 %** |
| `100Kkeys-hash-hgetex-persist-50-fields-10B-values` | listpackex | 34,829 → **78,926** | **+126.6 %** | 45,762 → **178,691** | **+290.5 %** |
| `100Kkeys-hash-hgetex-50-fields-10B-values` | listpackex | 17,646 → **19,626** | **+11.2 %** | 18,804 → **22,980** | **+22.2 %** |
| `100Kkeys-hash-hgetex-5-fields-10B-values` | listpackex | 111,283 → 110,498 | −0.7 % | 293,756 → 292,252 | −0.5 % |
| `1Mkeys-hash-hmget-5-fields-with-100B-values-pipeline-10` | hashtable | 491,974 → 486,402 | −1.1 % | 937,633 → 911,809 | −2.8 % |
| `100Kkeys-hash-hgetall-50-fields-100B-values` † | hashtable | 93,911 → 93,601 | −0.3 % | 231,050 → 225,540 | −2.4 % |
| `10Kkeys-hash-hgetall-100-fields-100B-values` † | hashtable | 69,057 → 68,616 | −0.6 % | 128,495 → 129,670 | +0.9 % |
| `10Kkeys-hash-hgetall-200-fields-100B-values` † | hashtable | 38,147 → 38,672 | +1.4 % | 57,367 → 58,322 | +1.7 % |
| `10Kkeys-hash-hgetall-500-fields-100B-values` † | hashtable | 15,517 → 17,130 | +10.4 %‡ | 22,226 → 22,220 | −0.0 % |
| `1key-hash-1K-fields-hgetall` † | hashtable | 16,867 → 16,525 | −2.0 % | 19,318 → 19,130 | −1.0 % |
| `1key-hash-1K-fields-hgetall-pipeline-10` † | hashtable | 15,726 → 16,099 | +2.4 % | 17,434 → 17,379 | −0.3 % |
| `1Mkeys-hash-hgetall-50-fields-10B-values` † | listpack | 105,471 → 104,618 | −0.8 % | 226,382 → 228,643 | +1.0 % |
| `1Mkeys-hash-hget-hgetall-hkeys-hvals-with-100B-values` † | hashtable | 148,101 → 152,569 | +3.0 % | 460,906 → 463,346 | +0.5 % |

Command CPU, `usec_per_call`, base → patched (the mixed spec reports four commands against one
`Ops/sec` figure):

| test case | command | µs/call, single-thread | Δ | µs/call, `io-threads 16` | Δ |
|---|---|---|---|---|---|
| `1Mkeys-hash-hmget-100of100-fields-…-pipeline-1` | `HMGET` | 34.526 → **8.286** | **−76.0 %** | 35.748 → **7.833** | **−78.1 %** |
| `100Kkeys-hash-hgetex-persist-50-fields-10B-values` | `HGETEX` | 21.254 → **4.613** | **−78.3 %** | 21.134 → **4.738** | **−77.6 %** |
| `100Kkeys-hash-hgetex-50-fields-10B-values` | `HGETEX` | 48.979 → **42.857** | **−12.5 %** | 52.237 → **42.528** | **−18.6 %** |
| `100Kkeys-hash-hgetex-5-fields-10B-values` | `HGETEX` | 2.594 → 2.600 | +0.3 % | 2.645 → 2.646 | +0.1 % |
| `1Mkeys-hash-hmget-5-fields-…-pipeline-10` | `HMGET` | 0.650 → 0.655 | +0.8 % | 0.699 → 0.696 | −0.4 % |
| `100Kkeys-hash-hgetall-50-fields-100B-values` † | `HGETALL` | 3.848 → 3.826 | −0.6 % | 3.681 → 3.746 | +1.8 % |
| `10Kkeys-hash-hgetall-100-fields-100B-values` † | `HGETALL` | 7.232 → 7.358 | +1.7 % | 7.127 → 7.042 | −1.2 % |
| `10Kkeys-hash-hgetall-200-fields-100B-values` † | `HGETALL` | 17.183 → 17.127 | −0.3 % | 16.742 → 16.449 | −1.7 % |
| `10Kkeys-hash-hgetall-500-fields-100B-values` † | `HGETALL` | 48.658 → 43.566 | −10.5 %‡ | 44.234 → 44.257 | +0.1 % |
| `1key-hash-1K-fields-hgetall` † | `HGETALL` | 50.508 → 51.714 | +2.4 % | 51.114 → 51.613 | +1.0 % |
| `1key-hash-1K-fields-hgetall-pipeline-10` † | `HGETALL` | 56.486 → 55.309 | −2.1 % | 56.773 → 56.927 | +0.3 % |
| `1Mkeys-hash-hgetall-50-fields-10B-values` † | `HGETALL` | 3.660 → 3.577 | −2.3 % | 3.815 → 3.759 | −1.5 % |
| `1Mkeys-hash-hget-hgetall-hkeys-hvals-…` † | `HGET` | 0.415 → 0.399 | −3.8 % | 0.442 → 0.455 | +3.1 % |
| ” | `HGETALL` | 0.782 → 0.735 | −6.1 % | 0.918 → 0.933 | +1.7 % |
| ” | `HKEYS` | 0.553 → 0.513 | −7.3 % | 0.522 → 0.553 | +6.0 % |
| ” | `HVALS` | 0.655 → 0.607 | −7.3 % | 0.786 → 0.797 | +1.5 % |

**† executes none of the changed code** — `HGETALL`/`HKEYS`/`HVALS` iterate the whole hash and `HGET` is
single-field, so these eight specs are the rig's measurement floor: ±2 % on the byte-heavy tests, up to
±7 % on the mixed four-command spec, which is the least saturated test in the suite (0.31 core of
execution) and moves as a block in whichever direction the run lands. Their implementations are
byte-identical between the arms. (These eight rows come from an earlier revision of the patch; the only
code that changed since is the reply-reporting struct, which none of them reaches, so the figures carry
over. The five changed-path rows are all from the tree as it stands.)

**‡** `hgetall-500-fields` was the one control that looked like an effect, so it was re-run from
scratch: 45.166 → 45.345 µs (**+0.4 %**), 16,643 → 16,428 ops/s (−1.3 %). The *base* arm alone moved
48.658 → 45.166 µs between the two runs, i.e. this test's within-arm spread is larger than the "effect".

**Hashtable-encoded `HMGET`** (`hmget-5-fields`) is gated out of the single pass by
`hashTypeMultiGetApplies()`, so it is on the untouched per-field path. An earlier revision of this PR
still cost ≈ +5 % there by giving every caller a per-field `GetFieldRes` array plus a pass over it;
`hashMultiGetOut` makes each member optional, so `HMGET` — which only reads — asks for nothing but the
vector of lazily expired fields, and `hmgetCommand`'s stack frame ends up at 616 B, below the base's
648 B. This is a 0.6 – 0.7 µs command whose base arm varies ±3 % run to run, so read its row as "no
change" rather than as a win.

The specification has no `HGETDEL` test case, so that command's improvement is not measured here; it
takes the same code path as `HMGET`.

Separately, a preload defect had to be fixed before any of this could be measured: six hash test cases
preloaded a **10× wider keyspace than they measure**, and because the preload uses
`--command-key-pattern=P` each client fills only the first `-n` keys of its (10× too wide) block, so
~90 % of the measured commands hit keys that were never written and never reached any hash code. Five of
the six are fixed upstream (`redis-benchmarks-specification` [#489](https://github.com/redis/redis-benchmarks-specification/pull/489), which covers `hmget-5-fields`,
`hexists`, `hgetall-50-fields-100B`, `hgetall-50-fields-10B` and `hget-hgetall-hkeys-hvals`); the sixth,
`1Mkeys-hash-hmget-100of100-fields-with-32B-values-pipeline-1`, is still pending as a follow-up to [#489](https://github.com/redis/redis-benchmarks-specification/pull/489).
All runs above use the corrected `--key-maximum 1000000` for it. On that spec the defect inflated
throughput 3.4× (78,890 → 23,099 ops/s) and understated `HMGET` cost 8.0× (4.33 → 34.49 µs/call), and it
hid in plain sight because `dbsize` is 1,000,000 either way — the preload writes the same number of keys,
they just land outside the measured range — so the suite's `keyspacelen` check passes regardless.

## Tests

`tests/unit/type/hash.tcl` (+189) and `tests/unit/type/hash-field-expire.tcl` (+232), all under both
`listpack` and `hashtable` encodings via the existing `hash-max-listpack-entries` toggles:

* duplicate field names in `HMGET`/`HGETDEL`/`HGETEX`, pinning the interleaved fallback;
* integer-encoded field names — `HMGET key 1 42 0 -1 2` resolves, while `01`, `+1`, `" 1"`, `1.`,
  `0042` and `-0` must all miss; repeated above 8 fields so the same names go through the hashed index,
  including the `int64` extremes;
* an empty field name, the one input where the `memcmp` guard is trivially satisfied;
* mixed present / absent / expired fields in one command, including a 200-field request that exceeds the
  64-field stack budget, and the case where the last live field lazily expires and the hash is deleted;
* `HGETEX PERSIST` on fields without a TTL — no dirty bump, unchanged replication stream;
* the replication ordering described above, via `assert_replication_stream` per encoding;
* two fuzz tests cross-checking `HMGET`/`HGETEX`/`HGETDEL` against a Tcl model, with request widths of
  `randomRange 1 71` so the linear (< 8), stack-indexed (≤ 64) and heap-indexed (> 64) paths are all
  covered, and — in the HFE one — a per-field random mix of TTL-free / live / far-future / already
  logically expired fields under `debug set-active-expire 0`, which exercises the `skip = 2` walk
  together with the mid-reply fallback.

Existing suites pass: `unit/type/hash`, `unit/type/hash-field-expire`, `unit/type/hash-templates`,
`unit/pubsub`, `unit/other`, `unit/keyspace`, `unit/info-keysizes` — the same set under `--force-resp3`,
and a `SANITIZER=address` build with zero sanitizer reports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core hash read/mutation paths for widely used commands with subtle edge cases (duplicates, lazy expiry, replication ordering); behavior is heavily tested but mistakes could affect correctness or replica state.
> 
> **Overview**
> **Listpack-encoded hashes** now resolve multiple requested fields in **one listpack walk** instead of one `lpFind()` per field, cutting **HMGET**, **HGETEX**, and **HGETDEL** lookup cost from O(fields × entries) toward O(entries + fields) on `OBJ_ENCODING_LISTPACK` / `LISTPACK_EX`.
> 
> The implementation adds `hashTypeGetMultiFromListpack()` with stack/heap scratch, linear compare for ≤8 fields, and an open-addressing index for larger batches; duplicate field names or lazy-expiration work still use the old per-field interleaved path so semantics stay correct. **HGETEX**/**HGETDEL** reply in a read phase then mutate; **HGETEX PERSIST** skips `hashTypeSetEx()` when the read pass shows no TTL. Lazy-expire checks are centralized in `hashTypeFieldNeedsLazyExpire()`.
> 
> Tests cover duplicates, integer field names, empty names, mixed absent/expired fields, replication ordering for lazy vs past-TTL deletes, and fuzz cross-checks against single-field **HGET**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b831002e469bd6afff6660bf417a4874d983ec73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->