### PR TITLE
Recount failed connections per chunk in rioConnsetWrite()

### DIFF
--- a/src/rio.c
+++ b/src/rio.c
@@ -430,7 +430,6 @@ static size_t rioConnsetWrite(rio *r, const void *buf, size_t len) {
     const size_t pre_flush_size = 256 * 1024;
     unsigned char *p = (unsigned char*) buf;
     size_t buflen = len;
-    size_t failed = 0; /* number of connections that write() returned error. */
 
     /* For small writes, we rather keep the data in user-space buffer, and flush
      * it only when it grows. however for larger writes, we prefer to flush
@@ -455,6 +454,10 @@ static size_t rioConnsetWrite(rio *r, const void *buf, size_t len) {
          * TCP socket. */
         size_t limit = PROTO_IOBUF_LEN * 2;
         size_t count = buflen < limit ? buflen : limit;
+        /* Number of connections that are down. Recounted for every chunk:
+         * connections that failed earlier are counted again here, so this
+         * must not carry over from the previous iteration. */
+        size_t failed = 0;
 
         for (size_t i = 0; i < r->io.connset.n_dst; i++) {
             size_t n_written = 0;
@@ -638,3 +641,96 @@ size_t rioWriteBulkDouble(rio *r, double d) {
     dbuf[dlen] = '\0';
     return rioWriteBulkString(r,dbuf,dlen);
 }
+
+/* -------------------------------- Tests ---------------------------------- */
+#ifdef REDIS_TEST
+#include <pthread.h>
+#include <sys/socket.h>
+#include <signal.h>
+#include "testhelp.h"
+
+#define RIOTEST_MAXCONN 8
+
+static void *rioTestDrain(void *arg) {
+    int fd = (int)(long)arg;
+    char buf[16384];
+    ssize_t n;
+    long long total = 0;
+    while ((n = read(fd, buf, sizeof(buf))) > 0) total += n;
+    return (void*)(long)total;
+}
+
+/* Write 'payload' bytes to a connset of 'nconn' connections, of which the
+ * first one is broken before the write starts. Returns what rioWrite()
+ * returned; 'delivered' gets the number of bytes the healthy connections
+ * received (they all receive the same amount). */
+static int rioTestConnsetOneBroken(int nconn, size_t payload, long long *delivered) {
+    int sp[RIOTEST_MAXCONN][2];
+    connection *conns[RIOTEST_MAXCONN];
+    pthread_t drainer[RIOTEST_MAXCONN];
+    long long got = 0;
+    char *buf = zmalloc(payload);
+    rio r;
+    int i, ret;
+
+    memset(buf, 'x', payload);
+    for (i = 0; i < nconn; i++) {
+        if (socketpair(AF_UNIX, SOCK_STREAM, 0, sp[i]) != 0) { zfree(buf); return -1; }
+        conns[i] = connectionTypeTcp()->conn_create_accepted(NULL, sp[i][0], NULL);
+        conns[i]->state = CONN_STATE_CONNECTED;
+        connBlock(conns[i]); /* rdb.c puts these connections in blocking mode. */
+    }
+    /* Connection 0 is broken: half-close it so every write returns EPIPE.
+     * The rest are healthy, and are drained so they never block. */
+    shutdown(sp[0][0], SHUT_WR);
+    for (i = 1; i < nconn; i++)
+        pthread_create(&drainer[i], NULL, rioTestDrain, (void*)(long)sp[i][1]);
+
+    rioInitWithConnset(&r, conns, nconn);
+    ret = rioWrite(&r, buf, payload);
+    /* rdb.c only flushes when the save succeeded:
+     *   if (retval == C_OK && rioFlush(&rdb) == 0) retval = C_ERR; */
+    if (ret) rioFlush(&r);
+
+    for (i = 1; i < nconn; i++) {
+        long long n;
+        close(sp[i][0]);
+        pthread_join(drainer[i], (void**)&n);
+        if (i == 1 || n < got) got = n;
+    }
+    *delivered = got;
+
+    rioFreeConnset(&r);
+    for (i = 0; i < nconn; i++) { zfree(conns[i]); close(sp[i][1]); }
+    close(sp[0][0]);
+    zfree(buf);
+    return ret;
+}
+
+int rioTest(int argc, char **argv, int flags) {
+    UNUSED(argc); UNUSED(argv); UNUSED(flags);
+    static const size_t payloads[] = { 64*1024, 256*1024, 1024*1024 };
+    static const int nconns[] = { 2, 3, 8 };
+    unsigned int pi, ni;
+    int all_ok = 1;
+
+    signal(SIGPIPE, SIG_IGN);
+    initServerConfig();
+    connTypeInitialize();
+
+    printf("\n  conns  payload   rioWrite()  delivered to the healthy connections\n");
+    for (ni = 0; ni < sizeof(nconns)/sizeof(nconns[0]); ni++) {
+        for (pi = 0; pi < sizeof(payloads)/sizeof(payloads[0]); pi++) {
+            long long got = 0;
+            int ret = rioTestConnsetOneBroken(nconns[ni], payloads[pi], &got);
+            int ok = (ret == 1 && got == (long long)payloads[pi]);
+            printf("  %5d  %7zu   %10d   %lld%s\n",
+                   nconns[ni], payloads[pi], ret, got, ok ? "" : "   <== short");
+            if (!ok) all_ok = 0;
+        }
+    }
+    test_cond("connset: one broken connection does not abort the healthy ones",
+              all_ok);
+    return 0;
+}
+#endif

--- a/src/rio.h
+++ b/src/rio.h
@@ -187,3 +187,7 @@ void rioSetAutoSync(rio *r, off_t bytes);
 void rioSetReclaimCache(rio *r, int enabled); 
 uint8_t rioCheckType(rio *r);
 #endif
+
+#ifdef REDIS_TEST
+int rioTest(int argc, char *argv[], int flags);
+#endif

--- a/src/server.c
+++ b/src/server.c
@@ -8145,6 +8145,7 @@ struct redisTest {
     {"zset", zsetTest},
     {"topk", chkTopKTest},
     {"fastfloat", fastFloatTest},
+    {"rio", rioTest},
 };
 redisTestProc *getTestProcByName(const char *name) {
     int numtests = sizeof(redisTests)/sizeof(struct redisTest);

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -930,7 +930,11 @@ start_server {tags {"repl external:skip"}} {
     $master config set repl-diskless-sync yes
     $master config set repl-rdb-channel yes
     $master config set rdbcompression no
-    $master config set rdb-key-save-delay 300
+    # The upstream variant of this test populates 10000 keys, so at 300
+    # microseconds per key the save takes about 3 seconds, and that is the
+    # window a replica has to be killed in. This one populates 200 keys, so
+    # the delay per key is raised to keep the window the same length.
+    $master config set rdb-key-save-delay 15000
     $master config set client-output-buffer-limit "replica 0 0 0"
     $master config set repl-diskless-sync-delay 5
 
@@ -963,6 +967,11 @@ start_server {tags {"repl external:skip"}} {
                 } else {
                     fail "Replicas didn't connect: [s -2 connected_slaves]"
                 }
+
+                # The replica has to go away while the RDB is still being
+                # written, otherwise the master never reaches the second chunk
+                # of a value and the test passes without covering it.
+                assert_equal 1 [s -2 rdb_bgsave_in_progress]
 
                 # kill one of the replicas
                 catch {$replica1 shutdown nosave}

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -921,3 +921,66 @@ start_server {tags {"repl external:skip tsan:skip"}} {
         }
     }
 }
+
+start_server {tags {"repl external:skip"}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+
+    $master config set repl-diskless-sync yes
+    $master config set repl-rdb-channel yes
+    $master config set rdbcompression no
+    $master config set rdb-key-save-delay 300
+    $master config set client-output-buffer-limit "replica 0 0 0"
+    $master config set repl-diskless-sync-delay 5
+
+    # Same as the upstream test, but with values large enough that a single
+    # rdbWriteRaw() spans more than one 32 KB chunk.
+    populate 200 master 200000
+
+    start_server {} {
+        set replica1 [srv 0 client]
+        $replica1 config set repl-rdb-channel yes
+
+        start_server {} {
+            set replica2 [srv 0 client]
+            $replica2 config set repl-rdb-channel yes
+
+            set load_handle [start_write_load $master_host $master_port 100 "key"]
+
+            test "Test master continues RDB delivery if not all replicas are dropped (large values)" {
+                $replica1 replicaof $master_host $master_port
+                $replica2 replicaof $master_host $master_port
+
+                wait_for_condition 50 200 {
+                    [s -2 rdb_bgsave_in_progress] == 1
+                } else {
+                    fail "Sync did not start"
+                }
+
+                wait_for_condition 500 100 {
+                    [s -2 connected_slaves] == 2
+                } else {
+                    fail "Replicas didn't connect: [s -2 connected_slaves]"
+                }
+
+                # kill one of the replicas
+                catch {$replica1 shutdown nosave}
+
+                # Wait until replica completes full sync
+                # Verify there is no other full sync attempt
+                wait_for_condition 50 1000 {
+                    [s 0 master_link_status] == "up" &&
+                    [s -2 sync_full] == 2 &&
+                    [s -2 connected_slaves] == 1
+                } else {
+                    fail "Sync session did not continue
+                          master_link_status: [s 0 master_link_status]
+                          sync_full:[s -2 sync_full]
+                          connected_slaves: [s -2 connected_slaves]"
+                }
+            }
+            stop_write_load $load_handle
+        }
+    }
+}


### PR DESCRIPTION
Fix https://github.com/redis/redis/issues/15767

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches replication RDB streaming to multiple replicas; the logic fix is small but affects critical sync paths when replicas disconnect mid-transfer.
> 
> **Overview**
> Fixes a bug in **`rioConnsetWrite()`** where the **`failed`** connection counter lived outside the per-chunk loop, so already-dead replicas kept incrementing it on every 64KB-ish chunk. On large RDB writes that could make **`failed == n_dst`** and abort the whole stream even though other replicas were still healthy—breaking diskless / **repl-rdb-channel** sync when one replica drops mid-save.
> 
> The change **resets `failed` at the start of each chunk** (still counting permanently failed peers via the skip path for that chunk only) so delivery continues to surviving connections.
> 
> Adds a **`REDIS_TEST` `rioTest`** harness (one broken socket + multi-chunk payloads) wired into the unit test runner, plus an integration case that kills a replica during a large-value RDB with **`repl-rdb-channel`** enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59c8a711582f4c61f2d0189b3ac2bedd6621b35e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->