### PR TITLE
MOD-18280 - make install default build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ bootstrap:
 	+@scripts/bootstrap.sh $(BOOTSTRAP_ARGS)
 
 # deploy [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]
-#        [PROG_SUFFIX=<suffix>]
+#        [PROG_SUFFIX=<suffix>] [SKIP_BUILD=1]
 #   Install Redis core + selected modules (default: every cloned module),
 #   then rewrite the `loadmodule` paths in redis-full.conf (and redis.conf, if
 #   it carries a Modules block) to point at the installed .so paths under
@@ -128,7 +128,7 @@ bootstrap:
 deploy: PREFIX ?= /usr/local
 deploy:
 	+@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' PROG_SUFFIX='$(PROG_SUFFIX)' \
-	    scripts/deploy.sh $(DEPLOY_ARGS)
+	    SKIP_BUILD='$(SKIP_BUILD)' scripts/deploy.sh $(DEPLOY_ARGS)
 
 # uninstall [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]
 #           [PROG_SUFFIX=<suffix>]

--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,11 @@ endif
 .DEFAULT:
 	for dir in $(SUBDIRS); do $(MAKE) -C $$dir $@; done
 
-# `install` is an alias for `deploy` that does NOT build: it copies the
-# artifacts already in the tree, like upstream's install. Rebuild with
-# `make install SKIP_BUILD=0`, or just use `make deploy`.
-install: SKIP_BUILD ?= 1
+# `install` is an alias for `deploy` — same args, same PREFIX/DESTDIR. Like
+# upstream's install it builds first; nothing already up to date is recompiled,
+# because Redis core and each module short-circuit on their own artifacts. See
+# the `sudo make install` note in README.md: redisearch and redisjson ask cargo
+# whether they are up to date, so it has to be on root's PATH.
 install: deploy
 
 # clean [<name> ...|all|.|redis|none] — Redis core + selected modules.
@@ -127,7 +128,6 @@ bootstrap:
 deploy: PREFIX ?= /usr/local
 deploy:
 	+@PREFIX='$(PREFIX)' DESTDIR='$(DESTDIR)' PROG_SUFFIX='$(PROG_SUFFIX)' \
-	    SKIP_BUILD='$(SKIP_BUILD)' \
 	    scripts/deploy.sh $(DEPLOY_ARGS)
 
 # uninstall [<name> ...|all|.|redis|none] [PREFIX=<path>] [DESTDIR=<path>]

--- a/README.md
+++ b/README.md
@@ -314,6 +314,38 @@ make -j "$(nproc)"
 > with no config file, or `make build redis && ./src/redis-server redis.conf`
 > from a git checkout, where `redis.conf` has no module block at all.
 
+#### 4. Install
+
+```sh
+make install PREFIX=/usr/local          # core binaries + every built module
+sudo make install                       # same, into the default /usr/local
+make uninstall PREFIX=/usr/local        # removes exactly what install placed
+```
+
+`install` is an alias for `deploy`: it builds first (nothing already up to date
+is recompiled), copies `redis-server`, `redis-cli` and `redis-benchmark` plus
+the three `redis-server` symlinks to `$PREFIX/bin`, each module's `.so` to
+`$PREFIX/lib/redis/modules`, and rewrites the `loadmodule` paths in the
+generated config to point there. `DESTDIR=<path>` stages the files for
+packaging without changing the paths written to the config, and
+`PROG_SUFFIX=<suffix>` installs suffixed program names (`redis-server-alt`, …).
+
+> **`sudo make install` needs the Rust toolchain on root's `PATH`.** Because
+> install builds first, it asks each module whether it is up to date — and the
+> Query Engine (`redisearch`) and JSON (`redisjson`) answer that question by
+> invoking `cargo`. A default `rustup` installation lives in your home
+> directory, which `sudo` drops from `PATH`, so those two fail with
+> `cargo: command not found` even when there is nothing to compile. Either
+> build as your user first and keep the toolchain reachable:
+>
+> ```sh
+> make -j "$(nproc)"
+> sudo -E env "PATH=$PATH" make install
+> ```
+>
+> or install Rust system-wide so root can see it. Redis core, `redisbloom` and
+> `redistimeseries` are unaffected — they decide freshness with make alone.
+
 ### Building Redis - flags and general notes
 
 Redis can be compiled and used on Linux, OSX, OpenBSD, NetBSD, FreeBSD.

