### PR TITLE
Fix overflowing relative TTL in RESTORE

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -284,7 +284,10 @@ void restoreCommand(client *c) {
 
     /* Compute TTL early so we can add it to metadata spec in correct order */
     if (ttl) {
-        if (!absttl) ttl+=commandTimeSnapshot();
+        if (!absttl && add_overflow_ll(ttl, commandTimeSnapshot(), &ttl)) {
+            addReplyErrorExpireTime(c);
+            return;
+        }
         keyMetaSpecAdd(&keymeta, KEY_META_ID_EXPIRE, ttl);
     }
 

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -52,6 +52,24 @@ start_server {tags {"dump"}} {
         set e
     } {ERR no such key} {needs:debug}
 
+    test {RESTORE with a TTL that overflows when added to the current time} {
+        r set foo bar
+        set encoded [r dump foo]
+        set expiredkeys [s expired_keys]
+        assert_error "ERR invalid expire time in 'restore' command" {
+            r restore foo 9223372036854775807 $encoded replace
+        }
+        # The existing key is untouched and nothing was counted as expired.
+        assert_equal bar [r get foo]
+        assert_equal -1 [r pttl foo]
+        assert_equal $expiredkeys [s expired_keys]
+
+        # The same value is a valid absolute timestamp with ABSTTL.
+        r restore foo 9223372036854775807 $encoded absttl replace
+        assert_morethan [r pttl foo] 0
+        r del foo
+    }
+
     test {RESTORE can set LRU} {
         r set foo bar
         set encoded [r dump foo]


### PR DESCRIPTION
## Issue

`RESTORE` adds a relative `ttl` to the current command time without checking for signed integer overflow:

```text
SET k v
RESTORE k 9223372036854775807 <dump> REPLACE   -> OK
EXISTS k                                        -> 0
expired_keys                                    -> +1
```

The overflowed timestamp is negative, so `checkAlreadyExpired()` treats the key as already expired: the command replies `OK`, the key is silently dropped (and the existing key is deleted when `REPLACE` is given), and `expired_keys` is incremented.

This is the same class of bug fixed for `SET EX/PX` in #15626; `EXPIRE` already guards against it in `expireGenericCommand()`.

## Change

Use `add_overflow_ll()` when converting the relative TTL to an absolute timestamp and reply with the existing `invalid expire time` error before touching the key. `ABSTTL` values are unaffected.

## Test

Added a case to `tests/unit/dump.tcl` covering the error reply, the untouched key and `expired_keys` counter, and the same value working with `ABSTTL`. `./runtest --single unit/dump` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RESTORE expiry validation on a cluster/migration code path; behavior fix is narrow but affects TTL edge cases and REPLACE semantics when overflow would previously delete keys.
> 
> **Overview**
> Fixes **RESTORE** so a relative TTL that would overflow when added to the current time no longer silently treats the key as already expired.
> 
> When converting relative TTL to an absolute expire time, the command now uses **`add_overflow_ll()`** (same approach as **SET EX/PX**) and returns **`ERR invalid expire time in 'restore' command`** before loading or replacing the key. **`ABSTTL`** is unchanged—the large value is interpreted as an absolute timestamp.
> 
> Adds a **`dump.tcl`** test for the error path (existing key and **`expired_keys`** unchanged) and confirms the same numeric TTL works with **`ABSTTL`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3a15226f1f7c0a2cfebe87733ac3531c53bba11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->