### PR TITLE
Align lzf_compress to a cache line to stabilize BGSAVE performance on x86-64

### DIFF
--- a/src/lzf_c.c
+++ b/src/lzf_c.c
@@ -35,6 +35,7 @@
  */
 
 #include "lzfP.h"
+#include "config.h"
 
 #define HSIZE (1 << (HLOG))
 
@@ -112,6 +113,12 @@
  */
 NO_SANITIZE("alignment")
 NO_SANITIZE_MSAN("memory")
+/* Benchmarks show that the inner compression loop is sensitive to code
+ * alignment on x86-64, affecting RDB save duration by about 30%.
+ * Align the function to keep its cache-line placement stable. */
+#if defined(__x86_64__)
+__attribute__((aligned(CACHE_LINE_SIZE)))
+#endif
 size_t
 lzf_compress (const void *const in_data, size_t in_len,
 	      void *out_data, size_t out_len


### PR DESCRIPTION
A pipelined write benchmark with constant BGSAVE had a regression that kept coming and going across unrelated commits: about 20% less write throughput and about 33% longer BGSAVE. When we tested the commits one by one, the one that seemed responsible only changed code that never runs in this test, so it could not be the real cause.

The real reason is code alignment, not logic. lzf_compress is the hot function during BGSAVE and its small inner loop needs to fit in one instruction cache line. Its address only happened to be cache-line aligned by luck, so any unrelated change that moved the surrounding code pushed it to an unaligned address, the inner loop crossed a cache line and the CPU stalled more on x86-64. Only the placement changed, not the code.

Force cache-line alignment on lzf_compress so its placement no longer depends on surrounding code. ARM is not affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No behavioral or format changes—only linker placement of one function on x86-64; ARM and other arches are unaffected.
> 
> **Overview**
> **Stabilizes BGSAVE/RDB compression performance** on x86-64 by pinning `lzf_compress` to a cache line so unrelated code layout changes no longer shift the hot inner loop across instruction-cache boundaries (which had caused large, intermittent BGSAVE slowdowns).
> 
> The change pulls in `config.h` for `CACHE_LINE_SIZE` and applies `__attribute__((aligned(CACHE_LINE_SIZE)))` to `lzf_compress` only when `__x86_64__` is defined; compression logic is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe038e0e8150c5a39623fef7fec42296a5350b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->