### PR TITLE
Fix couple of flaky tests

### DIFF
--- a/tests/unit/type/hash-templates.tcl
+++ b/tests/unit/type/hash-templates.tcl
@@ -26,7 +26,7 @@ proc assert_same_hash_content {key1 key2} {
 # dropped on that background thread, so num_template_keys is eventually
 # consistent: it settles once the BIO free job runs.
 proc wait_num_template_keys {expected {level ""}} {
-    wait_for_condition 50 100 {
+    wait_for_condition 200 100 {
         [s {*}$level hash_template_keys] == $expected
     } else {
         fail "hash_template_keys did not settle to $expected\
@@ -39,7 +39,7 @@ proc wait_num_template_keys {expected {level ""}} {
 # thread and reclaimed in serverCron, so the registry size is eventually 
 # consistent like wait_num_template_keys above.
 proc wait_num_templates {expected {level ""}} {
-    wait_for_condition 50 100 {
+    wait_for_condition 200 100 {
         [s {*}$level hash_templates] == $expected
     } else {
         fail "hash_templates did not settle to $expected\
@@ -2458,6 +2458,7 @@ start_server {tags {"hash" "needs:debug" "cluster:skip" "external:skip"}
         # recorded; its single-use template must not survive.
         r hset gone w 1 x 2 y 3 z 4
         r pexpire gone 100
+        after 200
         assert_equal 0 [s hash_templates]
         r config set hash-rdb-load-min-template-entries 4
         r config set hash-rdb-load-template-disassembly-threshold 2


### PR DESCRIPTION
Fix for couple flaky tests due to timing: 

- Test: Stress test for template creation and deletion ([link](https://github.com/redis/redis/actions/runs/33574427420/job/100075164107)) 
  wait_num_template_keys could wait longer as the keys deleted in BIO thread is collected later on main thread. Under valgrind, current 5 second time limit may not be enough. Fix: Expanded to 20 seconds.
   
- Test: converting hash expired on load is dropped without leaking its template ([link](https://github.com/redis/redis/actions/runs/31980957673/job/95247508492)):
  Server restarts too fast (test expects it happen after 100 ms+). Fix: wait for key to expire before restart. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing adjustments; no production code paths are modified.
> 
> **Overview**
> Addresses **timing-related flakes** in `tests/unit/type/hash-templates.tcl` only; no server behavior changes.
> 
> **Longer polls for eventually consistent template stats:** `wait_num_template_keys` and `wait_num_templates` now pass **200** tries (was **50**) to `wait_for_condition` with the same **100 ms** step, extending the wait from ~5s to ~20s so `hash_template_keys` / `hash_templates` can settle after BIO lazyfree and main-thread cleanup—especially under Valgrind.
> 
> **RDB load + expired key:** In *converting hash expired on load is dropped without leaking its template*, adds **`after 200`** after `pexpire gone 100` so the key is actually expired (and templates cleared) before `save` / `restart_server`, instead of restarting while `gone` might still exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08bce7e401862c43320a214ed3e733e2814192c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->