### PR TITLE
redis-cli: derive TLS SNI from target hostname when --sni is not given

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -32,6 +32,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <hiredis_ssl.h>
+#include <arpa/inet.h>
 #endif
 #include <sdscompat.h> /* Use hiredis' sds compat header that maps sds calls to their hi_ variants */
 #include <sds.h> /* use sds.h from hiredis, so that only one set of sds functions will be present in the binary */
@@ -1706,6 +1707,24 @@ static int cliSetName(void) {
     return result;
 }
 
+/* Returns a copy of the TLS configuration where the SNI host, if not
+ * explicitly provided via --sni, is derived from the target hostname. This
+ * matches the behavior of TLS client libraries. Literal IP addresses are
+ * skipped because they are not valid SNI values (RFC 6066), mirroring what
+ * the server does for its outbound TLS connections. */
+static cliSSLconfig cliSslConfigWithDerivedSni(void) {
+    cliSSLconfig sslconfig = config.sslconfig;
+#ifdef USE_OPENSSL
+    unsigned char addr_buf[sizeof(struct in6_addr)];
+    if (!sslconfig.sni &&
+        inet_pton(AF_INET, config.conn_info.hostip, addr_buf) != 1 &&
+        inet_pton(AF_INET6, config.conn_info.hostip, addr_buf) != 1) {
+        sslconfig.sni = config.conn_info.hostip;
+    }
+#endif
+    return sslconfig;
+}
+
 /* Connect to the server. It is possible to pass certain flags to the function:
  *      CC_FORCE: The connection is performed even if there is already
  *                a connected socket.
@@ -1731,7 +1750,8 @@ static int cliConnect(int flags) {
 
         if (!context->err && config.tls) {
             const char *err = NULL;
-            if (cliSecureConnection(context, config.sslconfig, &err) == REDIS_ERR && err) {
+            cliSSLconfig sslconfig = cliSslConfigWithDerivedSni();
+            if (cliSecureConnection(context, sslconfig, &err) == REDIS_ERR && err) {
                 fprintf(stderr, "Could not negotiate a TLS connection: %s\n", err);
                 redisFree(context);
                 context = NULL;
@@ -2675,7 +2695,8 @@ static redisReply *reconnectingRedisCommand(redisContext *c, const char *fmt, ..
                                     config.connect_timeout);
             if (!c->err && config.tls) {
                 const char *err = NULL;
-                if (cliSecureConnection(c, config.sslconfig, &err) == REDIS_ERR && err) {
+                cliSSLconfig sslconfig = cliSslConfigWithDerivedSni();
+                if (cliSecureConnection(c, sslconfig, &err) == REDIS_ERR && err) {
                     fprintf(stderr, "TLS Error: %s\n", err);
                     exit(1);
                 }
@@ -3181,6 +3202,8 @@ static void usage(int err) {
 #ifdef USE_OPENSSL
 "  --tls              Establish a secure TLS connection.\n"
 "  --sni <host>       Server name indication for TLS.\n"
+"                     Defaults to the target hostname when it is not a literal\n"
+"                     IP address.\n"
 "  --cacert <file>    CA Certificate file to verify with.\n"
 "  --cacertdir <dir>  Directory where trusted CA certificates are stored.\n"
 "                     If neither cacert nor cacertdir are specified, the default\n"


### PR DESCRIPTION
### Description

Fixes #15602.

`redis-cli` sends a TLS SNI extension only when `--sni` is passed explicitly,
while TLS client libraries derive the server name from the host being
connected to (redis-py passes the host as `server_hostname`; go-redis leaves
it unset so Go's TLS stack fills it in from the dial address). An endpoint
distinguished by its server name — a common arrangement behind a proxy or load
balancer — can therefore be reached by an application but not by `redis-cli`.

### Changes

When TLS is enabled and `--sni` is not given, the SNI host is now derived
from the target hostname (`config.conn_info.hostip`) on both TLS connect
paths in `redis-cli.c`:

- `cliConnect()` (interactive, one-shot command, pipe, latency, etc.)
- `reconnectingRedisCommand()` (reconnects in `--rdb`/replica-like flows)

Literal IPv4/IPv6 addresses are skipped because they are not valid SNI values
(RFC 6066). This mirrors what the server already does for its outbound TLS
connections in `connTLSConnect()` (`src/tls.c`):

```c
/* Check whether addr is an IP address, if not, use the value for Server Name Indication */
if (inet_pton(AF_INET, addr, addr_buf) != 1 && inet_pton(AF_INET6, addr, addr_buf) != 1) {
    SSL_set_tlsext_host_name(conn->ssl, addr);
}
```

Behavior notes:

- An explicit `--sni` still takes precedence.
- In cluster mode, a MOVED/ASK redirect updates `config.conn_info.hostip`, so
  re-issued commands derive the SNI from the redirect target.
- Cluster-manager connections to individual nodes (`clusterManagerNodeConnect`)
  keep the previous behavior; deriving a single global SNI there would be
  wrong for per-node connections.
- The default host (`127.0.0.1`) is an IP literal, so nothing changes for the
  default connection.
- `redis-benchmark` and other `cli_common` users are not affected.

### Verification

Verified against a local TLS endpoint that logs the SNI extension received
from the client:

| Command | SNI received |
|---|---|
| `redis-cli --tls -h localhost ping` | `localhost` (was: none) |
| `redis-cli --tls -h 127.0.0.1 ping` | none (IP skipped) |
| `redis-cli --tls -h localhost --sni custom.example.com ping` | `custom.example.com` |
| `redis-cli --tls -u rediss://localhost:6379 ping` | `localhost` (was: none) |

- Built with `make BUILD_TLS=yes` and without TLS; both clean.
- `./runtest --single integration/redis-cli` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped TLS handshake behavior in redis-cli only; explicit --sni and IP literal hosts are unchanged, with no auth or data-path changes.
> 
> **Overview**
> **`redis-cli` now sends a TLS SNI hostname by default** when `--tls` is used without `--sni`, using the connection target (`config.conn_info.hostip`) so behavior aligns with typical TLS clients and name-based endpoints behind proxies.
> 
> A new **`cliSslConfigWithDerivedSni()`** copies the CLI SSL config and sets `sni` from the target host only when it is **not** a literal IPv4/IPv6 address (RFC 6066), matching the server’s outbound TLS logic in `tls.c`. **Explicit `--sni` is unchanged.** Both TLS upgrade paths in `redis-cli.c`—**`cliConnect()`** and **`reconnectingRedisCommand()`**—use this derived config instead of `config.sslconfig` directly. Help text for `--sni` documents the default.
> 
> **`redis-benchmark`** and other `cli_common` callers are **not** modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ca0406e91f418db404d052923486c075b7b53ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->