### PR TITLE
Make client unshared reply memory accounting incremental in cron

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3331,7 +3331,7 @@ static int applyClientMaxMemoryUsage(const char **err) {
             removeClientFromMemUsageBucket(c, 0);
         } else {
             /* Update each client(s) memory usage and add to appropriate bucket. */
-            updateClientMemUsageAndBucket(c);
+            updateClientMemUsageAndBucket(c, 0);
         }
     }
     resumeAllIOThreads();

--- a/src/db.c
+++ b/src/db.c
@@ -1339,7 +1339,7 @@ void unblockClientForAsyncFlush(uint64_t client_id, struct slotRangeArray *slots
     }
 
     /* On flush completion, update the client's memory */
-    updateClientMemUsageAndBucket(c);
+    updateClientMemUsageAndBucket(c, 0);
 
     /* restore current_client */
     server.current_client = old_client;

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -103,7 +103,7 @@ int runClientCronFromIOThread(client *c) {
     } else {
         /* Update the client in the mem usage if clientsCronRunClient is not
          * being called, since that function already performs the update. */
-        updateClientMemUsageAndBucket(c);
+        updateClientMemUsageAndBucket(c, 0);
     }
 
     return 0;

--- a/src/module.c
+++ b/src/module.c
@@ -702,7 +702,8 @@ void moduleReleaseTempClient(client *c) {
     }
     clearClientConnectionState(c);
     listEmpty(c->reply);
-    c->reply_bytes = c->reply_bytes_shared = c->reply_bytes_unshared = 0;
+    c->reply_bytes = c->reply_bytes_shared = 0;
+    setClientUnsharedReplyBytes(c, 0);
     c->duration = 0;
     resetClient(c, -1);
     serverAssert(c->all_argv_len_sum == 0);

--- a/src/networking.c
+++ b/src/networking.c
@@ -2046,8 +2046,7 @@ void tryUnlinkClientFromPendingRefReply(client *c, int force) {
     if (clientIsInPendingRefReplyList(c) && (force || !clientHasPendingReplies(c))) {
         /* Withdraw this client's contribution before it leaves the list,
          * since it won't be revisited by clientsUnsharedMemCron() again. */
-        server.clients_unshared_mem -= c->reply_bytes_unshared;
-        c->reply_bytes_unshared = 0;
+        setClientUnsharedReplyBytes(c, 0);
         listUnlinkNode(server.clients_with_pending_ref_reply, &c->pending_ref_reply_node);
     }
 }
@@ -2077,16 +2076,34 @@ static size_t computeUnsharedReplyBytes(char *buf, size_t bufpos) {
     return total;
 }
 
+/* Set the client's cached unshared reply bytes to an already-known value,
+ * keeping server.clients_unshared_mem in sync when the client is tracked in
+ * clients_with_pending_ref_reply. Every writer of reply_bytes_unshared - full
+ * recompute, forcing it to 0, or withdrawing it on unlink - goes through this
+ * so the running total never drifts from the field it mirrors. */
+void setClientUnsharedReplyBytes(client *c, unsigned long long new_unshared) {
+    if (new_unshared != c->reply_bytes_unshared && clientIsInPendingRefReplyList(c)) {
+        if (new_unshared >= c->reply_bytes_unshared)
+            server.clients_unshared_mem += new_unshared - c->reply_bytes_unshared;
+        else
+            server.clients_unshared_mem -= c->reply_bytes_unshared - new_unshared;
+    }
+    c->reply_bytes_unshared = new_unshared;
+}
+
 /* Update the client's unshared reply memory (solely owned). */
 void updateClientUnsharedReplyBytes(client *c) {
-    c->reply_bytes_unshared = 0;
+    unsigned long long new_unshared = 0;
 
     /* No shared memory means no unshared memory either. */
-    if (c->reply_bytes_shared == 0) return;
+    if (c->reply_bytes_shared == 0) {
+        setClientUnsharedReplyBytes(c, new_unshared);
+        return;
+    }
 
     /* Scan the static output buffer. */
     if (c->buf_encoded)
-        c->reply_bytes_unshared += computeUnsharedReplyBytes(c->buf, c->bufpos);
+        new_unshared += computeUnsharedReplyBytes(c->buf, c->bufpos);
 
     /* Scan each block in the reply list. */
     listIter reply_li;
@@ -2096,8 +2113,10 @@ void updateClientUnsharedReplyBytes(client *c) {
         clientReplyBlock *block = listNodeValue(reply_ln);
         if (block == NULL) continue; /* deferred-length placeholder */
         if (block->buf_encoded)
-            c->reply_bytes_unshared += computeUnsharedReplyBytes(block->buf, block->used);
+            new_unshared += computeUnsharedReplyBytes(block->buf, block->used);
     }
+
+    setClientUnsharedReplyBytes(c, new_unshared);
 }
 
 /* Compute shared reply memory: total shared reply bytes and the unshared subset where the key

--- a/src/networking.c
+++ b/src/networking.c
@@ -2044,6 +2044,10 @@ void unlinkClient(client *c) {
  * contain any referenced robj. */
 void tryUnlinkClientFromPendingRefReply(client *c, int force) {
     if (clientIsInPendingRefReplyList(c) && (force || !clientHasPendingReplies(c))) {
+        /* Withdraw this client's contribution before it leaves the list,
+         * since it won't be revisited by clientsUnsharedMemCron() again. */
+        server.clients_unshared_mem -= c->reply_bytes_unshared;
+        c->reply_bytes_unshared = 0;
         listUnlinkNode(server.clients_with_pending_ref_reply, &c->pending_ref_reply_node);
     }
 }
