### PR TITLE
Make an unauthenticated cluster bus port an explicit choice

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -46,7 +46,7 @@ jobs:
       run: make REDIS_CFLAGS=-Werror
     - name: Start redis-server
       run: |
-        ./src/redis-server --cluster-enabled yes --cluster-bus-require-tls no --daemonize yes --save "" --logfile external-redis-cluster.log \
+        ./src/redis-server --cluster-enabled yes --cluster-bus-port-protected-mode no --daemonize yes --save "" --logfile external-redis-cluster.log \
           --enable-protected-configs yes --enable-debug-command yes --enable-module-command yes
     - name: Create a single node cluster
       run: ./src/redis-cli cluster addslots $(for slot in {0..16383}; do echo $slot; done); sleep 5

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -46,7 +46,7 @@ jobs:
       run: make REDIS_CFLAGS=-Werror
     - name: Start redis-server
       run: |
-        ./src/redis-server --cluster-enabled yes --daemonize yes --save "" --logfile external-redis-cluster.log \
+        ./src/redis-server --cluster-enabled yes --cluster-bus-require-tls no --daemonize yes --save "" --logfile external-redis-cluster.log \
           --enable-protected-configs yes --enable-debug-command yes --enable-module-command yes
     - name: Create a single node cluster
       run: ./src/redis-cli cluster addslots $(for slot in {0..16383}; do echo $slot; done); sleep 5

--- a/TLS.md
+++ b/TLS.md
@@ -76,14 +76,14 @@ explicitly waived; see "Cluster bus protection" below.
 Cluster bus protection
 ----------------------
 
-The cluster bus protocol has no authentication of its own: a message's sender is
-identified only by the node ID in its header, which is public information, so any
-host able to reach a node's cluster bus port can speak the protocol. What
-authenticates the bus is `tls-cluster`, which makes every peer present a
-certificate that verifies against the configured CA — in both the accepting and
-the connecting direction, and `tls-cluster` also makes configuring a CA
-mandatory. This does not depend on `tls-auth-clients`, which governs the client
-port only.
+The cluster bus protocol has no authentication of its own: any host able to reach
+a node's cluster bus port can speak the protocol — a `MEET` from an unknown host
+is enough to have it added as a node, with its gossip trusted — and so threaten
+the whole cluster. What authenticates the bus is `tls-cluster`, which makes every
+peer present a certificate that verifies against the configured CA — in both the
+accepting and the connecting direction, and `tls-cluster` also makes configuring
+a CA mandatory. This does not depend on `tls-auth-clients`, which governs the
+client port only.
 
 For that reason `cluster-bus-port-protected-mode` defaults to **yes**, and a node
 started with `cluster-enabled yes` refuses to start unless `tls-cluster` is

--- a/TLS.md
+++ b/TLS.md
@@ -59,8 +59,40 @@ To connect to this Redis server with `redis-cli`:
 This will disable TCP and enable TLS on port 6379. It's also possible to have
 both TCP and TLS available, but you'll need to assign different ports.
 
+Note why that `redis-cli` invocation passes a certificate of its own: by default
+clients on a TLS port must present one that verifies against the configured CA,
+replicas connecting to a master included. `tls-auth-clients no` accepts no client
+certificate at all, and `tls-auth-clients optional` validates one only when it is
+offered. Both relax the client port alone — see "Cluster bus protection" below for
+why neither can relax the cluster bus. Setting `tls-auth-clients-user CN`
+additionally maps a validated certificate's Common Name to a Redis ACL user, so
+the certificate authenticates the client without an `AUTH` command.
+
 To make a Replica connect to the master using TLS, use `--tls-replication yes`,
-and to make Redis Cluster use TLS across nodes use `--tls-cluster yes`.
+and to make Redis Cluster use TLS across nodes use `--tls-cluster yes`. Note that
+a cluster node refuses to start without `tls-cluster` unless the requirement is
+explicitly waived; see "Cluster bus protection" below.
+
+Cluster bus protection
+----------------------
+
+The cluster bus protocol has no authentication of its own: a message's sender is
+identified only by the node ID in its header, which is public information, so any
+host able to reach a node's cluster bus port can speak the protocol. What
+authenticates the bus is `tls-cluster`, which makes every peer present a
+certificate that verifies against the configured CA — in both the accepting and
+the connecting direction, and `tls-cluster` also makes configuring a CA
+mandatory. This does not depend on `tls-auth-clients`, which governs the client
+port only.
+
+For that reason `cluster-bus-port-protected-mode` defaults to **yes**, and a node
+started with `cluster-enabled yes` refuses to start unless `tls-cluster` is
+enabled. Running an unauthenticated cluster bus remains supported, but it has to
+be stated explicitly with `cluster-bus-port-protected-mode no`, acknowledging
+that the port is reachable by trusted hosts only — because a firewall, a VPN or a
+private network keeps untrusted hosts away from it. A node started that way
+records the fact in its log. The option has no effect outside cluster mode, as
+only a cluster node opens a cluster bus port.
 
 Peer certificate verification
 -----------------------------

--- a/redis.conf
+++ b/redis.conf
@@ -271,10 +271,11 @@ tcp-keepalive 300
 #
 # tls-replication yes
 
-# The Redis Cluster bus uses a plain TCP connection unless the following
-# directive is enabled. Note that, by default, a cluster node refuses to start
-# with a plaintext cluster bus: either enable TLS here or acknowledge the
-# plaintext bus with "cluster-bus-require-tls no". See the REDIS CLUSTER section.
+# Enabling the following directive is what authenticates the Redis Cluster bus:
+# every cluster bus peer then has to present a certificate that verifies against
+# the configured CA. Note that, by default, a cluster node refuses to start with
+# an unauthenticated bus: either enable it here or acknowledge the unauthenticated
+# bus with "cluster-bus-port-protected-mode no". See the REDIS CLUSTER section.
 #
 # tls-cluster yes
 
@@ -1784,23 +1785,30 @@ backup-sealed-ttl 0
 # you to specify the cluster bus port when executing cluster meet.
 # cluster-port 0
 
-# The cluster bus carries the internal cluster protocol and has no
+# The cluster bus port carries the internal cluster protocol and has no
 # authentication of its own: the sender of a packet is identified solely by the
-# node ID in its header, which is public information. The bus also carries
-# sensitive information shared between the nodes, which must not leak outside the
-# cluster. Any host that can reach the cluster bus port, or eavesdrop on it, can
-# therefore potentially threaten the whole cluster and its data.
+# node ID in its header, which is public information. Any host that can reach the
+# cluster bus port can therefore speak the cluster protocol and potentially
+# threaten the whole cluster and its data.
 #
-# For that reason a cluster node refuses to start unless its cluster bus is
-# protected by TLS ("tls-cluster yes", see the TLS section) or the requirement
-# is explicitly waived with the directive below. Waive it only if the cluster
-# bus port cannot be reached by untrusted clients, for instance because a
-# firewall blocks it.
+# What authenticates the bus is "tls-cluster yes" (see the TLS section): a peer
+# then has to present, in either direction, a certificate that verifies against
+# the CA that tls-cluster makes mandatory. Note that this does not depend on
+# tls-auth-clients, which governs the client port only; the cluster bus always
+# requires a peer certificate. With a CA dedicated to the cluster that is enough,
+# since every certificate it signs belongs to a member; with a shared CA, pin the
+# members with tls-expected-peer-name as well.
+#
+# For that reason a cluster node refuses to start unless its cluster bus port is
+# authenticated, or protection is explicitly waived with the directive below,
+# much like protected-mode for unauthenticated client access. Waive it only if
+# the cluster bus port cannot be reached by untrusted hosts, for instance because
+# a firewall blocks it.
 #
 # The directive has no effect outside cluster mode, as only a cluster node opens
 # a cluster bus port. The default is "yes".
 #
-# cluster-bus-require-tls no
+# cluster-bus-port-protected-mode no
 
 # A replica of a failing master will avoid to start a failover if its data
 # looks too old.

--- a/redis.conf
+++ b/redis.conf
@@ -244,6 +244,12 @@ tcp-keepalive 300
 # If "optional" is specified, client certificates are accepted and must be
 # valid if provided, but are not required.
 #
+# This directive governs the client port only. The Redis Cluster bus always
+# requires the peer to present a certificate that verifies against the configured
+# CA, in both the accepting and the connecting direction, so relaxing this
+# setting cannot weaken the cluster bus. See "tls-cluster" below, and
+# "cluster-bus-port-protected-mode" in the REDIS CLUSTER section.
+#
 # tls-auth-clients no
 # tls-auth-clients optional
 

--- a/redis.conf
+++ b/redis.conf
@@ -271,8 +271,10 @@ tcp-keepalive 300
 #
 # tls-replication yes
 
-# By default, the Redis Cluster bus uses a plain TCP connection. To enable
-# TLS for the bus protocol, use the following directive:
+# The Redis Cluster bus uses a plain TCP connection unless the following
+# directive is enabled. Note that, by default, a cluster node refuses to start
+# with a plaintext cluster bus: either enable TLS here or acknowledge the
+# plaintext bus with "cluster-bus-require-tls no". See the REDIS CLUSTER section.
 #
 # tls-cluster yes
 
@@ -1781,6 +1783,24 @@ backup-sealed-ttl 0
 # to the default value, 0, it will be bound to the command port + 10000. Setting this value requires 
 # you to specify the cluster bus port when executing cluster meet.
 # cluster-port 0
+
+# The cluster bus carries the internal cluster protocol and has no
+# authentication of its own: the sender of a packet is identified solely by the
+# node ID in its header, which is public information. The bus also carries
+# sensitive information shared between the nodes, which must not leak outside the
+# cluster. Any host that can reach the cluster bus port, or eavesdrop on it, can
+# therefore potentially threaten the whole cluster and its data.
+#
+# For that reason a cluster node refuses to start unless its cluster bus is
+# protected by TLS ("tls-cluster yes", see the TLS section) or the requirement
+# is explicitly waived with the directive below. Waive it only if the cluster
+# bus port cannot be reached by untrusted clients, for instance because a
+# firewall blocks it.
+#
+# The directive has no effect outside cluster mode, as only a cluster node opens
+# a cluster bus port. The default is "yes".
+#
+# cluster-bus-require-tls no
 
 # A replica of a failing master will avoid to start a failover if its data
 # looks too old.

--- a/redis.conf
+++ b/redis.conf
@@ -1792,10 +1792,10 @@ backup-sealed-ttl 0
 # cluster-port 0
 
 # The cluster bus port carries the internal cluster protocol and has no
-# authentication of its own: the sender of a packet is identified solely by the
-# node ID in its header, which is public information. Any host that can reach the
-# cluster bus port can therefore speak the cluster protocol and potentially
-# threaten the whole cluster and its data.
+# authentication of its own: any host that can reach the port can speak the
+# cluster protocol and potentially threaten the whole cluster and its data - a
+# MEET from an unknown host is enough to have it added as a node, with its gossip
+# trusted.
 #
 # What authenticates the bus is "tls-cluster yes" (see the TLS section): a peer
 # then has to present, in either direction, a certificate that verifies against

