### PR TITLE
deps/fpconv: remove every integer division from Grisu digit generation

### DIFF
--- a/deps/fpconv/Makefile
+++ b/deps/fpconv/Makefile
@@ -1,6 +1,10 @@
 STD=
 WARN= -Wall
-OPT= -Os
+# -O3, not -Os: at -Os the compiler declines to strength-reduce the constant
+# divisors in generate_digits() (a multiply-shift costs more bytes than a divq)
+# and does not unroll the digit loop, so the hot double->string path executes
+# real 64-bit divisions. See the comment on tens[] in fpconv_dtoa.c.
+OPT= -O3
 
 R_CFLAGS= $(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS)
 R_LDFLAGS= $(LDFLAGS)

--- a/deps/fpconv/fpconv_dtoa.c
+++ b/deps/fpconv/fpconv_dtoa.c
@@ -51,26 +51,30 @@
 #define absv(n) ((n) < 0 ? -(n) : (n))
 #define minv(a, b) ((a) < (b) ? (a) : (b))
 
-static uint64_t tens[] = { 10000000000000000000U,
-                           1000000000000000000U,
-                           100000000000000000U,
-                           10000000000000000U,
-                           1000000000000000U,
-                           100000000000000U,
-                           10000000000000U,
-                           1000000000000U,
-                           100000000000U,
-                           10000000000U,
-                           1000000000U,
-                           100000000U,
-                           10000000U,
-                           1000000U,
-                           100000U,
-                           10000U,
-                           1000U,
-                           100U,
-                           10U,
-                           1U };
+/* Must stay const: generate_digits() divides part1 by tens[i], and the compiler
+ * can only replace those divisions with multiply-shifts if it may assume the
+ * table's contents. Dropping const puts a real 64-bit divq back on the hot
+ * double->string path. */
+static const uint64_t tens[] = { 10000000000000000000U,
+                                 1000000000000000000U,
+                                 100000000000000000U,
+                                 10000000000000000U,
+                                 1000000000000000U,
+                                 100000000000000U,
+                                 10000000000000U,
+                                 1000000000000U,
+                                 100000000000U,
+                                 10000000000U,
+                                 1000000000U,
+                                 100000000U,
+                                 10000000U,
+                                 1000000U,
+                                 100000U,
+                                 10000U,
+                                 1000U,
+                                 100U,
+                                 10U,
+                                 1U };
 
 static inline uint64_t get_dbits(double d) {
     union
@@ -176,7 +180,7 @@ static int generate_digits(Fp *fp, Fp *upper, Fp *lower, char *digits, int *K) {
     uint64_t part2 = upper->frac & (one.frac - 1);
 
     int idx = 0, kappa = 10;
-    uint64_t *divp;
+    const uint64_t *divp;
     /* 1000000000 */
     for (divp = tens + 10; kappa > 0; divp++) {
         uint64_t div = *divp;
@@ -199,7 +203,7 @@ static int generate_digits(Fp *fp, Fp *upper, Fp *lower, char *digits, int *K) {
     }
 
     /* 10 */
-    uint64_t *unit = tens + 18;
+    const uint64_t *unit = tens + 18;
 
     while (true) {
         part2 *= 10;


### PR DESCRIPTION
`generate_digits()` in `deps/fpconv/fpconv_dtoa.c` divides by a divisor **loaded from the static
`tens[]` table**. Because the table is mutable the compiler cannot assume its contents, so it keeps
the load and emits a real 64-bit `divq` for every double formatted into a RESP reply.

Two lines of substance:

1. `deps/fpconv/fpconv_dtoa.c` — `static uint64_t tens[]` → `static const uint64_t tens[]` (plus the
   two pointers into it, which must be const-qualified or the build warns).
2. `deps/fpconv/Makefile` — `OPT= -Os` → `OPT= -O3`.

`fpconv_dtoa.o` goes from **5 `div` instructions to 0**. Output is byte-for-byte identical.

## Why

Profiling `ZRANGE … WITHSCORES` over a 1000-element sorted set with fractional scores on a
Xeon 6972P shows the server is compute-bound on the **integer divider**, not on floating point:

| metric | value |
|---|---|
| `FP Arithmetic` | **0.0% of uOps** |
| `Backend_Bound.Core_Bound` | 13.7% of slots |
| — of which `INT Divider` | **21.8% of clockticks** |
| `generate_digits()` share of server CPU | **42.6%** |
| whole Grisu stack | 61.7% |
| 64-bit `DIV`s executed per score converted | **9.997**, a median of **6** of which produce no digit |

The cause is one line:

```c
for (divp = tens + 10; kappa > 0; divp++) {
    uint64_t div = *divp;
    unsigned digit = part1 / div;
```

The divisor comes from a table, so the compiler must emit a division — the highest-latency,
lowest-throughput integer operation on the machine. But the trip count is a literal `10` and the
divisors are exactly 10⁹…10⁰, all known at compile time. Nothing about the algorithm needs a runtime
divide; the compiler just is not allowed to see that.

## Both hunks are load-bearing

Three independent conditions must hold before the divisions disappear, and the shipped build fails
two of them:

1. **The loop must be unrolled**, or `div` genuinely varies across iterations and there is nothing to
   specialise. GCC unrolls this loop only at `-O3`.
2. **The compiler must be able to prove each divisor's value.** `static uint64_t tens[]` is mutable,
   so even after unrolling GCC keeps the load — which is why plain `-O3` on the current source is a
   *regression*, emitting **10** runtime divides against `-Os`'s 5. `const` is what unblocks it.
3. **The compiler must choose to strength-reduce.** At `-Os` it declines, because a multiply-shift is
   more bytes than a `divq`. This is why the `const` alone changes nothing today.

`deps/*/Makefile` files carry their own `OPT`; `src/Makefile`'s `-O3` does not propagate, and
`deps/fpconv` has built at `-Os` since it was introduced. Divide counts in `fpconv_dtoa.o`:

| build | `-Os` | `-O2` | `-O3` |
|---|---|---|---|
| as shipped | **5** | 1 | 10 |
| `+ const tens[]` (this PR) | 5 | 1 | **0** |

Identical on gcc 11.4 and gcc 13.3. clang 18/19 already reach 0 at `-O3` without the `const` — it
proves the table is never written on its own — so for clang the flag alone is sufficient and the
`const` is simply documentation.

`.text` for the object grows 1,556 → 3,162 bytes (gcc 11.4). `fpconv_dtoa.c` is 373 lines on a hot
reply path; its size is not worth trading for divider stalls.

**Degradation is graceful.** `deps/Makefile` passes `CFLAGS="$(DEPS_CFLAGS)"` into this Makefile
*after* `$(OPT)`, so a distro build that forces `-O2` or `-Os` overrides the flag above. That costs
the optimisation but never regresses: `-O2` leaves 1 divide, `-Os` returns to exactly today's 5.

## Results

`redis-benchmarks-specification` 0.3.38, `unstable` @ `dce0c76d4`, Xeon 6972P, `performance`
governor. Server and client co-located on separate NUMA nodes of one socket (loopback, no NIC),
server pinned to node 0, client to node 1. Arms interleaved within each test, cell order rotated
every rep, 5 reps per cell, 0 failures. `srv_cores` is real CPU from an `INFO cpu`
(`used_cpu_user + used_cpu_sys`) delta across the run window; `cli_cores` is sampled with
`ps -o pcpu -C memtier_benchmark` to show the client was never the limit.

**Single-threaded (no `--io-threads`):**

| test | Ops/sec | Δ | `usec_per_call` | Δ | `srv_cores` |
|---|---|---|---|---|---|
| `1key-zset-1K-elements-zrange-all-elements` | 6,797 → **9,616** | **+41.5%** | 138.12 → **95.02** | **−31.2%** | 0.99 |
| `1key-zset-100-elements-zrange-all-elements` | 42,181 → **48,555** | **+15.1%** | 17.33 → 14.10 | −18.6% | 0.99 |
| `…-zrangebyscore-all-elements-long-scores` **(control)** | 69,321 → 69,420 | **+0.14%** | 8.12 → 8.13 | +0.2% | 0.99 |

**With `io-threads 16`:**

| test | Ops/sec | Δ | `usec_per_call` | `srv_cores` |
|---|---|---|---|---|
| `zset-1K` zrange | 7,197 → **10,526** | **+46.3%** | 138.17 → 94.22 | 1.25 → 1.30 |
| `zset-100` zrange | 54,784 → **66,937** | **+22.2%** | 17.68 → 14.32 | 1.54 → 1.77 |
| `long-scores` **(control)** | 108,970 → 108,993 | **+0.02%** | 8.60 → 8.61 | 1.99 → 1.98 |

Rep-to-rep spread is ≤1.5% in every cell except one: the patched 1K single-threaded cell has 5.2%
spread from a single slow rep (9,243 against 9,637/9,724/9,735/9,743). It is kept in the table above.
Dropping it gives 9,710 = **+42.8%**, i.e. the outlier *understates* the gain, and the `io-threads 16`
cell agrees at 94.22 µs.

Three things to read off these tables.

**The control is the guard.** `…-long-scores` uses **integer** scores, which take the `double2ll()`
fast path in `d2string()` and never reach Grisu. It moves +0.14% single-threaded and +0.02% under
io-threads — inside noise in both cases — so the win belongs to the float-formatting path and is not
a code-layout artifact.

**The gain scales with elements emitted per reply,** because that is how many conversions run
back-to-back: 18.0 ns saved per formatted score at 10 elements, 32.2 ns at 100, 43.1 ns at 1000
(the 100-element figure reproduces to three digits on `ZRANGEBYSCORE`, a different command). The upper bound
implied by the standalone cycles-per-conversion delta on this host is 44.5 ns, so at 1000 elements
the in-server gain has essentially reached the microbenchmark's. Workloads returning one double per
command pay the divider too, but amortised against per-command overhead.

**No regression anywhere else in the sorted-set family.** Because the flag change applies to the
whole `deps/fpconv` object, I swept 12 further sorted-set specs base-vs-patch (n=3, 72 runs, single-
threaded, order rotated): `ZSCORE`, `ZMSCORE`, `ZRANK`, `ZADD`, `ZINCRBY`-style `ZADD`-new-member,
`ZREVRANGE … WITHSCORES`, `ZRANDMEMBER`, `ZSCAN`, `ZUNION`, `ZINTERCARD`, `ZRANGESTORE`, and
`ZRANGEBYSCORE`. **Nothing resolves as a regression**; the largest negative movement is −0.51%,
inside noise. Eight of the twelve arms are execution-bound (`srv_cores` ≥ 0.94), so they are capable
of showing a code-layout cost from the 1,606 B larger object, and none does. Most of those specs
preload *integer* scores and so never reach Grisu — they are effectively extra controls, and they are
flat. The two that do emit fractional doubles gain: `ZRANGEBYSCORE` over 100 elements
**42,240 → 48,811 (+15.6%)** and a 10-element `ZRANGE … WITHSCORES` +1.5%.

**This composes with `io-threads` rather than competing with it.** A 1000-element `WITHSCORES` reply
spends ~95% of its server CPU *inside command execution* (`exec_share` = `ops/s × usec_per_call ÷
srv_cores` = 0.95), so `io-threads 16` alone is worth only 1.06× there — it offloads socket I/O,
which is the 5% this workload does not spend. This patch attacks the 95%. Best measured
configuration is both together: **6,797 → 10,526 Ops/sec, +54.9%** over the shipped single-threaded
build (and 42,181 → 66,937, **+58.7%**, on the 100-element test).

## Correctness

Output is byte-identical, verified three ways:

- **195,200 in-server doubles** spanning 10⁻³⁰…10³⁰ loaded with `ZADD` and read back through
  `ZRANGE … WITHSCORES`, `ZSCORE`, `ZINCRBY` and `INCRBYFLOAT` — 585,924 reply lines, md5
  `ff30d54a3b7afa0554898e8707d1be60` on **both** builds, on this commit.
- **3,258,000 standalone conversions** (a −320…+308 decade sweep plus 2 M raw-bitpattern samples) —
  identical, gcc 13.3.
- **25 M standalone inputs** in an earlier pass — identical, gcc 11.4.
- **5.25 M more** on gcc 13.3 — every decade 10⁻³²⁰…10³⁰⁸ signed, 4 M raw 64-bit patterns, and the
  denormal / `DBL_MIN` / `DBL_MAX` / 2⁵³ / ±0.0 edge cases — identical, and clean under
  **ASan + UBSan at `-O3`**.

`tens[]` is `static`, so only this file can reach it; it has exactly three references and all three
are reads. Marking it `const` also moves it from `.data` to `.rodata`, which means a hypothetical
write to it becomes an immediate crash instead of silent table corruption — verified by injecting one
(SIGSEGV) and then confirming the real build takes none across those sweeps. It is also a small
thread-safety improvement, since `fpconv_dtoa()` is called concurrently from io-threads.

`unit/type/zset`, `unit/type/incr`, `unit/type/hash`, `unit/geo`, `unit/scripting`, `unit/dump`,
`unit/protocol`, `unit/type/string` and `unit/expire` all pass. Both builds report
`monotonic_clock: X86 TSC`, so the `usec_per_call` figures above are not contaminated by a
POSIX-clock fallback. The build is warning-free under the existing `-Wall`, and also under
`-Wextra -Wcast-qual -Wdiscarded-qualifiers -Wpedantic` — nothing anywhere drops the new qualifier.

## Scope

Every RESP double reply benefits, not only `ZRANGE`: `addReplyDouble()` → `d2string()` →
`fpconv_dtoa()` also serves `ZSCORE`, `ZMSCORE`, `ZINCRBY`, `ZADD INCR`, `ZRANGEBYSCORE` /
`ZRANGEBYLEX … WITHSCORES`, `GEODIST`, `GEOPOS`, `INCRBYFLOAT`, `HINCRBYFLOAT`, plus `d2string()` in
RDB/AOF and Lua conversion paths. Only *fractional* values are affected; integers already
short-circuit through `double2ll()`.

## Prior art

Continues #10587 ("optimizing `d2string()` and `addReplyDouble()` with grisu2", merged as
`29380ff77`), which introduced `deps/fpconv` and its `OPT= -Os`, and issue #8826 which asked for it.
Complementary to #11779 (integer-score fast path for `ZRANGE … WITHSCORES`), which covers exactly
the case this PR does not touch. No open PR modifies `deps/fpconv`.

## Notes for reviewers

- **Hand-unrolling the digit loop was measured and rejected — twice.** Unrolling with literal
  divisors also reaches 0 divides and is robust to a forced `-O2`, but in a 3-arm interleaved run
  against this same base it was **4.3–11.6% slower** than the patch above on all four signal cells
  (`zset-1K` single-thread 8,775 vs 9,616; `io-threads 16` 9,432 vs 10,526), while being 1,144 bytes
  larger and a +41/−21 diff.
  To rule out the flag as the explanation, a third arm combined the unroll *with* this patch's `const`
  and `-O3` — also 0 divides, `.text` 4,253 B. At n=5 it stayed **5.4–12.2% behind** the rolled loop
  and did not improve on the `-O2` unroll:

  | `zset-1K` ZRANGE | base | rolled + `const` + `-O3` (this PR) | unrolled + `const` + `-O3` |
  | --- | --- | --- | --- |
  | single-thread   | 6,707 | **9,741** (+45.2%) | 8,662 (+29.2%), −11.1% vs this PR |
  | `io-threads 16` | 7,220 | **10,542** (+46.0%) | 9,261 (+28.3%), −12.2% vs this PR |

  So the optimization level was never what held the unroll back: **the unroll itself costs ~11%.**
  Ten inlined copies of the digit step spread a hot loop that ran ≤10 iterations over ~1.1 KB more
  `.text`, and the front end pays for it. Keeping the loop rolled and letting GCC strength-reduce
  it is both the smaller diff and the faster code.
- The `tens[]` hunk looks large in the diff because the initializer's continuation lines are
  re-indented to the new `{` column. `git diff -w` is 4 changed lines of code.
- The uarch counters in **Why** were collected on this host and byte-identical `deps/fpconv` sources
  but a slightly older `src/` tree, so they are cited as diagnosis of the divider bottleneck rather
  than as this commit's own numbers. A zero-divide build re-profiles with **`INT Divider` at 0.0% of
  clockticks**, `Core_Bound` 13.7% → 7.2%, `Retiring` 59.3% → 68.9%, CPI 0.372 → 0.276, and
  `generate_digits()` down from 42.6% to 16.7% of server CPU. Happy to re-collect the whole set on
  `dce0c76d4` if wanted.
- `round_digit()` has a pre-existing latent out-of-bounds — `round_digit(digits, ndigits=0, …)` would
  write `digits[-1]`. It predates this change and is not reachable in practice (probed over 299.9 M
  inputs: **0** occurrences); mentioned only because reading this code invites the question. Happy to
  file it separately.
- Reproducing the divide count:
  ```sh
  make -C deps/fpconv clean && make -C deps/fpconv
  objdump -d deps/fpconv/fpconv_dtoa.o | grep -cE '\s(div|idiv)q?\s'   # 5 before, 0 after
  ```
- Reproducing the benchmark:
  ```sh
  redis-benchmarks-spec-client-runner \
    --db_server_host 127.0.0.1 --db_server_port 6379 \
    --test memtier_benchmark-1key-zset-1K-elements-zrange-all-elements.yml \
    --flushall_on_every_test_start --benchmark_local_install
  ```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Same Grisu algorithm and verified identical strings; only build flags and `const` qualifiers affect codegen, with graceful fallback if parent builds override to `-O2`/`-Os`.
> 
> **Overview**
> Speeds up fractional **double → RESP string** conversion by removing **64-bit integer divides** from `generate_digits()` in `deps/fpconv/fpconv_dtoa.c`.
> 
> **`tens[]` is now `static const`**, with matching `const uint64_t *` pointers, so GCC can treat powers-of-ten divisors as compile-time constants and replace `part1 / div` with multiply-shift instead of `divq`. Comments document that dropping `const` or building at `-Os` puts real divides back on the hot path.
> 
> **`deps/fpconv/Makefile` switches `OPT` from `-Os` to `-O3`**, which is required together with `const` for loop unrolling and strength reduction (at `-Os` the optimizer keeps divides to save code size).
> 
> Formatting output stays **byte-for-byte identical**; the change is compile-time/codegen only. Workloads that emit many fractional scores (e.g. `ZRANGE … WITHSCORES`) benefit most; integer-score paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40080f2dda6569675d2ee93185647d345c10b77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->