--- a/README.md
+++ b/README.md
@@ -330,21 +330,8 @@ generated config to point there. `DESTDIR=<path>` stages the files for
 packaging without changing the paths written to the config, and
 `PROG_SUFFIX=<suffix>` installs suffixed program names (`redis-server-alt`, …).
 
-> **`sudo make install` needs the Rust toolchain on root's `PATH`.** Because
-> install builds first, it asks each module whether it is up to date — and the
-> Query Engine (`redisearch`) and JSON (`redisjson`) answer that question by
-> invoking `cargo`. A default `rustup` installation lives in your home
-> directory, which `sudo` drops from `PATH`, so those two fail with
-> `cargo: command not found` even when there is nothing to compile. Either
-> build as your user first and keep the toolchain reachable:
->
-> ```sh
-> make -j "$(nproc)"
-> sudo -E env "PATH=$PATH" make install
-> ```
->
-> or install Rust system-wide so root can see it. Redis core, `redisbloom` and
-> `redistimeseries` are unaffected — they decide freshness with make alone.
+> To install without building at all, use `SKIP_BUILD=1`:
+> `sudo make install SKIP_BUILD=1`
 
 ### Building Redis - flags and general notes
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,8 +7,6 @@
 #                     $PREFIX/lib/redis/modules/    - per-module .so files
 #         DESTDIR   optional staging root prepended to PREFIX (for packaging).
 #                   Where files are copied; never part of the conf's paths.
-#         SKIP_BUILD  1 = install what is already built, skip phase 1 entirely
-#                   (the default for `make install`; `make deploy` builds).
 #         PROG_SUFFIX  suffix appended to the core program names, matching
 #                   `make PROG_SUFFIX=…` (src/Makefile). Modules are unaffected.
 #         MAKE      make binary (defaults to `make`); only used when shelling
@@ -46,10 +44,8 @@ modules="$(resolve_modules "$*" "$cloned" "redis none")"
 # Phase 1: build via the shared orchestrator. Pass the resolved module list
 # verbatim so build.sh sees the same selection we intend to install.
 # ---------------------------------------------------------------------------
-if [ "${SKIP_BUILD:-0}" = 0 ]; then
-  echo "==> Building before deploy (delegating to scripts/build.sh)"
-  echo
-fi
+echo "==> Building before deploy (delegating to scripts/build.sh)"
+echo
 # Build artifacts always go to the dev tree — PREFIX is irrelevant to the
 # build phase. Two scrubs needed before handing off to build.sh:
 #   1. PREFIX env shadow — so anything reading $PREFIX in build.sh / scripts
@@ -71,9 +67,7 @@ build_makeflags="$(printf '%s' " ${MAKEFLAGS:-} " | sed -E 's/ PREFIX=[^ ]*/ /g;
 # phase 2 below filters out modules that genuinely don't have a .so to copy,
 # so we'd rather install what's available than bail out wholesale.
 build_rc=0
-if [ "${SKIP_BUILD:-0}" != 0 ]; then
-  echo "==> SKIP_BUILD=$SKIP_BUILD — installing the artifacts already in the tree"
-elif [ -z "$modules" ]; then
+if [ -z "$modules" ]; then
   MAKEFLAGS="$build_makeflags" PREFIX="" "$SCRIPT_DIR/build.sh" redis || build_rc=$?
 else
   MAKEFLAGS="$build_makeflags" PREFIX="" "$SCRIPT_DIR/build.sh" $modules || build_rc=$?
@@ -174,6 +168,10 @@ if [ -n "$installed_modules" ]; then
     grep -qF "$LOADMODULE_BEGIN" "$conf" 2>/dev/null || return 0
     local tmp
     tmp="$(mktemp "${conf}.deploy.XXXXXX")"
