### PR TITLE
Batch HFE active expire propagation

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -217,8 +217,8 @@ uint64_t activeSubexpires(redisDb *db, int slot, uint32_t maxFieldsToExpire) {
     estoreActiveExpire(db->subexpires, slot, &info);
 
     /* Drain module post-notification jobs queued by the "hexpired"/"del" events.
-     * Propagation of the expired fields, batched per key for hashtable hashes and
-     * per field for listpackex, runs before those notifications fire, so its own
+     * Propagation of the expired fields, batched into bounded HDELs for hashtable
+     * hashes and per field for listpackex, runs before those notifications fire, so its own
      * drain cannot pick them up and they would otherwise linger until the tail of
      * the next command's call(). No execution unit is wrapped around the walk:
      * that would suppress those drains and wrap the propagated commands in

--- a/src/expire.c
+++ b/src/expire.c
@@ -217,11 +217,12 @@ uint64_t activeSubexpires(redisDb *db, int slot, uint32_t maxFieldsToExpire) {
     estoreActiveExpire(db->subexpires, slot, &info);
 
     /* Drain module post-notification jobs queued by the "hexpired"/"del" events.
-     * The per-field propagation in propagateHashFieldDeletion() runs before those
-     * notifications fire, so its own drain cannot pick them up and they would
-     * otherwise linger until the tail of the next command's call(). No execution
-     * unit is wrapped around the walk: that would suppress the per-field drains
-     * and batch the HDELs into a single MULTI/EXEC. */
+     * Propagation of the expired fields, batched per key for hashtable hashes and
+     * per field for listpackex, runs before those notifications fire, so its own
+     * drain cannot pick them up and they would otherwise linger until the tail of
+     * the next command's call(). No execution unit is wrapped around the walk:
+     * that would suppress those drains and wrap the propagated commands in
+     * MULTI/EXEC. */
     postExecutionUnitOperations();
 
     /* Return number of fields active-expired */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -64,7 +64,8 @@ static ExpireMeta* hentryGetExpireMeta(const eItem field);
 static void hexpireGenericCommand(client *c, long long basetime, int unit);
 static void hfieldPersist(robj *hashObj, Entry *entry);
 static void propagateHashFieldDeletion(redisDb *db, sds key, char *field, size_t fieldLen);
-static void propagateHashFieldDeletionBatch(redisDb *db, robj *keyobj, vec *fields);
+static void propagateHashFieldDeletionObj(redisDb *db, robj *keyobj, char *field, size_t fieldLen);
+static void propagateHashFieldDeletionBatch(redisDb *db, robj *keyobj, robj **fields, uint32_t numFields);
 
 /* hash dictType funcs */
 static void dictEntryDestructor(dict *d, void *entry);
@@ -139,13 +140,13 @@ EbucketsType hashFieldExpireBucketsType = {
 
 /* OnFieldExpireCtx passed to OnFieldExpire() */
 typedef struct OnFieldExpireCtx {
-    robj *hashObj;
-    robj *keyObj;
-    redisDb *db;
     int activeEx; /* 1 for active expire, 0 for lazy expire */
-    int batchPropagate; /* 1 to flush HDEL propagation at the end of the batch */
-    vec *vpropagate; /* Expired fields vector for batched HDEL propagation */
     vec *vexpired; /* Expired fields vector */
+    eItem *entries; /* Expired entries (HT encoding only), recorded as-is by
+                     * onFieldExpire() and consumed by hashTypeExpire() which
+                     * propagates the deletions and deletes the fields. Holds at
+                     * most FIELDS_STACK_SIZE entries per ebExpire() call. */
+    uint32_t numEntries;
 } OnFieldExpireCtx;
 
 /* The implementation of hashes by dict was modified from storing fields as sds
@@ -3952,22 +3953,14 @@ uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexp
     fieldvec fvexpired;
     vec *vexpired = isSubkeyNotifyEnabled(NOTIFY_HASH) ?
                         fieldvecInit(&fvexpired, FIELDS_STACK_SIZE) : NULL;
-    fieldvec fvpropagate;
-    vec *vpropagate = NULL;
 
-    OnFieldExpireCtx onFieldExpireCtx = {
-        .hashObj = o,
-        .db = db,
-        .activeEx = activeEx,
-        .vexpired = vexpired
-    };
+    OnFieldExpireCtx onFieldExpireCtx = { .activeEx = activeEx, .vexpired = vexpired };
     ExpireInfo info = (ExpireInfo) {
                 .maxToExpire = *quota,
                 .now = commandTimeSnapshot(),
                 .ctx = &onFieldExpireCtx,
                 .itemsExpired = 0};
-    uint64_t ht_old_len = 0;
-    int ht_expire = 0;
+    robj *keyObj = NULL;
 
     if (o->encoding == OBJ_ENCODING_LISTPACK_EX) {
         listpackExExpire(db, o, &info);
@@ -3976,34 +3969,88 @@ uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexp
 
         dict *d = o->ptr;
         htMetadataEx *dictExpireMeta = htGetMetadataEx(d);
-        ht_old_len = dictSize(d);
-        ht_expire = 1;
-        onFieldExpireCtx.batchPropagate = activeEx;
-        if (onFieldExpireCtx.batchPropagate) {
-            vpropagate = fieldvecInit(&fvpropagate, FIELDS_STACK_SIZE);
-            onFieldExpireCtx.vpropagate = vpropagate;
-        }
+        sds keystr = kvobjGetKey(o);
+        uint64_t oldLen = dictSize(d), totalExpired = 0;
+        uint32_t chunk, expired = 0;
 
+        /* onFieldExpire() only records the expired entries in `entries`. They
+         * are consumed here in chunks of at most FIELDS_STACK_SIZE fields each:
+         * first the deletion is propagated (a single HDEL per chunk for
+         * active-expire, per-field HDEL for lazy-expire), only then the fields
+         * are deleted. Bounded chunks keep the collection array on the stack
+         * and cap the size of a single propagated HDEL, regardless of quota. */
+        eItem entries[FIELDS_STACK_SIZE];
+        onFieldExpireCtx.entries = entries;
         info.onExpireItem = onFieldExpire;
-        ebExpire(&dictExpireMeta->hfe, &hashFieldExpireBucketsType, &info);
+
+        do {
+            chunk = *quota - totalExpired;
+            if (chunk > FIELDS_STACK_SIZE) chunk = FIELDS_STACK_SIZE;
+            info.maxToExpire = chunk;
+            onFieldExpireCtx.numEntries = 0;
+            ebExpire(&dictExpireMeta->hfe, &hashFieldExpireBucketsType, &info);
+            expired = info.itemsExpired;
+            if (expired == 0) break;
+            serverAssert(onFieldExpireCtx.numEntries == expired);
+
+            if (!keyObj)
+                keyObj = createStringObject(keystr, sdslen(keystr));
+
+            /* Propagate the deletion before deleting the fields */
+            if (activeEx) {
+                robj *fields[FIELDS_STACK_SIZE];
+                for (uint32_t i = 0; i < expired; i++) {
+                    sds field = entryGetField((Entry *) entries[i]);
+                    fields[i] = createStringObject(field, sdslen(field));
+                    /* vexpired, if exists, takes ownership of the field robj */
+                    if (vexpired) vecPush(vexpired, fields[i]);
+                }
+                propagateHashFieldDeletionBatch(db, keyObj, fields, expired);
+                if (!vexpired) {
+                    for (uint32_t i = 0; i < expired; i++)
+                        decrRefCount(fields[i]);
+                }
+            } else {
+                for (uint32_t i = 0; i < expired; i++) {
+                    sds field = entryGetField((Entry *) entries[i]);
+                    if (vexpired)
+                        vecPush(vexpired, createStringObject(field, sdslen(field)));
+                    propagateHashFieldDeletionObj(db, keyObj, field, sdslen(field));
+                }
+            }
+
+            /* Delete the expired fields from the hash */
+            size_t oldsize = 0;
+            if (server.memory_tracking_enabled)
+                oldsize = kvobjAllocSize(o);
+            for (uint32_t i = 0; i < expired; i++) {
+                sds field = entryGetField((Entry *) entries[i]);
+                serverAssert(hashTypeDelete(o, field) == 1);
+            }
+            if (server.memory_tracking_enabled)
+                updateSlotAllocSize(db, getKeySlot(keystr), o, oldsize, kvobjAllocSize(o));
+
+            totalExpired += expired;
+        } while (expired == chunk && totalExpired < *quota);
+
+        if (totalExpired) {
+            server.stat_expired_subkeys += totalExpired;
+            if (activeEx)
+                server.stat_expired_subkeys_active += totalExpired;
+            updateKeysizesHist(db, OBJ_HASH, oldLen, oldLen - totalExpired);
+        }
+        info.itemsExpired = totalExpired;
     }
 
     /* Update quota left */
     *quota -= info.itemsExpired;
-
-    if (ht_expire && info.itemsExpired) {
-        if (onFieldExpireCtx.batchPropagate) {
-            propagateHashFieldDeletionBatch(db, onFieldExpireCtx.keyObj, vpropagate);
-        }
-        updateKeysizesHist(db, OBJ_HASH, ht_old_len, ht_old_len - info.itemsExpired);
-    }
 
     /* In some cases, a field might have been deleted without updating the global DS.
      * As a result, active-expire might not expire any fields, in such cases,
      * we don't need to send notifications or perform other operations for this key. */
     if (info.itemsExpired) {
         sds keystr = kvobjGetKey(o);
-        robj *key = onFieldExpireCtx.keyObj ? onFieldExpireCtx.keyObj : createStringObject(keystr, sdslen(keystr));
+        robj *key = keyObj ? keyObj : createStringObject(keystr, sdslen(keystr));
 
         /* Send subkey notification with all expired fields */
         notifyKeyspaceEventWithSubkeys(NOTIFY_HASH, "hexpired", key, db->id,
@@ -4029,8 +4076,6 @@ uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexp
 
         keyModified(NULL, db, key, deleted ? NULL : o, 1);
         decrRefCount(key);
-    } else if (onFieldExpireCtx.keyObj) {
-        decrRefCount(onFieldExpireCtx.keyObj);
     }
 
     /* Free collected expired fields */
@@ -4039,12 +4084,6 @@ uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexp
             decrRefCount(vecGet(vexpired, i));
         }
         vecRelease(vexpired);
-    }
-    if (vpropagate) {
-        for (size_t i = 0; i < vecSize(vpropagate); i++) {
-            decrRefCount(vecGet(vpropagate, i));
-        }
-        vecRelease(vpropagate);
     }
 
     /* return 0 if hash got deleted, EB_EXPIRE_TIME_INVALID if no more fields
@@ -6288,29 +6327,25 @@ static void propagateHashFieldDeletionObj(redisDb *db, robj *keyobj, char *field
     decrRefCount(argv[2]);
 }
 
-static void propagateHashFieldDeletionBatch(redisDb *db, robj *keyobj, vec *fields) {
-    size_t numFields = vecSize(fields);
-    if (numFields == 0)
-        return;
-
-    serverAssert(numFields <= INT_MAX - 2);
-    int argc = (int)(2 + numFields);
-    robj **argv = zmalloc(sizeof(robj*) * argc);
+/* Propagate deletion of hash fields as a single HDEL command. Called by
+ * hashTypeExpire() during active expiration, once per chunk of at most
+ * FIELDS_STACK_SIZE expired fields. */
+static void propagateHashFieldDeletionBatch(redisDb *db, robj *keyobj, robj **fields, uint32_t numFields) {
+    robj *argv[2 + FIELDS_STACK_SIZE];
+    serverAssert(numFields > 0 && numFields <= FIELDS_STACK_SIZE);
     argv[0] = shared.hdel;
     argv[1] = keyobj;
-    memcpy(argv + 2, vecData(fields), sizeof(robj*) * numFields);
+    memcpy(argv + 2, fields, sizeof(robj*) * numFields);
 
     enterExecutionUnit(1, 0);
     int prev_replication_allowed = server.replication_allowed;
     server.replication_allowed = 1;
-    alsoPropagate(db->id, argv, argc, PROPAGATE_AOF|PROPAGATE_REPL);
+    alsoPropagate(db->id, argv, 2 + numFields, PROPAGATE_AOF|PROPAGATE_REPL);
     server.replication_allowed = prev_replication_allowed;
     exitExecutionUnit();
 
     /* Propagate the HDEL command */
     postExecutionUnitOperations();
-
-    zfree(argv);
 }
 
 /*  Can be called either by active-expire cron job or query from the client */