--- a/src/config.c
+++ b/src/config.c
@@ -3011,7 +3011,7 @@ static int applyTlsCluster(const char **err) {
     if (clusterBusPortProtectionUnmet()) {
         *err = "can't disable tls-cluster while cluster-bus-port-protected-mode is enabled, "
                "as that would leave the cluster bus port unauthenticated; disable "
-               "cluster-bus-port-protected-mode in the same CONFIG SET call to allow it";
+               "cluster-bus-port-protected-mode first, or in the same CONFIG SET call";
         return 0;
     }
 
@@ -3041,8 +3041,8 @@ static int applyTlsCluster(const char **err) {
 static int applyClusterBusPortProtectedMode(const char **err) {
     if (clusterBusPortProtectionUnmet()) {
         *err = "can't enable cluster-bus-port-protected-mode while tls-cluster is disabled, "
-               "as that leaves the cluster bus port unauthenticated; enable tls-cluster in "
-               "the same CONFIG SET call to authenticate the cluster bus";
+               "as that leaves the cluster bus port unauthenticated; enable tls-cluster "
+               "first, or in the same CONFIG SET call";
         return 0;
     }
     return 1;

--- a/src/config.c
+++ b/src/config.c
@@ -464,14 +464,14 @@ static int tls_cluster_applied;
 /* Defined with the TLS config hooks below; used by the post-load checks. */
 static void tlsWarnExpectedPeerNameScope(void);
 
-/* The cluster bus protocol has no authentication of its own: the sender of a
- * packet is identified solely by the node ID in its header, which is public
- * information, so any host that can reach the port can speak the protocol and
- * threaten the whole cluster. Enabling tls-cluster is what authenticates the bus:
- * a peer then has to present, in either direction, a certificate that verifies
- * against the CA that tls-cluster makes mandatory. It does so regardless of
- * tls-auth-clients, which governs the client port only - clusterAcceptHandler()
- * always demands a peer certificate.
+/* The cluster bus protocol has no authentication of its own: any host that can
+ * reach the port can speak it and threaten the whole cluster - a MEET from an
+ * unknown host is enough to have it added as a node, with its gossip trusted.
+ * Enabling tls-cluster is what authenticates the bus: a peer then has to present,
+ * in either direction, a certificate that verifies against the CA that
+ * tls-cluster makes mandatory. It does so regardless of tls-auth-clients, which
+ * governs the client port only - clusterAcceptHandler() always demands a peer
+ * certificate.
  *
  * cluster-bus-port-protected-mode therefore refuses an unauthenticated bus by
  * default, and makes running one an explicit choice, exactly as protected-mode
@@ -488,10 +488,9 @@ static int clusterBusPortProtectionUnmet(void) {
  * option it refuses to change instead. */
 #define CLUSTER_BUS_PORT_PROTECTED_MODE_ERR \
     "cluster-bus-port-protected-mode is enabled but tls-cluster is disabled, which " \
-    "leaves the cluster bus port of this node unauthenticated: the sender of a cluster " \
-    "bus packet is identified only by the node ID in its header, which is public " \
-    "information, so any host able to reach the port can speak the cluster protocol and " \
-    "threaten the whole cluster. Either set 'tls-cluster yes', which makes every cluster " \
+    "leaves the cluster bus port of this node unauthenticated: any host able to reach " \
+    "the port can join the cluster and speak the cluster protocol, and threaten the " \
+    "whole cluster. Either set 'tls-cluster yes', which makes every cluster " \
     "bus peer present a certificate verified against your CA, or set " \
     "'cluster-bus-port-protected-mode no' to acknowledge that the cluster bus port is " \
     "reachable by trusted hosts only, for instance because a firewall blocks it."

--- a/src/config.c
+++ b/src/config.c
@@ -452,6 +452,15 @@ static int reading_config_file;
  * post-load advisories must run only when the outermost load finishes. */
 static int config_load_depth;
 
+/* Value of tls-cluster as of the last time applyTlsCluster() acted on it, in the
+ * manner of clusterUpdateMyselfIp()'s prev_ip. It lets a refused CONFIG SET be a
+ * true no-op: configSetCommand() restores the previous value and calls every
+ * apply callback of the command a second time, and that second call must not
+ * reconfigure anything for a value that never effectively moved. The zero
+ * initialiser matches the tls-cluster default, which is what is in force when no
+ * configuration is loaded at all; the post-load block below takes it from there. */
+static int tls_cluster_applied;
+
 /* Defined with the TLS config hooks below; used by the post-load checks. */
 static void tlsWarnExpectedPeerNameScope(void);
 
@@ -699,6 +708,10 @@ void loadServerConfigFromString(char *config) {
             serverLog(LL_WARNING, "WARNING: Changing databases number from %d to 1 since we are in cluster mode", server.dbnum);
             server.dbnum = 1;
         }
+        /* The startup value is the one in force: initListeners() configures TLS
+         * from it, and the server exits if that fails. */
+        tls_cluster_applied = server.tls_cluster;
+
         clusterBusWarnIfPlaintextBus();
         tlsWarnExpectedPeerNameScope();
     }
@@ -2996,6 +3009,14 @@ static int applyTlsCluster(const char **err) {
         return 0;
     }
 
+    /* Nothing below may run when the value did not effectively move, which is
+     * what configSetCommand() hands us after it has restored a refused set: both
+     * steps are observable - reconfiguring TLS rebuilds the SSL_CTX, and
+     * clusterNotifyTopologyChanged() cancels the ASM tasks invalidated by the new
+     * topology besides notifying modules - so a refused set would otherwise not
+     * be the no-op it reports being. */
+    if (server.tls_cluster == tls_cluster_applied) return 1;
+
     if (!applyTlsCfg(err)) return 0;
 
     /* tls-cluster selects which client port is advertised by the cluster.
@@ -3003,6 +3024,7 @@ static int applyTlsCluster(const char **err) {
      * them when the preferred port changes. */
     clusterNotifyTopologyChanged(CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE, NULL);
 
+    tls_cluster_applied = server.tls_cluster;
     clusterBusWarnIfPlaintextBus();
     return 1;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -464,46 +464,52 @@ static int tls_cluster_applied;
 /* Defined with the TLS config hooks below; used by the post-load checks. */
 static void tlsWarnExpectedPeerNameScope(void);
 
-/* The cluster bus has no authentication of its own: the sender of a packet is
- * identified solely by the node ID in its header, which is public, so any peer
- * able to reach the bus port can speak the protocol. The bus also carries
- * sensitive information shared between the nodes, which must not leak outside
- * the cluster. A plaintext bus exposes both to anyone able to reach or eavesdrop
- * on the bus port, which can threaten the whole cluster, so cluster-bus-require-tls
- * refuses such a setup by default and makes running a plaintext bus an explicit
- * choice, in the spirit of protected-mode. Only cluster mode opens the bus, so a
- * standalone instance is never affected.
+/* The cluster bus protocol has no authentication of its own: the sender of a
+ * packet is identified solely by the node ID in its header, which is public
+ * information, so any host that can reach the port can speak the protocol and
+ * threaten the whole cluster. Enabling tls-cluster is what authenticates the bus:
+ * a peer then has to present, in either direction, a certificate that verifies
+ * against the CA that tls-cluster makes mandatory. It does so regardless of
+ * tls-auth-clients, which governs the client port only - clusterAcceptHandler()
+ * always demands a peer certificate.
  *
- * Returns non-zero when the current configuration violates the requirement. */
-static int clusterBusTlsRequirementUnmet(void) {
-    return server.cluster_enabled && server.cluster_bus_require_tls && !server.tls_cluster;
+ * cluster-bus-port-protected-mode therefore refuses an unauthenticated bus by
+ * default, and makes running one an explicit choice, exactly as protected-mode
+ * does for unauthenticated client access. Only cluster mode opens the bus port,
+ * so a standalone instance is never affected.
+ *
+ * Returns non-zero when the current configuration leaves the bus unprotected
+ * while protected mode asks for it. */
+static int clusterBusPortProtectionUnmet(void) {
+    return server.cluster_enabled && server.cluster_bus_port_protected_mode && !server.tls_cluster;
 }
 
-/* Reported when the requirement above is violated at startup. The CONFIG SET
- * path names the option it refuses to change instead. */
-#define CLUSTER_BUS_REQUIRE_TLS_ERR \
-    "cluster-bus-require-tls is enabled but tls-cluster is disabled: the cluster bus " \
-    "of this node would run on plain TCP. The cluster bus is not authenticated and it " \
-    "carries sensitive information shared between the nodes, which must not leak " \
-    "outside the cluster, so any host able to reach or eavesdrop on the cluster bus " \
-    "port can potentially threaten the whole cluster. Either set 'tls-cluster yes' to " \
-    "protect the cluster bus with TLS, or set 'cluster-bus-require-tls no' to " \
-    "acknowledge that the cluster bus port is reachable by trusted hosts only, for " \
-    "instance because a firewall blocks it."
+/* Reported when the check above trips at startup. The CONFIG SET path names the
+ * option it refuses to change instead. */
+#define CLUSTER_BUS_PORT_PROTECTED_MODE_ERR \
+    "cluster-bus-port-protected-mode is enabled but tls-cluster is disabled, which " \
+    "leaves the cluster bus port of this node unauthenticated: the sender of a cluster " \
+    "bus packet is identified only by the node ID in its header, which is public " \
+    "information, so any host able to reach the port can speak the cluster protocol and " \
+    "threaten the whole cluster. Either set 'tls-cluster yes', which makes every cluster " \
+    "bus peer present a certificate verified against your CA, or set " \
+    "'cluster-bus-port-protected-mode no' to acknowledge that the cluster bus port is " \
+    "reachable by trusted hosts only, for instance because a firewall blocks it."
 
-/* Counterpart of the check above: report a cluster node running a plaintext bus
- * once the operator has waived the requirement. Called when the outermost config
- * load finishes and from the tls-cluster apply callback, which covers every way
- * the bus can become plaintext at runtime (leaving TLS always changes
- * tls-cluster, whether alone or together with cluster-bus-require-tls). */
-static void clusterBusWarnIfPlaintextBus(void) {
-    if (!server.cluster_enabled || server.tls_cluster || server.cluster_bus_require_tls) return;
+/* Counterpart of the check above: report a cluster node whose bus port is left
+ * unauthenticated once the operator has waived protected mode. Called when the
+ * outermost config load finishes and from the tls-cluster apply callback, which
+ * covers every way the bus can lose its authentication at runtime (leaving TLS
+ * always changes tls-cluster, whether alone or together with 
+ * cluster_bus_port_protected_mode). */
+static void clusterBusWarnIfUnprotected(void) {
+    if (!server.cluster_enabled || server.tls_cluster || server.cluster_bus_port_protected_mode) return;
 
     serverLog(LL_WARNING,
-        "WARNING: the cluster bus is not protected by TLS: 'tls-cluster' is disabled and "
-        "the requirement was waived with 'cluster-bus-require-tls no'. The cluster bus is "
-        "not authenticated and it carries sensitive information shared between the nodes, "
-        "so make sure the cluster bus port is reachable by trusted hosts only.");
+        "WARNING: the cluster bus port is not authenticated: 'tls-cluster' is disabled and "
+        "protected mode was waived with 'cluster-bus-port-protected-mode no'. Any host able "
+        "to reach the cluster bus port can speak the cluster protocol, so make sure the port "
+        "is reachable by trusted hosts only.");
 }
 
 void loadServerConfigFromString(char *config) {
@@ -695,11 +701,11 @@ void loadServerConfigFromString(char *config) {
      * been parsed. */
     config_load_depth--;
     if (config_load_depth == 0) {
-        /* Refuse a cluster node whose bus would run on plain TCP, unless the
-         * operator waived the requirement. Checked before anything else in this
-         * block so that a fatal error is not preceded by unrelated warnings. */
-        if (clusterBusTlsRequirementUnmet()) {
-            err = CLUSTER_BUS_REQUIRE_TLS_ERR;
+        /* Refuse a cluster node whose bus port would be left unauthenticated,
+         * unless the operator waived protection. Checked before anything else in
+         * this block so that a fatal error is not preceded by unrelated warnings. */
+        if (clusterBusPortProtectionUnmet()) {
+            err = CLUSTER_BUS_PORT_PROTECTED_MODE_ERR;
             goto loaderr;
         }
 
@@ -712,7 +718,7 @@ void loadServerConfigFromString(char *config) {
          * from it, and the server exits if that fails. */
         tls_cluster_applied = server.tls_cluster;
 
-        clusterBusWarnIfPlaintextBus();
+        clusterBusWarnIfUnprotected();
         tlsWarnExpectedPeerNameScope();
     }
 
@@ -2998,14 +3004,14 @@ static int applyTlsCfg(const char **err) {
 static int applyTlsCluster(const char **err) {
     /* Checked before any side effect, so a rejected CONFIG SET leaves the TLS
      * context and the module topology notifications untouched. The check reads
-     * cluster-bus-require-tls as it is *after* the whole CONFIG SET was stored:
-     * configSetCommand() runs every setter before the first apply callback, so a
-     * single command disabling both options is accepted whatever the order of
-     * its arguments, while disabling tls-cluster alone is not. */
-    if (clusterBusTlsRequirementUnmet()) {
-        *err = "can't disable tls-cluster while cluster-bus-require-tls is enabled, "
-               "as that would move the cluster bus to plain TCP; disable "
-               "cluster-bus-require-tls in the same CONFIG SET call to allow it";
+     * cluster-bus-port-protected-mode as it is *after* the whole CONFIG SET was
+     * stored: configSetCommand() runs every setter before the first apply
+     * callback, so a single command disabling both options is accepted whatever
+     * the order of its arguments, while disabling tls-cluster alone is not. */
+    if (clusterBusPortProtectionUnmet()) {
+        *err = "can't disable tls-cluster while cluster-bus-port-protected-mode is enabled, "
+               "as that would leave the cluster bus port unauthenticated; disable "
+               "cluster-bus-port-protected-mode in the same CONFIG SET call to allow it";
         return 0;
     }
 
@@ -3025,18 +3031,18 @@ static int applyTlsCluster(const char **err) {
     clusterNotifyTopologyChanged(CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE, NULL);
 
     tls_cluster_applied = server.tls_cluster;
-    clusterBusWarnIfPlaintextBus();
+    clusterBusWarnIfUnprotected();
     return 1;
 }
 
-/* Apply callback for cluster-bus-require-tls. The value drives no machinery of
- * its own, it only has to stay consistent with tls-cluster; see applyTlsCluster()
- * for why the check belongs here rather than in a set handler. */
-static int applyClusterBusRequireTls(const char **err) {
-    if (clusterBusTlsRequirementUnmet()) {
-        *err = "can't enable cluster-bus-require-tls while tls-cluster is disabled, "
-               "as the cluster bus is running on plain TCP; enable tls-cluster in the "
-               "same CONFIG SET call to protect the cluster bus with TLS";
+/* Apply callback for cluster-bus-port-protected-mode. The value drives no
+ * machinery of its own, it only has to stay consistent with tls-cluster; see
+ * applyTlsCluster() for why the check belongs here rather than in a set handler. */
+static int applyClusterBusPortProtectedMode(const char **err) {
+    if (clusterBusPortProtectionUnmet()) {
+        *err = "can't enable cluster-bus-port-protected-mode while tls-cluster is disabled, "
+               "as that leaves the cluster bus port unauthenticated; enable tls-cluster in "
+               "the same CONFIG SET call to authenticate the cluster bus";
         return 0;
     }
     return 1;
@@ -3478,7 +3484,7 @@ standardConfig static_configs[] = {
     createBoolConfig("activedefrag", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.active_defrag_enabled, 0, isValidActiveDefrag, NULL),
     createBoolConfig("syslog-enabled", NULL, IMMUTABLE_CONFIG, server.syslog_enabled, 0, NULL, NULL),
     createBoolConfig("cluster-enabled", NULL, IMMUTABLE_CONFIG, server.cluster_enabled, 0, NULL, NULL),
-    createBoolConfig("cluster-bus-require-tls", NULL, MODIFIABLE_CONFIG, server.cluster_bus_require_tls, 1, NULL, applyClusterBusRequireTls),
+    createBoolConfig("cluster-bus-port-protected-mode", NULL, MODIFIABLE_CONFIG, server.cluster_bus_port_protected_mode, 1, NULL, applyClusterBusPortProtectedMode),
     createBoolConfig("appendonly", NULL, MODIFIABLE_CONFIG, server.aof_enabled, 0, NULL, updateAppendonly),
     createBoolConfig("cluster-allow-reads-when-down", NULL, MODIFIABLE_CONFIG, server.cluster_allow_reads_when_down, 0, NULL, NULL),
     createBoolConfig("cluster-allow-pubsubshard-when-down", NULL, MODIFIABLE_CONFIG, server.cluster_allow_pubsubshard_when_down, 1, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3017,10 +3017,10 @@ static int applyTlsCluster(const char **err) {
 
     /* Nothing below may run when the value did not effectively move, which is
      * what configSetCommand() hands us after it has restored a refused set: both
-     * steps are observable - reconfiguring TLS rebuilds the SSL_CTX, and
-     * clusterNotifyTopologyChanged() cancels the ASM tasks invalidated by the new
-     * topology besides notifying modules - so a refused set would otherwise not
-     * be the no-op it reports being. */
+     * steps are observable - reconfiguring TLS rebuilds the SSL_CTX, discarding
+     * the session cache held on it, and clusterNotifyTopologyChanged() reports a
+     * NODE change to modules - so a refused set would otherwise not be the no-op
+     * it reports being. */
     if (server.tls_cluster == tls_cluster_applied) return 1;
 
     if (!applyTlsCfg(err)) return 0;

--- a/src/config.c
+++ b/src/config.c
@@ -455,6 +455,48 @@ static int config_load_depth;
 /* Defined with the TLS config hooks below; used by the post-load checks. */
 static void tlsWarnExpectedPeerNameScope(void);
 
+/* The cluster bus has no authentication of its own: the sender of a packet is
+ * identified solely by the node ID in its header, which is public, so any peer
+ * able to reach the bus port can speak the protocol. The bus also carries
+ * sensitive information shared between the nodes, which must not leak outside
+ * the cluster. A plaintext bus exposes both to anyone able to reach or eavesdrop
+ * on the bus port, which can threaten the whole cluster, so cluster-bus-require-tls
+ * refuses such a setup by default and makes running a plaintext bus an explicit
+ * choice, in the spirit of protected-mode. Only cluster mode opens the bus, so a
+ * standalone instance is never affected.
+ *
+ * Returns non-zero when the current configuration violates the requirement. */
+static int clusterBusTlsRequirementUnmet(void) {
+    return server.cluster_enabled && server.cluster_bus_require_tls && !server.tls_cluster;
+}
+
+/* Reported when the requirement above is violated at startup. The CONFIG SET
+ * path names the option it refuses to change instead. */
+#define CLUSTER_BUS_REQUIRE_TLS_ERR \
+    "cluster-bus-require-tls is enabled but tls-cluster is disabled: the cluster bus " \
+    "of this node would run on plain TCP. The cluster bus is not authenticated and it " \
+    "carries sensitive information shared between the nodes, which must not leak " \
+    "outside the cluster, so any host able to reach or eavesdrop on the cluster bus " \
+    "port can potentially threaten the whole cluster. Either set 'tls-cluster yes' to " \
+    "protect the cluster bus with TLS, or set 'cluster-bus-require-tls no' to " \
+    "acknowledge that the cluster bus port is reachable by trusted hosts only, for " \
+    "instance because a firewall blocks it."
+
+/* Counterpart of the check above: report a cluster node running a plaintext bus
+ * once the operator has waived the requirement. Called when the outermost config
+ * load finishes and from the tls-cluster apply callback, which covers every way
+ * the bus can become plaintext at runtime (leaving TLS always changes
+ * tls-cluster, whether alone or together with cluster-bus-require-tls). */
+static void clusterBusWarnIfPlaintextBus(void) {
+    if (!server.cluster_enabled || server.tls_cluster || server.cluster_bus_require_tls) return;
+
+    serverLog(LL_WARNING,
+        "WARNING: the cluster bus is not protected by TLS: 'tls-cluster' is disabled and "
+        "the requirement was waived with 'cluster-bus-require-tls no'. The cluster bus is "
+        "not authenticated and it carries sensitive information shared between the nodes, "
+        "so make sure the cluster bus port is reachable by trusted hosts only.");
+}
+
 void loadServerConfigFromString(char *config) {
     deprecatedConfig deprecated_configs[] = {
         {"list-max-ziplist-entries", 2, 2},
@@ -644,11 +686,20 @@ void loadServerConfigFromString(char *config) {
      * been parsed. */
     config_load_depth--;
     if (config_load_depth == 0) {
+        /* Refuse a cluster node whose bus would run on plain TCP, unless the
+         * operator waived the requirement. Checked before anything else in this
+         * block so that a fatal error is not preceded by unrelated warnings. */
+        if (clusterBusTlsRequirementUnmet()) {
+            err = CLUSTER_BUS_REQUIRE_TLS_ERR;
+            goto loaderr;
+        }
+
         /* in case cluster mode is enabled dbnum must be 1 */
         if (server.cluster_enabled && server.dbnum > 1) {
             serverLog(LL_WARNING, "WARNING: Changing databases number from %d to 1 since we are in cluster mode", server.dbnum);
             server.dbnum = 1;
         }
+        clusterBusWarnIfPlaintextBus();
         tlsWarnExpectedPeerNameScope();
     }
 
@@ -2932,12 +2983,40 @@ static int applyTlsCfg(const char **err) {
 }
 
 static int applyTlsCluster(const char **err) {
+    /* Checked before any side effect, so a rejected CONFIG SET leaves the TLS
+     * context and the module topology notifications untouched. The check reads
+     * cluster-bus-require-tls as it is *after* the whole CONFIG SET was stored:
+     * configSetCommand() runs every setter before the first apply callback, so a
+     * single command disabling both options is accepted whatever the order of
+     * its arguments, while disabling tls-cluster alone is not. */
+    if (clusterBusTlsRequirementUnmet()) {
+        *err = "can't disable tls-cluster while cluster-bus-require-tls is enabled, "
+               "as that would move the cluster bus to plain TCP; disable "
+               "cluster-bus-require-tls in the same CONFIG SET call to allow it";
+        return 0;
+    }
+
     if (!applyTlsCfg(err)) return 0;
 
     /* tls-cluster selects which client port is advertised by the cluster.
      * Modules cache that topology through the cluster module APIs, so notify
      * them when the preferred port changes. */
     clusterNotifyTopologyChanged(CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE, NULL);
+
+    clusterBusWarnIfPlaintextBus();
+    return 1;
+}
+
+/* Apply callback for cluster-bus-require-tls. The value drives no machinery of
+ * its own, it only has to stay consistent with tls-cluster; see applyTlsCluster()
+ * for why the check belongs here rather than in a set handler. */
+static int applyClusterBusRequireTls(const char **err) {
+    if (clusterBusTlsRequirementUnmet()) {
+        *err = "can't enable cluster-bus-require-tls while tls-cluster is disabled, "
+               "as the cluster bus is running on plain TCP; enable tls-cluster in the "
+               "same CONFIG SET call to protect the cluster bus with TLS";
+        return 0;
+    }
     return 1;
 }
 
@@ -3377,6 +3456,7 @@ standardConfig static_configs[] = {
     createBoolConfig("activedefrag", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.active_defrag_enabled, 0, isValidActiveDefrag, NULL),
     createBoolConfig("syslog-enabled", NULL, IMMUTABLE_CONFIG, server.syslog_enabled, 0, NULL, NULL),
     createBoolConfig("cluster-enabled", NULL, IMMUTABLE_CONFIG, server.cluster_enabled, 0, NULL, NULL),
+    createBoolConfig("cluster-bus-require-tls", NULL, MODIFIABLE_CONFIG, server.cluster_bus_require_tls, 1, NULL, applyClusterBusRequireTls),
     createBoolConfig("appendonly", NULL, MODIFIABLE_CONFIG, server.aof_enabled, 0, NULL, updateAppendonly),
     createBoolConfig("cluster-allow-reads-when-down", NULL, MODIFIABLE_CONFIG, server.cluster_allow_reads_when_down, 0, NULL, NULL),
     createBoolConfig("cluster-allow-pubsubshard-when-down", NULL, MODIFIABLE_CONFIG, server.cluster_allow_pubsubshard_when_down, 1, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3010,7 +3010,7 @@ static int applyTlsCluster(const char **err) {
     if (clusterBusPortProtectionUnmet()) {
         *err = "can't disable tls-cluster while cluster-bus-port-protected-mode is enabled, "
                "as that would leave the cluster bus port unauthenticated; disable "
-               "cluster-bus-port-protected-mode first, or in the same CONFIG SET call";
+               "cluster-bus-port-protected-mode first, or in the same CONFIG SET command";
         return 0;
     }
 

--- a/src/config.c
+++ b/src/config.c
@@ -3041,7 +3041,7 @@ static int applyClusterBusPortProtectedMode(const char **err) {
     if (clusterBusPortProtectionUnmet()) {
         *err = "can't enable cluster-bus-port-protected-mode while tls-cluster is disabled, "
                "as that leaves the cluster bus port unauthenticated; enable tls-cluster "
-               "first, or in the same CONFIG SET call";
+               "first, or in the same CONFIG SET command";
         return 0;
     }
     return 1;

--- a/src/config.c
+++ b/src/config.c
@@ -481,17 +481,6 @@ static int clusterBusPortProtectionUnmet(void) {
     return server.cluster_enabled && server.cluster_bus_port_protected_mode && !server.tls_cluster;
 }
 
-/* Reported when the check above trips at startup. The CONFIG SET path names the
- * option it refuses to change instead. */
-#define CLUSTER_BUS_PORT_PROTECTED_MODE_ERR \
-    "cluster-bus-port-protected-mode is enabled but tls-cluster is disabled, which " \
-    "leaves the cluster bus port of this node unauthenticated: any host able to reach " \
-    "the port can join the cluster and speak the cluster protocol, and threaten the " \
-    "whole cluster. Either set 'tls-cluster yes', which makes every cluster " \
-    "bus peer present a certificate verified against your CA, or set " \
-    "'cluster-bus-port-protected-mode no' to acknowledge that the cluster bus port is " \
-    "reachable by trusted hosts only, for instance because a firewall blocks it."
-
 /* Counterpart of the check above: report a cluster node whose bus port is left
  * unauthenticated once the operator has waived protected mode. Called when the
  * outermost config load finishes and from the tls-cluster apply callback, which
@@ -699,9 +688,18 @@ void loadServerConfigFromString(char *config) {
     if (config_load_depth == 0) {
         /* Refuse a cluster node whose bus port would be left unauthenticated,
          * unless the operator waived protection. Checked before anything else in
-         * this block so that a fatal error is not preceded by unrelated warnings. */
+         * this block so that a fatal error is not preceded by unrelated warnings.
+         * The CONFIG SET path reports the option it refuses to change instead. */
         if (clusterBusPortProtectionUnmet()) {
-            err = CLUSTER_BUS_PORT_PROTECTED_MODE_ERR;
+            err = "cluster-bus-port-protected-mode is enabled but tls-cluster is "
+                  "disabled, which leaves the cluster bus port of this node "
+                  "unauthenticated: any host able to reach the port can join the "
+                  "cluster and speak the cluster protocol, and threaten the whole "
+                  "cluster. Either set 'tls-cluster yes', which makes every cluster "
+                  "bus peer present a certificate verified against your CA, or set "
+                  "'cluster-bus-port-protected-mode no' to acknowledge that the "
+                  "cluster bus port is reachable by trusted hosts only, for instance "
+                  "because a firewall blocks it.";
             goto loaderr;
         }
 

--- a/src/config.c
+++ b/src/config.c
@@ -452,14 +452,11 @@ static int reading_config_file;
  * post-load advisories must run only when the outermost load finishes. */
 static int config_load_depth;
 
-/* Value of tls-cluster as of the last time applyTlsCluster() acted on it, in the
- * manner of clusterUpdateMyselfIp()'s prev_ip. It lets a refused CONFIG SET be a
- * true no-op: configSetCommand() restores the previous value and calls every
- * apply callback of the command a second time, and that second call must not
- * reconfigure anything for a value that never effectively moved. The zero
- * initialiser matches the tls-cluster default, which is what is in force when no
- * configuration is loaded at all; the post-load block below takes it from there. */
-static int tls_cluster_applied;
+/* Previous value of tls-cluster. This variable is used to detect if the
+ * value actually changed after a CONFIG SET. configSetCommand() calls every
+ * apply callback again on rollback even when nothing changed, so without it,
+ * things like TLS setup below would run again for no reason. */
+static int prev_tls_cluster;
 
 /* Defined with the TLS config hooks below; used by the post-load checks. */
 static void tlsWarnExpectedPeerNameScope(void);
@@ -499,7 +496,7 @@ static int clusterBusPortProtectionUnmet(void) {
  * unauthenticated once the operator has waived protected mode. Called when the
  * outermost config load finishes and from the tls-cluster apply callback, which
  * covers every way the bus can lose its authentication at runtime (leaving TLS
- * always changes tls-cluster, whether alone or together with 
+ * always changes tls-cluster, whether alone or together with
  * cluster_bus_port_protected_mode). */
 static void clusterBusWarnIfUnprotected(void) {
     if (!server.cluster_enabled || server.tls_cluster || server.cluster_bus_port_protected_mode) return;
@@ -715,7 +712,7 @@ void loadServerConfigFromString(char *config) {
         }
         /* The startup value is the one in force: initListeners() configures TLS
          * from it, and the server exits if that fails. */
-        tls_cluster_applied = server.tls_cluster;
+        prev_tls_cluster = server.tls_cluster;
 
         clusterBusWarnIfUnprotected();
         tlsWarnExpectedPeerNameScope();
@@ -3020,7 +3017,7 @@ static int applyTlsCluster(const char **err) {
      * the session cache held on it, and clusterNotifyTopologyChanged() reports a
      * NODE change to modules - so a refused set would otherwise not be the no-op
      * it reports being. */
-    if (server.tls_cluster == tls_cluster_applied) return 1;
+    if (server.tls_cluster == prev_tls_cluster) return 1;
 
     if (!applyTlsCfg(err)) return 0;
 
@@ -3029,7 +3026,7 @@ static int applyTlsCluster(const char **err) {
      * them when the preferred port changes. */
     clusterNotifyTopologyChanged(CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE, NULL);
 
-    tls_cluster_applied = server.tls_cluster;
+    prev_tls_cluster = server.tls_cluster;
     clusterBusWarnIfUnprotected();
     return 1;
 }

--- a/src/server.h
+++ b/src/server.h
@@ -2624,8 +2624,9 @@ struct redisServer {
     unsigned int watching_clients; /* # of clients are watching keys */
     /* Cluster */
     int cluster_enabled;      /* Is cluster enabled? */
-    int cluster_bus_require_tls; /* Refuse to run a cluster node whose bus is
-                                    plain TCP (see cluster-bus-require-tls). */
+    int cluster_bus_port_protected_mode; /* Refuse to run a cluster node whose bus
+                                            port is unauthenticated. See
+                                            cluster-bus-port-protected-mode. */
     int cluster_port;         /* Set the cluster port for a node. */
     mstime_t cluster_node_timeout; /* Cluster node timeout. */
     mstime_t cluster_ping_interval;    /* A debug configuration for setting how often cluster nodes send ping messages. */

--- a/src/server.h
+++ b/src/server.h
@@ -2624,6 +2624,8 @@ struct redisServer {
     unsigned int watching_clients; /* # of clients are watching keys */
     /* Cluster */
     int cluster_enabled;      /* Is cluster enabled? */
+    int cluster_bus_require_tls; /* Refuse to run a cluster node whose bus is
+                                    plain TCP (see cluster-bus-require-tls). */
     int cluster_port;         /* Set the cluster port for a node. */
     mstime_t cluster_node_timeout; /* Cluster node timeout. */
     mstime_t cluster_ping_interval;    /* A debug configuration for setting how often cluster nodes send ping messages. */

--- a/tests/assets/default.conf
+++ b/tests/assets/default.conf
@@ -31,10 +31,10 @@ enable-protected-configs yes
 enable-debug-command yes
 enable-module-command yes
 
-# Cluster nodes refuse to start with a plaintext cluster bus unless the
-# requirement is waived, and non-TLS runs have no TLS to offer. Waive it for the
-# whole suite; the tests covering the requirement itself enable it explicitly.
-cluster-bus-require-tls no
+# Cluster nodes refuse to start with an unauthenticated cluster bus port unless
+# protection is waived, and non-TLS runs have no TLS to offer. Waive it for the
+# whole suite; the tests covering the protection itself enable it explicitly.
+cluster-bus-port-protected-mode no
 
 propagation-error-behavior panic
 

--- a/tests/assets/default.conf
+++ b/tests/assets/default.conf
@@ -31,6 +31,11 @@ enable-protected-configs yes
 enable-debug-command yes
 enable-module-command yes
 
+# Cluster nodes refuse to start with a plaintext cluster bus unless the
+# requirement is waived, and non-TLS runs have no TLS to offer. Waive it for the
+# whole suite; the tests covering the requirement itself enable it explicitly.
+cluster-bus-require-tls no
+
 propagation-error-behavior panic
 
 # Make sure shutdown doesn't fail if there's an initial AOFRW

--- a/tests/cluster/run.tcl
+++ b/tests/cluster/run.tcl
@@ -19,7 +19,7 @@ proc main {} {
     parse_options
     spawn_instance redis $::redis_base_port $::instances_count {
         "cluster-enabled yes"
-        "cluster-bus-require-tls no"
+        "cluster-bus-port-protected-mode no"
         "appendonly yes"
         "enable-protected-configs yes"
         "enable-debug-command yes"

--- a/tests/cluster/run.tcl
+++ b/tests/cluster/run.tcl
@@ -19,6 +19,7 @@ proc main {} {
     parse_options
     spawn_instance redis $::redis_base_port $::instances_count {
         "cluster-enabled yes"
+        "cluster-bus-require-tls no"
         "appendonly yes"
         "enable-protected-configs yes"
         "enable-debug-command yes"

--- a/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
+++ b/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
@@ -1,10 +1,10 @@
 # cluster-bus-port-protected-mode makes an unauthenticated cluster bus port an
 # explicit choice.
 #
-# The cluster bus port has no authentication of its own: a packet's sender is
-# identified only by the public node ID in its header, so any host able to reach
-# the port can speak the cluster protocol and potentially threaten the whole
-# cluster. What authenticates it is tls-cluster, which makes every peer present a
+# The cluster bus port has no authentication of its own: any host able to reach it
+# can speak the cluster protocol and potentially threaten the whole cluster - a
+# MEET from an unknown host is enough to have it added as a node, with its gossip
+# trusted. What authenticates it is tls-cluster, which makes every peer present a
 # certificate verified against the CA. The option defaults to yes and refuses an
 # unauthenticated bus, in the spirit of protected-mode; the operator waives it
 # with "cluster-bus-port-protected-mode no" once the port is known to be

--- a/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
+++ b/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
@@ -249,6 +249,21 @@ tags {external:skip cluster} {
                     assert_equal {cluster-bus-port-protected-mode yes} [r config get cluster-bus-port-protected-mode]
                 }
             }
+
+            test {each option can also be changed on its own, in the safe order} {
+                # A single command is not the only way out, and the refusals say
+                # so: waiving protection before disabling tls-cluster, and
+                # authenticating the bus before enabling protection, are accepted
+                # as separate calls, since the check only judges the state each
+                # one produces.
+                r config set cluster-bus-port-protected-mode no
+                r config set tls-cluster no
+                assert_equal {tls-cluster no} [r config get tls-cluster]
+
+                r config set tls-cluster yes
+                r config set cluster-bus-port-protected-mode yes
+                assert_equal {cluster-bus-port-protected-mode yes} [r config get cluster-bus-port-protected-mode]
+            }
         }
     }
 }

--- a/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
+++ b/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
@@ -265,5 +265,32 @@ tags {external:skip cluster} {
                 assert_equal {cluster-bus-port-protected-mode yes} [r config get cluster-bus-port-protected-mode]
             }
         }
+
+        # Protected mode reads tls-cluster alone as an authenticated bus, which
+        # only holds because tls-auth-clients cannot reach the bus. Pin that with
+        # the setting that would weaken it if it could.
+        start_cluster 1 0 {overrides {tls-auth-clients no}} {
+            test {tls-auth-clients does not relax the cluster bus} {
+                set host [srv 0 host]
+                set bus [expr {[srv 0 port] + 10000}]
+
+                # The setting is in effect: on the client port a peer presenting
+                # no certificate is served. Driven through redis-cli, since the
+                # suite's own client always offers one.
+                assert_equal {PONG} [string trim [exec src/redis-cli --tls \
+                    --cacert "$::tlsdir/ca.crt" -h $host -p [srv 0 port] ping]]
+
+                # The cluster bus is unaffected: clusterAcceptHandler() demands a
+                # certificate whatever tls-auth-clients says, so the same peer is
+                # refused there. Read from the log, as a TLS 1.3 client is not
+                # told: its own handshake completes before the server judges it.
+                set loglines [count_log_lines 0]
+                catch {exec openssl s_client -connect $host:$bus \
+                    -CAfile "$::tlsdir/ca.crt" << "" 2> /dev/null}
+                wait_for_log_messages 0 \
+                    {"*Error accepting cluster node connection*peer did not return a certificate*"} \
+                    $loglines 50 100
+            }
+        }
     }
 }

--- a/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
+++ b/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
@@ -30,6 +30,19 @@ proc write_included_conf {dir port inner_lines} {
     close $fd
 }
 
+# Opens a cluster bus connection presenting the given client certificate, then
+# closes it. The handshake outcome is deliberately not inspected here: under TLS
+# 1.3 the client's own handshake completes before the server has validated the
+# certificate, so a rejection is only visible in the server's log. Callers assert
+# on that.
+proc bus_connect_with_cert {host port crt key} {
+    catch {
+        set fd [::tls::socket -cafile "$::tlsdir/ca.crt" -certfile $crt -keyfile $key $host $port]
+        ::tls::handshake $fd
+        close $fd
+    }
+}
+
 tags {external:skip cluster} {
 
     test {cluster-bus-port-protected-mode defaults to yes and refuses an unauthenticated bus} {
@@ -137,6 +150,78 @@ tags {external:skip cluster} {
                 assert_equal 0 [count_log_message 0 "cluster bus port is not authenticated"]
             }
 
+            test {a cluster bus peer whose certificate does not chain to the CA is rejected} {
+                # What protected mode buys is authentication of the bus port, so
+                # pin what that authentication actually rejects. A self-signed
+                # certificate is valid TLS material with no path to
+                # tls-ca-cert-file, and has to be refused on the very port that
+                # accepts the suite's CA-signed one.
+                set dir [file normalize [tmpdir cluster-bus-untrusted-ca]]
+                exec -ignorestderr openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+                    -subj "/O=Rogue/CN=rogue.example" \
+                    -keyout $dir/rogue.key -out $dir/rogue.crt 2>/dev/null
+
+                set host [srv 0 host]
+                set bus [expr {[srv 0 port] + 10000}]
+                set rejection "Error accepting cluster node connection"
+                set before [count_log_message 0 $rejection]
+                set loglines [count_log_lines 0]
+
+                bus_connect_with_cert $host $bus $::tlsdir/redis.crt $::tlsdir/redis.key
+                bus_connect_with_cert $host $bus $dir/rogue.crt $dir/rogue.key
+
+                wait_for_log_messages 0 \
+                    {"*Error accepting cluster node connection*certificate verify failed*"} \
+                    $loglines 50 100
+                # Exactly one rejection, so the CA-signed peer was accepted on the
+                # same port rather than everything being refused.
+                assert_equal [expr {$before + 1}] [count_log_message 0 $rejection]
+            }
+
+            test {a cluster bus peer whose server certificate does not chain to the CA is refused} {
+                # The dialling side verifies too: an outbound bus link uses the
+                # client-role context, which loads the same CA, so a peer serving
+                # a certificate that does not chain to it must be refused and
+                # never admitted to the cluster.
+                set dir [file normalize [tmpdir cluster-bus-untrusted-peer]]
+                exec -ignorestderr openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+                    -subj "/O=Rogue/CN=rogue.example" \
+                    -keyout $dir/rogue.key -out $dir/rogue.crt 2>/dev/null
+
+                # A second cluster node, identical to this one except that it
+                # serves a self-signed certificate. "wait_ready false" because the
+                # suite's own client would refuse that certificate as well, so no
+                # client is created for it; inside this block R 1 is the node
+                # under test and srv 0 the untrusted peer.
+                start_server [list wait_ready false overrides [list cluster-enabled yes \
+                        tls-cert-file $dir/rogue.crt tls-key-file $dir/rogue.key \
+                        tls-client-cert-file $dir/rogue.crt tls-client-key-file $dir/rogue.key]] {
+                    wait_for_condition 50 100 {
+                        [count_message_lines [srv 0 stdout] "Ready to accept"] > 0
+                    } else {
+                        fail "the peer serving an untrusted certificate did not start"
+                    }
+
+                    # Commands use R's positive indexing, the log helpers take
+                    # srv's negative one; both mean the node under test here.
+                    set rogue_bus [expr {[srv 0 port] + 10000}]
+                    set loglines [count_log_lines -1]
+                    R 1 cluster meet [srv 0 host] [srv 0 port]
+
+                    wait_for_log_messages -1 \
+                        [list "*at [srv 0 host]:$rogue_bus failed*certificate verify failed*"] \
+                        $loglines 50 100
+
+                    # And it is never admitted: the handshake node is dropped once
+                    # it expires, leaving this node on its own again.
+                    wait_for_condition 50 100 {
+                        [llength [get_cluster_nodes 1]] == 1
+                    } else {
+                        fail "the peer serving an untrusted certificate was admitted"
+                    }
+                }
+            }
+
             test {CONFIG SET tls-cluster no is refused while protected mode is enabled} {
                 assert_error {*can't disable tls-cluster while cluster-bus-port-protected-mode is enabled*} {
                     r config set tls-cluster no
@@ -145,7 +230,7 @@ tags {external:skip cluster} {
                 assert_equal 0 [count_log_message 0 "cluster bus port is not authenticated"]
             }
 
-            test {a single CONFIG SET can unauthenticate the bus, in either argument order} {
+            test {a single CONFIG SET can un-authenticate the bus, in either argument order} {
                 # Every setter of a CONFIG SET runs before the first apply
                 # callback, so the pair is judged on the state it produces and
                 # not on the order it is written in.

--- a/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
+++ b/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
@@ -1,14 +1,16 @@
-# cluster-bus-require-tls makes a plaintext cluster bus an explicit choice.
+# cluster-bus-port-protected-mode makes an unauthenticated cluster bus port an
+# explicit choice.
 #
-# The cluster bus has no authentication of its own (a packet's sender is
-# identified only by the public node ID in its header) and it carries sensitive
-# information shared between the nodes, which must not leak outside the cluster.
-# So anyone able to reach or eavesdrop on the cluster bus port of a plaintext bus
-# can potentially threaten the whole cluster. The option defaults to yes and
-# refuses such a setup, in the spirit of protected-mode; the operator waives it with
-# "cluster-bus-require-tls no" once the port is known to be firewalled off.
+# The cluster bus port has no authentication of its own: a packet's sender is
+# identified only by the public node ID in its header, so any host able to reach
+# the port can speak the cluster protocol and potentially threaten the whole
+# cluster. What authenticates it is tls-cluster, which makes every peer present a
+# certificate verified against the CA. The option defaults to yes and refuses an
+# unauthenticated bus, in the spirit of protected-mode; the operator waives it
+# with "cluster-bus-port-protected-mode no" once the port is known to be
+# firewalled off.
 #
-# Note that the suite's default.conf waives the requirement for every server it
+# Note that the suite's default.conf waives protection for every server it
 # starts (non-TLS runs have no TLS to offer), so the tests below that care about
 # the default state must set the option, or bypass default.conf altogether.
 
@@ -30,18 +32,18 @@ proc write_included_conf {dir port inner_lines} {
 
 tags {external:skip cluster} {
 
-    test {cluster-bus-require-tls defaults to yes and refuses a plaintext cluster bus} {
+    test {cluster-bus-port-protected-mode defaults to yes and refuses an unauthenticated bus} {
         # No config file at all: this observes the compiled-in default rather
         # than anything the suite configures. "--daemonize yes" only matters if
         # this check ever regresses: the server would then start instead of
         # failing, and exec would return at once instead of blocking forever.
         catch {exec src/redis-server --cluster-enabled yes --port 0 --daemonize yes} err
         assert_match {*FATAL CONFIG FILE ERROR*} $err
-        assert_match {*cluster-bus-require-tls is enabled but tls-cluster is disabled*} $err
-        assert_match {*'cluster-bus-require-tls no'*} $err
+        assert_match {*cluster-bus-port-protected-mode is enabled but tls-cluster is disabled*} $err
+        assert_match {*'cluster-bus-port-protected-mode no'*} $err
     }
 
-    test {the requirement is judged after the whole configuration is loaded} {
+    test {protection is judged after the whole configuration is loaded} {
         # The check runs when the OUTERMOST config load finishes, so directives
         # that reach the server through "include" are accounted for. This matters
         # because an included file ends at the position of its "include" line,
@@ -53,14 +55,14 @@ tags {external:skip cluster} {
         set port [find_available_port $::baseport $::portcount]
 
         # cluster mode arrives via the include: the node does open a cluster bus,
-        # so the default requirement must still refuse the plaintext one.
+        # so the default protection must still refuse an unauthenticated one.
         write_included_conf $dir $port {"cluster-enabled yes"}
         catch {exec src/redis-server $dir/main.conf --daemonize yes} err
-        assert_match {*cluster-bus-require-tls is enabled but tls-cluster is disabled*} $err
+        assert_match {*cluster-bus-port-protected-mode is enabled but tls-cluster is disabled*} $err
 
         # And the waiver arrives via the include too: it is honoured, and the
-        # node starts with a plaintext bus.
-        write_included_conf $dir $port {"cluster-enabled yes" "cluster-bus-require-tls no"}
+        # node starts with an unauthenticated bus.
+        write_included_conf $dir $port {"cluster-enabled yes" "cluster-bus-port-protected-mode no"}
         exec src/redis-server $dir/main.conf --daemonize yes --logfile $logf
         wait_for_condition 100 100 {
             [count_message_lines $logf "Ready to accept"] > 0
@@ -70,33 +72,33 @@ tags {external:skip cluster} {
         # Connect over the plain port: this server knows nothing about the
         # suite's TLS configuration, in a --tls run just as much as without it.
         set rd [redis 127.0.0.1 $port 0 0]
-        assert_equal {cluster-bus-require-tls no} [$rd config get cluster-bus-require-tls]
+        assert_equal {cluster-bus-port-protected-mode no} [$rd config get cluster-bus-port-protected-mode]
         assert_equal 1 [status $rd cluster_enabled]
-        assert_equal 1 [count_message_lines $logf "cluster bus is not protected by TLS"]
+        assert_equal 1 [count_message_lines $logf "cluster bus port is not authenticated"]
         catch {$rd shutdown nosave}
         $rd close
     }
 
-    # A standalone instance opens no cluster bus, so the default requirement must
-    # not stop it from starting with plain TCP everywhere.
-    start_server {overrides {cluster-bus-require-tls yes tls-cluster no}} {
-        test {cluster-bus-require-tls only applies to cluster mode} {
-            assert_equal {cluster-bus-require-tls yes} [r config get cluster-bus-require-tls]
+    # A standalone instance opens no cluster bus port, so the default protection
+    # must not stop it from starting without any TLS at all.
+    start_server {overrides {cluster-bus-port-protected-mode yes tls-cluster no}} {
+        test {cluster-bus-port-protected-mode only applies to cluster mode} {
+            assert_equal {cluster-bus-port-protected-mode yes} [r config get cluster-bus-port-protected-mode]
             assert_equal {tls-cluster no} [r config get tls-cluster]
             assert_equal 0 [s cluster_enabled]
             assert_equal {PONG} [r ping]
             # Outside cluster mode the two options are unrelated, so both stay
             # freely settable.
-            r config set cluster-bus-require-tls no
-            r config set cluster-bus-require-tls yes
-            assert_equal 0 [count_log_message 0 "cluster bus is not protected by TLS"]
+            r config set cluster-bus-port-protected-mode no
+            r config set cluster-bus-port-protected-mode yes
+            assert_equal 0 [count_log_message 0 "cluster bus port is not authenticated"]
         }
 
-        test {the cluster-mode gate of the requirement cannot be opened at runtime} {
-            # Gating the requirement on cluster mode is only sound because
+        test {the cluster-mode gate of protection cannot be opened at runtime} {
+            # Gating protection on cluster mode is only sound because
             # cluster-enabled is IMMUTABLE_CONFIG. Could it be set, this very
-            # server - requirement enabled, tls-cluster off - would open a
-            # plaintext cluster bus without ever facing the startup check. The
+            # server - protection enabled, tls-cluster off - would open an
+            # unauthenticated cluster bus without ever facing the startup check. The
             # immutable mechanism itself is covered by "CONFIG SET set immutable"
             # in unit/introspection; what is pinned here is that cluster-enabled
             # in particular still carries the flag.
@@ -105,61 +107,61 @@ tags {external:skip cluster} {
         }
     }
 
-    start_cluster 1 0 {overrides {cluster-bus-require-tls no tls-cluster no}} {
-        test {waiving the requirement starts a cluster node with a plaintext bus} {
+    start_cluster 1 0 {overrides {cluster-bus-port-protected-mode no tls-cluster no}} {
+        test {waiving protection starts a cluster node with an unauthenticated bus} {
             assert_equal 1 [s cluster_enabled]
             assert_equal {tls-cluster no} [r config get tls-cluster]
             wait_for_cluster_state ok
         }
 
-        test {a waived requirement is reported in the log} {
-            verify_log_message 0 "*cluster bus is not protected by TLS*" 0
+        test {waived protection is reported in the log} {
+            verify_log_message 0 "*cluster bus port is not authenticated*" 0
         }
 
-        test {CONFIG SET cluster-bus-require-tls yes is refused while the bus is plaintext} {
-            assert_error {*can't enable cluster-bus-require-tls while tls-cluster is disabled*} {
-                r config set cluster-bus-require-tls yes
+        test {CONFIG SET cluster-bus-port-protected-mode yes is refused while the bus is unauthenticated} {
+            assert_error {*can't enable cluster-bus-port-protected-mode while tls-cluster is disabled*} {
+                r config set cluster-bus-port-protected-mode yes
             }
-            assert_equal {cluster-bus-require-tls no} [r config get cluster-bus-require-tls]
+            assert_equal {cluster-bus-port-protected-mode no} [r config get cluster-bus-port-protected-mode]
         }
     }
 
     # The other direction, and the atomic transitions between the two states,
     # need a cluster bus that can actually run on TLS.
     if {$::tls} {
-        start_cluster 1 0 {overrides {cluster-bus-require-tls yes}} {
-            test {a cluster node starts with the requirement met by tls-cluster} {
+        start_cluster 1 0 {overrides {cluster-bus-port-protected-mode yes}} {
+            test {a cluster node starts with its bus authenticated by tls-cluster} {
                 assert_equal 1 [s cluster_enabled]
                 assert_equal {tls-cluster yes} [r config get tls-cluster]
                 wait_for_cluster_state ok
-                assert_equal 0 [count_log_message 0 "cluster bus is not protected by TLS"]
+                assert_equal 0 [count_log_message 0 "cluster bus port is not authenticated"]
             }
 
-            test {CONFIG SET tls-cluster no is refused while the requirement is enabled} {
-                assert_error {*can't disable tls-cluster while cluster-bus-require-tls is enabled*} {
+            test {CONFIG SET tls-cluster no is refused while protected mode is enabled} {
+                assert_error {*can't disable tls-cluster while cluster-bus-port-protected-mode is enabled*} {
                     r config set tls-cluster no
                 }
                 assert_equal {tls-cluster yes} [r config get tls-cluster]
-                assert_equal 0 [count_log_message 0 "cluster bus is not protected by TLS"]
+                assert_equal 0 [count_log_message 0 "cluster bus port is not authenticated"]
             }
 
-            test {a single CONFIG SET can move the bus to plain TCP, in either argument order} {
+            test {a single CONFIG SET can unauthenticate the bus, in either argument order} {
                 # Every setter of a CONFIG SET runs before the first apply
                 # callback, so the pair is judged on the state it produces and
                 # not on the order it is written in.
-                foreach args {{cluster-bus-require-tls no tls-cluster no}
-                              {tls-cluster no cluster-bus-require-tls no}} {
-                    set logged [count_log_message 0 "cluster bus is not protected by TLS"]
+                foreach args {{cluster-bus-port-protected-mode no tls-cluster no}
+                              {tls-cluster no cluster-bus-port-protected-mode no}} {
+                    set logged [count_log_message 0 "cluster bus port is not authenticated"]
                     r config set {*}$args
                     assert_equal {tls-cluster no} [r config get tls-cluster]
-                    assert_equal {cluster-bus-require-tls no} [r config get cluster-bus-require-tls]
+                    assert_equal {cluster-bus-port-protected-mode no} [r config get cluster-bus-port-protected-mode]
                     # Leaving TLS is reported once, as it is at startup.
-                    assert_equal [expr {$logged + 1}] [count_log_message 0 "cluster bus is not protected by TLS"]
+                    assert_equal [expr {$logged + 1}] [count_log_message 0 "cluster bus port is not authenticated"]
 
-                    # And back: enabling the requirement again needs TLS back on.
-                    r config set tls-cluster yes cluster-bus-require-tls yes
+                    # And back: enabling protection again needs TLS back on.
+                    r config set tls-cluster yes cluster-bus-port-protected-mode yes
                     assert_equal {tls-cluster yes} [r config get tls-cluster]
-                    assert_equal {cluster-bus-require-tls yes} [r config get cluster-bus-require-tls]
+                    assert_equal {cluster-bus-port-protected-mode yes} [r config get cluster-bus-port-protected-mode]
                 }
             }
         }

--- a/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
+++ b/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
@@ -92,18 +92,8 @@ tags {external:skip cluster} {
             r config set cluster-bus-port-protected-mode no
             r config set cluster-bus-port-protected-mode yes
             assert_equal 0 [count_log_message 0 "cluster bus port is not authenticated"]
-        }
-
-        test {the cluster-mode gate of protection cannot be opened at runtime} {
-            # Gating protection on cluster mode is only sound because
-            # cluster-enabled is IMMUTABLE_CONFIG. Could it be set, this very
-            # server - protection enabled, tls-cluster off - would open an
-            # unauthenticated cluster bus without ever facing the startup check. The
-            # immutable mechanism itself is covered by "CONFIG SET set immutable"
-            # in unit/introspection; what is pinned here is that cluster-enabled
-            # in particular still carries the flag.
+            # cluster-bus-port-protected-mode expects cluster-enabled to be immutable
             assert_error {*can't set immutable config*} {r config set cluster-enabled yes}
-            assert_equal 0 [s cluster_enabled]
         }
     }
 

--- a/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
+++ b/tests/unit/cluster/cluster-bus-port-protected-mode.tcl
@@ -30,19 +30,6 @@ proc write_included_conf {dir port inner_lines} {
     close $fd
 }
 
-# Opens a cluster bus connection presenting the given client certificate, then
-# closes it. The handshake outcome is deliberately not inspected here: under TLS
-# 1.3 the client's own handshake completes before the server has validated the
-# certificate, so a rejection is only visible in the server's log. Callers assert
-# on that.
-proc bus_connect_with_cert {host port crt key} {
-    catch {
-        set fd [::tls::socket -cafile "$::tlsdir/ca.crt" -certfile $crt -keyfile $key $host $port]
-        ::tls::handshake $fd
-        close $fd
-    }
-}
-
 tags {external:skip cluster} {
 
     test {cluster-bus-port-protected-mode defaults to yes and refuses an unauthenticated bus} {
@@ -150,78 +137,6 @@ tags {external:skip cluster} {
                 assert_equal 0 [count_log_message 0 "cluster bus port is not authenticated"]
             }
 
-            test {a cluster bus peer whose certificate does not chain to the CA is rejected} {
-                # What protected mode buys is authentication of the bus port, so
-                # pin what that authentication actually rejects. A self-signed
-                # certificate is valid TLS material with no path to
-                # tls-ca-cert-file, and has to be refused on the very port that
-                # accepts the suite's CA-signed one.
-                set dir [file normalize [tmpdir cluster-bus-untrusted-ca]]
-                exec -ignorestderr openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
-                    -subj "/O=Rogue/CN=rogue.example" \
-                    -keyout $dir/rogue.key -out $dir/rogue.crt 2>/dev/null
-
-                set host [srv 0 host]
-                set bus [expr {[srv 0 port] + 10000}]
-                set rejection "Error accepting cluster node connection"
-                set before [count_log_message 0 $rejection]
-                set loglines [count_log_lines 0]
-
-                bus_connect_with_cert $host $bus $::tlsdir/redis.crt $::tlsdir/redis.key
-                bus_connect_with_cert $host $bus $dir/rogue.crt $dir/rogue.key
-
-                wait_for_log_messages 0 \
-                    {"*Error accepting cluster node connection*certificate verify failed*"} \
-                    $loglines 50 100
-                # Exactly one rejection, so the CA-signed peer was accepted on the
-                # same port rather than everything being refused.
-                assert_equal [expr {$before + 1}] [count_log_message 0 $rejection]
-            }
-
-            test {a cluster bus peer whose server certificate does not chain to the CA is refused} {
-                # The dialling side verifies too: an outbound bus link uses the
-                # client-role context, which loads the same CA, so a peer serving
-                # a certificate that does not chain to it must be refused and
-                # never admitted to the cluster.
-                set dir [file normalize [tmpdir cluster-bus-untrusted-peer]]
-                exec -ignorestderr openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
-                    -subj "/O=Rogue/CN=rogue.example" \
-                    -keyout $dir/rogue.key -out $dir/rogue.crt 2>/dev/null
-
-                # A second cluster node, identical to this one except that it
-                # serves a self-signed certificate. "wait_ready false" because the
-                # suite's own client would refuse that certificate as well, so no
-                # client is created for it; inside this block R 1 is the node
-                # under test and srv 0 the untrusted peer.
-                start_server [list wait_ready false overrides [list cluster-enabled yes \
-                        tls-cert-file $dir/rogue.crt tls-key-file $dir/rogue.key \
-                        tls-client-cert-file $dir/rogue.crt tls-client-key-file $dir/rogue.key]] {
-                    wait_for_condition 50 100 {
-                        [count_message_lines [srv 0 stdout] "Ready to accept"] > 0
-                    } else {
-                        fail "the peer serving an untrusted certificate did not start"
-                    }
-
-                    # Commands use R's positive indexing, the log helpers take
-                    # srv's negative one; both mean the node under test here.
-                    set rogue_bus [expr {[srv 0 port] + 10000}]
-                    set loglines [count_log_lines -1]
-                    R 1 cluster meet [srv 0 host] [srv 0 port]
-
-                    wait_for_log_messages -1 \
-                        [list "*at [srv 0 host]:$rogue_bus failed*certificate verify failed*"] \
-                        $loglines 50 100
-
-                    # And it is never admitted: the handshake node is dropped once
-                    # it expires, leaving this node on its own again.
-                    wait_for_condition 50 100 {
-                        [llength [get_cluster_nodes 1]] == 1
-                    } else {
-                        fail "the peer serving an untrusted certificate was admitted"
-                    }
-                }
-            }
-
             test {CONFIG SET tls-cluster no is refused while protected mode is enabled} {
                 assert_error {*can't disable tls-cluster while cluster-bus-port-protected-mode is enabled*} {
                     r config set tls-cluster no
@@ -263,33 +178,6 @@ tags {external:skip cluster} {
                 r config set tls-cluster yes
                 r config set cluster-bus-port-protected-mode yes
                 assert_equal {cluster-bus-port-protected-mode yes} [r config get cluster-bus-port-protected-mode]
-            }
-        }
-
-        # Protected mode reads tls-cluster alone as an authenticated bus, which
-        # only holds because tls-auth-clients cannot reach the bus. Pin that with
-        # the setting that would weaken it if it could.
-        start_cluster 1 0 {overrides {tls-auth-clients no}} {
-            test {tls-auth-clients does not relax the cluster bus} {
-                set host [srv 0 host]
-                set bus [expr {[srv 0 port] + 10000}]
-
-                # The setting is in effect: on the client port a peer presenting
-                # no certificate is served. Driven through redis-cli, since the
-                # suite's own client always offers one.
-                assert_equal {PONG} [string trim [exec src/redis-cli --tls \
-                    --cacert "$::tlsdir/ca.crt" -h $host -p [srv 0 port] ping]]
-
-                # The cluster bus is unaffected: clusterAcceptHandler() demands a
-                # certificate whatever tls-auth-clients says, so the same peer is
-                # refused there. Read from the log, as a TLS 1.3 client is not
-                # told: its own handshake completes before the server judges it.
-                set loglines [count_log_lines 0]
-                catch {exec openssl s_client -connect $host:$bus \
-                    -CAfile "$::tlsdir/ca.crt" << "" 2> /dev/null}
-                wait_for_log_messages 0 \
-                    {"*Error accepting cluster node connection*peer did not return a certificate*"} \
-                    $loglines 50 100
             }
         }
     }

--- a/tests/unit/cluster/cluster-bus-require-tls.tcl
+++ b/tests/unit/cluster/cluster-bus-require-tls.tcl
@@ -25,10 +25,10 @@ tags {external:skip cluster} {
         assert_match {*'cluster-bus-require-tls no'*} $err
     }
 
-    test {cluster-bus-require-tls only applies to cluster mode} {
-        # A standalone instance opens no cluster bus, so the default requirement
-        # must not stop it from starting with plain TCP everywhere.
-        start_server {overrides {cluster-bus-require-tls yes tls-cluster no}} {
+    # A standalone instance opens no cluster bus, so the default requirement must
+    # not stop it from starting with plain TCP everywhere.
+    start_server {overrides {cluster-bus-require-tls yes tls-cluster no}} {
+        test {cluster-bus-require-tls only applies to cluster mode} {
             assert_equal {cluster-bus-require-tls yes} [r config get cluster-bus-require-tls]
             assert_equal {tls-cluster no} [r config get tls-cluster]
             assert_equal 0 [s cluster_enabled]
@@ -38,6 +38,18 @@ tags {external:skip cluster} {
             r config set cluster-bus-require-tls no
             r config set cluster-bus-require-tls yes
             assert_equal 0 [count_log_message 0 "cluster bus is not protected by TLS"]
+        }
+
+        test {the cluster-mode gate of the requirement cannot be opened at runtime} {
+            # Gating the requirement on cluster mode is only sound because
+            # cluster-enabled is IMMUTABLE_CONFIG. Could it be set, this very
+            # server - requirement enabled, tls-cluster off - would open a
+            # plaintext cluster bus without ever facing the startup check. The
+            # immutable mechanism itself is covered by "CONFIG SET set immutable"
+            # in unit/introspection; what is pinned here is that cluster-enabled
+            # in particular still carries the flag.
+            assert_error {*can't set immutable config*} {r config set cluster-enabled yes}
+            assert_equal 0 [s cluster_enabled]
         }
     }
 

--- a/tests/unit/cluster/cluster-bus-require-tls.tcl
+++ b/tests/unit/cluster/cluster-bus-require-tls.tcl
@@ -1,0 +1,103 @@
+# cluster-bus-require-tls makes a plaintext cluster bus an explicit choice.
+#
+# The cluster bus has no authentication of its own (a packet's sender is
+# identified only by the public node ID in its header) and it carries sensitive
+# information shared between the nodes, which must not leak outside the cluster.
+# So anyone able to reach or eavesdrop on the cluster bus port of a plaintext bus
+# can potentially threaten the whole cluster. The option defaults to yes and
+# refuses such a setup, in the spirit of protected-mode; the operator waives it with
+# "cluster-bus-require-tls no" once the port is known to be firewalled off.
+#
+# Note that the suite's default.conf waives the requirement for every server it
+# starts (non-TLS runs have no TLS to offer), so the tests below that care about
+# the default state must set the option, or bypass default.conf altogether.
+
+tags {external:skip cluster} {
+
+    test {cluster-bus-require-tls defaults to yes and refuses a plaintext cluster bus} {
+        # No config file at all: this observes the compiled-in default rather
+        # than anything the suite configures. "--daemonize yes" only matters if
+        # this check ever regresses: the server would then start instead of
+        # failing, and exec would return at once instead of blocking forever.
+        catch {exec src/redis-server --cluster-enabled yes --port 0 --daemonize yes} err
+        assert_match {*FATAL CONFIG FILE ERROR*} $err
+        assert_match {*cluster-bus-require-tls is enabled but tls-cluster is disabled*} $err
+        assert_match {*'cluster-bus-require-tls no'*} $err
+    }
+
+    test {cluster-bus-require-tls only applies to cluster mode} {
+        # A standalone instance opens no cluster bus, so the default requirement
+        # must not stop it from starting with plain TCP everywhere.
+        start_server {overrides {cluster-bus-require-tls yes tls-cluster no}} {
+            assert_equal {cluster-bus-require-tls yes} [r config get cluster-bus-require-tls]
+            assert_equal {tls-cluster no} [r config get tls-cluster]
+            assert_equal 0 [s cluster_enabled]
+            assert_equal {PONG} [r ping]
+            # Outside cluster mode the two options are unrelated, so both stay
+            # freely settable.
+            r config set cluster-bus-require-tls no
+            r config set cluster-bus-require-tls yes
+            assert_equal 0 [count_log_message 0 "cluster bus is not protected by TLS"]
+        }
+    }
+
+    start_cluster 1 0 {overrides {cluster-bus-require-tls no tls-cluster no}} {
+        test {waiving the requirement starts a cluster node with a plaintext bus} {
+            assert_equal 1 [s cluster_enabled]
+            assert_equal {tls-cluster no} [r config get tls-cluster]
+            wait_for_cluster_state ok
+        }
+
+        test {a waived requirement is reported in the log} {
+            verify_log_message 0 "*cluster bus is not protected by TLS*" 0
+        }
+
+        test {CONFIG SET cluster-bus-require-tls yes is refused while the bus is plaintext} {
+            assert_error {*can't enable cluster-bus-require-tls while tls-cluster is disabled*} {
+                r config set cluster-bus-require-tls yes
+            }
+            assert_equal {cluster-bus-require-tls no} [r config get cluster-bus-require-tls]
+        }
+    }
+
+    # The other direction, and the atomic transitions between the two states,
+    # need a cluster bus that can actually run on TLS.
+    if {$::tls} {
+        start_cluster 1 0 {overrides {cluster-bus-require-tls yes}} {
+            test {a cluster node starts with the requirement met by tls-cluster} {
+                assert_equal 1 [s cluster_enabled]
+                assert_equal {tls-cluster yes} [r config get tls-cluster]
+                wait_for_cluster_state ok
+                assert_equal 0 [count_log_message 0 "cluster bus is not protected by TLS"]
+            }
+
+            test {CONFIG SET tls-cluster no is refused while the requirement is enabled} {
+                assert_error {*can't disable tls-cluster while cluster-bus-require-tls is enabled*} {
+                    r config set tls-cluster no
+                }
+                assert_equal {tls-cluster yes} [r config get tls-cluster]
+                assert_equal 0 [count_log_message 0 "cluster bus is not protected by TLS"]
+            }
+
+            test {a single CONFIG SET can move the bus to plain TCP, in either argument order} {
+                # Every setter of a CONFIG SET runs before the first apply
+                # callback, so the pair is judged on the state it produces and
+                # not on the order it is written in.
+                foreach args {{cluster-bus-require-tls no tls-cluster no}
+                              {tls-cluster no cluster-bus-require-tls no}} {
+                    set logged [count_log_message 0 "cluster bus is not protected by TLS"]
+                    r config set {*}$args
+                    assert_equal {tls-cluster no} [r config get tls-cluster]
+                    assert_equal {cluster-bus-require-tls no} [r config get cluster-bus-require-tls]
+                    # Leaving TLS is reported once, as it is at startup.
+                    assert_equal [expr {$logged + 1}] [count_log_message 0 "cluster bus is not protected by TLS"]
+
+                    # And back: enabling the requirement again needs TLS back on.
+                    r config set tls-cluster yes cluster-bus-require-tls yes
+                    assert_equal {tls-cluster yes} [r config get tls-cluster]
+                    assert_equal {cluster-bus-require-tls yes} [r config get cluster-bus-require-tls]
+                }
+            }
+        }
+    }
+}

--- a/tests/unit/cluster/cluster-bus-require-tls.tcl
+++ b/tests/unit/cluster/cluster-bus-require-tls.tcl
@@ -12,6 +12,22 @@
 # starts (non-TLS runs have no TLS to offer), so the tests below that care about
 # the default state must set the option, or bypass default.conf altogether.
 
+# Writes a two-file configuration into $dir: the given directives go to
+# inner.conf, which main.conf pulls in with "include" before setting the port and
+# the directory. Anything in inner.conf is therefore parsed before the rest of
+# main.conf, which is what the include test below needs to exercise.
+proc write_included_conf {dir port inner_lines} {
+    set fd [open $dir/inner.conf w]
+    foreach line $inner_lines { puts $fd $line }
+    close $fd
+
+    set fd [open $dir/main.conf w]
+    puts $fd "include $dir/inner.conf"
+    puts $fd "port $port"
+    puts $fd "dir $dir"
+    close $fd
+}
+
 tags {external:skip cluster} {
 
     test {cluster-bus-require-tls defaults to yes and refuses a plaintext cluster bus} {
@@ -23,6 +39,42 @@ tags {external:skip cluster} {
         assert_match {*FATAL CONFIG FILE ERROR*} $err
         assert_match {*cluster-bus-require-tls is enabled but tls-cluster is disabled*} $err
         assert_match {*'cluster-bus-require-tls no'*} $err
+    }
+
+    test {the requirement is judged after the whole configuration is loaded} {
+        # The check runs when the OUTERMOST config load finishes, so directives
+        # that reach the server through "include" are accounted for. This matters
+        # because an included file ends at the position of its "include" line,
+        # before the rest of the parent file has been parsed. start_server cannot
+        # be used here: it generates the config file itself and offers no way to
+        # place directives behind an include.
+        set dir [file normalize [tmpdir cluster-bus-include]]
+        set logf $dir/redis.log
+        set port [find_available_port $::baseport $::portcount]
+
+        # cluster mode arrives via the include: the node does open a cluster bus,
+        # so the default requirement must still refuse the plaintext one.
+        write_included_conf $dir $port {"cluster-enabled yes"}
+        catch {exec src/redis-server $dir/main.conf --daemonize yes} err
+        assert_match {*cluster-bus-require-tls is enabled but tls-cluster is disabled*} $err
+
+        # And the waiver arrives via the include too: it is honoured, and the
+        # node starts with a plaintext bus.
+        write_included_conf $dir $port {"cluster-enabled yes" "cluster-bus-require-tls no"}
+        exec src/redis-server $dir/main.conf --daemonize yes --logfile $logf
+        wait_for_condition 100 100 {
+            [count_message_lines $logf "Ready to accept"] > 0
+        } else {
+            fail "Server did not start; log: $logf"
+        }
+        # Connect over the plain port: this server knows nothing about the
+        # suite's TLS configuration, in a --tls run just as much as without it.
+        set rd [redis 127.0.0.1 $port 0 0]
+        assert_equal {cluster-bus-require-tls no} [$rd config get cluster-bus-require-tls]
+        assert_equal 1 [status $rd cluster_enabled]
+        assert_equal 1 [count_message_lines $logf "cluster bus is not protected by TLS"]
+        catch {$rd shutdown nosave}
+        $rd close
     }
 
     # A standalone instance opens no cluster bus, so the default requirement must

--- a/tests/unit/cluster/cluster-bus-tls.tcl
+++ b/tests/unit/cluster/cluster-bus-tls.tcl
@@ -1,0 +1,121 @@
+# Certificate trust on the cluster bus, which is what "tls-cluster yes" buys: a
+# peer has to present a certificate that verifies against the configured CA, in
+# the accepting and in the connecting direction alike, and neither direction can
+# be relaxed through tls-auth-clients.
+#
+# These properties are what cluster-bus-port-protected-mode relies on when it
+# treats tls-cluster on its own as an authenticated bus port, but they belong to
+# tls-cluster and are pinned here independently of that option.
+
+# Opens a cluster bus connection presenting the given client certificate, then
+# closes it. The handshake outcome is deliberately not inspected here: under TLS
+# 1.3 the client's own handshake completes before the server has validated the
+# certificate, so a rejection is only visible in the server's log. Callers assert
+# on that.
+proc bus_connect_with_cert {host port crt key} {
+    catch {
+        set fd [::tls::socket -cafile "$::tlsdir/ca.crt" -certfile $crt -keyfile $key $host $port]
+        ::tls::handshake $fd
+        close $fd
+    }
+}
+
+if {$::tls} {
+    start_cluster 1 0 {tags {external:skip cluster tls}} {
+        test {a cluster bus peer whose certificate does not chain to the CA is rejected} {
+            # A self-signed certificate is valid TLS material with no path to
+            # tls-ca-cert-file, and has to be refused on the very port that
+            # accepts the suite's CA-signed one.
+            set dir [file normalize [tmpdir cluster-bus-untrusted-ca]]
+            exec -ignorestderr openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+                -subj "/O=Rogue/CN=rogue.example" \
+                -keyout $dir/rogue.key -out $dir/rogue.crt 2>/dev/null
+
+            set host [srv 0 host]
+            set bus [expr {[srv 0 port] + 10000}]
+            set rejection "Error accepting cluster node connection"
+            set before [count_log_message 0 $rejection]
+            set loglines [count_log_lines 0]
+
+            bus_connect_with_cert $host $bus $::tlsdir/redis.crt $::tlsdir/redis.key
+            bus_connect_with_cert $host $bus $dir/rogue.crt $dir/rogue.key
+
+            wait_for_log_messages 0 \
+                {"*Error accepting cluster node connection*certificate verify failed*"} \
+                $loglines 50 100
+            # Exactly one rejection, so the CA-signed peer was accepted on the
+            # same port rather than everything being refused.
+            assert_equal [expr {$before + 1}] [count_log_message 0 $rejection]
+        }
+
+        test {a cluster bus peer whose server certificate does not chain to the CA is refused} {
+            # The dialling side verifies too: an outbound bus link uses the
+            # client-role context, which loads the same CA, so a peer serving
+            # a certificate that does not chain to it must be refused and
+            # never admitted to the cluster.
+            set dir [file normalize [tmpdir cluster-bus-untrusted-peer]]
+            exec -ignorestderr openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+                -subj "/O=Rogue/CN=rogue.example" \
+                -keyout $dir/rogue.key -out $dir/rogue.crt 2>/dev/null
+
+            # A second cluster node, identical to this one except that it serves
+            # a self-signed certificate. "wait_ready false" because the suite's
+            # own client would refuse that certificate as well, so no client is
+            # created for it; inside this block R 1 is the node under test and
+            # srv 0 the untrusted peer.
+            start_server [list wait_ready false overrides [list cluster-enabled yes \
+                    tls-cert-file $dir/rogue.crt tls-key-file $dir/rogue.key \
+                    tls-client-cert-file $dir/rogue.crt tls-client-key-file $dir/rogue.key]] {
+                wait_for_condition 50 100 {
+                    [count_message_lines [srv 0 stdout] "Ready to accept"] > 0
+                } else {
+                    fail "the peer serving an untrusted certificate did not start"
+                }
+
+                # Commands use R's positive indexing, the log helpers take srv's
+                # negative one; both mean the node under test here.
+                set rogue_bus [expr {[srv 0 port] + 10000}]
+                set loglines [count_log_lines -1]
+                R 1 cluster meet [srv 0 host] [srv 0 port]
+
+                wait_for_log_messages -1 \
+                    [list "*at [srv 0 host]:$rogue_bus failed*certificate verify failed*"] \
+                    $loglines 50 100
+
+                # And it is never admitted: the handshake node is dropped once it
+                # expires, leaving this node on its own again.
+                wait_for_condition 50 100 {
+                    [llength [get_cluster_nodes 1]] == 1
+                } else {
+                    fail "the peer serving an untrusted certificate was admitted"
+                }
+            }
+        }
+    }
+
+    # tls-auth-clients governs the client port only. Pin that with the setting
+    # that would weaken the bus if it could reach it.
+    start_cluster 1 0 {tags {external:skip cluster tls} overrides {tls-auth-clients no}} {
+        test {tls-auth-clients does not relax the cluster bus} {
+            set host [srv 0 host]
+            set bus [expr {[srv 0 port] + 10000}]
+
+            # The setting is in effect: on the client port a peer presenting no
+            # certificate is served. Driven through redis-cli, since the suite's
+            # own client always offers one.
+            assert_equal {PONG} [string trim [exec src/redis-cli --tls \
+                --cacert "$::tlsdir/ca.crt" -h $host -p [srv 0 port] ping]]
+
+            # The cluster bus is unaffected: clusterAcceptHandler() demands a
+            # certificate whatever tls-auth-clients says, so the same peer is
+            # refused there. Read from the log, as a TLS 1.3 client is not told:
+            # its own handshake completes before the server judges it.
+            set loglines [count_log_lines 0]
+            catch {exec openssl s_client -connect $host:$bus \
+                -CAfile "$::tlsdir/ca.crt" << "" 2> /dev/null}
+            wait_for_log_messages 0 \
+                {"*Error accepting cluster node connection*peer did not return a certificate*"} \
+                $loglines 50 100
+        }
+    }
+}

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -321,10 +321,10 @@ start_cluster 1 0 [list tags {external:skip cluster modules} config_lines [list 
             # A CONFIG SET whose apply fails is rolled back by
             # configSetCommand(), which restores the previous values and calls
             # every apply callback of the command again. tls-cluster ends up
-            # where it started, so nothing may be reported - the notification is
-            # not only a module event, it also cancels the ASM tasks invalidated
-            # by the new topology. Here the failure comes from the unusable
-            # certificate, with cluster-bus-port-protected-mode not involved at all.
+            # where it started, so nothing may be reported: reporting it would
+            # also mean having rebuilt the SSL_CTX, discarding the session cache
+            # held on it. Here the failure comes from the unusable certificate,
+            # with cluster-bus-port-protected-mode not involved at all.
             R 0 config set cluster-bus-port-protected-mode no
 
             set before [dict get [topo_stats 0] node]
@@ -358,9 +358,9 @@ start_cluster 1 0 [list tags {external:skip cluster modules} config_lines [list 
             # cluster-bus-port-protected-mode refuses to leave the cluster bus
             # port unauthenticated. A refused CONFIG SET must change nothing,
             # which is not free: configSetCommand() restores the previous value
-            # and calls the apply callback a second time, and this notification is
-            # not only a module event - it also cancels the ASM tasks invalidated
-            # by the new topology. The suite waives protection, so enable it here.
+            # and calls the apply callback a second time, which would both report
+            # this change to modules and rebuild the SSL_CTX, discarding the
+            # session cache. The suite waives protection, so enable it here.
             R 0 config set cluster-bus-port-protected-mode yes
 
             set before [dict get [topo_stats 0] node]

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -324,8 +324,8 @@ start_cluster 1 0 [list tags {external:skip cluster modules} config_lines [list 
             # where it started, so nothing may be reported - the notification is
             # not only a module event, it also cancels the ASM tasks invalidated
             # by the new topology. Here the failure comes from the unusable
-            # certificate, with cluster-bus-require-tls not involved at all.
-            R 0 config set cluster-bus-require-tls no
+            # certificate, with cluster-bus-port-protected-mode not involved at all.
+            R 0 config set cluster-bus-port-protected-mode no
 
             set before [dict get [topo_stats 0] node]
             assert_error {*Unable to update TLS configuration*} {
@@ -355,13 +355,13 @@ start_cluster 1 0 [list tags {external:skip cluster modules} config_lines [list 
         }
 
         test "ClusterTopologyChange is not reported when a tls-cluster change is refused" {
-            # cluster-bus-require-tls refuses to move the cluster bus to plain
-            # TCP. A refused CONFIG SET must change nothing, which is not free:
-            # configSetCommand() restores the previous value and calls the apply
-            # callback a second time, and this notification is not only a module
-            # event - it also cancels the ASM tasks invalidated by the new
-            # topology. The suite waives the requirement, so enable it here.
-            R 0 config set cluster-bus-require-tls yes
+            # cluster-bus-port-protected-mode refuses to leave the cluster bus
+            # port unauthenticated. A refused CONFIG SET must change nothing,
+            # which is not free: configSetCommand() restores the previous value
+            # and calls the apply callback a second time, and this notification is
+            # not only a module event - it also cancels the ASM tasks invalidated
+            # by the new topology. The suite waives protection, so enable it here.
+            R 0 config set cluster-bus-port-protected-mode yes
 
             set before [dict get [topo_stats 0] node]
             assert_error {*can't disable tls-cluster*} {R 0 config set tls-cluster no}
@@ -371,7 +371,7 @@ start_cluster 1 0 [list tags {external:skip cluster modules} config_lines [list 
             assert_equal $before [dict get [topo_stats 0] node]
             assert_equal {tls-cluster yes} [R 0 config get tls-cluster]
 
-            R 0 config set cluster-bus-require-tls no
+            R 0 config set cluster-bus-port-protected-mode no
         }
     }
 }

--- a/tests/unit/cluster/cluster-topology-change.tcl
+++ b/tests/unit/cluster/cluster-topology-change.tcl
@@ -316,5 +316,62 @@ start_cluster 1 0 [list tags {external:skip cluster modules} config_lines [list 
                 fail "NODE change reason was not reported when tls-cluster was enabled"
             }
         }
+
+        test "ClusterTopologyChange is not reported when a tls-cluster change is rolled back" {
+            # A CONFIG SET whose apply fails is rolled back by
+            # configSetCommand(), which restores the previous values and calls
+            # every apply callback of the command again. tls-cluster ends up
+            # where it started, so nothing may be reported - the notification is
+            # not only a module event, it also cancels the ASM tasks invalidated
+            # by the new topology. Here the failure comes from the unusable
+            # certificate, with cluster-bus-require-tls not involved at all.
+            R 0 config set cluster-bus-require-tls no
+
+            set before [dict get [topo_stats 0] node]
+            assert_error {*Unable to update TLS configuration*} {
+                R 0 config set tls-cluster no tls-cert-file /nonexistent
+            }
+            # A pending notification is fired on the next event loop iteration,
+            # which the round trip below has certainly gone through.
+            R 0 ping
+            assert_equal $before [dict get [topo_stats 0] node]
+            assert_equal {tls-cluster yes} [R 0 config get tls-cluster]
+
+            # The rollback must not leave the value this node last acted on out
+            # of step with tls-cluster, or the next real change would be
+            # swallowed. The certificate needs no such care: it is applied by
+            # its own callback, which the rollback runs too.
+            assert_error {*Unable to update TLS configuration*} {
+                R 0 config set tls-cert-file /nonexistent
+            }
+            set before [dict get [topo_stats 0] node]
+            R 0 config set tls-cluster no
+            wait_for_condition 50 100 {
+                [dict get [topo_stats 0] node] > $before
+            } else {
+                fail "NODE change reason was not reported after a rolled back change"
+            }
+            R 0 config set tls-cluster yes
+        }
+
+        test "ClusterTopologyChange is not reported when a tls-cluster change is refused" {
+            # cluster-bus-require-tls refuses to move the cluster bus to plain
+            # TCP. A refused CONFIG SET must change nothing, which is not free:
+            # configSetCommand() restores the previous value and calls the apply
+            # callback a second time, and this notification is not only a module
+            # event - it also cancels the ASM tasks invalidated by the new
+            # topology. The suite waives the requirement, so enable it here.
+            R 0 config set cluster-bus-require-tls yes
+
+            set before [dict get [topo_stats 0] node]
+            assert_error {*can't disable tls-cluster*} {R 0 config set tls-cluster no}
+            # A pending notification is fired on the next event loop iteration,
+            # which the round trip below has certainly gone through.
+            R 0 ping
+            assert_equal $before [dict get [topo_stats 0] node]
+            assert_equal {tls-cluster yes} [R 0 config get tls-cluster]
+
+            R 0 config set cluster-bus-require-tls no
+        }
     }
 }

--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -10,6 +10,9 @@ TIMEOUT=2000
 NODES=6
 REPLICAS=1
 PROTECTED_MODE=yes
+# The nodes talk over a plaintext cluster bus on loopback, which a cluster node
+# refuses to do by default, so the requirement has to be waived explicitly.
+BUS_REQUIRE_TLS=no
 ADDITIONAL_OPTIONS=""
 
 # You may want to put the above config parameters into config.sh in order to
@@ -28,7 +31,7 @@ then
     while [ $((PORT < ENDPORT)) != "0" ]; do
         PORT=$((PORT+1))
         echo "Starting $PORT"
-        $BIN_PATH/redis-server --port $PORT --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --appenddirname appendonlydir-${PORT} --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
+        $BIN_PATH/redis-server --port $PORT --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-bus-require-tls $BUS_REQUIRE_TLS --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --appenddirname appendonlydir-${PORT} --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
     done
     exit 0
 fi
@@ -70,7 +73,7 @@ then
     while [ $((PORT < ENDPORT)) != "0" ]; do
         PORT=$((PORT+1))
         echo "Starting $PORT"
-        $BIN_PATH/redis-server --port $PORT --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --appenddirname appendonlydir-${PORT} --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
+        $BIN_PATH/redis-server --port $PORT --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-bus-require-tls $BUS_REQUIRE_TLS --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --appenddirname appendonlydir-${PORT} --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
     done
     exit 0
 fi

--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -10,9 +10,9 @@ TIMEOUT=2000
 NODES=6
 REPLICAS=1
 PROTECTED_MODE=yes
-# The nodes talk over a plaintext cluster bus on loopback, which a cluster node
-# refuses to do by default, so the requirement has to be waived explicitly.
-BUS_REQUIRE_TLS=no
+# The nodes talk over an unauthenticated cluster bus on loopback, which a cluster
+# node refuses to do by default, so protection has to be waived explicitly.
+BUS_PROTECTED_MODE=no
 ADDITIONAL_OPTIONS=""
 
 # You may want to put the above config parameters into config.sh in order to
@@ -31,7 +31,7 @@ then
     while [ $((PORT < ENDPORT)) != "0" ]; do
         PORT=$((PORT+1))
         echo "Starting $PORT"
-        $BIN_PATH/redis-server --port $PORT --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-bus-require-tls $BUS_REQUIRE_TLS --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --appenddirname appendonlydir-${PORT} --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
+        $BIN_PATH/redis-server --port $PORT --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-bus-port-protected-mode $BUS_PROTECTED_MODE --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --appenddirname appendonlydir-${PORT} --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
     done
     exit 0
 fi
@@ -73,7 +73,7 @@ then
     while [ $((PORT < ENDPORT)) != "0" ]; do
         PORT=$((PORT+1))
         echo "Starting $PORT"
-        $BIN_PATH/redis-server --port $PORT --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-bus-require-tls $BUS_REQUIRE_TLS --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --appenddirname appendonlydir-${PORT} --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
+        $BIN_PATH/redis-server --port $PORT --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-bus-port-protected-mode $BUS_PROTECTED_MODE --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --appenddirname appendonlydir-${PORT} --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
     done
     exit 0
 fi


### PR DESCRIPTION
## Make an unauthenticated cluster bus port an explicit choice

### Problem

The cluster bus protocol has no authentication of its own: any host that can reach a node's cluster bus port can speak the protocol and so threaten the whole cluster. What authenticates the bus is `tls-cluster`, which is disabled by default — so until it is enabled, the only thing standing between the cluster and an arbitrary host is whatever the operator has done to keep the cluster bus port inaccessible to untrusted hosts (firewall, VPN, private network), and nothing in Redis says so.

### What this PR does

Introduces `cluster-bus-port-protected-mode`, a boolean defaulting to **yes**. A cluster node now refuses to start unless its bus port is authenticated; running an unauthenticated one becomes something the operator opts into, in the spirit of `protected-mode`.

| `cluster-enabled` | `cluster-bus-port-protected-mode` | `tls-cluster` | Result |
|---|---|---|---|
| no | yes (default) | no | starts normally — no cluster bus port exists |
| yes | yes (default) | yes | starts, unchanged from today |
| yes | yes (default) | no | **refuses to start**, with an error naming both ways out |
| yes | no | no | starts, and logs a warning that the bus port is unauthenticated |

The refusal message:

> cluster-bus-port-protected-mode is enabled but tls-cluster is disabled, which leaves the cluster bus port of this node unauthenticated: any host able to reach the port can join the cluster and speak the cluster protocol, and threaten the whole cluster. Either set 'tls-cluster yes', which makes every cluster bus peer present a certificate verified against your CA, or set 'cluster-bus-port-protected-mode no' to acknowledge that the cluster bus port is reachable by trusted hosts only, for instance because a firewall blocks it.

### ⚠️ Breaking change

Non-TLS cluster deployments will not start after upgrading until they add `cluster-bus-port-protected-mode no`. This is deliberate and unavoidable: a default that is safe for new deployments cannot also be silent for existing ones. The failure is loud, immediate (before any listener is opened or pid file written), and the message states both remedies.

**Upgrade path for a cluster on a trusted network:** add `cluster-bus-port-protected-mode no` to `redis.conf`, or pass `--cluster-bus-port-protected-mode no`. No data or topology implications.

### Design notes

Two decisions worth a reviewer's attention:

**Protection is gated on cluster mode.** Only a cluster node opens a bus port, so the enforced invariant is `cluster_enabled && cluster_bus_port_protected_mode ⟹ tls_cluster`. A standalone instance is unaffected regardless of `tls-cluster` — otherwise the new default would refuse to start every non-TLS Redis in existence, not just clusters. The gate is safe to rely on because `cluster-enabled` is `IMMUTABLE_CONFIG` (no assignment to `server.cluster_enabled` exists outside the config system), so it cannot flip at runtime; there is a test pinning that.

Testing `tls-cluster` alone is sound because it does not depend on `tls-auth-clients`, which governs the client port only: the bus has dedicated dial/accept paths, and `clusterAcceptHandler()` hardcodes `TLS_CLIENT_AUTH_YES`, so a peer certificate verified against the CA — which `tls-cluster` makes mandatory — is required in both directions regardless of how client authentication is configured. A test pins this by running a cluster with `tls-auth-clients no` and requiring the two ports to disagree: a certificate-less peer is served on the client port and refused on the bus.

**Runtime enforcement lives in the `apply` callbacks, not the setters.** `configSetCommand()` stores every value before running the first apply callback, so an apply-time check judges the pair of values the command *produces*. That makes `CONFIG SET tls-cluster no cluster-bus-port-protected-mode no` succeed in either argument order, while `CONFIG SET tls-cluster no` alone is refused. A setter-time check would have rejected the legitimate atomic waiver depending on argument order. A refused set is also a true no-op, which takes more than putting the check first: `configSetCommand()` restores the previous value and calls every apply callback of the command again, so `applyTlsCluster()` additionally short-circuits when `tls-cluster` did not effectively move — otherwise a refusal would rebuild the `SSL_CTX` and, through `clusterNotifyTopologyChanged()`, rebuild the SSL_CTX, discarding the TLS session cache, and report a NODE topology change to modules for a change that never happened. Same shadow-previous-value pattern as `clusterUpdateMyselfIp()`.

The option is kept `MODIFIABLE_CONFIG`, like `protected-mode`. Making it immutable would additionally have removed the existing ability to `CONFIG SET tls-cluster no` without a restart, which would be a second breaking change.

**Startup check placement.** It runs in the post-load block of `loadServerConfigFromString()` (the `config_load_depth == 0` guard), so it observes the *final* configuration: main config file, `include`-d files and command-line arguments alike. Covered by the "protection is judged after the whole configuration is loaded" test, which drives `src/redis-server` against a hand-written `include` pair in both directions — `start_server` cannot express this, as it generates the config file itself.

**Logging.** A node whose bus port is unauthenticated because protection was waived says so once at startup, and again whenever the bus loses its authentication at runtime (any such transition necessarily changes `tls-cluster`, so the `tls-cluster` apply callback is the single place that needs to report it). This mirrors how Redis warns about `protected-mode` / a passwordless default user.

### Tests

New `tests/unit/cluster/cluster-bus-port-protected-mode.tcl`, 10 tests (4 of them TLS-only), green in
both non-TLS and `--tls` runs:

- the shipped default is `yes` and refuses an unauthenticated bus — run with no config file at all, so it observes the compiled-in default rather than anything the suite configures
- protection is judged only once the whole configuration is loaded: both `cluster-enabled` and the waiver are honoured when they reach the server through an `include`, which an included file's early end would otherwise hide
- protection does not apply outside cluster mode, both options stay freely settable there, and `cluster-enabled` is still immutable so the cluster-mode gate cannot be opened at runtime
- waiving protection starts a cluster node with an unauthenticated bus
- the waived requirement is reported in the log
- `CONFIG SET cluster-bus-port-protected-mode yes` is refused while the bus is unauthenticated
- with `tls-cluster` on, a cluster node starts with its bus authenticated and logs no advisory
- `CONFIG SET tls-cluster no` is refused while protected mode is enabled
- a single `CONFIG SET` can un-authenticate the bus in either argument order, and put it back
- each option can also be changed on its own, in the safe order — waiving protection before disabling `tls-cluster`, and authenticating the bus before enabling protection, since the check judges only the state each call produces

New `tests/unit/cluster/cluster-bus-tls.tcl`, 3 TLS-only tests. These cover what `tls-cluster`
verifies rather than the new option — the properties protected mode relies on when it treats
`tls-cluster` alone as an authenticated bus port, which nothing pinned before:

- a peer whose certificate does not chain to the CA is rejected on accept, on the same port that accepts a CA-signed one — exactly one rejection, so neither "everything is refused" nor "nothing is" can pass
- a peer whose server certificate does not chain to the CA is refused when dialled, and never admitted to the cluster
- `tls-auth-clients no` does not relax the cluster bus: a certificate-less peer is served on the client port, and refused on the bus with `peer did not return a certificate`

`tests/unit/cluster/cluster-topology-change.tcl` gains two TLS-only tests for the
`applyTlsCluster()` short-circuit described above, since it already loads the module that
counts the notifications:

- a **rolled back** `CONFIG SET tls-cluster no tls-cert-file /nonexistent` reports no NODE change — the trigger that predates this PR, with `cluster-bus-port-protected-mode` explicitly out of the picture
- a **refused** `CONFIG SET tls-cluster no` reports no NODE change — the trigger this PR adds

Both also assert that the tracked value is not left out of step with `tls-cluster`, by driving
a real change afterwards and requiring it to still be reported. Both were verified to fail
without the short-circuit (`Expected '11' to be equal to '12'`), so they are not vacuous.

### Test infrastructure and tooling

The new default means anything that starts a cluster node with an unauthenticated bus has to waive protection:

- `tests/assets/default.conf` — waived suite-wide; non-TLS runs have no TLS to offer, so without this *every* cluster test fails to start. The tests that cover the protection itself enable it explicitly. Chosen over per-test overrides because the alternative silently breaks any future test that adds `cluster-enabled yes`.
- `tests/cluster/run.tcl`, `.github/workflows/external.yml`, `utils/create-cluster/create-cluster` — the three places that start cluster nodes without going through `default.conf` (`git grep cluster-enabled` confirms there are no others). `create-cluster` gets a `BUS_PROTECTED_MODE` variable, overridable from `config.sh` like the existing `PROTECTED_MODE`.

### Documentation

`redis.conf` gains a documented block in the **REDIS CLUSTER** section explaining what the bus port exposes, what `tls-cluster` authenticates, and when waiving is acceptable. `tls-auth-clients` gains a paragraph recording that it governs the client port only and cannot weaken the cluster bus, since that is the property the startup check relies on. The **TLS** section's `tls-cluster` note is also rewritten — it described the option as a way to encrypt the bus, and stated a default that a cluster node no longer has, neither of which reflects what the option is for.

`TLS.md` gains a **Cluster bus protection** section describing what the cluster bus port exposes, what `tls-cluster` verifies in each direction, that it is independent of `tls-auth-clients`, and the new default. Previously the guide stated only that `--tls-cluster yes` makes Redis Cluster use TLS across nodes.

The **Getting Started** section also now describes `tls-auth-clients`, which the guide did not cover before although the `redis-cli` example depends on it: clients on a TLS port are required to present a certificate by default, `no` accepts none and `optional` validates one only when offered, both apply to the client port only, and `tls-auth-clients-user` maps a validated certificate's Common Name to a Redis ACL user.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking startup for non-TLS Redis Cluster until operators waive protection or enable tls-cluster; changes cluster security defaults and CONFIG SET behavior around tls-cluster.
> 
> **Overview**
> Adds **`cluster-bus-port-protected-mode`** (default **yes**): cluster nodes **fail startup** when `cluster-enabled` is on, protection is on, and **`tls-cluster`** is off, unless the operator sets **`cluster-bus-port-protected-mode no`** to acknowledge a bus reachable only by trusted hosts. Waived setups **log a warning** once at startup and when the bus loses TLS at runtime.
> 
> Enforcement runs after the **full config load** (includes + CLI) and on **`CONFIG SET`** via **`applyTlsCluster`** / **`applyClusterBusPortProtectedMode`**, so atomic pairs like `tls-cluster no` + `cluster-bus-port-protected-mode no` work in either order; **`applyTlsCluster`** also **no-ops** when `tls-cluster` did not actually change, avoiding spurious TLS rebuilds and module topology notifications on refused or rolled-back sets.
> 
> **Breaking:** existing non-TLS clusters must add **`cluster-bus-port-protected-mode no`** (or enable **`tls-cluster`**). Test harness, external CI cluster job, and **`create-cluster`** waive protection where they start plain cluster nodes. New tests cover protection defaults, include ordering, TLS bus cert requirements vs **`tls-auth-clients`**, and topology-change behavior.
> 
> **Docs:** `redis.conf` and **`TLS.md`** explain bus risk, that **`tls-cluster`** authenticates the bus independently of **`tls-auth-clients`**, and the new option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3baaa58edbffbc8ffedf81489275bfa0b47a594f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->