### PR TITLE
Do not log a clean TLS shutdown as a client read error

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -4078,6 +4078,14 @@ void readQueryFromClient(connection *conn) {
     if (nread == -1) {
         if (connGetState(conn) == CONN_STATE_CONNECTED) {
             goto done;
+        } else if (connGetState(conn) == CONN_STATE_CLOSED) {
+            /* The peer closed the connection cleanly (for TLS this means a
+             * close_notify alert was received). Report it the same way as a
+             * plain TCP EOF, which arrives as a zero-length read below,
+             * instead of treating it as an error disconnect. */
+            c->read_error = CLIENT_READ_CONN_CLOSED;
+            freeClientAsync(c);
+            goto done;
         } else {
             c->read_error = CLIENT_READ_CONN_DISCONNECTED;
             freeClientAsync(c);

--- a/src/tls.c
+++ b/src/tls.c
@@ -568,6 +568,16 @@ static int handleSSLReturnCode(tls_connection *conn, int ret_value, WantIOType *
                 if (conn->ssl_error) zfree(conn->ssl_error);
                 conn->ssl_error = errno ? zstrdup(strerror(errno)) : NULL;
                 break;
+            case SSL_ERROR_ZERO_RETURN:
+                /* The peer sent a close_notify alert, which is a clean
+                 * shutdown and not an error. OpenSSL leaves the error queue
+                 * empty in this case, so going through updateTLSError() would
+                 * record a meaningless "error:00000000:lib(0)::reason(0)"
+                 * string and report it as if it were a failure. */
+                conn->c.last_errno = 0;
+                if (conn->ssl_error) zfree(conn->ssl_error);
+                conn->ssl_error = NULL;
+                break;
             default:
                 /* Error! */
                 updateTLSError(conn);

--- a/src/tls.c
+++ b/src/tls.c
@@ -576,7 +576,7 @@ static int handleSSLReturnCode(tls_connection *conn, int ret_value, WantIOType *
                  * string and report it as if it were a failure. */
                 conn->c.last_errno = 0;
                 if (conn->ssl_error) zfree(conn->ssl_error);
-                conn->ssl_error = NULL;
+                conn->ssl_error = zstrdup("connection closed");
                 break;
             default:
                 /* Error! */

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -379,6 +379,38 @@ start_server {tags {"tls"}} {
             assert_equal "tls-cert" [dict get $entry reason]
             assert_equal "admin\x00innocent" [dict get $entry username]
         }
+
+        test {TLS: a clean client disconnect is not reported as a read error} {
+            # redis-cli ends a TLS session with a close_notify alert, which
+            # SSL_read() reports as SSL_ERROR_ZERO_RETURN. That is an orderly
+            # shutdown rather than a failure, and OpenSSL leaves the error queue
+            # empty for it, so formatting the queue used to log the placeholder
+            # "Reading from client: error:00000000:lib(0)::reason(0)". Both
+            # messages are emitted at verbose level only.
+            start_server [list overrides [list loglevel verbose]] {
+                set tlsdir [file join [pwd] tests tls]
+                set res [exec src/redis-cli \
+                    -h [srv 0 host] \
+                    -p [srv 0 port] \
+                    --tls \
+                    --cert [file join $tlsdir client.crt] \
+                    --key [file join $tlsdir client.key] \
+                    --cacert [file join $tlsdir ca.crt] \
+                    PING]
+                assert_equal {PONG} $res
+
+                wait_for_condition 50 100 {
+                    [count_log_message 0 "Client closed connection"] > 0
+                } else {
+                    fail "the clean disconnect was never logged"
+                }
+                # Only the placeholder is checked. A peer that drops the socket
+                # without a close_notify still fails inside OpenSSL and is still
+                # reported as a read error, and the test suite's own clients
+                # disconnect that way.
+                assert_equal 0 [count_log_message 0 "error:00000000"]
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #15745.

After #14721 made redis-cli shut TLS connections down gracefully, a clean
disconnect started logging a placeholder error on the server:

    Reading from client: error:00000000:lib(0)::reason(0)

close_notify reaches SSL_read() as SSL_ERROR_ZERO_RETURN. handleSSLReturnCode()
had no case for it, so it fell into the default branch and called
updateTLSError(), which formats ERR_get_error(). An orderly shutdown leaves the
error queue empty, so that call formatted the value 0 into the string above.

updateStateAfterSSLIO() already classifies SSL_ERROR_ZERO_RETURN as a close and
sets CONN_STATE_CLOSED, but readQueryFromClient() only treated a zero-length
read as a clean EOF, so a TLS close still took the error path.

This change handles SSL_ERROR_ZERO_RETURN explicitly so no error string is
recorded for it, and reports a connection already in CONN_STATE_CLOSED the same
way as a plain TCP EOF.

Reproduced on unstable with a stock TLS build at loglevel verbose, running
"redis-cli --tls ... PING":

before:  - Reading from client: error:00000000:lib(0)::reason(0)
after:   - Client closed connection id=4 addr=127.0.0.1:58020 ... cmd=ping ...

which matches what a non-TLS client already produced.

The change is deliberately narrow: a peer that drops the socket without sending
close_notify still fails inside OpenSSL (error:0A000126, "unexpected eof while
reading") and is still reported as a read error. The test suite's own Tcl
clients disconnect that way, so that path stayed observable throughout.

One behaviour change worth calling out: SSL_ERROR_SYSCALL with errno == 0 also
sets CONN_STATE_CLOSED, so on OpenSSL versions that report an abrupt EOF that
way it is now logged as a closed connection rather than a read error. That
seemed consistent with updateStateAfterSSLIO() already treating it as a close,
but I am happy to narrow the check to SSL_ERROR_ZERO_RETURN only if you prefer.

A regression test is added to tests/unit/tls.tcl. It runs redis-cli --tls
against a verbose-logging server and asserts the disconnect is logged as a
closed connection with no error:00000000 placeholder. Confirmed to fail without
the source change and pass with it.

Tested with make REDIS_CFLAGS=-Werror BUILD_TLS=yes, then ./runtest and
./runtest --tls with --tags -slow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to TLS shutdown and read-error classification; may also log some OpenSSL `SSL_ERROR_SYSCALL` with errno 0 as closed rather than read errors, matching existing `CONN_STATE_CLOSED` handling.
> 
> **Overview**
> Fixes spurious **"Reading from client: error:00000000:lib(0)::reason(0)"** logs when clients (e.g. `redis-cli --tls`) shut down with a TLS `close_notify` after graceful disconnect behavior landed.
> 
> **`handleSSLReturnCode()`** in `tls.c` now handles **`SSL_ERROR_ZERO_RETURN`** explicitly: clears errno, sets a benign `"connection closed"` ssl_error string, and avoids **`updateTLSError()`** on an empty OpenSSL error queue.
> 
> **`readQueryFromClient()`** in `networking.c` treats **`clientConnRead` failure** with **`CONN_STATE_CLOSED`** the same as a zero-length read—**`CLIENT_READ_CONN_CLOSED`** and async free—instead of the disconnect error path.
> 
> A **`tls.tcl`** test runs `redis-cli --tls` PING at verbose loglevel and asserts **"Client closed connection"** appears without the **`error:00000000`** placeholder. Abrupt drops without `close_notify` remain read errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74021e803ea95559aa2aaeae6d98c9521584f694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->