### PR TITLE
Route monotonic clock fallback diagnostics through serverLog instead of stderr

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -48,7 +48,7 @@ aeEventLoop *aeCreateEventLoop(int setsize) {
     aeEventLoop *eventLoop;
     int i;
 
-    monotonicInit();    /* just in case the calling app didn't initialize */
+    monotonicInit(NULL);    /* just in case the calling app didn't initialize */
 
     if ((eventLoop = zmalloc(sizeof(*eventLoop))) == NULL) goto err;
     eventLoop->nevents = setsize < INITIAL_EVENT ? setsize : INITIAL_EVENT;

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -18,13 +18,9 @@ static char monotonic_info_string[32];
  * paths (e.g. an unconfirmed TSC rate, a missing 'constant_tsc' flag). Not
  * written directly to stderr: this file is linked into every binary
  * (redis-server, redis-cli, redis-check-aof, ...), and some callers treat
- * any child stderr as failure. Unset (NULL) by default; the server registers
- * one via monotonicSetLogger(), same pattern as zmalloc_set_oom_handler(). */
+ * any child stderr as failure. Set via monotonicInit()'s argument; NULL
+ * (the default) discards these notes. */
 static void (*monotonic_logger)(const char *msg) = NULL;
-
-void monotonicSetLogger(void (*logger)(const char *msg)) {
-    monotonic_logger = logger;
-}
 
 static void monotonicLog(const char *fmt, ...) {
     if (!monotonic_logger) return;
@@ -395,7 +391,13 @@ static void monotonicInit_posix(void) {
 
 
 
-const char * monotonicInit(void) {
+const char * monotonicInit(void (*logger)(const char *msg)) {
+    /* Only the first call (the one that actually runs detection) sets the
+     * logger -- matches this function's existing "may be called additional
+     * times without impact" contract, and avoids a later no-op call (e.g.
+     * ae.c's fallback) clobbering the logger a prior caller registered. */
+    if (getMonotonicUs == NULL) monotonic_logger = logger;
+
     #if defined(__x86_64__) && defined(__linux__)
     if (getMonotonicUs == NULL) monotonicInit_x86linux();
     #endif

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -379,7 +379,7 @@ static void monotonicInit_posix(void) {
 
 
 const char * monotonicInit(void (*logger)(const char *fmt, ...)) {
-    monotonic_logger = logger;
+    if (getMonotonicUs == NULL) monotonic_logger = logger;
 
     #if defined(__x86_64__) && defined(__linux__)
     if (getMonotonicUs == NULL) monotonicInit_x86linux();

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -7,18 +7,34 @@
 #include <string.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdarg.h>
 
 /* The function pointer for clock retrieval.  */
 monotime (*getMonotonicUs)(void) = NULL;
 
 static char monotonic_info_string[32];
 
-/* Notes from clock detection/calibration fallback paths (e.g. an unconfirmed
- * TSC rate, a missing 'constant_tsc' flag). Not written directly to stderr:
- * this file is linked into every binary (redis-server, redis-cli,
- * redis-check-aof, ...), and some callers treat any child stderr as failure.
- * The server logs it via monotonicDiagnostics(); other callers may ignore it. */
-static char monotonic_diag_string[160];
+/* Optional callback for notes from clock detection/calibration fallback
+ * paths (e.g. an unconfirmed TSC rate, a missing 'constant_tsc' flag). Not
+ * written directly to stderr: this file is linked into every binary
+ * (redis-server, redis-cli, redis-check-aof, ...), and some callers treat
+ * any child stderr as failure. Unset (NULL) by default; the server registers
+ * one via monotonicSetLogger(), same pattern as zmalloc_set_oom_handler(). */
+static void (*monotonic_logger)(const char *msg) = NULL;
+
+void monotonicSetLogger(void (*logger)(const char *msg)) {
+    monotonic_logger = logger;
+}
+
+static void monotonicLog(const char *fmt, ...) {
+    if (!monotonic_logger) return;
+    char buf[160];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    monotonic_logger(buf);
+}
 
 /* Using the processor clock (aka TSC on x86) can provide improved performance
  * throughout Redis wherever the monotonic clock is used.  The processor clock
@@ -143,8 +159,7 @@ static void monotonicInit_x86linux(void) {
     FILE *cs = fopen("/sys/devices/system/clocksource/clocksource0/current_clocksource", "r");
     if (cs == NULL || fgets(buf, bufflen, cs) == NULL || strncmp(buf, "tsc", 3) != 0) {
         if (cs) fclose(cs);
-        snprintf(monotonic_diag_string, sizeof(monotonic_diag_string),
-                "x86 linux, kernel clocksource is not 'tsc'");
+        monotonicLog("x86 linux, kernel clocksource is not 'tsc'");
         return;
     }
     fclose(cs);
@@ -183,8 +198,7 @@ static void monotonicInit_x86linux(void) {
     regfree(&constTscRegex);
 
     if (!constantTsc) {
-        snprintf(monotonic_diag_string, sizeof(monotonic_diag_string),
-                "x86 linux, 'constant_tsc' flag not present");
+        monotonicLog("x86 linux, 'constant_tsc' flag not present");
         return;
     }
 
@@ -219,8 +233,7 @@ static void monotonicInit_x86linux(void) {
         if (measured > 0 && labs(measured - nominal_model) * 1000 <= nominal_model) { /* within 0.1% */
             mono_ticksPerMicrosecond = nominal_model;
         } else {
-            snprintf(monotonic_diag_string, sizeof(monotonic_diag_string),
-                    "x86 linux, advertised clock rate "
+            monotonicLog("x86 linux, advertised clock rate "
                     "(%ld ticks/us) unconfirmed by the measured rate "
                     "(%ld ticks/us), using calibration",
                     nominal_model, measured);
@@ -252,8 +265,7 @@ static void monotonicInit_x86linux(void) {
     }
 
     if (mono_ticksPerMicrosecond == 0) {
-        snprintf(monotonic_diag_string, sizeof(monotonic_diag_string),
-                "x86 linux, unable to determine clock rate");
+        monotonicLog("x86 linux, unable to determine clock rate");
         return;
     }
 
@@ -292,8 +304,7 @@ static monotime getMonotonicUs_aarch64(void) {
 static void monotonicInit_aarch64(void) {
     mono_ticksPerMicrosecond = (long)cntfrq_hz() / 1000L / 1000L;
     if (mono_ticksPerMicrosecond == 0) {
-        snprintf(monotonic_diag_string, sizeof(monotonic_diag_string),
-                "aarch64, unable to determine clock rate");
+        monotonicLog("aarch64, unable to determine clock rate");
         return;
     }
 
@@ -350,8 +361,7 @@ static monotime getMonotonicUs_riscv(void) {
 static void monotonicInit_riscv(void) {
     mono_ticksPerMicrosecond = (long)get_timebase_frequency() / 1000L / 1000L;
     if (mono_ticksPerMicrosecond == 0) {
-        snprintf(monotonic_diag_string, sizeof(monotonic_diag_string),
-                "riscv, unable to determine clock rate");
+        monotonicLog("riscv, unable to determine clock rate");
         return;
     }
     snprintf(monotonic_info_string, sizeof(monotonic_info_string),
@@ -405,13 +415,6 @@ const char * monotonicInit(void) {
 
 const char *monotonicInfoString(void) {
     return monotonic_info_string;
-}
-
-/* Return a note from the clock detection/calibration fallback paths, or an
- * empty string if none was recorded. Callers with a logger (i.e. the server)
- * should log it; callers without one may ignore it. */
-const char *monotonicDiagnostics(void) {
-    return monotonic_diag_string;
 }
 
 monotonic_clock_type monotonicGetType(void) {

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -14,6 +14,19 @@ monotime (*getMonotonicUs)(void) = NULL;
 
 static char monotonic_info_string[32];
 
+/* Only the hardware-clock paths below ever have a fallback note to log
+ * (the plain POSIX clock has no failure branch), so gate the logger itself
+ * on whichever of them (if any) is being compiled -- same as how each path's
+ * own helpers (e.g. monotonicCalibrateOnce_x86linux) are excluded on
+ * platforms that don't use them. Ungated, a build with none of these arch
+ * blocks compiled in (e.g. 32-bit x86) would leave monotonicLog() with no
+ * caller and fail -Werror=unused-function. */
+#if (defined(__x86_64__) && defined(__linux__)) || defined(__aarch64__) || \
+    (defined(USE_PROCESSOR_CLOCK) && defined(__riscv) && defined(__linux__))
+#define MONOTONIC_HAS_LOG_FALLBACK 1
+#endif
+
+#ifdef MONOTONIC_HAS_LOG_FALLBACK
 /* Optional callback for notes from clock detection/calibration fallback
  * paths (e.g. an unconfirmed TSC rate, a missing 'constant_tsc' flag). Not
  * written directly to stderr: this file is linked into every binary
@@ -31,6 +44,7 @@ static void monotonicLog(const char *fmt, ...) {
     va_end(ap);
     monotonic_logger(buf);
 }
+#endif
 
 /* Using the processor clock (aka TSC on x86) can provide improved performance
  * throughout Redis wherever the monotonic clock is used.  The processor clock
@@ -392,11 +406,15 @@ static void monotonicInit_posix(void) {
 
 
 const char * monotonicInit(void (*logger)(const char *msg)) {
+    #ifdef MONOTONIC_HAS_LOG_FALLBACK
     /* Only the first call (the one that actually runs detection) sets the
      * logger -- matches this function's existing "may be called additional
      * times without impact" contract, and avoids a later no-op call (e.g.
      * ae.c's fallback) clobbering the logger a prior caller registered. */
     if (getMonotonicUs == NULL) monotonic_logger = logger;
+    #else
+    (void)logger; /* no arch path here has a fallback note to log */
+    #endif
 
     #if defined(__x86_64__) && defined(__linux__)
     if (getMonotonicUs == NULL) monotonicInit_x86linux();

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -7,44 +7,17 @@
 #include <string.h>
 #include <errno.h>
 #include <limits.h>
-#include <stdarg.h>
 
 /* The function pointer for clock retrieval.  */
 monotime (*getMonotonicUs)(void) = NULL;
 
 static char monotonic_info_string[32];
 
-/* Only the hardware-clock paths below ever have a fallback note to log
- * (the plain POSIX clock has no failure branch), so gate the logger itself
- * on whichever of them (if any) is being compiled -- same as how each path's
- * own helpers (e.g. monotonicCalibrateOnce_x86linux) are excluded on
- * platforms that don't use them. Ungated, a build with none of these arch
- * blocks compiled in (e.g. 32-bit x86) would leave monotonicLog() with no
- * caller and fail -Werror=unused-function. */
-#if (defined(__x86_64__) && defined(__linux__)) || defined(__aarch64__) || \
-    (defined(USE_PROCESSOR_CLOCK) && defined(__riscv) && defined(__linux__))
-#define MONOTONIC_HAS_LOG_FALLBACK 1
-#endif
-
-#ifdef MONOTONIC_HAS_LOG_FALLBACK
-/* Optional callback for notes from clock detection/calibration fallback
- * paths (e.g. an unconfirmed TSC rate, a missing 'constant_tsc' flag). Not
- * written directly to stderr: this file is linked into every binary
- * (redis-server, redis-cli, redis-check-aof, ...), and some callers treat
- * any child stderr as failure. Set via monotonicInit()'s argument; NULL
- * (the default) discards these notes. */
-static void (*monotonic_logger)(const char *msg) = NULL;
-
-static void monotonicLog(const char *fmt, ...) {
-    if (!monotonic_logger) return;
-    char buf[160];
-    va_list ap;
-    va_start(ap, fmt);
-    vsnprintf(buf, sizeof(buf), fmt, ap);
-    va_end(ap);
-    monotonic_logger(buf);
-}
-#endif
+/* Optional log callback, set via monotonicInit(). */
+static void (*monotonic_logger)(const char *fmt, ...) __attribute__((format(printf, 1, 2))) = NULL;
+#define monotonicLog(...) do { \
+    if (monotonic_logger) monotonic_logger(__VA_ARGS__); \
+} while (0)
 
 /* Using the processor clock (aka TSC on x86) can provide improved performance
  * throughout Redis wherever the monotonic clock is used.  The processor clock
@@ -405,16 +378,8 @@ static void monotonicInit_posix(void) {
 
 
 
-const char * monotonicInit(void (*logger)(const char *msg)) {
-    #ifdef MONOTONIC_HAS_LOG_FALLBACK
-    /* Only the first call (the one that actually runs detection) sets the
-     * logger -- matches this function's existing "may be called additional
-     * times without impact" contract, and avoids a later no-op call (e.g.
-     * ae.c's fallback) clobbering the logger a prior caller registered. */
-    if (getMonotonicUs == NULL) monotonic_logger = logger;
-    #else
-    (void)logger; /* no arch path here has a fallback note to log */
-    #endif
+const char * monotonicInit(void (*logger)(const char *fmt, ...)) {
+    monotonic_logger = logger;
 
     #if defined(__x86_64__) && defined(__linux__)
     if (getMonotonicUs == NULL) monotonicInit_x86linux();

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -13,6 +13,12 @@ monotime (*getMonotonicUs)(void) = NULL;
 
 static char monotonic_info_string[32];
 
+/* Notes from clock detection/calibration fallback paths (e.g. an unconfirmed
+ * TSC rate, a missing 'constant_tsc' flag). Not written directly to stderr:
+ * this file is linked into every binary (redis-server, redis-cli,
+ * redis-check-aof, ...), and some callers treat any child stderr as failure.
+ * The server logs it via monotonicDiagnostics(); other callers may ignore it. */
+static char monotonic_diag_string[160];
 
 /* Using the processor clock (aka TSC on x86) can provide improved performance
  * throughout Redis wherever the monotonic clock is used.  The processor clock
@@ -137,7 +143,8 @@ static void monotonicInit_x86linux(void) {
     FILE *cs = fopen("/sys/devices/system/clocksource/clocksource0/current_clocksource", "r");
     if (cs == NULL || fgets(buf, bufflen, cs) == NULL || strncmp(buf, "tsc", 3) != 0) {
         if (cs) fclose(cs);
-        fprintf(stderr, "monotonic: x86 linux, kernel clocksource is not 'tsc'\n");
+        snprintf(monotonic_diag_string, sizeof(monotonic_diag_string),
+                "x86 linux, kernel clocksource is not 'tsc'");
         return;
     }
     fclose(cs);
@@ -176,7 +183,8 @@ static void monotonicInit_x86linux(void) {
     regfree(&constTscRegex);
 
     if (!constantTsc) {
-        fprintf(stderr, "monotonic: x86 linux, 'constant_tsc' flag not present\n");
+        snprintf(monotonic_diag_string, sizeof(monotonic_diag_string),
+                "x86 linux, 'constant_tsc' flag not present");
         return;
     }
 
@@ -211,9 +219,10 @@ static void monotonicInit_x86linux(void) {
         if (measured > 0 && labs(measured - nominal_model) * 1000 <= nominal_model) { /* within 0.1% */
             mono_ticksPerMicrosecond = nominal_model;
         } else {
-            fprintf(stderr, "monotonic: x86 linux, advertised clock rate "
+            snprintf(monotonic_diag_string, sizeof(monotonic_diag_string),
+                    "x86 linux, advertised clock rate "
                     "(%ld ticks/us) unconfirmed by the measured rate "
-                    "(%ld ticks/us), using calibration\n",
+                    "(%ld ticks/us), using calibration",
                     nominal_model, measured);
         }
     }
@@ -243,7 +252,8 @@ static void monotonicInit_x86linux(void) {
     }
 
     if (mono_ticksPerMicrosecond == 0) {
-        fprintf(stderr, "monotonic: x86 linux, unable to determine clock rate\n");
+        snprintf(monotonic_diag_string, sizeof(monotonic_diag_string),
+                "x86 linux, unable to determine clock rate");
         return;
     }
 
@@ -282,7 +292,8 @@ static monotime getMonotonicUs_aarch64(void) {
 static void monotonicInit_aarch64(void) {
     mono_ticksPerMicrosecond = (long)cntfrq_hz() / 1000L / 1000L;
     if (mono_ticksPerMicrosecond == 0) {
-        fprintf(stderr, "monotonic: aarch64, unable to determine clock rate\n");
+        snprintf(monotonic_diag_string, sizeof(monotonic_diag_string),
+                "aarch64, unable to determine clock rate");
         return;
     }
 
@@ -339,7 +350,8 @@ static monotime getMonotonicUs_riscv(void) {
 static void monotonicInit_riscv(void) {
     mono_ticksPerMicrosecond = (long)get_timebase_frequency() / 1000L / 1000L;
     if (mono_ticksPerMicrosecond == 0) {
-        fprintf(stderr, "monotonic: riscv, unable to determine clock rate\n");
+        snprintf(monotonic_diag_string, sizeof(monotonic_diag_string),
+                "riscv, unable to determine clock rate");
         return;
     }
     snprintf(monotonic_info_string, sizeof(monotonic_info_string),
@@ -393,6 +405,13 @@ const char * monotonicInit(void) {
 
 const char *monotonicInfoString(void) {
     return monotonic_info_string;
+}
+
+/* Return a note from the clock detection/calibration fallback paths, or an
+ * empty string if none was recorded. Callers with a logger (i.e. the server)
+ * should log it; callers without one may ignore it. */
+const char *monotonicDiagnostics(void) {
+    return monotonic_diag_string;
 }
 
 monotonic_clock_type monotonicGetType(void) {

--- a/src/monotonic.h
+++ b/src/monotonic.h
@@ -34,14 +34,12 @@ typedef enum monotonic_clock_type {
  * Returns a printable string indicating the type of clock initialized.
  * (The returned string is static and doesn't need to be freed.)
  *
- * 'logger', if non-NULL, is invoked with a one-line note for anything found
- * on the clock detection/calibration fallback paths (e.g. an unconfirmed TSC
- * rate). Not written directly to stderr by monotonic.c itself, since some
- * callers (this file is linked into every binary) treat any child stderr as
- * failure. Pass NULL to discard these notes -- e.g. the server passes a
- * wrapper around serverLog(), other callers pass NULL. Only the first call
- * (the one that runs detection) uses 'logger'; later calls ignore it. */
-const char *monotonicInit(void (*logger)(const char *msg));
+ * 'logger' is a printf-alike used to report notes from the clock detection
+ * and calibration fallback paths (e.g. an unconfirmed TSC rate); the server
+ * passes a serverLog() wrapper.  Pass NULL to discard those notes -- nothing
+ * is written to stderr, as this file is linked into every binary and some
+ * callers treat any child stderr output as failure.  */
+const char *monotonicInit(void (*logger)(const char *fmt, ...));
 
 /* Return a string indicating the type of monotonic clock being used. */
 const char *monotonicInfoString(void);

--- a/src/monotonic.h
+++ b/src/monotonic.h
@@ -38,6 +38,12 @@ const char *monotonicInit(void);
 /* Return a string indicating the type of monotonic clock being used. */
 const char *monotonicInfoString(void);
 
+/* Return a note from the clock detection/calibration fallback paths (e.g. an
+ * unconfirmed TSC rate), or an empty string if none was recorded. This is
+ * deliberately not printed to stderr by monotonic.c itself -- callers with a
+ * logging facility (the server) should log it themselves. */
+const char *monotonicDiagnostics(void);
+
 /* Return the type of monotonic clock being used. */
 monotonic_clock_type monotonicGetType(void);
 

--- a/src/monotonic.h
+++ b/src/monotonic.h
@@ -38,11 +38,13 @@ const char *monotonicInit(void);
 /* Return a string indicating the type of monotonic clock being used. */
 const char *monotonicInfoString(void);
 
-/* Return a note from the clock detection/calibration fallback paths (e.g. an
- * unconfirmed TSC rate), or an empty string if none was recorded. This is
- * deliberately not printed to stderr by monotonic.c itself -- callers with a
- * logging facility (the server) should log it themselves. */
-const char *monotonicDiagnostics(void);
+/* Register a callback for notes from the clock detection/calibration
+ * fallback paths (e.g. an unconfirmed TSC rate). Not written directly to
+ * stderr by monotonic.c itself, since some callers (this file is linked
+ * into every binary) treat any child stderr as failure. Pass NULL (the
+ * default) to discard these notes -- e.g. the server registers one via
+ * serverLog(), matching zmalloc_set_oom_handler()'s callback pattern. */
+void monotonicSetLogger(void (*logger)(const char *msg));
 
 /* Return the type of monotonic clock being used. */
 monotonic_clock_type monotonicGetType(void);

--- a/src/monotonic.h
+++ b/src/monotonic.h
@@ -32,19 +32,19 @@ typedef enum monotonic_clock_type {
 /* Call once at startup to initialize the monotonic clock.  Though this only
  * needs to be called once, it may be called additional times without impact.
  * Returns a printable string indicating the type of clock initialized.
- * (The returned string is static and doesn't need to be freed.)  */
-const char *monotonicInit(void);
+ * (The returned string is static and doesn't need to be freed.)
+ *
+ * 'logger', if non-NULL, is invoked with a one-line note for anything found
+ * on the clock detection/calibration fallback paths (e.g. an unconfirmed TSC
+ * rate). Not written directly to stderr by monotonic.c itself, since some
+ * callers (this file is linked into every binary) treat any child stderr as
+ * failure. Pass NULL to discard these notes -- e.g. the server passes a
+ * wrapper around serverLog(), other callers pass NULL. Only the first call
+ * (the one that runs detection) uses 'logger'; later calls ignore it. */
+const char *monotonicInit(void (*logger)(const char *msg));
 
 /* Return a string indicating the type of monotonic clock being used. */
 const char *monotonicInfoString(void);
-
-/* Register a callback for notes from the clock detection/calibration
- * fallback paths (e.g. an unconfirmed TSC rate). Not written directly to
- * stderr by monotonic.c itself, since some callers (this file is linked
- * into every binary) treat any child stderr as failure. Pass NULL (the
- * default) to discard these notes -- e.g. the server registers one via
- * serverLog(), matching zmalloc_set_oom_handler()'s callback pattern. */
-void monotonicSetLogger(void (*logger)(const char *msg));
 
 /* Return the type of monotonic clock being used. */
 monotonic_clock_type monotonicGetType(void);

--- a/src/server.c
+++ b/src/server.c
@@ -3091,6 +3091,8 @@ void initServer(void) {
     adjustOpenFilesLimit();
     const char *clk_msg = monotonicInit();
     serverLog(LL_NOTICE, "monotonic clock: %s", clk_msg);
+    const char *clk_diag = monotonicDiagnostics();
+    if (clk_diag[0] != '\0') serverLog(LL_NOTICE, "monotonic clock: %s", clk_diag);
     server.el = aeCreateEventLoop(server.maxclients+CONFIG_FDSET_INCR);
     if (server.el == NULL) {
         serverLog(LL_WARNING,

--- a/src/server.c
+++ b/src/server.c
@@ -3006,7 +3006,14 @@ void makeThreadKillable(void) {
     pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 }
 
-static void monotonicLogCallback(const char *msg) {
+/* printf-alike handed to monotonicInit(), so clock detection fallbacks end up
+ * in the server log instead of stderr. */
+static void monotonicLogCallback(const char *fmt, ...) {
+    char msg[160];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(msg, sizeof(msg), fmt, ap);
+    va_end(ap);
     serverLog(LL_NOTICE, "monotonic clock: %s", msg);
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -3006,6 +3006,10 @@ void makeThreadKillable(void) {
     pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 }
 
+static void monotonicLogCallback(const char *msg) {
+    serverLog(LL_NOTICE, "monotonic clock: %s", msg);
+}
+
 void initServer(void) {
     int j;
 
@@ -3089,10 +3093,9 @@ void initServer(void) {
     hashTemplatesInit();
     createSharedObjects();
     adjustOpenFilesLimit();
+    monotonicSetLogger(monotonicLogCallback);
     const char *clk_msg = monotonicInit();
     serverLog(LL_NOTICE, "monotonic clock: %s", clk_msg);
-    const char *clk_diag = monotonicDiagnostics();
-    if (clk_diag[0] != '\0') serverLog(LL_NOTICE, "monotonic clock: %s", clk_diag);
     server.el = aeCreateEventLoop(server.maxclients+CONFIG_FDSET_INCR);
     if (server.el == NULL) {
         serverLog(LL_WARNING,

--- a/src/server.c
+++ b/src/server.c
@@ -3093,8 +3093,7 @@ void initServer(void) {
     hashTemplatesInit();
     createSharedObjects();
     adjustOpenFilesLimit();
-    monotonicSetLogger(monotonicLogCallback);
-    const char *clk_msg = monotonicInit();
+    const char *clk_msg = monotonicInit(monotonicLogCallback);
     serverLog(LL_NOTICE, "monotonic clock: %s", clk_msg);
     server.el = aeCreateEventLoop(server.maxclients+CONFIG_FDSET_INCR);
     if (server.el == NULL) {
@@ -8086,7 +8085,7 @@ int main(int argc, char **argv) {
     char config_from_stdin = 0;
 
 #ifdef REDIS_TEST
-    monotonicInit(); /* Required for dict tests, that are relying on monotime during dict rehashing. */
+    monotonicInit(NULL); /* Required for dict tests, that are relying on monotime during dict rehashing. */
     if (argc >= 3 && !strcasecmp(argv[1], "test")) {
         int flags = 0;
         for (j = 3; j < argc; j++) {


### PR DESCRIPTION
## Summary

`monotonic.c`'s clock detection/calibration fallback paths (unconfirmed TSC
rate, missing `constant_tsc`, unable to determine clock rate, etc., across
the x86/aarch64/riscv init paths) write directly to `stderr` via `fprintf`.

This file is linked into every Redis binary, not just `redis-server` —
`redis-cli`, `redis-check-aof`, `redis-check-rdb`, and `redis-benchmark` all
pull it in, either via `ae.c`'s `monotonicInit()` fallback call or as a
direct link dependency. None of those have a logging facility of their own,
so an unconditional `stderr` print from this library-level init routine has
no good outlet: it either goes nowhere useful, or — for any tool that treats
child `stderr` as a failure signal (e.g. a test harness wrapping `exec`, or
`subprocess.run(check=True, stderr=PIPE)`) — risks being misread as an error
even though the process succeeded.

## Change

`monotonicInit()` now takes an optional logger callback directly:

```c
const char *monotonicInit(void (*logger)(const char *msg));
```

`redis-server` passes a small wrapper around `serverLog()`; every other
caller (`ae.c`'s fallback call, dict tests, `redis-cli`, `redis-check-aof`,
`redis-check-rdb`, `redis-benchmark`) passes `NULL` and stays exactly as
silent as before. Only the first call (the one that actually runs clock
detection) applies the logger, so a later no-op call can't clobber one a
prior caller already registered.

The logger itself, and its small `monotonicLog()` formatting helper, are
only compiled in when at least one of the x86_64/aarch64/riscv hardware-clock
paths is — a build with none of them (e.g. 32-bit x86) has no fallback note
to ever produce, and gating avoids leaving `monotonicLog()` uncalled under
`-Werror=unused-function`.

No behavior change for `redis-server` operators beyond the message moving
from raw `stderr` into the normal log stream at `LL_NOTICE`, right after the
existing `monotonicInit()` clock-type message; `INFO`'s `monotonic_clock`
field and `monotonicInfoString()` are untouched.

## Test plan

- [x] `make` (default flags) builds clean
- [x] `make REDIS_CFLAGS='-Werror' 32bit` builds clean
- [x] `./runtest --single integration/aof` passes
- [x] Manually verified `INFO server`'s `monotonic_clock` field is unchanged
- [x] Manually verified `redis-check-aof --version` / `redis-check-rdb --version` still work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup logging plumbing only; monotonic clock selection and timing behavior are unchanged, with NULL logger preserving silence for non-server binaries.
> 
> **Overview**
> Monotonic clock detection and calibration fallback messages (non-TSC clocksource, missing `constant_tsc`, unconfirmed TSC rate, failed rate detection on x86/aarch64/riscv, etc.) no longer go to **stderr**. They are emitted only through an optional **printf-style callback** registered on the first `monotonicInit()` call.
> 
> **`monotonicInit()`** now takes `void (*logger)(const char *fmt, ...)`. Passing **`NULL`** suppresses those notes entirely—used by **`ae.c`**, dict tests, and other utilities that link `monotonic.c` without a logging layer. **`redis-server`** registers **`monotonicLogCallback`**, which formats the text and writes it with **`serverLog(LL_NOTICE, "monotonic clock: %s", ...)`** alongside the existing clock-type startup line.
> 
> Clock selection behavior and **`monotonicInfoString()`** / INFO output are unchanged; only where diagnostic text goes (server log vs silent vs former stderr) changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67dfa35511bad99d4cbeaf98536898262fa63131. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