@@ -6320,42 +6355,16 @@ static void propagateHashFieldDeletion(redisDb *db, sds key, char *field, size_t
     decrRefCount(keyobj);
 }
 
-/* Called during active expiration of hash-fields. Propagate to replica & Delete. */
+/* Called during expiration of hash-fields. Only collects the expired entries;
+ * hashTypeExpire() propagates the deletions and deletes the fields afterwards.
+ * Deferring the deletion is safe: ebExpire() detaches the entry from ebuckets
+ * before invoking this callback and never accesses it afterwards. The entries
+ * array cannot overflow since ebExpire() is called with maxToExpire that is
+ * bounded to FIELDS_STACK_SIZE. */
 static ExpireAction onFieldExpire(eItem item, void *ctx) {
     OnFieldExpireCtx *expCtx = ctx;
-    Entry *e = item;
-    kvobj *kv = expCtx->hashObj;
-    size_t oldsize = 0;
-    sds key = kvobjGetKey(kv);
-    if (!expCtx->keyObj)
-        expCtx->keyObj = createStringObject((char*)key, sdslen(key));
-
-    if (server.memory_tracking_enabled)
-        oldsize = kvobjAllocSize(kv);
-    sds field = entryGetField(e);
-
-    robj *fieldObj = NULL;
-    if (expCtx->vexpired || expCtx->batchPropagate)
-        fieldObj = createStringObject(field, sdslen(field));
-
-    /* Collect expired field for subkey notification (before deletion) */
-    if (expCtx->vexpired)
-        vecPush(expCtx->vexpired, fieldObj);
-
-    if (expCtx->batchPropagate) {
-        if (expCtx->vexpired)
-            incrRefCount(fieldObj);
-        vecPush(expCtx->vpropagate, fieldObj);
-    } else {
-        propagateHashFieldDeletionObj(expCtx->db, expCtx->keyObj, field, sdslen(field));
-    }
-
-    serverAssert(hashTypeDelete(kv, field) == 1);
-    if (server.memory_tracking_enabled)
-        updateSlotAllocSize(expCtx->db, getKeySlot(key), kv, oldsize, kvobjAllocSize(kv));
-    server.stat_expired_subkeys++;
-    if (expCtx->activeEx)
-        server.stat_expired_subkeys_active++;
+    debugServerAssert(expCtx->numEntries < FIELDS_STACK_SIZE);
+    expCtx->entries[expCtx->numEntries++] = item;
     return ACT_REMOVE_EXP_ITEM;
 }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -64,6 +64,7 @@ static ExpireMeta* hentryGetExpireMeta(const eItem field);
 static void hexpireGenericCommand(client *c, long long basetime, int unit);
 static void hfieldPersist(robj *hashObj, Entry *entry);
 static void propagateHashFieldDeletion(redisDb *db, sds key, char *field, size_t fieldLen);
