### PR TITLE
Add fork-child-timeout to kill a fork child that never finishes; fail the build if jemalloc lacks pthread_atfork support

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -144,9 +144,26 @@ ifneq ($(DEB_HOST_GNU_TYPE),)
 JEMALLOC_CONFIGURE_OPTS += --host=$(DEB_HOST_GNU_TYPE)
 endif
 
+# Redis forks (BGSAVE, AOF rewrite) from a multi-threaded process and allocates
+# in the child. That is only safe because jemalloc registers pthread_atfork
+# handlers. jemalloc's configure enables them after a link test of
+# pthread_atfork(); if that test silently fails on some toolchain, the allocator
+# is built without any fork protection and fork children can deadlock on a mutex
+# held by another thread at fork() time (see #15666). Fail the build instead.
+# FreeBSD (JEMALLOC_MUTEX_INIT_CB) and macOS (JEMALLOC_ZONE) protect fork through
+# other mechanisms and are exempt.
+JEMALLOC_DEFS=include/jemalloc/internal/jemalloc_internal_defs.h
+
 jemalloc: .make-prerequisites
 	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)
 	cd jemalloc && ./configure --disable-cxx --with-version=5.3.0-0-g0 --with-lg-quantum=3 --disable-cache-oblivious --with-jemalloc-prefix=je_ CFLAGS="$(JEMALLOC_CFLAGS)" LDFLAGS="$(JEMALLOC_LDFLAGS)" $(JEMALLOC_CONFIGURE_OPTS)
+	@cd jemalloc && \
+	if ! grep -Eq '^#define (JEMALLOC_MUTEX_INIT_CB|JEMALLOC_ZONE)' $(JEMALLOC_DEFS) && \
+	   ! grep -q '^#define JEMALLOC_HAVE_PTHREAD_ATFORK' $(JEMALLOC_DEFS); then \
+		echo "ERROR: jemalloc was configured without pthread_atfork() support; fork children would not be fork-safe." >&2; \
+		echo "       See the pthread_atfork(3) test in deps/jemalloc/config.log." >&2; \
+		exit 1; \
+	fi
 	cd jemalloc && $(MAKE) lib/libjemalloc.a
 
 .PHONY: jemalloc

--- a/redis.conf
+++ b/redis.conf
@@ -531,6 +531,23 @@ locale-collate ""
 # permissions, and so forth.
 stop-writes-on-bgsave-error yes
 
+# Redis performs background saves (BGSAVE), AOF rewrites (BGREWRITEAOF) and
+# module forks in a forked child process. If such a child stops making progress
+# but never exits (for instance because it inherited a lock held by another
+# thread at fork() time), persistence is blocked indefinitely: no new child can
+# be forked, rdb_bgsave_in_progress / aof_rewrite_in_progress stay set and the
+# AOF keeps growing.
+#
+# When fork-child-timeout is set to a number of seconds greater than zero, a
+# child that has been running for longer than that is killed (SIGKILL) and the
+# operation is reported as failed (rdb_last_bgsave_status / aof_last_bgrewrite_status
+# are set to "err" and a warning is logged), so it can be retried by the usual
+# mechanisms. Set it well above the time your slowest save or rewrite legitimately
+# takes, e.g. 10 times the usual aof_last_rewrite_time_sec / rdb_last_bgsave_time_sec.
+#
+# A value of 0 (the default) disables the timeout.
+fork-child-timeout 0
+
 # Compress string objects using LZF when dump .rdb databases?
 # By default compression is enabled as it's almost always a win.
 # If you want to save some CPU in the saving child set it to 'no' but

