### PR TITLE
Avoid flaky HPEXPIRETIME persistence test after slow RDB reload

### DIFF
--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -148,6 +148,29 @@ proc wait_for_condition {maxtries delay e _else_ elsescript} {
     }
 }
 
+# Run body until condition evaluates to true, up to max_iter attempts.
+proc assert_with_retry {max_iter iter_var body condition} {
+    if {$max_iter < 1} {
+        error "max_iter must be greater than 0"
+    }
+
+    upvar 1 $iter_var iter
+    set iter 1
+    while 1 {
+        uplevel 1 $body
+        if {[uplevel 1 [list expr $condition]]} {
+            return
+        }
+
+        if {$iter >= $max_iter} {
+            set context "(context: [info frame -1])"
+            error "assertion:Expected [uplevel 1 [list subst -nocommands $condition]] $context (gave up after ${iter} attempts)"
+        }
+        puts "Retrying assertion in $::cur_test (attempt ${iter}/${max_iter})"
+        incr iter
+    }
+}
+
 # try to match a value to a list of patterns that are either regex (starts with "/") or plain string.
 # The caller can specify to use only glob-pattern match
 proc search_pattern_list {value pattern_list {glob_pattern false}} {

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -296,7 +296,7 @@ start_server {tags {"external:skip needs:debug"}} {
         test "HPEXPIRETIME persists after RDB reload ($type)" {
             r del myhash
             r hset myhash field1 value1 field2 value2
-            r hpexpire myhash 500 NX FIELDS 1 field1
+            r hpexpire myhash 2000 NX FIELDS 1 field1
             set before [r HPEXPIRETIME myhash FIELDS 1 field1]
             r debug reload
             set after [r HPEXPIRETIME myhash FIELDS 1 field1]
@@ -305,7 +305,7 @@ start_server {tags {"external:skip needs:debug"}} {
             assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY
             assert_equal [get_stat_subexpiry r] 1
             # Wait for field1 to expire robustly
-            wait_for_condition 50 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" } 
+            wait_for_condition 50 60 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
             assert_equal [r hget myhash field1] ""
             # field2 remains without expiration
             assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -295,7 +295,7 @@ start_server {tags {"external:skip needs:debug"}} {
         
         test "HPEXPIRETIME persists after RDB reload ($type)" {
             # Retry with a longer TTL when DEBUG RELOAD is slow.
-            assert_with_retry 8 iter {
+            assert_with_retry 3 iter {
                 r del myhash
                 r hset myhash field1 value1 field2 value2
                 set ttl_ms [expr {500 * $iter}]

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -310,8 +310,7 @@ start_server {tags {"external:skip needs:debug"}} {
             }
 
             # Wait for field1 to expire robustly
-            set maxtries [expr {50 + (25 * ($iter - 1))}]
-            wait_for_condition $maxtries 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
+            wait_for_condition 50 40 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
             assert_equal [r hget myhash field1] ""
             # field2 remains without expiration
             assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -310,7 +310,7 @@ start_server {tags {"external:skip needs:debug"}} {
             }
 
             # Wait for field1 to expire robustly
-            wait_for_condition 50 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
+            wait_for_condition 50 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" } 
             assert_equal [r hget myhash field1] ""
             # field2 remains without expiration
             assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -310,7 +310,7 @@ start_server {tags {"external:skip needs:debug"}} {
             }
 
             # Wait for field1 to expire robustly
-            wait_for_condition 50 40 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
+            wait_for_condition 50 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
             assert_equal [r hget myhash field1] ""
             # field2 remains without expiration
             assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -296,16 +296,23 @@ start_server {tags {"external:skip needs:debug"}} {
         test "HPEXPIRETIME persists after RDB reload ($type)" {
             r del myhash
             r hset myhash field1 value1 field2 value2
-            r hpexpire myhash 2000 NX FIELDS 1 field1
-            set before [r HPEXPIRETIME myhash FIELDS 1 field1]
+
+            # Keep one time snapshot so slow reload cannot expire field1 early.
+            r multi
+            r hpexpire myhash 500 NX FIELDS 1 field1
+            r HPEXPIRETIME myhash FIELDS 1 field1
             r debug reload
-            set after [r HPEXPIRETIME myhash FIELDS 1 field1]
-            assert_equal $before $after
+            r HPEXPIRETIME myhash FIELDS 1 field1
+            r HTTL myhash FIELDS 1 field2
+            r info keyspace
+            set res [r exec]
+
+            assert_equal [lindex $res 1] [lindex $res 3]
             # field2 should not have expiration
-            assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY
-            assert_equal [get_stat_subexpiry r] 1
+            assert_equal [lindex $res 4] $T_NO_EXPIRY
+            assert_match {*subexpiry=1*} [lindex $res 5]
             # Wait for field1 to expire robustly
-            wait_for_condition 50 60 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
+            wait_for_condition 50 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
             assert_equal [r hget myhash field1] ""
             # field2 remains without expiration
             assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -294,25 +294,24 @@ start_server {tags {"external:skip needs:debug"}} {
         }
         
         test "HPEXPIRETIME persists after RDB reload ($type)" {
-            r del myhash
-            r hset myhash field1 value1 field2 value2
+            # Retry with a longer TTL when DEBUG RELOAD is slow.
+            assert_with_retry 8 iter {
+                r del myhash
+                r hset myhash field1 value1 field2 value2
+                set ttl_ms [expr {500 * $iter}]
+                r hpexpire myhash $ttl_ms NX FIELDS 1 field1
+                set before [r HPEXPIRETIME myhash FIELDS 1 field1]
+                r debug reload
+                set after [r HPEXPIRETIME myhash FIELDS 1 field1]
+            } {
+                $before == $after &&
+                [r HTTL myhash FIELDS 1 field2] == $T_NO_EXPIRY &&
+                [get_stat_subexpiry r] == 1
+            }
 
-            # Keep one time snapshot so slow reload cannot expire field1 early.
-            r multi
-            r hpexpire myhash 500 NX FIELDS 1 field1
-            r HPEXPIRETIME myhash FIELDS 1 field1
-            r debug reload
-            r HPEXPIRETIME myhash FIELDS 1 field1
-            r HTTL myhash FIELDS 1 field2
-            r info keyspace
-            set res [r exec]
-
-            assert_equal [lindex $res 1] [lindex $res 3]
-            # field2 should not have expiration
-            assert_equal [lindex $res 4] $T_NO_EXPIRY
-            assert_match {*subexpiry=1*} [lindex $res 5]
             # Wait for field1 to expire robustly
-            wait_for_condition 50 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
+            set maxtries [expr {50 + (25 * ($iter - 1))}]
+            wait_for_condition $maxtries 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" }
             assert_equal [r hget myhash field1] ""
             # field2 remains without expiration
             assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY


### PR DESCRIPTION

## Issue

`HPEXPIRETIME persists after RDB reload` uses a 500 ms field TTL. `DEBUG RELOAD` synchronously saves and fsyncs the RDB, clears the in-memory dataset, and loads it again, so slow CI storage can exhaust the TTL before the assertions run.

Failed CI:

- https://github.com/redis/redis/actions/runs/32431428079/job/96623606725 (523 ms)
- https://github.com/redis/redis/actions/runs/32316004047/job/96268225514 (1002 ms)
- https://github.com/redis/redis/actions/runs/32913727382/job/98012870155 (641 ms)

## Change

Add `assert_with_retry` and retry the test up to three times with a progressively longer TTL. Scale the final expiration wait with the successful attempt. Other timing-sensitive hash field expiration tests remain unchanged because we have not observed CI failures in those cases.


Thanks to Moti Cohen (@moticless) for suggesting the retry-based approach.
Co-authored-by: Moti Cohen <moticless@gmail.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to Tcl harness and one unit test; no server or persistence logic modified.
> 
> **Overview**
> Addresses flaky CI on **HPEXPIRETIME persists after RDB reload**, where a fixed **500 ms** field TTL could expire while **`DEBUG RELOAD`** runs on slow storage.
> 
> Adds **`assert_with_retry`** in `tests/support/test.tcl`: it re-runs a test body until an expression holds, up to **`max_iter`** times, with assertion-style failures and retry logging tied to **`$::cur_test`**.
> 
> The hash field expiration test now retries up to **three** times with **`ttl_ms = 500 * iter`**, and folds reload persistence checks (matching **`HPEXPIRETIME`**, **`field2`** without expiry, **`subexpiry`** stat) into the retry condition. Post-reload expiry waits are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33e0737aed1cc0cc499a2eabca056ea7a478474b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->