@@ -2104,14 +2108,9 @@ void getClientsSharedMemoryUsage(size_t *shared_mem, size_t *unshared_mem) {
     listRewind(server.clients_with_pending_ref_reply, &li);
     while ((ln = listNext(&li))) {
         client *c = listNodeValue(ln);
-
-        /* Total shared reply bytes (logical size, shared with keyspace). */
         *shared_mem += c->reply_bytes_shared;
-
-        /* Unshared reply bytes: the client is the sole owner because the key was deleted. */
-        updateClientUnsharedReplyBytes(c);
-        *unshared_mem += c->reply_bytes_unshared;
     }
+    *unshared_mem += server.clients_unshared_mem;
 }
 
 /* Drop all of the client's Pub/Sub state: unsubscribe every channel, shard

--- a/src/networking.c
+++ b/src/networking.c
@@ -215,6 +215,7 @@ client *createClient(connection *conn) {
     c->reply = listCreate();
     c->deferred_reply_errors = NULL;
     c->reply_bytes = c->reply_bytes_shared = c->reply_bytes_unshared = 0;
+    c->last_unshared_refresh = 0;
     c->obuf_soft_limit_reached_time = 0;
     listSetFreeMethod(c->reply,freeClientReplyValue);
     listSetDupMethod(c->reply,dupClientReplyValue);

--- a/src/networking.c
+++ b/src/networking.c
@@ -3047,7 +3047,7 @@ int writeToClient(client *c, int handler_installed) {
     /* Update client's memory usage after writing.
      * Since this isn't thread safe we do this conditionally. */
     if (c->running_tid == IOTHREAD_MAIN_THREAD_ID) {
-        updateClientMemUsageAndBucket(c);
+        updateClientMemUsageAndBucket(c, 0);
     }
     return C_OK;
 }
@@ -3667,7 +3667,7 @@ int processCommandAndResetClient(client *c) {
         commandProcessed(c);
         /* Update the client's memory to include output buffer growth following the
          * processed command. */
-        if (c->conn) updateClientMemUsageAndBucket(c);
+        if (c->conn) updateClientMemUsageAndBucket(c, 0);
     }
 
     if (server.current_client == NULL) deadclient = 1;
@@ -3992,7 +3992,7 @@ int processInputBuffer(client *c) {
      * important in case the query buffer is big and wasn't drained during
      * the above loop (because of partially sent big commands). */
     if (c->running_tid == IOTHREAD_MAIN_THREAD_ID)
-        updateClientMemUsageAndBucket(c);
+        updateClientMemUsageAndBucket(c, 0);
 
     return C_OK;
 }
