### PR TITLE
Module API: validate key/channel positions against argc to prevent OO…

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1026,6 +1026,23 @@ int moduleGetCommandKeysViaAPI(struct redisCommand *cmd, robj **argv, int argc, 
     /* We currently always use the array allocated by RM_KeyAtPos() and don't try
      * to optimize for the pre-allocated buffer.
      */
+
+    /* Validate key positions returned by the module. A buggy or malicious
+     * module may declare positions >= argc, which would cause an OOB read
+     * when the positions are used downstream (e.g., in ACL checks at
+     * ACLSelectorCheckKey which does argv[idx]->ptr). Filter them out
+     * here. This matches the validation already done in
+     * RM_RedactClientCommandArgument (which checks pos < argc). */
+    int valid_keys = 0;
+    for (int j = 0; j < result->numkeys; j++) {
+        if (result->keys[j].pos > 0 && result->keys[j].pos < argc) {
+            if (valid_keys != j)
+                result->keys[valid_keys] = result->keys[j];
+            valid_keys++;
+        }
+    }
+    result->numkeys = valid_keys;
+
     moduleFreeContext(&ctx);
     return result->numkeys;
 }
@@ -1045,6 +1062,20 @@ int moduleGetCommandChannelsViaAPI(struct redisCommand *cmd, robj **argv, int ar
     cp->func(&ctx,(void**)argv,argc);
     /* We currently always use the array allocated by RM_RM_ChannelAtPosWithFlags() and don't try
      * to optimize for the pre-allocated buffer. */
+
+    /* Validate channel positions returned by the module. Same rationale
+     * as in moduleGetCommandKeysViaAPI: filter out positions >= argc to
+     * prevent OOB reads downstream. */
+    int valid_channels = 0;
+    for (int j = 0; j < result->numkeys; j++) {
+        if (result->keys[j].pos > 0 && result->keys[j].pos < argc) {
+            if (valid_channels != j)
+                result->keys[valid_channels] = result->keys[j];
+            valid_channels++;
+        }
+    }
+    result->numkeys = valid_channels;
+
     moduleFreeContext(&ctx);
     return result->numkeys;
 }

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -88,7 +88,8 @@ TEST_MODULES = \
     keymeta_notify.so \
     postnotifications_perkey_metadata.so \
     atomicslotmigration.so \
-    cluster_topology.so
+    cluster_topology.so \
+    keyposvalidate.so
 
 .PHONY: all
 

