### PR TITLE
Fix reclaim-cache CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -551,12 +551,28 @@ jobs:
         vmtouch -v ./dump.rdb > /dev/null
     - name: test
       run: |
+        wait_for_redis() {
+          local port="$1"
+          for attempt in {1..100}; do
+            ./src/redis-cli -p "$port" ping 2>/dev/null | grep -q PONG && return 0
+            if [ "$attempt" -eq 100 ]; then
+              echo "Redis on port $port did not become ready"
+              return 1
+            fi
+            sleep 0.1
+          done
+        }
+
         echo "test SAVE doesn't increase cache"
         CACHE0=$(grep -w file /sys/fs/cgroup/memory.stat | awk '{print $2}')
         echo "$CACHE0"
         ./src/redis-server --daemonize yes --logfile /dev/null --dir /tmp/master --port 8080 --repl-diskless-sync no --pidfile /tmp/master/redis.pid --rdbcompression no --enable-debug-command yes
+        # Runtime TSC calibration can delay startup on x86, while the daemonized
+        # parent exits before the child listens. Wait before the first command.
+        wait_for_redis 8080
         ./src/redis-cli -p 8080 debug populate 10000 k 102400
         ./src/redis-server --daemonize yes --logfile /dev/null --dir /tmp/slave --port 8081 --repl-diskless-load disabled --rdbcompression no
+        wait_for_redis 8081
         ./src/redis-cli -p 8080 save > /dev/null
         VMOUT=$(vmtouch -v /tmp/master/dump.rdb)
         echo $VMOUT
@@ -584,6 +600,7 @@ jobs:
         kill -15 $PID
         while [ -x /proc/${PID} ]; do sleep 1; done
         ./src/redis-server --daemonize yes --logfile /dev/null --dir /tmp/master --port 8080
+        wait_for_redis 8080
         while [ $(./src/redis-cli -p 8080 info persistence | grep "loading:1") ]; do sleep 1; done;
         sleep 1 # wait for the completion of cache reclaim bio
         VMOUT=$(vmtouch -v /tmp/master/dump.rdb)

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -604,9 +604,16 @@ jobs:
         
         # The daemonized parent can exit before the child listens, so tolerate
         # connection failures until INFO is available, then wait for RDB loading.
-        while ! ./src/redis-cli -p 8080 info persistence 2>/dev/null |
-          grep "^loading:0" > /dev/null; do
+        for attempt in {1..600}; do
+          if ./src/redis-cli -p 8080 info persistence 2>/dev/null |
+            grep "^loading:0" > /dev/null; then
+            break
+          fi
           sleep 1
+          if [ "$attempt" -eq 600 ]; then
+            echo "Redis on port 8080 did not finish loading within 10 minutes"
+            exit 1
+          fi
         done
         sleep 1 # wait for the completion of cache reclaim bio
         

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -551,7 +551,7 @@ jobs:
         vmtouch -v ./dump.rdb > /dev/null
     - name: test
       run: |
