### PR TITLE
Fix AOF restoration of deleted Stream PEL entries

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -2504,10 +2504,10 @@ int rioWriteBulkStreamID(rio *r,streamID *id) {
  * key and group. */
 int rioWriteStreamPendingEntry(rio *r, robj *key, const char *groupname, size_t groupname_len, streamConsumer *consumer, unsigned char *rawid, streamNACK *nack) {
      /* XCLAIM <key> <group> <consumer> 0 <id> TIME <milliseconds-unix-time>
-               RETRYCOUNT <count> JUSTID FORCE. */
+               RETRYCOUNT <count> JUSTID FORCE AOFRESTORE. */
     streamID id;
     streamDecodeID(rawid,&id);
-    if (rioWriteBulkCount(r,'*',12) == 0) return 0;
+    if (rioWriteBulkCount(r,'*',13) == 0) return 0;
     if (rioWriteBulkString(r,"XCLAIM",6) == 0) return 0;
     if (rioWriteBulkObject(r,key) == 0) return 0;
     if (rioWriteBulkString(r,groupname,groupname_len) == 0) return 0;
@@ -2520,6 +2520,7 @@ int rioWriteStreamPendingEntry(rio *r, robj *key, const char *groupname, size_t 
     if (rioWriteBulkLongLong(r,nack->delivery_count) == 0) return 0;
     if (rioWriteBulkString(r,"JUSTID",6) == 0) return 0;
     if (rioWriteBulkString(r,"FORCE",5) == 0) return 0;
+    if (rioWriteBulkString(r,"AOFRESTORE",10) == 0) return 0;
     return 1;
 }
 
@@ -2532,9 +2533,9 @@ int rioWriteStreamNackedEntries(rio *r, robj *key, const char *groupname,
                                 int count, uint64_t delivery_count) {
     serverAssert(count > 0 && count <= AOF_REWRITE_ITEMS_PER_CMD);
 
-    /* XNACK <key> <group> FAIL IDS <n> <id..> RETRYCOUNT <cnt> FORCE
-     * 6 fixed tokens before IDs + count IDs + 3 fixed tokens after. */
-    if (rioWriteBulkCount(r,'*',6+count+3) == 0) return 0;
+    /* XNACK <key> <group> FAIL IDS <n> <id..> RETRYCOUNT <cnt> FORCE AOFRESTORE
+     * 6 fixed tokens before IDs + count IDs + 4 fixed tokens after. */
+    if (rioWriteBulkCount(r,'*',6+count+4) == 0) return 0;
     if (rioWriteBulkString(r,"XNACK",5) == 0) return 0;
     if (rioWriteBulkObject(r,key) == 0) return 0;
     if (rioWriteBulkString(r,groupname,groupname_len) == 0) return 0;
@@ -2549,6 +2550,7 @@ int rioWriteStreamNackedEntries(rio *r, robj *key, const char *groupname,
     if (rioWriteBulkString(r,"RETRYCOUNT",10) == 0) return 0;
     if (rioWriteBulkLongLong(r,delivery_count) == 0) return 0;
     if (rioWriteBulkString(r,"FORCE",5) == 0) return 0;
+    if (rioWriteBulkString(r,"AOFRESTORE",10) == 0) return 0;
     return 1;
 }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4025,6 +4025,7 @@ void xnackCommand(client *c) {
     int ids_start = 0;
     int numids = 0;
     int force = 0;
+    int aof_restore = 0;
     long long retrycount = -1;
     for (int i = 4; i < c->argc; i++) {
         int moreargs = (c->argc-1) - i; /* Number of additional arguments. */
@@ -4043,6 +4044,12 @@ void xnackCommand(client *c) {
             i = ids_start + numids - 1;
         } else if (!strcasecmp(opt,"FORCE")) {
             force = 1;
+        } else if (!strcasecmp(opt,"AOFRESTORE") &&
+                   server.loading && c->id == CLIENT_ID_AOF)
+        {
+            /* AOF rewrites use this internal option to restore PEL entries
+             * whose stream payload was already deleted. */
+            aof_restore = 1;
         } else if (!strcasecmp(opt,"RETRYCOUNT") && moreargs) {
             i++;
             if (getLongLongFromObjectOrReply(c,c->argv[i],&retrycount,NULL) != C_OK)
@@ -4060,6 +4067,10 @@ void xnackCommand(client *c) {
 
     if (ids_start == 0) {
         addReplyError(c,"syntax error, expected IDS keyword");
+        return;
+    }
+    if (aof_restore && !force) {
+        addReplyError(c,"AOFRESTORE requires FORCE");
         return;
     }
 
@@ -4095,8 +4106,10 @@ void xnackCommand(client *c) {
             pelListInsertNacked(group, nack);
         } else if (force) {
             /* FORCE: create new unowned PEL entry only if the stream
-             * entry exists, otherwise skip silently (same as XCLAIM). */
-            if (!streamEntryExists(s, &ids[j]))
+             * entry exists, otherwise skip silently (same as XCLAIM).
+             * AOFRESTORE bypasses this check only while loading an AOF so
+             * rewritten ghost PEL entries can be reconstructed. */
+            if (!aof_restore && !streamEntryExists(s, &ids[j]))
                 continue;
             streamNACK *nack = streamCreateNACK(s, NULL, &ids[j]);
             
@@ -4520,6 +4533,7 @@ void xclaimCommand(client *c) {
     mstime_t deliverytime = -1;  /* -1 means IDLE/TIME options not given. */
     int force = 0;
     int justid = 0;
+    int aof_restore = 0;
 
     if (o) {
         if (checkType(c,o,OBJ_STREAM)) return; /* Type error. */
@@ -4567,6 +4581,12 @@ void xclaimCommand(client *c) {
             force = 1;
         } else if (!strcasecmp(opt,"JUSTID")) {
             justid = 1;
+        } else if (!strcasecmp(opt,"AOFRESTORE") &&
+                   server.loading && c->id == CLIENT_ID_AOF)
+        {
+            /* AOF rewrites use this internal option to restore PEL entries
+             * whose stream payload was already deleted. */
+            aof_restore = 1;
         } else if (!strcasecmp(opt,"IDLE") && moreargs) {
             j++;
             if (getLongLongFromObjectOrReply(c,c->argv[j],&deliverytime,
@@ -4590,6 +4610,11 @@ void xclaimCommand(client *c) {
             addReplyErrorFormat(c,"Unrecognized XCLAIM option '%s'",opt);
             goto cleanup;
         }
+    }
+
+    if (aof_restore && (!force || !justid)) {
+        addReplyError(c,"AOFRESTORE requires FORCE and JUSTID");
+        goto cleanup;
     }
 
     if (streamCompareID(&last_id,&group->last_id) > 0) {
@@ -4635,7 +4660,7 @@ void xclaimCommand(client *c) {
         streamNACK *nack = result;
 
         /* Item must exist for us to transfer it to another consumer. */
-        if (!streamEntryExists(s,&id)) {
+        if (!aof_restore && !streamEntryExists(s,&id)) {
             /* Clear this entry from the PEL, it no longer exists */
             if (nack != NULL) {
                 /* Propagate this change (we are going to delete the NACK). */
@@ -4662,7 +4687,8 @@ void xclaimCommand(client *c) {
          * exists in the Stream. In such case, we'll create a new
          * entry in the PEL from scratch, so that XCLAIM can also
          * be used to create entries in the PEL. Useful for AOF
-         * and replication of consumer groups. */
+         * and replication of consumer groups. AOFRESTORE is accepted only
+         * while loading an AOF and permits this for deleted entries too. */
         if (force && nack == NULL) {
             /* Create the NACK. */
             nack = streamCreateNACK(s, NULL, &id);

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -4485,6 +4485,56 @@ start_server {
 }
 
 start_server {tags {"stream needs:debug"} overrides {appendonly yes aof-use-rdb-preamble no}} {
+    test "Deleted pending entries survive AOF rewrite" {
+        r DEL mystream
+        r XADD mystream 1-0 f v1
+        r XADD mystream 2-0 f v2
+        r XADD mystream 3-0 f v3
+        r XGROUP CREATE mystream grp 0
+
+        # The restore option is private to the AOF loading client. Normal
+        # clients cannot use it to extend the public FORCE semantics.
+        assert_error {*Unrecognized XCLAIM option 'AOFRESTORE'*} {
+            r XCLAIM mystream grp c1 0 9-0 FORCE JUSTID AOFRESTORE
+        }
+        assert_error {*Unrecognized XNACK option 'AOFRESTORE'*} {
+            r XNACK mystream grp FAIL IDS 1 9-0 FORCE AOFRESTORE
+        }
+
+        r XREADGROUP GROUP grp c1 COUNT 3 STREAMS mystream >
+
+        # Keep one deleted pending entry owned and move the other into the
+        # unowned NACK zone. Use distinct delivery counts so the rewrite must
+        # preserve more than just their IDs.
+        r XCLAIM mystream grp c1 0 1-0 TIME [expr {[clock milliseconds] - 60000}] RETRYCOUNT 7 JUSTID
+        r XNACK mystream grp FAIL IDS 1 2-0 RETRYCOUNT 9
+        r XDEL mystream 1-0 2-0
+
+        set pending_before [r XPENDING mystream grp - + 10]
+        assert_equal [llength $pending_before] 3
+        assert_match {1-0 c1 * 7} [lindex $pending_before 0]
+        assert_equal [lindex $pending_before 1] {2-0 {} -1 9}
+        assert_match {3-0 c1 * 1} [lindex $pending_before 2]
+
+        r bgrewriteaof
+        waitForBgrewriteaof r
+        r debug loadaof
+
+        set pending_after [r XPENDING mystream grp - + 10]
+        assert_equal [llength $pending_after] 3
+        assert_match {1-0 c1 * 7} [lindex $pending_after 0]
+        assert {[lindex $pending_after 0 2] > 50000}
+        assert_equal [lindex $pending_after 1] {2-0 {} -1 9}
+        assert_match {3-0 c1 * 1} [lindex $pending_after 2]
+
+        set info [r XINFO STREAM mystream FULL]
+        set group [lindex [dict get $info groups] 0]
+        assert_equal [dict get $group nacked-count] 1
+
+        # The rewrite must not recreate the deleted stream payloads.
+        assert_equal [r XRANGE mystream - +] {{3-0 {f v3}}}
+    }
+
     # Verify that NACKed entries are correctly emitted during AOF rewrite
     # and fully restored via `debug loadaof`. After rewrite + reload,
     # delivery_counts, unowned status, and NACK zone claim order must


### PR DESCRIPTION
## Problem

Redis intentionally keeps consumer-group PEL records after their Stream payloads are deleted. Command-form AOF rewrites currently serialize owned PEL records with `XCLAIM ... FORCE` and unowned/NACKed records with `XNACK ... FORCE`. During replay, both commands skip IDs whose Stream entries no longer exist.

As a result, replaying a rewritten AOF loses pending count, ownership, delivery time/count, and NACK state, even though replaying the original incremental AOF or loading an RDB preserves them.

## Fix

- Add an internal `AOFRESTORE` marker to rewritten `XCLAIM` and `XNACK` commands.
- Accept that marker only from the AOF client while the server is loading.
- Allow that restricted path to reconstruct a PEL record without recreating its deleted Stream payload.
- Keep the public `FORCE` behavior unchanged; normal clients receive the existing unrecognized-option error.
- Require `FORCE` for both restore paths and `JUSTID` for `XCLAIM`, preventing the loader from attempting to return a missing payload.

The restored records retain their owner, delivery time/count, and NACK-zone membership and ordering.

## Tests

Added a regression test covering an owned deleted PEL record and an unowned deleted NACK record in the same group. It verifies ownership, delivery counts, delivery time, NACK count, total pending count, and that deleted payloads are not recreated.

```text
./runtest --single unit/type/stream-cgroups
```

The complete unit passed locally.

Fixes #15729

## Interaction with #14957

#14957 changes the in-memory PEL representation and iteration APIs but leaves the AOF restore semantics unchanged. This fix is intentionally based on `unstable`. If #14957 lands first, the small PEL lookup/insertion portions can be mechanically adapted to its `pel*` APIs during rebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stream command parsing and AOF replay semantics for PEL restoration, but the new path is gated to the AOF loader and does not alter public client behavior.
> 
> **Overview**
> Fixes **loss of consumer-group pending state** when replaying a rewritten AOF: owned and NACK-zone PEL entries whose stream messages were **XDEL**’d were dropped because rewritten `XCLAIM … FORCE` / `XNACK … FORCE` replay skipped IDs with no stream payload.
> 
> **AOF rewrite** now appends an internal **`AOFRESTORE`** flag on those commands (`rioWriteStreamPendingEntry`, `rioWriteStreamNackedEntries`). **`XCLAIM`** and **`XNACK`** accept it only for the **AOF loading client** while `server.loading`, with **`FORCE`** required (and **`JUSTID`** for `XCLAIM`), so replay can rebuild PEL metadata without recreating deleted entries. Regular clients still get unrecognized-option errors.
> 
> Adds regression coverage: `bgrewriteaof` + `debug loadaof` preserves pending ownership, delivery counts/time, NACK count, and stream contents without restoring deleted payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c82b0811db31b33b51e9cbc5ca4be9a7c747db84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->