### PR TITLE
Fix cluster bus extension length validation truncation leading to OOB read

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2855,13 +2855,19 @@ int clusterProcessPacket(clusterLink *link) {
         if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
             clusterMsgPingExt *ext = getInitialPingExt(hdr, count);
             while (extensions--) {
-                uint16_t extlen = getPingExtLength(ext);
+                /* ext->length is a 32-bit wire field. Keep it in a 32-bit
+                 * variable: a truncated 16-bit value would pass the checks
+                 * below while getNextPingExt() advances the cursor by the
+                 * full 32-bit length. */
+                uint32_t extlen = getPingExtLength(ext);
                 if (extlen < sizeof(clusterMsgPingExt) || extlen % 8 != 0) {
-                    serverLog(LL_WARNING, "Received a %s packet without proper padding (%d bytes)",
-                        clusterGetMessageTypeString(type), (int) extlen);
+                    serverLog(LL_WARNING, "Received a %s packet without proper padding (%u bytes)",
+                        clusterGetMessageTypeString(type), extlen);
                     return 1;
                 }
-                if ((totlen - explen) < extlen) {
+                /* explen may legitimately exceed totlen here when the gossip
+                 * count is inflated; guard the unsigned subtraction. */
+                if (totlen < explen || (totlen - explen) < extlen) {
                     serverLog(LL_WARNING, "Received invalid %s packet with extension data that exceeds "
                         "total packet length (%lld)", clusterGetMessageTypeString(type),
                         (unsigned long long) totlen);

--- a/tests/unit/cluster/packet-validation.tcl
+++ b/tests/unit/cluster/packet-validation.tcl
@@ -87,4 +87,56 @@ test "MODULE with len overflow is rejected" {
     assert_equal [R 0 PING] {PONG}
 }
 
+test "PING extension with 32-bit length that truncates to a valid uint16 is rejected" {
+    set CLUSTERMSG_TYPE_PING 0
+    set CLUSTERMSG_MIN_LEN 2256
+    set CLUSTERMSG_FLAG0_EXT_DATA 4 ;# (1<<2)
+
+    set target_host [srv 0 host]
+    set target_bus_port [expr {[srv 0 port] + 10000}]
+    set node_id [R 1 CLUSTER MYID]
+    set sender_port [srv -1 port]
+    set sender_cport [expr {$sender_port + 10000}]
+
+    # sizeof(clusterMsgPingExt) = 8. The 32-bit wire field ext->length is
+    # declared as 0x40000008 (1 GiB + 8). Without the fix, the validation
+    # stores it in a uint16_t, truncating it to 0x0008, which passes the
+    # ">= 8 and 8-byte aligned" checks, while getNextPingExt() advances the
+    # parser cursor by the full 32-bit value. An unknown extension type
+    # (0x9999) skips every payload validation branch, so the next loop
+    # iteration dereferences an address ~1 GiB past the receive buffer.
+    set ext_len 0x40000008
+    set totlen [expr {$CLUSTERMSG_MIN_LEN + 8 + 8}] ;# ext header + 8 bytes padding
+
+    set packet [build_cluster_bus_header $node_id $sender_port $sender_cport \
+        $CLUSTERMSG_TYPE_PING $totlen 2 0 $CLUSTERMSG_FLAG0_EXT_DATA]
+    append packet [binary format I $ext_len]   ;# length (32-bit, big endian)
+    append packet [binary format S 0x9999]     ;# unknown extension type
+    append packet [binary format S 0]          ;# unused
+    append packet [string repeat \x00 8]       ;# padding keeps the length
+                                               ;# accounting consistent
+
+    if {$::tls} {
+        set fd [::tls::socket \
+            -cafile "$::tlsdir/ca.crt" \
+            -certfile "$::tlsdir/client.crt" \
+            -keyfile "$::tlsdir/client.key" \
+            $target_host $target_bus_port]
+    } else {
+        set fd [socket $target_host $target_bus_port]
+    }
+    fconfigure $fd -translation binary -buffering full
+    puts -nonewline $fd $packet
+    flush $fd
+
+    # The fix keeps ext->length in a 32-bit variable and rejects the packet
+    # because the declared extension length exceeds the remaining bytes.
+    wait_for_log_messages 0 {"*extension data that exceeds total packet length*"} 0 20 500
+    close $fd
+
+    # Verify the server did not dereference the wild cursor and is still
+    # responsive after the malformed packet.
+    assert_equal [R 0 PING] {PONG}
+}
+
 }


### PR DESCRIPTION
## Summary

`clusterMsgPingExt.length` is a 32-bit wire field, but the extension validation loop in `clusterProcessPacket()` stored it in a `uint16_t` before checking it. `getNextPingExt()` then advances the cursor by the full 32-bit value. A PING/PONG/MEET packet carrying an unknown extension type with length `0x40000008` passes every check: the truncated value `8` satisfies the minimum size and 8-byte alignment checks, and the `(totlen - explen) >= extlen` test sees `8` as well. The cursor jumps ~1 GiB past the link receive buffer, and the next loop iteration dereferences that wild address, crashing the server (SIGSEGV).

Unknown extension types skip all payload validation branches, and the cluster bus port is unauthenticated, so a single ~2 KB packet is enough to crash a node from the network with no prior handshake.

While working on this I also noticed the `(totlen - explen)` subtraction wraps around when the gossip `count` is inflated beyond the packet length (making `totlen < explen`), so the fix rejects that case too.

## Changes

- Keep `ext->length` in a `uint32_t` so validation sees the full wire value.
- Reject packets where `totlen < explen` before the unsigned subtraction.
- Add a regression test to `tests/unit/cluster/packet-validation.tcl` that sends the crafted packet and asserts the server rejects it and stays responsive.

## Testing

- `./runtest --single unit/cluster/packet-validation`: 3/3 pass with the fix. Without the fix, the new test fails: the server crashes while parsing, so the rejection log line never appears.
- Reproduced the original crash with a standalone script against a cluster node: SIGSEGV in `clusterProcessPacket`, fault address exactly `rcvbuf + 0x40000008` as declared in the packet. With the fix the packet is rejected and the node keeps serving.
- Verified a 2-node cluster with announced hostnames still exchanges extension data correctly (hostname propagation and gossip work as before).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Patches cluster bus packet parsing against network-triggerable memory corruption; behavior change is limited to rejecting malformed packets that previously could crash the node.
> 
> **Overview**
> Fixes a **remote crash** on the unauthenticated cluster bus when a PING/PONG/MEET packet carries a ping extension whose 32-bit `length` truncates to a small valid value (e.g. `0x40000008` → 8) but `getNextPingExt()` still advances by the full wire length, leading to an out-of-bounds read on the next extension iteration (especially with unknown extension types that skip payload checks).
> 
> In `clusterProcessPacket()`, extension validation now keeps `getPingExtLength()` in a **`uint32_t`**, rejects extensions whose declared length exceeds remaining packet bytes using that full value, and **guards `totlen < explen`** before `(totlen - explen)` so inflated gossip counts cannot wrap the unsigned subtraction.
> 
> Adds a regression test in `packet-validation.tcl` that crafts the malicious extension, expects the “extension data exceeds total packet length” warning, and confirms the node still responds to `PING`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ea22cb6ff37695329584d25e892093031c1abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->