+static void propagateHashFieldDeletionBatch(redisDb *db, robj *keyobj, vec *fields);
 
 /* hash dictType funcs */
 static void dictEntryDestructor(dict *d, void *entry);
@@ -139,8 +140,11 @@ EbucketsType hashFieldExpireBucketsType = {
 /* OnFieldExpireCtx passed to OnFieldExpire() */
 typedef struct OnFieldExpireCtx {
     robj *hashObj;
+    robj *keyObj;
     redisDb *db;
     int activeEx; /* 1 for active expire, 0 for lazy expire */
+    int batchPropagate; /* 1 to flush HDEL propagation at the end of the batch */
+    vec *vpropagate; /* Expired fields vector for batched HDEL propagation */
     vec *vexpired; /* Expired fields vector */
 } OnFieldExpireCtx;
 
@@ -3948,13 +3952,22 @@ uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexp
     fieldvec fvexpired;
     vec *vexpired = isSubkeyNotifyEnabled(NOTIFY_HASH) ?
                         fieldvecInit(&fvexpired, FIELDS_STACK_SIZE) : NULL;
+    fieldvec fvpropagate;
+    vec *vpropagate = NULL;
 
-    OnFieldExpireCtx onFieldExpireCtx = { .hashObj = o, .db = db, .activeEx = activeEx, .vexpired = vexpired };
+    OnFieldExpireCtx onFieldExpireCtx = {
+        .hashObj = o,
+        .db = db,
+        .activeEx = activeEx,
+        .vexpired = vexpired
+    };
     ExpireInfo info = (ExpireInfo) {
                 .maxToExpire = *quota,
                 .now = commandTimeSnapshot(),
                 .ctx = &onFieldExpireCtx,
                 .itemsExpired = 0};
+    uint64_t ht_old_len = 0;
+    int ht_expire = 0;
 
     if (o->encoding == OBJ_ENCODING_LISTPACK_EX) {
         listpackExExpire(db, o, &info);
@@ -3963,6 +3976,13 @@ uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexp
 
         dict *d = o->ptr;
         htMetadataEx *dictExpireMeta = htGetMetadataEx(d);
+        ht_old_len = dictSize(d);
+        ht_expire = 1;
+        onFieldExpireCtx.batchPropagate = activeEx;
+        if (onFieldExpireCtx.batchPropagate) {
+            vpropagate = fieldvecInit(&fvpropagate, FIELDS_STACK_SIZE);
+            onFieldExpireCtx.vpropagate = vpropagate;
+        }
 
         info.onExpireItem = onFieldExpire;
         ebExpire(&dictExpireMeta->hfe, &hashFieldExpireBucketsType, &info);
@@ -3971,12 +3991,19 @@ uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexp
     /* Update quota left */
     *quota -= info.itemsExpired;
 
+    if (ht_expire && info.itemsExpired) {
+        if (onFieldExpireCtx.batchPropagate) {
+            propagateHashFieldDeletionBatch(db, onFieldExpireCtx.keyObj, vpropagate);
+        }
+        updateKeysizesHist(db, OBJ_HASH, ht_old_len, ht_old_len - info.itemsExpired);
+    }
+
     /* In some cases, a field might have been deleted without updating the global DS.
      * As a result, active-expire might not expire any fields, in such cases,
      * we don't need to send notifications or perform other operations for this key. */
     if (info.itemsExpired) {
         sds keystr = kvobjGetKey(o);
-        robj *key = createStringObject(keystr, sdslen(keystr));
+        robj *key = onFieldExpireCtx.keyObj ? onFieldExpireCtx.keyObj : createStringObject(keystr, sdslen(keystr));
 
         /* Send subkey notification with all expired fields */
         notifyKeyspaceEventWithSubkeys(NOTIFY_HASH, "hexpired", key, db->id,
@@ -4002,6 +4029,8 @@ uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexp
 
         keyModified(NULL, db, key, deleted ? NULL : o, 1);
         decrRefCount(key);
+    } else if (onFieldExpireCtx.keyObj) {
+        decrRefCount(onFieldExpireCtx.keyObj);
     }
 
     /* Free collected expired fields */
@@ -4010,6 +4039,12 @@ uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexp
             decrRefCount(vecGet(vexpired, i));
         }
         vecRelease(vexpired);
+    }
+    if (vpropagate) {
+        for (size_t i = 0; i < vecSize(vpropagate); i++) {
+            decrRefCount(vecGet(vpropagate, i));
+        }
+        vecRelease(vpropagate);
     }
 
     /* return 0 if hash got deleted, EB_EXPIRE_TIME_INVALID if no more fields
@@ -6233,11 +6268,10 @@ static void hfieldPersist(robj *hashObj, Entry *entry) {
 /*-----------------------------------------------------------------------------
  * Hash Field Expiration (HFE)
  *----------------------------------------------------------------------------*/
-/*  Can be called either by active-expire cron job or query from the client */
-static void propagateHashFieldDeletion(redisDb *db, sds key, char *field, size_t fieldLen) {
+static void propagateHashFieldDeletionObj(redisDb *db, robj *keyobj, char *field, size_t fieldLen) {
     robj *argv[] = {
         shared.hdel,
-        createStringObject((char*) key, sdslen(key)),
+        keyobj,
         createStringObject(field, fieldLen)
     };
 
@@ -6251,8 +6285,39 @@ static void propagateHashFieldDeletion(redisDb *db, sds key, char *field, size_t
     /* Propagate the HDEL command */
     postExecutionUnitOperations();
 
-    decrRefCount(argv[1]);
     decrRefCount(argv[2]);
+}
+
+static void propagateHashFieldDeletionBatch(redisDb *db, robj *keyobj, vec *fields) {
+    size_t numFields = vecSize(fields);
+    if (numFields == 0)
+        return;
+
+    serverAssert(numFields <= INT_MAX - 2);
+    int argc = (int)(2 + numFields);
+    robj **argv = zmalloc(sizeof(robj*) * argc);
+    argv[0] = shared.hdel;
+    argv[1] = keyobj;
+    memcpy(argv + 2, vecData(fields), sizeof(robj*) * numFields);
+
+    enterExecutionUnit(1, 0);
+    int prev_replication_allowed = server.replication_allowed;
+    server.replication_allowed = 1;
+    alsoPropagate(db->id, argv, argc, PROPAGATE_AOF|PROPAGATE_REPL);
+    server.replication_allowed = prev_replication_allowed;
+    exitExecutionUnit();
+
+    /* Propagate the HDEL command */
+    postExecutionUnitOperations();
+
+    zfree(argv);
+}
+
+/*  Can be called either by active-expire cron job or query from the client */
+static void propagateHashFieldDeletion(redisDb *db, sds key, char *field, size_t fieldLen) {
+    robj *keyobj = createStringObject((char*) key, sdslen(key));
+    propagateHashFieldDeletionObj(db, keyobj, field, fieldLen);
+    decrRefCount(keyobj);
 }
 
 /* Called during active expiration of hash-fields. Propagate to replica & Delete. */
@@ -6262,22 +6327,30 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     kvobj *kv = expCtx->hashObj;
     size_t oldsize = 0;
     sds key = kvobjGetKey(kv);
+    if (!expCtx->keyObj)
+        expCtx->keyObj = createStringObject((char*)key, sdslen(key));
 
     if (server.memory_tracking_enabled)
         oldsize = kvobjAllocSize(kv);
     sds field = entryGetField(e);
 
+    robj *fieldObj = NULL;
+    if (expCtx->vexpired || expCtx->batchPropagate)
+        fieldObj = createStringObject(field, sdslen(field));
+
     /* Collect expired field for subkey notification (before deletion) */
     if (expCtx->vexpired)
-        vecPush(expCtx->vexpired, createStringObject(field, sdslen(field)));
+        vecPush(expCtx->vexpired, fieldObj);
 
-    propagateHashFieldDeletion(expCtx->db, key, field, sdslen(field));
+    if (expCtx->batchPropagate) {
+        if (expCtx->vexpired)
+            incrRefCount(fieldObj);
+        vecPush(expCtx->vpropagate, fieldObj);
+    } else {
+        propagateHashFieldDeletionObj(expCtx->db, expCtx->keyObj, field, sdslen(field));
+    }
 
-    /* update keysizes */
-    unsigned long l = hashTypeLength(expCtx->hashObj, 0);
-    updateKeysizesHist(expCtx->db, OBJ_HASH, l, l - 1);
-
-    serverAssert(hashTypeDelete(expCtx->hashObj, field) == 1);
+    serverAssert(hashTypeDelete(kv, field) == 1);
     if (server.memory_tracking_enabled)
         updateSlotAllocSize(expCtx->db, getKeySlot(key), kv, oldsize, kvobjAllocSize(kv));
     server.stat_expired_subkeys++;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -3978,7 +3978,11 @@ uint64_t hashTypeExpire(redisDb *db, kvobj *o, uint32_t *quota, int updateSubexp
          * first the deletion is propagated (a single HDEL per chunk for
          * active-expire, per-field HDEL for lazy-expire), only then the fields
          * are deleted. Bounded chunks keep the collection array on the stack
-         * and cap the size of a single propagated HDEL, regardless of quota. */
+         * and cap the size of a single propagated HDEL, regardless of quota.
+         * Deferring the deletion is safe: ebExpire() detaches the entry from
+         * ebuckets before invoking this callback and never accesses it
+         * afterwards; the hash dict still owns it until hashTypeDelete()
+         * below. */
         eItem entries[FIELDS_STACK_SIZE];
         onFieldExpireCtx.entries = entries;
         info.onExpireItem = onFieldExpire;
@@ -6357,10 +6361,8 @@ static void propagateHashFieldDeletion(redisDb *db, sds key, char *field, size_t
 
 /* Called during expiration of hash-fields. Only collects the expired entries;
  * hashTypeExpire() propagates the deletions and deletes the fields afterwards.
- * Deferring the deletion is safe: ebExpire() detaches the entry from ebuckets
- * before invoking this callback and never accesses it afterwards. The entries
- * array cannot overflow since ebExpire() is called with maxToExpire that is
- * bounded to FIELDS_STACK_SIZE. */
+ * The entries array cannot overflow since ebExpire() is called with maxToExpire
+ * that is bounded to FIELDS_STACK_SIZE. */
 static ExpireAction onFieldExpire(eItem item, void *ctx) {
     OnFieldExpireCtx *expCtx = ctx;
     debugServerAssert(expCtx->numEntries < FIELDS_STACK_SIZE);

--- a/tests/unit/info-keysizes.tcl
+++ b/tests/unit/info-keysizes.tcl
@@ -696,6 +696,19 @@ proc test_all_keysizes { {replMode 0} } {
 
             $server debug set-active-expire 1
         } {OK} {cluster:skip needs:debug}
+
+        if {$type eq "hashtable"} {
+            test "KEYSIZES - Test Hash field active expiration batch ($type) $suffixRepl" {
+                $server debug set-active-expire 0
+
+                run_cmd_verify_hist {$server FLUSHALL} {}
+                run_cmd_verify_hist {$server HSETEX h1 PX 50 FIELDS 4 f1 v1 f2 v2 f3 v3 f4 v4} {db0_HASH:4=1}
+                run_cmd_verify_hist {after 100} {db0_HASH:4=1}
+                $server debug set-active-expire 1
+                run_cmd_verify_hist {after 100} {} 1
+                $server debug set-active-expire 1
+            } {OK} {cluster:skip needs:debug}
+        }
     }
     
     test "KEYSIZES - Test STRING BITS $suffixRepl" {

--- a/tests/unit/info-keysizes.tcl
+++ b/tests/unit/info-keysizes.tcl
@@ -706,6 +706,14 @@ proc test_all_keysizes { {replMode 0} } {
                 run_cmd_verify_hist {after 100} {db0_HASH:4=1}
                 $server debug set-active-expire 1
                 run_cmd_verify_hist {after 100} {} 1
+
+                # Partial expiration: only the volatile fields expire, hash survives
+                $server debug set-active-expire 0
+                run_cmd_verify_hist {$server HSET h1 f1 v1 f2 v2} {db0_HASH:2=1}
+                run_cmd_verify_hist {$server HSETEX h1 PX 50 FIELDS 2 f3 v3 f4 v4} {db0_HASH:4=1}
+                run_cmd_verify_hist {after 100} {db0_HASH:4=1}
+                $server debug set-active-expire 1
+                run_cmd_verify_hist {after 100} {db0_HASH:2=1} 1
                 $server debug set-active-expire 1
             } {OK} {cluster:skip needs:debug}
         }

--- a/tests/unit/info-keysizes.tcl
+++ b/tests/unit/info-keysizes.tcl
@@ -706,14 +706,29 @@ proc test_all_keysizes { {replMode 0} } {
                 run_cmd_verify_hist {after 100} {db0_HASH:4=1}
                 $server debug set-active-expire 1
                 run_cmd_verify_hist {after 100} {} 1
-
-                # Partial expiration: only the volatile fields expire, hash survives
-                $server debug set-active-expire 0
-                run_cmd_verify_hist {$server HSET h1 f1 v1 f2 v2} {db0_HASH:2=1}
-                run_cmd_verify_hist {$server HSETEX h1 PX 50 FIELDS 2 f3 v3 f4 v4} {db0_HASH:4=1}
-                run_cmd_verify_hist {after 100} {db0_HASH:4=1}
                 $server debug set-active-expire 1
-                run_cmd_verify_hist {after 100} {db0_HASH:2=1} 1
+            } {OK} {cluster:skip needs:debug}
+
+            test "KEYSIZES - Test Hash field active partial expiration ($type) $suffixRepl" {
+                $server debug set-active-expire 0
+
+                set hset_args {}
+                set expire_fields {}
+                for {set j 0} {$j < 130} {incr j} {
+                    lappend hset_args f$j v$j
+                    if {$j < 65} {
+                        lappend expire_fields f$j
+                    }
+                }
+
+                run_cmd_verify_hist {$server FLUSHALL} {}
+                run_cmd_verify_hist [concat [list $server HSET hpartial] $hset_args] {db0_HASH:128=1}
+                run_cmd_verify_hist [concat [list $server HPEXPIRE hpartial 50 FIELDS 65] $expire_fields] {db0_HASH:128=1}
+                run_cmd_verify_hist {after 100} {db0_HASH:128=1}
+                $server debug set-active-expire 1
+                run_cmd_verify_hist {after 100} {db0_HASH:64=1} 1
+                assert_equal 1 [$server EXISTS hpartial]
+                assert_equal 65 [$server HLEN hpartial]
                 $server debug set-active-expire 1
             } {OK} {cluster:skip needs:debug}
         }

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -2242,35 +2242,42 @@ start_server {tags {"external:skip needs:debug"}} {
         }
     } {} {needs:debug}
 
-    test "Active Expire - propagated HDELs are chunked (hashtable)" {
+    test "Active Expire - HDEL propagation is chunked at field stack size (hashtable)" {
         start_server {overrides {appendonly {yes} appendfsync always hash-max-listpack-entries 0} tags {external:skip}} {
             r debug set-active-expire 0
             set aof [get_last_incr_aof_path r]
 
             set fields {}
-            set fieldvals {}
-            for {set i 1} {$i <= 100} {incr i} {
-                lappend fields f$i
-                lappend fieldvals f$i v$i
+            set hset_cmd [list hset hchunk]
+            for {set j 0} {$j < 65} {incr j} {
+                lappend fields f$j
+                lappend hset_cmd f$j v$j
             }
-            r hset h1 {*}$fieldvals
-            r hpexpire h1 10 FIELDS 100 {*}$fields
+
+            r hset hchunk {*}[lrange $hset_cmd 2 end]
+            r hpexpire hchunk 10 FIELDS 65 {*}$fields
             after 20
             r debug set-active-expire 1
 
-            wait_for_condition 50 100 { [r exists h1] == 0 } else { fail "hash h1 wasn't deleted" }
+            wait_for_condition 50 100 { [r exists hchunk] == 0 } else { fail "hash hchunk wasn't deleted" }
 
-            # 100 expired fields are propagated in chunks of at most
-            # FIELDS_STACK_SIZE (64) fields, that is two HDEL commands. The
-            # trailing empty pattern asserts nothing else was propagated.
-            assert_aof_content $aof {
-                {select *}
-                {hset h1 *}
-                {hpexpireat h1 * FIELDS 100 *}
-                {hdel h1 *}
-                {hdel h1 *}
-                {}
+            set hpexpire_cmd [list hpexpireat hchunk * FIELDS 65]
+            foreach field $fields {
+                lappend hpexpire_cmd $field
             }
+            set hdel_chunk1 [list hdel hchunk]
+            for {set j 0} {$j < 64} {incr j} {
+                lappend hdel_chunk1 *
+            }
+            set hdel_chunk2 [list hdel hchunk *]
+
+            assert_aof_content $aof [list \
+                {select *} \
+                $hset_cmd \
+                $hpexpire_cmd \
+                $hdel_chunk1 \
+                $hdel_chunk2 \
+                {}]
         }
     } {} {needs:debug}
 }

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -2220,6 +2220,27 @@ start_server {tags {"external:skip needs:debug"}} {
             }
         } {} {needs:repl external:skip}
     }
+
+    test "Active Expire - HDELs are propagated without MULTI-EXEC (hashtable)" {
+        start_server {overrides {appendonly {yes} appendfsync always hash-max-listpack-entries 0} tags {external:skip}} {
+            r debug set-active-expire 0
+            set aof [get_last_incr_aof_path r]
+
+            r hset h1 f1 v1 f2 v2 f3 v3 f4 v4
+            r hpexpire h1 10 FIELDS 4 f1 f2 f3 f4
+            after 20
+            r debug set-active-expire 1
+
+            wait_for_condition 50 100 { [r exists h1] == 0 } else { fail "hash h1 wasn't deleted" }
+
+            assert_aof_content $aof {
+                {select *}
+                {hset h1 f1 v1 f2 v2 f3 v3 f4 v4}
+                {hpexpireat h1 * FIELDS 4 f1 f2 f3 f4}
+                {hdel h1 * * * *}
+            }
+        }
+    } {} {needs:debug}
 }
 
 # Comprehensive tests for flexible parsing improvements and field validation fixes

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -2241,6 +2241,38 @@ start_server {tags {"external:skip needs:debug"}} {
             }
         }
     } {} {needs:debug}
