### PR TITLE
Accelerate CRC64 checksumming for RDB load with PCLMULQDQ

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -377,6 +377,14 @@ void setcpuaffinity(const char *cpulist);
 #endif
 #endif
 
+/* Check if we can compile PCLMULQDQ (carry-less multiply) code */
+#if defined (__x86_64__) && ((defined(__GNUC__) && __GNUC__ >= 5) || (defined(__clang__) && __clang_major__ >= 4))
+#if defined(__has_attribute) && __has_attribute(target)
+#define HAVE_PCLMUL
+#define ATTRIBUTE_TARGET_PCLMUL __attribute__((target("pclmul")))
+#endif
+#endif
+
 /* Check for AArch64 (ARM v8) specific optimizations */
 #if defined(__aarch64__) && ((defined(__GNUC__) && __GNUC__ >= 5) || defined(__clang__))
 #if defined(__has_attribute) && __has_attribute(target)

--- a/src/crc64.c
+++ b/src/crc64.c
@@ -30,6 +30,7 @@
  * POSSIBILITY OF SUCH DAMAGE. */
 
 #include <stdlib.h>
+#include "config.h"
 #include "crc64.h"
 #include "crcspeed.h"
 #include "redisassert.h"
@@ -137,13 +138,163 @@ uint64_t _crc64(uint_fast64_t crc, const void *in_data, const uint64_t len) {
 
 /******************** END GENERATED PYCRC FUNCTIONS ********************/
 
+#ifdef HAVE_PCLMUL
+/* PCLMULQDQ-accelerated CRC64 (reflected, poly 0xad93d23594c935a9).
+ *
+ * Folding scheme (Gopal et al., "Fast CRC Computation for Generic
+ * Polynomials Using PCLMULQDQ Instruction", Intel 2009), adapted to a
+ * reflected 64-bit CRC:
+ *
+ * The input stream is viewed as one huge polynomial M(x) over GF(2) and the
+ * CRC is reflect64(M(x)*x^64 mod P(x)). In reflected form, a 128-bit
+ * register loaded from memory represents a degree <= 127 polynomial whose
+ * high 64 coefficients sit in the low qword. Folding a register A over a
+ * distance of D bits (i.e. multiplying by x^D and reducing) is:
+ *
+ *   fold(A) = clmul(A.lo, x^(D+63) mod P) xor clmul(A.hi, x^(D-1) mod P)
+ *
+ * The "-1" in the exponents compensates for the extra x factor that
+ * PCLMULQDQ introduces when both operands are bit-reflected. Four
+ * accumulators fold 64 bytes per iteration (D = 512), are then merged with
+ * D = 384/256/128 folds, and remaining 16-byte blocks fold with D = 128.
+ * Instead of a Barrett reduction, the final 128-bit remainder is simply run
+ * through the table implementation (16 bytes), which also handles the tail.
+ *
+ * The fold constants x^e mod P are derived at init time by
+ * crc64_xpow_mod() and stored bit-reflected, ready for PCLMULQDQ. */
+
+#include <immintrin.h>
+
+#define CRC64_PCLMUL_CUTOFF 64
+
+/* Bit-reflected fold constants for D = 512, 384, 256, 128, as
+ * {x^(D+63) mod P, x^(D-1) mod P} pairs. Filled in by crc64_pclmul_init(). */
+static uint64_t crc64_pclmul_consts[8];
+static int crc64_pclmul_supported = 0; /* CPU support verified at init. */
+static int crc64_pclmul_enabled = 0;   /* Dispatch toggle, see crc64_pclmul_enable(). */
+
+/* Return x^e mod P(x) in normal bit order (bit j = coefficient of x^j),
+ * where P(x) = x^64 + POLY. Requires e >= 64. */
+static uint64_t crc64_xpow_mod(unsigned int e) {
+    uint64_t r = POLY; /* x^64 mod P */
+    for (unsigned int i = 64; i < e; i++)
+        r = (r << 1) ^ ((r & UINT64_C(0x8000000000000000)) ? POLY : 0);
+    return r;
+}
+
+ATTRIBUTE_TARGET_PCLMUL
+static inline __m128i crc64_fold128(__m128i x, __m128i k) {
+    return _mm_xor_si128(_mm_clmulepi64_si128(x, k, 0x00),
+                         _mm_clmulepi64_si128(x, k, 0x11));
+}
+
+ATTRIBUTE_TARGET_PCLMUL
+static uint64_t crc64_pclmul(uint64_t crc, const unsigned char *s, uint64_t l) {
+    const __m128i k512 = _mm_set_epi64x(crc64_pclmul_consts[1], crc64_pclmul_consts[0]);
+    const __m128i k384 = _mm_set_epi64x(crc64_pclmul_consts[3], crc64_pclmul_consts[2]);
+    const __m128i k256 = _mm_set_epi64x(crc64_pclmul_consts[5], crc64_pclmul_consts[4]);
+    const __m128i k128 = _mm_set_epi64x(crc64_pclmul_consts[7], crc64_pclmul_consts[6]);
+    __m128i x0, x1, x2, x3, acc;
+    unsigned char rem[16];
+
+    /* XORing the initial CRC into the first 8 bytes of the stream is
+     * equivalent to seeding the state with it (the state is 64 bits wide). */
+    x0 = _mm_xor_si128(_mm_loadu_si128((const __m128i *)s),
+                       _mm_cvtsi64_si128((long long)crc));
+    x1 = _mm_loadu_si128((const __m128i *)(s + 16));
+    x2 = _mm_loadu_si128((const __m128i *)(s + 32));
+    x3 = _mm_loadu_si128((const __m128i *)(s + 48));
+    s += 64;
+    l -= 64;
+
+    while (l >= 64) {
+        x0 = _mm_xor_si128(crc64_fold128(x0, k512), _mm_loadu_si128((const __m128i *)s));
+        x1 = _mm_xor_si128(crc64_fold128(x1, k512), _mm_loadu_si128((const __m128i *)(s + 16)));
+        x2 = _mm_xor_si128(crc64_fold128(x2, k512), _mm_loadu_si128((const __m128i *)(s + 32)));
+        x3 = _mm_xor_si128(crc64_fold128(x3, k512), _mm_loadu_si128((const __m128i *)(s + 48)));
+        s += 64;
+        l -= 64;
+    }
+
+    acc = _mm_xor_si128(crc64_fold128(x0, k384), crc64_fold128(x1, k256));
+    acc = _mm_xor_si128(acc, crc64_fold128(x2, k128));
+    acc = _mm_xor_si128(acc, x3);
+
+    while (l >= 16) {
+        acc = _mm_xor_si128(crc64_fold128(acc, k128), _mm_loadu_si128((const __m128i *)s));
+        s += 16;
+        l -= 16;
+    }
+
+    /* Reduce the 128-bit remainder (and up to 15 tail bytes) with the
+     * table implementation. */
+    _mm_storeu_si128((__m128i *)rem, acc);
+    crc = crcspeed64native(crc64_table, 0, rem, sizeof(rem));
+    if (l) crc = crcspeed64native(crc64_table, crc, (void *)s, l);
+    return crc;
+}
+
+static void crc64_pclmul_init(void) {
+    static const unsigned int exps[8] = {575, 511, 447, 383, 319, 255, 191, 127};
+    unsigned char buf[512];
+    static const uint64_t seeds[] = {0, UINT64_C(0x0123456789abcdef)};
+    static const uint64_t lens[] = {64, 65, 127, 128, 129, 250, 448, 509};
+
+    crc64_pclmul_supported = crc64_pclmul_enabled = 0;
+    if (!__builtin_cpu_supports("pclmul")) return;
+    for (int i = 0; i < 8; i++)
+        crc64_pclmul_consts[i] = crc_reflect(crc64_xpow_mod(exps[i]), 64);
+
+    /* Sanity check against the table implementation on various lengths,
+     * alignments and seeds; stay disabled on any mismatch. */
+    for (unsigned int i = 0; i < sizeof(buf); i++)
+        buf[i] = (unsigned char)(i * 251 + 7);
+    for (unsigned int i = 0; i < sizeof(lens)/sizeof(lens[0]); i++) {
+        for (unsigned int off = 0; off < 3; off++) {
+            for (unsigned int j = 0; j < sizeof(seeds)/sizeof(seeds[0]); j++) {
+                if (crc64_pclmul(seeds[j], buf + off, lens[i]) !=
+                    crcspeed64native(crc64_table, seeds[j], buf + off, lens[i]))
+                    return;
+            }
+        }
+    }
+    crc64_pclmul_supported = crc64_pclmul_enabled = 1;
+}
+#endif /* HAVE_PCLMUL */
+
+int crc64_pclmul_available(void) {
+#ifdef HAVE_PCLMUL
+    return crc64_pclmul_supported;
+#else
+    return 0;
+#endif
+}
+
+/* Toggle PCLMUL dispatch, mainly so tests/benchmarks can measure the table
+ * implementation on machines where PCLMUL is available. Enabling has no
+ * effect if support wasn't verified at init time. */
+void crc64_pclmul_enable(int enable) {
+#ifdef HAVE_PCLMUL
+    crc64_pclmul_enabled = enable && crc64_pclmul_supported;
+#else
+    (void) enable;
+#endif
+}
+
 /* Initializes the 16KB lookup tables. */
 void crc64_init(void) {
     crcspeed64native_init(_crc64, crc64_table);
+#ifdef HAVE_PCLMUL
+    crc64_pclmul_init();
+#endif
 }
 
 /* Compute crc64 */
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l) {
+#ifdef HAVE_PCLMUL
+    if (crc64_pclmul_enabled && l >= CRC64_PCLMUL_CUTOFF)
+        return crc64_pclmul(crc, s, l);
+#endif
     return crcspeed64native(crc64_table, crc, (void *) s, l);
 }
 
