### PR TITLE
memory_prefetch: track the active lookups instead of scanning for them

### DIFF
--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -53,9 +53,11 @@ typedef struct dictPrefetchLookup {
  * callbacks of each key's dict. The same prefetcher is used by both the
  * cross-command batch path and the intra-command dictPrefetchKeys() API. */
 typedef struct dictPrefetcher {
-    size_t cur_idx;              /* Cursor; advances on each prefetch issue */
+    size_t cur_idx;              /* Key index of the lookup being advanced */
+    size_t cur;                  /* Cursor into active[]; advances on each prefetch issue */
+    size_t *active;              /* Key indices not yet PREFETCH_DONE, unordered */
+    size_t nactive;              /* Entries in active[] */
     size_t nkeys;                /* Total key lookups in this batch */
-    size_t remaining;            /* Number of in-flight key lookups (not yet PREFETCH_DONE) */
     void **keys;                 /* Array of key pointers (sds) */
     dict **dicts;                /* Per-key dictionary pointers */
     dictPrefetchLookup *lookups; /* Per-key lookup state, capacity == max_keys */
@@ -94,21 +96,21 @@ typedef struct dictPrefetcher {
  * advancing the cursor. */
 static inline void dictPrefetchAdvance(dictPrefetcher *p, void *addr) {
     redis_prefetch_read(addr);
-    if (++p->cur_idx >= p->nkeys) p->cur_idx = 0;
+    if (++p->cur >= p->nactive) p->cur = 0;
 }
 
 static inline void dictPrefetchMarkDone(dictPrefetcher *p, dictPrefetchLookup *lk) {
     lk->state = PREFETCH_DONE;
-    p->remaining--;
+    /* Swap-remove: the cursor now holds the moved-in lookup. */
+    p->active[p->cur] = p->active[--p->nactive];
+    if (p->cur >= p->nactive) p->cur = 0;
     server.stat_total_prefetch_entries++;
 }
 
 /* Return the next in-flight lookup that still needs work, or NULL if all done. */
 static inline dictPrefetchLookup *dictPrefetchNextInFlight(dictPrefetcher *p) {
-    if (p->remaining == 0) return NULL;
-    while (p->lookups[p->cur_idx].state == PREFETCH_DONE) {
-        if (++p->cur_idx >= p->nkeys) p->cur_idx = 0;
-    }
+    if (p->nactive == 0) return NULL;
+    p->cur_idx = p->active[p->cur];
     return &p->lookups[p->cur_idx];
 }
 
@@ -192,11 +194,10 @@ static void dictPrefetchEntryValue(dictPrefetcher *p, dictPrefetchLookup *lk) {
     if ((!dictGetNext(lk->current_entry) && !dictIsRehashing(d)) ||
         dictCompareKeys(d, p->keys[i], cmp_key))
     {
-        if (type->prefetchEntryValue) {
-            void *addr = type->prefetchEntryValue(lk->current_entry);
-            if (addr) dictPrefetchAdvance(p, addr);
-        }
+        /* Removal moves the cursor, so retire before prefetching. */
+        void *addr = type->prefetchEntryValue ? type->prefetchEntryValue(lk->current_entry) : NULL;
         dictPrefetchMarkDone(p, lk);
+        if (addr) redis_prefetch_read(addr);
     } else {
         /* Not found in the current entry, move to the next entry */
         lk->state = PREFETCH_ENTRY;
@@ -207,12 +208,15 @@ static void dictPrefetchEntryValue(dictPrefetcher *p, dictPrefetchLookup *lk) {
  * many batches by repeated dictPrefetcherReset / dictPrefetcherRun calls. */
 static void dictPrefetcherInit(dictPrefetcher *p, size_t max_keys) {
     p->lookups = zcalloc(max_keys * sizeof(dictPrefetchLookup));
+    p->active = zmalloc(max_keys * sizeof(size_t));
     p->max_keys = max_keys;
 }
 
 static void dictPrefetcherFree(dictPrefetcher *p) {
     zfree(p->lookups);
+    zfree(p->active);
     p->lookups = NULL;
+    p->active = NULL;
     p->max_keys = 0;
 }
 
@@ -225,8 +229,9 @@ static void dictPrefetcherReset(dictPrefetcher *p, dict **dicts, void **keys, si
     p->keys = keys;
     p->nkeys = nkeys;
     p->cur_idx = 0;
+    p->cur = 0;
 
-    size_t remaining = 0;
+    size_t nactive = 0;
     for (size_t i = 0; i < nkeys; i++) {
         dictPrefetchLookup *lk = &p->lookups[i];
         if (!dicts[i] || dictSize(dicts[i]) == 0) {
@@ -242,9 +247,9 @@ static void dictPrefetcherReset(dictPrefetcher *p, dict **dicts, void **keys, si
         lk->current_entry = NULL;
         lk->state = PREFETCH_BUCKET;
         lk->key_hash = dictGetHash(dicts[i], keys[i]);
-        remaining++;
+        p->active[nactive++] = i;
     }
-    p->remaining = remaining;
+    p->nactive = nactive;
 }
 
 /* Drive the prefetch state machine across all dict lookups until every lookup
@@ -313,7 +318,8 @@ void dictPrefetchKeys(dict **dicts, void **keys, size_t nkeys) {
     server.stat_total_prefetch_batches++;
 
     dictPrefetchLookup lookups[DICT_PREFETCH_MAX_SIZE];
-    dictPrefetcher p = { .lookups = lookups, .max_keys = nkeys };
+    size_t active[DICT_PREFETCH_MAX_SIZE];
+    dictPrefetcher p = { .lookups = lookups, .active = active, .max_keys = nkeys };
     dictPrefetcherReset(&p, dicts, keys, nkeys);
     dictPrefetcherRun(&p);
 }


### PR DESCRIPTION
`dictPrefetchNextInFlight()` scans `lookups[]` for the next entry that is not
`PREFETCH_DONE`. As a batch drains, that scan walks a progressively sparser
array with a data-dependent exit test, so it mispredicts. Under memtier
(4 I/O threads, 9:1 GET/SET, pipeline 8) `dictPrefetcherRun` was the top site
in both profiles: 2.98% of cycles and 17.40% of all branch misses.

Keeping the not-yet-done indices in a small unordered array and swap-removing
on completion means the cursor always points at work, so the scan goes away.

The one catch is ordering: swap-removal leaves the cursor on the lookup to
advance to next, so `dictPrefetchEntryValue` has to retire before it
prefetches, or it retires the wrong slot.

`dictPrefetcherRun`'s share of branch misses falls to 8.44%, 10.8% off the
process-wide total. Throughput +0.66% at 1 I/O thread (t=6.46, 12/12) and
+0.54% at 4 (t=3.72, 10/12).

`make test` passes. `dictPrefetchKeys()` uses a stack-allocated prefetcher, so
I exercised it separately with MGET at widths either side of the 16-key batch
cap and with mixed hit/miss batches. Bigger batches should gain more, since
the scan grows with batch size, but I have not measured that.