### PR TITLE
Allow long hostnames in cluster-announce-ip

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2555,15 +2555,10 @@ static int isValidClusterAnnounceIp(char *val, const char **err) {
     if (inet_pton(AF_INET, val, buf) == 1 || inet_pton(AF_INET6, val, buf) == 1) {
         return 1;
     }
-    /* Also accept valid hostnames, but limited to NET_IP_STR_LEN since
-     * cluster_announce_ip is stored in a NET_IP_STR_LEN buffer */
-    if (strlen(val) >= NET_IP_STR_LEN) {
-        *err = "Hostnames for cluster-announce-ip must be less than "
-               STRINGIFY(NET_IP_STR_LEN) " characters";
-        return 0;
-    }
-    /* Also accept valid hostnames */
-    return isValidHostnameChars(val, err);
+    /* Otherwise accept a valid hostname. cluster_announce_ip is a heap-allocated
+     * string config (see createStringConfig below), so it is only bounded by
+     * NET_HOST_STR_LEN - the same limit applied to cluster-announce-hostname. */
+    return isValidAnnouncedHostname(val, err);
 }
 
 /* Validate specified string is a valid proc-title-template */

--- a/tests/unit/cluster/announced-endpoints.tcl
+++ b/tests/unit/cluster/announced-endpoints.tcl
@@ -107,6 +107,16 @@ start_cluster 2 2 {tags {external:skip cluster}} {
         R 0 config set cluster-announce-ip "redis-node-1.example.com"
         assert_equal "redis-node-1.example.com" [lindex [R 0 config get cluster-announce-ip] 1]
 
+        # Accept a long FQDN (regression for #15760: the hostname branch
+        # previously capped length at NET_IP_STR_LEN == 46)
+        set long_host "redis-node-0.redis-headless.some-long-namespace.svc.cluster.local"
+        R 0 config set cluster-announce-ip $long_host
+        assert_equal $long_host [lindex [R 0 config get cluster-announce-ip] 1]
+
+        # Reject a hostname at/over NET_HOST_STR_LEN (256)
+        catch {R 0 config set cluster-announce-ip [string repeat "a" 256]} err
+        assert_match "*less than 256*" $err
+
         # Can be cleared
         R 0 config set cluster-announce-ip ""
         assert_equal "" [lindex [R 0 config get cluster-announce-ip] 1]


### PR DESCRIPTION
## What does this PR do?

Fixes hostname validation for `cluster-announce-ip` by removing the incorrect 46-character `NET_IP_STR_LEN` limit and using the existing `isValidAnnouncedHostname()` helper.

This allows valid long FQDNs, such as Kubernetes service hostnames, while still enforcing the standard 256-character hostname limit.

Adds regression tests for long hostnames and the length boundary.

Fixes #15760

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation change for cluster announce config only; aligns limits with existing hostname config and adds unit tests.
> 
> **Overview**
> Fixes **`cluster-announce-ip`** so hostname values are validated like **`cluster-announce-hostname`**, not capped at the old **46-character** (`NET_IP_STR_LEN`) limit that blocked long Kubernetes FQDNs ([#15760](https://github.com/redis/redis/issues/15760)).
> 
> **`isValidClusterAnnounceIp`** still accepts empty strings, IPv4, and IPv6; for anything else it now calls **`isValidAnnouncedHostname`** (character rules + **&lt; 256** chars via `NET_HOST_STR_LEN`) instead of a separate length check and **`isValidHostnameChars`**.
> 
> Cluster tests add acceptance of a long headless-service-style FQDN and rejection at the **256**-character boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e55fd45a7e8d30f7c353c1de46a822948a8b52c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->