@@ -283,7 +434,31 @@ again:
             (uint64_t)_crc64(0, li, sizeof(li)));
         printf("[64speed]: c7794709e69683b3 == %016" PRIx64 "\n",
             (uint64_t)crc64(0, (unsigned char*)li, sizeof(li)));
-        
+
+        /* Cross-validate the dispatched implementation (PCLMUL when
+         * available) against the table implementation over a range of
+         * lengths, alignments and seed values. */
+        {
+            unsigned char *cross = zmalloc(4200);
+            uint64_t seed = 0;
+            genBenchmarkRandomData((char*)cross, 4200);
+            crc64_pclmul_enable(0);
+            for (uint64_t len = 0; len <= 4096; len += (len < 96 ? 1 : 37)) {
+                for (int off = 0; off < 3; off++) {
+                    uint64_t expected = crc64(seed, cross + off, len);
+                    crc64_pclmul_enable(1);
+                    uint64_t got = crc64(seed, cross + off, len);
+                    crc64_pclmul_enable(0);
+                    assert(got == expected);
+                    seed = expected * 31 + 1;
+                }
+            }
+            crc64_pclmul_enable(1);
+            zfree(cross);
+            printf("[crossval]: ok (pclmul %s)\n",
+                crc64_pclmul_available() ? "enabled" : "not available");
+        }
+
         if (!testAll) return 0;
     }
 