+
+    test "Active Expire - propagated HDELs are chunked (hashtable)" {
+        start_server {overrides {appendonly {yes} appendfsync always hash-max-listpack-entries 0} tags {external:skip}} {
+            r debug set-active-expire 0
+            set aof [get_last_incr_aof_path r]
+
+            set fields {}
+            set fieldvals {}
+            for {set i 1} {$i <= 100} {incr i} {
+                lappend fields f$i
+                lappend fieldvals f$i v$i
+            }
+            r hset h1 {*}$fieldvals
+            r hpexpire h1 10 FIELDS 100 {*}$fields
+            after 20
+            r debug set-active-expire 1
+
+            wait_for_condition 50 100 { [r exists h1] == 0 } else { fail "hash h1 wasn't deleted" }
+
+            # 100 expired fields are propagated in chunks of at most
+            # FIELDS_STACK_SIZE (64) fields, that is two HDEL commands. The
+            # trailing empty pattern asserts nothing else was propagated.
+            assert_aof_content $aof {
+                {select *}
+                {hset h1 *}
+                {hpexpireat h1 * FIELDS 100 *}
+                {hdel h1 *}
+                {hdel h1 *}
+                {}
+            }
+        }
+    } {} {needs:debug}
 }
 
 # Comprehensive tests for flexible parsing improvements and field validation fixes


