### PR TITLE
Fix invalid slot range merging into a valid one

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1847,9 +1847,8 @@ int slotRangeArrayNormalizeAndValidate(slotRangeArray *slots, sds *err) {
         return C_ERR;
     }
 
-    /* Sort and merge adjacent slot ranges. */
-    slotRangeArraySortAndMerge(slots);
-
+    /* Validate each range before sorting and merging since merge itself relies
+     * on each range already being well-formed. */
     for (int i = 0; i < slots->num_ranges; i++) {
         if (slots->ranges[i].start >= CLUSTER_SLOTS ||
             slots->ranges[i].end >= CLUSTER_SLOTS)
@@ -1873,6 +1872,9 @@ int slotRangeArrayNormalizeAndValidate(slotRangeArray *slots, sds *err) {
             used_slots[j]++;
         }
     }
+
+    /* Sort and merge adjacent slot ranges. */
+    slotRangeArraySortAndMerge(slots);
     return C_OK;
 }
 

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -275,6 +275,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # invalid slot range
         assert_error {*greater than end slot number*} {R 0 CLUSTER MIGRATION IMPORT 200 100}
+        assert_error {*greater than end slot number*} {R 0 CLUSTER MIGRATION IMPORT 100 200 201 150}
         assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT 17000 18000}
         assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT 14000 18000}
         assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT 0 16384}

--- a/tests/unit/cluster/multi-slot-operations.tcl
+++ b/tests/unit/cluster/multi-slot-operations.tcl
@@ -129,6 +129,7 @@ test "SFLUSH - Errors and output validation" {
     assert_error {ERR Invalid or out of range slot}         {$master1 SFLUSH 0 12x}
     assert_error {ERR Slot 3 specified multiple times}      {$master1 SFLUSH 2 4 3 5}
     assert_error {ERR start slot number 8 is greater than*} {$master1 SFLUSH 8 4}
+    assert_error {ERR start slot number 201 is greater than*} {$master1 SFLUSH 100 200 201 150}
     assert_error {ERR wrong number of arguments*}           {$master1 SFLUSH 4 8 10}
     assert_error {ERR wrong number of arguments*}           {$master1 SFLUSH 0 999 2001 8191 ASYNCX}
 


### PR DESCRIPTION
`slotRangeArrayNormalizeAndValidate()` merged adjacent slot ranges before checking that each range had start <= end. For example, `CLUSTER MIGRATION IMPORT 100 200 201 150` merged 100-200 and 201-150 into 100-150, silently accepting the invalid 201-150 range instead of rejecting it. Affects SFLUSH too.

Fix: Validate each range first, then merge. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small reordering of existing validation in cluster slot parsing; behavior change only rejects inputs that were incorrectly accepted before.
> 
> **Overview**
> **Fixes a validation ordering bug** in `slotRangeArrayNormalizeAndValidate()` where adjacent ranges were sorted and merged before each range was checked. An invalid pair like `201-150` could be folded together with `100-200` into `100-150`, so commands that parse multi-range slot arguments would accept bad input instead of returning *start greater than end*.
> 
> The change **runs per-range checks first** (bounds, `start <= end`, no duplicate slots), then calls `slotRangeArraySortAndMerge()`. That path is shared by **`CLUSTER MIGRATION IMPORT`** and **`SFLUSH`** (via `parseSlotRangesOrReply`).
> 
> Tests assert the multi-range failure case for both commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10c88a7d1c2d507b30c2dcd8ecd3bc3de35db13b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->