@@ -312,6 +487,9 @@ again:
         if ((!combine || testAll) && crc64_test_size) {
             if (csv && init_this_loop) printf("algorithm,buffer,performance,crc64_matches\n");
 
+            /* bench the table implementations with PCLMUL dispatch disabled */
+            crc64_pclmul_enable(0);
+
             /* get the single-character version for single-byte Redis behavior */
             set_crc64_cutoffs(0, crc64_test_size+1);
             assert(!bench_crc64(data, crc64_test_size, passes, expect, "crc_1byte", csv));
@@ -327,6 +505,13 @@ again:
             /* run with tri 8-byte paths */
             set_crc64_cutoffs(1, 1);
             assert(!(bench_crc64(data, crc64_test_size, passes, expect, "crctri", csv)));
+
+            /* run with PCLMUL folding, when the CPU has it (the final
+             * reduction goes through the plain 8-byte table path) */
+            set_crc64_cutoffs(crc64_test_size+1, crc64_test_size+1);
+            crc64_pclmul_enable(1);
+            if (crc64_pclmul_available())
+                assert(!(bench_crc64(data, crc64_test_size, passes, expect, "pclmul", csv)));
 
             /* Be free memory region, be free. */
             zfree(data);

--- a/src/crc64.c
+++ b/src/crc64.c
@@ -454,6 +454,34 @@ again:
                 }
             }
             crc64_pclmul_enable(1);
+
+            /* Chained/continuation check: a CRC seeded from one dispatch
+             * path (table, below the cutoff) must continue correctly
+             * through the other (PCLMUL, at/above the cutoff), matching
+             * how rdbLoad() folds checksums across buffered physical
+             * reads whose boundaries don't align with the cutoff. */
+            for (uint64_t n1 = 0; n1 <= CRC64_PCLMUL_CUTOFF + 64; n1++) {
+                for (uint64_t n2 = 1; n2 <= CRC64_PCLMUL_CUTOFF + 64; n2 += 7) {
+                    if (n1 + n2 > 4200) continue;
+                    uint64_t whole = crc64(seed, cross, n1 + n2);
+                    uint64_t chained = crc64(crc64(seed, cross, n1), cross + n1, n2);
+                    assert(chained == whole);
+                }
+            }
+
+            /* Degenerate content: all-zero and all-one-bit buffers are
+             * the classic carry-less-multiply corner cases and are not
+             * represented in the "random" buffer above. */
+            unsigned char degenerate[256];
+            memset(degenerate, 0x00, sizeof(degenerate));
+            for (uint64_t len = 0; len <= sizeof(degenerate); len++)
+                assert(crc64(seed, degenerate, len) ==
+                    crcspeed64native(crc64_table, seed, degenerate, len));
+            memset(degenerate, 0xff, sizeof(degenerate));
+            for (uint64_t len = 0; len <= sizeof(degenerate); len++)
+                assert(crc64(seed, degenerate, len) ==
+                    crcspeed64native(crc64_table, seed, degenerate, len));
+
             zfree(cross);
             printf("[crossval]: ok (pclmul %s)\n",
                 crc64_pclmul_available() ? "enabled" : "not available");

