### PR TITLE
Avoid flaky timing-sensitive asserts in hash field-expiration tests

### DIFF
--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -3,7 +3,6 @@ set ::num_passed 0
 set ::num_failed 0
 set ::num_skipped 0
 set ::num_aborted 0
-set ::num_timing_skips 0
 set ::tests_failed {}
 set ::cur_test ""
 
@@ -149,29 +148,35 @@ proc wait_for_condition {maxtries delay e _else_ elsescript} {
     }
 }
 
-# Run 'body', then evaluate 'condition' (always executed, regardless of
-# timing, so any reads/commands it contains always happen - chain multiple
-# checks with && if needed). The result is only asserted to be true if the
-# total time elapsed since 'body' started - including evaluating
-# 'condition' - is within 'limit_ms' milliseconds. This lets a test exercise
-# the same code path on every run, while only failing when a short-lived
-# condition (e.g. a TTL) is guaranteed not to have already changed due to a
-# slow environment.
-proc assert_within_time_limit {limit_ms body condition} {
-    set start [clock milliseconds]
-    uplevel 1 $body
-    set result [uplevel 1 [list expr $condition]]
-    set elapsed [expr {[clock milliseconds] - $start}]
-    if {$elapsed >= $limit_ms} {
-        incr ::num_timing_skips
-        set msg "$::cur_test (elapsed ${elapsed}ms >= limit ${limit_ms}ms)"
-        puts "Warning: assert_within_time_limit skipped verification: $msg"
-        catch {send_data_packet $::test_server_fd timing_skip $msg}
-        return
-    }
-    if {!$result} {
-        set context "(context: [info frame -1])"
-        error "assertion:Expected [uplevel 1 [list subst -nocommands $condition]] $context (elapsed: ${elapsed}ms)"
+# Run 'body', then check each expr in 'conditions', retrying (incrementing
+# '$iter_var' each time) up to 'max_iter'. 'body' must be self-contained and
+# scale its timing off '$iter_var' (e.g. `set ttl_ms [expr {20*$iter}]`), so
+# a slow environment gets more slack instead of a false failure, while a
+# genuine bug still fails at 'max_iter'. Listing several 'conditions'
+# instead of one '&&'-chained expr names exactly which check(s) failed.
+proc assert_with_retry {max_iter iter_var body conditions} {
+    upvar 1 $iter_var iter
+    set iter 1
+    while 1 {
+        uplevel 1 $body
+        set failed {}
+        foreach condition $conditions {
+            if {![uplevel 1 [list expr $condition]]} {
+                lappend failed $condition
+            }
+        }
+        if {[llength $failed] == 0} {
+            return
+        }
+        if {$iter >= $max_iter} {
+            set context "(context: [info frame -1])"
+            set details {}
+            foreach condition $failed {
+                lappend details "Expected [uplevel 1 [list subst -nocommands $condition]]"
+            }
+            error "assertion:[join $details {, }] $context (gave up after ${iter}x, max ${max_iter}x)"
+        }
+        incr iter
     }
 }
 

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -3,6 +3,7 @@ set ::num_passed 0
 set ::num_failed 0
 set ::num_skipped 0
 set ::num_aborted 0
+set ::num_timing_skips 0
 set ::tests_failed {}
 set ::cur_test ""
 
@@ -145,6 +146,32 @@ proc wait_for_condition {maxtries delay e _else_ elsescript} {
     if {$maxtries == -1} {
         set errcode [catch {uplevel 1 $elsescript} result]
         return -code $errcode $result
+    }
+}
+
+# Run 'body', then evaluate 'condition' (always executed, regardless of
+# timing, so any reads/commands it contains always happen - chain multiple
+# checks with && if needed). The result is only asserted to be true if the
+# total time elapsed since 'body' started - including evaluating
+# 'condition' - is within 'limit_ms' milliseconds. This lets a test exercise
+# the same code path on every run, while only failing when a short-lived
+# condition (e.g. a TTL) is guaranteed not to have already changed due to a
+# slow environment.
+proc assert_within_time_limit {limit_ms body condition} {
+    set start [clock milliseconds]
+    uplevel 1 $body
+    set result [uplevel 1 [list expr $condition]]
+    set elapsed [expr {[clock milliseconds] - $start}]
+    if {$elapsed >= $limit_ms} {
+        incr ::num_timing_skips
+        set msg "$::cur_test (elapsed ${elapsed}ms >= limit ${limit_ms}ms)"
+        puts "Warning: assert_within_time_limit skipped verification: $msg"
+        catch {send_data_packet $::test_server_fd timing_skip $msg}
+        return
+    }
+    if {!$result} {
+        set context "(context: [info frame -1])"
+        error "assertion:Expected [uplevel 1 [list subst -nocommands $condition]] $context (elapsed: ${elapsed}ms)"
     }
 }
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -310,6 +310,7 @@ proc test_server_main {} {
     array set ::clients_start_time {}
     set ::clients_time_history {}
     set ::failed_tests {}
+    set ::timing_skips {}
 
     # Enter the event loop to handle clients I/O
     after 100 test_server_cron
@@ -353,6 +354,8 @@ proc accept_test_clients {fd addr port} {
 # exception: there was a runtime exception while executing the test.
 # done: all the specified test file was processed, this test client is
 #       ready to accept a new task.
+# timing_skip: a timing-sensitive assertion (assert_within_time_limit) was
+#              skipped because the environment was too slow.
 proc read_from_test_client fd {
     set bytes [gets $fd]
     set payload [encoding convertfrom utf-8 [read $fd $bytes]]
@@ -413,6 +416,9 @@ proc read_from_test_client fd {
     } elseif {$status eq {server-killed}} {
         set ::active_servers [lsearch -all -inline -not -exact $::active_servers $data]
         set ::active_clients_task($fd) "(KILLED SERVER) pid:$data"
+    } elseif {$status eq {timing_skip}} {
+        puts "\[[colorstr yellow $status]\]: $data"
+        lappend ::timing_skips $data
     } elseif {$status eq {run_solo}} {
         lappend ::run_solo_tests $data
     } else {
@@ -506,6 +512,12 @@ proc the_end {} {
     puts "Execution time of different units:"
     foreach {time name} $::clients_time_history {
         puts "  $time seconds - $name"
+    }
+    if {[llength $::timing_skips]} {
+        puts "\n[colorstr bold-yellow {!!! NOTICE}] [llength $::timing_skips] timing-sensitive check(s) were skipped due to a slow environment:\n"
+        foreach skip $::timing_skips {
+            puts "*** $skip"
+        }
     }
     if {[llength $::failed_tests]} {
         puts "\n[colorstr bold-red {!!! WARNING}] The following tests failed:\n"

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -310,7 +310,6 @@ proc test_server_main {} {
     array set ::clients_start_time {}
     set ::clients_time_history {}
     set ::failed_tests {}
-    set ::timing_skips {}
 
     # Enter the event loop to handle clients I/O
     after 100 test_server_cron
@@ -354,8 +353,6 @@ proc accept_test_clients {fd addr port} {
 # exception: there was a runtime exception while executing the test.
 # done: all the specified test file was processed, this test client is
 #       ready to accept a new task.
-# timing_skip: a timing-sensitive assertion (assert_within_time_limit) was
-#              skipped because the environment was too slow.
 proc read_from_test_client fd {
     set bytes [gets $fd]
     set payload [encoding convertfrom utf-8 [read $fd $bytes]]
@@ -416,9 +413,6 @@ proc read_from_test_client fd {
     } elseif {$status eq {server-killed}} {
         set ::active_servers [lsearch -all -inline -not -exact $::active_servers $data]
         set ::active_clients_task($fd) "(KILLED SERVER) pid:$data"
-    } elseif {$status eq {timing_skip}} {
-        puts "\[[colorstr yellow $status]\]: $data"
-        lappend ::timing_skips $data
     } elseif {$status eq {run_solo}} {
         lappend ::run_solo_tests $data
     } else {
@@ -512,12 +506,6 @@ proc the_end {} {
     puts "Execution time of different units:"
     foreach {time name} $::clients_time_history {
         puts "  $time seconds - $name"
-    }
-    if {[llength $::timing_skips]} {
-        puts "\n[colorstr bold-yellow {!!! NOTICE}] [llength $::timing_skips] timing-sensitive check(s) were skipped due to a slow environment:\n"
-        foreach skip $::timing_skips {
-            puts "*** $skip"
-        }
     }
     if {[llength $::failed_tests]} {
         puts "\n[colorstr bold-red {!!! WARNING}] The following tests failed:\n"

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -294,18 +294,18 @@ start_server {tags {"external:skip needs:debug"}} {
         }
         
         test "HPEXPIRETIME persists after RDB reload ($type)" {
-            r del myhash
-            r hset myhash field1 value1 field2 value2
-
-            assert_within_time_limit 450 {
-                r hpexpire myhash 500 NX FIELDS 1 field1
+            assert_with_retry 8 iter {
+                r del myhash
+                r hset myhash field1 value1 field2 value2
+                set ttl_ms [expr {300 * $iter}]
+                r hpexpire myhash $ttl_ms NX FIELDS 1 field1
                 set before [r HPEXPIRETIME myhash FIELDS 1 field1]
                 r debug reload
                 set after [r HPEXPIRETIME myhash FIELDS 1 field1]
             } {
-               $before == $after &&
-               [r HTTL myhash FIELDS 1 field2] == $T_NO_EXPIRY &&
-               [get_stat_subexpiry r] == 1
+                {$before == $after}
+                {[r HTTL myhash FIELDS 1 field2] == $T_NO_EXPIRY}
+                {[get_stat_subexpiry r] == 1}
             }
             
             # Wait for field1 to expire robustly
@@ -661,17 +661,18 @@ start_server {tags {"external:skip needs:debug"}} {
 
         test "Test RENAME hash with fields to be expired ($type)" {
             r debug set-active-expire 0
-            r del myhash
-            r hset myhash field1 value1
 
-            assert_within_time_limit 15 {
-                r hpexpire myhash 20 NX FIELDS 1 field1
+            assert_with_retry 8 iter {
+                r del myhash myhash2
+                r hset myhash field1 value1
+                set ttl_ms [expr {20 * $iter}]
+                r hpexpire myhash $ttl_ms NX FIELDS 1 field1
                 r rename myhash myhash2
                 assert_equal [r exists myhash] 0
                 set ttl [r hpttl myhash2 FIELDS 1 field1]
-            } {$ttl >= 1 && $ttl <= 20}
+            } { {$ttl >= 1} {$ttl <= $ttl_ms} }
 
-            after 25
+            after [expr {$ttl_ms + 5}]
             # Verify the renamed key exists
             assert_equal [r exists myhash2] 1
             r debug set-active-expire 1
@@ -694,13 +695,13 @@ start_server {tags {"external:skip needs:debug"}} {
         }
 
         test "MOVE to another DB hash with fields to be expired ($type)" {
-            r select 9
-            r flushall
-            r hset myhash field1 value1
-            r expireat myhash 2000000000000 ;# Force kvobj reallocation during move command
-
-            assert_within_time_limit 80 {
-                r hpexpire myhash 100 NX FIELDS 1 field1
+            assert_with_retry 8 iter {
+                r select 9
+                r flushall
+                r hset myhash field1 value1
+                r expireat myhash 2000000000000 ;# Force kvobj reallocation during move command
+                set ttl_ms [expr {100 * $iter}]
+                r hpexpire myhash $ttl_ms NX FIELDS 1 field1
                 r move myhash 10
                 assert_equal [r exists myhash] 0
                 assert_equal [r dbsize] 0
@@ -708,8 +709,8 @@ start_server {tags {"external:skip needs:debug"}} {
                 # Verify the key and its field exists in the target DB
                 r select 10
             } {
-               [r hget myhash field1] == "value1" &&
-               [r exists myhash] == 1
+                {[r hget myhash field1] == "value1"}
+                {[r exists myhash] == 1}
             }
 
             # Eventually the field will be expired and the key will be deleted
@@ -718,23 +719,23 @@ start_server {tags {"external:skip needs:debug"}} {
         } {} {singledb:skip}
 
         test "Test COPY hash with fields to be expired ($type)" {
-            r flushall
-            r hset h1 f1 v1 f2 v2
-            r hset h2 f1 v1 f2 v2 f3 v3 f4 v4 f5 v5 f6 v6 f7 v7 f8 v8 f9 v9 f10 v10 f11 v11 f12 v12 f13 v13 f14 v14 f15 v15 f16 v16 f17 v17 f18 v18
-
-            assert_within_time_limit 80 {
-                r hpexpire h1 100 NX FIELDS 1 f1
-                r hpexpire h2 100 NX FIELDS 18 f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 f13 f14 f15 f16 f17 f18
+            assert_with_retry 8 iter {
+                r flushall
+                r hset h1 f1 v1 f2 v2
+                r hset h2 f1 v1 f2 v2 f3 v3 f4 v4 f5 v5 f6 v6 f7 v7 f8 v8 f9 v9 f10 v10 f11 v11 f12 v12 f13 v13 f14 v14 f15 v15 f16 v16 f17 v17 f18 v18
+                set ttl_ms [expr {100 * $iter}]
+                r hpexpire h1 $ttl_ms NX FIELDS 1 f1
+                r hpexpire h2 $ttl_ms NX FIELDS 18 f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 f13 f14 f15 f16 f17 f18
                 r COPY h1 h1copy
                 r COPY h2 h2copy
             } {
-               [r hget h1 f1] == "v1" &&
-               [r hget h1copy f1] == "v1" &&
-               [r exists h2] == 1 &&
-               [r exists h2copy] == 1
+                {[r hget h1 f1] == "v1"}
+                {[r hget h1copy f1] == "v1"}
+                {[r exists h2] == 1}
+                {[r exists h2copy] == 1}
             }
 
-            after 105
+            after [expr {$ttl_ms + 5}]
 
             # Verify lazy expire of field in h1 and its copy
             assert_equal [r hget h1 f1] ""
@@ -761,12 +762,12 @@ start_server {tags {"external:skip needs:debug"}} {
         }
 
         test "Test SWAPDB hash-fields to be expired ($type)" {
-            r select 9
-            r flushall
-            r hset myhash field1 value1
-
-            assert_within_time_limit 40 {
-                r hpexpire myhash 50 NX FIELDS 1 field1
+            assert_with_retry 8 iter {
+                r select 9
+                r flushall
+                r hset myhash field1 value1
+                set ttl_ms [expr {50 * $iter}]
+                r hpexpire myhash $ttl_ms NX FIELDS 1 field1
 
                 r swapdb 9 10
 
@@ -777,8 +778,8 @@ start_server {tags {"external:skip needs:debug"}} {
                 # Verify the key and its field exists in the target DB
                 r select 10
             } {
-               [r hget myhash field1] == "value1" &&
-               [r dbsize] == 1
+                {[r hget myhash field1] == "value1"}
+                {[r dbsize] == 1}
             }
 
             # Eventually the field will be expired and the key will be deleted

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -296,14 +296,18 @@ start_server {tags {"external:skip needs:debug"}} {
         test "HPEXPIRETIME persists after RDB reload ($type)" {
             r del myhash
             r hset myhash field1 value1 field2 value2
-            r hpexpire myhash 500 NX FIELDS 1 field1
-            set before [r HPEXPIRETIME myhash FIELDS 1 field1]
-            r debug reload
-            set after [r HPEXPIRETIME myhash FIELDS 1 field1]
-            assert_equal $before $after
-            # field2 should not have expiration
-            assert_equal [r HTTL myhash FIELDS 1 field2] $T_NO_EXPIRY
-            assert_equal [get_stat_subexpiry r] 1
+
+            assert_within_time_limit 450 {
+                r hpexpire myhash 500 NX FIELDS 1 field1
+                set before [r HPEXPIRETIME myhash FIELDS 1 field1]
+                r debug reload
+                set after [r HPEXPIRETIME myhash FIELDS 1 field1]
+            } {
+               $before == $after &&
+               [r HTTL myhash FIELDS 1 field2] == $T_NO_EXPIRY &&
+               [get_stat_subexpiry r] == 1
+            }
+            
             # Wait for field1 to expire robustly
             wait_for_condition 50 20 { [get_stat_subexpiry r] == 0 } else { fail "subexpiry should be 0" } 
             assert_equal [r hget myhash field1] ""
@@ -659,10 +663,14 @@ start_server {tags {"external:skip needs:debug"}} {
             r debug set-active-expire 0
             r del myhash
             r hset myhash field1 value1
-            r hpexpire myhash 20 NX FIELDS 1 field1
-            r rename myhash myhash2
-            assert_equal [r exists myhash] 0
-            assert_range [r hpttl myhash2 FIELDS 1 field1] 1 20
+
+            assert_within_time_limit 15 {
+                r hpexpire myhash 20 NX FIELDS 1 field1
+                r rename myhash myhash2
+                assert_equal [r exists myhash] 0
+                set ttl [r hpttl myhash2 FIELDS 1 field1]
+            } {$ttl >= 1 && $ttl <= 20}
+
             after 25
             # Verify the renamed key exists
             assert_equal [r exists myhash2] 1
@@ -690,15 +698,19 @@ start_server {tags {"external:skip needs:debug"}} {
             r flushall
             r hset myhash field1 value1
             r expireat myhash 2000000000000 ;# Force kvobj reallocation during move command
-            r hpexpire myhash 100 NX FIELDS 1 field1
-            r move myhash 10
-            assert_equal [r exists myhash] 0
-            assert_equal [r dbsize] 0
 
-            # Verify the key and its field exists in the target DB
-            r select 10
-            assert_equal [r hget myhash field1] "value1"
-            assert_equal [r exists myhash] 1
+            assert_within_time_limit 80 {
+                r hpexpire myhash 100 NX FIELDS 1 field1
+                r move myhash 10
+                assert_equal [r exists myhash] 0
+                assert_equal [r dbsize] 0
+
+                # Verify the key and its field exists in the target DB
+                r select 10
+            } {
+               [r hget myhash field1] == "value1" &&
+               [r exists myhash] == 1
+            }
 
             # Eventually the field will be expired and the key will be deleted
             wait_for_condition 40 10 { [r hget myhash field1] == "" } else { fail "`field1` should be expired" }
@@ -709,14 +721,19 @@ start_server {tags {"external:skip needs:debug"}} {
             r flushall
             r hset h1 f1 v1 f2 v2
             r hset h2 f1 v1 f2 v2 f3 v3 f4 v4 f5 v5 f6 v6 f7 v7 f8 v8 f9 v9 f10 v10 f11 v11 f12 v12 f13 v13 f14 v14 f15 v15 f16 v16 f17 v17 f18 v18
-            r hpexpire h1 100 NX FIELDS 1 f1
-            r hpexpire h2 100 NX FIELDS 18 f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 f13 f14 f15 f16 f17 f18
-            r COPY h1 h1copy
-            r COPY h2 h2copy
-            assert_equal [r hget h1 f1] "v1"
-            assert_equal [r hget h1copy f1] "v1"
-            assert_equal [r exists h2] 1
-            assert_equal [r exists h2copy] 1
+
+            assert_within_time_limit 80 {
+                r hpexpire h1 100 NX FIELDS 1 f1
+                r hpexpire h2 100 NX FIELDS 18 f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 f13 f14 f15 f16 f17 f18
+                r COPY h1 h1copy
+                r COPY h2 h2copy
+            } {
+               [r hget h1 f1] == "v1" &&
+               [r hget h1copy f1] == "v1" &&
+               [r exists h2] == 1 &&
+               [r exists h2copy] == 1
+            }
+
             after 105
 
             # Verify lazy expire of field in h1 and its copy
@@ -747,18 +764,22 @@ start_server {tags {"external:skip needs:debug"}} {
             r select 9
             r flushall
             r hset myhash field1 value1
-            r hpexpire myhash 50 NX FIELDS 1 field1
 
-            r swapdb 9 10
+            assert_within_time_limit 40 {
+                r hpexpire myhash 50 NX FIELDS 1 field1
 
-            # Verify the key and its field doesn't exist in the source DB
-            assert_equal [r exists myhash] 0
-            assert_equal [r dbsize] 0
+                r swapdb 9 10
 
-            # Verify the key and its field exists in the target DB
-            r select 10
-            assert_equal [r hget myhash field1] "value1"
-            assert_equal [r dbsize] 1
+                # Verify the key and its field doesn't exist in the source DB
+                assert_equal [r exists myhash] 0
+                assert_equal [r dbsize] 0
+
+                # Verify the key and its field exists in the target DB
+                r select 10
+            } {
+               [r hget myhash field1] == "value1" &&
+               [r dbsize] == 1
+            }
 
             # Eventually the field will be expired and the key will be deleted
             wait_for_condition 20 10 { [r exists myhash] == 0 } else { fail "'myhash' should be expired" }


### PR DESCRIPTION
## Summary

Several `hash-field-expire.tcl` tests set a short TTL, run an operation of variable cost (`debug reload`, `RENAME`, `MOVE`, `COPY`, `SWAPDB`), then assert something that's only true if the TTL hasn't expired yet. On a slow CI box, the intervening op can legitimately outlast the TTL, failing the test for a reason unrelated to the code under test.

- Add `assert_with_retry {max_iter iter_var body conditions}` (`tests/support/test.tcl`). It runs `body`, then checks each expr in `conditions`; if any is false it increments `$iter_var` and retries, up to `max_iter`. `body` must be self-contained (rebuild its state from scratch) and scale its timing off `$iter_var` (e.g. `set ttl_ms [expr {20 * $iter}]`), so a slow environment gets more slack on each retry instead of a false failure, while a genuine bug still fails once `max_iter` is exhausted.
- `conditions` is a list rather than one `&&`-chained expr, so a final failure names exactly which check(s) failed instead of dumping one opaque compound boolean.
- `$iter_var` is left set to whichever attempt finally succeeded (or was last attempted), so code after the call can reuse the same timing scale (e.g. `after [expr {$ttl_ms + 5}]`).
- Applied it to the 5 hash field-expiration tests that had this exact shape: the RDB-reload/HPEXPIRETIME test, RENAME, MOVE, COPY, and SWAPDB.

## Usage

```tcl
assert_with_retry 8 iter {
    r del myhash
    r hset myhash field1 value1 field2 value2
    set ttl_ms [expr {300 * $iter}]
    r hpexpire myhash $ttl_ms NX FIELDS 1 field1
    set before [r HPEXPIRETIME myhash FIELDS 1 field1]
    r debug reload
    set after [r HPEXPIRETIME myhash FIELDS 1 field1]
} {
    {$before == $after}
    {[r HTTL myhash FIELDS 1 field2] == $T_NO_EXPIRY}
    {[get_stat_subexpiry r] == 1}
}
```

`body` re-creates the key and re-issues the TTL from scratch on every attempt, scaled by `$iter`. If `debug reload` is slow enough that the TTL already expired, one of the `conditions` comes back false, `iter` increments (giving the next attempt a longer TTL), and `body` runs again — the check keeps exercising the real code path instead of being skipped.

