### PR TITLE
Update redisbloom module reference to v8.11.81

### DIFF
--- a/modules/modules.yaml
+++ b/modules/modules.yaml
@@ -64,7 +64,7 @@
 modules:
   - name: redisbloom
     repo: https://github.com/redisbloom/redisbloom
-    ref: v8.11.80
+    ref: v8.11.81
     target_module: redisbloom.so
     loadmodule: ./modules/redisbloom/redisbloom.so
   - name: redisearch


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Routine dependency pin bump in the release manifest with no build or config logic changes.
> 
> **Overview**
> Bumps the bundled **RedisBloom** module pin in `modules/modules.yaml` from **v8.11.80** to **v8.11.81**.
> 
> That manifest ref drives `make modules-update`, Docker bundled-module installs, tarball builds, and the `loadmodule` path for `./modules/redisbloom/redisbloom.so`—no other module entries change in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0162f7d7f8a673ec9a4e006c5812671cefaa7ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->