--- a/src/crc64.h
+++ b/src/crc64.h
@@ -5,6 +5,8 @@
 
 void crc64_init(void);
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
+int crc64_pclmul_available(void);
+void crc64_pclmul_enable(int enable);
 
 #ifdef REDIS_TEST
 int crc64Test(int argc, char *argv[], int flags);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4601,7 +4601,10 @@ void stopSaving(int success) {
 /* Track loading progress in order to serve client's from time to time
    and if needed calculate rdb checksum  */
 void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
-    if (server.rdb_checksum && !server.loading_skip_checksum)
+    /* When RIO_FLAG_CKSUM_AT_SOURCE is set, the rio's read() method already
+     * folded these bytes into the checksum itself (see rioInitWithFileLoad);
+     * doing it again here would checksum every byte twice. */
+    if (server.rdb_checksum && !server.loading_skip_checksum && !(r->flags & RIO_FLAG_CKSUM_AT_SOURCE))
         rioGenericUpdateChecksum(r, buf, len);
     if (server.loading_process_events_interval_bytes &&
         (r->processed_bytes + len)/server.loading_process_events_interval_bytes > r->processed_bytes/server.loading_process_events_interval_bytes)
@@ -5152,7 +5155,8 @@ int rdbLoadWithEmptyFunc(char *filename, rdbSaveInfo *rsi, int rdbflags, void (*
         return RDB_FAILED;
     }
 
-    if (fstat(fileno(fp), &sb) == -1)
+    int have_filesize = fstat(fileno(fp), &sb) != -1;
+    if (!have_filesize)
         sb.st_size = 0;
 
     loadingSetFlags(filename, sb.st_size, 0);
@@ -5161,10 +5165,17 @@ int rdbLoadWithEmptyFunc(char *filename, rdbSaveInfo *rsi, int rdbflags, void (*
     if (emptyDbFunc)
         emptyDbFunc(); /* Flush existing db. */
     loadingFireEvent(rdbflags);
-    rioInitWithFile(&rdb,fp);
+    /* rioInitWithFileLoad() needs a real file size to know where the
+     * trailing checksum footer begins; fall back to the plain rio in the
+     * rare case fstat() failed on an already-open fd. */
+    if (have_filesize)
+        rioInitWithFileLoad(&rdb,fp,sb.st_size,server.rdb_checksum && !server.loading_skip_checksum);
+    else
+        rioInitWithFile(&rdb,fp);
 
     retval = rdbLoadRio(&rdb,rdbflags,rsi);
 
+    if (have_filesize) rioFreeFileLoad(&rdb);
     fclose(fp);
     if (retval != C_OK && emptyDbFunc)
         emptyDbFunc(); /* Clean up partial db. */

--- a/src/rio.c
+++ b/src/rio.c
@@ -209,7 +209,7 @@ void rioInitWithFile(rio *r, FILE *fp) {
  * since the clip is based on absolute file offsets and doesn't care where
  * in memory the bytes landed. */
 static void rioFileLoadChecksumChunk(rio *r, const void *buf, ssize_t n) {
-    if (r->io.file.checksum_enabled) {
+    if (r->flags & RIO_FLAG_CKSUM_AT_SOURCE) {
         off_t cksum_len = r->io.file.content_end - r->io.file.read_offset;
         if (cksum_len > n) cksum_len = n;
         if (cksum_len > 0) r->cksum = crc64(r->cksum, buf, (size_t)cksum_len);
@@ -262,13 +262,12 @@ static size_t rioFileLoadRead(rio *r, void *dst, size_t len) {
 void rioInitWithFileLoad(rio *r, FILE *fp, off_t filesize, int compute_checksum) {
     rioInitWithFile(r, fp);
     r->read = rioFileLoadRead;
-    r->flags |= RIO_FLAG_CKSUM_AT_SOURCE;
+    if (compute_checksum) r->flags |= RIO_FLAG_CKSUM_AT_SOURCE;
     r->io.file.read_buf = zmalloc(RIO_FILE_LOAD_BUFLEN);
     r->io.file.read_buf_pos = 0;
     r->io.file.read_buf_valid = 0;
     r->io.file.read_offset = 0;
     r->io.file.content_end = filesize > 8 ? filesize - 8 : 0;
-    r->io.file.checksum_enabled = compute_checksum ? 1 : 0;
 }
 
 void rioFreeFileLoad(rio *r) {

--- a/src/rio.c
+++ b/src/rio.c
@@ -190,6 +190,67 @@ void rioInitWithFile(rio *r, FILE *fp) {
     r->io.file.reclaim_cache = 0;
 }
 
+/* Buffered read used by rioInitWithFileLoad(): reads directly from the
+ * underlying fd in RIO_FILE_LOAD_BUFLEN-sized chunks (bypassing stdio) and
+ * checksums each freshly read chunk in one crc64() call, rather than once
+ * per (often just a few bytes) caller request. This lets small RDB fields
+ * still feed the checksum buffers large enough to engage SIMD-accelerated
+ * crc64 implementations.
+ *
+ * The trailing 8-byte RDB checksum footer must never itself be folded into
+ * the running checksum, but a single physical read routinely spans both the
+ * last content bytes and the footer. content_end (filesize - 8) is used to
+ * clip the checksum to the content portion of each chunk. */
+#define RIO_FILE_LOAD_BUFLEN (4*1024)
+
+static size_t rioFileLoadRead(rio *r, void *dst, size_t len) {
+    unsigned char *out = dst;
+    while (len) {
+        if (r->io.file.read_buf_pos == r->io.file.read_buf_valid) {
+            ssize_t n = read(fileno(r->io.file.fp), r->io.file.read_buf, RIO_FILE_LOAD_BUFLEN);
+            if (n <= 0) return 0;
+            if (r->io.file.checksum_enabled) {
+                off_t cksum_len = r->io.file.content_end - r->io.file.read_offset;
+                if (cksum_len > n) cksum_len = n;
+                if (cksum_len > 0) r->cksum = crc64(r->cksum, r->io.file.read_buf, (size_t)cksum_len);
+            }
+            r->io.file.read_offset += n;
+            r->io.file.read_buf_pos = 0;
+            r->io.file.read_buf_valid = (size_t)n;
+        }
+        size_t avail = r->io.file.read_buf_valid - r->io.file.read_buf_pos;
+        size_t take = avail < len ? avail : len;
+        memcpy(out, r->io.file.read_buf + r->io.file.read_buf_pos, take);
+        r->io.file.read_buf_pos += take;
+        out += take;
+        len -= take;
+    }
+    return 1;
+}
+
+/* Create an RIO for sequentially loading an existing file of known size
+ * (an RDB, possibly an AOF's RDB preamble). Checksum computation happens
+ * inside the read() method itself (see rioFileLoadRead), at the granularity
+ * of physical reads rather than the caller's request size; callers that
+ * otherwise checksum every rioRead() unconditionally must check the
+ * RIO_FLAG_CKSUM_AT_SOURCE flag and skip their own checksum step. */
+void rioInitWithFileLoad(rio *r, FILE *fp, off_t filesize, int compute_checksum) {
+    rioInitWithFile(r, fp);
+    r->read = rioFileLoadRead;
+    r->flags |= RIO_FLAG_CKSUM_AT_SOURCE;
+    r->io.file.read_buf = zmalloc(RIO_FILE_LOAD_BUFLEN);
+    r->io.file.read_buf_pos = 0;
+    r->io.file.read_buf_valid = 0;
+    r->io.file.read_offset = 0;
+    r->io.file.content_end = filesize > 8 ? filesize - 8 : 0;
+    r->io.file.checksum_enabled = compute_checksum ? 1 : 0;
+}
+
+void rioFreeFileLoad(rio *r) {
+    zfree(r->io.file.read_buf);
+    r->io.file.read_buf = NULL;
+}
+
 /* ------------------- Connection implementation -------------------
  * We use this RIO implementation when reading an RDB file directly from
  * the connection to the memory via rdbLoadRio(), thus this implementation

--- a/src/rio.c
+++ b/src/rio.c
@@ -244,6 +244,9 @@ static size_t rioFileLoadRead(rio *r, void *dst, size_t len) {
             len -= n;
             continue;
         }
+
+        /* read_buf is empty and the remaining request fits one buffer:
+         * refill read_buf, then serve len on the next iteration. */        
         ssize_t n = read(fileno(r->io.file.fp), r->io.file.read_buf, RIO_FILE_LOAD_BUFLEN);
         if (n <= 0) return 0;
         rioFileLoadChecksumChunk(r, r->io.file.read_buf, n);

--- a/src/rio.c
+++ b/src/rio.c
@@ -203,27 +203,52 @@ void rioInitWithFile(rio *r, FILE *fp) {
  * clip the checksum to the content portion of each chunk. */
 #define RIO_FILE_LOAD_BUFLEN (4*1024)
 
+/* Fold up to 'n' freshly read bytes at 'buf' into the running checksum,
+ * clipped to the content/footer boundary, and advance read_offset. Shared
+ * by both the buffered-refill and direct-to-destination read paths below,
+ * since the clip is based on absolute file offsets and doesn't care where
+ * in memory the bytes landed. */
+static void rioFileLoadChecksumChunk(rio *r, const void *buf, ssize_t n) {
+    if (r->io.file.checksum_enabled) {
+        off_t cksum_len = r->io.file.content_end - r->io.file.read_offset;
+        if (cksum_len > n) cksum_len = n;
+        if (cksum_len > 0) r->cksum = crc64(r->cksum, buf, (size_t)cksum_len);
+    }
+    r->io.file.read_offset += n;
+}
+
 static size_t rioFileLoadRead(rio *r, void *dst, size_t len) {
     unsigned char *out = dst;
     while (len) {
-        if (r->io.file.read_buf_pos == r->io.file.read_buf_valid) {
-            ssize_t n = read(fileno(r->io.file.fp), r->io.file.read_buf, RIO_FILE_LOAD_BUFLEN);
-            if (n <= 0) return 0;
-            if (r->io.file.checksum_enabled) {
-                off_t cksum_len = r->io.file.content_end - r->io.file.read_offset;
-                if (cksum_len > n) cksum_len = n;
-                if (cksum_len > 0) r->cksum = crc64(r->cksum, r->io.file.read_buf, (size_t)cksum_len);
-            }
-            r->io.file.read_offset += n;
-            r->io.file.read_buf_pos = 0;
-            r->io.file.read_buf_valid = (size_t)n;
-        }
         size_t avail = r->io.file.read_buf_valid - r->io.file.read_buf_pos;
-        size_t take = avail < len ? avail : len;
-        memcpy(out, r->io.file.read_buf + r->io.file.read_buf_pos, take);
-        r->io.file.read_buf_pos += take;
-        out += take;
-        len -= take;
+        if (avail) {
+            size_t take = avail < len ? avail : len;
+            memcpy(out, r->io.file.read_buf + r->io.file.read_buf_pos, take);
+            r->io.file.read_buf_pos += take;
+            out += take;
+            len -= take;
+            continue;
+        }
+        /* read_buf is empty. A request at least as large as one buffer's
+         * worth can be read straight into the destination for its
+         * RIO_FILE_LOAD_BUFLEN-aligned bulk, skipping the extra copy
+         * through read_buf entirely - the same optimization glibc's
+         * fread() applies for large reads. Only the unaligned remainder
+         * (always < RIO_FILE_LOAD_BUFLEN) goes through the buffer. */
+        if (len >= RIO_FILE_LOAD_BUFLEN) {
+            size_t direct_len = len - (len % RIO_FILE_LOAD_BUFLEN);
+            ssize_t n = read(fileno(r->io.file.fp), out, direct_len);
+            if (n <= 0) return 0;
+            rioFileLoadChecksumChunk(r, out, n);
+            out += n;
+            len -= n;
+            continue;
+        }
+        ssize_t n = read(fileno(r->io.file.fp), r->io.file.read_buf, RIO_FILE_LOAD_BUFLEN);
+        if (n <= 0) return 0;
+        rioFileLoadChecksumChunk(r, r->io.file.read_buf, n);
+        r->io.file.read_buf_pos = 0;
+        r->io.file.read_buf_valid = (size_t)n;
     }
     return 1;
 }

--- a/src/rio.h
+++ b/src/rio.h
@@ -24,6 +24,13 @@
 #define RIO_FLAG_READ_ERROR (1<<0)
 #define RIO_FLAG_WRITE_ERROR (1<<1)
 #define RIO_FLAG_DUMP_PAYLOAD (1ULL<<2)
+/* Set on rio objects (see rioInitWithFileLoad) whose 'read' method already
+ * updates the checksum itself, over the granularity of its own physical
+ * reads rather than the caller's request size. Callers that otherwise
+ * checksum every rioRead() call (e.g. rdbLoadProgressCallback) must skip
+ * their own checksum step when this flag is set, or bytes get checksummed
+ * twice. */
+#define RIO_FLAG_CKSUM_AT_SOURCE (1<<3)
 
 #define RIO_TYPE_FILE (1<<0)
 #define RIO_TYPE_BUFFER (1<<1)
@@ -67,6 +74,20 @@ struct _rio {
             off_t buffered; /* Bytes written since last fsync. */
             off_t autosync; /* fsync after 'autosync' bytes written. */
             unsigned reclaim_cache:1; /* A flag to indicate reclaim cache after fsync */
+            /* Read-side buffering used only by rioInitWithFileLoad(): batches
+             * checksum computation at the granularity of physical read(2)
+             * calls instead of the caller's (often tiny) per-field request
+             * size, so small fields still feed the checksum large enough
+             * buffers to engage SIMD-accelerated implementations. */
+            unsigned char *read_buf;
+            size_t read_buf_pos, read_buf_valid;
+            off_t read_offset;  /* Absolute file offset of the next physical read. */
+            off_t content_end;  /* File offset where the trailing checksum footer
+                                  * begins; bytes at/after this offset must never
+                                  * be folded into the running checksum, even
+                                  * though a single physical read routinely
+                                  * reads straight through this boundary. */
+            unsigned checksum_enabled:1; /* Whether to compute the checksum at all. */
         } file;
         /* Connection object (used to read from socket) */
         struct {
@@ -165,12 +186,14 @@ static inline void rioClearErrors(rio *r) {
 }
 
 void rioInitWithFile(rio *r, FILE *fp);
+void rioInitWithFileLoad(rio *r, FILE *fp, off_t filesize, int compute_checksum);
 void rioInitWithBuffer(rio *r, sds s);
 void rioInitWithConn(rio *r, connection *conn, size_t read_limit);
 void rioInitWithFd(rio *r, int fd);
 void rioInitWithConnset(rio *r, connection **conns, size_t n_conns);
 
 void rioFreeFd(rio *r);
+void rioFreeFileLoad(rio *r);
 void rioFreeConn(rio *r, sds* out_remainingBufferedData);
 void rioFreeConnset(rio *r);
 

--- a/src/rio.h
+++ b/src/rio.h
@@ -24,12 +24,10 @@
 #define RIO_FLAG_READ_ERROR (1<<0)
 #define RIO_FLAG_WRITE_ERROR (1<<1)
 #define RIO_FLAG_DUMP_PAYLOAD (1ULL<<2)
-/* Set on rio objects (see rioInitWithFileLoad) whose 'read' method already
- * updates the checksum itself, over the granularity of its own physical
- * reads rather than the caller's request size. Callers that otherwise
- * checksum every rioRead() call (e.g. rdbLoadProgressCallback) must skip
- * their own checksum step when this flag is set, or bytes get checksummed
- * twice. */
+/* Set on rio objects whose read() already checksums internally, at
+ * physical-read granularity (see rioInitWithFileLoad). Callers that
+ * normally checksum every rioRead() — e.g. rdbLoadProgressCallback —
+ * must skip that step here, or bytes get checksummed twice. */
 #define RIO_FLAG_CKSUM_AT_SOURCE (1<<3)
 
 #define RIO_TYPE_FILE (1<<0)
@@ -87,7 +85,6 @@ struct _rio {
                                   * be folded into the running checksum, even
                                   * though a single physical read routinely
                                   * reads straight through this boundary. */
-            unsigned checksum_enabled:1; /* Whether to compute the checksum at all. */
         } file;
         /* Connection object (used to read from socket) */
         struct {


### PR DESCRIPTION
## Summary

Three changes that together accelerate RDB checksumming and loading:

1. **PCLMULQDQ crc64** (`crc64.c`/`config.h`/`crc64.h`): ~6x faster carry-less-multiplication `crc64()` for buffers >= 64 bytes, runtime-dispatched, with the existing table implementation as fallback.
2. **Batch checksum computation for RDB file loading** (`rio.c`/`rio.h`/`rdb.c`): `crc64()` was called once per *parsed field*, often just a few bytes, never reaching PCLMUL's 64-byte cutoff. `rioInitWithFileLoad()` reads the fd directly in 4KB chunks (bypassing stdio) and checksums each chunk once, so tiny fields still hit PCLMUL-sized buffers.
3. **Read large fields straight into the destination** (`rio.c`): (2)'s 4KB buffer meant even a 128KB or 20MB value got copied through it in dozens of round trips. When the buffer is empty and the request is >= one buffer's worth, `rioFileLoadRead()` now reads the aligned bulk directly into the destination in one syscall (same trick glibc's `fread()` uses for large reads), checksumming it in place - no extra copy.

(1) alone helped value-heavy RDBs but did nothing for small-key datasets. (2) is what makes it apply broadly. (3) is an independent win on top, and helps even with `rdb-checksum no` since it's pure copy avoidance.

## Design notes

- crc64 dispatch: PCLMUL only for buffers >= 64 bytes on x86-64 with the `pclmul` CPUID flag; everything else keeps using crcspeed unchanged. Fold constants are derived at init, not hardcoded. No Barrett reduction - the final 128-bit remainder is reduced via the table path instead. `crc64_init()` self-checks PCLMUL against the table implementation on 48 cases and disables it on any mismatch, so a broken build loses the speedup, never produces a wrong checksum.
- The RDB's trailing 8-byte checksum footer must never be folded into the running checksum, but a read (buffered or direct) routinely spans both the last content bytes and the footer. `content_end` (`filesize - 8`) clips the checksum to content only - this is the bug I actually hit building this: without the clip, a read straddling the boundary corrupts every load, caught immediately by the RDB's own checksum verification.
- `rdbLoadProgressCallback()` skips its own checksum step via `RIO_FLAG_CKSUM_AT_SOURCE` when the rio's `read()` already accounted for it.
- 4KB buffer size chosen from a sweep (64B-4MB): syscall overhead dominates below ~4-16KB, flat within ~1% from 16KB-1MB, larger buffers give a little back to cache eviction.

**Not touched, deliberately:**
- `redis-check-rdb` - same shape, could use the same fix, left simple since it's not a hot path.
- AOF RDB-preamble loading - unsafe: it hands off to `fgets()`/`ftello()` on the same `FILE*` right after the RDB portion, and `rioInitWithFileLoad()` bypassing stdio would desync that. Needs a different design.
- Diskless replication full sync - prototyped an analogous batching scheme; benchmarks showed it made small-key diskless syncs ~4% *slower* (three fix attempts, no improvement) with no benefit for large values either. Dropped; left as a follow-up.

## Testing

- `crc64Test`: known vectors, PCLMUL-vs-table cross-validation across lengths/alignments/seeds; both crc64 safety nets mutation-tested.
- `DEBUG RELOAD`/`redis-check-rdb` round-trips: tiny-key, value-heavy, empty DB, checksum disabled, and values straddling every 4KB boundary in both directions - all byte-identical.
- `valgrind --tool=memcheck`: clean across small-key, value-heavy, and truncated/corrupt files.
- Full suites passing: `integration/rdb`, `corrupt-dump`, `corrupt-dump-fuzzer`, `aof`, `aof-multi-part`, `convert-ziplist-*-on-load`, `replication`, `replication-psync`.

## Benchmarks (AWS Xeon Platinum 8488C)

Datasets sized to ~5s load time on `unstable` to keep round-to-round noise small. 6 alternating rounds each.

| Dataset | unstable | this branch | delta |
|---|---|---|---|
| Small keys (11M keys, 284MB) | 5.303s | 4.572s | **-13.8%** |
| Big keys (51,000 x 128KB, 6.3GB) | 4.985s | 3.673s | **-26.3%** |
| Huge values (370 x 20MB, 7.3GB) | 5.508s | 4.061s | **-26.3%** |
| Cold page cache (EBS-bound) | - | - | ~0% (I/O-bound) |

crc64 microbenchmark: 4.2 GB/s (best table path) -> 25.9 GB/s (PCLMUL), 6.2x.

**Isolating PCLMUL's contribution** (commit 1 is the one with review-worthy complexity; commits 2+3 are a straightforward buffered-I/O change). Built commits 2+3 cherry-picked directly onto `unstable`, skipping commit 1 entirely, and compared all three variants:

| Dataset | unstable | 2+3 only, no PCLMUL | all three |
|---|---|---|---|
| Small keys (11M keys, 284MB) | 5.124s | 4.382s (**-14.5%**) | 4.336s (**-15.4%**) |
| Big keys (51,000 x 128KB, 6.3GB) | 5.016s | 5.033s (**+0.3%, noise**) | 3.671s (**-26.8%**) |

For small keys, batching alone captures 94% of the total win - PCLMUL's own incremental contribution on top is only ~1%, since once tiny fields are consolidated into 4KB chunks, the existing `crcspeed` dual/tri-stream table path is already fast enough. For large values, PCLMUL is responsible for essentially the entire win - a large value was already read via one big `rioRead()` call that already exceeded `crcspeed`'s own 2048-byte tri-stream cutoff even in `unstable`, so there was no "many tiny calls" problem for batching to fix, and direct-read's copy-avoidance only becomes proportionally significant once PCLMUL has already shrunk the checksum cost. So whether commit 1 is worth its review complexity depends on which workload shape matters more; commits 2+3 alone are a much simpler change that still captures most of the benefit for small-key-dominated workloads.

## Follow-ups

AOF preamble loading, diskless replication (see above), ARM PMULL, VPCLMULQDQ (AVX-512) - all deliberately left out to keep this diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RDB checksum and I/O semantics on the hot load path; incorrect footer clipping or double-checksumming would break every verified load, though init self-tests and extensive cross-validation mitigate SIMD risk.
> 
> **Overview**
> Speeds up RDB load when **checksum verification** is on by combining a **PCLMULQDQ** fast path for `crc64()` with **read-path batching** so checksum work sees large buffers instead of per-field slices.
> 
> On x86-64 with `pclmul`, `crc64()` dispatches to a carry-less-multiply folder for inputs **≥ 64 bytes**, with fold constants computed at init and a **self-test against the existing table path** that disables SIMD on any mismatch. `crc64_pclmul_available()` / `crc64_pclmul_enable()` expose this for tests and benchmarks.
> 
> **`rioInitWithFileLoad()`** replaces plain file RIO for known-size RDB opens: it reads via `read(2)` in **4KB chunks**, checksums each physical read once (clipping at `content_end` so the **8-byte footer** is never folded in), and can **read large aligned spans straight into the caller buffer** to avoid extra copies. **`RIO_FLAG_CKSUM_AT_SOURCE`** tells `rdbLoadProgressCallback()` not to checksum again.
> 
> `rdb.c` wires this in when `fstat` succeeds, with `rioFreeFileLoad()` on teardown and a fallback to the old RIO if size is unknown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12ec69f53c3ee9b265108814bb12c7061b855a9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->