### PR TITLE
RED-132423 - Add module configuration compatibility checks for replication and ASM

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1567,7 +1567,10 @@ void asmSyncWithSource(connection *conn) {
 
     if (task->state == ASM_SEND_HANDSHAKE) {
         sds node_id = sdsnewlen(clusterNodeGetName(getMyClusterNode()), CLUSTER_NAMELEN);
-        err = sendCommand(conn, "CLUSTER", "SYNCSLOTS", "CONF", "NODE-ID", node_id, NULL);
+        sds compatibility = moduleReplicationCompatibility();
+        err = sendCommand(conn, "CLUSTER", "SYNCSLOTS", "CONF", "NODE-ID", node_id,
+                          sdslen(compatibility) ? "MODULE-COMPATIBILITY" : NULL, compatibility, NULL);
+        sdsfree(compatibility);
         sdsfree(node_id);
         if (err) goto write_error;
         task->state = ASM_HANDSHAKE_REPLY;
@@ -1921,6 +1924,8 @@ void clusterSyncSlotsCommand(client *c) {
     }
 
     if (!strcasecmp(c->argv[2]->ptr, "sync") && c->argc >= 6) {
+        /* Validate before creating an export task or transferring any data. */
+        if (moduleRequireReplicationCompatibility(c) != C_OK) return;
         /* CLUSTER SYNCSLOTS SYNC <ID> <start-slot> <end-slot> [<start-slot> <end-slot>] */
         if (c->argc % 2 == 1) {
             addReplyErrorArity(c);
@@ -2181,7 +2186,9 @@ void clusterSyncSlotsCommand(client *c) {
                 return;
             }
             /* Handle each option here */
-            if (!strcasecmp(c->argv[j]->ptr, "node-id")) {
+            if (!strcasecmp(c->argv[j]->ptr, "module-compatibility")) {
+                if (moduleCheckReplicationCompatibility(c, c->argv[j+1]->ptr) != C_OK) return;
+            } else if (!strcasecmp(c->argv[j]->ptr, "node-id")) {
                 /* node-id <node-id> */
                 sds node_id = c->argv[j + 1]->ptr;
                 int node_id_len = (int) sdslen(node_id);

--- a/src/module.c
+++ b/src/module.c
@@ -37,6 +37,7 @@
  * -------------------------------------------------------------------------- */
 
 #include "server.h"
+#include "sha256.h"
 #include "cluster.h"
 #include "cluster_asm.h"
 #include "slowlog.h"
@@ -2365,6 +2366,7 @@ void RM_SetModuleAttribs(RedisModuleCtx *ctx, const char *name, int ver, int api
     if (ctx->module != NULL) return;
     module = zmalloc(sizeof(*module));
     module->name = sdsnew(name);
+    module->replication_compatibility = NULL;
     module->ver = ver;
     module->apiver = apiver;
     module->types = listCreate();
@@ -2543,6 +2545,93 @@ void RM_Yield(RedisModuleCtx *ctx, int flags, const char *busy_reply) {
         ctx->next_yield_time = now + 1000000 / server.hz;
     }
     yield_nesting--;
+}
+
+/* Declare configuration that must match before replication or atomic slot migration.
+ * Call once from OnLoad during server startup, after loading immutable module
+ * configuration. The bytes must canonically identify the data format, algorithm
+ * version and configuration (for example a hash seed). Redis stores a SHA-256
+ * digest, not the original bytes, and compares the complete set of declarations.
+ *
+ * Modules using this API cannot be loaded or unloaded at runtime. The module
+ * must also validate restored data: this handshake does not validate RDB payloads
+ * or protect RESTORE/MIGRATE. This is a compatibility check, not authentication.
+ * Returns ERR for an invalid context, empty data, repeated registration or a
+ * runtime load. Peers without this API cannot replicate declared configurations. */
+int RM_SetReplicationCompatibility(RedisModuleCtx *ctx, const char *data, size_t len) {
+    if (!ctx->module || !ctx->module->onload || !listLength(server.loadmodule_queue) ||
+        ctx->module->replication_compatibility || !data || !len) return REDISMODULE_ERR;
+    SHA256_CTX hash;
+    unsigned char digest[SHA256_BLOCK_SIZE];
+    sha256_init(&hash);
+    sha256_update(&hash, (const unsigned char *)data, len);
+    sha256_final(&hash, digest);
+    ctx->module->replication_compatibility = sdsnewlen(digest, sizeof(digest));
+    return REDISMODULE_OK;
+}
+
+/* Order-independent, length-delimited manifest of all declared modules. */
+sds moduleReplicationCompatibility(void) {
+    rax *ordered = raxNew();
+    dictIterator di;
+    dictEntry *de;
+    dictInitIterator(&di, modules);
+    while ((de = dictNext(&di))) {
+        RedisModule *m = dictGetVal(de);
+        if (m->replication_compatibility)
+            raxInsert(ordered, (unsigned char *)m->name, sdslen(m->name), m, NULL);
+    }
+    dictResetIterator(&di);
+    sds result = sdsempty();
+    if (raxSize(ordered)) {
+        SHA256_CTX hash;
+        unsigned char digest[SHA256_BLOCK_SIZE];
+        sha256_init(&hash);
+        raxIterator it;
+        raxStart(&it, ordered);
+        raxSeek(&it, "^", NULL, 0);
+        while (raxNext(&it)) {
+            RedisModule *m = it.data;
+            /* Names contain no NUL and digests are fixed length. */
+            sha256_update(&hash, it.key, it.key_len);
+            sha256_update(&hash, (const unsigned char *)"\0", 1);
+            sha256_update(&hash, (unsigned char *)m->replication_compatibility, SHA256_BLOCK_SIZE);
+        }
+        raxStop(&it);
+        sha256_final(&hash, digest);
+        static const char hex[] = "0123456789abcdef";
+        char encoded[SHA256_BLOCK_SIZE * 2];
+        for (size_t i = 0; i < sizeof(digest); i++) {
+            encoded[2*i] = hex[digest[i] >> 4];
+            encoded[2*i+1] = hex[digest[i] & 15];
+        }
+        result = sdscatlen(result, encoded, sizeof(encoded));
+    }
+    raxFree(ordered);
+    return result;
+}
+
+int moduleCheckReplicationCompatibility(client *c, sds peer) {
+    sds local = moduleReplicationCompatibility();
+    c->module_compatibility_checked = sdscmp(local, peer) == 0;
+    sdsfree(local);
+    if (!c->module_compatibility_checked) {
+        addReplyError(c, "-MODULECONFIG incompatible module replication configuration");
+        return C_ERR;
+    }
+    return C_OK;
+}
+
+int moduleRequireReplicationCompatibility(client *c) {
+    if (c->module_compatibility_checked) return C_OK;
+    sds local = moduleReplicationCompatibility();
+    int required = sdslen(local) != 0;
+    sdsfree(local);
+    if (required) {
+        addReplyError(c, "-MODULECONFIG module compatibility handshake required");
+        return C_ERR;
+    }
+    return C_OK;
 }
 
 /* Set flags defining capabilities or behavior bit flags.
@@ -13519,6 +13608,7 @@ void moduleFreeModuleStructure(struct RedisModule *module) {
     listRelease(module->usedby);
     listRelease(module->using);
     listRelease(module->module_configs);
+    sdsfree(module->replication_compatibility);
     sdsfree(module->name);
     moduleLoadQueueEntryFree(module->loadmod);
     zfree(module);
@@ -13788,6 +13878,9 @@ int moduleUnload(sds name, const char **errmsg, int forced_unload) {
     } else if (sdslen(module->loadmod->path) == 0) {
         *errmsg = "the module can't be unloaded";
         return C_ERR;
+    } else if (module->replication_compatibility && !forced_unload) {
+        *errmsg = "module replication configuration is immutable until restart";
+        return C_ERR;
     } else if (listLength(module->types) && !forced_unload) {
         *errmsg = "the module exports one or more module-side data "
                   "types, can't unload";
@@ -13953,6 +14046,10 @@ sds genModulesInfoString(sds info) {
         sdsfree(options);
     }
     dictResetIterator(&di);
+    sds compatibility = moduleReplicationCompatibility();
+    if (sdslen(compatibility))
+        info = sdscatfmt(info, "module_replication_compatibility:%S\r\n", compatibility);
+    sdsfree(compatibility);
     return info;
 }
 
@@ -15852,6 +15949,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ModuleTypeGetValue);
     REGISTER_API(IsIOError);
     REGISTER_API(SetModuleOptions);
+    REGISTER_API(SetReplicationCompatibility);
     REGISTER_API(SignalModifiedKey);
     REGISTER_API(SaveUnsigned);
     REGISTER_API(LoadUnsigned);

--- a/src/networking.c
+++ b/src/networking.c
@@ -258,6 +258,7 @@ client *createClient(connection *conn) {
     c->stat_avg_pipeline_length_cnt = 0;
     c->task = NULL;
     c->node_id = NULL;
+    c->module_compatibility_checked = 0;
     c->himport_fieldsets = NULL;
     c->compression_level = 0;
     c->compression_state = NULL;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1286,6 +1286,7 @@ REDISMODULE_API int (*RedisModule_ModuleTypeReplaceValue)(RedisModuleKey *key, R
 REDISMODULE_API RedisModuleType * (*RedisModule_ModuleTypeGetType)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API void * (*RedisModule_ModuleTypeGetValue)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsIOError)(RedisModuleIO *io) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_SetReplicationCompatibility)(RedisModuleCtx *ctx, const char *data, size_t len) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetModuleOptions)(RedisModuleCtx *ctx, int options) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SignalModifiedKey)(RedisModuleCtx *ctx, RedisModuleString *keyname) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SaveUnsigned)(RedisModuleIO *io, uint64_t value) REDISMODULE_ATTR;
@@ -1688,6 +1689,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ModuleTypeGetValue);
     REDISMODULE_GET_API(IsIOError);
     REDISMODULE_GET_API(SetModuleOptions);
+    REDISMODULE_GET_API(SetReplicationCompatibility);
     REDISMODULE_GET_API(SignalModifiedKey);
     REDISMODULE_GET_API(SaveUnsigned);
     REDISMODULE_GET_API(LoadUnsigned);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1208,6 +1208,7 @@ int startBgsaveForReplication(int mincapa, int req) {
 void syncCommand(client *c) {
     /* ignore SYNC if already slave or in monitor mode */
     if (c->flags & CLIENT_SLAVE) return;
+    if (moduleRequireReplicationCompatibility(c) != C_OK) return;
 
     /* Check if this is a failover request to a replica with the same replid and
      * become a master if so. */
@@ -1475,7 +1476,9 @@ void replconfCommand(client *c) {
 
     /* Process every option-value pair. */
     for (j = 1; j < c->argc; j+=2) {
-        if (!strcasecmp(c->argv[j]->ptr,"listening-port")) {
+        if (!strcasecmp(c->argv[j]->ptr,"module-compatibility")) {
+            if (moduleCheckReplicationCompatibility(c, c->argv[j+1]->ptr) != C_OK) return;
+        } else if (!strcasecmp(c->argv[j]->ptr,"listening-port")) {
             long port;
 
             if ((getLongFromObjectOrReply(c,c->argv[j+1],
@@ -1643,6 +1646,7 @@ void replconfCommand(client *c) {
                 return;
             }
             c->main_ch_client_id = (uint64_t)client_id;
+            c->module_compatibility_checked = main_ch->module_compatibility_checked;
             /* Inherit the rdb-no-compress and rdb-no-checksum request from the main channel. */
             if (main_ch->slave_req & SLAVE_REQ_RDB_NO_COMPRESS)
                 c->slave_req |= SLAVE_REQ_RDB_NO_COMPRESS;
@@ -3115,6 +3119,13 @@ int slaveTryPartialResynchronization(connection *conn, int read_reply) {
      * Return PSYNC_NOT_SUPPORTED on errors we don't understand, otherwise
      * return PSYNC_TRY_LATER if we believe this is a transient error. */
 
+    if (!strncmp(reply, "-MODULECONFIG", 13)) {
+        /* Do not fall back to SYNC: it would fail identically and retry tightly. */
+        serverLog(LL_WARNING, "Module replication compatibility check failed: %s", reply);
+        sdsfree(reply);
+        return PSYNC_TRY_LATER;
+    }
+
     if (!strncmp(reply,"-NOMASTERLINK",13) ||
         !strncmp(reply,"-LOADING",8))
     {
@@ -3380,6 +3391,28 @@ void syncWithMaster(connection *conn) {
         if (err[0] == '-') {
             serverLog(LL_NOTICE,"(Non critical) Master does not understand "
                                   "REPLCONF capa: %s", err);
+        }
+        sdsfree(err);
+        err = NULL;
+        sds compatibility = moduleReplicationCompatibility();
+        if (sdslen(compatibility)) {
+            err = sendCommand(conn, "REPLCONF", "module-compatibility", compatibility, NULL);
+            sdsfree(compatibility);
+            if (err) goto write_error;
+            server.repl_state = REPL_STATE_RECEIVE_MODULE_COMPATIBILITY_REPLY;
+            return;
+        }
+        sdsfree(compatibility);
+        server.repl_state = REPL_STATE_SEND_PSYNC;
+    }
+
+    if (server.repl_state == REPL_STATE_RECEIVE_MODULE_COMPATIBILITY_REPLY) {
+        err = receiveSynchronousResponse(conn);
+        if (err == NULL) goto no_response_error;
+        if (strcmp(err, "+OK")) {
+            serverLog(LL_WARNING, "Module replication compatibility check failed: %s", err);
+            sdsfree(err);
+            goto error;
         }
         sdsfree(err);
         err = NULL;

--- a/src/server.h
+++ b/src/server.h
@@ -550,6 +550,7 @@ typedef enum {
     REPL_STATE_RECEIVE_REQ_REPLY,   /* Wait for REPLCONF reply */
     REPL_STATE_RECEIVE_CLIENT_COMP, /* Wait for CLIENT_COMP reply */
     REPL_STATE_RECEIVE_CAPA_REPLY,  /* Wait for REPLCONF reply */
+    REPL_STATE_RECEIVE_MODULE_COMPATIBILITY_REPLY, /* Wait for compatibility validation */
     REPL_STATE_SEND_PSYNC,          /* Send PSYNC */
     REPL_STATE_RECEIVE_PSYNC_REPLY, /* Wait for PSYNC reply */
     /* --- End of handshake states --- */
@@ -1030,6 +1031,7 @@ struct RedisModule {
     char *name;     /* Module name. */
     int ver;        /* Module version. We use just progressive integers. */
     int apiver;     /* Module API version as requested during initialization.*/
+    sds replication_compatibility; /* Immutable digest of module data configuration. */
     list *types;    /* Module data types. */
     list *usedby;   /* List of modules using APIs from this one. */
     list *using;    /* List of modules we use some APIs of. */
@@ -1695,6 +1697,7 @@ typedef struct client {
     unsigned long long net_output_bytes;   /* Total network output bytes sent to this client. */
     unsigned long long commands_processed; /* Total count of commands this client executed. */
     struct asmTask *task;       /* Atomic slot migration task */
+    int module_compatibility_checked; /* Peer matched the module configuration. */
     char *node_id;              /* Node ID to connect to for atomic slot migration */
 
     redisAtomic int pending_read; /* Flag indicating an IO thread client residing
@@ -3249,6 +3252,9 @@ void modulesCron(void);
 int moduleOnLoad(int (*onload)(void *, void **, int), const char *path, void *handle, void **module_argv, int module_argc, int is_loadex);
 int moduleLoad(const char *path, void **argv, int argc, int is_loadex);
 int moduleUnload(sds name, const char **errmsg, int forced_unload);
+sds moduleReplicationCompatibility(void);
+int moduleCheckReplicationCompatibility(client *c, sds peer);
+int moduleRequireReplicationCompatibility(client *c);
 void moduleLoadInternalModules(void);
 void moduleLoadFromQueue(void);
 int moduleGetCommandKeysViaAPI(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -45,6 +45,7 @@ TEST_MODULES = \
     commandfilter.so \
     basics.so \
     testrdb.so \
+    replicationcompat.so \
     fork.so \
     infotest.so \
     propagate.so \

--- a/tests/modules/replicationcompat.c
+++ b/tests/modules/replicationcompat.c
@@ -1,0 +1,27 @@
+#include "redismodule.h"
+#include <stdio.h>
+#include <string.h>
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 1 || argc > 2) return REDISMODULE_ERR;
+    /* Bootstrap the one API needed to select the module name before Init. */
+    RedisModule_GetApi = (int (*)(const char *, void *))((void **)ctx)[0];
+    REDISMODULE_GET_API(StringPtrLen);
+    const char *name = argc == 2 ? RedisModule_StringPtrLen(argv[1], NULL) : "replicationcompat";
+    if (RedisModule_Init(ctx, name, 1, REDISMODULE_APIVER_1) != REDISMODULE_OK)
+        return REDISMODULE_ERR;
+    size_t len;
+    const char *value = RedisModule_StringPtrLen(argv[0], &len);
+    if (!strcmp(value, "none")) return REDISMODULE_OK;
+    char port[32];
+    if (!strcmp(value, "local-port")) {
+        RedisModuleServerInfoData *info = RedisModule_GetServerInfo(ctx, "server");
+        int err;
+        long long n = RedisModule_ServerInfoGetFieldSigned(info, "tcp_port", &err);
+        RedisModule_FreeServerInfo(ctx, info);
+        if (err) return REDISMODULE_ERR;
+        len = snprintf(port, sizeof(port), "%lld", n);
+        value = port;
+    }
+    return RedisModule_SetReplicationCompatibility(ctx, value, len);
+}

--- a/tests/unit/cluster/module-replication-compatibility.tcl
+++ b/tests/unit/cluster/module-replication-compatibility.tcl
@@ -1,0 +1,22 @@
+set testmodule [file normalize tests/modules/replicationcompat.so]
+foreach ::compatibility_test_configuration {shared local-port} {
+    start_cluster 2 0 [list tags {external:skip cluster modules} overrides [list loadmodule "$testmodule $::compatibility_test_configuration"]] {
+        test "ASM validates module compatibility ($::compatibility_test_configuration)" {
+            R 0 set {{06S}:original} value
+            set task [R 1 cluster migration import 0 0]
+            wait_for_condition 200 50 {
+                [dict get [lindex [R 1 cluster migration status id $task] 0] state] in {completed failed}
+            } else { fail "Migration did not finish" }
+            set status [lindex [R 1 cluster migration status id $task] 0]
+            if {$::compatibility_test_configuration eq "shared"} {
+                assert_equal completed [dict get $status state]
+                assert_equal value [R 1 get {{06S}:original}]
+            } else {
+                assert_equal failed [dict get $status state]
+                assert_match {*MODULECONFIG*} [dict get $status last_error]
+                assert_equal value [R 0 get {{06S}:original}]
+                assert_equal 0 [R 1 cluster countkeysinslot 0]
+            }
+        }
+    }
+}

--- a/tests/unit/moduleapi/replicationcompat.tcl
+++ b/tests/unit/moduleapi/replicationcompat.tcl
@@ -1,0 +1,75 @@
+set testmodule [file normalize tests/modules/replicationcompat.so]
+
+tags "modules external:skip" {
+    foreach rdbchannel {yes no} {
+        test "Matching module configurations replicate (RDB channel $rdbchannel)" {
+            start_server [list overrides [list loadmodule "$testmodule shared" repl-rdb-channel $rdbchannel]] {
+                set replica [srv 0 client]
+                start_server [list overrides [list loadmodule "$testmodule shared" repl-rdb-channel $rdbchannel repl-diskless-sync-delay 0]] {
+                    r set before initial
+                    $replica replicaof [srv 0 host] [srv 0 port]
+                    wait_for_sync $replica
+                    assert_equal initial [$replica get before]
+                    r set after streamed
+                    wait_for_condition 100 50 {[$replica get after] eq "streamed"} else {
+                        fail "Incremental replication failed"
+                    }
+                    r client kill type replica
+                    wait_for_sync $replica
+                    r set reconnected yes
+                    wait_for_condition 100 50 {[$replica get reconnected] eq "yes"} else {
+                        fail "Replication failed after reconnect"
+                    }
+                }
+            }
+        }
+    }
+    foreach pair {{a b} {a none} {none a}} {
+        lassign $pair source_config destination_config
+        test "Incompatible module configurations preserve destination ($pair)" {
+            start_server [list overrides [list loadmodule "$testmodule $destination_config"]] {
+                set replica [srv 0 client]
+                $replica set preserve original
+                start_server [list overrides [list loadmodule "$testmodule $source_config" repl-diskless-sync-delay 0]] {
+                    r set source data
+                    $replica replicaof [srv 0 host] [srv 0 port]
+                    # Observe a completed rejection, not just a not-yet-established link.
+                    wait_for_log_messages -1 {"*Module replication compatibility check failed*"} 0 100 50
+                    assert_equal down [s -1 master_link_status]
+                    assert_equal original [$replica get preserve]
+                    assert_equal 0 [$replica exists source]
+                    assert_equal 0 [s 0 sync_full]
+                }
+            }
+        }
+    }
+    start_server {} {
+        test "Replication compatibility cannot be registered by runtime MODULE LOAD" {
+            assert_error {*Error loading the extension*} {r module load $testmodule shared}
+        }
+    }
+    start_server [list overrides [list loadmodule "$testmodule shared"]] {
+        test "Replication compatibility cannot be unloaded" {
+            assert_error {*immutable until restart*} {r module unload replicationcompat}
+        }
+        test "Missing compatibility preflight rejects direct SYNC and PSYNC" {
+            assert_error {*MODULECONFIG*} {r sync}
+            assert_error {*MODULECONFIG*} {r psync ? -1}
+        }
+        test "Mismatched compatibility preflight is explicit" {
+            assert_error {*MODULECONFIG*} {r replconf module-compatibility incorrect}
+        }
+    }
+}
+
+tags "modules external:skip" {
+    test "Module compatibility is independent of module load order" {
+        start_server [list config_lines [list loadmodule "$testmodule first moduleA" loadmodule "$testmodule second moduleB"]] {
+            set expected [s module_replication_compatibility]
+            assert_equal 64 [string length $expected]
+            start_server [list config_lines [list loadmodule "$testmodule second moduleB" loadmodule "$testmodule first moduleA"]] {
+                assert_equal $expected [s module_replication_compatibility]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Modules whose serialized data depends on immutable configuration need to reject incompatible replication peers before transferring data or flushing the destination. This adds a startup-only `RedisModule_SetReplicationCompatibility` API and checks its aggregate manifest before full/partial replication and atomic slot migration (ASM).

Modules register canonical bytes identifying their algorithm, format version and configuration. Redis hashes those declarations into an order-independent manifest; only the fingerprint is exchanged. Mismatches, missing declarations and unsupported peers fail closed with `MODULECONFIG`. Reconnects repeat validation, and the separate RDB channel inherits the main channel's validation. Deployments without declarations keep the existing handshake.

Registered modules cannot be loaded or unloaded at runtime. The API checks transport compatibility, not authentication or individual RDB/RESTORE payloads; modules must validate those separately. `INFO modules` exposes the aggregate fingerprint for diagnosis.

This supports the OSS Cluster RedisBloom shared-seed implementation in https://github.com/RedisBloom/RedisBloom/pull/1065. Enterprise provisioning, the Enterprise Replica Of syncer and HLL changes are outside this PR.

Validation on macOS arm64:
- Redis build passed.
- New module API and cluster compatibility suites passed, including matching/mismatching peers, both RDB-channel modes, reconnect, destination preservation, load order and ASM.
- Existing `integration/replication-rdbchannel` suite passed.

Draft for API and protocol review.
