### PR TITLE
Include run_id in HELLO reply for instance identification (#15744)

### DIFF
--- a/src/commands/hello.json
+++ b/src/commands/hello.json
@@ -40,6 +40,9 @@
                 "id": {
                     "type": "integer"
                 },
+                "run_id": {
+                    "type": "string"
+                },
                 "mode": {
                     "type": "string"
                 },

--- a/src/networking.c
+++ b/src/networking.c
@@ -5098,7 +5098,7 @@ void helloCommand(client *c) {
 
     /* Let's switch to the specified RESP mode. */
     if (ver) c->resp = ver;
-    addReplyMapLen(c,6 + !server.sentinel_mode);
+    addReplyMapLen(c,7 + !server.sentinel_mode);
 
     ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"server");
     ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"redis");
@@ -5112,6 +5112,9 @@ void helloCommand(client *c) {
 
     ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"id");
     addReplyLongLong(c,c->id);
+
+    ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"run_id");
+    addReplyBulkCString(c,server.runid);
 
     ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"mode");
     if (server.sentinel_mode) addReplyBulkCString(c,"sentinel");

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -248,6 +248,18 @@ start_server {tags {"protocol network"}} {
         set _ {}
     } {} {needs:debug resp3}
 
+    test {HELLO reply contains valid server run_id} {
+        set reply [r hello 3]
+        set run_id [dict get $reply run_id]
+        assert {[string length $run_id] == 40}
+        assert {[regexp {^[0-9a-f]{40}$} $run_id]}
+        assert_equal $run_id [s 0 run_id]
+
+        set reply2 [r hello 2]
+        set run_id2 [dict get $reply2 run_id]
+        assert_equal $run_id2 $run_id
+    }
+
     test "test verbatim str parsing" {
         r hello 3
         r debug protocol verbatim


### PR DESCRIPTION
### Problem
In modern proxied, containerized, or high-availability environments (Envoy, HAProxy, Sentinel, Kubernetes services), connecting clients have no lightweight way to identify which physical backend server instance handled their handshake:
- The existing `id` field returned by `HELLO` is an ephemeral per-connection client ID (`c->id`), not a server instance identity.
- Fetching `run_id` via `INFO` requires an extra network round-trip, returns a large multiline payload, and is frequently restricted under ACL rules.

As noted in #15744, observability agents and client drivers (e.g., OpenTelemetry instrumentation) need the server's stable identity during connect for connection affinity, tracing, and failover detection.

### Solution
This PR adds the server's 40-character `run_id` to the `HELLO` reply map alongside the existing metadata:
- Increments `HELLO` reply map length by 1 in `helloCommand()` (`src/networking.c`).
- Emits `"run_id"` -> `server.runid`.
- Updates `src/commands/hello.json` reply schema to include `run_id`.
- Adds regression tests in `tests/unit/protocol.tcl` verifying `run_id` format and correctness across both RESP2 and RESP3.

Fixes #15744.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive handshake field only; existing clients can ignore the extra map key with no behavior change to auth or connection setup.
> 
> **Overview**
> Clients can now read the server’s stable **40-character `run_id`** from the **`HELLO`** handshake map, without a separate **`INFO`** call.
> 
> **`helloCommand`** grows the reply map by one entry and sends **`"run_id"`** → **`server.runid`** for both RESP2 and RESP3. The **`HELLO`** command reply schema documents the new field, and protocol tests assert hex format and consistency with **`INFO run_id`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dee0563e94eaa9ae6e6147c750b5524d6507356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->