### PR TITLE
Repurpose the kvobj key-header byte into kvBits: 2 bits of sds type + 6 free bits

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -22,6 +22,8 @@
 #define strtold(a,b) ((long double)strtod((a),(b)))
 #endif
 
+static_assert(sizeof(kvBits) == 1, "kvBits must be a single byte");
+
 /* Map a metadata ID (bit index) to its compacted slot number among set bits,
  * then return a pointer to that slot. Caller must ensure the ID bit is set. */
 uint64_t *kvobjMetaRef(kvobj *kv, int metaId) {
@@ -52,9 +54,9 @@ uint64_t *kvobjMetaRef(kvobj *kv, int metaId) {
  * 
  * Example of "mykey" with expiration and metadata :
  * 
- *    +------------+------------+-----------+------------------+------------------------+
- *    | m.meta (8) | expiry (8) | robj (16) | key-hdr-size (1) | sdshdr5 "mykey" \0 (7) | 
- *    +------------+------------+-----------+------------------+------------------------+
+ *    +------------+------------+-----------+------------+------------------------+
+ *    | m.meta (8) | expiry (8) | robj (16) | kvbits (1) | sdshdr5 "mykey" \0 (7) | 
+ *    +------------+------------+-----------+------------+------------------------+
  *                              ^
  *                              |
  *                              kvobjCreate() returns pointer to here
@@ -74,11 +76,12 @@ kvobj *kvobjCreate(int type, const sds key, void *ptr, uint32_t keyMetaBits) {
     /* Calculate embedded key size */
     char key_sds_type = sdsReqType(key_sds_len);
     size_t key_sds_size = sdsReqSize(key_sds_len, key_sds_type);
+    debugServerAssert(key_sds_type <= SDS_TYPE_32); /* keys are never > 4GB */
 
     /* Compute the base object size */
-    size_t min_size = sizeof(robj);
+    size_t min_size = sizeof(robj) + sizeof(kvBits);
     min_size += sizeMetas;
-    min_size += 1 + key_sds_size; /* 1 byte for SDS header size */
+    min_size += key_sds_size;
 
     /* Allocate object memory */
     char *alloc = zmalloc(min_size);
@@ -90,12 +93,11 @@ kvobj *kvobjCreate(int type, const sds key, void *ptr, uint32_t keyMetaBits) {
     kv->lru = 0;
     kv->iskvobj = 1;
     kv->metabits = keyMetaBits;
+    kvobjBits(kv)->key_sds_type = key_sds_type;
+    kvobjBits(kv)->unused = 0;
 
-    /* The memory after the struct where we embedded data. */
-    char *data = (void *)(kv + 1);
-
-    /* Store embedded key. */
-    *data++ = sdsHdrSize(key_sds_type);
+    /* Store embedded key, right after the kvBits. */
+    char *data = (char *) (kvobjBits(kv) + 1);
     sdsnewplacement(data, key_sds_size, key_sds_type, key, key_sds_len);
 
     /* Reset each allocated metadata to its reset_value (such as Expiry=-1, etc) */
@@ -156,9 +158,9 @@ robj *createRawStringObject(const char *ptr, size_t len) {
  * expire to the new object. LRU is set to 0. 
  * 
  * Example of kvobj "mykey" with embedded "myvalue" (16+1+7+11 = 35bytes):
- *    +-----------+------------------+------------------------+----------------------------+
- *    | robj (16) | key-hdr-size (1) | sdshdr5 "mykey" \0 (7) | sdshdr8 "myvalue" \0  (11) | 
- *    +-----------+------------------+------------------------+----------------------------+
+ *    +-----------+------------+------------------------+----------------------------+
+ *    | robj (16) | kvbits (1) | sdshdr5 "mykey" \0 (7) | sdshdr8 "myvalue" \0  (11) | 
+ *    +-----------+------------+------------------------+----------------------------+
  */
 static kvobj *kvobjCreateEmbedString(const char *val_ptr, size_t val_len,
                                      const sds key, uint32_t keyMetaBits)
@@ -171,14 +173,15 @@ static kvobj *kvobjCreateEmbedString(const char *val_ptr, size_t val_len,
     size_t key_sds_len = sdslen(key);
     char key_sds_type = sdsReqType(key_sds_len);
     size_t key_sds_size = sdsReqSize(key_sds_len, key_sds_type);
+    debugServerAssert(key_sds_type <= SDS_TYPE_32); /* keys are never > 4GB */
 
     /* Calculate size for embedded value (always SDS_TYPE_8) */
     size_t val_sds_size = sdsReqSize(val_len, SDS_TYPE_8);
 
     /* Compute base object size */
-    size_t min_size = sizeof(robj) + val_sds_size;
+    size_t min_size = sizeof(robj) + sizeof(kvBits) + val_sds_size;
     min_size += sizeMetas;
-    min_size += 1 + key_sds_size; /* 1 byte for SDS header size */
+    min_size += key_sds_size;
 
     /* Allocate object memory */
     size_t bufsize = 0;
@@ -191,11 +194,11 @@ static kvobj *kvobjCreateEmbedString(const char *val_ptr, size_t val_len,
     o->lru = 0;
     o->metabits = keyMetaBits;
     o->iskvobj = 1;
+    kvobjBits(o)->key_sds_type = key_sds_type;
+    kvobjBits(o)->unused = 0;
 
-    /* The memory after the struct where we embedded data. */
-    char *data = (char *)(o + 1);
-    /* Store embedded key */
-    *data++ = sdsHdrSize(key_sds_type);
+    /* Store embedded key, right after the kvBits. */
+    char *data = (char *) (kvobjBits(o) + 1);
     sdsnewplacement(data, key_sds_size, key_sds_type, key, key_sds_len);
     data += key_sds_size;
 
@@ -213,10 +216,10 @@ static kvobj *kvobjCreateEmbedString(const char *val_ptr, size_t val_len,
  * an object where the sds string is actually an unmodifiable string
  * allocated in the same chunk as the object itself.
  * 
- * Example of robj with embedded "myvalue" (16+1+11 = 28 bytes):
- *    +-----------+------------------+----------------------------+
- *    | robj (16) | key-hdr-size (1) | sdshdr8 "myvalue" \0  (11) | 
- *    +-----------+------------------+----------------------------+
+ * Example of robj with embedded "myvalue" (16+11 = 27 bytes):
+ *    +-----------+----------------------------+
+ *    | robj (16) | sdshdr8 "myvalue" \0  (11) | 
+ *    +-----------+----------------------------+
  */
 static inline robj *createEmbeddedStringObject(const char *val_ptr, size_t val_len) {
     /* Calculate size for embedded value (always SDS_TYPE_8) */
@@ -242,12 +245,15 @@ static inline robj *createEmbeddedStringObject(const char *val_ptr, size_t val_l
     return o;
 }
 
+/* SDS header size of the embedded key, indexed by kvBits->key_sds_type. */
 sds kvobjGetKey(const kvobj *kv) {
-    unsigned char *data = (void *)(kv + 1);
+    static const uint8_t kvobjKeyHdrSize[4] = {
+        sizeof(struct sdshdr5), sizeof(struct sdshdr8),
+        sizeof(struct sdshdr16), sizeof(struct sdshdr32)
+    };
     debugServerAssert(kv->iskvobj);
-    uint8_t hdr_size = *(uint8_t *)data;
-    data += 1 + hdr_size;
-    return (sds)data;
+    kvBits *bits = kvobjBits(kv);
+    return (sds) ((char *) (bits + 1) + kvobjKeyHdrSize[bits->key_sds_type]);
 }
 
 long long kvobjGetExpire(const kvobj *kv) {
@@ -286,8 +292,8 @@ kvobj *kvobjSet(sds key, robj *val, uint32_t keyMetaBits) {
 
         /* Embed when the sum is less than a cache line (Metadata is discarded 
          * since we don't have to be accurate and it is placed before the object) */
-        size_t size = sizeof(kvobj);
-        size += (key != NULL) * (sdslen(key) + 3); /* hdr size (1) + hdr (1) + nullterm (1) */
+        size_t size = sizeof(kvobj) + sizeof(kvBits);
+        size += (key != NULL) * (sdslen(key) + 2); /* sds hdr (1) + nullterm (1) */
         size += 4 + len; /* embstr header (3) + nullterm (1) */
         if (size <= CACHE_LINE_SIZE) {
             kv = kvobjCreateEmbedString(val->ptr, len, key, keyMetaBits);
@@ -1352,11 +1358,10 @@ size_t kvobjComputeSize(robj *key, kvobj *o, size_t sample_size, int dbid) {
  */
 size_t kvobjAllocSize(kvobj *o) {
     debugServerAssert(o->iskvobj);
-    size_t asize = sizeof(kvobj);
+    size_t asize = sizeof(kvobj) + sizeof(kvBits);
     /* Add metadata size */
     asize += getNumMeta(o->metabits) * sizeof(uint64_t);
     /* Add embedded key size */
-    asize += 1; /* embedded key header size */
     asize += sdsAllocSize(kvobjGetKey(o));
     /* Add embedded string size */
     if (o->encoding == OBJ_ENCODING_EMBSTR)

--- a/src/object.h
+++ b/src/object.h
@@ -32,14 +32,15 @@
  * When iskvobj is set, it also contains:
  *   - metabits: bitmap of additional metadata attached to the object.
  *   - lru: LRU time (relative to global lru_clock) or LFU data (see robj above).
+ *   - kvbits: one extra byte that follows the robj (see struct kvBits below).
  *   - embedded key: the key string is stored inline after the struct.
  *   - embedded value: for small strings, the value is stored inline after the key.
  *
  * Example layout with key and embedded value "myvalue":
- *    +--------------+--------------+--------------------+----------------------+
- *    | serverObject | key-hdr-size | sdshdr5 "mykey" \0 | sdshdr8 "myvalue" \0 |
- *    | 16 bytes     | 1 byte       | 1      +   5   + 1 | 3    +      7    + 1 |
- *    +--------------+--------------+--------------------+----------------------+
+ *    +--------------+----------+--------------------+----------------------+
+ *    | serverObject | kvbits   | sdshdr5 "mykey" \0 | sdshdr8 "myvalue" \0 |
+ *    | 16 bytes     | 1 byte   | 1      +   5   + 1 | 3    +      7    + 1 |
+ *    +--------------+----------+--------------------+----------------------+
  * 
  * kvobj with metadata (+expiration)
  * ---------------------------------
@@ -48,18 +49,18 @@
  * the kvobj itself, in reverse class order.
  * 
  * Example of a key with expiration time (metabits=0b00000001):
- *     +--------------+--------------+--------------+--------------------+
- *     | Expiry Time  | serverObject | key-hdr-size | sdshdr5 "mykey" \0 |
- *     | 8 byte       | 16 bytes     | 1 byte       | 1      +   5   + 1 |
- *     +--------------+--------------+--------------+--------------------+
+ *     +--------------+--------------+----------+--------------------+
+ *     | Expiry Time  | serverObject | kvbits   | sdshdr5 "mykey" \0 |
+ *     | 8 byte       | 16 bytes     | 1 byte   | 1      +   5   + 1 |
+ *     +--------------+--------------+----------+--------------------+
  *                    ^
  *                    +---- kvobjCreate() returns pointer here
  * 
  * Example with metadata of class1 and class3 attached (metabits=0b00001010):
- * +--------------+--------------+--------------+--------------+--------------------+
- * | meta (class3)| meta (class1)| serverObject | key-hdr-size | sdshdr5 "mykey" \0 |
- * | 8 byte       | 8 byte       | 16 bytes     | 1 byte       | 1      +   5   + 1 |
- * +--------------+--------------+--------------+--------------+--------------------+
+ * +--------------+--------------+--------------+----------+--------------------+
+ * | meta (class3)| meta (class1)| serverObject | kvbits   | sdshdr5 "mykey" \0 |
+ * | 8 byte       | 8 byte       | 16 bytes     | 1 byte   | 1      +   5   + 1 |
+ * +--------------+--------------+--------------+----------+--------------------+
  *                               ^
  *                               +---- kvobjCreate() returns pointer here
  * 
@@ -118,6 +119,22 @@ typedef struct redisObject robj;
 
 /* kvobj: see header comment above for definition and memory layout. */
 typedef struct redisObject kvobj;
+
+/* Whenever an robj serves as a kvobj base (iskvobj=1), a single byte of extra
+ * bits is allocated right after it, before the embedded key. Only 2 bits are
+ * used for now, the remaining 6 are free for future use. */
+typedef struct __attribute__ ((__packed__)) kvBits {
+    /* SDS header type of the embedded key: SDS_TYPE_5/8/16 or 32 (values 0..3). 
+     * Keys are never longer than 4GB, so SDS_TYPE_64 is not needed. */
+    unsigned key_sds_type : 2;
+    unsigned unused : 6;       /* Free bits. Available for future use. */
+} kvBits;
+
+/* Returns the kvBits that follow the robj. Valid only if kv->iskvobj is set.
+ * Note that a plain robj has no such byte allocated after it. */
+static inline kvBits *kvobjBits(const kvobj *kv) {
+    return (kvBits *) (void *) (kv + 1);
+}
 
 kvobj *kvobjCreate(int type, const sds key, void *ptr, uint32_t keyMetaBits);
 kvobj *kvobjSet(sds key, robj *val, uint32_t keyMetaBits);


### PR DESCRIPTION
`kvobj` allocates one byte between the `robj` and the embedded key, which until
now held the sds header size of that key (1, 3, 5 or 9). This wastes most of the
byte: the key's sds type is one of `SDS_TYPE_5/8/16/32` only — keys are never
longer than 4GB, so `SDS_TYPE_64` is unreachable — and those four values are
already `0..3`, so 2 bits are enough to describe it.

This commit gives that byte a name and a layout, `struct kvBits`, storing the
sds type in 2 bits and leaving 6 bits free for future kvobj-only flags:

```c
typedef struct __attribute__ ((__packed__)) kvBits {
    unsigned key_sds_type : 2;
    unsigned unused : 6;
} kvBits;
```

Reached via `kvobjBits(kv)`, which is valid only when `kv->iskvobj` is set — a
plain `robj` has no such byte allocated after it.

Ideally `robj` and `kvobj` would be two distinct structs, and `kvBits` would be
a field of the latter. Until that split happens, `kvobj` remains a typedef of
`struct redisObject` and `kvBits` describes the byte that follows it.

**No functional or memory change:** the allocation layout is byte-identical, so
`MEMORY USAGE` output is unchanged, and nothing here is persisted or sent over
the wire (RDB stores the key separately), so the bitfield ordering is internal.

**Testing:** builds clean with `-pedantic -Wall -W`. `unit/type/string`,
`unit/expire`, `unit/other`, `unit/keyspace`, `unit/dump`, `unit/type/hash`,
`unit/info-keysizes`, `unit/memefficiency`, `unit/type/incr`, `unit/maxmemory`
all pass. Manually exercised all four key sds types (lengths 10 / 100 / 200 /
1000 / 70000) through set/get/strlen/ttl and a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core in-memory key-value object layout and key pointer arithmetic; mistakes could corrupt keys or TTL metadata, though the PR targets byte-identical allocation.
> 
> **Overview**
> Introduces **`struct kvBits`**, a named single-byte field immediately after `robj` on **`kvobj`** instances (`iskvobj=1`), accessed via **`kvobjBits()`**. The byte still sits in the same place as the old “key header size” byte, but it now stores the embedded key’s **SDS type in 2 bits** (`SDS_TYPE_5`–`32`) and reserves **6 bits** for future flags.
> 
> **`kvobjCreate`**, **`kvobjCreateEmbedString`**, **`kvobjGetKey`**, **`kvobjSet`** (cache-line embedding estimate), and **`kvobjAllocSize`** are updated to write/read **`key_sds_type`** and place the embedded key after `kvBits`, using a small header-size table in **`kvobjGetKey`** instead of a raw header-size byte. Layout docs and ASCII diagrams in **`object.h`** / **`object.c`** reflect the rename; a **`static_assert`** enforces one-byte `kvBits`.
> 
> **Intended behavior:** allocation size and on-wire/RDB semantics stay the same—the change is structural naming and bit packing, not new user-visible behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62674ef4581a6c74c7cb02ca3e3f305550c11e14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->