--- a/tests/modules/keyposvalidate.c
+++ b/tests/modules/keyposvalidate.c
@@ -1,0 +1,184 @@
+/* Test module for key/channel position validation.
+ *
+ * Provides commands that deliberately declare invalid key/channel positions
+ * (pos = 0, pos = argc, pos > argc) during getkeys-api / getchannels-api
+ * introspection. Used to verify that moduleGetCommandKeysViaAPI and
+ * moduleGetCommandChannelsViaAPI filter out invalid positions instead of
+ * causing an OOB read in ACL checks.
+ *
+ * See: tests/unit/moduleapi/keyposvalidate.tcl
+ */
+
+#include "redismodule.h"
+
+#define UNUSED(V) ((void) V)
+
+/* ------------------------------------------------------------------ */
+/* Key-position commands                                              */
+/* ------------------------------------------------------------------ */
+
+/* Declares pos=0 (invalid: must be > 0). */
+int keypos_validate_zero(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    if (RedisModule_IsKeysPositionRequest(ctx)) {
+        RedisModule_KeyAtPos(ctx, 0);  /* invalid */
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+/* Declares pos=argc (invalid: argv is 0-indexed, max valid is argc-1). */
+int keypos_validate_at_argc(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    if (RedisModule_IsKeysPositionRequest(ctx)) {
+        RedisModule_KeyAtPos(ctx, argc);  /* invalid: out of bounds */
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+/* Declares pos=999 (invalid: way beyond argc). */
+int keypos_validate_above_argc(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    if (RedisModule_IsKeysPositionRequest(ctx)) {
+        RedisModule_KeyAtPos(ctx, 999);  /* invalid: OOB */
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+/* Declares a mix of valid and invalid positions: pos=1 (valid),
+ * pos=999 (invalid), pos=argc (invalid), pos=0 (invalid), pos=2 (valid). */
+int keypos_validate_mixed(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    if (RedisModule_IsKeysPositionRequest(ctx)) {
+        RedisModule_KeyAtPos(ctx, 1);            /* valid */
+        RedisModule_KeyAtPos(ctx, 999);          /* invalid: way OOB */
+        RedisModule_KeyAtPos(ctx, argc);         /* invalid: OOB */
+        RedisModule_KeyAtPos(ctx, 0);            /* invalid: must be > 0 */
+        if (argc >= 3)
+            RedisModule_KeyAtPos(ctx, 2);        /* valid */
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/* Channel-position commands (use ChannelAtPosWithFlags)             */
+/* ------------------------------------------------------------------ */
+
+/* Declares pos=0 (invalid: must be > 0). */
+int chanpos_validate_zero(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    if (RedisModule_IsChannelsPositionRequest(ctx)) {
+        RedisModule_ChannelAtPosWithFlags(ctx, 0, REDISMODULE_CMD_CHANNEL_SUBSCRIBE);
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+/* Declares pos=argc (invalid). */
+int chanpos_validate_at_argc(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    if (RedisModule_IsChannelsPositionRequest(ctx)) {
+        RedisModule_ChannelAtPosWithFlags(ctx, argc, REDISMODULE_CMD_CHANNEL_SUBSCRIBE);
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+/* Declares pos=999 (invalid: way OOB). */
+int chanpos_validate_above_argc(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    if (RedisModule_IsChannelsPositionRequest(ctx)) {
+        RedisModule_ChannelAtPosWithFlags(ctx, 999, REDISMODULE_CMD_CHANNEL_SUBSCRIBE);
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+/* Declares valid + invalid positions mixed. */
+int chanpos_validate_mixed(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    if (RedisModule_IsChannelsPositionRequest(ctx)) {
+        RedisModule_ChannelAtPosWithFlags(ctx, 1, REDISMODULE_CMD_CHANNEL_SUBSCRIBE);
+        RedisModule_ChannelAtPosWithFlags(ctx, 999, REDISMODULE_CMD_CHANNEL_SUBSCRIBE);
+        RedisModule_ChannelAtPosWithFlags(ctx, argc, REDISMODULE_CMD_CHANNEL_SUBSCRIBE);
+        RedisModule_ChannelAtPosWithFlags(ctx, 0, REDISMODULE_CMD_CHANNEL_SUBSCRIBE);
+        if (argc >= 3)
+            RedisModule_ChannelAtPosWithFlags(ctx, 2, REDISMODULE_CMD_CHANNEL_SUBSCRIBE);
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/* Module onLoad                                                      */
+/* ------------------------------------------------------------------ */
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+
+    if (RedisModule_Init(ctx, "keyposvalidate", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    /* Key-position commands (use "getkeys-api" + "no-mandatory-keys" so that
+     * when all positions are filtered out as invalid, COMMAND GETKEYS returns
+     * an empty array rather than an error. This is what we want to test:
+     * invalid positions are filtered, command still works. */
+    if (RedisModule_CreateCommand(ctx, "keypos.validate.zero",
+                                  keypos_validate_zero, "getkeys-api no-mandatory-keys",
+                                  0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "keypos.validate.at_argc",
+                                  keypos_validate_at_argc, "getkeys-api no-mandatory-keys",
+                                  0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "keypos.validate.above_argc",
+                                  keypos_validate_above_argc, "getkeys-api no-mandatory-keys",
+                                  0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "keypos.validate.mixed",
+                                  keypos_validate_mixed, "getkeys-api no-mandatory-keys",
+                                  0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    /* Channel-position commands (use "getchannels-api"). */
+    if (RedisModule_CreateCommand(ctx, "chanpos.validate.zero",
+                                  chanpos_validate_zero, "getchannels-api",
+                                  0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "chanpos.validate.at_argc",
+                                  chanpos_validate_at_argc, "getchannels-api",
+                                  0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "chanpos.validate.above_argc",
+                                  chanpos_validate_above_argc, "getchannels-api",
+                                  0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "chanpos.validate.mixed",
+                                  chanpos_validate_mixed, "getchannels-api",
+                                  0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    return REDISMODULE_OK;
+}

--- a/tests/unit/moduleapi/keyposvalidate.tcl
+++ b/tests/unit/moduleapi/keyposvalidate.tcl
@@ -1,0 +1,106 @@
+# Test: validate that module API key/channel position filtering works.
+#
+# These tests verify the fix in moduleGetCommandKeysViaAPI and
+# moduleGetCommandChannelsViaAPI: positions declared by a module that
+# are <= 0 or >= argc are silently filtered out before being used by
+# ACL checks (which would otherwise read argv[pos]->ptr OOB and crash
+# Redis with SIGSEGV).
+#
+# Before the fix: the tests below would crash Redis.
+# After the fix: they return OK and the invalid positions are ignored.
+
+set testmodule [file normalize tests/modules/keyposvalidate.so]
+
+start_server {tags {"modules external:skip"}} {
+    r module load $testmodule
+
+    # ----------------------------------------------------------------
+    # Key-position tests
+    # ----------------------------------------------------------------
+
+    test "Module getkeys-api: pos=0 is filtered out (no crash)" {
+        # Should not crash; COMMAND GETKEYS should return empty list
+        # since the only declared position (0) is invalid.
+        assert_equal {} [r command getkeys keypos.validate.zero foo]
+    }
+
+    test "Module getkeys-api: pos=argc is filtered out (no crash)" {
+        # argc=2 (command + 1 arg). pos=2 is invalid (max valid is argc-1=1).
+        assert_equal {} [r command getkeys keypos.validate.at_argc foo]
+    }
+
+    test "Module getkeys-api: pos=999 is filtered out (no crash)" {
+        assert_equal {} [r command getkeys keypos.validate.above_argc foo]
+    }
+
+    test "Module getkeys-api: mixed valid and invalid positions" {
+        # keypos.validate.mixed declares: 1, 999, argc, 0, 2 (if argc >= 3)
+        # With argc=3 (cmd + 2 args), valid positions are 1 and 2.
+        # Expected: keys at positions 1 and 2 (foo, bar).
+        assert_equal {foo bar} [r command getkeys keypos.validate.mixed foo bar]
+    }
+
+    test "Module getkeys-api: invalid positions don't crash ACL check" {
+        # Create a user with restricted key access. The ACL check will
+        # iterate over the positions returned by the module; if invalid
+        # positions aren't filtered, argv[pos]->ptr causes OOB read.
+        # We use +@all and resetkeys, then allow only ~allowedkey:*.
+        r ACL setuser testuser on +@all resetkeys ~allowedkey:* ">secret123"
+
+        # All these commands declare invalid key positions. With the fix,
+        # the positions are filtered out and ACL check passes (no keys
+        # to check). Without the fix, Redis crashes with SIGSEGV.
+        assert_equal "OK" [r ACL DRYRUN testuser keypos.validate.zero foo]
+        assert_equal "OK" [r ACL DRYRUN testuser keypos.validate.at_argc foo]
+        assert_equal "OK" [r ACL DRYRUN testuser keypos.validate.above_argc foo]
+
+        # Cleanup
+        r ACL deluser testuser
+    }
+
+    test "Module getkeys-api: invalid positions in mixed case don't crash ACL" {
+        r ACL setuser testuser2 on +@all resetkeys ~allowedkey:* ">secret123"
+        # keypos.validate.mixed declares valid (1, 2) and invalid (999, argc, 0) positions.
+        # With the fix, only positions 1 and 2 are checked. foo is not in ~allowedkey:*
+        # so ACL denies.
+        set result [r ACL DRYRUN testuser2 keypos.validate.mixed foo bar]
+        # The user doesn't have access to foo, so ACL should deny.
+        assert_match {*no permissions*} $result
+        r ACL deluser testuser2
+    }
+
+    # ----------------------------------------------------------------
+    # Channel-position tests
+    # ----------------------------------------------------------------
+
+    test "Module getchannels-api: pos=0 is filtered out (no crash)" {
+        assert_equal "OK" [r ACL DRYRUN default chanpos.validate.zero foo]
+    }
+
+    test "Module getchannels-api: pos=argc is filtered out (no crash)" {
+        assert_equal "OK" [r ACL DRYRUN default chanpos.validate.at_argc foo]
+    }
+
+    test "Module getchannels-api: pos=999 is filtered out (no crash)" {
+        assert_equal "OK" [r ACL DRYRUN default chanpos.validate.above_argc foo]
+    }
+
+    test "Module getchannels-api: invalid positions don't crash restricted user ACL" {
+        # Create a user with NO channel access. With invalid positions
+        # filtered out, the ACL check sees no channels and passes (no
+        # channels to deny). Without the fix, Redis crashes.
+        r ACL setuser chanuser on +@all resetchannels ">secret123"
+        assert_equal "OK" [r ACL DRYRUN chanuser chanpos.validate.zero foo]
+        assert_equal "OK" [r ACL DRYRUN chanuser chanpos.validate.at_argc foo]
+        assert_equal "OK" [r ACL DRYRUN chanuser chanpos.validate.above_argc foo]
+        r ACL deluser chanuser
+    }
+
+    # ----------------------------------------------------------------
+    # Cleanup
+    # ----------------------------------------------------------------
+
+    test "Unload the keyposvalidate module" {
+        assert_equal {OK} [r module unload keyposvalidate]
+    }
+}


### PR DESCRIPTION
# Module API: validate key/channel positions against argc to prevent OOB read

## What

`RM_KeyAtPosWithFlags` and `RM_ChannelAtPosWithFlags` accept any `pos > 0`
from a module without checking that `pos < argc`. When the positions are
used downstream (e.g., in `ACLSelectorCheckKey` at `acl.c:1762` which does
`argv[idx]->ptr`), an out-of-bounds `pos` causes an OOB read that crashes
Redis with SIGSEGV.

This patch adds validation in `moduleGetCommandKeysViaAPI` and
`moduleGetCommandChannelsViaAPI` — after the module function returns,
positions where `pos <= 0 || pos >= argc` are filtered out.

## Why this is a real bug

`RM_RedactClientCommandArgument` (same file, line 11139) already
validates `pos` against `argc`:

```c
if (!ctx || !ctx->client || pos <= 0 || ctx->client->argc <= pos) {
    return REDISMODULE_ERR;
}
```

`RM_KeyAtPosWithFlags` (line 1087) only checks `pos <= 0` — it does not
check `pos < argc` because `ctx->client` is NULL during key-position
requests (the context is created without a client). The `argc` is
available in `moduleGetCommandKeysViaAPI` but is not used to validate
the positions the module returns.

## Reproduction

A PoC module that calls `RM_KeyAtPos(ctx, 999)` during a key-position
request, loaded into a Redis with a restricted ACL user, crashes Redis
with SIGSEGV:

```
Redis 8.9.241 crashed by signal: 11, si_code: 1
Accessing address: 0x8
Crashed running the instruction at: ACLCheckAllUserCommandPerm+0x285
```

Stack trace: `ACLCheckAllUserCommandPerm` → `processCommand` →
`processInputBuffer` → `readQueryFromClient`.

After applying the patch, the same PoC module returns `OK` and Redis
stays alive — the invalid position is silently filtered out.

## Severity

- A buggy module (off-by-one in key position declaration) can crash
  Redis. This is a DoS.
- A malicious module already has full process access, so the OOB read
  doesn't give the module anything it doesn't already have. The real
  victim is a buggy module crashing a production Redis.
- The crash requires a restricted ACL user (the default user has
  `allkeys` which short-circuits the ACL check before the OOB read).
- But the positions are also used for cluster slot routing and
  `COMMAND GETKEYS`, which may trigger the OOB read regardless of user.

## Files changed

```
 src/module.c | 35 +++++++++++++++++++++++++++++++++--
 1 file changed, 33 insertions(+), 2 deletions(-)
```

## PoC module

```c
#include "redismodule.h"

int poc_cmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
    if (RedisModule_IsKeysPositionRequest(ctx)) {
        RedisModule_KeyAtPos(ctx, 999);  /* pos=999, but argc=2 */
        return REDISMODULE_OK;
    }
    RedisModule_ReplyWithSimpleString(ctx, "OK");
    return REDISMODULE_OK;
}

int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
    REDISMODULE_NOT_USED(argv);
    REDISMODULE_NOT_USED(argc);
    if (RedisModule_Init(ctx, "poc_oob", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR)
        return REDISMODULE_ERR;
    if (RedisModule_CreateCommand(ctx, "poc.mycmd", poc_cmd, "getkeys-api",
                                  0, 0, 0) == REDISMODULE_ERR)
        return REDISMODULE_ERR;
    return REDISMODULE_OK;
}
```

Build: `gcc -shared -fPIC -o poc_oob_module.so poc_oob_module.c -Isrc -Ideps`

Reproduce:
```
redis-server --loadmodule ./poc_oob_module.so --port 16379
redis-cli -p 16379 ACL SETUSER testuser on +poc.mycmd '~foo/*' '>secret123'
redis-cli -p 16379 --user testuser -a secret123 POC.MYCMD arg1
# Before patch: Redis crashes with SIGSEGV
# After patch: returns OK, Redis stays alive
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the module command introspection path used by ACL and `COMMAND GETKEYS`, but the change is narrow defensive filtering with dedicated regression tests.
> 
> **Overview**
> Fixes a crash where module-declared key/channel argument positions could be out of range and later dereferenced as `argv[pos]` during ACL and introspection paths.
> 
> After `getkeys-api` / `getchannels-api` callbacks return in `moduleGetCommandKeysViaAPI` and `moduleGetCommandChannelsViaAPI`, positions with `pos <= 0` or `pos >= argc` are compacted out of `getKeysResult` before `numkeys` is returned—aligned with bounds checks already used in `RM_RedactClientCommandArgument`.
> 
> Adds the `keyposvalidate` test module plus TCL coverage for invalid positions (`0`, `argc`, OOB), mixed valid/invalid `COMMAND GETKEYS` results, and `ACL DRYRUN` for restricted users on keys and channels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65802e904c5eb6dbf3f1bf095fc7be41aa1766b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->