### PR TITLE
redis-cli: handle RESP3 big number replies in all output modes

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2199,9 +2199,12 @@ static sds cliFormatReplyJson(sds out, redisReply *r, int mode) {
     case REDIS_REPLY_INTEGER:
         out = sdscatprintf(out,"%lld",r->integer);
         break;
-    case REDIS_REPLY_BIGNUM:
     case REDIS_REPLY_DOUBLE:
         out = sdscatprintf(out,"%s",r->str);
+        break;
+    case REDIS_REPLY_BIGNUM:
+        /* Preserve arbitrary precision and leading zeros in valid JSON. */
+        out = jsonStringOutput(out,r->str,r->len,mode);
         break;
     case REDIS_REPLY_STRING:
     case REDIS_REPLY_VERB:

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1870,6 +1870,9 @@ static sds cliFormatReplyTTY(redisReply *r, char *prefix) {
     case REDIS_REPLY_INTEGER:
         out = sdscatprintf(out,"(integer) %lld\n",r->integer);
     break;
+    case REDIS_REPLY_BIGNUM:
+        out = sdscatprintf(out,"(big number) %s\n",r->str);
+    break;
     case REDIS_REPLY_DOUBLE:
         out = sdscatprintf(out,"(double) %s\n",r->str);
     break;
@@ -2078,6 +2081,7 @@ static sds cliFormatReplyRaw(redisReply *r) {
     case REDIS_REPLY_INTEGER:
         out = sdscatprintf(out,"%lld",r->integer);
         break;
+    case REDIS_REPLY_BIGNUM:
     case REDIS_REPLY_DOUBLE:
         out = sdscatprintf(out,"%s",r->str);
         break;
@@ -2126,6 +2130,7 @@ static sds cliFormatReplyCSV(redisReply *r) {
     case REDIS_REPLY_INTEGER:
         out = sdscatprintf(out,"%lld",r->integer);
     break;
+    case REDIS_REPLY_BIGNUM:
     case REDIS_REPLY_DOUBLE:
         out = sdscatprintf(out,"%s",r->str);
         break;
@@ -2194,6 +2199,7 @@ static sds cliFormatReplyJson(sds out, redisReply *r, int mode) {
     case REDIS_REPLY_INTEGER:
         out = sdscatprintf(out,"%lld",r->integer);
         break;
+    case REDIS_REPLY_BIGNUM:
     case REDIS_REPLY_DOUBLE:
         out = sdscatprintf(out,"%s",r->str);
         break;

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -488,15 +488,18 @@ start_server {tags {"cli"}} {
         --quoted-json {}
     } {
         test "RESP3 big number replies in $mode mode" {
-            foreach number {123456789012345678901234567890 -123456789012345678901234567890} {
-                assert_equal "${prefix}${number}" \
+            foreach number {123456789012345678901234567890 -123456789012345678901234567890 00123456789012345678901234567890 -00123456789012345678901234567890 0} {
+                set expected "${prefix}${number}"
+                if {$mode eq "--json" || $mode eq "--quoted-json"} {
+                    set expected "\"$number\""
+                }
+                assert_equal $expected \
                     [run_cli -3 $mode eval {return {big_number=ARGV[1]}} 0 $number]
 
-                set expected "${prefix}${number}"
                 if {$mode eq "--no-raw"} {
                     set expected "1) $expected"
                 } elseif {$mode eq "--json" || $mode eq "--quoted-json"} {
-                    set expected "\[$number\]"
+                    set expected "\[$expected\]"
                 }
                 assert_equal $expected \
                     [run_cli -3 $mode eval {return {{big_number=ARGV[1]}}} 0 $number]

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -480,6 +480,30 @@ start_server {tags {"cli"}} {
         assert_equal "(integer) 1" [run_cli incr counter]
     }
 
+    foreach {mode prefix} {
+        --no-raw {(big number) }
+        --raw {}
+        --csv {}
+        --json {}
+        --quoted-json {}
+    } {
+        test "RESP3 big number replies in $mode mode" {
+            foreach number {123456789012345678901234567890 -123456789012345678901234567890} {
+                assert_equal "${prefix}${number}" \
+                    [run_cli -3 $mode eval {return {big_number=ARGV[1]}} 0 $number]
+
+                set expected "${prefix}${number}"
+                if {$mode eq "--no-raw"} {
+                    set expected "1) $expected"
+                } elseif {$mode eq "--json" || $mode eq "--quoted-json"} {
+                    set expected "\[$number\]"
+                }
+                assert_equal $expected \
+                    [run_cli -3 $mode eval {return {{big_number=ARGV[1]}}} 0 $number]
+            }
+        }
+    }
+
     test_tty_cli "Bulk reply" {
         r set key "tab\tnewline\n"
         assert_equal "\"tab\\tnewline\\n\"" [run_cli get key]


### PR DESCRIPTION
`redis-cli` exits with `Unknown reply type: 13` when it receives a RESP3 big number, although hiredis already parses this reply type. This affects scripts returning `{big_number=...}` and module replies, in every CLI output mode.

For example:

```sh
redis-cli -3 --raw EVAL "return {big_number='123456789012345678901234567890'}" 0
```

Before this change, the command exits with status 1. Afterward, it prints `123456789012345678901234567890` and exits successfully.

Handle `REDIS_REPLY_BIGNUM` in the TTY, raw, CSV, and JSON formatters. TTY output uses a `(big number)` prefix; raw and CSV modes emit the decimal text directly. JSON and quoted-JSON modes emit a string to preserve arbitrary precision and leading zeros without producing invalid JSON or requiring consumers to support arbitrary-precision numeric values. No mode converts the value to a fixed-width integer or floating-point number.

Add regression coverage for positive and negative values beyond 64-bit range, leading zeros, and zero, both as standalone replies and inside arrays, across all five output modes.

Validation on macOS arm64, based on `48cc562064dbb52ef3f9cc1a5aa32db6811f5871`:

- Reproduced the failure in all five modes before the fix; the new regression test also fails on the original CLI.
- `make -j8 BUILD_TLS=no` and the updated CLI build succeeded.
- `./runtest --single integration/redis-cli --only '/RESP3 big number replies' --clients 1` passed all five new tests.
- `./runtest --single integration/redis-cli --clients 1` passed all 74 checks.
- 30 additional JSON parser round-trip checks passed for standalone values, arrays, and big-number map keys/values in both JSON modes, including leading zeros.
- `git diff --check` passed.

AI assistance was used to investigate and implement this change; the validation above was executed locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI display changes for a previously unhandled reply type; no server or wire-protocol impact.
> 
> **Overview**
> **Fixes `redis-cli` crashing with `Unknown reply type: 13`** when the server returns RESP3 big-number replies (e.g. Lua `{big_number=...}` or module output), even though hiredis already parses them.
> 
> Adds **`REDIS_REPLY_BIGNUM`** handling in the TTY, raw, CSV, and JSON reply formatters: TTY uses a `(big number)` prefix; raw/CSV print the decimal string; JSON modes wrap the value as a **string** so precision and leading zeros stay valid JSON.
> 
> Integration tests cover positive/negative oversized values, leading zeros, zero, standalone vs array replies, and all five CLI modes (`--no-raw`, `--raw`, `--csv`, `--json`, `--quoted-json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca24f0720af916ad00e1d33f21b3bd7b57df8905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->