### PR TITLE
Apply selective propagation flags to alsoPropagate() commands

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -3024,9 +3024,12 @@ static void propagateTrimSlots(slotRangeArray *slots) {
     enterExecutionUnit(1, 0);
 
     int prev_replication_allowed = server.replication_allowed;
+    int prev_call_propagation_flags = server.call_propagation_flags;
     server.replication_allowed = 1;
+    server.call_propagation_flags = PROPAGATE_AOF|PROPAGATE_REPL;
     alsoPropagate(-1, argv, argc, PROPAGATE_AOF | PROPAGATE_REPL);
     server.replication_allowed = prev_replication_allowed;
+    server.call_propagation_flags = prev_call_propagation_flags;
 
     exitExecutionUnit();
     postExecutionUnitOperations();

--- a/src/db.c
+++ b/src/db.c
@@ -2943,11 +2943,16 @@ void propagateDeletion(redisDb *db, robj *key, int lazy) {
     incrRefCount(argv[1]);
 
     /* If the master decided to delete a key we must propagate it to replicas no matter what.
-     * Even if module executed a command without asking for propagation. */
+     * Even if module executed a command without asking for propagation.
+     * Likewise bypass the call() propagation-flags mask, e.g. when a lazy
+     * expiry happens inside a script running with redis.set_repl(). */
     int prev_replication_allowed = server.replication_allowed;
+    int prev_call_propagation_flags = server.call_propagation_flags;
     server.replication_allowed = 1;
+    server.call_propagation_flags = PROPAGATE_AOF|PROPAGATE_REPL;
     alsoPropagate(db->id,argv,2,PROPAGATE_AOF|PROPAGATE_REPL);
     server.replication_allowed = prev_replication_allowed;
+    server.call_propagation_flags = prev_call_propagation_flags;
 
     decrRefCount(argv[0]);
     decrRefCount(argv[1]);

--- a/src/server.c
+++ b/src/server.c
@@ -3048,6 +3048,7 @@ void initServer(void) {
      * (see CLIENT_ST_KEYLEN / encodeTimeoutKey in timeout.c). */
     server.clients_timeout_table = raxNewEx(0, NULL, sizeof(uint64_t) * 2);
     server.replication_allowed = 1;
+    server.call_propagation_flags = PROPAGATE_AOF|PROPAGATE_REPL;
     server.slaveseldb = -1; /* Force to emit the first SELECT command. */
     server.unblocked_clients = listCreate();
     server.ready_keys = listCreate();
@@ -3795,6 +3796,14 @@ void alsoPropagate(int dbid, robj **argv, int argc, int target) {
     robj **argvcopy;
     int j;
 
+    /* Honor the propagation flags of the innermost active call(), so that
+     * selective propagation (e.g. redis.set_repl() in scripts, or RM_Call
+     * flags in modules) applies to commands queued here exactly like it
+     * applies to the verbatim propagation done by call(). CMD_CALL_PROPAGATE_*
+     * and PROPAGATE_* are numerically identical. Outside of call() the mask
+     * is full (set at startup and restored by call()). */
+    target &= server.call_propagation_flags;
+
     if (!shouldPropagate(target))
         return;
 
@@ -3892,10 +3901,19 @@ static void propagatePendingCommands(void) {
         transaction = 0;
     }
 
+    /* The targets of the MULTI/EXEC wrapper are the union of the targets of
+     * the queued commands, so that, e.g., when all the queued commands were
+     * restricted to the AOF by selective propagation (redis.set_repl()), the
+     * wrapper is not sent to the replicas as an empty transaction. */
+    int transaction_target = PROPAGATE_NONE;
+    for (j = 0; j < server.also_propagate.numops; j++) {
+        transaction_target |= server.also_propagate.ops[j].target;
+    }
+
     if (transaction) {
         /* We use dbid=-1 to indicate we do not want to replicate SELECT.
          * It'll be inserted together with the next command (inside the MULTI) */
-        propagateNow(-1,&shared.multi,1,PROPAGATE_AOF|PROPAGATE_REPL);
+        propagateNow(-1,&shared.multi,1,transaction_target);
     }
 
     for (j = 0; j < server.also_propagate.numops; j++) {
@@ -3906,7 +3924,7 @@ static void propagatePendingCommands(void) {
 
     if (transaction) {
         /* We use dbid=-1 to indicate we do not want to replicate select */
-        propagateNow(-1,&shared.exec,1,PROPAGATE_AOF|PROPAGATE_REPL);
+        propagateNow(-1,&shared.exec,1,transaction_target);
     }
 
     redisOpArrayFree(&server.also_propagate);
@@ -4017,6 +4035,13 @@ void call(client *c, int flags) {
     struct redisCommand *real_cmd = c->realcmd;
     client *prev_client = server.executing_client;
     server.executing_client = c;
+
+    /* Restrict alsoPropagate() targets (see alsoPropagate()) to what this
+     * call() is allowed to propagate. CMD_CALL_PROPAGATE_* and PROPAGATE_*
+     * are numerically identical. Restore before returning, since call() can
+     * be executed recursively. */
+    int prev_call_propagation_flags = server.call_propagation_flags;
+    server.call_propagation_flags = flags & CMD_CALL_PROPAGATE;
 
     /* When call() is issued during loading the AOF we don't want commands called
      * from module, exec or LUA to go into the slowlog or to populate statistics. */
@@ -4288,6 +4313,7 @@ void call(client *c, int flags) {
     }
 
     server.executing_client = prev_client;
+    server.call_propagation_flags = prev_call_propagation_flags;
 }
 
 /* Used when a command that is ready for execution needs to be rejected, due to

--- a/src/server.h
+++ b/src/server.h
@@ -2426,6 +2426,10 @@ struct redisServer {
     /* Propagation of commands in AOF / replication */
     redisOpArray also_propagate;    /* Additional command to propagate. */
     int replication_allowed;        /* Are we allowed to replicate? */
+    int call_propagation_flags;     /* PROPAGATE_AOF/PROPAGATE_REPL mask allowed
+                                       by the innermost active call(). Set by
+                                       call() from its flags, applied by
+                                       alsoPropagate(). Full outside call(). */
     /* Logging */
     char *logfile;                  /* Path of log file */
     int syslog_enabled;             /* Is syslog enabled? */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -6243,9 +6243,12 @@ static void propagateHashFieldDeletion(redisDb *db, sds key, char *field, size_t
 
     enterExecutionUnit(1, 0);
     int prev_replication_allowed = server.replication_allowed;
+    int prev_call_propagation_flags = server.call_propagation_flags;
     server.replication_allowed = 1;
+    server.call_propagation_flags = PROPAGATE_AOF|PROPAGATE_REPL;
     alsoPropagate(db->id,argv, 3, PROPAGATE_AOF|PROPAGATE_REPL);
     server.replication_allowed = prev_replication_allowed;
+    server.call_propagation_flags = prev_call_propagation_flags;
     exitExecutionUnit();
 
     /* Propagate the HDEL command */

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1667,6 +1667,51 @@ start_server {tags {"scripting repl external:skip"}} {
             assert {[r mget a b c d] eq {1 {} 3 4}}
         }
 
+        test "Selective replication applies to alsoPropagate()'d commands" {
+            # SPOP with a count propagates its effects as SREM commands
+            # queued via alsoPropagate(), which used to ignore
+            # redis.set_repl(). (The single-element SPOP, instead, is
+            # rewritten to a verbatim SREM, which call() masks already.)
+            r del myset myset2 marker
+            r sadd myset a b c d
+            r sadd myset2 w x y z
+            wait_for_condition 50 100 {
+                [r -1 scard myset] eq 4 &&
+                [r -1 scard myset2] eq 4
+            } else {
+                fail "Replica did not receive the initial sets"
+            }
+
+            run_script {
+                redis.set_repl(redis.REPL_NONE);
+                redis.call('spop','myset',1);
+                redis.set_repl(redis.REPL_AOF);
+                redis.call('spop','myset2',1);
+                redis.set_repl(redis.REPL_ALL);
+                redis.call('set','marker','done');
+            } 3 myset myset2 marker
+
+            # Master lost one element from both sets
+            assert {[r scard myset] eq 3}
+            assert {[r scard myset2] eq 3}
+
+            # Wait for the marker, replicated with REPL_ALL. Since the
+            # replication stream is ordered, any SREM queued by the two SPOP
+            # commands would have reached the replica before it.
+            wait_for_condition 50 100 {
+                [r -1 get marker] eq {done}
+            } else {
+                fail "Replica did not receive the marker"
+            }
+            assert {[r -1 scard myset] eq 4}
+            assert {[r -1 scard myset2] eq 4}
+
+            # After an AOF reload only myset2 (REPL_AOF) keeps its SPOP effect
+            r debug loadaof
+            assert {[r scard myset] eq 4}
+            assert {[r scard myset2] eq 3}
+        }
+
         test "PRNG is seeded randomly for command replication" {
             if {$is_eval eq 1} {
                 # on is_eval Lua we need to call redis.replicate_commands() to get real randomization


### PR DESCRIPTION
Fixes #15638.

## The problem

The selective propagation targets — `redis.set_repl()` in scripts and the `A`/`R` modifiers of module `RM_Call`/`RM_Replicate` — reach `call()` as `CMD_CALL_PROPAGATE_{AOF,REPL}`, but `call()` applies that mask only to the verbatim propagation it performs at its end. Commands that replace their own propagation by queueing other commands via `alsoPropagate()` — e.g. `SPOP` with a count (propagated as `SREM` batches), or the `XCLAIM`/`XACK`/`XGROUP` side effects of stream commands — are queued with a hard-coded `PROPAGATE_AOF|PROPAGATE_REPL` target and flushed as-is by `propagatePendingCommands()`, so the mask never applies to them.

Reproduction from the issue:

```
sadd myset a b c d e
eval "redis.set_repl(redis.REPL_NONE); redis.call('spop','myset',2)" 0
```

still delivers `SREM myset ...` to replicas (and to the AOF).

## The fix

Track the propagation flags of the innermost active `call()` in `server.call_propagation_flags` (full outside `call()`):

- `call()` saves/sets/restores the mask from its flags (`CMD_CALL_PROPAGATE_*` and `PROPAGATE_*` are numerically identical, no translation needed);
- `alsoPropagate()` masks the requested target before queueing;
- `propagatePendingCommands()` emits the `MULTI`/`EXEC` wrapper of a queued batch with the union of the batch targets instead of the hard-coded `AOF|REPL`, so e.g. an AOF-only batch no longer produces an empty transaction on the replicas;
- propagations that must happen no matter what (`propagateDeletion()` for expired/evicted keys, `propagateHashFieldDeletion()` for hash field TTLs, `propagateTrimSlots()`) bypass the mask the same way they already bypass `server.replication_allowed`, so e.g. a lazy expiry inside a script running under `REPL_NONE` still propagates its `DEL`.

Nested `RM_Call` semantics stay consistent with today: without `!`, `server.replication_allowed` already suppresses queued commands; with `!` and `NO_AOF`/`NO_REPLICAS`, queued commands now respect the same restriction as the verbatim one. Outside `call()` (module timers, cron) the mask is full, unchanged.

## Tests

Added `Selective replication applies to alsoPropagate()'d commands` to `tests/unit/scripting.tcl` (runs in both EVAL and functions modes): in a master + replica + AOF setup, a script runs `SPOP key 1` under `REPL_NONE` and `REPL_AOF` plus a `REPL_ALL` marker, then asserts (a) the replica received none of the `SREM` effects once the marker arrives, and (b) after `DEBUG LOADAOF` only the `REPL_AOF` effect survives. The test fails without this change (the replica sees the `SREM`).

Note: the single-element `SPOP` is not a reproducer — it rewrites itself into a verbatim `SREM`, which `call()` already masks; the count form is the `alsoPropagate()` path.

Local verification: `unit/scripting`, `unit/multi`, `unit/type/set`, `unit/type/hash`, `unit/type/stream` and `integration/aof` all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core replication propagation paths for many commands that use alsoPropagate(); incorrect masking could drop needed replica/AOF updates or leak suppressed writes, though mandatory expiry paths explicitly bypass the mask.
> 
> **Overview**
> Fixes selective replication/AOF targeting for commands queued through **`alsoPropagate()`** (e.g. **`SPOP`** with a count as **`SREM`**, stream side effects), which previously always propagated with **`PROPAGATE_AOF|PROPAGATE_REPL`** regardless of **`redis.set_repl()`** or module **`RM_Call`** flags.
> 
> The innermost active **`call()`** now sets **`server.call_propagation_flags`** from its **`CMD_CALL_PROPAGATE_*`** mask; **`alsoPropagate()`** ANDs the requested target with that mask before queueing. **`propagatePendingCommands()`** wraps queued ops in **`MULTI`/`EXEC`** using the **union** of queued targets so AOF-only batches do not send empty transactions to replicas.
> 
> Mandatory propagations (**lazy expiry `DEL`/`UNLINK`**, hash field TTL **`HDEL`**, **`TRIMSLOTS`**) temporarily force the full mask, matching how they already override **`replication_allowed`**. A scripting test verifies **`SPOP`** under **`REPL_NONE`** / **`REPL_AOF`** on master, replica, and AOF reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f727e599326d387825ef31c6703cd4ffc282d45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->