### PR TITLE
Stabilize ASM write pause timeout test under TSan

### DIFF
--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1456,8 +1456,13 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     }
 
     test "Source write pause timeout" {
+        set prev_config_lag [lindex [R 0 config get cluster-slot-migration-handoff-max-lag-bytes] 1]
+
         # set timeout to 0, so the task will fail immediately when checking timeout
         R 0 config set cluster-slot-migration-write-pause-timeout 0
+        # The destination cron will be paused before migration starts, so its first
+        # ACK must enter handoff even when TSan increases the accumulated stream lag.
+        R 0 config set cluster-slot-migration-handoff-max-lag-bytes 9223372036854775807
         R 1 debug asm-failpoint "import-main-channel" "takeover"
         R 1 debug pause-cron 1 ;# prevent retrying the failed import task
 
@@ -1474,13 +1479,14 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             [string match {*Write pause timeout*} \
                 [migration_status 0 $task_id last_error]]
         } else {
-            fail "ASM task did not fail"
+            fail "ASM task did not fail: source=[migration_status 0 $task_id state], destination=[migration_status 1 $task_id state]"
         }
 
         stop_write_load $load_handle
 
         # reset config
         R 0 config set cluster-slot-migration-write-pause-timeout 10000
+        R 0 config set cluster-slot-migration-handoff-max-lag-bytes $prev_config_lag
         R 0 cluster migration cancel id $task_id
         R 1 cluster migration cancel id $task_id
         R 1 debug asm-failpoint "" ""

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1460,9 +1460,9 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # set timeout to 0, so the task will fail immediately when checking timeout
         R 0 config set cluster-slot-migration-write-pause-timeout 0
-        # The destination cron will be paused before migration starts, so its first
-        # ACK must enter handoff even when TSan increases the accumulated stream lag.
-        R 0 config set cluster-slot-migration-handoff-max-lag-bytes 9223372036854775807
+        # The destination cron will be paused before migration starts. Increase the
+        # lag threshold so its first ACK can enter handoff under TSan's slower timing.
+        R 0 config set cluster-slot-migration-handoff-max-lag-bytes 100mb
         R 1 debug asm-failpoint "import-main-channel" "takeover"
         R 1 debug pause-cron 1 ;# prevent retrying the failed import task
 


### PR DESCRIPTION
`Source write pause timeout` pauses the destination cron before migration. Under TSan, the first ACK may leave more than the default 1 MB lag, and no later ACK advances the source from `send-stream` to `handoff`, so the test times out.

Failed CI: https://github.com/redis/redis/actions/runs/33029611842/job/98378830891

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to cluster ASM Tcl; no production code or migration behavior is modified.
> 
> **Overview**
> The **Source write pause timeout** integration test was flaky under Thread Sanitizer because pausing the destination cron can leave replication lag above the default **1 MB** handoff threshold on the first ACK, so the source never reaches **handoff** and the wait for **Write pause timeout** expires instead.
> 
> The test now temporarily raises **`cluster-slot-migration-handoff-max-lag-bytes`** to **100mb** (and restores the prior value after the run), matching the approach used elsewhere in `atomic-slot-migration.tcl` for TSan. The failure message on timeout now includes **source and destination** migration task states for easier CI debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9620d82a39e5964980da86fcf785488ce1b91ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->