### PR DESCRIPTION
## Problem

  Hash field active expiration propagated one `HDEL` per expired field for hashtable-encoded hashes.

  For large HFE batches this repeated the same propagation setup many times and produced larger AOF / replication streams than
  necessary:

  ```text
  HDEL key f1
  HDEL key f2
  HDEL key f3
  ...
  ```

  ## Solution

  Batch hashtable HFE active-expire propagation per key:

  ```text
  HDEL key f1 f2 f3 ...
  ```

  The batched path still uses `alsoPropagate()` and the normal `postExecutionUnitOperations()` flush. Since each batch is emitted as
  a single `HDEL` command, it is not wrapped in `MULTI` / `EXEC`.

  This also batches the key-size histogram update for the same path. The old per-field sequence from `(N, N-1)`, `(N-1, N-2)`, ... is
  equivalent to one update from `(N, N-expired)`.

  Field name objects are also reused when both subkey notifications and propagation need the same expired field names.

  ## Behavior

  - Hashtable active-expire HFE now propagates one `HDEL key field...` per expired batch.
  - Very large hashes may still produce multiple `HDEL`s across active-expire quota boundaries.
  - The propagated `HDEL` is emitted before the `hexpired` subkey notification. This ordering is unchanged from the previous path.
  - The propagated batch is not wrapped in `MULTI` / `EXEC`.
  - `listpackex` HFE remains unchanged and still uses the existing per-field path, since it is bounded by the listpack conversion
  threshold.
  - The `postExecutionUnitOperations()` drain in `activeSubexpires()` remains in place and is still required for module post-
  notification jobs.

  ## Benchmarks

  Measured with temporary `HFE_PROFILE` instrumentation around the HFE active-expire path.

  This was not measured with a `REDIS_TEST` build.

  Benchmark build/config:

  ```text
  REDIS_CFLAGS='-DHFE_PROFILE'
  active-expire-effort=1
  hz=10
  hash-max-listpack-entries=0
  optimized jemalloc build
  3-run average
  ```

  AOF enabled:

  | Expired fields | Baseline | This PR | Time reduction | Speedup |
  |---:|---:|---:|---:|---:|
  | 10k | 5,709 us | 2,665 us | 53.3% | 2.14x |
  | 80k | 45,746 us | 23,190 us | 49.3% | 1.97x |
  | 200k | 124,300 us | 64,983 us | 47.7% | 1.91x |

  AOF disabled:

  | Expired fields | Baseline | This PR | Time reduction | Speedup |
  |---:|---:|---:|---:|---:|
  | 10k | 2,838 us | 2,018 us | 28.9% | 1.41x |
  | 80k | 24,184 us | 19,098 us | 21.0% | 1.27x |
  | 200k | 71,477 us | 52,224 us | 26.9% | 1.37x |

  ## Tests

  Validation was run separately from the benchmark build.

  ```text
  make -j4 REDIS_CFLAGS='-DREDIS_TEST'
  ./runtest --single unit/type/hash-field-expire --clients 1
  ./runtest --single unit/info-keysizes --clients 1
  ./runtest-moduleapi
  git diff --check
  ```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replication/AOF propagation on the active HFE path for hashtable hashes; semantics are intended equivalent but replicas and persistence depend on the new batched HDEL shape.
> 
> **Overview**
> **Hashtable-encoded hash field active expiration** no longer propagates and deletes each field inside `onFieldExpire`. Expired entries are collected in bounded chunks (up to `FIELDS_STACK_SIZE`, 64), then **`hashTypeExpire`** propagates deletions and removes fields from the hash.
> 
> For **active expire**, each chunk is replicated/AOF’d as a **single `HDEL key f1 f2 …`** via new `propagateHashFieldDeletionBatch`, instead of one `HDEL` per field. **Lazy expire** still uses per-field propagation through `propagateHashFieldDeletionObj`. **Listpackex** HFE is unchanged.
> 
> The HT path also **batches keysizes histogram updates** per chunk, reuses the key `robj` when possible, and shares field name objects between subkey notifications and propagation when both are enabled. A comment in `activeSubexpires()` was updated to describe batched vs per-field propagation and why `postExecutionUnitOperations()` is still drained after the walk (no execution unit around the walk, so propagated commands stay out of `MULTI`/`EXEC`).
> 
> **Tests** assert AOF shape (one batched `HDEL`, chunking at 65 fields), KEYSIZES behavior under active HFE, and partial expiration of large hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b2451a9d42863dcf7d0716f143ef27b4438392f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->