### PR TITLE
Fix script BUSY state data race in replication with IO threads

### DIFF
--- a/src/iothread.c
+++ b/src/iothread.c
@@ -661,12 +661,17 @@ int processClientsFromIOThread(IOThread *t) {
         if (runClientCronFromIOThread(c)) continue;
 
         /* Process the pending command and input buffer. */
-        if (!isClientReadErrorFatal(c) && c->io_flags & CLIENT_IO_PENDING_COMMAND) {
+        if (!isClientReadErrorFatal(c) &&
+            ((c->io_flags & CLIENT_IO_PENDING_COMMAND) || (c->flags & CLIENT_MASTER))) {
             /* IO-thread reads may enqueue one-by-one complete commands that are
              * executed in main thread without re-entering processInputBuffer().
              * Account this client as active before processing that handoff path. */
-            statsUpdateActiveClients(c);
-            c->flags |= CLIENT_PENDING_COMMAND;
+            /* A master can return with a command deferred during BUSY, or
+             * buffered input explicitly scheduled after BUSY ends. */
+            if (c->io_flags & CLIENT_IO_PENDING_COMMAND)
+                c->flags |= CLIENT_PENDING_COMMAND;
+            if (c->flags & CLIENT_PENDING_COMMAND)
+                statsUpdateActiveClients(c);
             if (processPendingCommandAndInputBuffer(c) == C_ERR) {
                 /* If the client is no longer valid, it must be freed safely. */
                 continue;

--- a/src/networking.c
+++ b/src/networking.c
@@ -3676,6 +3676,14 @@ int processPendingCommandAndInputBuffer(client *c) {
      * So whenever we change the code here we need to consider if we need this change on module
      * blocked client as well */
     if (c->flags & CLIENT_PENDING_COMMAND) {
+        /* A master command may have been parsed before another client entered
+         * a yielding script or module. Preserve it until that operation ends,
+         * instead of letting processCommand reject it with BUSY. */
+        if (c->flags & CLIENT_MASTER && isInsideYieldingLongCommand()) {
+            /* Keep the pending command across the handoff back to its IO
+             * thread, which can keep reading without parsing another command. */
+            return C_OK;
+        }
         c->flags &= ~CLIENT_PENDING_COMMAND;
         if (processCommandAndResetClient(c) == C_ERR) {
             return C_ERR;
@@ -3806,7 +3814,13 @@ int processInputBuffer(client *c) {
          * condition on the slave. We want just to accumulate the replication
          * stream (instead of replying -BUSY like we do with other clients) and
          * later resume the processing. */
-        if (c->flags & CLIENT_MASTER && isInsideYieldingLongCommand()) break;
+        if (c->flags & CLIENT_MASTER) {
+            if (c->running_tid != IOTHREAD_MAIN_THREAD_ID) {
+                if (isInsideYieldingLongCommandFromIOThread()) break;
+            } else if (isInsideYieldingLongCommand()) {
+                break;
+            }
+        }
 
         /* CLIENT_CLOSE_AFTER_REPLY closes the connection once the reply is
          * written to the client. Make sure to not let the reply grow after

--- a/src/replication.c
+++ b/src/replication.c
@@ -58,6 +58,19 @@ static void rdbChannelCleanup(void);
  * the instance is configured to have no persistence. */
 int RDBGeneratedByReplication = 0;
 
+/* Reuse the unstable branch recovery path after yielding ends. */
+void replicationResumeMasterClient(void) {
+    if (isInsideYieldingLongCommand() || !server.masterhost || !server.master)
+        return;
+    if (server.master->running_tid == IOTHREAD_MAIN_THREAD_ID) {
+        queueClientForReprocessing(server.master);
+    } else {
+        pauseIOThread(server.master->tid);
+        enqueuePendingClientsToMainThread(server.master, 0);
+        resumeIOThread(server.master->tid);
+    }
+}
+
 /* Set the replication compression level. When Redis is built without
  * compression support (BUILD_COMPRESSION=yes enables it) the level is always
  * forced to 0, so replication compression stays completely disabled and the
@@ -4677,6 +4690,10 @@ void replicationCacheMaster(client *c) {
     c->bufpos = 0;
     resetClient(c, -1);
     resetClientQbufState(c);
+    /* The discarded command may have been deferred during BUSY. A resumed
+     * connection must parse it again from the last applied replication offset. */
+    c->flags &= ~CLIENT_PENDING_COMMAND;
+    c->io_flags &= ~CLIENT_IO_PENDING_COMMAND;
 
     /* Save the master. Server.master will be set to null later by
      * replicationHandleMasterDisconnection(). */

--- a/src/script.c
+++ b/src/script.c
@@ -36,24 +36,9 @@ static void exitScriptTimedoutMode(scriptRunCtx *run_ctx) {
     serverAssert(run_ctx == curr_run_ctx);
     serverAssert(scriptIsTimedout());
     run_ctx->flags &= ~SCRIPT_TIMEDOUT;
+    atomicSetWithSync(server.script_timedout, 0);
     blockingOperationEnds();
-    /* if we are a replica and we have an active master, set it for continue processing */
-    if (server.masterhost && server.master) {
-        /* Master running in IO thread needs to be sent to main thread so that
-         * it can process any pending commands ASAP without waiting for the next
-         * read.
-         * We don't queue the client for reprocessing in this case as it will
-         * create contention with main thread when it deals with unblocked
-         * clients - see comment above queueClientForReprocessing. */
-        if (server.master->running_tid != IOTHREAD_MAIN_THREAD_ID) {
-            pauseIOThread(server.master->tid);
-            enqueuePendingClientsToMainThread(server.master, 0);
-            resumeIOThread(server.master->tid);
-            return;
-        }
-
-        queueClientForReprocessing(server.master);
-    }
+    replicationResumeMasterClient();
 }
 
 static void enterScriptTimedoutMode(scriptRunCtx *run_ctx) {
@@ -61,6 +46,7 @@ static void enterScriptTimedoutMode(scriptRunCtx *run_ctx) {
     serverAssert(!scriptIsTimedout());
     /* Mark script as timedout */
     run_ctx->flags |= SCRIPT_TIMEDOUT;
+    atomicSetWithSync(server.script_timedout, 1);
     blockingOperationStarts();
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -875,6 +875,12 @@ int isInsideYieldingLongCommand(void) {
     return scriptIsTimedout() || server.busy_module_yield_flags;
 }
 
+int isInsideYieldingLongCommandFromIOThread(void) {
+    int script_timedout;
+    atomicGetWithSync(server.script_timedout, script_timedout);
+    return script_timedout;
+}
+
 /* Return true if this instance has persistence completely turned off:
  * both RDB and AOF are disabled. */
 int allPersistenceDisabled(void) {
@@ -3148,6 +3154,7 @@ void initServer(void) {
     server.cronloops = 0;
     server.in_exec = 0;
     server.busy_module_yield_flags = BUSY_MODULE_YIELD_NONE;
+    atomicSet(server.script_timedout, 0);
     server.busy_module_yield_reply = NULL;
     server.client_pause_in_transaction = 0;
     server.child_pid = -1;

--- a/src/server.h
+++ b/src/server.h
@@ -2105,6 +2105,7 @@ struct redisServer {
     pid_t child_pid;            /* PID of current child */
     int child_type;             /* Type of current child */
     redisAtomic int module_gil_acquiring; /* Indicates whether the GIL is being acquiring by the main thread. */
+    redisAtomic int script_timedout;
     /* Networking */
     int port;                   /* TCP listening port */
     int tls_port;               /* TLS listening port */
@@ -3580,6 +3581,7 @@ void freeReplicaReferencedReplBuffer(client *replica);
 void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv, int argc);
 void updateSlavesWaitingBgsave(int bgsaveerr, int type);
 void replicationCron(void);
+void replicationResumeMasterClient(void);
 void setReplCompression(int level);
 void enableMasterClientDecompressionIfNeeded(client *c);
 void replicationStartPendingFork(void);
@@ -4453,6 +4455,7 @@ unsigned long evalScriptsMemoryEngine(void);
 uint64_t evalGetCommandFlags(client *c, uint64_t orig_flags);
 uint64_t fcallGetCommandFlags(client *c, uint64_t orig_flags);
 int isInsideYieldingLongCommand(void);
+int isInsideYieldingLongCommandFromIOThread(void);
 
 typedef struct luaScript {
     uint64_t flags;

--- a/tests/integration/replication-iothreads.tcl
+++ b/tests/integration/replication-iothreads.tcl
@@ -494,7 +494,7 @@ proc busy_master_client_field {replica field} {
 foreach threads {1 4} {
     # Leave headroom for slow module GIL scheduling under sanitizers. A timeout
     # and PSYNC retry must not accidentally wake the input being tested.
-    start_server {tags {"repl modules external:skip"} overrides {save "" repl-timeout 300 repl-ping-replica-period 3600 repl-diskless-sync-delay 0}} {
+    start_server {tags {"iothreads repl modules external:skip"} overrides {save "" repl-timeout 300 repl-ping-replica-period 3600 repl-diskless-sync-delay 0}} {
         set master [srv 0 client]
         set master_host [srv 0 host]
         set master_port [srv 0 port]

--- a/tests/integration/replication-iothreads.tcl
+++ b/tests/integration/replication-iothreads.tcl
@@ -478,3 +478,92 @@ start_server {overrides {io-threads 4 save ""}} {
 }
 
 }
+
+
+# Regression: replication input must remain buffered while a script is BUSY.
+# Observe the master client through a test-only allow-busy module command.
+# CLIENT LIST pauses IO threads while taking the snapshot.
+proc busy_master_client_field {replica field} {
+    set clients [$replica do_rm_call_allow_busy client list type master]
+    if {![regexp [format {(?:^| )%s=([^ \r\n]+)} $field] $clients -> value]} {
+        fail "Missing master client field $field: $clients"
+    }
+    return $value
+}
+
+foreach threads {1 4} {
+    # Leave headroom for slow module GIL scheduling under sanitizers. A timeout
+    # and PSYNC retry must not accidentally wake the input being tested.
+    start_server {tags {"repl modules external:skip"} overrides {save "" repl-timeout 300 repl-ping-replica-period 3600 repl-diskless-sync-delay 0}} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+        start_server [list overrides [list save "" io-threads $threads busy-reply-threshold 10]] {
+            set replica [srv 0 client]
+            $replica module load [file normalize tests/modules/blockedclient.so]
+            $replica replicaof $master_host $master_port
+            wait_for_sync $replica
+
+            test "Replication retains buffered input across script BUSY with $threads IO threads" {
+                    $master del busy-counter busy-marker
+                    $master set busy-seed initial
+                    assert_equal 1 [$master wait 1 5000]
+                    if {$threads > 1} {
+                        wait_for_condition 100 10 {
+                            [busy_master_client_field $replica io-thread] > 0
+                        } else {
+                            fail "Master client was not assigned to an IO thread"
+                        }
+                    }
+                    set tid [busy_master_client_field $replica io-thread]
+                    set master_id [busy_master_client_field $replica id]
+                    set rd [redis_deferring_client]
+                    $rd eval {while true do end} 0
+                    wait_for_condition 100 10 {
+                        [catch {$replica ping} reply] && [string match {BUSY*} $reply]
+                    } else {
+                        fail "Replica did not enter BUSY"
+                    }
+
+                    # Once BUSY is published, reception must continue while
+                    # RESP parsing stays paused, just as before threaded IO.
+                    set parsed [busy_master_client_field $replica avg-pipeline-len-sum]
+                    $master incr busy-counter
+                    wait_for_condition 100 10 {
+                        [busy_master_client_field $replica qbuf] > 0
+                    } else {
+                        fail "Replication input was not buffered during BUSY"
+                    }
+                    set qbuf [busy_master_client_field $replica qbuf]
+                    for {set i 1} {$i < 100} {incr i} {
+                        $master incr busy-counter
+                    }
+                    set marker [string repeat x 65536]
+                    $master set busy-marker $marker
+                    wait_for_condition 100 10 {
+                        [busy_master_client_field $replica qbuf] > $qbuf + 65536
+                    } else {
+                        fail "Replica stopped receiving buffered input during BUSY"
+                    }
+                    assert_equal $tid [busy_master_client_field $replica io-thread]
+                    assert_equal $parsed [busy_master_client_field $replica avg-pipeline-len-sum]
+                    assert_equal 0 [busy_master_client_field $replica argv-mem]
+                    assert_equal 0 [$master wait 1 100]
+
+                    $replica script kill
+                    assert_error {ERR*Script killed*} {$rd read}
+                    # Do not issue WAIT or another upstream write to wake the
+                    # master client. Periodic replication PINGs are disabled.
+                    wait_for_condition 100 10 {
+                        [$replica get busy-marker] eq $marker
+                    } else {
+                        fail "Buffered replication did not resume after BUSY"
+                    }
+                    assert_equal 100 [$replica get busy-counter]
+                    assert_equal $master_id [busy_master_client_field $replica id]
+                    assert_equal 0 [status $replica unexpected_error_replies]
+                    assert_equal [$master debug digest] [$replica debug digest]
+            }
+        }
+    }
+}

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -667,6 +667,11 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                                   "write", 0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
+    /* Inspect replication buffers and IO ownership while a script/module yields. */
+    if (RedisModule_CreateCommand(ctx, "do_rm_call_allow_busy", do_rm_call,
+                                 "allow-busy", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
     if (RedisModule_CreateCommand(ctx, "do_rm_call_async", do_rm_call_async,
                                   "write", 0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;


### PR DESCRIPTION

## Issue

When a replica runs a long Lua script, the IO thread may receive replication data and check whether the script is BUSY before parsing commands.

This check calls `scriptIsTimedout()` and reads the script context owned by the main thread. The main thread can update this context at the same time.

Related failed daily CI: https://github.com/redis/redis/actions/runs/34420266410/job/102693934244

TSan reported a race between this read and clearing `SCRIPT_TIMEDOUT` in `exitScriptTimedoutMode()`. The test `Master stream is correctly processed while the replica has a script in -BUSY state` showed `[ok]`, but the job failed during cleanup because of the TSan report.

Below is my understanding of the original flow. I may miss some cases or understand some parts wrong please correct if needed.

The long Lua script comes from a test client connected directly to the replica. The replication stream comes from the upstream master through another connection.

```mermaid
sequenceDiagram
    participant C as 1. Test client
    participant U as 2. Upstream master
    participant IO as 3. Replica IO thread
    participant MT as 4. Replica main thread
    participant DB as 5. Replica database

    Note over U,MT: A. Replication is connected
    C->>MT: B. Send a long EVAL directly to the replica
    MT->>MT: C. Execute Lua
    MT->>MT: D. Reach timeout and set SCRIPT_TIMEDOUT
    Note over MT: Lua continues and processes events while BUSY

    loop E. Replication data arrives while BUSY
        U->>IO: E1. Send replication bytes
        IO->>IO: E2. Read socket and append bytes to querybuf
        IO->>IO: E3. Check BUSY before RESP parsing
        Note over IO,MT: E4. DATA RACE<br/>IO reads curr_run_ctx->flags<br/>while main thread changes the same flags
        IO->>IO: E5. If BUSY, stop parsing and keep bytes in querybuf
    end

    IO->>IO: F. If the check sees non-BUSY, parse a complete command
    IO->>MT: G. Mark command pending and hand over the client
    MT->>MT: H. Execute pending command
    Note over MT: Another timing window:<br/>the command may arrive here after BUSY starts
    MT->>MT: I. Lua finishes and clears SCRIPT_TIMEDOUT
    MT->>MT: J. Schedule the master client for recovery
    MT->>DB: K. Apply buffered replication commands
```

- **Step E4 is the TSan race:** the IO thread reads the script state while the main thread writes it.
- **Step H is another execution window:** a replication command can be parsed before BUSY starts, then reach the main thread after BUSY starts. Without a second BUSY check, it may be rejected with a BUSY error.
- Bytes kept in `querybuf` at step E5 are received but not yet parsed into a new pending command.

## Change

Add an atomic `server.script_timedout` flag for the IO thread to read. The main thread updates this flag when entering and leaving script timeout mode, so the IO thread no longer reads the script context.

The main thread also checks BUSY before executing a pending replication command. If BUSY is still active, the command remains pending and the client can return to the IO thread.

When BUSY ends, the master client is scheduled for processing again. Buffered input can then be parsed and executed without waiting for another upstream write.

This is how I understand the flow after the change

```mermaid
sequenceDiagram
    participant C as 1. Test client
    participant U as 2. Upstream master
    participant IO as 3. Replica IO thread
    participant MT as 4. Replica main thread
    participant DB as 5. Replica database

    Note over U,MT: A. Replication is connected
    C->>MT: B. Send a long EVAL directly to the replica
    MT->>MT: C. Execute Lua
    MT->>MT: D. Set SCRIPT_TIMEDOUT and atomic script_timedout = 1

    loop E. Replication data arrives while BUSY
        U->>IO: E1. Send replication bytes
        IO->>IO: E2. Append bytes to querybuf
        IO->>IO: E3. Read atomic script_timedout
        IO->>IO: E4. If BUSY, stop parsing and keep bytes buffered
    end

    IO->>MT: F. A command parsed before BUSY may be handed over
    MT->>MT: G. Check BUSY before executing pending replication command
    MT->>IO: H. Keep pending command and return client to IO if BUSY

    MT->>MT: I. Lua finishes or is killed
    MT->>MT: J. Clear SCRIPT_TIMEDOUT and atomic script_timedout = 0
    MT->>MT: K. Schedule the master client for processing
    MT->>MT: L. Process pending command and buffered input
    MT->>DB: M. Apply replication commands in order
```

## Test


| PR Validation CI Item | PR Validation CI Details |
| --- | --- |
| Executed daily jobs | sanitizer,iothreads |
| Tests | redis |
| Extra test arguments | --loops 50 --single integration/replication |
| CI link | [https://github.com/vitahlin/redis/actions/runs/34695871518](https://github.com/vitahlin/redis/actions/runs/34695871518) |


| PR Validation CI Item | PR Validation CI Details |
| --- | --- |
| Executed daily jobs | valgrind,sanitizer,tls,freebsd,macos,alpine,32bit,iothreads,ubuntu,centos,malloc,specific,fortify,reply-schema,oldTC,defrag,vectorset,assert-keyspace,arm,compression |
| Tests | redis |
| Extra test arguments | --single integration/replication-iothreads |
| CI link | [https://github.com/vitahlin/redis/actions/runs/34700999709](https://github.com/vitahlin/redis/actions/runs/34700999709) |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes replication command scheduling and cross-thread client ownership during BUSY/yield, where ordering bugs or races could corrupt replica state; mitigated by atomics and targeted handoff logic but the area is inherently high risk.
> 
> **Overview**
> Fixes replica replication handling when a long Lua script or yielding module keeps the instance **BUSY**, especially with **IO threads** owning the master client connection.
> 
> **Thread-safe BUSY visibility:** IO threads no longer read main-thread script context. The main thread sets atomic `server.script_timedout` and `server.busy_module_yielding` on enter/exit; `isInsideYieldingLongCommandFromIOThread()` uses those for master input parsing pauses in `processInputBuffer`.
> 
> **Deferred replication commands:** If a master command was parsed before BUSY but runs on the main thread during BUSY, execution is skipped and `CLIENT_PENDING_COMMAND` is kept instead of returning **-BUSY**. IO-thread handoff in `processClientsFromIOThread` and `enqueuePendingClientsToMainThread` covers clients bounced between threads while still pending. When BUSY ends, `replicationResumeMasterClient()` re-queues the master (main thread or IO thread path); script timeout exit calls this instead of inlined logic. Master disconnect reset clears stale pending-command flags.
> 
> **Tests:** New `replication-iothreads.tcl` case (1 and 4 IO threads) asserts replication bytes keep buffering during BUSY and apply after `SCRIPT KILL`, via test module command `do_rm_call_allow_busy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ffdbd28fd5da926d490451d4242145b79ac4e87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->