### PR TITLE
Warn when a memory config value has no numeric part

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2173,8 +2173,16 @@ static int numericParseString(standardConfig *config, sds value, const char **er
     if (config->data.numeric.flags & MEMORY_CONFIG) {
         int memerr;
         *res = memtoull(value, &memerr);
-        if (!memerr)
+        if (!memerr) {
+            /* A value with no digits at all ("", or a bare unit like "gb")
+             * parses as 0. Keep accepting it for backward compatibility, but
+             * warn: for limits like maxmemory, 0 silently means "unlimited". */
+            if (strpbrk(value, "0123456789") == NULL)
+                serverLog(LL_WARNING,
+                    "WARNING: %s value '%s' has no numeric part and was interpreted as 0",
+                    config->name, value);
             return 1;
+        }
     }
 
     /* Attempt to parse as percent */

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -706,3 +706,22 @@ start_server {tags {"maxmemory" "external:skip"}} {
         }
     }
 }
+
+start_server {tags {"maxmemory" "external:skip"}} {
+    test {A memory config value with no digits warns and is interpreted as 0} {
+        set loglines [count_log_lines 0]
+        r config set maxmemory gb
+        assert_equal 0 [lindex [r config get maxmemory] 1]
+        wait_for_log_messages 0 {"*maxmemory value 'gb' has no numeric part*"} $loglines 100 10
+        r config set maxmemory {}
+        wait_for_log_messages 0 {"*maxmemory value '' has no numeric part*"} $loglines 100 10
+    }
+
+    test {An explicit zero memory config value does not warn} {
+        set before [count_log_message 0 "has no numeric part"]
+        r config set maxmemory 0
+        r config set maxmemory 0kb
+        r config set maxmemory 100mb
+        assert_equal $before [count_log_message 0 "has no numeric part"]
+    }
+}


### PR DESCRIPTION
A MEMORY_CONFIG value with no digits at all ("" or a bare unit like "gb") parses as 0 via memtoull(). For maxmemory that silently removes the memory limit — e.g. a "maxmemory 512gb" line with the number dropped starts the server with no limit and no diagnostic, while the neighbouring typo "maxmemory bla" is rejected.

Keep accepting such values for backward compatibility, but log a warning, as agreed in #15719. An explicit zero ("0", "0kb") stays silent.

Closes #15719 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a log-only diagnostic on an existing parse path; behavior for accepted values stays backward compatible aside from new warnings.
> 
> **Overview**
> **Memory-style numeric configs** (e.g. `maxmemory`) still accept values with no digits—`""` or a bare unit like `gb`—and treat them as **0** via `memtoull`, but **`numericParseString` now logs a warning** naming the directive and value so operators see that the limit was cleared instead of failing silently.
> 
> **Explicit zeros** (`0`, `0kb`) are unchanged and **do not** emit this warning.
> 
> New **maxmemory** integration tests assert the log line for `gb` and `{}`, and that legitimate zero and sized values do not increase the warning count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 837b6489cb38e656eb436123355c10d88387b757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->