### PR TITLE
Fix --bigkeys/--keystats not reporting the biggest key when its size is 0

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -9994,7 +9994,7 @@ static void findBigKeys(int memkeys, long long memkeys_samples) {
             totlen += keys->element[i]->len;
             sampled++;
 
-            if(type->biggest<sizes[i]) {
+            if(type->biggest<sizes[i] || (!type->biggest_key && type->sizecmd)) {
                 /* Keep track of biggest key name for this type */
                 if (type->biggest_key)
                     sdsfree(type->biggest_key);
@@ -10032,7 +10032,7 @@ static void findBigKeys(int memkeys, long long memkeys_samples) {
                 dictInitIterator(&di, types_dict);
                 while ((de = dictNext(&di))) {
                     typeinfo *current_type = dictGetVal(de);
-                    if (current_type->biggest > 0) {
+                    if (current_type->biggest_key) {
                         line_count += cleanPrintfln("Biggest %-9s found so far %s with %llu %s",
                             current_type->name, current_type->biggest_key, current_type->biggest,
                             !memkeys? current_type->sizeunit: "bytes");
@@ -11085,7 +11085,7 @@ static void updateKeyType(redisReply *element, unsigned long long size, typeinfo
     type->totalsize += size;
     type->count++;
 
-    if (type->biggest<size) {
+    if (type->biggest<size || (!type->biggest_key && type->sizecmd)) {
         /* Keep track of biggest key name for this type */
         if (type->biggest_key)
             sdsfree(type->biggest_key);

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -907,7 +907,7 @@ start_server {tags {"cli external:skip"}} {
         # every sampled key of a type has size 0, leaving biggest_key unset even
         # though the key was counted.
         r set foo ""
-        set cmd [rediscli [srv host] [srv port] [list -n 9 --bigkeys]]
+        set cmd [rediscli [srv host] [srv port] [list -n $::dbnum --bigkeys]]
         set result [exec {*}$cmd]
         assert_match {*Biggest string found "foo" has 0 bytes*} $result
     }

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -902,6 +902,18 @@ start_server {tags {"cli external:skip"}} {
 }
 
 start_server {tags {"cli external:skip"}} {
+    test "bigkeys reports a zero-size key as the biggest key of its type" {
+        # type->biggest starts at 0, so a strict '<' comparison never fires when
+        # every sampled key of a type has size 0, leaving biggest_key unset even
+        # though the key was counted.
+        r set foo ""
+        set cmd [rediscli [srv host] [srv port] [list -n 9 --bigkeys]]
+        set result [exec {*}$cmd]
+        assert_match {*Biggest string found "foo" has 0 bytes*} $result
+    }
+}
+
+start_server {tags {"cli external:skip"}} {
     # Regression for the parseRedisUri() bug where "redis://:password@host"
     # produced an empty ACL username and the server replied WRONGPASS.
     r config set requirepass "uri-no-username-pass"


### PR DESCRIPTION
`type->biggest` starts at 0, so the strict '<' comparison never fires when the first (or every) sampled key of a type has size/cardinality 0, leaving `type->biggest_key` unset even though the key was counted. A valid zero-cardinality key (e.g. SETBIT key 0 0) was therefore counted but omitted from the biggest-key output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized redis-cli display and tracking logic for bigkeys/keystats with no server or data-path changes.
> 
> **Overview**
> **`redis-cli --bigkeys` and related keystats sampling** no longer skip reporting the largest key when its measured size is **0**.
> 
> The update condition now also records a key name when none has been chosen yet and the type uses a size command (`!type->biggest_key && type->sizecmd`), fixing the case where `type->biggest` starts at 0 so a strict `biggest < size` check never runs for all-zero samples. The same logic is applied in **`updateKeyType`**, and live progress output gates on **`biggest_key`** instead of **`biggest > 0`**.
> 
> An integration test asserts **`--bigkeys`** reports an empty string key as the biggest string with **0 bytes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b79821c923ab2d10c42443d18b27c3b0ee5ae73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->