### PR TITLE
Add USE_PROCESSOR_CLOCK for LoongArch64

### DIFF
--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -353,6 +353,63 @@ static void monotonicInit_riscv(void) {
 }
 #endif
 
+#if defined(USE_PROCESSOR_CLOCK) && defined(__loongarch_lp64) && defined(__linux__)
+#define LOONGARCH_CPUCFG2   2
+#define LOONGARCH_CPUCFG4   4
+#define LOONGARCH_CPUCFG5   5
+#define CPUCFG2_LLFTP       (1 << 14)
+
+static long mono_ticksPerMicrosecond = 0;
+
+static inline uint64_t rdtime_d(void) {
+    uint64_t val;
+    __asm__ __volatile__("rdtime.d %0, $r0": "=r" (val));
+    return val;
+}
+
+static inline uint32_t read_cpucfg(uint32_t reg) {
+    uint32_t val;
+    __asm__ volatile("cpucfg %0, %1" : "=r" (val) : "r" (reg));
+    return val;
+}
+
+static inline uint32_t calc_const_freq(void) {
+    uint32_t res, base_freq, cfm, cfd;
+
+    res = read_cpucfg(LOONGARCH_CPUCFG2);
+    if (!(res & CPUCFG2_LLFTP)) {
+        return 0;
+    }
+
+    base_freq = read_cpucfg(LOONGARCH_CPUCFG4);
+    res = read_cpucfg(LOONGARCH_CPUCFG5);
+    cfm = res & 0xffff;
+    cfd = (res >> 16) & 0xffff;
+
+    if (!base_freq || !cfm || !cfd) {
+        return 0;
+    }
+
+    return (base_freq * cfm / cfd);
+}
+
+static monotime getMonotonicUs_loongarch64(void) {
+    return rdtime_d() / mono_ticksPerMicrosecond;
+}
+
+static void monotonicInit_loongarch64(void) {
+    mono_ticksPerMicrosecond = (long)calc_const_freq() / 1000L / 1000L;
+    if (mono_ticksPerMicrosecond == 0) {
+        monotonicLog("loongarch64, unable to determine clock rate");
+        return;
+    }
+
+    snprintf(monotonic_info_string, sizeof(monotonic_info_string),
+            "Loong64 rdtime @ %ld ticks/us", mono_ticksPerMicrosecond);
+    getMonotonicUs = getMonotonicUs_loongarch64;
+}
+#endif
+
 static monotime getMonotonicUs_posix(void) {
     /* clock_gettime() is specified in POSIX.1b (1993).  Even so, some systems
      * did not support this until much later.  CLOCK_MONOTONIC is technically
@@ -391,6 +448,10 @@ const char * monotonicInit(void (*logger)(const char *fmt, ...)) {
 
     #if defined(USE_PROCESSOR_CLOCK) && defined(__riscv) && defined(__linux__)
     if (getMonotonicUs == NULL) monotonicInit_riscv();
+    #endif
+
+    #if defined(USE_PROCESSOR_CLOCK) && defined(__loongarch_lp64) && defined(__linux__)
+    if (getMonotonicUs == NULL) monotonicInit_loongarch64();
     #endif
 
     if (getMonotonicUs == NULL) monotonicInit_posix();


### PR DESCRIPTION

# Description
Implement processor clock support for LoongArch64 architecture using the `rdtime.d` and `cpucfg` instructions.

Key changes in src/monotonic.c:
- Add `__rdtime_d()` to read the 64-bit stable counter via `rdtime.d`
- Add `read_cpucfg()` to query CPU configuration registers
- Add `calc_const_freq()` to calculate the counter frequency, the implementation follows the Linux kernel's [calc_const_freq()](https://github.com/torvalds/linux/blob/940de590b839f71d6dc846160534bf202401b8b7/arch/loongarch/include/asm/time.h#L18 ) function for CPU frequency calculation.  
- Implement `getMonotonicUs_loongarch64()` and `monotonicInit_loongarch64()` to integrate with the existing monotonic clock framework

The implementation follows the LoongArch Architecture Reference Manual and is conditionally compiled when `USE_PROCESSOR_CLOCK` is defined on `__loongarch_lp64` Linux systems.

# Testing

use the same micro-benchmark monotonic_bench.c from https://github.com/redis/redis/pull/14251

<details>
  <summary> monotonic_bench.c </summary>
 
```c
#include <stdio.h>
#include <time.h>
#include <stdint.h>
#include <stdlib.h>
#include <assert.h>

#define ITERATIONS 10000000
typedef uint64_t monotime;


#define LOONGARCH_CPUCFG2   2
#define LOONGARCH_CPUCFG4   4
#define LOONGARCH_CPUCFG5   5
#define CPUCFG2_LLFTP       (1 << 14)

static long mono_ticksPerMicrosecond = 0;

static inline uint64_t rdtime_d(void) {
    uint64_t val;
    __asm__ __volatile__("rdtime.d %0, $r0": "=r" (val));
    return val;
}

static inline uint32_t read_cpucfg(uint32_t reg) {
    uint32_t val;
    __asm__ volatile("cpucfg %0, %1" : "=r" (val) : "r" (reg));
    return val;
}

static inline uint32_t get_timebase_frequency(void) {
    uint32_t res, base_freq, cfm, cfd;

    res = read_cpucfg(LOONGARCH_CPUCFG2);
    if (!(res & CPUCFG2_LLFTP)) {
        return 0;
    }

    base_freq = read_cpucfg(LOONGARCH_CPUCFG4);
    res = read_cpucfg(LOONGARCH_CPUCFG5);
    cfm = res & 0xffff;
    cfd = (res >> 16) & 0xffff;

    if (!base_freq || !cfm || !cfd) {
        return 0;
    }

    return (base_freq * cfm / cfd);
}

static monotime getMonotonicUs_loongarch64(void) {
    return rdtime_d() / mono_ticksPerMicrosecond;
}

static void monotonicInit_loongarch64(void) {
    mono_ticksPerMicrosecond = (long)get_timebase_frequency() / 1000L / 1000L;
    if (mono_ticksPerMicrosecond == 0) {
        fprintf(stderr, "monotonic: loongarch64, unable to determine clock rate");
        return;
    }
}


static monotime getMonotonicUs_posix(void) {
    /* clock_gettime() is specified in POSIX.1b (1993).  Even so, some systems
     * did not support this until much later.  CLOCK_MONOTONIC is technically
     * optional and may not be supported - but it appears to be universal.
     * If this is not supported, provide a system-specific alternate version.  */
    struct timespec ts;
    clock_gettime(CLOCK_MONOTONIC, &ts);
    return ((uint64_t)ts.tv_sec) * 1000000 + ts.tv_nsec / 1000;
}