-        wait_for_redis() {
+        wait_for_redis_start() {
           local port="$1"
           for attempt in {1..100}; do
             ./src/redis-cli -p "$port" ping 2>/dev/null | grep -q PONG && return 0
@@ -567,12 +567,13 @@ jobs:
         CACHE0=$(grep -w file /sys/fs/cgroup/memory.stat | awk '{print $2}')
         echo "$CACHE0"
         ./src/redis-server --daemonize yes --logfile /dev/null --dir /tmp/master --port 8080 --repl-diskless-sync no --pidfile /tmp/master/redis.pid --rdbcompression no --enable-debug-command yes
+        
         # Runtime TSC calibration can delay startup on x86, while the daemonized
         # parent exits before the child listens. Wait before the first command.
-        wait_for_redis 8080
+        wait_for_redis_start 8080
         ./src/redis-cli -p 8080 debug populate 10000 k 102400
         ./src/redis-server --daemonize yes --logfile /dev/null --dir /tmp/slave --port 8081 --repl-diskless-load disabled --rdbcompression no
-        wait_for_redis 8081
+        wait_for_redis_start 8081
         ./src/redis-cli -p 8080 save > /dev/null
         VMOUT=$(vmtouch -v /tmp/master/dump.rdb)
         echo $VMOUT
@@ -600,9 +601,15 @@ jobs:
         kill -15 $PID
         while [ -x /proc/${PID} ]; do sleep 1; done
         ./src/redis-server --daemonize yes --logfile /dev/null --dir /tmp/master --port 8080
-        wait_for_redis 8080
-        while [ $(./src/redis-cli -p 8080 info persistence | grep "loading:1") ]; do sleep 1; done;
+        
+        # The daemonized parent can exit before the child listens, so tolerate
+        # connection failures until INFO is available, then wait for RDB loading.
+        while ! ./src/redis-cli -p 8080 info persistence 2>/dev/null |
+          grep "^loading:0" > /dev/null; do
+          sleep 1
+        done
         sleep 1 # wait for the completion of cache reclaim bio
+        
         VMOUT=$(vmtouch -v /tmp/master/dump.rdb)
         echo $VMOUT
         grep -q " 0%" <<< $VMOUT

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -546,6 +546,16 @@ jobs:
     - name: warm up
       run: |
         ./src/redis-server --daemonize yes --logfile /dev/null
+        # Wait up to 10 seconds for the daemonized child to finish startup after its parent exit
+        for attempt in {1..100}; do
+          ./src/redis-cli ping 2>/dev/null | grep -q PONG && break
+          if [ "$attempt" -eq 100 ]; then
+            echo "Redis on port 6379 did not become ready"
+            exit 1
+          fi
+          sleep 0.1
+        done
+
         ./src/redis-benchmark -n 1 > /dev/null
         ./src/redis-cli save | grep OK > /dev/null
         vmtouch -v ./dump.rdb > /dev/null

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -5,8 +5,6 @@
 #include <time.h>
 #include "redisassert.h"
 #include <string.h>
-#include <errno.h>
-#include <limits.h>
 
 /* The function pointer for clock retrieval.  */
 monotime (*getMonotonicUs)(void) = NULL;
@@ -16,47 +14,13 @@ static char monotonic_info_string[32];
 
 /* Using the processor clock (aka TSC on x86) can provide improved performance
  * throughout Redis wherever the monotonic clock is used.  The processor clock
- * is significantly faster than calling 'clock_gettime' (POSIX).  While this is
+ * is significantly faster than calling 'clock_getting' (POSIX).  While this is
  * generally safe on modern systems, this link provides additional information
  * about use of the x86 TSC: http://oliveryang.net/2015/09/pitfalls-of-TSC-usage
  *
- * On x86_64 Linux the hardware clock is enabled by default, with two safety
- * gates and a layered frequency-detection chain.  The reasoning, for future
- * generations:
- *
- * Reliability: rather than replicating the kernel's knowledge of broken TSCs
- * (known-bad CPU quirk lists, boot-time sync tests, the clocksource watchdog
- * that demotes a TSC that drifts at runtime), we simply require that the
- * kernel's ACTIVE clocksource is "tsc".  Machines where Linux distrusts the
- * TSC never satisfy that, so they transparently stay on the POSIX clock.
- * 'constant_tsc' in /proc/cpuinfo is additionally required (fixed tick rate
- * regardless of frequency scaling).
- *
- * Speed vs the VDSO: clock_gettime(CLOCK_MONOTONIC) on a tsc clocksource is
- * a fast VDSO call (no context switch), but it still costs ~2-3x a raw
- * RDTSC: the seqlock-protected read of the timekeeper data, the mult/shift
- * conversion, ns scaling and the libc call.  The monotonic clock is read
- * several times per command, so the difference is measurable end-to-end
- * once the network stops being the bottleneck (measured on bare-metal
- * Sapphire Rapids at 1KiB SET/GET, 2000 connections: +7-9% throughput at
- * 8-16 io-threads; flat at 0-4 io-threads, which are network-bound).
- *
- * Tick rate: the frequency advertised in the "model name" cpuinfo string is
- * the marketing value and can differ from the real TSC rate by a few tenths
- * of a percent (e.g. a "2.30GHz" part whose TSC ticks at ~2294 MHz) — a rate
- * error that size skews every measured duration and accumulates as drift.
- * The kernel measures the true rate at boot, but does not expose it to
- * userspace on mainline; the tsc_freq_khz sysfs file IS that kernel-measured
- * value on kernels that carry the patch.  Calibrating RDTSC against
- * CLOCK_MONOTONIC recovers the same kernel-measured rate indirectly, because
- * with a tsc clocksource CLOCK_MONOTONIC itself advances at the kernel's
- * calibrated TSC frequency.  Hence the chain: model-name parse, validated
- * against one measured sample (calibration wins when they disagree beyond
- * noise), then tsc_freq_khz, then median-of-3 calibration.
- *
  * On ARM aarch64 systems, the hardware clock is enabled by default because the
  * ARM Generic Timer is architecturally guaranteed to be available and monotonic
- * on all ARMv8-A processors (see the "The Generic Timer in AArch64 state"
+ * on all ARMv8-A processors (see the “The Generic Timer in AArch64 state”
  * section of the Arm Architecture Reference Manual for Armv8-A).
  *
  * To use the processor clock on other architectures, either uncomment this line,
@@ -66,7 +30,7 @@ static char monotonic_info_string[32];
  */
 
 
-#if defined(__x86_64__) && defined(__linux__)
+#if defined(USE_PROCESSOR_CLOCK) && defined(__x86_64__) && defined(__linux__)
 #include <regex.h>
 #include <x86intrin.h>
 
@@ -76,49 +40,6 @@ static monotime getMonotonicUs_x86(void) {
     return __rdtsc() / mono_ticksPerMicrosecond;
 }
 
-/* One calibration measurement: RDTSC ticks across a ~10ms nanosleep, bounded
- * by CLOCK_MONOTONIC readings.  Returns ticks-per-microsecond, or 0 on any
- * failure (clock error, non-monotonic TSC sample pair).  */
-static long monotonicCalibrateOnce_x86linux(void) {
-    struct timespec ts_start, ts_end;
-    uint64_t tsc_start, tsc_end;
-
-    if (clock_gettime(CLOCK_MONOTONIC, &ts_start) != 0) return 0;
-    tsc_start = __rdtsc();
-
-    /* Sleep ~10 ms to accumulate enough ticks for an accurate measurement.
-     * Retry on EINTR to ensure we get a meaningful interval. */
-    struct timespec req = {0, 10000000}, rem;
-    while (nanosleep(&req, &rem) != 0) {
-        if (errno != EINTR) return 0;
-        req = rem;
-    }
-
-    if (clock_gettime(CLOCK_MONOTONIC, &ts_end) != 0) return 0;
-    tsc_end = __rdtsc();
-
-    long long elapsed_ns = (long long)(ts_end.tv_sec - ts_start.tv_sec) * 1000000000LL
-                         + (ts_end.tv_nsec - ts_start.tv_nsec);
-    if (elapsed_ns <= 0) return 0;
-
-    /* Invariant TSC on modern x86 is guaranteed to be monotonic across a
-     * single core's context, but migration across sockets/cores with
-     * misaligned TSC, virtualisation, or firmware quirks can still produce
-     * a non-monotonic sample pair. Subtracting uint64_t in that case would
-     * wrap to a huge value and yield a nonsense tick rate, so reject the
-     * sample. */
-    if (tsc_end <= tsc_start) return 0;
-
-    /* ticks_per_us = total_ticks / total_microseconds
-     * Multiply first to preserve precision, then divide. */
-    return (long)((tsc_end - tsc_start) * 1000 / elapsed_ns);
-}
-
-static int longcmp(const void *a, const void *b) {
-    long la = *(const long *)a, lb = *(const long *)b;
-    return (la > lb) - (la < lb);
-}
-
 static void monotonicInit_x86linux(void) {
     const int bufflen = 256;
     char buf[bufflen];
@@ -126,124 +47,48 @@ static void monotonicInit_x86linux(void) {
     const size_t nmatch = 2;
     regmatch_t pmatch[nmatch];
     int constantTsc = 0;
-    long nominal_model = 0;
     int rc;
 
-    /* Only use the TSC directly when the kernel itself trusts it: the active
-     * clocksource is "tsc" exactly when Linux has verified the TSC is stable
-     * on this machine (CPUs with known-unreliable TSCs, or a TSC the kernel
-     * watchdog has marked unstable, never get it).  This defers the
-     * reliability decision to the kernel instead of re-deriving it here.  */
-    FILE *cs = fopen("/sys/devices/system/clocksource/clocksource0/current_clocksource", "r");
-    if (cs == NULL || fgets(buf, bufflen, cs) == NULL || strncmp(buf, "tsc", 3) != 0) {
-        if (cs) fclose(cs);
-        fprintf(stderr, "monotonic: x86 linux, kernel clocksource is not 'tsc'\n");
-        return;
-    }
-    fclose(cs);
-
-    /* Determine the number of TSC ticks in a micro-second from the CPU model
-     * name.  This is a constant value matching the standard speed of the
-     * processor.  On modern processors, this speed remains constant even
-     * though the actual clock speed varies dynamically for each core.  */
+    /* Determine the number of TSC ticks in a micro-second.  This is
+     * a constant value matching the standard speed of the processor.
+     * On modern processors, this speed remains constant even though
+     * the actual clock speed varies dynamically for each core.  */
     rc = regcomp(&cpuGhzRegex, "^model name\\s+:.*@ ([0-9.]+)GHz", REG_EXTENDED);
     assert(rc == 0);
 
-    /* Also check that the constant_tsc flag is present.  This ensures the TSC
-     * runs at a fixed rate regardless of CPU frequency scaling.  Without it,
-     * the TSC is unreliable for timekeeping.  */
+    /* Also check that the constant_tsc flag is present.  (It should be
+     * unless this is a really old CPU.  */
     rc = regcomp(&constTscRegex, "^flags\\s+:.* constant_tsc", REG_EXTENDED);
     assert(rc == 0);
 
     FILE *cpuinfo = fopen("/proc/cpuinfo", "r");
     if (cpuinfo != NULL) {
         while (fgets(buf, bufflen, cpuinfo) != NULL) {
-            if (nominal_model == 0 &&
-                regexec(&cpuGhzRegex, buf, nmatch, pmatch, 0) == 0) {
+            if (regexec(&cpuGhzRegex, buf, nmatch, pmatch, 0) == 0) {
                 buf[pmatch[1].rm_eo] = '\0';
                 double ghz = atof(&buf[pmatch[1].rm_so]);
-                nominal_model = (long)(ghz * 1000);
+                mono_ticksPerMicrosecond = (long)(ghz * 1000);
+                break;
             }
-            if (!constantTsc &&
-                regexec(&constTscRegex, buf, 0, NULL, 0) == 0) {
-                constantTsc = 1;
-            }
-            if (nominal_model != 0 && constantTsc) break;
         }
+        while (fgets(buf, bufflen, cpuinfo) != NULL) {
+            if (regexec(&constTscRegex, buf, nmatch, pmatch, 0) == 0) {
+                constantTsc = 1;
+                break;
+            }
+        }
+
         fclose(cpuinfo);
     }
     regfree(&cpuGhzRegex);
     regfree(&constTscRegex);
 
-    if (!constantTsc) {
-        fprintf(stderr, "monotonic: x86 linux, 'constant_tsc' flag not present\n");
-        return;
-    }
-
-    /* Source 1: the kernel-measured TSC frequency, on kernels that expose it.
-     * This is the ground-truth rate (what the kernel itself uses for
-     * timekeeping), so when present it wins outright and needs no
-     * validation.  */
-    FILE *khz = fopen("/sys/devices/system/cpu/cpu0/tsc_freq_khz", "r");
-    if (khz != NULL) {
-        long tsc_khz = 0;
-        if (fscanf(khz, "%ld", &tsc_khz) == 1 && tsc_khz > 0)
-            mono_ticksPerMicrosecond = tsc_khz / 1000;
-        fclose(khz);
-    }
-
-    /* Source 2: the frequency advertised in the model name, cross-checked
-     * against one measurement.  The advertised frequency is the marketing
-     * value and the real TSC rate can differ by a few tenths of a percent
-     * (e.g. a "2.30GHz" part whose TSC ticks at ~2294 MHz); a rate error
-     * that size makes every measured duration proportionally wrong and
-     * accumulates as drift.  The nominal value is used only when a measured
-     * sample confirms it within calibration noise; on disagreement OR when
-     * no valid measurement could be taken, fall through to full
-     * calibration.  */
-    if (mono_ticksPerMicrosecond == 0 && nominal_model != 0) {
-        long measured = monotonicCalibrateOnce_x86linux();
-        /* measured <= 0 means calibration itself failed (non-monotonic
-         * sample pair) -- treat that the same as "unconfirmed" and fall
-         * through, rather than encoding failure as a sentinel that then
-         * participates in the diff*1000 multiplication below (which can
-         * overflow a signed long and is undefined behavior in C). */
-        if (measured > 0 && labs(measured - nominal_model) * 1000 <= nominal_model) { /* within 0.1% */
-            mono_ticksPerMicrosecond = nominal_model;
-        } else {
-            fprintf(stderr, "monotonic: x86 linux, advertised clock rate "
-                    "(%ld ticks/us) unconfirmed by the measured rate "
-                    "(%ld ticks/us), using calibration\n",
-                    nominal_model, measured);
-        }
-    }
-
-    /* Source 3 (last resort): runtime calibration — measure RDTSC ticks over a known
-     * CLOCK_MONOTONIC interval.  A single measurement can be perturbed by a
-     * context switch between the clock read and the TSC read, so take three
-     * and use the median.  */
-    if (mono_ticksPerMicrosecond == 0) {
-        long samples[3];
-        int valid = 0;
-        for (int i = 0; i < 3; i++) {
-            long s = monotonicCalibrateOnce_x86linux();
-            if (s > 0) samples[valid++] = s;
-        }
-        if (valid > 0) {
-            qsort(samples, valid, sizeof(long), longcmp);
-            /* Median for odd counts; mean of the two central samples when an
-             * even number survived (with exactly two, samples[valid/2] alone
-             * would systematically pick the higher one). */
-            if (valid % 2 == 0)
-                mono_ticksPerMicrosecond =
-                    (samples[valid/2 - 1] + samples[valid/2]) / 2;
-            else
-                mono_ticksPerMicrosecond = samples[valid/2];
-        }
-    }
-
     if (mono_ticksPerMicrosecond == 0) {
         fprintf(stderr, "monotonic: x86 linux, unable to determine clock rate\n");
+        return;
+    }
+    if (!constantTsc) {
+        fprintf(stderr, "monotonic: x86 linux, 'constant_tsc' flag not present\n");
         return;
     }
 
@@ -374,7 +219,7 @@ static void monotonicInit_posix(void) {
 
 
 const char * monotonicInit(void) {
-    #if defined(__x86_64__) && defined(__linux__)
+    #if defined(USE_PROCESSOR_CLOCK) && defined(__x86_64__) && defined(__linux__)
     if (getMonotonicUs == NULL) monotonicInit_x86linux();
     #endif
 

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -5,6 +5,8 @@
 #include <time.h>
 #include "redisassert.h"
 #include <string.h>
+#include <errno.h>
+#include <limits.h>
 
 /* The function pointer for clock retrieval.  */
 monotime (*getMonotonicUs)(void) = NULL;
@@ -14,13 +16,47 @@ static char monotonic_info_string[32];
 
 /* Using the processor clock (aka TSC on x86) can provide improved performance
  * throughout Redis wherever the monotonic clock is used.  The processor clock
- * is significantly faster than calling 'clock_getting' (POSIX).  While this is
+ * is significantly faster than calling 'clock_gettime' (POSIX).  While this is
  * generally safe on modern systems, this link provides additional information
  * about use of the x86 TSC: http://oliveryang.net/2015/09/pitfalls-of-TSC-usage
  *
+ * On x86_64 Linux the hardware clock is enabled by default, with two safety
+ * gates and a layered frequency-detection chain.  The reasoning, for future
+ * generations:
+ *
+ * Reliability: rather than replicating the kernel's knowledge of broken TSCs
+ * (known-bad CPU quirk lists, boot-time sync tests, the clocksource watchdog
+ * that demotes a TSC that drifts at runtime), we simply require that the
+ * kernel's ACTIVE clocksource is "tsc".  Machines where Linux distrusts the
+ * TSC never satisfy that, so they transparently stay on the POSIX clock.
+ * 'constant_tsc' in /proc/cpuinfo is additionally required (fixed tick rate
+ * regardless of frequency scaling).
+ *
+ * Speed vs the VDSO: clock_gettime(CLOCK_MONOTONIC) on a tsc clocksource is
+ * a fast VDSO call (no context switch), but it still costs ~2-3x a raw
+ * RDTSC: the seqlock-protected read of the timekeeper data, the mult/shift
+ * conversion, ns scaling and the libc call.  The monotonic clock is read
+ * several times per command, so the difference is measurable end-to-end
+ * once the network stops being the bottleneck (measured on bare-metal
+ * Sapphire Rapids at 1KiB SET/GET, 2000 connections: +7-9% throughput at
+ * 8-16 io-threads; flat at 0-4 io-threads, which are network-bound).
+ *
+ * Tick rate: the frequency advertised in the "model name" cpuinfo string is
+ * the marketing value and can differ from the real TSC rate by a few tenths
+ * of a percent (e.g. a "2.30GHz" part whose TSC ticks at ~2294 MHz) — a rate
+ * error that size skews every measured duration and accumulates as drift.
+ * The kernel measures the true rate at boot, but does not expose it to
+ * userspace on mainline; the tsc_freq_khz sysfs file IS that kernel-measured
+ * value on kernels that carry the patch.  Calibrating RDTSC against
+ * CLOCK_MONOTONIC recovers the same kernel-measured rate indirectly, because
+ * with a tsc clocksource CLOCK_MONOTONIC itself advances at the kernel's
+ * calibrated TSC frequency.  Hence the chain: model-name parse, validated
+ * against one measured sample (calibration wins when they disagree beyond
+ * noise), then tsc_freq_khz, then median-of-3 calibration.
+ *
  * On ARM aarch64 systems, the hardware clock is enabled by default because the
  * ARM Generic Timer is architecturally guaranteed to be available and monotonic
- * on all ARMv8-A processors (see the “The Generic Timer in AArch64 state”
+ * on all ARMv8-A processors (see the "The Generic Timer in AArch64 state"
  * section of the Arm Architecture Reference Manual for Armv8-A).
  *
  * To use the processor clock on other architectures, either uncomment this line,
@@ -30,7 +66,7 @@ static char monotonic_info_string[32];
  */
 
 
-#if defined(USE_PROCESSOR_CLOCK) && defined(__x86_64__) && defined(__linux__)
+#if defined(__x86_64__) && defined(__linux__)
 #include <regex.h>
 #include <x86intrin.h>
 
@@ -40,6 +76,49 @@ static monotime getMonotonicUs_x86(void) {
     return __rdtsc() / mono_ticksPerMicrosecond;
 }
 
+/* One calibration measurement: RDTSC ticks across a ~10ms nanosleep, bounded
+ * by CLOCK_MONOTONIC readings.  Returns ticks-per-microsecond, or 0 on any
+ * failure (clock error, non-monotonic TSC sample pair).  */
+static long monotonicCalibrateOnce_x86linux(void) {
+    struct timespec ts_start, ts_end;
+    uint64_t tsc_start, tsc_end;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts_start) != 0) return 0;
+    tsc_start = __rdtsc();
+
+    /* Sleep ~10 ms to accumulate enough ticks for an accurate measurement.
+     * Retry on EINTR to ensure we get a meaningful interval. */
+    struct timespec req = {0, 10000000}, rem;
+    while (nanosleep(&req, &rem) != 0) {
+        if (errno != EINTR) return 0;
+        req = rem;
+    }
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts_end) != 0) return 0;
+    tsc_end = __rdtsc();
+
+    long long elapsed_ns = (long long)(ts_end.tv_sec - ts_start.tv_sec) * 1000000000LL
+                         + (ts_end.tv_nsec - ts_start.tv_nsec);
+    if (elapsed_ns <= 0) return 0;
+
+    /* Invariant TSC on modern x86 is guaranteed to be monotonic across a
+     * single core's context, but migration across sockets/cores with
+     * misaligned TSC, virtualisation, or firmware quirks can still produce
+     * a non-monotonic sample pair. Subtracting uint64_t in that case would
+     * wrap to a huge value and yield a nonsense tick rate, so reject the
+     * sample. */
+    if (tsc_end <= tsc_start) return 0;
+
+    /* ticks_per_us = total_ticks / total_microseconds
+     * Multiply first to preserve precision, then divide. */
+    return (long)((tsc_end - tsc_start) * 1000 / elapsed_ns);
+}
+
+static int longcmp(const void *a, const void *b) {
+    long la = *(const long *)a, lb = *(const long *)b;
+    return (la > lb) - (la < lb);
+}
+
 static void monotonicInit_x86linux(void) {
     const int bufflen = 256;
     char buf[bufflen];
@@ -47,48 +126,124 @@ static void monotonicInit_x86linux(void) {
     const size_t nmatch = 2;
     regmatch_t pmatch[nmatch];
     int constantTsc = 0;
+    long nominal_model = 0;
     int rc;
 
-    /* Determine the number of TSC ticks in a micro-second.  This is
-     * a constant value matching the standard speed of the processor.
-     * On modern processors, this speed remains constant even though
-     * the actual clock speed varies dynamically for each core.  */
+    /* Only use the TSC directly when the kernel itself trusts it: the active
+     * clocksource is "tsc" exactly when Linux has verified the TSC is stable
+     * on this machine (CPUs with known-unreliable TSCs, or a TSC the kernel
+     * watchdog has marked unstable, never get it).  This defers the
+     * reliability decision to the kernel instead of re-deriving it here.  */
+    FILE *cs = fopen("/sys/devices/system/clocksource/clocksource0/current_clocksource", "r");
+    if (cs == NULL || fgets(buf, bufflen, cs) == NULL || strncmp(buf, "tsc", 3) != 0) {
+        if (cs) fclose(cs);
+        fprintf(stderr, "monotonic: x86 linux, kernel clocksource is not 'tsc'\n");
+        return;
+    }
+    fclose(cs);
+
+    /* Determine the number of TSC ticks in a micro-second from the CPU model
+     * name.  This is a constant value matching the standard speed of the
+     * processor.  On modern processors, this speed remains constant even
+     * though the actual clock speed varies dynamically for each core.  */
     rc = regcomp(&cpuGhzRegex, "^model name\\s+:.*@ ([0-9.]+)GHz", REG_EXTENDED);
     assert(rc == 0);
 
-    /* Also check that the constant_tsc flag is present.  (It should be
-     * unless this is a really old CPU.  */
+    /* Also check that the constant_tsc flag is present.  This ensures the TSC
+     * runs at a fixed rate regardless of CPU frequency scaling.  Without it,
+     * the TSC is unreliable for timekeeping.  */
     rc = regcomp(&constTscRegex, "^flags\\s+:.* constant_tsc", REG_EXTENDED);
     assert(rc == 0);
 
     FILE *cpuinfo = fopen("/proc/cpuinfo", "r");
     if (cpuinfo != NULL) {
         while (fgets(buf, bufflen, cpuinfo) != NULL) {
-            if (regexec(&cpuGhzRegex, buf, nmatch, pmatch, 0) == 0) {
+            if (nominal_model == 0 &&
+                regexec(&cpuGhzRegex, buf, nmatch, pmatch, 0) == 0) {
                 buf[pmatch[1].rm_eo] = '\0';
                 double ghz = atof(&buf[pmatch[1].rm_so]);
-                mono_ticksPerMicrosecond = (long)(ghz * 1000);
-                break;
+                nominal_model = (long)(ghz * 1000);
             }
-        }
-        while (fgets(buf, bufflen, cpuinfo) != NULL) {
-            if (regexec(&constTscRegex, buf, nmatch, pmatch, 0) == 0) {
+            if (!constantTsc &&
+                regexec(&constTscRegex, buf, 0, NULL, 0) == 0) {
                 constantTsc = 1;
-                break;
             }
+            if (nominal_model != 0 && constantTsc) break;
         }
-
         fclose(cpuinfo);
     }
     regfree(&cpuGhzRegex);
     regfree(&constTscRegex);
 
-    if (mono_ticksPerMicrosecond == 0) {
-        fprintf(stderr, "monotonic: x86 linux, unable to determine clock rate\n");
-        return;
-    }
     if (!constantTsc) {
         fprintf(stderr, "monotonic: x86 linux, 'constant_tsc' flag not present\n");
+        return;
+    }
+
+    /* Source 1: the kernel-measured TSC frequency, on kernels that expose it.
+     * This is the ground-truth rate (what the kernel itself uses for
+     * timekeeping), so when present it wins outright and needs no
+     * validation.  */
+    FILE *khz = fopen("/sys/devices/system/cpu/cpu0/tsc_freq_khz", "r");
+    if (khz != NULL) {
+        long tsc_khz = 0;
+        if (fscanf(khz, "%ld", &tsc_khz) == 1 && tsc_khz > 0)
+            mono_ticksPerMicrosecond = tsc_khz / 1000;
+        fclose(khz);
+    }
+
+    /* Source 2: the frequency advertised in the model name, cross-checked
+     * against one measurement.  The advertised frequency is the marketing
+     * value and the real TSC rate can differ by a few tenths of a percent
+     * (e.g. a "2.30GHz" part whose TSC ticks at ~2294 MHz); a rate error
+     * that size makes every measured duration proportionally wrong and
+     * accumulates as drift.  The nominal value is used only when a measured
+     * sample confirms it within calibration noise; on disagreement OR when
+     * no valid measurement could be taken, fall through to full
+     * calibration.  */
+    if (mono_ticksPerMicrosecond == 0 && nominal_model != 0) {
+        long measured = monotonicCalibrateOnce_x86linux();
+        /* measured <= 0 means calibration itself failed (non-monotonic
+         * sample pair) -- treat that the same as "unconfirmed" and fall
+         * through, rather than encoding failure as a sentinel that then
+         * participates in the diff*1000 multiplication below (which can
+         * overflow a signed long and is undefined behavior in C). */
+        if (measured > 0 && labs(measured - nominal_model) * 1000 <= nominal_model) { /* within 0.1% */
+            mono_ticksPerMicrosecond = nominal_model;
+        } else {
+            fprintf(stderr, "monotonic: x86 linux, advertised clock rate "
+                    "(%ld ticks/us) unconfirmed by the measured rate "
+                    "(%ld ticks/us), using calibration\n",
+                    nominal_model, measured);
+        }
+    }
+
+    /* Source 3 (last resort): runtime calibration — measure RDTSC ticks over a known
+     * CLOCK_MONOTONIC interval.  A single measurement can be perturbed by a
+     * context switch between the clock read and the TSC read, so take three
+     * and use the median.  */
+    if (mono_ticksPerMicrosecond == 0) {
+        long samples[3];
+        int valid = 0;
+        for (int i = 0; i < 3; i++) {
+            long s = monotonicCalibrateOnce_x86linux();
+            if (s > 0) samples[valid++] = s;
+        }
+        if (valid > 0) {
+            qsort(samples, valid, sizeof(long), longcmp);
+            /* Median for odd counts; mean of the two central samples when an
+             * even number survived (with exactly two, samples[valid/2] alone
+             * would systematically pick the higher one). */
+            if (valid % 2 == 0)
+                mono_ticksPerMicrosecond =
+                    (samples[valid/2 - 1] + samples[valid/2]) / 2;
+            else
+                mono_ticksPerMicrosecond = samples[valid/2];
+        }
+    }
+
+    if (mono_ticksPerMicrosecond == 0) {
+        fprintf(stderr, "monotonic: x86 linux, unable to determine clock rate\n");
         return;
     }
 
@@ -219,7 +374,7 @@ static void monotonicInit_posix(void) {
 
 
 const char * monotonicInit(void) {
-    #if defined(USE_PROCESSOR_CLOCK) && defined(__x86_64__) && defined(__linux__)
+    #if defined(__x86_64__) && defined(__linux__)
     if (getMonotonicUs == NULL) monotonicInit_x86linux();
     #endif
 


### PR DESCRIPTION

### Issue 

Failed Redis CI: https://github.com/redis/redis/actions/runs/32913727382/job/98012870180
>test SAVE doesn't increase cache
3468541952
Could not connect to Redis at 127.0.0.1:8080: Connection refused
Error: Process completed with exit code 1.



With --daemonize the launcher exits immediately after forking, before the Redis child may have started listening. 
```shell
The shell starts redis-server
        |
        v
The redis-server parent process calls fork()
        |
        +-- The parent process immediately calls exit(0)
        |   The shell considers the startup command successful
        |
        +-- The child process continues running
            calls setsid()
            initializes Redis
            performs TSC calibration
            creates the listening socket
            starts accepting connections
```

TSC calibration(https://github.com/redis/redis/pull/15018) delays the redis child from listening. The daemonized parent exits before that initialization completes, so test-ubuntu-reclaim-cache may connect too early and fail with Connection refused.

### Test

Revert PR #15018 makes CI passed: https://github.com/vitahlin/redis/actions/runs/32956610373
CI result of this PR: https://github.com/vitahlin/redis/actions/runs/32959353087

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only shell changes in one daily workflow job; no Redis server or runtime behavior changes.
> 
> **Overview**
> Fixes flaky **test-ubuntu-reclaim-cache** failures (`Connection refused` on ports 8080/8081) by not assuming `--daemonize` means the server is ready to accept clients.
> 
> The workflow now **polls until `redis-cli ping` returns PONG** after startup: inline in the warm-up step for the default instance, and via a new `wait_for_redis_start` helper before master (8080) and replica (8081) commands. Comments call out that the daemon parent can exit before the child finishes init (e.g. x86 TSC calibration).
> 
> For the **reboot** scenario, the old loop that assumed immediate `INFO` connectivity while `loading:1` is replaced with a retry loop that ignores connection errors until `INFO persistence` reports `loading:0`, with a 10-minute cap and an explicit timeout error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b9b25d55da74c7d9c7787e9b7c5ae39db9ec285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->