--- a/src/config.c
+++ b/src/config.c
@@ -3484,6 +3484,7 @@ standardConfig static_configs[] = {
     createIntConfig("min-replicas-max-lag", "min-slaves-max-lag", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_max_lag, 10, INTEGER_CONFIG, NULL, updateGoodSlaves),
     createIntConfig("watchdog-period", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.watchdog_period, 0, INTEGER_CONFIG, NULL, updateWatchdogPeriod),
     createIntConfig("shutdown-timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.shutdown_timeout, 10, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("fork-child-timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.fork_child_timeout, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("repl-diskless-sync-max-replicas", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_diskless_sync_max_replicas, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-compatibility-sample-ratio", NULL, MODIFIABLE_CONFIG, 0, 100, server.cluster_compatibility_sample_ratio, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-slot-migration-max-archived-tasks", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1, INT_MAX, server.asm_max_archived_tasks, 32, INTEGER_CONFIG, NULL, NULL),

--- a/src/server.c
+++ b/src/server.c
@@ -852,6 +852,8 @@ int hasActiveChildProcess(void) {
 void resetChildState(void) {
     server.child_type = CHILD_TYPE_NONE;
     server.child_pid = -1;
+    server.child_start_time = 0;
+    server.child_timeout_killed = 0;
     server.stat_current_cow_peak = 0;
     server.stat_current_cow_bytes = 0;
     server.stat_current_cow_updated = 0;
@@ -1427,6 +1429,48 @@ void exitExecutionUnit(void) {
     --server.execution_nesting;
 }
 
+/* Watchdog for the current fork child (RDB save, AOF rewrite or module fork).
+ *
+ * A child that stops making progress but never exits (for example because it
+ * inherited a locked allocator mutex from another thread at fork() time, see
+ * #15666) otherwise blocks persistence forever: aof_rewrite_in_progress /
+ * rdb_bgsave_in_progress stay set, no new child can be forked, and in the AOF
+ * case the incremental file grows without bound. When fork-child-timeout is
+ * configured, kill such a child once it has been running for that long.
+ *
+ * We use SIGKILL rather than SIGUSR1: a stuck child may not be able to run a
+ * signal handler, and we want this to be reported as a failed save/rewrite
+ * (SIGUSR1 is whitelisted by the done handlers as an intentional kill). The
+ * child is reaped by checkChildrenDone(), which runs the regular
+ * terminated-by-signal handling: status set to error, temp files removed,
+ * AOF rewrite backoff (aofRewriteLimited) applied. */
+void checkChildTimeout(void) {
+    if (!server.fork_child_timeout || !hasActiveChildProcess()) return;
+    if (server.child_timeout_killed) return;
+
+    long long elapsed_ms = (getMonotonicUs() - server.child_start_time) / 1000;
+    if (elapsed_ms < (long long)server.fork_child_timeout * 1000) return;
+
+    long long last_progress_sec = -1; /* -1: no progress report received yet */
+    if (server.stat_current_cow_updated) {
+        last_progress_sec = (long long)(getMonotonicUs() -
+                             server.stat_current_cow_updated) / 1000000;
+    }
+    serverLog(LL_WARNING,
+        "%s child process %ld has been running for %lld seconds, longer than "
+        "fork-child-timeout (%d). Keys processed so far: %zu, last progress "
+        "report %lld seconds ago. Killing it with SIGKILL.",
+        strChildType(server.child_type), (long) server.child_pid,
+        elapsed_ms / 1000, server.fork_child_timeout,
+        server.stat_current_save_keys_processed, last_progress_sec);
+    if (kill(server.child_pid, SIGKILL) == -1 && errno != ESRCH) {
+        serverLog(LL_WARNING, "Failed to kill child process %ld: %s",
+            (long) server.child_pid, strerror(errno));
+    }
+    /* Only kill once; the child is reaped by checkChildrenDone(). */
+    server.child_timeout_killed = 1;
+}
+
 void checkChildrenDone(void) {
     int statloc = 0;
     pid_t pid;
@@ -1709,6 +1753,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     if (hasActiveChildProcess() || ldbPendingChildren())
     {
         run_with_period(1000) receiveChildInfo();
+        run_with_period(1000) checkChildTimeout();
         checkChildrenDone();
     } else {
         /* If there is not a background saving/rewrite in progress check if
@@ -3152,6 +3197,8 @@ void initServer(void) {
     server.client_pause_in_transaction = 0;
     server.child_pid = -1;
     server.child_type = CHILD_TYPE_NONE;
+    server.child_start_time = 0;
+    server.child_timeout_killed = 0;
     server.rdb_child_type = RDB_CHILD_TYPE_NONE;
     server.rdb_pipe_conns = NULL;
     server.rdb_pipe_numconns = 0;
@@ -7659,6 +7706,8 @@ int redisFork(int purpose) {
         if (isMutuallyExclusiveChildType(purpose)) {
             server.child_pid = childpid;
             server.child_type = purpose;
+            server.child_start_time = getMonotonicUs();
+            server.child_timeout_killed = 0;
             server.stat_current_cow_peak = 0;
             server.stat_current_cow_bytes = 0;
             server.stat_current_cow_updated = 0;

--- a/src/server.h
+++ b/src/server.h
@@ -2104,6 +2104,9 @@ struct redisServer {
     int module_pipe[2];         /* Pipe used to awake the event loop by module threads. */
     pid_t child_pid;            /* PID of current child */
     int child_type;             /* Type of current child */
+    monotime child_start_time;  /* When the current child was forked (us) */
+    int child_timeout_killed;   /* True once fork-child-timeout killed the current child */
+    int fork_child_timeout;     /* Kill a fork child running longer than this (seconds), 0 = never */
     redisAtomic int module_gil_acquiring; /* Indicates whether the GIL is being acquiring by the main thread. */
     /* Networking */
     int port;                   /* TCP listening port */
@@ -3919,6 +3922,7 @@ const char *evictPolicyToString(void);
 struct redisMemOverhead *getMemoryOverheadData(void);
 void freeMemoryOverheadData(struct redisMemOverhead *mh);
 void checkChildrenDone(void);
+void checkChildTimeout(void);
 int setOOMScoreAdj(int process_class);
 void rejectCommandFormat(client *c, const char *fmt, ...);
 void *activeDefragAlloc(void *ptr);

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -357,6 +357,43 @@ tags {"aof external:skip"} {
         }
     }
 
+    test {fork-child-timeout kills an AOF rewrite child that runs for too long} {
+        start_server {overrides {appendonly {yes} save {""}}} {
+            # 10 seconds per key: the child would need ~100 seconds.
+            r config set rdb-key-save-delay 10000000
+            populate 10
+            r config set fork-child-timeout 1
+            set loglines [count_log_lines 0]
+
+            r bgrewriteaof
+            set pid [get_child_pid 0]
+            wait_for_condition 100 100 {
+                [s aof_rewrite_in_progress] == 0
+            } else {
+                fail "stuck AOF rewrite child was not killed by fork-child-timeout"
+            }
+
+            # Reported as a failed rewrite, child gone, temp file removed.
+            assert_equal {err} [s aof_last_bgrewrite_status]
+            assert_equal 1 [s aof_rewrites_consecutive_failures]
+            verify_log_message 0 "*AOF child process $pid has been running for*longer than fork-child-timeout (1)*Killing it with SIGKILL*" $loglines
+            verify_log_message 0 "*Background AOF rewrite terminated by signal 9*" $loglines
+            wait_for_condition 50 100 {
+                ![process_is_alive $pid]
+            } else {
+                fail "child process $pid is still alive"
+            }
+            assert_equal 0 [llength [glob -nocomplain [file join [lindex [r config get dir] 1] temp-rewriteaof-*]]]
+
+            # Once the child is fast again a new rewrite succeeds.
+            r config set rdb-key-save-delay 0
+            r bgrewriteaof
+            waitForBgrewriteaof r
+            assert_equal {ok} [s aof_last_bgrewrite_status]
+            assert_equal 0 [s aof_rewrites_consecutive_failures]
+        }
+    } {} {needs:local-process}
+
     test {Generate timestamp annotations in AOF} {
         start_server {overrides {appendonly {yes}}} {
             r config set aof-timestamp-enabled yes

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -696,3 +696,55 @@ foreach {type lp_entries} {listpack 512 dict 0} {
 }
 
 } ;# tags
+
+start_server {tags {"rdb external:skip"} overrides {save ""}} {
+    test {fork-child-timeout kills a BGSAVE child that runs for too long} {
+        # 10 seconds per key: the child would need ~100 seconds.
+        r config set rdb-key-save-delay 10000000
+        populate 10
+        r config set fork-child-timeout 1
+        set loglines [count_log_lines 0]
+
+        r bgsave
+        set pid [get_child_pid 0]
+        wait_for_condition 100 100 {
+            [s rdb_bgsave_in_progress] == 0
+        } else {
+            fail "stuck BGSAVE child was not killed by fork-child-timeout"
+        }
+
+        # Reported as a failed save, child gone, temp file removed.
+        assert_equal {err} [s rdb_last_bgsave_status]
+        verify_log_message 0 "*RDB child process $pid has been running for*longer than fork-child-timeout (1)*Killing it with SIGKILL*" $loglines
+        verify_log_message 0 "*Background saving terminated by signal 9*" $loglines
+        wait_for_condition 50 100 {
+            ![process_is_alive $pid]
+        } else {
+            fail "child process $pid is still alive"
+        }
+        assert_equal 0 [llength [glob -nocomplain [file join [lindex [r config get dir] 1] temp-*.rdb]]]
+
+        # Once the child is fast again a new BGSAVE succeeds.
+        r config set rdb-key-save-delay 0
+        r bgsave
+        waitForBgsave r
+        assert_equal {ok} [s rdb_last_bgsave_status]
+    } {} {needs:local-process}
+
+    test {fork-child-timeout does not kill a child that finishes in time} {
+        # 100ms per key: the child needs ~1 second, the timeout is 10.
+        r config set rdb-key-save-delay 100000
+        r config set fork-child-timeout 10
+        set loglines [count_log_lines 0]
+
+        r bgsave
+        waitForBgsave r
+        assert_equal {ok} [s rdb_last_bgsave_status]
+        # Nothing was killed: no watchdog message since the test started.
+        set new_log [exec tail -n +[expr {$loglines + 1}] [srv 0 stdout]]
+        assert_no_match "*longer than fork-child-timeout*" $new_log
+        r config set rdb-key-save-delay 0
+        r config set fork-child-timeout 0
+    }
+}
+


### PR DESCRIPTION
Related: https://github.com/redis/redis/issues/15666

## Issue

A fork child (RDB save, AOF rewrite, module fork) that stops making progress
but never exits blocks persistence indefinitely: `aof_rewrite_in_progress` /
`rdb_bgsave_in_progress` stay set, no new child can be forked and the AOF
grows without bound. The parent only reaps children (`checkChildrenDone()`)
and has no notion of a stuck one. In #15666 an AOF-rewrite child sat for 8
days in `pthread_mutex_lock` inside jemalloc (`ecache_dirty.mtx` /
`bin->lock`, first tcache GC pass after fork); after a manual `kill -9` the
next rewrite finished in seconds.

Both mutexes are covered by jemalloc's `pthread_atfork` handlers (taken before
`fork()`, `pthread_mutex_init`'d in the child), so this can only happen when
those handlers are not in effect. jemalloc's `configure` enables their
registration only if a link test of `pthread_atfork()` succeeds; if the probe
fails on a toolchain, `JEMALLOC_HAVE_PTHREAD_ATFORK` stays undefined and the
allocator is silently built with no fork protection. Compiling the registration
out reproduces the reported signature (child single-threaded, 0 CPU,
`futex_wait`, mutex `__owner` = TID of the parent's `jemalloc_bg_thd`) in a
few hundred forks; a stock build survived 18.5k forks under the same stress.

## Change

1. New config `fork-child-timeout <seconds>` (default `0` = disabled,
   `CONFIG SET`-able). Once a second `serverCron` calls `checkChildTimeout()`;
   a child running longer than the timeout is logged (type, pid, age, keys
   processed, age of the last progress report) and killed with SIGKILL. The
   existing `checkChildrenDone()` path handles it as terminated-by-signal:
   status `err`, temp files removed, `aof_rewrites_consecutive_failures` /
   `aofRewriteLimited()` backoff, next save or rewrite scheduled as usual.
   SIGKILL rather than SIGUSR1: a stuck child may not run a signal handler,
   and SIGUSR1 is whitelisted by the done handlers as an intentional kill.
   Default off: a legitimate save of a very large dataset can take arbitrarily
   long, and with `stop-writes-on-bgsave-error` a mis-tuned default would
   reject writes; `redis.conf` suggests ~10× the usual
   `aof_last_rewrite_time_sec` / `rdb_last_bgsave_time_sec`.

2. `deps/Makefile` fails the build if the configured jemalloc does not define
   `JEMALLOC_HAVE_PTHREAD_ATFORK` (FreeBSD `JEMALLOC_MUTEX_INIT_CB` and macOS
   `JEMALLOC_ZONE` protect fork differently and are exempt). No change to the
   binary on a healthy toolchain.

## Test

`tests/integration/rdb.tcl`: a BGSAVE child slowed with `rdb-key-save-delay`
is killed at the timeout, `rdb_last_bgsave_status` is `err`, the temp file is
gone, the next BGSAVE succeeds; a child that finishes within the timeout is
left alone. `tests/integration/aof.tcl`: same for BGREWRITEAOF, including
`aof_rewrites_consecutive_failures` 1 → 0 after the retry.
`./runtest --single integration/rdb --single integration/aof --single
integration/aof-multi-part --single unit/introspection --single unit/other
--single unit/shutdown` pass. With the Makefile check, `make MALLOC=jemalloc`
passes normally and fails with a pointer to `config.log` when the define is
removed from the generated header. Against a fault-injected jemalloc without
fork handlers and `fork-child-timeout 5`, a 900 s stress run produced 11
wedged children in 3,927 forks; all were killed at the timeout and the next
save completed in ~170 ms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fork-child lifecycle and persistence failure handling when enabled; mis-tuned timeouts could kill legitimate long saves. The jemalloc Makefile guard only affects builds without fork-safe allocator support.
> 
> **Overview**
> Adds **`fork-child-timeout`** (default `0`, off) so BGSAVE, AOF rewrite, and module fork children that hang without exiting can be **SIGKILL**’d after a configurable age; the existing child-reap path then treats the job as failed, cleans temp files, and allows retries. **`checkChildTimeout()`** runs about once per second while a mutually exclusive child is active, logging pid, runtime, keys processed, and last progress before killing once.
> 
> **`deps/Makefile`** now **fails the jemalloc build** when neither `JEMALLOC_HAVE_PTHREAD_ATFORK` nor platform-specific fork-safe paths (FreeBSD/macOS) are present, avoiding silently unsafe allocators linked to fork deadlocks ([#15666](https://github.com/redis/redis/issues/15666)).
> 
> Integration tests cover timeout kill vs. successful completion for RDB and AOF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 405beb9a9e4d19d595be8439c488ebbd428d47aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->