static void monotonicInit_posix(void) {
    /* Ensure that CLOCK_MONOTONIC is supported.  This should be supported
     * on any reasonably current OS.  If the assertion below fails, provide
     * an appropriate alternate implementation.  */
    struct timespec ts;
    int rc = clock_gettime(CLOCK_MONOTONIC, &ts);
    assert(rc == 0);

}



volatile monotime dummy;

int main() {
    monotime start_loongarch64, end_loongarch64;
    monotime start_posix, end_posix;

    monotonicInit_loongarch64();

    start_loongarch64 = getMonotonicUs_loongarch64();

    for (int i = 0; i < ITERATIONS; i++) {
        dummy = getMonotonicUs_loongarch64(); 
    }

    end_loongarch64 = getMonotonicUs_loongarch64(); 

    start_posix = getMonotonicUs_posix();

    for (int i = 0; i < ITERATIONS; i++) {
        dummy = getMonotonicUs_posix();
    }

    end_posix = getMonotonicUs_posix();

    printf("iterations: %d\n", ITERATIONS);
    printf("getMonotonicUs_loongarch64 total elapsed: %llu us\n", (unsigned long long)(end_loongarch64 - start_loongarch64));
    printf("getMonotonicUs_posix   total elapsed: %llu us\n", (unsigned long long)(end_posix - start_posix));

    return 0;
}

```
</details>


```bash
[root@loongson ~]# gcc monotonic_bench.c -o monotonic_bench
[root@loongson ~]# ./monotonic_bench
iterations: 10000000
getMonotonicUs_loongarch64 total elapsed: 66080 us
getMonotonicUs_posix   total elapsed: 164107 us
```
From `monotonic_bench` on **LoongArch64 3C6000** CPU, we can see that the LoongArch64 processor clock implementation is approximately **2.48 times** faster than the POSIX monotonic clock method on this platform.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are gated by `USE_PROCESSOR_CLOCK` and only affect LoongArch64 Linux builds, with POSIX fallback when the clock rate cannot be determined.
> 
> **Overview**
> Adds an optional **LoongArch64** monotonic backend when building with `USE_PROCESSOR_CLOCK` on Linux `__loongarch_lp64`, matching the existing RISC-V processor-clock pattern.
> 
> Init reads the stable counter via **`rdtime.d`**, derives tick rate from **`cpucfg`** registers using a Linux-kernel-style **`calc_const_freq()`**, and wires **`getMonotonicUs_loongarch64`** into the shared `getMonotonicUs` function pointer (with an info string like other HW backends). **`monotonicInit()`** tries this path before the POSIX `clock_gettime` fallback; if frequency detection fails, behavior stays on POSIX unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63fb43cc7e0766ab552a38f14458175577c39ce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->