### PR TITLE
Reject overflowing save config values

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2937,9 +2937,50 @@ static sds getConfigDirOption(standardConfig *config) {
     return sdsnew(buf);
 }
 
+/* Parse a single "<seconds> <changes>" save point. On success 1 is returned and
+ * the parsed values are stored in seconds_out and changes_out, otherwise 0 is
+ * returned and *err is set.
+ *
+ * Both values are capped at INT_MAX (about 68 years for the seconds, which is
+ * way more than any sane save point): changes is stored in an int, and seconds,
+ * while stored in a time_t, is emitted as a long by rewriteConfigSaveOption().
+ * Without the check the values silently wrap, and a negative changes count
+ * makes serverCron() fire a background save on every single change. */
+static int parseSaveParamPair(sds seconds_str, sds changes_str,
+                              time_t *seconds_out, int *changes_out,
+                              const char **err)
+{
+    char *eptr;
+    long long seconds, changes;
+
+    errno = 0;
+    seconds = strtoll(seconds_str,&eptr,10);
+    if (eptr == seconds_str || eptr[0] != '\0' || errno == ERANGE ||
+        seconds < 1 || seconds > INT_MAX)
+    {
+        *err = "Invalid save parameters";
+        return 0;
+    }
+
+    errno = 0;
+    changes = strtoll(changes_str,&eptr,10);
+    if (eptr == changes_str || eptr[0] != '\0' || errno == ERANGE ||
+        changes < 0 || changes > INT_MAX)
+    {
+        *err = "Invalid save parameters";
+        return 0;
+    }
+
+    *seconds_out = seconds;
+    *changes_out = changes;
+    return 1;
+}
+
 static int setConfigSaveOption(standardConfig *config, sds *argv, int argc, const char **err) {
     UNUSED(config);
     int j;
+    time_t seconds;
+    int changes;
 
     /* Special case: treat single arg "" as zero args indicating empty save configuration */
     if (argc == 1 && !strcasecmp(argv[0],"")) {
@@ -2949,23 +2990,16 @@ static int setConfigSaveOption(standardConfig *config, sds *argv, int argc, cons
 
     /* Perform sanity check before setting the new config:
     * - Even number of args
-    * - Seconds >= 1, changes >= 0 */
+    * - Seconds >= 1, changes >= 0, and both fitting struct saveparam */
     if (argc & 1) {
         *err = "Invalid save parameters";
         return 0;
     }
-    for (j = 0; j < argc; j++) {
-        char *eptr;
-        long val;
-
-        val = strtoll(argv[j], &eptr, 10);
-        if (eptr[0] != '\0' ||
-            ((j & 1) == 0 && val < 1) ||
-            ((j & 1) == 1 && val < 0)) {
-            *err = "Invalid save parameters";
+    for (j = 0; j < argc; j += 2) {
+        if (!parseSaveParamPair(argv[j],argv[j+1],&seconds,&changes,err))
             return 0;
-        }
     }
+
     /* Finally set the new config */
     if (!reading_config_file) {
         resetServerSaveParams();
@@ -2981,11 +3015,8 @@ static int setConfigSaveOption(standardConfig *config, sds *argv, int argc, cons
     }
 
     for (j = 0; j < argc; j += 2) {
-        time_t seconds;
-        int changes;
-
-        seconds = strtoll(argv[j],NULL,10);
-        changes = strtoll(argv[j+1],NULL,10);
+        /* Already validated above, so this can't fail. */
+        serverAssert(parseSaveParamPair(argv[j],argv[j+1],&seconds,&changes,err));
         appendServerSaveParams(seconds, changes);
     }
 

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -620,7 +620,68 @@ start_server {tags {"introspection"}} {
         start_server {config "default.conf" overrides {save {900 1}} args {--save {}}} {
             assert_match [r config get save] {save {}}
         }
+
     } {} {external:skip}
+
+    test {CONFIG SET save rejects out of range params} {
+        set original [lindex [r config get save] 1]
+
+        # Values that don't fit struct saveparam, both just above the limit and
+        # way beyond what strtoll() can represent.
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "1 2147483648"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "2147483648 1"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "1 999999999999999999999999"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "999999999999999999999999 1"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "1 21474836499999999999999999999999"}
+
+        # Non numeric, empty and out of range values, also when a valid pair comes first
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "900 foo"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "900 "}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "900 1 1 2147483648"}
+
+        # A rejected CONFIG SET must leave the previous save params untouched
+        assert_equal $original [lindex [r config get save] 1]
+
+        # Valid values are still accepted, leading zeros and '+' included
+        r config set save "3600 1 300 100"
+        assert_equal {3600 1 300 100} [lindex [r config get save] 1]
+        r config set save "0300 +010"
+        assert_equal {300 10} [lindex [r config get save] 1]
+        r config set save "2147483647 2147483647"
+        assert_equal {2147483647 2147483647} [lindex [r config get save] 1]
+
+        # The same limits apply when the value comes from the command line
+        set pidfile [tmpfile invalid-save.pid]
+        set code [catch {
+            exec src/redis-server --port 0 --daemonize yes --pidfile $pidfile --save "1 2147483648"
+        } err]
+        if {$code == 0 && [file exists $pidfile]} {
+            set fd [open $pidfile r]
+            catch {exec kill [string trim [read $fd]]}
+            close $fd
+        }
+        file delete $pidfile
+        assert {$code != 0}
+        assert_match {*Invalid save parameters*} $err
+
+        # The same limits apply when loading a config file
+        set config [tmpfile invalid-save.conf]
+        set pidfile [tmpfile invalid-save.pid]
+        set fd [open $config w]
+        puts $fd "port 0\ndaemonize yes\npidfile $pidfile\nsave 1 2147483648"
+        close $fd
+        set code [catch {exec src/redis-server $config} err]
+        if {$code == 0 && [file exists $pidfile]} {
+            set fd [open $pidfile r]
+            catch {exec kill [string trim [read $fd]]}
+            close $fd
+        }
+        file delete $config $pidfile
+        assert {$code != 0}
+        assert_match {*Invalid save parameters*} $err
+
+        r config set save $original
+    } {OK} {external:skip}
 
     test {CONFIG sanity} {
         # Do CONFIG GET, CONFIG SET and then CONFIG GET again


### PR DESCRIPTION
The save config was parsed twice: once for validation, with the value stored in a long, and once for the actual assignment, where seconds and changes are stored in the time_t and int fields of struct saveparam. Neither pass checked for overflow, so out of range values were silently truncated. "save 1 2147483648" turned into a changes count of -2147483648, making serverCron() start a background save on every single change, and values beyond long long were accepted as LLONG_MAX because strtoll() reports overflow through errno only.

Route both passes through a single parseSaveParamPair() helper so that they can no longer disagree, reject anything that does not fit struct saveparam, and keep the validation of all pairs ahead of resetServerSaveParams() so that a rejected value leaves the current save points untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence scheduling validation; misconfiguration could previously cause runaway BGSAVE, and the fix alters accepted `save` values at startup and runtime.
> 
> **Overview**
> **Tightens validation for `save` RDB snapshot rules** so seconds/changes cannot silently truncate when they exceed what `struct saveparam` can store.
> 
> Parsing used to run twice with weak checks; overflow could turn a huge changes count negative and trigger background saves on every write. Both validation and application now go through **`parseSaveParamPair()`**, which uses `strtoll` with `errno`/range checks and caps values at **`INT_MAX`**. All pairs are validated before **`resetServerSaveParams()`**, so a failed **`CONFIG SET save`** leaves the current save points unchanged.
> 
> **Tests** cover **`CONFIG SET`**, **`--save`**, and config-file loading for overflow, non-numeric input, and boundary-legal values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1962bc7e7b0bd8dae939a36cdce6a1da09a73471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->