### PR TITLE
Fix same-key LMOVEM OBO moves on the same side

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1552,11 +1552,38 @@ static void lmovemMoveAndReply(client *c, robj *srckey, kvobj *srcobj,
 {
     int samekey = (dstobj == srcobj);
 
-    /* Pop the 'count' elements out of the source, preserving pop order. */
-    robj **vals = zmalloc(sizeof(robj*) * count);
     size_t src_oldsize = 0;
     if (server.memory_tracking_enabled)
         src_oldsize = kvobjAllocSize(srcobj);
+
+    /* OBO moves each element independently. When the source and destination
+     * are the same list and the ends match, each move is a no-op rotation, so
+     * pop and push one element at a time instead of batching the block. */
+    if (samekey && ordering == LMOVEM_ORDER_OBO && wherefrom == whereto && count > 1) {
+        addReplyArrayLen(c, count);
+        for (long i = 0; i < count; i++) {
+            robj *value = listTypePop(srcobj, wherefrom);
+            serverAssert(value != NULL);
+            addReplyBulk(c, value);
+            listTypeTryConversionAppend(srcobj, &value, 0, 0, NULL, NULL);
+            listTypePush(srcobj, value, whereto);
+            decrRefCount(value);
+        }
+
+        notifyKeyspaceEvent(NOTIFY_LIST, whereto == LIST_HEAD ? "lpush" : "rpush",
+                            srckey, c->db->id);
+        notifyKeyspaceEvent(NOTIFY_LIST, wherefrom == LIST_HEAD ? "lpop" : "rpop",
+                            srckey, c->db->id);
+        keyModified(c, c->db, srckey, srcobj, 1);
+        if (server.memory_tracking_enabled)
+            updateSlotAllocSize(c->db, getKeySlot(srckey->ptr), srcobj,
+                                src_oldsize, kvobjAllocSize(srcobj));
+        server.dirty += count;
+        return;
+    }
+
+    /* Pop the 'count' elements out of the source, preserving pop order. */
+    robj **vals = zmalloc(sizeof(robj*) * count);
     for (long i = 0; i < count; i++) {
         vals[i] = listTypePop(srcobj, wherefrom);
         serverAssert(vals[i] != NULL);

--- a/tests/unit/type/list-4.tcl
+++ b/tests/unit/type/list-4.tcl
@@ -96,6 +96,35 @@ foreach {type large} [array get largevalue] {
         assert_equal {1 2} [r lmovem k{t} k{t} left right count 2 bulk]
         assert_equal "3 4 $large 1 2" [r lrange k{t} 0 -1]
     }
+
+    test "LMOVEM same-key OBO same-side moves one-by-one - $type" {
+        r del k{t}
+        create_$type k{t} "1 2 3 4 $large"
+        assert_equal {1 1} [r lmovem k{t} k{t} left left count 2 obo]
+        assert_equal "1 2 3 4 $large" [r lrange k{t} 0 -1]
+
+        r del k{t}
+        create_$type k{t} "1 2 3 4 $large"
+        assert_equal [list $large $large] [r lmovem k{t} k{t} right right count 2 obo]
+        assert_equal "1 2 3 4 $large" [r lrange k{t} 0 -1]
+
+        r del k{t}
+        create_$type k{t} "1 2 3 4 $large"
+        assert_equal {1 1} [r lmovem k{t} k{t} left left exactly 2 obo]
+        assert_equal "1 2 3 4 $large" [r lrange k{t} 0 -1]
+    }
+
+    test "BLMOVEM same-key OBO same-side moves one-by-one - $type" {
+        r del k{t}
+        create_$type k{t} "1 2 3 4 $large"
+        assert_equal {1 1} [r blmovem k{t} k{t} left left 0 count 2 obo]
+        assert_equal "1 2 3 4 $large" [r lrange k{t} 0 -1]
+
+        r del k{t}
+        create_$type k{t} "1 2 3 4 $large"
+        assert_equal [list $large $large] [r blmovem k{t} k{t} right right 0 count 2 obo]
+        assert_equal "1 2 3 4 $large" [r lrange k{t} 0 -1]
+    }
 }
 
     test {LMOVEM notifications match LMOVE push-before-pop order} {


### PR DESCRIPTION


Fix `LMOVEM` and `BLMOVEM` when the source and destination are the same key, `OBO` ordering is selected, and the pop and push sides are the same.



`OBO` is defined as moving elements one by one.

For example:

    RPUSH k 1 2 3 4
    LMOVEM k k LEFT LEFT COUNT 2 OBO

Each individual move should behave as:

    POP LEFT -> 1
    PUSH LEFT 1

The list is unchanged. Repeating the operation should return `1`, `1` and leave the list as `1 2 3 4`.

The current implementation first pops the entire block, stores the values, reorders them, and pushes them back in one batch. As a result, the command returns `2`, `1` and changes the list to `2 1 3 4`.

The same issue occurs for `RIGHT RIGHT`.



For same-key `OBO` moves where the source and destination sides match, move each element independently:

1. Pop one element.
2. Add it to the reply.
3. Push it back to the same side.
4. Repeat for the requested count.

The existing bulk path and all cross-key paths are unchanged.

`BLMOVEM` uses the same move helper once it can execute, so it receives the same fix.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow behavioral fix for a specific LMOVEM/BLMOVEM edge case; other move paths are untouched.
> 
> **Overview**
> Fixes **`LMOVEM`** and **`BLMOVEM`** when source and destination are the same key, ordering is **`OBO`**, and pop/push use the same end (e.g. `LEFT LEFT` or `RIGHT RIGHT`).
> 
> Previously **`lmovemMoveAndReply`** popped the full block, reordered, and pushed in one batch. For this case each logical OBO step should be pop-then-push on the same side (a no-op on list order), so batching wrongly rotated the list and returned values like `{2 1}` instead of `{1 1}`.
> 
> The change adds an early path in **`lmovemMoveAndReply`**: for `samekey && OBO && wherefrom == whereto && count > 1`, it loops **one element at a time** (pop, reply, push), then applies the usual notifications, **`keyModified`**, memory tracking, and **`server.dirty`**. Bulk ordering and cross-key moves are unchanged; **`BLMOVEM`** picks this up via the same helper.
> 
> Unit tests cover **`LMOVEM`** / **`BLMOVEM`** same-key OBO same-side for **`COUNT`** and **`EXACTLY`**, on both listpack and quicklist encodings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739d7b9e02f819d5581d1112c3fc0854a5484df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->