### PR TITLE
Fix infinite loop in rdb-channel streaming when decompression fails

### DIFF
--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -496,8 +496,9 @@ int decompressInto(compressionState *state, char *buf, size_t buflen) {
 
 /* Read data from input_buf and decompress it immediately. The result is written
  * into output_buf.
- * Return number of bytes decompressed. *consumed stores number of bytes consumed
- * from input_buf.
+ * Return number of bytes decompressed, or -1 if no compression state is
+ * configured or decompression fails (connection closed). *consumed stores
+ * bytes consumed from input_buf.
  * Note, that we may have enough compressed data inside input buf so that decompressing
  * it will exceed output_len. The function must be ran in a loop until input_buf
  * is fully consumed - so make sure to have free space in output_buf on each call. */
@@ -528,8 +529,10 @@ int clientReadBufAndDecompress(client *c, char *input_buf, size_t input_len,
                                           output_len - tot_decompressed);
         if (decompressed <= 0) {
             /* Compression library failure, we should close the connection */
-            if (decompressed < 0)
+            if (decompressed < 0) {
                 c->conn->state = CONN_STATE_CLOSED;
+                return -1;
+            }
             break;
         }
         tot_decompressed += decompressed;

--- a/src/replication.c
+++ b/src/replication.c
@@ -4235,7 +4235,7 @@ int replDataBufStreamToDb(replDataBuf *buf, replDataBufToDbCtx *ctx) {
         !(c->flags & CLIENT_ASM_IMPORTING) &&
         (server.repl_master_compression_level > 0);
     if (compressed_stream)
-        serverAssert(server.master->compression_state);
+        serverAssert(c->compression_state);
 
     blockingOperationStarts();
     while ((n = listFirst(buf->blocks))) {
@@ -4258,7 +4258,13 @@ int replDataBufStreamToDb(replDataBuf *buf, replDataBufToDbCtx *ctx) {
                                                               c->querybuf + qblen,
                                                               avail,
                                                               &consumed);
-                serverAssert(decompressed >= 0);
+                if (decompressed < 0 || (decompressed == 0 && consumed == 0)) {
+                    c->flags |= CLIENT_PROTOCOL_ERROR;
+                    serverLog(LL_WARNING,
+                              "MASTER <-> REPLICA sync: Failed to decompress master stream, aborting sync");
+                    ret = C_ERR;
+                    break;
+                }
                 sdsIncrLen(c->querybuf, decompressed);
                 c->read_reploff += (long long) decompressed;
                 c->io_read_reploff += (long long int) decompressed;

--- a/tests/helpers/fake_rdbchannel_master.tcl
+++ b/tests/helpers/fake_rdbchannel_master.tcl
@@ -1,0 +1,57 @@
+# Fake rdb-channel master: streams a corrupt compressed frame. Usage: tclsh fake_rdbchannel_master.tcl PORT RDB_FILE
+
+set port [lindex $argv 0]
+set f [open [lindex $argv 1] rb]
+fconfigure $f -translation binary
+set rdb_bytes [read $f]
+close $f
+set rdb_len [string length $rdb_bytes]
+
+proc read_command {sock} {
+    set char [read $sock 1]
+    if {$char eq ""} { return "" }
+    if {$char eq "*"} {
+        set n [string trimright [gets $sock] "\r\n"]
+        set parts {}
+        for {set i 0} {$i < $n} {incr i} {
+            read $sock 1
+            set len [string trimright [gets $sock] "\r\n"]
+            set s [read $sock $len]
+            read $sock 2
+            lappend parts $s
+        }
+        return [join $parts " "]
+    }
+    set rest [string trimright [gets $sock] "\r\n"]
+    return "$char$rest"
+}
+
+proc handle {sock} {
+    global rdb_bytes rdb_len
+    if {[eof $sock]} { catch {close $sock}; return }
+    set cmd [read_command $sock]
+    if {$cmd eq ""} return
+    if {[string match "REPLCONF *rdb-only*" $cmd]} { set ::rdb_ch($sock) 1 }
+    if {[string match "PSYNC*" $cmd]} {
+        if {[info exists ::rdb_ch($sock)]} {
+            puts -nonewline $sock "+FULLRESYNC [string repeat a 40] 0\r\n"
+            puts -nonewline $sock "\$$rdb_len\r\n$rdb_bytes\r\n"
+        } else {
+            puts $sock "+RDBCHANNELSYNC 1"
+            puts -nonewline $sock [string repeat "\xDE\xAD\xBE\xEF" 51200]
+        }
+        flush $sock
+        return
+    }
+    puts $sock "+OK"
+    flush $sock
+}
+
+proc accept {sock host port} {
+    fconfigure $sock -translation binary
+    fileevent $sock readable [list handle $sock]
+}
+
+socket -server accept -myaddr 127.0.0.1 $port
+after 120000 exit
+vwait forever

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -921,3 +921,30 @@ start_server {tags {"repl external:skip tsan:skip"}} {
         }
     }
 }
+
+if {$::compression} {
+start_server {tags {"repl external:skip tsan:skip tls:skip"} overrides {repl-compression 1}} {
+    set replica [srv 0 client]
+
+    set tclsh [info nameofexecutable]
+    set fake_port [find_available_port $::baseport $::portcount]
+    set fake_pid [exec $tclsh tests/helpers/fake_rdbchannel_master.tcl $fake_port tests/assets/encodings.rdb &]
+
+    test "Replica aborts sync on master stream decompression failure" {
+        wait_for_condition 50 50 {
+            [catch {close [socket "127.0.0.1" $fake_port]}] == 0
+        } else {
+            fail "fake master did not start"
+        }
+
+        $replica config set repl-rdb-channel yes
+        $replica replicaof 127.0.0.1 $fake_port
+
+        wait_for_log_messages 0 {"*Failed to decompress master stream*"} 0 500 10
+        assert_equal PONG [$replica ping]
+    }
+
+    $replica replicaof no one
+    catch {exec /bin/kill -9 $fake_pid}
+}
+}


### PR DESCRIPTION
When the master stream fails to decompress during a diskless rdb-channel sync, `clientReadBufAndDecompress` consumes no bytes, so `replDataBufStreamToDb`'s inner loop never advances and the replica spins forever.

Fix: return -1 on decompression failure (the connection is closed as before) and abort the streaming loop on it, so the replica tears down the master link and retries. Graceful EOF keeps the drain-and-apply behavior.

Also fix the `compressed_stream` assert to check `c` instead of `server.master`.

Regression test: a fake rdb-channel master (`tests/helpers/fake_rdbchannel_master.tcl`) streams a corrupt compressed frame larger than the zstd input buffer. Run with `--compression` / `BUILD_COMPRESSION=yes`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error handling on the compressed replication ingest path; incorrect handling could abort valid syncs, but the fix replaces an infinite loop with an explicit abort on decompression failure.
> 
> **Overview**
> Fixes a **spinning replica** during diskless **rdb-channel** sync when the master sends compressed data that cannot be decompressed: `clientReadBufAndDecompress` could return **0 bytes decompressed with 0 input consumed**, so `replDataBufStreamToDb` never advanced and looped forever.
> 
> **`clientReadBufAndDecompress`** now documents and returns **`-1`** when there is no compression state or when zstd fails (connection closed as before, but the error propagates immediately instead of returning 0).
> 
> **`replDataBufStreamToDb`** treats **`-1`** or the stuck **(0, 0)** case as fatal: sets **`CLIENT_PROTOCOL_ERROR`**, logs *Failed to decompress master stream*, and aborts sync so the master link can be torn down and retried. The compressed-stream assert now checks **`c->compression_state`** instead of **`server.master`**.
> 
> Adds a **regression test** (compression builds only): a Tcl fake rdb-channel master streams a corrupt compressed frame; the replica must log the failure and stay responsive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed3ee7514fb09bdd1ea8fb45f4d318ebb2cc2945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->