### PR TITLE
siphash: replace the tail switch with an overlapping load

### DIFF
--- a/src/siphash.c
+++ b/src/siphash.c
@@ -153,15 +153,21 @@ uint64_t siphash(const uint8_t *in, const size_t inlen, const uint8_t *k) {
         v0 ^= m;
     }
 
-    switch (left) {
-    case 7: b |= ((uint64_t)in[6]) << 48; /* fall-thru */
-    case 6: b |= ((uint64_t)in[5]) << 40; /* fall-thru */
-    case 5: b |= ((uint64_t)in[4]) << 32; /* fall-thru */
-    case 4: b |= ((uint64_t)in[3]) << 24; /* fall-thru */
-    case 3: b |= ((uint64_t)in[2]) << 16; /* fall-thru */
-    case 2: b |= ((uint64_t)in[1]) << 8; /* fall-thru */
-    case 1: b |= ((uint64_t)in[0]); break;
-    case 0: break;
+    /* Reads the key's last 8 bytes, so only valid while inlen >= 8. */
+    if (inlen >= 8) {
+        const uint64_t w = U8TO64_LE(in + left - 8);
+        b |= left ? (w >> (8 * (8 - left))) : 0;
+    } else {
+        switch (left) {
+        case 7: b |= ((uint64_t)in[6]) << 48; /* fall-thru */
+        case 6: b |= ((uint64_t)in[5]) << 40; /* fall-thru */
+        case 5: b |= ((uint64_t)in[4]) << 32; /* fall-thru */
+        case 4: b |= ((uint64_t)in[3]) << 24; /* fall-thru */
+        case 3: b |= ((uint64_t)in[2]) << 16; /* fall-thru */
+        case 2: b |= ((uint64_t)in[1]) << 8; /* fall-thru */
+        case 1: b |= ((uint64_t)in[0]); break;
+        case 0: break;
+        }
     }
 
     v3 ^= b;


### PR DESCRIPTION
The tail switch on `inlen & 7` compiles to a jump table indexed by key length
mod 8. Over a keyspace of mixed lengths that index is effectively random, so
the predictor never learns it, and siphash ends up carrying 7.75% of every
branch miss in redis-server under memtier at 9:1 GET/SET.

Those bytes are the top `left` bytes of the key's last 8-byte window, so an
overlapping load and a shift do the same job without the branch.
`in + left - 8` is `key + inlen - 8`, in bounds whenever `inlen >= 8`; shorter
keys keep the switch. Linux made the same change to the same switch in
`lib/siphash.c`, reading forward with a page-fault fixup; reading backward
needs none.

Output is unchanged, checked for every length 0 to 128. +1.05% ops/sec
(t=3.79, ahead in 10 of 12 paired rounds), and siphash drops to 0.02% of
branch misses.

It's also worth noting before benchmarking that at a single fixed key length, the switch
predicts perfectly and this loses about 8.6%. It only pays once lengths vary.