@@ -4616,7 +4616,7 @@ NULL
             addReply(c,shared.ok);
         } else if (!strcasecmp(c->argv[2]->ptr,"off")) {
             c->flags &= ~CLIENT_NO_EVICT;
-            updateClientMemUsageAndBucket(c);
+            updateClientMemUsageAndBucket(c, 0);
             addReply(c,shared.ok);
         } else {
             addReplyErrorObject(c,shared.syntaxerr);
@@ -5867,7 +5867,7 @@ void evictClients(void) {
                  * evicting clients, we update again before evicting, if the memory
                  * used by the client does not decrease or memory usage bucket is not
                  * changed, then we will evict it, otherwise, not evict it. */
-                updateClientMemUsageAndBucket(c);
+                updateClientMemUsageAndBucket(c, 0);
             }
             if (c->last_memory_usage >= last_memory ||
                 c->mem_usage_bucket == &server.client_mem_usage_buckets[curr_bucket])

--- a/src/networking.c
+++ b/src/networking.c
@@ -2045,7 +2045,7 @@ void unlinkClient(client *c) {
 void tryUnlinkClientFromPendingRefReply(client *c, int force) {
     if (clientIsInPendingRefReplyList(c) && (force || !clientHasPendingReplies(c))) {
         /* Withdraw this client's contribution before it leaves the list,
-         * since it won't be revisited by clientsUnsharedMemCron() again. */
+         * since it won't be revisited by clientsCronRunClient() again. */
         setClientUnsharedReplyBytes(c, 0);
         listUnlinkNode(server.clients_with_pending_ref_reply, &c->pending_ref_reply_node);
     }

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -716,7 +716,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
             addReplyPubsubMessage(c,channel,message,*type.messageBulk);
             if (clusterSlotStatsEnabled(CLUSTER_SLOT_STATS_NET))
                 clusterSlotStatsAddNetworkBytesOutForShardedPubSubInternalPropagation(c, slot);
-            updateClientMemUsageAndBucket(c);
+            updateClientMemUsageAndBucket(c, 0);
             receivers++;
         }
         dictResetIterator(&iter);
@@ -746,7 +746,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
             while ((entry = dictNext(&iter)) != NULL) {
                 client *c = dictGetKey(entry);
                 addReplyPubsubPatMessage(c,pattern,channel,message);
-                updateClientMemUsageAndBucket(c);
+                updateClientMemUsageAndBucket(c, 0);
                 receivers++;
             }
             dictResetIterator(&iter);

--- a/src/replication.c
+++ b/src/replication.c
@@ -843,7 +843,7 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
             continue;
         }
         addReply(monitor,cmdobj);
-        updateClientMemUsageAndBucket(monitor);
+        updateClientMemUsageAndBucket(monitor, 0);
     }
     decrRefCount(cmdobj);
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -4673,7 +4673,8 @@ void replicationCacheMaster(client *c) {
     if (c->flags & CLIENT_MULTI) discardTransaction(c);
     listEmpty(c->reply);
     c->sentlen = 0;
-    c->reply_bytes = c->reply_bytes_shared = c->reply_bytes_unshared = 0;
+    c->reply_bytes = c->reply_bytes_shared = 0;
+    setClientUnsharedReplyBytes(c, 0);
     c->bufpos = 0;
     resetClient(c, -1);
     resetClientQbufState(c);

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -961,7 +961,8 @@ static int luaRedisGenericCommand(lua_State *lua, int raise_error) {
         ldbLogRedisReply(reply);
 
     if (reply != c->buf) sdsfree(reply);
-    c->reply_bytes = c->reply_bytes_shared = c->reply_bytes_unshared = 0;
+    c->reply_bytes = c->reply_bytes_shared = 0;
+    setClientUnsharedReplyBytes(c, 0);
 
 cleanup:
     /* Clean up. Command code may have changed argv/argc so we use the

--- a/src/server.c
+++ b/src/server.c
@@ -1210,6 +1210,14 @@ int clientsCronRunClient(client *c) {
 
     if (clientsCronTrackExpansiveClients(c)) return 1;
 
+    /* Recomputing c->reply_bytes_unshared requires rescanning the client's
+     * whole pending reply buffer, so instead of doing that on every write we
+     * refresh it here, since this function already runs once per second per
+     * client (from clientsCron() for main-thread clients, or from
+     * runClientCronFromIOThread() for IO-thread-owned ones, which is why this
+     * is safe to call regardless of which thread owns the client). */
+    updateClientUnsharedReplyBytes(c);
+
     /* Iterating all the clients in getMemoryOverheadData() is too slow and
      * in turn would make the INFO command too slow. So we perform this
      * computation incrementally and track the (not instantaneous but updated
@@ -1302,41 +1310,6 @@ void clientsCron(void) {
         if (c->tid != IOTHREAD_MAIN_THREAD_ID) continue;
 
         clientsCronRunClient(c);
-    }
-}
-
-/* Refresh server.clients_unshared_mem incrementally, once per serverCron tick.
- *
- * Recomputing c->reply_bytes_unshared requires rescanning a client's whole pending
- * reply buffer, so instead of redoing that for every client on every call, we spread
- * it out like clientsCron() does for updateClientMemoryUsage(): process a rotating
- * slice of clients_with_pending_ref_reply per tick (~listLength/hz clients, so the
- * whole list gets rescanned about once per second). updateClientUnsharedReplyBytes()
- * itself folds each client's delta into the running total, so it stays correct even
- * when other callers (e.g. CLIENT LIST) refresh the same field between cron ticks.
- *
- * c->reply_bytes_shared needs no such treatment since it's already kept exact for
- * free at write time, so getClientsSharedMemoryUsage() still sums it on demand. */
-void clientsUnsharedMemCron(void) {
-    int numclients = listLength(server.clients_with_pending_ref_reply);
-    if (!numclients) return;
-    int iterations = numclients / server.hz;
-    if (iterations < CLIENTS_CRON_MIN_ITERATIONS)
-        iterations = (numclients < CLIENTS_CRON_MIN_ITERATIONS) ?
-                     numclients : CLIENTS_CRON_MIN_ITERATIONS;
-
-    while (listLength(server.clients_with_pending_ref_reply) && iterations--) {
-        listNode *head = listFirst(server.clients_with_pending_ref_reply);
-        client *c = listNodeValue(head);
-        listRotateHeadToTail(server.clients_with_pending_ref_reply);
-
-        /* Clients handled by IO threads own their reply buffers: the IO thread may
-         * be concurrently freeing/mutating them from writeToClient(), so scanning
-         * them here would race. Their IO thread refreshes reply_bytes_unshared
-         * itself instead, see runClientCronFromIOThread(). */
-        if (c->tid != IOTHREAD_MAIN_THREAD_ID) continue;
-
-        updateClientUnsharedReplyBytes(c);
     }
 }
 
@@ -1729,14 +1702,6 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     databasesCron();
 
     backupCron();
-
-    /* Refresh the cached unshared client reply memory total used by
-     * getClientsSharedMemoryUsage(), instead of rescanning every pending client's
-     * reply buffer on every INFO/MEMORY call (or, in some deployments, per-command).
-     * Like clientsCron() above, this must run every tick (not throttled to
-     * once/sec) since it paces itself at listLength/server.hz clients per call so
-     * the full list gets rescanned roughly once per second. */
-    clientsUnsharedMemCron();
 
     /* Start a scheduled AOF rewrite if this was requested while another state
      * prevented it earlier. */

--- a/src/server.c
+++ b/src/server.c
@@ -1134,9 +1134,13 @@ void removeClientFromMemUsageBucket(client *c, int allow_eviction) {
  * of whether the eviction is enabled or not, so the memory usage we get from these
  * types of clients via the INFO command may be out of date.
  *
+ * 'unshared_reply_bytes_fresh' should be non-zero when the caller has just
+ * recomputed c->reply_bytes_unshared itself (currently only
+ * clientsCronRunClient()), so this function can skip redoing that scan.
+ *
  * returns 1 if client eviction for this client is allowed, 0 otherwise.
  */
-int updateClientMemUsageAndBucket(client *c) {
+int updateClientMemUsageAndBucket(client *c, int unshared_reply_bytes_fresh) {
     /* The unlikely case this function was called from a thread different
      * than the main one is a module call from a spawned thread. This is safe
      * since this call must have been made after calling
@@ -1157,15 +1161,18 @@ int updateClientMemUsageAndBucket(client *c) {
     /* Include unshared reply bytes in the client's memory usage for eviction.
      * Walking the reply buffer is costly, so skip the scan when its outcome
      * cannot affect bucket placement: since 0 <= unshared <= shared, if both
-     * endpoints map to the same bucket the cached value is reused. */
-    if (c->reply_bytes_shared > 0) {
-        size_t lower_bound = getClientMemoryUsage(c) - c->reply_bytes_unshared;
-        size_t upper_bound = lower_bound + c->reply_bytes_shared;
-        if (getMemUsageBucket(lower_bound) != getMemUsageBucket(upper_bound))
-            updateClientUnsharedReplyBytes(c);
-    } else {
-        /* No shared bytes: clear any stale cached unshared. */
-        setClientUnsharedReplyBytes(c, 0);
+     * endpoints map to the same bucket the cached value is reused. Skip it
+     * altogether when the caller already refreshed it for us. */
+    if (!unshared_reply_bytes_fresh) {
+        if (c->reply_bytes_shared > 0) {
+            size_t lower_bound = getClientMemoryUsage(c) - c->reply_bytes_unshared;
+            size_t upper_bound = lower_bound + c->reply_bytes_shared;
+            if (getMemUsageBucket(lower_bound) != getMemUsageBucket(upper_bound))
+                updateClientUnsharedReplyBytes(c);
+        } else {
+            /* No shared bytes: clear any stale cached unshared. */
+            setClientUnsharedReplyBytes(c, 0);
+        }
     }
 
     /* Update client memory usage. */
@@ -1218,7 +1225,8 @@ int clientsCronRunClient(client *c) {
      * of which thread owns the client, since this is invoked either from
      * clientsCron() for main-thread clients or from runClientCronFromIOThread()
      * for IO-thread-owned ones, i.e. always on the thread that owns c. */
-    if (c->last_unshared_refresh + 1000/server.hz <= now) {
+    int unshared_reply_bytes_fresh = c->last_unshared_refresh + 1000/server.hz <= now;
+    if (unshared_reply_bytes_fresh) {
         c->last_unshared_refresh = now;
         updateClientUnsharedReplyBytes(c);
     }
@@ -1229,7 +1237,7 @@ int clientsCronRunClient(client *c) {
      * to the second) total memory used by clients using clientsCron() in
      * a more incremental way (depending on server.hz).
      * If client eviction is enabled, update the bucket as well. */
-    if (!updateClientMemUsageAndBucket(c))
+    if (!updateClientMemUsageAndBucket(c, unshared_reply_bytes_fresh))
         updateClientMemoryUsage(c);
 
     if (closeClientOnOutputBufferLimitReached(c, 0)) return 1;

--- a/src/server.c
+++ b/src/server.c
@@ -1305,6 +1305,36 @@ void clientsCron(void) {
     }
 }
 
+/* Refresh server.clients_unshared_mem incrementally, once per serverCron tick.
+ *
+ * Recomputing c->reply_bytes_unshared requires rescanning a client's whole pending
+ * reply buffer, so instead of redoing that for every client on every call, we spread
+ * it out like clientsCron() does for updateClientMemoryUsage(): process a rotating
+ * slice of clients_with_pending_ref_reply per tick (~listLength/hz clients, so the
+ * whole list gets rescanned about once per second), folding each client's delta into
+ * the running total.
+ *
+ * c->reply_bytes_shared needs no such treatment since it's already kept exact for
+ * free at write time, so getClientsSharedMemoryUsage() still sums it on demand. */
+void clientsUnsharedMemCron(void) {
+    int numclients = listLength(server.clients_with_pending_ref_reply);
+    if (!numclients) return;
+    int iterations = numclients / server.hz;
+    if (iterations < CLIENTS_CRON_MIN_ITERATIONS)
+        iterations = (numclients < CLIENTS_CRON_MIN_ITERATIONS) ?
+                     numclients : CLIENTS_CRON_MIN_ITERATIONS;
+
+    while (listLength(server.clients_with_pending_ref_reply) && iterations--) {
+        listNode *head = listFirst(server.clients_with_pending_ref_reply);
+        client *c = listNodeValue(head);
+        listRotateHeadToTail(server.clients_with_pending_ref_reply);
+
+        server.clients_unshared_mem -= c->reply_bytes_unshared;
+        updateClientUnsharedReplyBytes(c);
+        server.clients_unshared_mem += c->reply_bytes_unshared;
+    }
+}
+
 static int resizeShouldSkip(int didx) {
     if (!server.cluster_enabled) return 0;
 
@@ -1694,6 +1724,14 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     databasesCron();
 
     backupCron();
+
+    /* Refresh the cached unshared client reply memory total used by
+     * getClientsSharedMemoryUsage(), instead of rescanning every pending client's
+     * reply buffer on every INFO/MEMORY call (or, in some deployments, per-command).
+     * Like clientsCron() above, this must run every tick (not throttled to
+     * once/sec) since it paces itself at listLength/server.hz clients per call so
+     * the full list gets rescanned roughly once per second. */
+    clientsUnsharedMemCron();
 
     /* Start a scheduled AOF rewrite if this was requested while another state
      * prevented it earlier. */

--- a/src/server.c
+++ b/src/server.c
@@ -1165,7 +1165,7 @@ int updateClientMemUsageAndBucket(client *c) {
             updateClientUnsharedReplyBytes(c);
     } else {
         /* No shared bytes: clear any stale cached unshared. */
-        c->reply_bytes_unshared = 0;
+        setClientUnsharedReplyBytes(c, 0);
     }
 
     /* Update client memory usage. */
@@ -1311,8 +1311,9 @@ void clientsCron(void) {
  * reply buffer, so instead of redoing that for every client on every call, we spread
  * it out like clientsCron() does for updateClientMemoryUsage(): process a rotating
  * slice of clients_with_pending_ref_reply per tick (~listLength/hz clients, so the
- * whole list gets rescanned about once per second), folding each client's delta into
- * the running total.
+ * whole list gets rescanned about once per second). updateClientUnsharedReplyBytes()
+ * itself folds each client's delta into the running total, so it stays correct even
+ * when other callers (e.g. CLIENT LIST) refresh the same field between cron ticks.
  *
  * c->reply_bytes_shared needs no such treatment since it's already kept exact for
  * free at write time, so getClientsSharedMemoryUsage() still sums it on demand. */
@@ -1329,9 +1330,13 @@ void clientsUnsharedMemCron(void) {
         client *c = listNodeValue(head);
         listRotateHeadToTail(server.clients_with_pending_ref_reply);
 
-        server.clients_unshared_mem -= c->reply_bytes_unshared;
+        /* Clients handled by IO threads own their reply buffers: the IO thread may
+         * be concurrently freeing/mutating them from writeToClient(), so scanning
+         * them here would race. Their IO thread refreshes reply_bytes_unshared
+         * itself instead, see runClientCronFromIOThread(). */
+        if (c->tid != IOTHREAD_MAIN_THREAD_ID) continue;
+
         updateClientUnsharedReplyBytes(c);
-        server.clients_unshared_mem += c->reply_bytes_unshared;
     }
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -1210,13 +1210,18 @@ int clientsCronRunClient(client *c) {
 
     if (clientsCronTrackExpansiveClients(c)) return 1;
 
-    /* Recomputing c->reply_bytes_unshared requires rescanning the client's
-     * whole pending reply buffer, so instead of doing that on every write we
-     * refresh it here, since this function already runs once per second per
-     * client (from clientsCron() for main-thread clients, or from
-     * runClientCronFromIOThread() for IO-thread-owned ones, which is why this
-     * is safe to call regardless of which thread owns the client). */
-    updateClientUnsharedReplyBytes(c);
+    /* Recomputing c->reply_bytes_unshared requires rescanning the client's whole
+     * pending reply buffer, so throttle it to once per 1000/server.hz ms: this
+     * function can run as often as every tick when there are few clients (see
+     * CLIENTS_CRON_MIN_ITERATIONS below), and we don't want to pay for a full
+     * buffer rescan on every one of those visits. It's safe to call regardless
+     * of which thread owns the client, since this is invoked either from
+     * clientsCron() for main-thread clients or from runClientCronFromIOThread()
+     * for IO-thread-owned ones, i.e. always on the thread that owns c. */
+    if (c->last_unshared_refresh + 1000/server.hz <= now) {
+        c->last_unshared_refresh = now;
+        updateClientUnsharedReplyBytes(c);
+    }
 
     /* Iterating all the clients in getMemoryOverheadData() is too slow and
      * in turn would make the INFO command too slow. So we perform this

--- a/src/server.h
+++ b/src/server.h
@@ -2121,6 +2121,7 @@ struct redisServer {
     list *clients_pending_write; /* There is to write or install handler. */
     list *clients_pending_read;  /* Client has pending read socket buffers. */
     list *clients_with_pending_ref_reply; /* Clients with referenced reply objects. */
+    size_t clients_unshared_mem; /* Sum of c->reply_bytes_unshared across clients_with_pending_ref_reply, updated incrementally by cron. */
     list *slaves, *monitors;    /* List of slaves and MONITORs */
     client *current_client;     /* The client that triggered the command execution (External or AOF). */
     client *executing_client;   /* The client executing the current command (possibly script or module). */

--- a/src/server.h
+++ b/src/server.h
@@ -3415,6 +3415,7 @@ size_t getClientOutputBufferMemoryUsage(client *c);
 size_t getNormalClientPendingReplyBytes(client *c);
 size_t getClientMemoryUsage(client *c);
 void updateClientUnsharedReplyBytes(client *c);
+void setClientUnsharedReplyBytes(client *c, unsigned long long new_unshared);
 void getClientsSharedMemoryUsage(size_t *shared_mem, size_t *unshared_mem);
 int freeClientsInAsyncFreeQueue(void);
 int closeClientOnOutputBufferLimitReached(client *c, int async);

--- a/src/server.h
+++ b/src/server.h
@@ -3440,7 +3440,7 @@ void blockingOperationStarts(void);
 void blockingOperationEnds(void);
 int handleClientsWithPendingWrites(void);
 int clientHasPendingReplies(client *c);
-int updateClientMemUsageAndBucket(client *c);
+int updateClientMemUsageAndBucket(client *c, int unshared_reply_bytes_fresh);
 void removeClientFromMemUsageBucket(client *c, int allow_eviction);
 void unlinkClient(client *c);
 void tryUnlinkClientFromPendingRefReply(client *c, int force);

--- a/src/server.h
+++ b/src/server.h
@@ -1551,6 +1551,7 @@ typedef struct client {
     unsigned long long reply_bytes; /* Tot bytes of objects in reply list. */
     unsigned long long reply_bytes_shared; /* Bytes shared with keyspace objects in reply list. */
     unsigned long long reply_bytes_unshared; /* Cached subset of reply_bytes_shared solely owned by this client. */
+    mstime_t last_unshared_refresh; /* Timestamp of last reply_bytes_unshared recompute */
     list *deferred_reply_errors;    /* Used for module thread safe contexts. */
     size_t sentlen;         /* Amount of bytes already sent in the current
                                buffer or object being sent. */

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -316,7 +316,7 @@ void sendTrackingMessage(client *c, char *keyname, size_t keylen, int proto) {
         addReplyArrayLen(c,1);
         addReplyBulkCBuffer(c,keyname,keylen);
     }
-    updateClientMemUsageAndBucket(c);
+    updateClientMemUsageAndBucket(c, 0);
     if (!(old_flags & CLIENT_PUSHING)) c->flags &= ~CLIENT_PUSHING;
 
 done:


### PR DESCRIPTION
getClientsSharedMemoryUsage() rescanned every client's pending reply buffer (updateClientUnsharedReplyBytes) on each call, and was called synchronously from getMemoryOverheadData() on every INFO/MEMORY call.

Split the two components: the shared byte count is cheap (already incrementally maintained per-client, no scanning) so it's still summed on demand for exact, real-time values. The unshared count requires an actual buffer rescan, so that part is now spread across serverCron ticks the same way clientsCron() spreads updateClientMemoryUsage() over server.clients - rotating a slice of clients_with_pending_ref_reply per tick and folding the delta into a running total instead of rescanning the whole list on every call.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how client unshared reply memory is computed and reported for INFO/MEMORY and client eviction buckets; incorrect totals could skew memory stats or eviction decisions, though updates are centralized through one setter.
> 
> **Overview**
> **INFO/MEMORY** no longer rescans every client’s pending reply buffers on each `getClientsSharedMemoryUsage()` call. Shared reply bytes are still summed live from each tracked client; **unshared** bytes are maintained incrementally instead.
> 
> Adds `setClientUnsharedReplyBytes()` and `server.clients_unshared_mem` so any change to a client’s cached unshared reply size updates the global total when the client is on `clients_with_pending_ref_reply` (including zeroing on unlink from that list). `clientsCronRunClient()` recomputes unshared reply bytes at most once per ~1s (`last_unshared_refresh`) and passes `unshared_reply_bytes_fresh` into `updateClientMemUsageAndBucket()` so eviction-path updates can skip a redundant buffer walk. All other call sites pass `0` and keep the existing lazy rescan when bucket placement might change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8052052a9344586a8b2ecdb4f3d146229055ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->