+    # Clone the conf's mode (and owner, when root) onto the temp file: mktemp
+    # creates it 0600, and the mv below would carry that — plus root ownership
+    # under `sudo` — onto a conf the user still has to write.
+    cp -p "$conf" "$tmp"
     trap 'rm -f "$tmp" "$new_lines_file"' EXIT
     awk -v begin="$LOADMODULE_BEGIN" -v end="$LOADMODULE_END" -v newfile="$new_lines_file" '
       $0 == begin {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,6 +9,13 @@
 #                   Where files are copied; never part of the conf's paths.
 #         PROG_SUFFIX  suffix appended to the core program names, matching
 #                   `make PROG_SUFFIX=…` (src/Makefile). Modules are unaffected.
+#         SKIP_BUILD  1 = do not build, install the artifacts already in the
+#                   tree. Not a default: `make install` and `make deploy` both
+#                   build, and each module's build short-circuits on an
+#                   up-to-date artifact anyway. Meant for
+#                   `sudo make install SKIP_BUILD=1`, where compiling as root
+#                   would leave root-owned files in ~/.cargo and
+#                   modules/*/src/bin.
 #         MAKE      make binary (defaults to `make`); only used when shelling
 #                   into build.sh, which itself respects it.
 #
@@ -44,8 +51,10 @@ modules="$(resolve_modules "$*" "$cloned" "redis none")"
 # Phase 1: build via the shared orchestrator. Pass the resolved module list
 # verbatim so build.sh sees the same selection we intend to install.
 # ---------------------------------------------------------------------------
-echo "==> Building before deploy (delegating to scripts/build.sh)"
-echo
+if [ "${SKIP_BUILD:-0}" = 0 ]; then
+  echo "==> Building before deploy (delegating to scripts/build.sh)"
+  echo
+fi
 # Build artifacts always go to the dev tree — PREFIX is irrelevant to the
 # build phase. Two scrubs needed before handing off to build.sh:
 #   1. PREFIX env shadow — so anything reading $PREFIX in build.sh / scripts
@@ -67,7 +76,9 @@ build_makeflags="$(printf '%s' " ${MAKEFLAGS:-} " | sed -E 's/ PREFIX=[^ ]*/ /g;
 # phase 2 below filters out modules that genuinely don't have a .so to copy,
 # so we'd rather install what's available than bail out wholesale.
 build_rc=0
-if [ -z "$modules" ]; then
+if [ "${SKIP_BUILD:-0}" != 0 ]; then
+  echo "==> SKIP_BUILD=$SKIP_BUILD — installing the artifacts already in the tree"
+elif [ -z "$modules" ]; then
   MAKEFLAGS="$build_makeflags" PREFIX="" "$SCRIPT_DIR/build.sh" redis || build_rc=$?
 else
   MAKEFLAGS="$build_makeflags" PREFIX="" "$SCRIPT_DIR/build.sh" $modules || build_rc=$?


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior change is limited to install defaults and safer config file permissions during deploy; no auth or runtime data-path changes.
> 
> **Overview**
> **`make install` now runs a build before copying artifacts**, matching upstream Redis behavior and aligning it with `make deploy`. The Makefile no longer sets `install: SKIP_BUILD ?= 1`; install and deploy both invoke `scripts/build.sh` unless you pass **`SKIP_BUILD=1`** (documented for cases like `sudo make install` where compiling as root would pollute `~/.cargo` and module build dirs).
> 
> The README adds an **Install** subsection with `PREFIX`/`DESTDIR`/`uninstall` examples and the opt-out build flag.
> 
> **`scripts/deploy.sh`** updates header comments for the new defaults and fixes config rewriting under `sudo`: before patching `loadmodule` blocks, the temp file is seeded with **`cp -p`** on the existing conf so **`mv` does not leave `redis.conf` / `redis-full.conf` at mode 0600 or root-owned** when the user still needs to edit them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 782c3bcd7925c031fa3e6656102d965e4421d020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->