### PR TITLE
reuse computed key hash

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -276,9 +276,22 @@ void dbgRunAssertions(redisDb *db) {
  * Even if the key expiry is master-driven, we can correctly report a key is
  * expired on replicas even if the master is lagging expiring our key via DELs
  * in the replication link. */
+static kvobj *dbFindByLinkWithHash(redisDb *db, sds key, uint64_t hash, dictEntryLink *plink);
+
 kvobj *lookupKey(redisDb *db, robj *key, int flags, dictEntryLink *link) {
 
-    kvobj *val = dbFindByLink(db, key->ptr, link);
+    /* Fast path (AMD): if the cross-command prefetch batch already computed the
+     * SipHash of this exact key object, reuse it and skip re-hashing. The
+     * pointer match against key_hash_obj guarantees the cached hash belongs to
+     * the same live key bytes; the flag is cleared on every pendingCommand
+     * (re)acquire so it can never refer to a stale key. */
+    client *cc = server.current_client;
+    pendingCommand *pc = cc ? cc->current_pending_cmd : NULL;
+    kvobj *val;
+    if (pc && (pc->flags & PENDING_CMD_KEY_HASH_VALID) && pc->key_hash_obj == key)
+        val = dbFindByLinkWithHash(db, key->ptr, pc->key_hash, link);
+    else
+        val = dbFindByLink(db, key->ptr, link);
 
     if (val) {
         /* Forcing deletion of expired keys on a replica makes the replica
@@ -3125,6 +3138,23 @@ kvobj *dbFindByLink(redisDb *db, sds key, dictEntryLink *plink) {
     dictEntryLink link, bucket;
 
     link = kvstoreDictFindLink(db->keys, slot, key, &bucket);
+    if (link == NULL) {
+        if (plink) *plink = bucket;
+        return NULL;
+    } else {
+        if (plink) *plink = link;
+        return dictGetKV(*link);
+    }
+}
+
+/* Like dbFindByLink(), but reuses a precomputed key hash (see
+ * dictFindLinkWithHash()). Used by lookupKey() when the command-batch
+ * prefetcher already hashed this key (AMD). */
+static kvobj *dbFindByLinkWithHash(redisDb *db, sds key, uint64_t hash, dictEntryLink *plink) {
+    int slot = getKeySlot(key);
+    dictEntryLink link, bucket;
+
+    link = kvstoreDictFindLinkWithHash(db->keys, slot, key, hash, &bucket);
     if (link == NULL) {
         if (plink) *plink = bucket;
         return NULL;

--- a/src/db.c
+++ b/src/db.c
@@ -276,22 +276,9 @@ void dbgRunAssertions(redisDb *db) {
  * Even if the key expiry is master-driven, we can correctly report a key is
  * expired on replicas even if the master is lagging expiring our key via DELs
  * in the replication link. */
-static kvobj *dbFindByLinkWithHash(redisDb *db, sds key, uint64_t hash, dictEntryLink *plink);
-
 kvobj *lookupKey(redisDb *db, robj *key, int flags, dictEntryLink *link) {
 
-    /* Fast path (AMD): if the cross-command prefetch batch already computed the
-     * SipHash of this exact key object, reuse it and skip re-hashing. The
-     * pointer match against key_hash_obj guarantees the cached hash belongs to
-     * the same live key bytes; the flag is cleared on every pendingCommand
-     * (re)acquire so it can never refer to a stale key. */
-    client *cc = server.current_client;
-    pendingCommand *pc = cc ? cc->current_pending_cmd : NULL;
-    kvobj *val;
-    if (pc && (pc->flags & PENDING_CMD_KEY_HASH_VALID) && pc->key_hash_obj == key)
-        val = dbFindByLinkWithHash(db, key->ptr, pc->key_hash, link);
-    else
-        val = dbFindByLink(db, key->ptr, link);
+    kvobj *val = dbFindByLink(db, key->ptr, link);
 
     if (val) {
         /* Forcing deletion of expired keys on a replica makes the replica
@@ -3137,24 +3124,18 @@ kvobj *dbFindByLink(redisDb *db, sds key, dictEntryLink *plink) {
     int slot = getKeySlot(key);
     dictEntryLink link, bucket;
 
-    link = kvstoreDictFindLink(db->keys, slot, key, &bucket);
-    if (link == NULL) {
-        if (plink) *plink = bucket;
-        return NULL;
-    } else {
-        if (plink) *plink = link;
-        return dictGetKV(*link);
-    }
-}
+    /* If the cross-command prefetch batch already computed the SipHash of this
+     * exact key, reuse it and skip re-hashing. The pointer match against
+     * key_hash_obj guarantees the cached hash belongs to the same live key
+     * bytes; the flag is cleared on every pendingCommand (re)acquire so it can
+     * never refer to a stale key. */
+    client *cc = server.current_client;
+    pendingCommand *pc = cc ? cc->current_pending_cmd : NULL;
+    if (pc && (pc->flags & PENDING_CMD_KEY_HASH_VALID) && pc->key_hash_obj == key)
+        link = kvstoreDictFindLinkWithHash(db->keys, slot, key, pc->key_hash, &bucket);
+    else
+        link = kvstoreDictFindLink(db->keys, slot, key, &bucket);
 
-/* Like dbFindByLink(), but reuses a precomputed key hash (see
- * dictFindLinkWithHash()). Used by lookupKey() when the command-batch
- * prefetcher already hashed this key (AMD). */
-static kvobj *dbFindByLinkWithHash(redisDb *db, sds key, uint64_t hash, dictEntryLink *plink) {
-    int slot = getKeySlot(key);
-    dictEntryLink link, bucket;
-
-    link = kvstoreDictFindLinkWithHash(db->keys, slot, key, hash, &bucket);
     if (link == NULL) {
         if (plink) *plink = bucket;
         return NULL;

--- a/src/dict.c
+++ b/src/dict.c
@@ -875,7 +875,7 @@ dictEntryLink dictFindLink(dict *d, const void *key, dictEntryLink *bucket) {
  * calling the dict's hash function. The caller MUST guarantee that 'hash' was
  * produced by this dict's hash function for exactly the same key bytes as
  * 'key'; otherwise the lookup result is undefined. Used by the command-batch
- * prefetcher to avoid hashing the same key twice (AMD). */
+ * prefetcher to avoid hashing the same key twice. */
 dictEntryLink dictFindLinkWithHash(dict *d, const void *key, uint64_t hash, dictEntryLink *bucket) {
     if (bucket) *bucket = NULL;
     if (unlikely(dictSize(d) == 0))

--- a/src/dict.c
+++ b/src/dict.c
@@ -763,7 +763,7 @@ void dictRelease(dict *d)
  * 
  * bucket - return pointer to bucket that the key was mapped. unless dict is empty.
  */
-static dictEntryLink dictFindLinkInternal(dict *d, const void *key, dictEntryLink *bucket) {
+static dictEntryLink dictFindLinkInternalHashed(dict *d, const void *key, dictEntryLink *bucket, const uint64_t hash) {
     dictCmpCache cmpCache = {0};
     dictEntryLink link;
     uint64_t idx;
@@ -776,7 +776,6 @@ static dictEntryLink dictFindLinkInternal(dict *d, const void *key, dictEntryLin
         if (dictSize(d) == 0) return NULL; 
     }
 
-    const uint64_t hash = dictGetHash(d, key);
     idx = hash & DICTHT_SIZE_MASK(d->ht_size_exp[0]);
     keyCmpFunc cmpFunc = dictGetCmpFunc(d);
 
@@ -800,6 +799,10 @@ static dictEntryLink dictFindLinkInternal(dict *d, const void *key, dictEntryLin
         }
     }
     return NULL;
+}
+
+static dictEntryLink dictFindLinkInternal(dict *d, const void *key, dictEntryLink *bucket) {
+    return dictFindLinkInternalHashed(d, key, bucket, dictGetHash(d, key));
 }
 
 dictEntry *dictFind(dict *d, const void *key)
@@ -866,6 +869,19 @@ dictEntryLink dictFindLink(dict *d, const void *key, dictEntryLink *bucket) {
         return NULL;
     
     return dictFindLinkInternal(d, key, bucket);
+}
+
+/* Like dictFindLink(), but uses a caller-supplied precomputed hash instead of
+ * calling the dict's hash function. The caller MUST guarantee that 'hash' was
+ * produced by this dict's hash function for exactly the same key bytes as
+ * 'key'; otherwise the lookup result is undefined. Used by the command-batch
+ * prefetcher to avoid hashing the same key twice (AMD). */
+dictEntryLink dictFindLinkWithHash(dict *d, const void *key, uint64_t hash, dictEntryLink *bucket) {
+    if (bucket) *bucket = NULL;
+    if (unlikely(dictSize(d) == 0))
+        return NULL;
+
+    return dictFindLinkInternalHashed(d, key, bucket, hash);
 }
 
 /* Set the key with link 

--- a/src/dict.h
+++ b/src/dict.h
@@ -304,6 +304,7 @@ void dictCombineStats(dictStats *from, dictStats *into);
 void dictFreeStats(dictStats *stats);
 
 dictEntryLink dictFindLink(dict *d, const void *key, dictEntryLink *bucket);
+dictEntryLink dictFindLinkWithHash(dict *d, const void *key, uint64_t hash, dictEntryLink *bucket);
 void dictSetKeyAtLink(dict *d, void *key __stored_key, dictEntryLink *link, int newItem);
 
 /* API relevant only when dict is used as a hash-map (no_value=0) */ 

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -865,7 +865,7 @@ dictEntryLink kvstoreDictFindLink(kvstore *kvs, int didx, void *key, dictEntryLi
 
 /* Like kvstoreDictFindLink(), but reuses a caller-supplied precomputed hash
  * (see dictFindLinkWithHash()). Used by the command-batch prefetch hash-reuse
- * path (AMD). */
+ * path. */
 dictEntryLink kvstoreDictFindLinkWithHash(kvstore *kvs, int didx, void *key, uint64_t hash, dictEntryLink *bucket) {
     if (bucket) *bucket = NULL;
     dict *d = kvstoreGetDict(kvs, didx);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -863,6 +863,16 @@ dictEntryLink kvstoreDictFindLink(kvstore *kvs, int didx, void *key, dictEntryLi
     return dictFindLink(d, key, bucket);
 }
 
+/* Like kvstoreDictFindLink(), but reuses a caller-supplied precomputed hash
+ * (see dictFindLinkWithHash()). Used by the command-batch prefetch hash-reuse
+ * path (AMD). */
+dictEntryLink kvstoreDictFindLinkWithHash(kvstore *kvs, int didx, void *key, uint64_t hash, dictEntryLink *bucket) {
+    if (bucket) *bucket = NULL;
+    dict *d = kvstoreGetDict(kvs, didx);
+    if (!d) return NULL;
+    return dictFindLinkWithHash(d, key, hash, bucket);
+}
+
 /* Set a key (or key-value) in the specified kvstore. 
  *
  * This function inserts a new key or updates an existing one, depending on 

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -146,6 +146,7 @@ void *kvstoreGetDictMeta(kvstore *kvs, int didx, int createIfNeeded);
 void *kvstoreGetMetadata(kvstore *kvs);
 
 dictEntryLink kvstoreDictFindLink(kvstore *kvs, int didx, void *key, dictEntryLink *bucket);
+dictEntryLink kvstoreDictFindLinkWithHash(kvstore *kvs, int didx, void *key, uint64_t hash, dictEntryLink *bucket);
 void kvstoreDictSetAtLink(kvstore *kvs, int didx, void *kv, dictEntryLink *link, int newItem);
 
 /* dict with distinct key & value (no_value=1) currently is used only by pubsub. */

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -332,6 +332,7 @@ typedef struct PrefetchCommandsBatch {
     client **clients;               /* Array of clients in the current batch */
     pendingCommand **pending_cmds;  /* Array of pending commands in the current batch */
     dict **keys_dicts;              /* Main dict for each key */
+    pendingCommand **key_src;       /* Owning pending command for each key (hash reuse, AMD) */
     dictPrefetcher prefetcher;      /* Initialized once; reset and reused per batch. */
 } PrefetchCommandsBatch;
 
@@ -346,6 +347,7 @@ void freePrefetchCommandsBatch(void) {
     zfree(batch->pending_cmds);
     zfree(batch->keys);
     zfree(batch->keys_dicts);
+    zfree(batch->key_src);
     dictPrefetcherFree(&batch->prefetcher);
     zfree(batch);
     batch = NULL;
@@ -369,6 +371,7 @@ void prefetchCommandsBatchInit(void) {
     batch->pending_cmds = zcalloc(max_prefetch_size * sizeof(pendingCommand *));
     batch->keys = zcalloc(max_prefetch_size * sizeof(void *));
     batch->keys_dicts = zcalloc(max_prefetch_size * sizeof(dict *));
+    batch->key_src = zcalloc(max_prefetch_size * sizeof(pendingCommand *));
     dictPrefetcherInit(&batch->prefetcher, max_prefetch_size);
 }
 
@@ -466,6 +469,23 @@ void prefetchCommands(void) {
          * is driven by dbDictType->prefetchEntryValue. */
         dictPrefetcherReset(&batch->prefetcher, batch->keys_dicts, batch->keys, batch->key_count);
         dictPrefetcherRun(&batch->prefetcher);
+
+        /* Hash reuse (AMD): the prefetcher already computed SipHash for every
+         * key. Hand the hash to the owning command for single-key commands so
+         * the execution-time dict lookup can skip re-hashing. We only do this
+         * for single-key commands (numkeys == 1) so the pointer match in
+         * lookupKey() is unambiguous, and only when the key's dict was non-empty
+         * (otherwise the prefetcher left key_hash uninitialized). */
+        for (size_t i = 0; i < batch->key_count; i++) {
+            pendingCommand *pcmd = batch->key_src[i];
+            if (pcmd && pcmd->keys_result.numkeys == 1 &&
+                batch->keys_dicts[i] && dictSize(batch->keys_dicts[i]) > 0)
+            {
+                pcmd->key_hash = batch->prefetcher.lookups[i].key_hash;
+                pcmd->key_hash_obj = pcmd->argv[pcmd->keys_result.keys[0].pos];
+                pcmd->flags |= PENDING_CMD_KEY_HASH_VALID;
+            }
+        }
     }
 }
 
@@ -513,6 +533,7 @@ int addCommandToBatch(client *c) {
         for (int i = 0; i < pcmd->keys_result.numkeys && batch->key_count < batch->max_prefetch_size; i++) {
             batch->keys[batch->key_count] = pcmd->argv[pcmd->keys_result.keys[i].pos];
             batch->keys_dicts[batch->key_count] = cmd_dict;
+            batch->key_src[batch->key_count] = pcmd;
             batch->key_count++;
             /* Mark the command as prefetched so the intra-command prefetch
              * path skips it. Even on a partial batch, running both paths

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -332,7 +332,7 @@ typedef struct PrefetchCommandsBatch {
     client **clients;               /* Array of clients in the current batch */
     pendingCommand **pending_cmds;  /* Array of pending commands in the current batch */
     dict **keys_dicts;              /* Main dict for each key */
-    pendingCommand **key_src;       /* Owning pending command for each key (hash reuse, AMD) */
+    pendingCommand **key_src;       /* Owning pending command for each key (hash reuse) */
     dictPrefetcher prefetcher;      /* Initialized once; reset and reused per batch. */
 } PrefetchCommandsBatch;
 
@@ -470,19 +470,19 @@ void prefetchCommands(void) {
         dictPrefetcherReset(&batch->prefetcher, batch->keys_dicts, batch->keys, batch->key_count);
         dictPrefetcherRun(&batch->prefetcher);
 
-        /* Hash reuse (AMD): the prefetcher already computed SipHash for every
-         * key. Hand the hash to the owning command for single-key commands so
-         * the execution-time dict lookup can skip re-hashing. We only do this
-         * for single-key commands (numkeys == 1) so the pointer match in
-         * lookupKey() is unambiguous, and only when the key's dict was non-empty
-         * (otherwise the prefetcher left key_hash uninitialized). */
+        /* Hash reuse: the prefetcher already computed SipHash for every key.
+         * Hand the hash to the owning command for single-key commands so the
+         * execution-time dict lookup can skip re-hashing. We only do this for
+         * single-key commands (numkeys == 1) so the pointer match in
+         * dbFindByLink() is unambiguous, and only when the key's dict was
+         * non-empty (otherwise the prefetcher left key_hash uninitialized). */
         for (size_t i = 0; i < batch->key_count; i++) {
             pendingCommand *pcmd = batch->key_src[i];
             if (pcmd && pcmd->keys_result.numkeys == 1 &&
                 batch->keys_dicts[i] && dictSize(batch->keys_dicts[i]) > 0)
             {
                 pcmd->key_hash = batch->prefetcher.lookups[i].key_hash;
-                pcmd->key_hash_obj = pcmd->argv[pcmd->keys_result.keys[0].pos];
+                pcmd->key_hash_obj = pcmd->argv[pcmd->keys_result.keys[0].pos]->ptr;
                 pcmd->flags |= PENDING_CMD_KEY_HASH_VALID;
             }
         }

--- a/src/networking.c
+++ b/src/networking.c
@@ -5807,7 +5807,7 @@ static pendingCommand *acquirePendingCommand(void) {
         initPendingCommand(pcmd);
     }
     /* Clear the batch prefetch hash-reuse hint so a command reused from the
-     * pool can never carry a stale hash from a previous key (AMD). */
+     * pool can never carry a stale hash from a previous key. */
     pcmd->flags &= ~PENDING_CMD_KEY_HASH_VALID;
     pcmd->key_hash_obj = NULL;
     return pcmd;

--- a/src/networking.c
+++ b/src/networking.c
@@ -5806,6 +5806,10 @@ static pendingCommand *acquirePendingCommand(void) {
         pcmd = zmalloc(sizeof(pendingCommand));
         initPendingCommand(pcmd);
     }
+    /* Clear the batch prefetch hash-reuse hint so a command reused from the
+     * pool can never carry a stale hash from a previous key (AMD). */
+    pcmd->flags &= ~PENDING_CMD_KEY_HASH_VALID;
+    pcmd->key_hash_obj = NULL;
     return pcmd;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -2782,6 +2782,7 @@ enum {
     PENDING_CMD_FLAG_PREPROCESSED = 1 << 1,   /* This command has passed pre-processing */
     PENDING_CMD_KEYS_RESULT_VALID = 1 << 2,   /* Command's keys_result is valid and cached */
     PENDING_CMD_KEYS_PREFETCHED = 1 << 3,     /* Command's keys were prefetched by the cross-command batch */
+    PENDING_CMD_KEY_HASH_VALID = 1 << 4,      /* key_hash holds the precomputed hash of key_hash_obj (single-key cmd) */
 };
 
 /* Parser state and parse result of a command from a client's input buffer. */
@@ -2798,6 +2799,14 @@ struct pendingCommand {
     int slot;         /* The slot the command is executing against. Set to INVALID_CLUSTER_SLOT
                        * if no slot is being used or if the command has a cross slot error */
     uint8_t read_error;
+
+    /* Batch prefetch hash reuse (AMD): when the cross-command prefetch batch
+     * computes the key hash for a single-key command, it is cached here so the
+     * execution-time dict lookup can skip recomputing SipHash. Reused only when
+     * key_hash_obj matches the exact key object being looked up. Cleared on
+     * every pendingCommand (re)acquire, so it can never refer to a stale key. */
+    uint64_t key_hash;        /* Precomputed hash of key_hash_obj->ptr. */
+    robj *key_hash_obj;       /* Key object the hash was computed for. */
 
     struct pendingCommand *next;
     struct pendingCommand *prev;

--- a/src/server.h
+++ b/src/server.h
@@ -2800,13 +2800,13 @@ struct pendingCommand {
                        * if no slot is being used or if the command has a cross slot error */
     uint8_t read_error;
 
-    /* Batch prefetch hash reuse (AMD): when the cross-command prefetch batch
-     * computes the key hash for a single-key command, it is cached here so the
+    /* Batch prefetch hash reuse: when the cross-command prefetch batch computes
+     * the key hash for a single-key command, it is cached here so the
      * execution-time dict lookup can skip recomputing SipHash. Reused only when
-     * key_hash_obj matches the exact key object being looked up. Cleared on
-     * every pendingCommand (re)acquire, so it can never refer to a stale key. */
-    uint64_t key_hash;        /* Precomputed hash of key_hash_obj->ptr. */
-    robj *key_hash_obj;       /* Key object the hash was computed for. */
+     * key_hash_obj matches the exact key being looked up. Cleared on every
+     * pendingCommand (re)acquire, so it can never refer to a stale key. */
+    uint64_t key_hash;        /* Precomputed hash of the key sds bytes. */
+    sds key_hash_obj;         /* Key sds (argv[..]->ptr) the hash was computed for. */
 
     struct pendingCommand *next;
     struct pendingCommand *prev;


### PR DESCRIPTION
Reusing already-computed key hashes: For pipelined requests, Redis pre-computes a cryptographic hash (SipHash) of each key during a prefetch step, then throws it away and computes the same hash again at lookup time. We threaded the first result through to the lookup time so the redundant hash is skipped.

The command-prefetch batch (memory_prefetch.c) already computes each key's SipHash via dictGetHash() during batch setup, but lookupKey() re-hashes the same key again at execution time. We thread the already-computed hash through (dictFindLinkWithHash / kvstoreDictFindLinkWithHash) so the second SipHash is skipped. Pure C, no ISA dependency, behavior-identical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot-path key lookup and depends on correct hash/key pairing; mitigations (pointer match, single-key only, pool reset) reduce but do not eliminate risk if those assumptions break.
> 
> **Overview**
> **Avoids a second SipHash on pipelined single-key commands** when the cross-command prefetch batch already hashed the key. After batch prefetch runs, each **single-key** pending command with a non-empty slot dict stores the prefetcher’s `key_hash` and matching `key_hash_obj` (`argv` key `sds` pointer).
> 
> At execution, **`dbFindByLink`** checks the current client’s `pendingCommand` for `PENDING_CMD_KEY_HASH_VALID` and pointer equality on `key_hash_obj`, then calls **`kvstoreDictFindLinkWithHash`** / **`dictFindLinkWithHash`** instead of hashing again. Dict lookup internals are split so **`dictFindLinkInternalHashed`** accepts a caller-supplied hash.
> 
> **Safety:** hash reuse is limited to one key per command, skipped when the dict was empty during prefetch, and the flag/`key_hash_obj` are cleared whenever a `pendingCommand` is taken from the pool so pooled commands cannot carry a stale hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9197e42393df89c86295f9d11eb3ca999966245c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->