### PR TITLE
Update redisbloom module reference to v8.11.80

### DIFF
--- a/modules/modules.yaml
+++ b/modules/modules.yaml
@@ -64,7 +64,7 @@
 modules:
   - name: redisbloom
     repo: https://github.com/redisbloom/redisbloom
-    ref: v8.10.1
+    ref: v8.11.80
     target_module: redisbloom.so
     loadmodule: ./modules/redisbloom/redisbloom.so
   - name: redisearch


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single dependency pin in the module manifest; behavior changes only with whatever RedisBloom v8.11.80 introduces upstream.
> 
> **Overview**
> Pins the bundled **redisbloom** upstream from **v8.10.1** to **v8.11.80** in `modules/modules.yaml`.
> 
> That manifest drives `make modules-update`, Docker bundled-module installs, and release tarballs, so builds and releases will pull and compile the newer RedisBloom tag instead of the previous one. No other modules or build flags change in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf05247135c958c1d88e99e80185fc493b4726c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->