### PR TITLE
Fix falky test XREADGROUP CLAIM idle time resets after RDB reload

### DIFF
--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -3305,7 +3305,6 @@ start_server {
             set claim_before [r XREADGROUP GROUP group1 consumer2 CLAIM 500 STREAMS mystream >]
             assert_equal [llength [lindex $claim_before 0 1]] 1
             
-            r SAVE
             r DEBUG RELOAD
 
             # After reload: idle time resets, message not immediately claimable


### PR DESCRIPTION
Failed CI on 2026-09-01: https://github.com/redis/redis/actions/runs/33454017107/job/99689987110
>*** [err]: XREADGROUP CLAIM idle time resets after RDB reload in tests/unit/type/stream-cgroups.tcl
Expected '1' to be equal to '0' (context: type eval line 19 cmd {assert_equal [llength $claim_after] 0} proc ::test)
Cleanup: may take some time... OK
Error: Process completed with exit code 1.

The redundant SAVE before DEBUG RELOAD makes the reload take longer and can exceed the 500 ms idle threshold.

| PR Validation CI Item | PR Validation CI Details |
| --- | --- |
| Executed daily jobs | valgrind,sanitizer,tls,centos,oldTC,defrag,assert-keyspace |
| Tests | redis |
| Extra test arguments | --loops 100 --single unit/type/stream-cgroups |
| CI link | [https://github.com/vitahlin/redis/actions/runs/33466080281](https://github.com/vitahlin/redis/actions/runs/33466080281) |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no server or persistence logic modifications.
> 
> **Overview**
> Stabilizes the **XREADGROUP CLAIM idle time resets after RDB reload** test in `stream-cgroups.tcl` by dropping the extra `SAVE` that ran immediately before `DEBUG RELOAD`.
> 
> That synchronous save stretched the gap before the post-reload `CLAIM 500` check enough that pending idle could cross the 500 ms threshold again, so the test sometimes saw a claimable message when it expected none. Reload alone still exercises RDB persistence; the assertion behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1c8f89c2b07772243090ea9c82d19d4926f10cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->