### PR TITLE
siphash avx512 implementation

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -112,9 +112,38 @@ void dictSetHashFunctionSeed(uint8_t *seed) {
 
 uint64_t siphash(const uint8_t *in, const size_t inlen, const uint8_t *k);
 uint64_t siphash_nocase(const uint8_t *in, const size_t inlen, const uint8_t *k);
+#if defined(__x86_64__) || defined(__i386__)
+void siphash_x8(const uint8_t *const in[8], const size_t inlen[8],
+                const uint8_t *k, uint64_t out[8]);
+#endif
 
 uint64_t dictGenHashFunction(const void *key, size_t len) {
     return siphash(key, len, dict_hash_function_seed);
+}
+
+/* Batch variant of dictGenHashFunction(): fills out[i] with the hash of the
+ * key at keys[i] of length lens[i]. On AMD Zen 5 / any AVX-512F CPU this uses
+ * the 8-wide lane-parallel SipHash (siphash_x8), processing the batch in groups
+ * of eight and the remainder scalar; otherwise it falls back to the scalar
+ * path. Results are identical to calling dictGenHashFunction() per key. */
+void dictGenHashFunctionBatch(const void **keys, const size_t *lens,
+                              uint64_t *out, unsigned int n) {
+#if defined(__x86_64__) || defined(__i386__)
+    static int have_avx512 = -1;
+    if (have_avx512 < 0)
+        have_avx512 = __builtin_cpu_supports("avx512f") ? 1 : 0;
+    if (have_avx512) {
+        unsigned int i = 0;
+        for (; i + 8 <= n; i += 8)
+            siphash_x8((const uint8_t *const *)&keys[i], &lens[i],
+                       dict_hash_function_seed, &out[i]);
+        for (; i < n; i++)
+            out[i] = siphash(keys[i], lens[i], dict_hash_function_seed);
+        return;
+    }
+#endif
+    for (unsigned int i = 0; i < n; i++)
+        out[i] = siphash(keys[i], lens[i], dict_hash_function_seed);
 }
 
 uint64_t dictGenCaseHashFunction(const unsigned char *buf, size_t len) {

--- a/src/dict.h
+++ b/src/dict.h
@@ -287,6 +287,7 @@ dictEntry *dictGetFairRandomKey(dict *d);
 unsigned int dictGetSomeKeys(dict *d, dictEntry **des, unsigned int count);
 void dictGetStats(char *buf, size_t bufsize, dict *d, int full);
 uint64_t dictGenHashFunction(const void *key, size_t len);
+void dictGenHashFunctionBatch(const void **keys, const size_t *lens, uint64_t *out, unsigned int n);
 uint64_t dictGenCaseHashFunction(const unsigned char *buf, size_t len);
 void dictEmpty(dict *d, void(callback)(dict*));
 void dictSetResizeEnabled(dictResizeEnable enable);

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -226,15 +226,20 @@ static void dictPrefetcherReset(dictPrefetcher *p, dict **dicts, void **keys, si
     p->nkeys = nkeys;
     p->cur_idx = 0;
 
-    /* Collect the sds-keyed lookups so their SipHash can be computed together
-     * with the AVX-512 8-wide batch hasher (AMD Zen 5). Every dict whose hash
-     * function is dictSdsHash hashes an sds key via siphash(key, sdslen, seed),
-     * so they can all share one batched call. Other dict types (or non-sds
-     * keys) fall back to the per-key scalar hash below. */
+    /* On x86 we collect the sds-keyed lookups so their SipHash can be computed
+     * together with the AVX-512 8-wide batch hasher (dictGenHashFunctionBatch),
+     * which itself falls back to scalar when the CPU lacks AVX-512. Every dict
+     * whose hash function is dictSdsHash hashes an sds key via
+     * siphash(key, sdslen, seed), so they can all share one batched call; other
+     * dict types (or non-sds keys) use the per-key scalar hash. On non-x86
+     * platforms there is no batch hasher, so each key is hashed inline and the
+     * batch arrays are never allocated or populated. */
+#if defined(__x86_64__) || defined(__i386__)
     const void *bkeys[PREFETCH_BATCH_MAX_SIZE * 2];
     size_t blens[PREFETCH_BATCH_MAX_SIZE * 2];
     unsigned int bpos[PREFETCH_BATCH_MAX_SIZE * 2];
     unsigned int bn = 0;
+#endif
 
     size_t remaining = 0;
     for (size_t i = 0; i < nkeys; i++) {
@@ -253,6 +258,7 @@ static void dictPrefetcherReset(dictPrefetcher *p, dict **dicts, void **keys, si
         lk->state = PREFETCH_BUCKET;
         remaining++;
 
+#if defined(__x86_64__) || defined(__i386__)
         if (dicts[i]->type->hashFunction == dictSdsHash) {
             bkeys[bn] = keys[i];
             blens[bn] = sdslen((sds)keys[i]);
@@ -261,14 +267,19 @@ static void dictPrefetcherReset(dictPrefetcher *p, dict **dicts, void **keys, si
         } else {
             lk->key_hash = dictGetHash(dicts[i], keys[i]);
         }
+#else
+        lk->key_hash = dictGetHash(dicts[i], keys[i]);
+#endif
     }
 
+#if defined(__x86_64__) || defined(__i386__)
     if (bn) {
         uint64_t bhash[PREFETCH_BATCH_MAX_SIZE * 2];
         dictGenHashFunctionBatch(bkeys, blens, bhash, bn);
         for (unsigned int j = 0; j < bn; j++)
             p->lookups[bpos[j]].key_hash = bhash[j];
     }
+#endif
 
     p->remaining = remaining;
 }

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -226,6 +226,16 @@ static void dictPrefetcherReset(dictPrefetcher *p, dict **dicts, void **keys, si
     p->nkeys = nkeys;
     p->cur_idx = 0;
 
+    /* Collect the sds-keyed lookups so their SipHash can be computed together
+     * with the AVX-512 8-wide batch hasher (AMD Zen 5). Every dict whose hash
+     * function is dictSdsHash hashes an sds key via siphash(key, sdslen, seed),
+     * so they can all share one batched call. Other dict types (or non-sds
+     * keys) fall back to the per-key scalar hash below. */
+    const void *bkeys[PREFETCH_BATCH_MAX_SIZE * 2];
+    size_t blens[PREFETCH_BATCH_MAX_SIZE * 2];
+    unsigned int bpos[PREFETCH_BATCH_MAX_SIZE * 2];
+    unsigned int bn = 0;
+
     size_t remaining = 0;
     for (size_t i = 0; i < nkeys; i++) {
         dictPrefetchLookup *lk = &p->lookups[i];
@@ -241,9 +251,25 @@ static void dictPrefetcherReset(dictPrefetcher *p, dict **dicts, void **keys, si
         lk->ht_idx = HT_IDX_INVALID;
         lk->current_entry = NULL;
         lk->state = PREFETCH_BUCKET;
-        lk->key_hash = dictGetHash(dicts[i], keys[i]);
         remaining++;
+
+        if (dicts[i]->type->hashFunction == dictSdsHash) {
+            bkeys[bn] = keys[i];
+            blens[bn] = sdslen((sds)keys[i]);
+            bpos[bn] = (unsigned int)i;
+            bn++;
+        } else {
+            lk->key_hash = dictGetHash(dicts[i], keys[i]);
+        }
     }
+
+    if (bn) {
+        uint64_t bhash[PREFETCH_BATCH_MAX_SIZE * 2];
+        dictGenHashFunctionBatch(bkeys, blens, bhash, bn);
+        for (unsigned int j = 0; j < bn; j++)
+            p->lookups[bpos[j]].key_hash = bhash[j];
+    }
+
     p->remaining = remaining;
 }
 

--- a/src/siphash.c
+++ b/src/siphash.c
@@ -244,13 +244,13 @@ uint64_t siphash_nocase(const uint8_t *in, const size_t inlen, const uint8_t *k)
 #endif
 }
 
-/* --------- AVX-512 lane-parallel SipHash-1-2 (AMD Zen 5 "Turin") ----------- *
+/* --------- AVX-512 lane-parallel SipHash-1-2 (any CPU with AVX-512 support) ----------- *
  *
  * siphash_x8() computes eight independent SipHash-1-2 digests at once and is
  * bit-exact with the scalar siphash() above. It targets the case where Redis
- * already needs a batch of key hashes together ΓÇö the cross-command prefetcher
+ * already needs a batch of key hashes together -- the cross-command prefetcher
  * (dictPrefetcherReset) hashes every key of a pipelined command batch in a
- * tight scalar loop. On Zen 5 that loop is a natural fit for 512-bit vectors:
+ * tight scalar loop. On any CPU with AVX-512 that loop is a natural fit for 512-bit vectors:
  * SipHash's state is 4x uint64, and AVX-512 gives us native VPROLQ rotates,
  * 8-lane 64-bit masked gathers to fetch each lane's message words from its own
  * key pointer, and mask-blend to "freeze" lanes that have already consumed all

--- a/src/siphash.c
+++ b/src/siphash.c
@@ -244,6 +244,103 @@ uint64_t siphash_nocase(const uint8_t *in, const size_t inlen, const uint8_t *k)
 #endif
 }
 
+/* --------- AVX-512 lane-parallel SipHash-1-2 (AMD Zen 5 "Turin") ----------- *
+ *
+ * siphash_x8() computes eight independent SipHash-1-2 digests at once and is
+ * bit-exact with the scalar siphash() above. It targets the case where Redis
+ * already needs a batch of key hashes together ΓÇö the cross-command prefetcher
+ * (dictPrefetcherReset) hashes every key of a pipelined command batch in a
+ * tight scalar loop. On Zen 5 that loop is a natural fit for 512-bit vectors:
+ * SipHash's state is 4x uint64, and AVX-512 gives us native VPROLQ rotates,
+ * 8-lane 64-bit masked gathers to fetch each lane's message words from its own
+ * key pointer, and mask-blend to "freeze" lanes that have already consumed all
+ * their full 8-byte blocks (keys differ in length).
+ *
+ * Built with a function-level target attribute so the rest of this TU stays
+ * baseline-ISA; callers must gate the call on runtime AVX-512F support (see
+ * dictGenHashFunctionBatch()).
+ *
+ * Note on the message tail: for lanes with a partial trailing block we issue a
+ * full 8-byte gather at offset (len & ~7) and mask to the low (len & 7) bytes.
+ * This can read up to 7 bytes past the key end; for heap-allocated sds keys
+ * (always followed by a NUL terminator and allocator slack) this is safe in
+ * practice. A production-hardened variant would fall back to scalar for keys
+ * whose tail read would cross a page boundary. */
+#if defined(__x86_64__) || defined(__i386__)
+#include <immintrin.h>
+
+#define SIPROUND_X8(v0, v1, v2, v3)                                            \
+    do {                                                                       \
+        v0 = _mm512_add_epi64(v0, v1); v1 = _mm512_rol_epi64(v1, 13);          \
+        v1 = _mm512_xor_si512(v1, v0); v0 = _mm512_rol_epi64(v0, 32);          \
+        v2 = _mm512_add_epi64(v2, v3); v3 = _mm512_rol_epi64(v3, 16);          \
+        v3 = _mm512_xor_si512(v3, v2);                                         \
+        v0 = _mm512_add_epi64(v0, v3); v3 = _mm512_rol_epi64(v3, 21);          \
+        v3 = _mm512_xor_si512(v3, v0);                                         \
+        v2 = _mm512_add_epi64(v2, v1); v1 = _mm512_rol_epi64(v1, 17);          \
+        v1 = _mm512_xor_si512(v1, v2); v2 = _mm512_rol_epi64(v2, 32);          \
+    } while (0)
+
+__attribute__((target("avx512f,avx512dq")))
+void siphash_x8(const uint8_t *const in[8], const size_t inlen[8],
+                const uint8_t *k, uint64_t out[8]) {
+    const __m512i vk0 = _mm512_set1_epi64((long long)U8TO64_LE(k));
+    const __m512i vk1 = _mm512_set1_epi64((long long)U8TO64_LE(k + 8));
+    __m512i v0 = _mm512_xor_si512(_mm512_set1_epi64((long long)0x736f6d6570736575ULL), vk0);
+    __m512i v1 = _mm512_xor_si512(_mm512_set1_epi64((long long)0x646f72616e646f6dULL), vk1);
+    __m512i v2 = _mm512_xor_si512(_mm512_set1_epi64((long long)0x6c7967656e657261ULL), vk0);
+    __m512i v3 = _mm512_xor_si512(_mm512_set1_epi64((long long)0x7465646279746573ULL), vk1);
+
+    /* x86-64: pointers and size_t are 8 bytes, so we can load them straight
+     * into 64-bit lanes. */
+    __m512i vptr = _mm512_loadu_si512((const void *)in);
+    __m512i vlen = _mm512_loadu_si512((const void *)inlen);
+    __m512i vfull = _mm512_srli_epi64(vlen, 3);   /* number of full 8-byte blocks */
+
+    size_t maxfull = 0;
+    for (int i = 0; i < 8; i++) {
+        size_t fb = inlen[i] >> 3;
+        if (fb > maxfull) maxfull = fb;
+    }
+
+    for (size_t j = 0; j < maxfull; j++) {
+        __mmask8 active = _mm512_cmpgt_epi64_mask(vfull, _mm512_set1_epi64((long long)j));
+        __m512i addr = _mm512_add_epi64(vptr, _mm512_set1_epi64((long long)(j * 8)));
+        __m512i m = _mm512_mask_i64gather_epi64(_mm512_setzero_si512(), active, addr, (const void *)0, 1);
+        __m512i s0 = v0, s1 = v1, s2 = v2, s3 = v3;
+        v3 = _mm512_xor_si512(v3, m);
+        SIPROUND_X8(v0, v1, v2, v3);
+        v0 = _mm512_xor_si512(v0, m);
+        /* Lanes with no block at index j must be left untouched (SipHash rounds
+         * are not idempotent): blend back their saved state. */
+        v0 = _mm512_mask_blend_epi64(active, s0, v0);
+        v1 = _mm512_mask_blend_epi64(active, s1, v1);
+        v2 = _mm512_mask_blend_epi64(active, s2, v2);
+        v3 = _mm512_mask_blend_epi64(active, s3, v3);
+    }
+
+    /* Trailing block: b = (len << 56) | last (len & 7) bytes. */
+    __m512i b = _mm512_slli_epi64(vlen, 56);
+    __m512i vleft = _mm512_and_si512(vlen, _mm512_set1_epi64(7));
+    __mmask8 hastail = _mm512_cmpgt_epi64_mask(vleft, _mm512_setzero_si512());
+    __m512i toff = _mm512_and_si512(vlen, _mm512_set1_epi64((long long)~(uint64_t)7));
+    __m512i taddr = _mm512_add_epi64(vptr, toff);
+    __m512i traw = _mm512_mask_i64gather_epi64(_mm512_setzero_si512(), hastail, taddr, (const void *)0, 1);
+    __m512i shift = _mm512_slli_epi64(vleft, 3);  /* keep low 8*left bits */
+    __m512i lomask = _mm512_sub_epi64(_mm512_sllv_epi64(_mm512_set1_epi64(1), shift), _mm512_set1_epi64(1));
+    b = _mm512_or_si512(b, _mm512_and_si512(traw, lomask));
+
+    v3 = _mm512_xor_si512(v3, b);
+    SIPROUND_X8(v0, v1, v2, v3);
+    v0 = _mm512_xor_si512(v0, b);
+    v2 = _mm512_xor_si512(v2, _mm512_set1_epi64((long long)0xff));
+    SIPROUND_X8(v0, v1, v2, v3);
+    SIPROUND_X8(v0, v1, v2, v3);
+    __m512i h = _mm512_xor_si512(_mm512_xor_si512(v0, v1), _mm512_xor_si512(v2, v3));
+    _mm512_storeu_si512((void *)out, h);
+}
+#endif /* x86 */
+
 
 /* --------------------------------- TEST ------------------------------------ */
 
@@ -355,6 +452,33 @@ int siphash_test(void) {
     h1 = siphash((uint8_t*)"HELLO world",11,(uint8_t*)"1234567812345678");
     h2 = siphash_nocase((uint8_t*)"HELLO world",11,(uint8_t*)"1234567812345678");
     if (h1 == h2) fails++;
+
+#if defined(__x86_64__) || defined(__i386__)
+    /* Verify the AVX-512 8-lane variant is bit-exact with scalar siphash()
+     * across a spread of lengths (incl. 0, sub-block, block-aligned, multi-block
+     * with mixed tails). Skipped on CPUs without AVX-512F. */
+    if (__builtin_cpu_supports("avx512f")) {
+        static uint8_t buf[8][80];
+        for (int lane = 0; lane < 8; lane++)
+            for (int j = 0; j < 80; j++)
+                buf[lane][j] = (uint8_t)(lane * 31 + j * 7 + 3);
+        for (int base = 0; base <= 64; base++) {
+            const uint8_t *in8[8];
+            size_t len8[8];
+            uint64_t out8[8];
+            for (int lane = 0; lane < 8; lane++) {
+                in8[lane] = buf[lane];
+                /* mix lengths across lanes so all tail cases occur together */
+                len8[lane] = (size_t)(base + lane) % 73;
+            }
+            siphash_x8(in8, len8, k, out8);
+            for (int lane = 0; lane < 8; lane++) {
+                uint64_t ref = siphash(in8[lane], len8[lane], k);
+                if (ref != out8[lane]) fails++;
+            }
+        }
+    }
+#endif
 
     if (!fails) return 0;
     return 1;


### PR DESCRIPTION
AVX-512 batch SipHash: an 8-wide, lane-parallel SipHash-1-2 (siphash_x8) that hashes eight keys at once when a full prefetch batch is available, with a scalar fallback and a bit-exactness self-test; it is guarded so non-AVX-512 and non-x86 builds are unaffected.

The per-key hashing in the prefetch batch is a scalar loop. We add dictGenHashFunctionBatch(), which on AVX-512 hosts computes 8 SipHash-1-2 digests lane-parallel (siphash_x8), remainder scalar.
It is:
a.	bit-exact with the scalar siphash() (we ship a self-test that asserts this)
b.	behind #if defined(__x86_64__) || defined(__i386__) AND a runtime __builtin_cpu_supports("avx512f") check, with a scalar fallback
c.	completely compiled out on non-x86

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dict bucket indexing inputs for batched prefetch lookups; correctness relies on bit-exact SIMD SipHash and documented tail reads past short keys (safe for SDS but not generalized).
> 
> **Overview**
> Adds **lane-parallel SipHash-1-2** (`siphash_x8`) on x86 when AVX-512F is available, plus **`dictGenHashFunctionBatch`** to hash many keys in groups of eight with a scalar tail and full scalar fallback when the feature is missing or on non-x86.
> 
> The **dict prefetch batch reset** path no longer hashes every SDS key one-by-one: on x86 it gathers lookups that use `dictSdsHash`, runs one batched SipHash pass, and leaves other dict types on the existing per-key hash. Digests stay **bit-exact** with scalar `siphash()` (including a self-test under `SIPHASH_TEST`). The SIMD implementation is isolated with a function target attribute and a runtime CPU check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d658b8fe9bfad78cc13e50b5a09a6283dbf4bcfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->