### PR TITLE
Fix spurious error log on graceful TLS client shutdown

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -568,6 +568,15 @@ static int handleSSLReturnCode(tls_connection *conn, int ret_value, WantIOType *
                 if (conn->ssl_error) zfree(conn->ssl_error);
                 conn->ssl_error = errno ? zstrdup(strerror(errno)) : NULL;
                 break;
+            case SSL_ERROR_ZERO_RETURN:
+                /* The peer sent a close_notify alert: a graceful TLS shutdown,
+                 * the equivalent of a zero-length read on a plain socket. This
+                 * is not an error and the OpenSSL error queue is empty here, so
+                 * it must not be formatted (that yields the meaningless
+                 * "error:00000000:lib(0)::reason(0)"). Leave ssl_error untouched
+                 * and let the caller report a clean EOF. */
+                conn->c.last_errno = 0;
+                break;
             default:
                 /* Error! */
                 updateTLSError(conn);
@@ -1160,7 +1169,13 @@ static int connTLSRead(connection *conn_, void *buf, size_t buf_len) {
     if (conn->c.state != CONN_STATE_CONNECTED) return -1;
     ERR_clear_error();
     ret = SSL_read(conn->ssl, buf, buf_len);
-    return updateStateAfterSSLIO(conn, ret, 1);
+    ret = updateStateAfterSSLIO(conn, ret, 1);
+    /* A graceful TLS shutdown (peer close_notify) leaves the connection in the
+     * CLOSED state and returns -1. Report it as a zero-length read so callers
+     * treat it as a clean EOF -- matching a plain socket read() returning 0 --
+     * rather than as an error disconnect. */
+    if (ret == -1 && conn->c.state == CONN_STATE_CLOSED) return 0;
+    return ret;
 }
 
 static const char *connTLSGetLastError(connection *conn_) {

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -89,6 +89,35 @@ start_server {tags {"tls"}} {
             set e
         } {*I/O error*}
 
+        test {TLS: a graceful client shutdown is not logged as a connection error} {
+            # Regression test for #15745. Since #14721 redis-cli performs a
+            # graceful SSL_shutdown (sends close_notify) on exit. On the server
+            # that surfaces as SSL_ERROR_ZERO_RETURN with an empty OpenSSL error
+            # queue, which used to be formatted into a meaningless
+            # "Reading from client: error:00000000:lib(0)::reason(0)" log line.
+            # A peer close_notify is a clean EOF and must be logged as such,
+            # exactly like a plain socket read() returning 0.
+            set tlsdir [file join [pwd] tests tls]
+            set stdout [srv 0 stdout]
+            set loglines [count_log_lines 0]
+
+            assert_match {*PONG*} [exec src/redis-cli \
+                -h [srv 0 host] -p [srv 0 port] --tls \
+                --cert [file join $tlsdir client.crt] \
+                --key [file join $tlsdir client.key] \
+                --cacert [file join $tlsdir ca.crt] \
+                PING 2>@1]
+
+            # The disconnect must be handled through the clean-close path...
+            wait_for_log_messages 0 {"*Client closed connection*"} $loglines 50 100
+
+            # ...and never through the error path that formatted the empty
+            # OpenSSL error queue.
+            set newlog [exec tail -n +[expr {$loglines + 1}] < $stdout]
+            assert_no_match {*error:00000000*} $newlog
+            assert_no_match {*Reading from client*} $newlog
+        }
+
         test {TLS: Verify tls-auth-clients behaves as expected} {
             set s [redis [srv 0 host] [srv 0 port]]
             ::tls::import [$s channel]


### PR DESCRIPTION
Fixes #15745.

## The problem

Since #14721, redis-cli performs a graceful `SSL_shutdown()` (sends a `close_notify` alert) before exiting. On the server, a clean TLS shutdown makes `SSL_read()` return `0` with `SSL_get_error() == SSL_ERROR_ZERO_RETURN`.

`handleSSLReturnCode()` had no case for `SSL_ERROR_ZERO_RETURN`, so it fell through to the `default:` branch and called `updateTLSError()`. But on a clean shutdown the OpenSSL error queue is empty, so `ERR_error_string_n()` formatted error code `0` into the meaningless string `error:00000000:lib(0)::reason(0)`. That string was then logged at `LL_VERBOSE` on every graceful client disconnect:

```
Reading from client: error:00000000:lib(0)::reason(0)
```

A peer `close_notify` is the TLS equivalent of a zero-length read on a plain socket — a clean EOF, not an error. The non-TLS path already handles this correctly: `read()` returning `0` is logged benignly as `Client closed connection` instead of going through the error path.

## The fix

Two small changes in `src/tls.c`:

1. `handleSSLReturnCode()`: handle `SSL_ERROR_ZERO_RETURN` explicitly and leave `conn->ssl_error` untouched, so no bogus string is formatted from the empty error queue.
2. `connTLSRead()`: when the connection reaches `CONN_STATE_CLOSED` after a graceful shutdown, return `0` (clean EOF) instead of `-1`, so callers take the clean-close path exactly as they do for a plain socket EOF.

The handshake paths (`CONNECTING` / `ACCEPTING`) are unaffected — they still treat a non-handled return as an error, since a `close_notify` during handshake is genuinely unexpected there.

I also added a regression test to `tests/unit/tls.tcl` asserting that a graceful client shutdown is logged through the clean-close path and never produces `error:00000000` / `Reading from client`.

## Verification

Built and verified locally on `8.9.241` (base `60b4364f`) using `redis-cli --tls`.

Before the fix (origin/unstable):

```
Reading from client: error:00000000:lib(0)::reason(0)
```

After the fix:

```
Client closed connection id=5 addr=127.0.0.1:52083 laddr=127.0.0.1:21379 fd=10 ... cmd=ping
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted TLS I/O error-handling change aligned with existing plain-socket EOF behavior; handshake paths unchanged.
> 
> **Overview**
> Fixes spurious **Reading from client: error:00000000:lib(0)::reason(0)** logs when clients (e.g. `redis-cli --tls` after #14721) shut down TLS gracefully with `close_notify`.
> 
> **`handleSSLReturnCode`** now handles **`SSL_ERROR_ZERO_RETURN`** without calling **`updateTLSError`**, so an empty OpenSSL error queue is not turned into a bogus error string. **`connTLSRead`** maps a graceful shutdown (**`CONN_STATE_CLOSED`**) to a **zero-length read** (`0`), so disconnect handling matches plain TCP EOF and logs **Client closed connection** instead of the read-error path.
> 
> A regression test in **`tests/unit/tls.tcl`** runs a TLS **`PING`** via **`redis-cli`**, expects the clean-close log line, and asserts the old OpenSSL error / **Reading from client** messages never appear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7756a61c1ddbdec07bf0d51b285a823d9f78be05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->