### PR TITLE
Add run_id to HELLO response

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -5098,10 +5098,13 @@ void helloCommand(client *c) {
 
     /* Let's switch to the specified RESP mode. */
     if (ver) c->resp = ver;
-    addReplyMapLen(c,6 + !server.sentinel_mode);
+    addReplyMapLen(c,7 + !server.sentinel_mode);
 
     ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"server");
     ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"redis");
+
+    ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"run_id");
+    ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,server.runid);
 
     ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"version");
     ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,REDIS_VERSION);


### PR DESCRIPTION
## Description

Adds the server's run_id to the HELLO response.

This allows clients to identify the Redis server instance they are
connected to without making an additional INFO request.

## Changes

- Add run_id to the HELLO response map.
- Update the HELLO response map length accordingly.

## Testing

- [describe the tests you actually ran]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive HELLO field only; existing clients that ignore unknown map keys are unaffected.
> 
> **Overview**
> **HELLO** now includes **`run_id`** (`server.runid`) in its reply map so clients can tell which Redis instance they are on without a separate **INFO** call.
> 
> The map entry count is bumped from 6 to 7 (non-sentinel) to match the new field, placed after **`server`** and before **`version`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a20c1d65e53528c1df0fde34b4a80c605de469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->